### PR TITLE
fix(approval): classify resolved decide races

### DIFF
--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -27,7 +27,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">Doku</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">@senamakel folgen (Creator)</a>
@@ -80,7 +80,7 @@ OpenHuman ist ein quelloffener, agentenbasierter Assistent, der sich in deinen A
 
 - **[Memory Tree](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian-Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: eine lokal-zentrierte Wissensbasis, aufgebaut aus deinen Daten und deinen Aktivitäten. Alles, was du verbindest, wird in Markdown-Chunks von ≤3k Tokens kanonisiert, bewertet und in hierarchische Zusammenfassungs-Bäume gefaltet, gespeichert in **SQLite auf deiner Maschine**. Dieselben Chunks landen als `.md`-Dateien in einem Obsidian-kompatiblen Vault, das du öffnen, durchstöbern und editieren kannst — inspiriert von Karpathys [obsidian-wiki-Workflow](https://x.com/karpathy/status/2039805659525644595).
 
-- **Alles eingebaut**: Web-Suche, ein Web-Fetch-[Scraper](https://tinyhumans.gitbook.io/openhuman/features/native-tools), ein vollständiges Coder-Toolset (Dateisystem, Git, Lint, Test, Grep) und [native Sprache](https://tinyhumans.gitbook.io/openhuman/features/voice) (STT als Eingabe, ElevenLabs TTS als Ausgabe, Lippensynchronisation für das Maskottchen, Live-Google-Meet-Agent) sind ab Werk verdrahtet. Standardmäßig nutzt [Model-Routing](https://tinyhumans.gitbook.io/openhuman/features/model-routing) das OpenHuman-Backend, um das passende LLM für jede Workload auszuwählen und zu proxien (Reasoning, Fast oder Vision). Ein Abo umfasst alle Modelle. Keine "erst-ein-Plugin-installieren-um-Dateien-zu-lesen"-Hürde. [Optional lokale KI über Ollama](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) für On-Device-Workloads.
+- **Alles eingebaut**: Web-Suche, ein Web-Fetch-[Scraper](https://tinyhumans.gitbook.io/openhuman/features/native-tools), ein vollständiges Coder-Toolset (Dateisystem, Git, Lint, Test, Grep) und [native Sprache](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice) (STT als Eingabe, ElevenLabs TTS als Ausgabe, Lippensynchronisation für das Maskottchen, Live-Google-Meet-Agent) sind ab Werk verdrahtet. Standardmäßig nutzt [Model-Routing](https://tinyhumans.gitbook.io/openhuman/features/model-routing) das OpenHuman-Backend, um das passende LLM für jede Workload auszuwählen und zu proxien (Reasoning, Fast oder Vision). Ein Abo umfasst alle Modelle. Keine "erst-ein-Plugin-installieren-um-Dateien-zu-lesen"-Hürde. [Optional lokale KI über Ollama](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) für On-Device-Workloads.
 
 - **[Smarte Token-Kompression (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: Jeder Tool-Aufruf, jedes Scrape-Ergebnis, jeder E-Mail-Text und jeder Such-Payload läuft durch eine Token-Kompressionsschicht, bevor er ein LLM-Modell erreicht. HTML wird zu Markdown konvertiert, lange URLs werden gekürzt, und ausschweifende Tool-Ausgaben werden über eine konfigurierbare Regel-Ebene dedupliziert und zusammengefasst usw. CJK, Emojis und andere Multi-Byte-Texte bleiben Graphem für Graphem erhalten — niemals abgeschnitten. Du erhältst dieselbe Information bei einem Bruchteil der Tokens. Kosten und Latenz sinken um bis zu 80%.
 
@@ -133,7 +133,7 @@ Du hostest [agentmemory](https://github.com/rohitg00/agentmemory) bereits selbst
 _Baust du auch in Richtung AGI und künstlichem Bewusstsein? Setze einen Stern und hilf anderen, den Weg zu finden._
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.ja-JP.md
+++ b/docs/README.ja-JP.md
@@ -22,7 +22,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">ドキュメント</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">@senamakel（作者）をフォロー</a>
@@ -80,7 +80,7 @@ OpenHuman は、あなたの日常生活に統合されるよう設計された�
 
 - **[Memory Tree](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: あなたのデータとアクティビティから構築されるローカルファーストのナレッジベースです。接続したすべての情報は ≤3k トークンの Markdown チャンクへ正規化され、スコアリングされ、階層的なサマリーツリーに畳み込まれて **あなたのマシン上の SQLite** に保存されます。同じチャンクは Obsidian 互換のボルトに `.md` ファイルとして配置され、開いて閲覧・編集できます。Karpathy 氏の [obsidian-wiki ワークフロー](https://x.com/karpathy/status/2039805659525644595)にインスパイアされています。
 
-- **電池同梱(Batteries included)**: ウェブ検索、ウェブフェッチ用[スクレイパー](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、フルコーダーツールセット(ファイルシステム、git、lint、test、grep)、そして[ネイティブ音声](https://tinyhumans.gitbook.io/openhuman/features/voice)(STT 入力、ElevenLabs TTS 出力、マスコットのリップシンク、ライブ Google Meet エージェント)がデフォルトで組み込まれています。デフォルトで、[モデルルーティング](https://tinyhumans.gitbook.io/openhuman/features/model-routing)は OpenHuman バックエンドを使用して各ワークロードに適切な LLM(reasoning、fast、または vision)を選択およびプロキシします。一つのサブスクリプションですべてのモデルが含まれます。「ファイル読み込みのためにプラグインをインストール」という煩わしさはありません。デバイス上のワークロード向けに [Ollama によるオプショナルなローカル AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) も利用できます。
+- **電池同梱(Batteries included)**: ウェブ検索、ウェブフェッチ用[スクレイパー](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、フルコーダーツールセット(ファイルシステム、git、lint、test、grep)、そして[ネイティブ音声](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice)(STT 入力、ElevenLabs TTS 出力、マスコットのリップシンク、ライブ Google Meet エージェント)がデフォルトで組み込まれています。デフォルトで、[モデルルーティング](https://tinyhumans.gitbook.io/openhuman/features/model-routing)は OpenHuman バックエンドを使用して各ワークロードに適切な LLM(reasoning、fast、または vision)を選択およびプロキシします。一つのサブスクリプションですべてのモデルが含まれます。「ファイル読み込みのためにプラグインをインストール」という煩わしさはありません。デバイス上のワークロード向けに [Ollama によるオプショナルなローカル AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) も利用できます。
 
 - **[スマートトークン圧縮 (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: すべてのツール呼び出し、スクレイプ結果、メール本文、検索ペイロードは、LLM モデルに渡される前にトークン圧縮レイヤーを通過します。HTML は Markdown に変換され、長い URL は短縮され、冗長なツール出力は設定可能なルールレイヤーで重複排除と要約が行われるなど…。CJK、絵文字などのマルチバイト文字は書記素(grapheme)単位で完全に保持され、除去されることはありません。同じ情報をわずかなトークン数で得られます。コストとレイテンシを最大 80% 削減します。
 
@@ -133,7 +133,7 @@ OpenHuman はその待ち時間をスキップします。アカウントを接�
 _AGI と人工意識への道を進んでいますか? リポジトリにスターをつけて、他の人にも道筋を見つけてもらいましょう。_
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -22,7 +22,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">문서</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">@senamakel(제작자) 팔로우</a>
@@ -79,7 +79,7 @@ OpenHuman은 일상 생활에 통합되도록 설계된 오픈 소스 에이전�
 
 - **[메모리 트리(Memory Tree)](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian 위키](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: 당신의 데이터와 활동을 바탕으로 구축된 로컬 우선 지식 베이스입니다. 연결된 모든 것은 3k 토큰 이하의 Markdown 청크로 규격화되고 점수가 매겨지며, **당신의 머신에 있는 SQLite**에 저장되는 계층적 요약 트리로 접힙니다. 동일한 청크는 당신이 열고, 탐색하고, 편집할 수 있는 Obsidian 호환 볼트에 `.md` 파일로 저장됩니다. 이는 Karpathy의 [obsidian-wiki 워크플로우](https://x.com/karpathy/status/2039805659525644595)에서 영감을 받았습니다.
 
-- **모든 것이 포함됨(Batteries included)**: 웹 검색, 웹 가져오기 [스크레이퍼](https://tinyhumans.gitbook.io/openhuman/features/native-tools), 전체 코더 툴셋(파일 시스템, git, lint, test, grep), 그리고 [네이티브 음성](https://tinyhumans.gitbook.io/openhuman/features/voice)(STT 입력, ElevenLabs TTS 출력, 마스코트 립싱크, 라이브 Google Meet 에이전트)이 기본적으로 연결되어 있습니다. 기본적으로 [모델 라우팅](https://tinyhumans.gitbook.io/openhuman/features/model-routing)은 OpenHuman 백엔드를 사용하여 각 워크로드에 적합한 LLM(추론, 고속 또는 비전)을 선택하고 프록시합니다. 하나의 구독에 모든 모델이 포함됩니다. "파일을 읽기 위해 플러그인 설치"와 같은 번거로움이 없습니다. 온디바이스 워크로드를 위해 [Ollama를 통한 선택적 로컬 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai)를 지원합니다.
+- **모든 것이 포함됨(Batteries included)**: 웹 검색, 웹 가져오기 [스크레이퍼](https://tinyhumans.gitbook.io/openhuman/features/native-tools), 전체 코더 툴셋(파일 시스템, git, lint, test, grep), 그리고 [네이티브 음성](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice)(STT 입력, ElevenLabs TTS 출력, 마스코트 립싱크, 라이브 Google Meet 에이전트)이 기본적으로 연결되어 있습니다. 기본적으로 [모델 라우팅](https://tinyhumans.gitbook.io/openhuman/features/model-routing)은 OpenHuman 백엔드를 사용하여 각 워크로드에 적합한 LLM(추론, 고속 또는 비전)을 선택하고 프록시합니다. 하나의 구독에 모든 모델이 포함됩니다. "파일을 읽기 위해 플러그인 설치"와 같은 번거로움이 없습니다. 온디바이스 워크로드를 위해 [Ollama를 통한 선택적 로컬 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai)를 지원합니다.
 
 - **[스마트 토큰 압축(TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: 모든 도구 호출, 스크레이핑 결과, 이메일 본문 및 검색 페이로드는 LLM 모델에 전달되기 전에 토큰 압축 레이어를 거칩니다. HTML은 Markdown으로 변환되고, 긴 URL은 단축되며, 장황한 도구 출력은 구성 가능한 규칙 오버레이 등을 통해 중복 제거 및 요약됩니다. CJK, 이모지 및 기타 멀티바이트 텍스트는 자소(grapheme) 단위로 보존되며 절대 삭제되지 않습니다. 동일한 정보를 훨씬 적은 토큰으로 얻을 수 있어 비용과 지연 시간을 최대 80%까지 줄일 수 있습니다.
 
@@ -132,7 +132,7 @@ OpenHuman은 기다림을 생략합니다. 계정을 연결하고, [자동 가�
 _AGI와 인공 의식을 향해 나아가고 계신가요? 저장소에 스타를 눌러 다른 사람들도 이 길을 찾을 수 있도록 도와주세요._
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.ur-pk.md
+++ b/docs/README.ur-pk.md
@@ -34,7 +34,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">ڈسکارڈ</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">ریڈٹ</a> •
+ ریڈٹ •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/ٹویٹر</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">دستاویزات</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">فالو کریں @senamakel (مصنف)</a>
@@ -152,7 +152,7 @@ OpenHuman ایک اوپن سورس ایجنٹک اسسٹنٹ ہے جو آپ کی
 
 - **[میموری ٹری](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**: ایک مقامی اول علم کا ذخیرہ جو آپ کے ڈیٹا اور سرگرمی سے بنایا گیا ہے۔ آپ جو کچھ بھی جوڑتے ہیں وہ ≤3k-token کے Markdown ٹکڑوں میں معیاری ہو جاتا ہے، اسکور کیا جاتا ہے، اور درجہ بندی کے خلاصے کے درختوں میں جوڑ دیا جاتا ہے جو **آپ کی مشین پر SQLite** میں محفوظ ہوتے ہیں۔ وہی ٹکڑے Obsidian-مطابق والٹ میں `.md` فائلوں کے طور پر اترتے ہیں جسے آپ کھول سکتے ہیں، براؤز اور ایڈٹ کر سکتے ہیں، کارپیتھی کے [obsidian-wiki ورک فلو](https://x.com/karpathy/status/2039805659525644595) سے متاثر۔
 
-- **سب کچھ شامل ہے**: ویب سرچ، ایک ویب فیچ [سکریپر](https://tinyhumans.gitbook.io/openhuman/features/native-tools)، ایک مکمل کوڈر ٹول سیٹ (فائل سسٹم، گٹ، لنٹ، ٹیسٹ، گریپ)، اور [مقامی آواز](https://tinyhumans.gitbook.io/openhuman/features/voice) (STT ان پٹ، ElevenLabs TTS آؤٹ پٹ، مسکاٹ لپ سنک، لائیو Google Meet ایجنٹ) ڈیفالٹ طور پر وائرڈ ہیں۔ ڈیفالٹ طور پر، [ماڈل روٹنگ](https://tinyhumans.gitbook.io/openhuman/features/model-routing) ہر ورک لوڈ (reasoning، fast، یا vision) کے لیے صحیح LLM کو منتخب اور پروکسی کرنے کے لیے OpenHuman بیک اینڈ استعمال کرتی ہے۔ ایک سبسکرپشن میں تمام ماڈلز شامل ہیں۔ کوئی "فائل پڑھنے کے لیے پلگ ان انسٹال کریں" رگڑ نہیں۔ تعاون یافتہ ڈیوائس پر ورک لوڈز کے لیے [Ollama کے ذریعے اختیاری مقامی AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) استعمال کریں۔
+- **سب کچھ شامل ہے**: ویب سرچ، ایک ویب فیچ [سکریپر](https://tinyhumans.gitbook.io/openhuman/features/native-tools)، ایک مکمل کوڈر ٹول سیٹ (فائل سسٹم، گٹ، لنٹ، ٹیسٹ، گریپ)، اور [مقامی آواز](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice) (STT ان پٹ، ElevenLabs TTS آؤٹ پٹ، مسکاٹ لپ سنک، لائیو Google Meet ایجنٹ) ڈیفالٹ طور پر وائرڈ ہیں۔ ڈیفالٹ طور پر، [ماڈل روٹنگ](https://tinyhumans.gitbook.io/openhuman/features/model-routing) ہر ورک لوڈ (reasoning، fast، یا vision) کے لیے صحیح LLM کو منتخب اور پروکسی کرنے کے لیے OpenHuman بیک اینڈ استعمال کرتی ہے۔ ایک سبسکرپشن میں تمام ماڈلز شامل ہیں۔ کوئی "فائل پڑھنے کے لیے پلگ ان انسٹال کریں" رگڑ نہیں۔ تعاون یافتہ ڈیوائس پر ورک لوڈز کے لیے [Ollama کے ذریعے اختیاری مقامی AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) استعمال کریں۔
 
 - **[اسمارٹ ٹوکن کمپریشن (TokenJuice)](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**: ہر ٹول کال، سکریپ نتیجہ، ای میل باڈی، اور سرچ پے لوڈ کسی بھی LLM ماڈل کو چھونے سے پہلے ٹوکن کمپریشن پرت سے گزرتا ہے۔ HTML کو Markdown میں تبدیل کیا جاتا ہے، لمبے URLs کو چھوٹا کیا جاتا ہے، اور لمبے ٹول آؤٹ پٹ کو ایک قابل ترتیب اصول اوورلے وغیرہ کے ذریعے ڈیڈپ اور خلاصہ کیا جاتا ہے... CJK، ایموجی، اور دیگر ملٹی بائٹ ٹیکسٹ گرافیم بہ گرافیم محفوظ رہتے ہیں — کبھی نہیں ہٹائے جاتے۔ آپ کو وہی معلومات ملتی ہیں لیکن ٹوکنز کے ایک حصے میں۔ لاگت اور تاخیر کو 80% تک کم کرنا۔
 
@@ -225,7 +225,7 @@ _AGI اور مصنوعی شعور کی طرف بڑھ رہے ہیں؟ ریپو ک
 <div dir="ltr">
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -26,7 +26,7 @@
 
 <p align="center">
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
- <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
+ Reddit •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •
  <a href="https://tinyhumans.gitbook.io/openhuman/">文档</a> •
  <a href="https://x.com/intent/follow?screen_name=senamakel">关注 @senamakel（作者）</a>
@@ -78,7 +78,7 @@ OpenHuman 是一个开源智能助手，旨在融入你的日常生活。以下�
 
 - **[记忆树](https://tinyhumans.gitbook.io/openhuman/features/memory-tree) + [Obsidian Wiki](https://tinyhumans.gitbook.io/openhuman/features/obsidian-wiki)**：一个基于你的数据和活动构建的本地优先知识库。你连接的所有内容都被规范化为不超过 3k token 的 Markdown 片段，经过评分后折叠成层级化的摘要树，存储在**你本机的 SQLite** 中。同样的片段以 `.md` 文件形式落地到兼容 Obsidian 的仓库中，你可以打开、浏览和编辑，灵感来源于 Karpathy 的 [obsidian-wiki 工作流](https://x.com/karpathy/status/2039805659525644595)。
 
-- **开箱即用**：默认内置网络搜索、网页抓取[爬虫](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、完整的编码工具集（文件系统、git、lint、test、grep）以及[原生语音](https://tinyhumans.gitbook.io/openhuman/features/voice)（STT 输入、ElevenLabs TTS 输出、吉祥物口型同步、实时 Google Meet 智能体）。默认情况下，[模型路由](https://tinyhumans.gitbook.io/openhuman/features/model-routing)使用 OpenHuman 后端来选择和代理每个工作负载的合适 LLM（推理型、快速型或视觉型）。一个订阅包含所有模型。没有"安装插件才能读文件"的摩擦。[可选通过 Ollama 使用本地 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) 处理端侧工作负载。
+- **开箱即用**：默认内置网络搜索、网页抓取[爬虫](https://tinyhumans.gitbook.io/openhuman/features/native-tools)、完整的编码工具集（文件系统、git、lint、test、grep）以及[原生语音](https://tinyhumans.gitbook.io/openhuman/features/native-tools/voice)（STT 输入、ElevenLabs TTS 输出、吉祥物口型同步、实时 Google Meet 智能体）。默认情况下，[模型路由](https://tinyhumans.gitbook.io/openhuman/features/model-routing)使用 OpenHuman 后端来选择和代理每个工作负载的合适 LLM（推理型、快速型或视觉型）。一个订阅包含所有模型。没有"安装插件才能读文件"的摩擦。[可选通过 Ollama 使用本地 AI](https://tinyhumans.gitbook.io/openhuman/features/model-routing/local-ai) 处理端侧工作负载。
 
 - **[智能 Token 压缩（TokenJuice）](https://tinyhumans.gitbook.io/openhuman/features/token-compression)**：每个工具调用、抓取结果、邮件正文和搜索载荷在触达任何 LLM 模型之前都会经过 token 压缩层处理。HTML 被转换为 Markdown，长 URL 被缩短，冗长的工具输出会通过可配置的规则层去重并摘要等等。中文、emoji 等多字节字符按字形（grapheme）完整保留，绝不丢弃。你获得相同的信息，但 token 消耗仅为原来的几分之一。最多可降低 80% 的成本和延迟。
 
@@ -131,7 +131,7 @@ OpenHuman 跳过了等待期。连接你的账户，让[自动拉取](https://ti
 _致力于 AGI 和人工意识？为仓库加星，帮助更多人找到这条路。_
 
 <p align="center">
- <a href="https://www.star-history.com/#tinyhumansai/openhuman&type=date&legend=top-left">
+ <a href="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left">
  <picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&theme=dark&legend=top-left" />
  <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tinyhumansai/openhuman&type=date&legend=top-left" />

--- a/docs/agent-workflows/cursor-cloud-agents.md
+++ b/docs/agent-workflows/cursor-cloud-agents.md
@@ -1,6 +1,6 @@
 # Cursor Cloud Agents — parallel workflow
 
-Operator playbook for running 15–20 [Cursor Cloud Agents](https://docs.cursor.com/agents/cloud) in parallel against OpenHuman. Companion to [`codex-pr-checklist.md`](codex-pr-checklist.md); the same merge gates apply.
+Operator playbook for running 15–20 [Cursor Cloud Agents](https://cursor.com/docs/cloud-agent) in parallel against OpenHuman. Companion to [`codex-pr-checklist.md`](codex-pr-checklist.md); the same merge gates apply.
 
 This doc closes [`tinyhumansai/openhuman#1480`](https://github.com/tinyhumansai/openhuman/issues/1480).
 

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -556,6 +556,7 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
 
 fn is_approval_already_resolved_message(lower: &str) -> bool {
     lower.contains("no pending approval found for request_id")
+        && lower.contains("already decided as")
 }
 
 /// Detect filesystem-out-of-space errors that bubble up from any syscall
@@ -2830,6 +2831,11 @@ mod tests {
             expected_error_kind("approval request not found for request_id 'req-2'"),
             None,
             "a request id that never existed should remain observable"
+        );
+        assert_eq!(
+            expected_error_kind("no pending approval found for request_id 'req-3'"),
+            None,
+            "prefix-only messages should not be classified as replay races"
         );
     }
 

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -109,6 +109,12 @@ pub enum ExpectedErrorKind {
     LocalAiCapabilityUnavailable,
     BudgetExhausted,
     SessionExpired,
+    /// Approval decision replay/race: a second operator, double click, or
+    /// expiry tried to decide a request that is already terminal. The request
+    /// existed and the security outcome is already fail-closed or decided, so
+    /// Sentry has no product-actionable signal. A truly unknown request id uses
+    /// a different message and remains reportable.
+    ApprovalAlreadyResolved,
     /// Boot-window failure where the in-process core HTTP listener
     /// (`127.0.0.1:<port>`) is not yet accepting connections, so a sibling
     /// component (frontend RPC relay, agent-integrations client) sees a TCP
@@ -336,6 +342,9 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
     if lower.contains("codex cli auth") || lower.contains(".codex/auth.json") {
         return Some(ExpectedErrorKind::CodexCliAuthUnavailable);
     }
+    if is_approval_already_resolved_message(&lower) {
+        return Some(ExpectedErrorKind::ApprovalAlreadyResolved);
+    }
     if lower.contains("local ai is disabled") {
         return Some(ExpectedErrorKind::LocalAiDisabled);
     }
@@ -543,6 +552,10 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
         return Some(ExpectedErrorKind::FilesystemUserPathInvalid);
     }
     None
+}
+
+fn is_approval_already_resolved_message(lower: &str) -> bool {
+    lower.contains("no pending approval found for request_id")
 }
 
 /// Detect filesystem-out-of-space errors that bubble up from any syscall
@@ -1764,6 +1777,19 @@ fn report_expected_message(kind: ExpectedErrorKind, message: &str, domain: &str,
                 "[observability] {domain}.{operation} skipped expected session-expired error: {message}"
             );
         }
+        ExpectedErrorKind::ApprovalAlreadyResolved => {
+            // Approval UI/Telegram callbacks can race: duplicate taps, two
+            // operators, or expiry can arrive after the request is already
+            // terminal. The decision store now distinguishes those benign
+            // replays from unknown ids; only this replay string is demoted.
+            tracing::info!(
+                domain = domain,
+                operation = operation,
+                kind = "approval_already_resolved",
+                error = %message,
+                "[observability] {domain}.{operation} skipped expected already-resolved approval error: {message}"
+            );
+        }
         ExpectedErrorKind::LoopbackUnavailable => {
             // In-process-core boot-window condition: a sibling component
             // tried to reach `127.0.0.1:<port>` before the embedded core's
@@ -2789,6 +2815,21 @@ mod tests {
         assert_eq!(
             expected_error_kind("ollama embed failed with status 500"),
             None
+        );
+    }
+
+    #[test]
+    fn classifies_resolved_approval_decide_race_as_expected() {
+        assert_eq!(
+            expected_error_kind(
+                "no pending approval found for request_id 'req-1' (already decided as 'deny')"
+            ),
+            Some(ExpectedErrorKind::ApprovalAlreadyResolved)
+        );
+        assert_eq!(
+            expected_error_kind("approval request not found for request_id 'req-2'"),
+            None,
+            "a request id that never existed should remain observable"
         );
     }
 

--- a/src/openhuman/approval/gate.rs
+++ b/src/openhuman/approval/gate.rs
@@ -721,14 +721,18 @@ impl ApprovalGate {
                 ApprovalDecisionOutcome::AlreadyTerminal {
                     decision: persisted_decision,
                 } => {
+                    if let Some(tx) = self.take_waiter(request_id) {
+                        let _ = tx.send(*persisted_decision);
+                    }
                     tracing::debug!(
                         request_id = %request_id,
                         persisted_decision = persisted_decision.as_str(),
                         attempted_decision = decision.as_str(),
-                        "[approval::gate] decision ignored for already-terminal request"
+                        "[approval::gate] released waiter for already-terminal request"
                     );
                 }
                 ApprovalDecisionOutcome::NotFound => {
+                    drop(self.take_waiter(request_id));
                     tracing::warn!(
                         request_id = %request_id,
                         attempted_decision = decision.as_str(),
@@ -1119,6 +1123,54 @@ mod tests {
             .decide("does-not-exist", ApprovalDecision::ApproveOnce)
             .unwrap();
         assert!(decided.is_none());
+    }
+
+    #[tokio::test]
+    async fn decide_with_status_releases_waiter_for_already_terminal_row() {
+        let (gate, _dir) = test_gate();
+        let config = gate.config.clone();
+        let gate = Arc::new(gate);
+
+        let g = gate.clone();
+        let handle = tokio::spawn(async move {
+            turn_origin::with_origin(
+                web_origin(),
+                APPROVAL_CHAT_CONTEXT.scope(
+                    chat_ctx(),
+                    g.intercept("composio", "send slack", serde_json::json!({})),
+                ),
+            )
+            .await
+        });
+
+        let mut tries = 0;
+        let pending = loop {
+            let list = gate.list_pending().unwrap();
+            if let Some(p) = list.into_iter().next() {
+                break p;
+            }
+            tries += 1;
+            assert!(tries < 50, "pending row never appeared");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        };
+
+        store::decide(&config, &pending.request_id, ApprovalDecision::Deny).unwrap();
+        let outcome = gate
+            .decide_with_status(&pending.request_id, ApprovalDecision::ApproveOnce)
+            .unwrap();
+        assert!(matches!(
+            outcome,
+            ApprovalDecisionOutcome::AlreadyTerminal {
+                decision: ApprovalDecision::Deny
+            }
+        ));
+
+        let parked = tokio::time::timeout(Duration::from_millis(100), handle)
+            .await
+            .expect("already-terminal replay should release the parked waiter")
+            .expect("intercept task");
+        assert!(matches!(parked, GateOutcome::Deny { .. }));
+        assert!(gate.pending_for_thread("t-test").is_none());
     }
 
     #[tokio::test]

--- a/src/openhuman/approval/gate.rs
+++ b/src/openhuman/approval/gate.rs
@@ -43,7 +43,9 @@ use crate::openhuman::config::Config;
 use crate::openhuman::security::POLICY_DENIED_MARKER;
 
 use super::store;
-use super::types::{ApprovalDecision, ExecutionOutcome, GateOutcome, PendingApproval};
+use super::types::{
+    ApprovalDecision, ApprovalDecisionOutcome, ExecutionOutcome, GateOutcome, PendingApproval,
+};
 
 /// How long the gate will park a future before timing out and
 /// returning `Deny`. 10 minutes matches the default `expires_at`
@@ -693,15 +695,15 @@ impl ApprovalGate {
         }
     }
 
-    /// Apply a user decision. Returns the now-decided
-    /// [`PendingApproval`] row when one was found.
-    pub fn decide(
+    /// Apply a user decision and classify whether the request was pending,
+    /// already terminal, or never persisted.
+    pub fn decide_with_status(
         &self,
         request_id: &str,
         decision: ApprovalDecision,
-    ) -> anyhow::Result<Option<PendingApproval>> {
-        let decided = store::decide(&self.config, request_id, decision)?;
-        if let Some(row) = &decided {
+    ) -> anyhow::Result<ApprovalDecisionOutcome> {
+        let outcome = store::decide_with_status(&self.config, request_id, decision)?;
+        if let ApprovalDecisionOutcome::Decided(row) = &outcome {
             // `ApproveAlwaysForTool` persistence (append to `autonomy.auto_approve`
             // + reload the live policy) is handled by the `approval_decide` RPC
             // handler, which is async and owns the config save+reload path. The
@@ -714,8 +716,44 @@ impl ApprovalGate {
                 tool_name: row.tool_name.clone(),
                 decision: decision.as_str().to_string(),
             });
+        } else {
+            match &outcome {
+                ApprovalDecisionOutcome::AlreadyTerminal {
+                    decision: persisted_decision,
+                } => {
+                    tracing::debug!(
+                        request_id = %request_id,
+                        persisted_decision = persisted_decision.as_str(),
+                        attempted_decision = decision.as_str(),
+                        "[approval::gate] decision ignored for already-terminal request"
+                    );
+                }
+                ApprovalDecisionOutcome::NotFound => {
+                    tracing::warn!(
+                        request_id = %request_id,
+                        attempted_decision = decision.as_str(),
+                        "[approval::gate] decision ignored for unknown request"
+                    );
+                }
+                ApprovalDecisionOutcome::Decided(_) => {}
+            }
         }
-        Ok(decided)
+        Ok(outcome)
+    }
+
+    /// Apply a user decision. Returns the now-decided
+    /// [`PendingApproval`] row when one was found.
+    pub fn decide(
+        &self,
+        request_id: &str,
+        decision: ApprovalDecision,
+    ) -> anyhow::Result<Option<PendingApproval>> {
+        match self.decide_with_status(request_id, decision)? {
+            ApprovalDecisionOutcome::Decided(row) => Ok(Some(row)),
+            ApprovalDecisionOutcome::AlreadyTerminal { .. } | ApprovalDecisionOutcome::NotFound => {
+                Ok(None)
+            }
+        }
     }
 
     /// List all undecided rows, including orphans from prior launches.

--- a/src/openhuman/approval/mod.rs
+++ b/src/openhuman/approval/mod.rs
@@ -28,5 +28,6 @@ pub use redact::{redact_args, summarize_action};
 pub use schemas::all_controller_schemas as all_approval_controller_schemas;
 pub use schemas::all_registered_controllers as all_approval_registered_controllers;
 pub use types::{
-    ApprovalAuditEntry, ApprovalDecision, ExecutionOutcome, GateOutcome, PendingApproval,
+    ApprovalAuditEntry, ApprovalDecision, ApprovalDecisionOutcome, ExecutionOutcome, GateOutcome,
+    PendingApproval,
 };

--- a/src/openhuman/approval/rpc.rs
+++ b/src/openhuman/approval/rpc.rs
@@ -8,7 +8,9 @@ use anyhow::anyhow;
 use crate::rpc::RpcOutcome;
 
 use super::gate::{try_boot_state, ApprovalGate, ApprovalGateBootState};
-use super::types::{ApprovalAuditEntry, ApprovalDecision, PendingApproval};
+use super::types::{
+    ApprovalAuditEntry, ApprovalDecision, ApprovalDecisionOutcome, PendingApproval,
+};
 
 /// Read the host-aware approval-gate boot decision so the UI banner can
 /// render the right state on first paint (rather than waiting for a
@@ -105,8 +107,8 @@ pub async fn approval_decide(
         );
         anyhow!("approval gate is not installed; supervised mode disabled")
     })?;
-    let decided = match gate.decide(request_id, decision) {
-        Ok(row) => row,
+    let outcome = match gate.decide_with_status(request_id, decision) {
+        Ok(outcome) => outcome,
         Err(err) => {
             tracing::error!(
                 request_id = request_id,
@@ -116,13 +118,34 @@ pub async fn approval_decide(
             return Err(err);
         }
     };
-    let row = decided.ok_or_else(|| {
-        tracing::warn!(
-            request_id = request_id,
-            "[rpc:approval_decide] no pending approval found"
-        );
-        anyhow!("no pending approval found for request_id '{request_id}'")
-    })?;
+    let row = match outcome {
+        ApprovalDecisionOutcome::Decided(row) => row,
+        ApprovalDecisionOutcome::AlreadyTerminal {
+            decision: persisted_decision,
+        } => {
+            tracing::warn!(
+                request_id = request_id,
+                persisted_decision = persisted_decision.as_str(),
+                attempted_decision = decision.as_str(),
+                "[rpc:approval_decide] no pending approval found; request already terminal"
+            );
+            return Err(anyhow!(
+                "no pending approval found for request_id '{request_id}' \
+                 (already decided as '{}')",
+                persisted_decision.as_str()
+            ));
+        }
+        ApprovalDecisionOutcome::NotFound => {
+            tracing::error!(
+                request_id = request_id,
+                attempted_decision = decision.as_str(),
+                "[rpc:approval_decide] approval request not found"
+            );
+            return Err(anyhow!(
+                "approval request not found for request_id '{request_id}'"
+            ));
+        }
+    };
 
     let mut logs = vec![format!(
         "[approval] decided request_id={} tool={} decision={}",

--- a/src/openhuman/approval/store.rs
+++ b/src/openhuman/approval/store.rs
@@ -30,7 +30,10 @@ use rusqlite::{params, types::Type, Connection};
 use crate::openhuman::config::Config;
 use crate::openhuman::memory_store::safety::sanitize_text;
 
-use super::types::{ApprovalAuditEntry, ApprovalDecision, ExecutionOutcome, PendingApproval};
+use super::types::{
+    ApprovalAuditEntry, ApprovalDecision, ApprovalDecisionOutcome, ExecutionOutcome,
+    PendingApproval,
+};
 
 /// SQL schema applied on every `with_connection` call.
 ///
@@ -246,41 +249,59 @@ pub fn list_pending(config: &Config) -> Result<Vec<PendingApproval>> {
     })
 }
 
+fn terminal_decision(conn: &Connection, request_id: &str) -> Result<Option<ApprovalDecision>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT decision FROM pending_approvals
+             WHERE request_id = ?1 AND decided_at IS NOT NULL",
+        )
+        .context("[approval::store] prepare get_decision")?;
+    let mut rows = stmt
+        .query(params![request_id])
+        .context("[approval::store] query get_decision")?;
+    if let Some(row) = rows.next().context("[approval::store] get_decision next")? {
+        let raw: String = row
+            .get(0)
+            .context("[approval::store] get_decision decode")?;
+        Ok(ApprovalDecision::from_str(&raw))
+    } else {
+        Ok(None)
+    }
+}
+
+fn decided_row(conn: &Connection, request_id: &str) -> Result<Option<PendingApproval>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT request_id, tool_name, action_summary, args_redacted,
+                    session_id, created_at, expires_at
+             FROM pending_approvals WHERE request_id = ?1",
+        )
+        .context("[approval::store] prepare select decided")?;
+    let mut rows = stmt
+        .query(params![request_id])
+        .context("[approval::store] query decided row")?;
+    if let Some(row) = rows.next().context("[approval::store] decided row next")? {
+        Ok(Some(row_to_pending(row)?))
+    } else {
+        Ok(None)
+    }
+}
+
 /// Look up the persisted decision for a request_id without mutating
 /// state. Returns `Ok(None)` when the row doesn't exist or hasn't
 /// been decided yet. Used to resolve gate-timeout vs decide races
 /// where the TTL elapses concurrently with a committed approval
 /// (CodeRabbit review on PR #2367).
 pub fn get_decision(config: &Config, request_id: &str) -> Result<Option<ApprovalDecision>> {
-    with_connection(config, |conn| {
-        let mut stmt = conn
-            .prepare(
-                "SELECT decision FROM pending_approvals
-                 WHERE request_id = ?1 AND decided_at IS NOT NULL",
-            )
-            .context("[approval::store] prepare get_decision")?;
-        let mut rows = stmt
-            .query(params![request_id])
-            .context("[approval::store] query get_decision")?;
-        if let Some(row) = rows.next().context("[approval::store] get_decision next")? {
-            let raw: String = row
-                .get(0)
-                .context("[approval::store] get_decision decode")?;
-            Ok(ApprovalDecision::from_str(&raw))
-        } else {
-            Ok(None)
-        }
-    })
+    with_connection(config, |conn| terminal_decision(conn, request_id))
 }
 
-/// Mark a pending row as decided and return the now-decided row.
-/// Returns `Ok(None)` if no row matched (already decided, expired, or
-/// unknown id).
-pub fn decide(
+/// Mark a pending row as decided and return a classified outcome.
+pub fn decide_with_status(
     config: &Config,
     request_id: &str,
     decision: ApprovalDecision,
-) -> Result<Option<PendingApproval>> {
+) -> Result<ApprovalDecisionOutcome> {
     with_connection(config, |conn| {
         expire_stale_with_now(conn, Utc::now())?;
 
@@ -295,24 +316,31 @@ pub fn decide(
             )
             .context("[approval::store] update decided")?;
         if updated == 0 {
-            return Ok(None);
+            return match terminal_decision(conn, request_id)? {
+                Some(decision) => Ok(ApprovalDecisionOutcome::AlreadyTerminal { decision }),
+                None => Ok(ApprovalDecisionOutcome::NotFound),
+            };
         }
-        let mut stmt = conn
-            .prepare(
-                "SELECT request_id, tool_name, action_summary, args_redacted,
-                        session_id, created_at, expires_at
-                 FROM pending_approvals WHERE request_id = ?1",
-            )
-            .context("[approval::store] prepare select decided")?;
-        let mut rows = stmt
-            .query(params![request_id])
-            .context("[approval::store] query decided row")?;
-        if let Some(row) = rows.next().context("[approval::store] decided row next")? {
-            Ok(Some(row_to_pending(row)?))
-        } else {
+        decided_row(conn, request_id)?.map_or(Ok(ApprovalDecisionOutcome::NotFound), |row| {
+            Ok(ApprovalDecisionOutcome::Decided(row))
+        })
+    })
+}
+
+/// Mark a pending row as decided and return the now-decided row.
+/// Returns `Ok(None)` if no row matched (already decided, expired, or
+/// unknown id).
+pub fn decide(
+    config: &Config,
+    request_id: &str,
+    decision: ApprovalDecision,
+) -> Result<Option<PendingApproval>> {
+    match decide_with_status(config, request_id, decision)? {
+        ApprovalDecisionOutcome::Decided(row) => Ok(Some(row)),
+        ApprovalDecisionOutcome::AlreadyTerminal { .. } | ApprovalDecisionOutcome::NotFound => {
             Ok(None)
         }
-    })
+    }
 }
 
 /// Persist the terminal status of a tool call the gate previously
@@ -507,7 +535,9 @@ fn parse_rfc3339(input: &str) -> DateTime<Utc> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::openhuman::approval::types::{ApprovalDecision, PendingApproval};
+    use crate::openhuman::approval::types::{
+        ApprovalDecision, ApprovalDecisionOutcome, PendingApproval,
+    };
     use chrono::Duration;
     use serde_json::json;
     use tempfile::TempDir;
@@ -620,6 +650,40 @@ mod tests {
         let (config, _dir) = test_config();
         let res = decide(&config, "never-existed", ApprovalDecision::Deny).unwrap();
         assert!(res.is_none());
+    }
+
+    #[test]
+    fn decide_with_status_distinguishes_terminal_expired_and_missing_rows() {
+        let (config, _dir) = test_config();
+
+        insert_pending(&config, &sample("dupe", "sess-A"), "sess-A").unwrap();
+        let first = decide_with_status(&config, "dupe", ApprovalDecision::Deny).unwrap();
+        assert!(matches!(first, ApprovalDecisionOutcome::Decided(_)));
+        let duplicate = decide_with_status(&config, "dupe", ApprovalDecision::ApproveOnce).unwrap();
+        assert!(matches!(
+            duplicate,
+            ApprovalDecisionOutcome::AlreadyTerminal {
+                decision: ApprovalDecision::Deny
+            }
+        ));
+
+        insert_pending(
+            &config,
+            &sample_with_expiry("expired", "sess-A", Some(Utc::now() - Duration::minutes(1))),
+            "sess-A",
+        )
+        .unwrap();
+        let expired =
+            decide_with_status(&config, "expired", ApprovalDecision::ApproveOnce).unwrap();
+        assert!(matches!(
+            expired,
+            ApprovalDecisionOutcome::AlreadyTerminal {
+                decision: ApprovalDecision::Deny
+            }
+        ));
+
+        let missing = decide_with_status(&config, "never-existed", ApprovalDecision::Deny).unwrap();
+        assert!(matches!(missing, ApprovalDecisionOutcome::NotFound));
     }
 
     #[test]

--- a/src/openhuman/approval/types.rs
+++ b/src/openhuman/approval/types.rs
@@ -108,6 +108,18 @@ impl ApprovalDecision {
     }
 }
 
+/// Result of attempting to decide an approval request.
+#[derive(Debug, Clone)]
+pub enum ApprovalDecisionOutcome {
+    /// This call transitioned a pending row to a terminal decision.
+    Decided(PendingApproval),
+    /// The row exists but was already terminal, either because another
+    /// caller decided it first or because expiry lazily denied it.
+    AlreadyTerminal { decision: ApprovalDecision },
+    /// No persisted row exists for this request id.
+    NotFound,
+}
+
 /// Outcome of routing a tool call through `ApprovalGate::intercept`.
 #[derive(Debug, Clone)]
 pub enum GateOutcome {

--- a/tests/tool_registry_approval_raw_coverage_e2e.rs
+++ b/tests/tool_registry_approval_raw_coverage_e2e.rs
@@ -1292,9 +1292,23 @@ async fn approval_rpc_decision_paths_persist_always_allow_and_recent_audit() {
     .await;
     assert!(error_message(&duplicate_decide, "duplicate decide").contains("no pending approval"));
 
-    let recent = rpc(
+    let missing_decide = rpc(
         &harness.rpc_base,
         24,
+        "openhuman.approval_decide",
+        json!({ "request_id": "never-persisted-approval", "decision": "deny" }),
+    )
+    .await;
+    let missing_message = error_message(&missing_decide, "missing decide");
+    assert!(missing_message.contains("approval request not found"));
+    assert!(
+        !missing_message.contains("no pending approval"),
+        "unknown request ids must stay distinct from benign duplicate decides"
+    );
+
+    let recent = rpc(
+        &harness.rpc_base,
+        25,
         "openhuman.approval_list_recent_decisions",
         json!({ "limit": 1 }),
     )


### PR DESCRIPTION
## Summary

- Distinguishes approval decisions that hit an already-terminal row from request ids that were never persisted.
- Keeps duplicate/expired `approval_decide` calls as benign expected errors while preserving Sentry signal for genuine missing registrations.
- Adds an explicit `ApprovalAlreadyResolved` observability bucket for the known `no pending approval found` race shape.
- Extends Rust unit and JSON-RPC E2E coverage for duplicate, expired, and never-persisted approval decide paths.
- Includes current Markdown link fixes needed for CI on branches based on `upstream/main`.

## Problem

- Issue #4176 reports 1,995 Sentry events across 8 users for `no pending approval found for request_id '<uuid>'`.
- The current `store::decide` returns `Ok(None)` for three different states: already decided, lazily expired, or unknown id.
- The RPC layer emits the same error for all three, so benign double-taps/operator races page Sentry, while a real lost registration cannot be separated.

## Solution

- Added `ApprovalDecisionOutcome` and `decide_with_status` so the store/gate can classify `Decided`, `AlreadyTerminal`, and `NotFound` without breaking the existing `decide` wrapper.
- Updated `approval_decide` to return classifiable `no pending approval found ... (already decided as ...)` only for terminal replays, and a distinct `approval request not found ...` error for never-persisted ids.
- Added `ExpectedErrorKind::ApprovalAlreadyResolved` for the benign replay string only.
- Added store, observability, and JSON-RPC E2E assertions covering duplicate decide, expired rows, and unknown ids.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines are covered by focused Rust unit and E2E tests; CI remains the enforced diff-cover gate.
- [x] Coverage matrix updated — N/A: behavior-only approval/observability fix, no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no coverage-matrix feature ID applies.
- [x] No new external network dependencies introduced (mock/local harness only)
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: approval RPC error classification only.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact: Rust core approval store/gate/RPC and central observability classification only.
- Sentry impact: duplicate or expiry-race `approval_decide` failures are demoted as expected; never-persisted request ids remain reportable under a different message.
- User-visible effect: duplicate/late approval actions still fail instead of re-running any tool; the error text now identifies already-terminal vs missing request ids.
- Docs impact: localized README links and the Cursor cloud-agent docs link are refreshed for the existing Markdown link gate.
- No migration, performance, or security weakening. The approval gate remains fail-closed.

## Related

- Closes #4176
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/GH-4176-approval-no-pending`
- Commit SHA: `8af9e22d8d75483a8af7c9b38ba15fb3d9f8be12`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no app TS/CSS changes.
- [x] `pnpm typecheck` — N/A: no frontend TypeScript changes.
- [x] Focused tests:
  - RED: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib decide_with_status_distinguishes_terminal_expired_and_missing_rows` failed before implementation on missing `decide_with_status` / `ApprovalDecisionOutcome`.
  - RED: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib classifies_resolved_approval_decide_race_as_expected` failed before implementation on missing `ApprovalAlreadyResolved`.
  - RED: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib classifies_resolved_approval_decide_race_as_expected` failed before review fix because prefix-only messages were over-classified.
  - RED: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib decide_with_status_releases_waiter_for_already_terminal_row` failed before review fix because the parked waiter timed out.
  - GREEN: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib decide_with_status_distinguishes_terminal_expired_and_missing_rows`
  - GREEN: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib classifies_resolved_approval_decide_race_as_expected`
  - GREEN: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib decide_with_status_releases_waiter_for_already_terminal_row`
  - GREEN: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --test tool_registry_approval_raw_coverage_e2e approval_rpc_decision_paths_persist_always_allow_and_recent_audit`
- [x] Rust fmt/check (if changed):
  - `cargo fmt --manifest-path Cargo.toml --check`
  - `git diff --check`
  - `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml`
- [x] Tauri fmt/check (if changed): N/A: no Tauri crate changes.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: already-decided/expired approval requests classify as expected approval replay races; request ids that never existed remain observable.
- User-visible effect: duplicate/late decisions keep failing safely, but now surface a more precise already-terminal error; unknown ids surface `approval request not found`.

### Parity Contract

- Legacy behavior preserved: successful decisions still publish `ApprovalDecided`, resolve waiters, and persist `ApproveAlwaysForTool`; the existing `decide` wrapper still returns `Option<PendingApproval>` for existing call sites.
- Guard/fallback/dispatch parity checks: JSON-RPC E2E covers duplicate vs unknown dispatch text, store tests cover duplicate/expired/missing classification, and observability tests prove only the benign replay string is demoted.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Approval decision handling now reports richer outcome states (newly processed, already resolved/terminal, or missing request).
* **Bug Fixes**
  * Prevented already-resolved approval replays/race scenarios from appearing as generic errors.
  * Updated RPC and UI-facing error messaging so unknown request IDs report “not found” rather than “no pending approval.”
* **Tests**
  * Added regression coverage for outcome classification and extended E2E coverage for missing-request decision paths.
* **Documentation**
  * Updated documentation links/embeds across multiple translations and refreshed an agent workflow URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

