### PR TITLE
perf(meet): keep CEF cache warm on pre-join scanner reload

### DIFF
--- a/app/src-tauri/src/meet_scanner/mod.rs
+++ b/app/src-tauri/src/meet_scanner/mod.rs
@@ -101,6 +101,20 @@ pub fn spawn<R: Runtime>(
     handle.abort_handle()
 }
 
+/// CDP `Page.reload` params for the Phase 0 pre-join reload.
+///
+/// We reload to drop the user's leaked Google session cookies (cleared
+/// just before) so Meet re-renders the anonymous pre-join page, but we
+/// deliberately leave the HTTP cache warm: `ignoreCache` is intentionally
+/// absent. Meet's multi-MB SPA bundle is identical for every visitor and
+/// the CEF HTTP cache is shared across joins, so re-fetching it cold was
+/// pure join-time cost with no privacy benefit. Re-adding `ignoreCache`
+/// here would reintroduce the cold-reload regression — the unit test
+/// guards against exactly that.
+fn pre_join_reload_params() -> Value {
+    json!({})
+}
+
 async fn run<R: Runtime>(
     app: &AppHandle<R>,
     request_id: &str,
@@ -117,23 +131,31 @@ async fn run<R: Runtime>(
     let _ = cdp.call("Page.enable", json!({}), Some(&session)).await;
     let _ = cdp.call("Runtime.enable", json!({}), Some(&session)).await;
 
-    // Phase 0 — strip any leaked Google session cookies/cache before
-    // we touch the page. The vendored tauri-cef runtime does not yet
-    // honour our per-request_id `data_directory` as a fresh CEF
-    // RequestContext — webviews end up sharing the parent process's
-    // cookie + cache store. Without this clear, Meet recognises the
-    // signed-in Google account on the user's main openhuman session
-    // ("nikhil@tinyhumans.ai" / "Verify it's you" screen) and the bot
-    // never reaches the anonymous "Your name" pre-join input we drive
-    // in Phase 2.
+    // Phase 0 — strip any leaked Google session cookies before we touch
+    // the page. The vendored tauri-cef runtime does not yet honour our
+    // per-request_id `data_directory` as a fresh CEF RequestContext —
+    // webviews end up sharing the parent process's cookie store. Without
+    // this clear, Meet recognises the signed-in Google account on the
+    // user's main openhuman session ("nikhil@tinyhumans.ai" / "Verify
+    // it's you" screen) and the bot never reaches the anonymous "Your
+    // name" pre-join input we drive in Phase 2.
     //
-    // `Network.clearBrowserCookies` + `Network.clearBrowserCache` are
-    // CDP-wide for the attached browser instance, so they wipe the
-    // session for THIS Meet target without touching the user's main
-    // openhuman webviews (those run in separate browser instances).
-    // Best-effort: if Network domain isn't enabled or CDP returns an
-    // error, we log and continue — the bot may still land on the
-    // verify screen but won't get worse than the pre-clear state.
+    // `Network.clearBrowserCookies` is CDP-wide for the attached browser
+    // instance, so it wipes the session for THIS Meet target without
+    // touching the user's main openhuman webviews (those run in separate
+    // browser instances). Best-effort: if the Network domain isn't
+    // enabled or CDP returns an error, we log and continue — the bot may
+    // still land on the verify screen but won't get worse than before.
+    //
+    // We deliberately do NOT clear the HTTP cache and do NOT reload with
+    // `ignoreCache`. Anonymity is a *cookie* concern, not a cache one:
+    // Meet's multi-MB JS/CSS bundle is identical for every visitor, and
+    // (because data_directory is ignored) the CEF HTTP cache is shared
+    // and warm across joins. Wiping it forced a fully cold re-fetch +
+    // re-parse of the SPA on every single join — the dominant join-time
+    // cost — for no privacy benefit. Clearing cookies then reloading
+    // with the cache intact gives the same anonymous pre-join page far
+    // faster.
     let _ = cdp.call("Network.enable", json!({}), Some(&session)).await;
     if let Err(err) = cdp
         .call("Network.clearBrowserCookies", json!({}), Some(&session))
@@ -143,18 +165,13 @@ async fn run<R: Runtime>(
     } else {
         log::info!("[meet-scanner] cleared browser cookies for fresh anonymous session");
     }
+    // Reload once so Meet re-evaluates auth without the user's Google
+    // session cookies. Without the reload, Meet's React state still holds
+    // the post-auth view and we'd be clicking buttons on a stale page.
+    // Cache is left warm (no `ignoreCache`) so the reload re-uses the
+    // already-downloaded bundle instead of re-fetching it cold.
     if let Err(err) = cdp
-        .call("Network.clearBrowserCache", json!({}), Some(&session))
-        .await
-    {
-        log::info!("[meet-scanner] clearBrowserCache skipped: {err}");
-    }
-    // Reload the page once so Meet re-fetches from scratch without the
-    // user's Google session cookies. Without the reload, Meet's React
-    // state still holds the post-auth view; we'd be clicking buttons
-    // on a stale page.
-    if let Err(err) = cdp
-        .call("Page.reload", json!({"ignoreCache": true}), Some(&session))
+        .call("Page.reload", pre_join_reload_params(), Some(&session))
         .await
     {
         log::warn!("[meet-scanner] post-cookie-clear reload failed: {err}");
@@ -668,6 +685,21 @@ async fn type_into_named_input(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pre_join_reload_keeps_cache_warm() {
+        // The pre-join reload must NOT set `ignoreCache`: doing so forces
+        // a cold re-fetch of Meet's multi-MB SPA bundle on every join,
+        // which was the dominant join-latency regression this change
+        // removed. Anonymity comes from clearing cookies, not the cache.
+        let params = pre_join_reload_params();
+        assert!(
+            params.get("ignoreCache").is_none(),
+            "pre-join reload must keep the HTTP cache warm (no ignoreCache); got {params}"
+        );
+        // It is an object payload (CDP expects a params object, even if empty).
+        assert!(params.is_object(), "reload params must be a JSON object");
+    }
 
     #[test]
     fn budget_constants_are_sane() {


### PR DESCRIPTION
## Summary

- Stop forcing a cold reload during Meet join: the Phase 0 scanner reload no longer clears the HTTP cache and no longer reloads with `ignoreCache`.
- Anonymity is preserved by clearing the leaked Google session **cookies** only — the cache is left warm.
- Extracts the reload params into `pre_join_reload_params()` with a unit test that fails if `ignoreCache` is reintroduced.

## Problem

On every Meet join, `meet_scanner::run` (Phase 0) calls `Network.clearBrowserCookies` + `Network.clearBrowserCache` and then `Page.reload({ignoreCache: true})`. Clearing the cache and bypassing it on reload forces CEF to re-fetch and re-parse Meet's multi-MB SPA bundle from cold on **every** join. A latency audit found this cold reload to be the single dominant contributor to join time.

The cache clear has no privacy benefit: Meet's JS/CSS bundle is identical for every visitor, and because the vendored `tauri-cef` runtime does not yet honour the per-`request_id` `data_directory` as a fresh `RequestContext`, the CEF HTTP cache is already shared (and warm) across joins. Only the **cookies** carry the user's signed-in Google identity that must be dropped so the bot reaches the anonymous "Your name" pre-join input.

## Solution

- Remove the `Network.clearBrowserCache` call.
- Reload with `pre_join_reload_params()` (an empty params object) instead of `{ignoreCache: true}`, so the reload re-uses the already-downloaded bundle.
- Keep `Network.clearBrowserCookies` + the reload so Meet re-evaluates auth and renders the anonymous pre-join page.
- The new `pre_join_reload_params()` helper documents the cache-warm decision; its unit test asserts no `ignoreCache` field, guarding against a regression that reintroduces the cold reload.

Behaviour is otherwise unchanged: cookies are still cleared, the page is still reloaded once, and the join automation phases run exactly as before — just against a warm cache.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `pre_join_reload_keeps_cache_warm` asserts the cache-warm contract (regression guard).
- [x] **Diff coverage ≥ 80%** — the only added executable line is `pre_join_reload_params()`, covered by the new test; the remaining diff is deletions + comments. Run `pnpm test:rust` locally before un-drafting.
- [x] Coverage matrix updated — `N/A: behaviour-preserving performance change, no new feature row.`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix feature touched.`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — removes a CDP call; adds none.
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A: no change to the smoke steps; join behaviour is unchanged, only faster.`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A: no tracking issue.`

## Impact

- **Platform**: desktop (Tauri CEF) only.
- **Performance**: removes a cold re-fetch + re-parse of Meet's SPA from the join hot path — meaningfully faster join, no behaviour change.
- **Security/Privacy**: unchanged — the bot still joins anonymously; cookies are still cleared each join. Only the redundant cache wipe is dropped.
- **Compatibility/Migration**: none.

## Related

- Closes:
- Follow-up PR(s)/TODOs: further join-latency work (collapse the duplicate page reloads into a single navigation; adaptive readiness polls replacing fixed sleeps) tracked as separate PRs.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/meet-warm-scanner-reload`
- Commit SHA: _set on push_

### Validation Run

- [ ] `pnpm --filter openhuman-app format:check` — N/A: no frontend change.
- [ ] `pnpm typecheck` — N/A: no TypeScript change.
- [ ] Focused tests: `cargo test -p OpenHuman meet_scanner`
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; N/A core crate.
- [x] Tauri fmt/check (if changed): `cargo check --manifest-path app/src-tauri/Cargo.toml`

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: join no longer forces a cold cache reload; cache stays warm.
- User-visible effect: faster Meet join; otherwise identical.

### Parity Contract

- Legacy behavior preserved: cookies cleared + single reload + same join phases.
- Guard/fallback/dispatch parity checks: reload still best-effort (logs + continues on CDP error), unchanged.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A
