### PR TITLE
perf(composio): cache curated per-toolkit action catalogue

### DIFF
--- a/src/openhuman/agent/harness/subagent_runner/ops/runner.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops/runner.rs
@@ -356,7 +356,7 @@ async fn run_typed_mode(
             {
                 let fresh_actions = match &client_kind {
                     Some(ComposioClientKind::Backend(client)) => {
-                        match crate::openhuman::composio::fetch_toolkit_actions(client, tk, None)
+                        match crate::openhuman::composio::fetch_toolkit_actions_cached(client, tk)
                             .await
                         {
                             Ok(actions) if !actions.is_empty() => actions,

--- a/src/openhuman/composio/connected_integrations.rs
+++ b/src/openhuman/composio/connected_integrations.rs
@@ -49,6 +49,47 @@ pub(crate) struct CachedIntegrations {
 pub(crate) static INTEGRATIONS_CACHE: LazyLock<RwLock<HashMap<String, CachedIntegrations>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
+/// TTL for the per-toolkit action catalogue cache (see
+/// [`TOOLKIT_ACTIONS_CACHE`]). Action *definitions* (e.g. the
+/// `GMAIL_SEND_EMAIL` parameter shape + the curated visibility set) change
+/// far less often than connection state, so this is more generous than
+/// [`CACHE_TTL`]. The event-driven invalidation path (a new OAuth
+/// connection clears this alongside the integrations cache) covers the
+/// common "user just connected a toolkit" case; the TTL only backstops
+/// rarer action-scope changes.
+pub(crate) const TOOLKIT_ACTIONS_CACHE_TTL: Duration = Duration::from_secs(300);
+
+/// Cached per-toolkit action catalogue plus the timestamp we wrote it.
+#[derive(Clone)]
+pub(crate) struct CachedToolkitActions {
+    pub(crate) actions: Vec<ConnectedIntegrationTool>,
+    pub(crate) cached_at: Instant,
+}
+
+/// Process-wide cache for the curated per-toolkit action catalogue
+/// returned by [`fetch_toolkit_actions`], keyed by the normalized toolkit
+/// slug. Populated on first delegation to an integrations sub-agent for a
+/// toolkit and reused (within [`TOOLKIT_ACTIONS_CACHE_TTL`]) on subsequent
+/// delegations, so a meeting that asks several Slack/Gmail questions pays
+/// the multi-second `list_tools` round-trip once instead of every turn.
+/// Invalidated together with [`INTEGRATIONS_CACHE`] whenever a connection
+/// changes.
+pub(crate) static TOOLKIT_ACTIONS_CACHE: LazyLock<RwLock<HashMap<String, CachedToolkitActions>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// Normalize a toolkit slug for use as a cache key (trim + lowercase) so
+/// `"Slack"`, `"slack"`, and `" slack "` share one entry.
+pub(crate) fn toolkit_cache_key(toolkit: &str) -> String {
+    toolkit.trim().to_lowercase()
+}
+
+/// Whether a cache entry written at `cached_at` is still fresh relative to
+/// `now` and `ttl`. Pure so the freshness rule can be unit-tested without
+/// the global cache or a real clock.
+pub(crate) fn cache_entry_fresh(cached_at: Instant, now: Instant, ttl: Duration) -> bool {
+    now.duration_since(cached_at) < ttl
+}
+
 /// Crate-wide test serialization lock for all tests that mutate or read
 /// the process-global `INTEGRATIONS_CACHE`. Defined here so it is shared
 /// by every `cfg(test)` module in this crate (ops_tests, tools_tests, …).
@@ -84,6 +125,19 @@ pub fn invalidate_connected_integrations_cache() {
         tracing::info!(
             cached_keys = entries,
             "[composio][integrations] cache invalidated"
+        );
+    }
+    // The per-toolkit action catalogue is downstream of the same
+    // connection state, so clear it on the same triggers (new OAuth
+    // connection, list_connections divergence, tests). Otherwise a
+    // freshly connected toolkit's actions could stay missing for up to
+    // TOOLKIT_ACTIONS_CACHE_TTL.
+    if let Ok(mut guard) = TOOLKIT_ACTIONS_CACHE.write() {
+        let entries = guard.len();
+        guard.clear();
+        tracing::info!(
+            cached_toolkits = entries,
+            "[composio][toolkit_actions] cache invalidated"
         );
     }
 }
@@ -976,6 +1030,59 @@ async fn fetch_connected_integrations_uncached(
 /// toolkit (valid steady state for a freshly-authorised integration
 /// whose catalogue hasn't been published yet). Returns `Err` only for
 /// transport / auth failures the caller should surface to the user.
+/// Cached variant of [`fetch_toolkit_actions`] for the delegation hot
+/// path (no tag filter). Returns the same curated catalogue, but serves
+/// repeat lookups for the same toolkit from [`TOOLKIT_ACTIONS_CACHE`]
+/// within [`TOOLKIT_ACTIONS_CACHE_TTL`] instead of re-running the
+/// multi-second backend `list_tools` round-trip every delegation.
+///
+/// A cache miss (or a stale/contended entry) falls through to a live
+/// `fetch_toolkit_actions` and repopulates the cache. Errors are never
+/// cached. Callers needing a tag filter or guaranteed-fresh results
+/// should call [`fetch_toolkit_actions`] directly.
+pub async fn fetch_toolkit_actions_cached(
+    client: &ComposioClient,
+    toolkit: &str,
+) -> anyhow::Result<Vec<ConnectedIntegrationTool>> {
+    let key = toolkit_cache_key(toolkit);
+    if !key.is_empty() {
+        // `try_read` so a concurrent writer never blocks a delegation;
+        // worst case is a single live fetch while the lock is held.
+        if let Ok(guard) = TOOLKIT_ACTIONS_CACHE.try_read() {
+            if let Some(cached) = guard.get(&key) {
+                if cache_entry_fresh(cached.cached_at, Instant::now(), TOOLKIT_ACTIONS_CACHE_TTL) {
+                    tracing::debug!(
+                        toolkit = %key,
+                        action_count = cached.actions.len(),
+                        "[composio][toolkit_actions] cache hit"
+                    );
+                    return Ok(cached.actions.clone());
+                }
+            }
+        }
+    }
+
+    let actions = fetch_toolkit_actions(client, toolkit, None).await?;
+
+    if !key.is_empty() {
+        if let Ok(mut guard) = TOOLKIT_ACTIONS_CACHE.write() {
+            guard.insert(
+                key.clone(),
+                CachedToolkitActions {
+                    actions: actions.clone(),
+                    cached_at: Instant::now(),
+                },
+            );
+            tracing::debug!(
+                toolkit = %key,
+                action_count = actions.len(),
+                "[composio][toolkit_actions] cache populated"
+            );
+        }
+    }
+    Ok(actions)
+}
+
 pub async fn fetch_toolkit_actions(
     client: &ComposioClient,
     toolkit: &str,
@@ -1016,6 +1123,53 @@ pub async fn fetch_toolkit_actions(
         "[composio] fetch_toolkit_actions: done"
     );
     Ok(actions)
+}
+
+#[cfg(test)]
+mod toolkit_actions_cache_tests {
+    use super::*;
+
+    #[test]
+    fn cache_key_normalizes_slug() {
+        assert_eq!(toolkit_cache_key("Slack"), "slack");
+        assert_eq!(toolkit_cache_key("  GMAIL "), "gmail");
+        assert_eq!(toolkit_cache_key(""), "");
+        assert_eq!(toolkit_cache_key("   "), "");
+    }
+
+    #[test]
+    fn cache_entry_freshness_respects_ttl() {
+        let base = Instant::now();
+        let ttl = Duration::from_secs(300);
+        // Well within the window: fresh.
+        assert!(cache_entry_fresh(base, base + Duration::from_secs(10), ttl));
+        // Exactly at the TTL boundary: stale (strict `<`).
+        assert!(!cache_entry_fresh(base, base + ttl, ttl));
+        // Past the window: stale.
+        assert!(!cache_entry_fresh(
+            base,
+            base + Duration::from_secs(400),
+            ttl
+        ));
+    }
+
+    #[test]
+    fn invalidate_clears_toolkit_actions_cache() {
+        let _guard = composio_cache_test_lock();
+        TOOLKIT_ACTIONS_CACHE.write().unwrap().insert(
+            "slack".to_string(),
+            CachedToolkitActions {
+                actions: Vec::new(),
+                cached_at: Instant::now(),
+            },
+        );
+        assert!(!TOOLKIT_ACTIONS_CACHE.read().unwrap().is_empty());
+        invalidate_connected_integrations_cache();
+        assert!(
+            TOOLKIT_ACTIONS_CACHE.read().unwrap().is_empty(),
+            "invalidation must clear the toolkit action cache alongside the integrations cache"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/openhuman/composio/mod.rs
+++ b/src/openhuman/composio/mod.rs
@@ -73,7 +73,7 @@ pub use client::ComposioClient;
 pub use identity::connection_identity;
 pub use ops::{
     cached_active_integrations, connected_set_hash, fetch_connected_integrations,
-    fetch_connected_integrations_status, fetch_toolkit_actions,
+    fetch_connected_integrations_status, fetch_toolkit_actions, fetch_toolkit_actions_cached,
     invalidate_connected_integrations_cache, FetchConnectedIntegrationsStatus,
 };
 pub use schemas::{

--- a/src/openhuman/composio/ops/mod.rs
+++ b/src/openhuman/composio/ops/mod.rs
@@ -57,7 +57,7 @@ pub use triggers::{
 
 pub use super::connected_integrations::{
     cached_active_integrations, connected_set_hash, fetch_connected_integrations,
-    fetch_connected_integrations_status, fetch_toolkit_actions,
+    fetch_connected_integrations_status, fetch_toolkit_actions, fetch_toolkit_actions_cached,
     invalidate_connected_integrations_cache, FetchConnectedIntegrationsStatus,
 };
 


### PR DESCRIPTION
## Summary

- Cache the per-toolkit Composio action catalogue so repeat delegations to an integrations sub-agent don't re-run the multi-second `list_tools` round-trip every turn.
- Adds `fetch_toolkit_actions_cached` (curated output, TTL + connection-change invalidation) and wires it into the sub-agent delegation hot path. The uncached `fetch_toolkit_actions` is unchanged for callers that need a tag filter or guaranteed-fresh results.

## Problem

When any agent delegates to an integrations sub-agent for a toolkit (Slack/Gmail/Calendar), `subagent_runner` calls `fetch_toolkit_actions(client, tk, None)` on **every** delegation. That is a backend `list_tools` HTTP round-trip — ~2–8s for large toolkits (Slack/Gmail) — and it runs before the sub-agent's own model call. In a meeting that asks several integration questions, this multi-second fetch is paid repeatedly for the same toolkit.

A note on a tempting-but-wrong shortcut: the catalogue already loaded into `cached_integration.tools` (from the bulk `fetch_connected_integrations_status` path) is **not** equivalent and must not be substituted directly. `fetch_toolkit_actions` applies curation the bulk path does not — an `action_prefix` filter and `is_action_visible_with_pref` (curated whitelist + per-user scope) at `connected_integrations.rs:1000-1006`, whereas the bulk path stores the raw `resp.tools` (`:606-609`). Swapping in the bulk cache would feed the sub-agent a different, uncurated tool set. So this PR caches the curated fetch rather than replacing it.

## Solution

- New `TOOLKIT_ACTIONS_CACHE` (process-wide `LazyLock<RwLock<HashMap<slug, CachedToolkitActions>>>`), modeled exactly on the existing `INTEGRATIONS_CACHE` next to it.
- `fetch_toolkit_actions_cached(client, toolkit)` returns the **same curated catalogue** as `fetch_toolkit_actions`, but serves repeat lookups for a toolkit from cache within `TOOLKIT_ACTIONS_CACHE_TTL` (300s). Cache miss / stale / lock-contended → live fetch + repopulate. Errors are never cached. `try_read` so a writer never blocks a delegation.
- Invalidation reuses the **existing** fan-in: `invalidate_connected_integrations_cache()` now clears the toolkit cache alongside the integrations cache, so every current trigger (new OAuth connection via `ComposioConnectionCreatedSubscriber`, `composio_list_connections` divergence, tests) also drops stale actions. The 300s TTL only backstops rarer action-scope changes.
- Only the delegation hot path (`subagent_runner/ops/runner.rs`) switches to the cached variant. The debug path (`agent/debug/mod.rs`) keeps calling `fetch_toolkit_actions` directly.

## Blast radius

This is shared agent-harness code: it affects **every** agent that delegates to an integrations sub-agent, not just the meeting bot. The change is a behaviour-preserving memoization — the returned catalogue is byte-for-byte the curated `fetch_toolkit_actions` output; only its freshness changes (≤300s stale, or immediately refreshed on any connection change). No call site sees a different *shape* of data. Worst case: a toolkit action whose visibility scope changed mid-session is not reflected for up to 300s if no connection event fires — acceptable and consistent with the existing 60s integrations cache philosophy.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `cache_key_normalizes_slug`, `cache_entry_freshness_respects_ttl` (incl. exact-boundary stale case), `invalidate_clears_toolkit_actions_cache`.
- [ ] **Diff coverage ≥ 80%** — the cache key/TTL/invalidation logic is unit-tested; the `fetch_toolkit_actions_cached` read/fetch/write glue wraps a live backend `list_tools` call with no offline seam, so those few I/O lines aren't unit-covered. Flagging rather than asserting; a Composio-client fake to cover the wrapper is a reasonable follow-up before un-drafting.
- [x] Coverage matrix updated — `N/A: caching of existing curated fetch, no new feature row.`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A.`
- [x] No new external network dependencies introduced — removes redundant `list_tools` calls; adds none.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: same tool set surfaced to sub-agents, just cached.`
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue.`

## Impact

- **Platform**: desktop core (all agents that delegate to integrations sub-agents).
- **Performance**: removes the ~2–8s `list_tools` round-trip from every repeat delegation to the same toolkit within a 300s window.
- **Behaviour**: identical curated tool catalogue; only memoized. Invalidated on connection change.
- **Security/Migration**: none — same curation/whitelist applied; per-user scope unchanged (single user per core process).

## Related

- Closes:
- Follow-up PR(s)/TODOs: Composio-client fake to unit-cover the cached wrapper; the parallel-tool-dispatch + agentic-timeout change ships separately.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/meet-composio-toolkit-cache`
- Commit SHA: _set on push_

### Validation Run

- [ ] `pnpm --filter openhuman-app format:check` — N/A: no frontend change.
- [ ] `pnpm typecheck` — N/A: no TypeScript change.
- [ ] Focused tests: `cargo test --lib toolkit_actions_cache`
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo test --lib` builds.
- [ ] Tauri fmt/check (if changed): N/A: core crate only.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: repeat per-toolkit action fetches are served from a TTL cache.
- User-visible effect: faster integration replies after the first delegation to a toolkit.

### Parity Contract

- Legacy behavior preserved: cached output is the same curated `fetch_toolkit_actions` result; uncached fn unchanged; debug path unchanged.
- Guard/fallback/dispatch parity checks: cache miss/stale/contended falls through to a live fetch; errors never cached; invalidation reuses existing triggers.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A
