### PR TITLE
feat(agent_meetings): forward detected platform in calendar auto-join bot:join

### DIFF
--- a/src/openhuman/agent_meetings/calendar.rs
+++ b/src/openhuman/agent_meetings/calendar.rs
@@ -565,17 +565,14 @@ fn is_meeting_imminent(payload: &serde_json::Value) -> bool {
     true
 }
 
-/// Supported meeting URL host patterns. A string is considered a meeting
-/// link when it contains any of these substrings.
-const MEETING_HOST_PATTERNS: &[&str] = &[
-    "meet.google.com",
-    "zoom.us",
-    "teams.microsoft.com",
-    "webex.com",
-];
-
+/// A string is considered a meeting link when it contains any supported host.
+///
+/// Derived from [`super::ops::ALLOWED_HOSTS`] so platform detection and link
+/// recognition share a single source of truth (no parallel host list).
 fn is_meeting_url(s: &str) -> bool {
-    MEETING_HOST_PATTERNS.iter().any(|pat| s.contains(pat))
+    super::ops::ALLOWED_HOSTS
+        .iter()
+        .any(|(host, _)| s.contains(host))
 }
 
 /// Pull the first parseable meeting URL out of a free-form string.
@@ -691,8 +688,11 @@ async fn auto_join_meeting(
         }
     };
 
+    let platform = super::ops::detect_platform(&meet_url);
+
     let payload = build_auto_join_payload(
         &meet_url,
+        platform,
         &correlation_id,
         listen_only,
         owner_display_name.as_deref(),
@@ -700,6 +700,7 @@ async fn auto_join_meeting(
 
     tracing::info!(
         meet_url = %meet_url,
+        platform = %platform,
         title = %event_title,
         correlation_id = %correlation_id,
         listen_only = listen_only,
@@ -745,12 +746,14 @@ fn build_action_payload(
 /// which the backend bot treats as "respond to everyone".
 fn build_auto_join_payload(
     meet_url: &str,
+    platform: &str,
     correlation_id: &str,
     listen_only: bool,
     owner_display_name: Option<&str>,
 ) -> serde_json::Value {
     let mut payload = serde_json::json!({
         "meetUrl": meet_url,
+        "platform": platform,
         "displayName": "Tiny",
         "correlationId": correlation_id,
         "listenOnly": listen_only,
@@ -1047,6 +1050,7 @@ mod tests {
     fn auto_join_payload_includes_respond_to_participant() {
         let p = build_auto_join_payload(
             "https://meet.google.com/abc",
+            "gmeet",
             "corr-1",
             false,
             Some("Aditya"),
@@ -1059,14 +1063,27 @@ mod tests {
 
     #[test]
     fn auto_join_payload_omits_respond_to_participant_when_absent() {
-        let p = build_auto_join_payload("https://meet.google.com/abc", "corr-1", true, None);
+        let p =
+            build_auto_join_payload("https://meet.google.com/abc", "gmeet", "corr-1", true, None);
         assert!(p.get("respondToParticipant").is_none());
     }
 
     #[test]
     fn auto_join_payload_omits_respond_to_participant_when_blank() {
-        let p = build_auto_join_payload("https://meet.google.com/abc", "corr-1", true, Some("   "));
+        let p = build_auto_join_payload(
+            "https://meet.google.com/abc",
+            "gmeet",
+            "corr-1",
+            true,
+            Some("   "),
+        );
         assert!(p.get("respondToParticipant").is_none());
+    }
+
+    #[test]
+    fn auto_join_payload_includes_platform() {
+        let p = build_auto_join_payload("https://zoom.us/j/123", "zoom", "corr-1", true, None);
+        assert_eq!(p["platform"], json!("zoom"));
     }
 
     // ── effective_listen_only ───────────────────────────────────

--- a/src/openhuman/agent_meetings/ops.rs
+++ b/src/openhuman/agent_meetings/ops.rs
@@ -18,7 +18,7 @@ use super::types::{
     BackendMeetLeaveRequest, BackendMeetSpeakRequest, MeetingSessionStatus,
 };
 
-const ALLOWED_HOSTS: &[(&str, &str)] = &[
+pub(super) const ALLOWED_HOSTS: &[(&str, &str)] = &[
     ("meet.google.com", "gmeet"),
     ("zoom.us", "zoom"),
     ("teams.microsoft.com", "teams"),
@@ -296,6 +296,24 @@ fn infer_platform(url: &url::Url) -> &'static str {
     let host = url.host_str().unwrap_or("");
     for (allowed, platform) in ALLOWED_HOSTS {
         if host == *allowed || host.ends_with(&format!(".{allowed}")) {
+            return platform;
+        }
+    }
+    "gmeet"
+}
+
+/// Resolve the meeting platform from a meeting-URL string.
+///
+/// String adapter over [`infer_platform`] so the calendar auto-join path can
+/// reuse the same `ALLOWED_HOSTS` table (single source of truth). Free-form
+/// strings that don't parse as a URL fall back to a substring host match.
+/// Unknown/unrecognized hosts resolve to `"gmeet"`.
+pub(super) fn detect_platform(meet_url: &str) -> &'static str {
+    if let Ok(url) = url::Url::parse(meet_url) {
+        return infer_platform(&url);
+    }
+    for (host, platform) in ALLOWED_HOSTS {
+        if meet_url.contains(host) {
             return platform;
         }
     }
@@ -875,6 +893,26 @@ mod tests {
 
         let url = url::Url::parse("https://company.zoom.us/j/123").unwrap();
         assert_eq!(infer_platform(&url), "zoom");
+    }
+
+    #[test]
+    fn detect_platform_across_hosts() {
+        assert_eq!(
+            detect_platform("https://meet.google.com/abc-defg-hij"),
+            "gmeet"
+        );
+        assert_eq!(detect_platform("https://zoom.us/j/123"), "zoom");
+        assert_eq!(
+            detect_platform("https://teams.microsoft.com/l/meetup"),
+            "teams"
+        );
+        assert_eq!(detect_platform("https://meet.webex.com/meet/abc"), "webex");
+
+        // Unknown host → gmeet default.
+        assert_eq!(detect_platform("https://example.com/x"), "gmeet");
+
+        // Non-parseable free-form string → substring host fallback.
+        assert_eq!(detect_platform("Zoom Meeting zoom.us/j/123"), "zoom");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The core emits `bot:join` for **calendar auto-join** without a `platform` field, so the backend defaults every meeting bot to Google Meet — even for Zoom / Teams / Webex meetings the core already recognizes. This resolves the platform from the meeting URL and includes it in the auto-join payload.

> Note: the **manual-join** path (`ops.rs::build_join_payload`) already set `platform` on `main`. The remaining gap was the calendar auto-join path plus the "single source of truth" requirement — that's what this PR closes.

## Changes

- Promote `ops.rs` `ALLOWED_HOSTS` to `pub(super)` as the single host→platform source of truth.
- Add `ops::detect_platform(&str)` — a string adapter over `infer_platform` that reuses `ALLOWED_HOSTS`, with a substring fallback for non-parseable free-form strings (unknown → `gmeet`).
- `calendar.rs::build_auto_join_payload` now sets `"platform"`; `auto_join_meeting` resolves it via `detect_platform` and logs it.
- Replace calendar's parallel `MEETING_HOST_PATTERNS` list with `ALLOWED_HOSTS` (no second source of truth; behavior-preserving — identical host strings).

## Acceptance criteria

- [x] **Platform in payload** — manual join (pre-existing) and calendar auto-join both include a URL-resolved `platform`.
- [x] **All four hosts** — gmeet/zoom/teams/webex resolve correctly.
- [x] **Shared detection** — reuses `ALLOWED_HOSTS`; `MEETING_HOST_PATTERNS` removed.
- [x] **Tests** — `detect_platform` across four hosts + unknown + non-parseable fallback; `build_auto_join_payload` sets the field.
- [x] **Diff coverage ≥ 80%** — every added line is exercised by unit tests.

## Test plan

- [x] `cargo test --lib agent_meetings` → 131 passed, 0 failed
- [x] `cargo fmt` clean
- [ ] CI (typecheck / lint / coverage gate)

Closes #4301