### PR TITLE
perf(meet): lower agentic turn timeout 90s->60s for live voice

### DIFF
--- a/src/openhuman/meet_agent/brain/constants.rs
+++ b/src/openhuman/meet_agent/brain/constants.rs
@@ -27,10 +27,17 @@ pub(super) fn agent_cache() -> &'static TokioMutex<HashMap<String, Arc<TokioMute
 
 /// Wall-clock ceiling on one agentic turn. Slack / Gmail fetches via
 /// Composio + per-message filtering + iteration-2 synthesis can hit
-/// 60-80s in the slow path. 90s gives the long integrations a chance
-/// to land. The turn_in_progress gate blocks new wakes during the
-/// wait, so the user cannot spawn parallel queries by re-asking.
-pub(super) const AGENTIC_TURN_TIMEOUT_SECS: u64 = 90;
+/// 60-80s in the slowest path, but in a *live* meeting that much dead
+/// air — even behind the pre-roll ack — means the participant has moved
+/// on. So we cap tighter than the slowest possible integration turn:
+/// 60s bounds the worst-case silence while still letting the large
+/// majority of integration queries land (and the per-toolkit action
+/// cache trims their latency further). Turns that exceed it fall back to
+/// the polite "let me get back to you" ack. The turn_in_progress gate
+/// blocks new wakes during the wait, so the user cannot spawn parallel
+/// queries by re-asking. Tunable — lower it for snappier voice at the
+/// cost of dropping the very slowest integration answers.
+pub(super) const AGENTIC_TURN_TIMEOUT_SECS: u64 = 60;
 
 /// Spoken filler played immediately after wake-word fires, before the
 /// (possibly slow) orchestrator+tool path runs. Bridges the 30-60s
@@ -164,3 +171,18 @@ name appearing inside a longer thought aimed at someone else), output an empty s
 - For dictation / note requests (\"remember…\", \"action item…\", \"follow up on…\"), a 2-3 word \
 ack is enough (\"Got it.\", \"Noted.\").\n\
 - For genuinely unanswerable questions, say so in one short sentence rather than guessing.";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agentic_timeout_is_in_live_voice_range() {
+        // Tight enough that a stuck turn doesn't strand a live meeting in
+        // dead air, loose enough that typical integration queries land.
+        assert!(
+            (20..=75).contains(&AGENTIC_TURN_TIMEOUT_SECS),
+            "AGENTIC_TURN_TIMEOUT_SECS={AGENTIC_TURN_TIMEOUT_SECS} outside the live-voice range"
+        );
+    }
+}

--- a/src/openhuman/meet_agent/brain/llm.rs
+++ b/src/openhuman/meet_agent/brain/llm.rs
@@ -36,8 +36,9 @@ pub(super) fn short_id(id: &str) -> String {
 ///
 /// We rebuild the Agent per turn (cheap relative to the LLM call
 /// itself, since the registry is initialised once at startup) and
-/// wrap `run_single` in a 20s timeout so a slow tool iteration
-/// doesn't leave the meeting participant in silence indefinitely.
+/// wrap `run_single` in an `AGENTIC_TURN_TIMEOUT_SECS` timeout so a slow
+/// tool iteration doesn't leave the meeting participant in silence
+/// indefinitely.
 ///
 /// Errors propagate to the caller, which falls back to the bare
 /// chat-completions path (`llm_meeting_basic`) so a config /


### PR DESCRIPTION
## Summary

- Lower the live meeting agent's per-turn agentic timeout from 90s to 60s so a stuck turn doesn't strand the call in dead air as long.
- Fix a stale doc comment that claimed a "20s timeout" (the constant was 90s).

## Problem

`AGENTIC_TURN_TIMEOUT_SECS` capped one meeting-agent turn at 90s. In a live call, 90s of silence — even behind the "On it." pre-roll ack — means the participant has long since moved on. The previous 90s was chosen so the very slowest Slack/Gmail integration turns (60–80s) could finish, but that optimizes the worst case at the expense of the common live-call experience. Separately, the `llm_meeting_agentic` doc comment still said "wrap `run_single` in a 20s timeout", which never matched the 90s constant.

## Solution

- Set `AGENTIC_TURN_TIMEOUT_SECS = 60`. This bounds worst-case dead air a third tighter while still letting the large majority of integration queries land — and the per-toolkit action cache (separate PR) trims integration latency further, so fewer turns approach the ceiling. Turns that exceed it fall back to the existing polite "let me get back to you" ack. The value is documented as tunable (lower for snappier voice, at the cost of the very slowest integration answers).
- Update the `llm.rs` doc comment to reference `AGENTIC_TURN_TIMEOUT_SECS` instead of the stale "20s".
- Unit test guards the constant stays in a sane live-voice range.

**This is a product trade-off, not a pure win** — please sanity-check 60s against how you want the bot to behave on slow integration questions in a live call. Easy to dial up or down.

## Deliberately deferred: parallel tool dispatch

The latency audit also flagged that `engine/core.rs` executes a model's tool calls **sequentially** within one iteration, and proposed parallelizing them. I did **not** include that here:

- `engine/core.rs` is the shared execution core for **every** agent, not just the meeting bot — maximum blast radius.
- There is no dependency detection between tool calls. A blind `join_all` would break any turn where the model emits dependent sequential calls (e.g. "send the email" then "check it's in the sent folder"), and could amplify upstream rate-limits.
- A safe version needs either provable-independence detection or an opt-in policy — a design decision for the harness maintainers, not a drive-by perf change.

Tracking it as a follow-up rather than shipping a risky core change blindly.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `agentic_timeout_is_in_live_voice_range` guards the constant.
- [x] **Diff coverage ≥ 80%** — the changed constant line is referenced by the new test; the comment edit is non-executable.
- [x] Coverage matrix updated — `N/A: timeout-value + comment change, no new feature row.`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A.`
- [x] No new external network dependencies introduced — none.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: same fallback behaviour, just a tighter ceiling.`
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue.`

## Impact

- **Platform**: desktop core (meeting agent only — `meet_agent/brain/constants.rs`).
- **Behaviour**: integration turns that would have run 60–90s now fall back to the polite ack at 60s instead of 90s. All other turns unaffected.
- **Performance**: bounds worst-case in-call dead air.
- **Security/Migration**: none.

## Related

- Closes:
- Follow-up PR(s)/TODOs: parallel (independence-aware) tool dispatch in `engine/core.rs` — needs harness-maintainer design.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/meet-agentic-timeout`
- Commit SHA: _set on push_

### Validation Run

- [ ] `pnpm --filter openhuman-app format:check` — N/A: no frontend change.
- [ ] `pnpm typecheck` — N/A: no TypeScript change.
- [ ] Focused tests: `cargo test --lib agentic_timeout_is_in_live_voice_range`
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo test --lib` builds.
- [ ] Tauri fmt/check (if changed): N/A: core crate only.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: per-turn agentic ceiling 90s → 60s.
- User-visible effect: snappier give-up on stuck turns; the very slowest integration answers may now time out to the polite ack.

### Parity Contract

- Legacy behavior preserved: same timeout mechanism and same fallback ack; only the ceiling value changes.
- Guard/fallback/dispatch parity checks: `turn_in_progress` gate unchanged; fallback path unchanged.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A
