### PR TITLE
perf(memory_conversations): rank before cloning hits in cross-thread search

### DIFF
--- a/src/openhuman/memory_conversations/inverted_index.rs
+++ b/src/openhuman/memory_conversations/inverted_index.rs
@@ -273,9 +273,29 @@ impl InvertedIndex {
         }
 
         let total_terms = terms.len() as f64;
-        let mut hits: Vec<CrossThreadHit> = hit_counts
+        // Rank on cheap keys first — the match count and a borrowed `created_at`
+        // — then materialize the heavy CrossThreadHit (which clones the KB-sized
+        // `content`) only for the `limit` survivors. Phase 2 can leave thousands
+        // of candidates in `hit_counts` while callers ask for 3-10 results, so
+        // cloning every candidate's content before truncating is ~99% wasted.
+        // Ranking by `matched` (usize) is order-equivalent to ranking by
+        // `score = matched / total_terms` since `total_terms` is a positive
+        // constant, so the returned order is unchanged.
+        let mut ranked: Vec<(u32, usize, &str)> = hit_counts
             .into_iter()
             .map(|(doc_id, matched)| {
+                let entry = self.docs[doc_id as usize]
+                    .as_ref()
+                    .expect("doc_id from hit_counts must be live");
+                (doc_id, matched, entry.created_at.as_str())
+            })
+            .collect();
+        ranked.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| b.2.cmp(a.2)));
+        ranked.truncate(limit);
+
+        ranked
+            .into_iter()
+            .map(|(doc_id, matched, _)| {
                 let entry = self.docs[doc_id as usize]
                     .as_ref()
                     .expect("doc_id from hit_counts must be live");
@@ -288,16 +308,7 @@ impl InvertedIndex {
                     score: matched as f64 / total_terms,
                 }
             })
-            .collect();
-
-        hits.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then_with(|| b.created_at.cmp(&a.created_at))
-        });
-        hits.truncate(limit);
-        hits
+            .collect()
     }
 
     /// Build the Phase 1 candidate set for one query term.
@@ -357,27 +368,41 @@ impl InvertedIndex {
         exclude_thread_id: Option<&str>,
         limit: usize,
     ) -> Vec<CrossThreadHit> {
-        let mut hits: Vec<CrossThreadHit> = self
+        // Rank the whole corpus by recency on a borrowed `created_at`, then
+        // clone the heavy fields only for the `limit` newest survivors — this
+        // fallback fires when a term matches >10k docs, so cloning every doc's
+        // content before truncating could allocate hundreds of MB needlessly.
+        let mut ranked: Vec<(usize, &str)> = self
             .docs
             .iter()
-            .filter_map(|slot| slot.as_ref())
-            .filter(|entry| exclude_thread_id != Some(entry.thread_id.as_ref()))
-            .map(|entry| CrossThreadHit {
-                thread_id: entry.thread_id.to_string(),
-                message_id: entry.message_id.clone(),
-                role: entry.role.to_string(),
-                content: entry.content.clone(),
-                created_at: entry.created_at.clone(),
-                // Score 0.0 signals "matched via recency fallback only" —
-                // documented in the function rustdoc above. Callers
-                // sorting by `(score desc, created_at desc)` still see
-                // the newest entries first.
-                score: 0.0,
-            })
+            .enumerate()
+            .filter_map(|(i, slot)| slot.as_ref().map(|entry| (i, entry)))
+            .filter(|(_, entry)| exclude_thread_id != Some(entry.thread_id.as_ref()))
+            .map(|(i, entry)| (i, entry.created_at.as_str()))
             .collect();
-        hits.sort_by(|a, b| b.created_at.cmp(&a.created_at));
-        hits.truncate(limit);
-        hits
+        ranked.sort_by(|a, b| b.1.cmp(a.1));
+        ranked.truncate(limit);
+
+        ranked
+            .into_iter()
+            .map(|(i, _)| {
+                let entry = self.docs[i]
+                    .as_ref()
+                    .expect("index from a live doc slot must stay live");
+                CrossThreadHit {
+                    thread_id: entry.thread_id.to_string(),
+                    message_id: entry.message_id.clone(),
+                    role: entry.role.to_string(),
+                    content: entry.content.clone(),
+                    created_at: entry.created_at.clone(),
+                    // Score 0.0 signals "matched via recency fallback only" —
+                    // documented in the function rustdoc above. Callers
+                    // sorting by `(score desc, created_at desc)` still see
+                    // the newest entries first.
+                    score: 0.0,
+                }
+            })
+            .collect()
     }
 }
 
@@ -532,6 +557,42 @@ mod tests {
             (hits[0].score - 0.4).abs() < 1e-9,
             "score = {}",
             hits[0].score
+        );
+    }
+
+    #[test]
+    fn ranks_by_score_then_recency_before_truncating() {
+        // More matches than `limit`, so truncation must keep the top-ranked
+        // hits by (score desc, created_at desc) — this pins that ranking still
+        // happens before the result set is cut, not after.
+        let mut idx = InvertedIndex::new();
+        // Both terms → score 1.0, but oldest.
+        idx.insert(
+            "t1",
+            msg("both", "alpha beta gamma", "2026-04-10T10:00:00Z"),
+        );
+        // One term → score 0.5, newest of the 0.5 group.
+        idx.insert("t1", msg("newest", "alpha delta", "2026-04-10T10:03:00Z"));
+        // One term → score 0.5, middle.
+        idx.insert("t1", msg("middle", "alpha epsilon", "2026-04-10T10:02:00Z"));
+        // One term → score 0.5, oldest of the 0.5 group.
+        idx.insert("t1", msg("oldest", "beta zeta", "2026-04-10T10:01:00Z"));
+
+        let hits = idx.search("alpha beta", 2, None);
+        assert_eq!(hits.len(), 2, "must respect the limit");
+        // Highest score wins outright; the recency tiebreak then picks the
+        // newest of the equal-score remainder. "middle"/"oldest" are dropped.
+        assert_eq!(hits[0].message_id, "both");
+        assert!(
+            (hits[0].score - 1.0).abs() < 1e-9,
+            "score = {}",
+            hits[0].score
+        );
+        assert_eq!(hits[1].message_id, "newest");
+        assert!(
+            (hits[1].score - 0.5).abs() < 1e-9,
+            "score = {}",
+            hits[1].score
         );
     }
 


### PR DESCRIPTION
## Summary

- `InvertedIndex::search` and `recency_fallback` built a full `CrossThreadHit` (cloning the KB-sized `content` plus four other strings) for **every** candidate, then sorted and truncated to the requested `limit`. Cross-thread conversation search asks for 3–10 results but Phase 2 can leave thousands of candidates, so the vast majority of those clones were thrown away.
- Rank on cheap keys first (match count + a borrowed `created_at`), truncate to `limit`, then materialize the heavy `CrossThreadHit` only for the survivors.
- Behavior is unchanged: ranking by `matched` (usize) is order-equivalent to ranking by `score = matched / total_terms` (a positive constant), and the `created_at desc` tiebreak is preserved.

## Problem

`memory_conversations::inverted_index::search` is on the conversation-recall hot path (agent memory loader + transcript search). After Phase 2 substring verification, `hit_counts` can hold thousands of matching docs. The old code did:

```rust
let mut hits: Vec<CrossThreadHit> = hit_counts.into_iter()
    .map(|(doc_id, matched)| CrossThreadHit {
        content: entry.content.clone(), // KB-sized, cloned for EVERY candidate
        // ...four more String clones
    })
    .collect();
hits.sort_by(/* score desc, created_at desc */);
hits.truncate(limit); // keep only 3–10
```

So for 1,000 candidates × ~10 KB content with `limit = 10`, it cloned ~10 MB and sorted 1,000 heavy structs to keep ~100 KB — ~99% wasted allocation and a sort comparing large structs. `recency_fallback` (the >10k-candidate path) had the same shape over the **entire corpus**, so it could clone hundreds of MB before truncating.

## Solution

Defer the expensive materialization past the truncation point:

- Collect `(doc_id, matched, &created_at)` — the borrow avoids cloning `created_at` just to sort.
- `sort_by` on the borrowed keys (`matched desc`, then `created_at desc`).
- `truncate(limit)`.
- Map the surviving `limit` entries into `CrossThreadHit`, cloning `content`/etc. only there.

`recency_fallback` gets the same treatment via `(doc_index, &created_at)`.

String clones drop from O(n·k) to O(limit·k) (k = content size); the sort now compares ints/`&str` instead of full structs. No public API change, no signature ripple — both functions are self-contained.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy
- [x] **Diff coverage ≥ 80%** — the reworked `search`/`recency_fallback` paths are covered by the existing suite plus the new `ranks_by_score_then_recency_before_truncating` (exercises rank+truncate with more candidates than `limit`); `pathological_query_short_circuits_to_recency` covers the fallback.
- [x] Coverage matrix updated — `N/A: internal perf refactor, no feature row added/removed/renamed`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature touched`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: internal index helper, no release-cut surface`
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue; found by code inspection`

## Impact

- Lower allocation and sort cost on the conversation-recall hot path (agent memory recall + transcript search), most pronounced on large corpora / broad queries and on the >10k-candidate recency fallback. Desktop/CLI core. No behavior, API, schema, or migration change.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: perf/conv-search-rank-before-clone
- Commit SHA: 7f731357c

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `cargo test --lib memory_conversations::inverted_index`
- [x] Rust fmt/check (if changed): `cargo fmt` + `pnpm rust:check`
- [x] Tauri fmt/check (if changed): N/A — no Tauri shell code changed

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none (pure perf refactor)
- User-visible effect: identical search results; less allocation/CPU on conversation recall


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result ordering so higher-quality matches are ranked first, with newer items used as a tie-breaker before results are limited.
  * Refined fallback result selection to return the most recent items more consistently when primary matching is unavailable.
  * Reduced unnecessary work during search result generation, helping keep searches more efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->