### PR TITLE
fix(agent): make goal completion directive imperative to ensure auto-complete

### DIFF
--- a/src/openhuman/thread_goals/continuation.rs
+++ b/src/openhuman/thread_goals/continuation.rs
@@ -150,7 +150,8 @@ fn continuation_prompt(objective: &str) -> String {
         "[goal continuation] You are resuming autonomous work toward this thread's goal — \
          no user is currently present.\n\nGoal: {objective}\n\n\
          Assess progress against concrete evidence, then take the next useful step. \
-         If the goal is already satisfied, call `goal_complete`. If you are blocked or \
+         Verify whether the goal is already satisfied. If yes, call `goal_complete` now. \
+         If you are blocked or \
          need the user (e.g. an irreversible external action, missing input), stop and \
          summarise the blocker and the next step rather than guessing — external actions \
          are not auto-approved while you run unattended."

--- a/src/openhuman/thread_goals/runtime.rs
+++ b/src/openhuman/thread_goals/runtime.rs
@@ -91,8 +91,9 @@ pub async fn pause_for_current_thread(workspace_dir: &Path) {
 pub fn active_goal_context_block(goal: &ThreadGoal) -> Option<String> {
     let directive = match goal.status {
         ThreadGoalStatus::Active => {
-            "Keep working toward this goal. When evidence confirms it's done, call \
-             goal_complete; if the objective has changed, update it with goal_set."
+            "Keep working toward this goal. Before responding, verify whether the \
+             objective is satisfied. If confirmed, call `goal_complete` now. \
+             If the objective has changed, call `goal_set` to update it."
         }
         ThreadGoalStatus::BudgetLimited => {
             "This goal has reached its token budget. Stop substantive work: summarise \


### PR DESCRIPTION
The agent was treating `goal_complete` as a soft suggestion rather than a requirement, often failing to call it when the objective was achieved.

**Changes**

Two prompt directives strengthened from suggestive to imperative:

1. `src/openhuman/thread_goals/runtime.rs` — `active_goal_context_block`: Changed "When evidence confirms its done, call goal_complete" to "Before responding, verify whether the objective is satisfied. If confirmed, call `goal_complete` now."

2. `src/openhuman/thread_goals/continuation.rs` — `continuation_prompt`: Changed "If the goal is already satisfied, call `goal_complete`" to "Verify whether the goal is already satisfied. If yes, call `goal_complete` now."

**Testing**

- `cargo check` passes (only pre-existing dead-code warnings in unrelated files)
- Existing test assertions for `goal_complete` still hold

Closes #4248

---

> **Note:** This PR was drafted with AI assistance for the research and implementation phases. All changes reviewed and verified by a human.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Updates**
  * Refined goal-handling guidance to better recognize when an objective is already satisfied.
  * Updated instructions to complete goals immediately once confirmed, and to reset the goal when the objective changes.
  * Improved consistency in how active goals are evaluated before a response is generated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->