### PR TITLE
perf(meet): keep CEF cache warm on audio-bridge reload

### DIFF
--- a/app/src-tauri/src/meet_audio/inject.rs
+++ b/app/src-tauri/src/meet_audio/inject.rs
@@ -56,6 +56,17 @@ pub const CAPTIONS_BRIDGE_JS: &str = include_str!("captions_bridge.js");
 const TARGET_DISCOVERY_BUDGET: Duration = Duration::from_secs(20);
 const TARGET_DISCOVERY_INTERVAL: Duration = Duration::from_millis(500);
 
+/// CDP `Page.reload` params for the audio/captions bridge install.
+///
+/// Intentionally omits `ignoreCache`: a plain reload already re-runs the
+/// document-start bridge scripts (a reload always reloads the document;
+/// bfcache applies only to history navigation), so forcing a cold cache
+/// bypass merely re-downloaded Meet's SPA bundle for no install benefit.
+/// The unit test guards against a regression that reintroduces it.
+fn audio_bridge_reload_params() -> Value {
+    json!({})
+}
+
 /// Run the inject + reload sequence. Returns the attached CDP
 /// connection + session id so the caller (the speak pump) can keep
 /// using it for `Runtime.evaluate` calls — opening one CDP session
@@ -94,16 +105,19 @@ pub async fn install_audio_bridge<R: tauri::Runtime>(
     .await
     .map_err(|e| format!("addScriptToEvaluateOnNewDocument(captions): {e}"))?;
 
-    // Reload so the script applies to the (already-loaded) meet page.
-    // `ignoreCache: true` defeats the bfcache so we get a real
-    // document-start hook for the bridge.
-    cdp.call(
-        "Page.reload",
-        json!({ "ignoreCache": true }),
-        Some(&session),
-    )
-    .await
-    .map_err(|e| format!("Page.reload: {e}"))?;
+    // Reload so the registered document-start scripts apply to the
+    // (already-loaded) Meet page. A plain reload is enough: `Page.reload`
+    // always performs a fresh document load, which re-runs every
+    // `addScriptToEvaluateOnNewDocument` hook — bfcache only applies to
+    // history (back/forward) navigation, not to an explicit reload. The
+    // previous `ignoreCache: true` additionally forced a cold re-fetch of
+    // Meet's multi-MB SPA bundle on this concurrent reload, doubling
+    // join-time network cost for no bridge-install benefit. Keep the cache
+    // warm; `confirm_bridge_alive` below still verifies the bridge booted
+    // and the speak pump retries if it somehow didn't.
+    cdp.call("Page.reload", audio_bridge_reload_params(), Some(&session))
+        .await
+        .map_err(|e| format!("Page.reload: {e}"))?;
 
     log::info!("[meet-audio] inject reload requested session={session}");
 
@@ -319,4 +333,23 @@ pub async fn flush_audio_bridge(cdp: &mut CdpConn, session: &str) -> Result<i64,
         .and_then(|v| v.as_i64())
         .unwrap_or(0);
     Ok(stopped)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn audio_bridge_reload_keeps_cache_warm() {
+        // The bridge install reload must NOT set `ignoreCache`: a plain
+        // reload already re-runs the document-start scripts, and forcing a
+        // cold re-fetch of Meet's SPA bundle is wasted join-time network
+        // cost. Regression guard.
+        let params = audio_bridge_reload_params();
+        assert!(
+            params.get("ignoreCache").is_none(),
+            "audio bridge reload must keep the cache warm (no ignoreCache); got {params}"
+        );
+        assert!(params.is_object(), "reload params must be a JSON object");
+    }
 }


### PR DESCRIPTION
## Summary

- Stop the audio/captions-bridge install from forcing a cold reload of the Meet page. The `Page.reload` that boots the bridges no longer passes `ignoreCache: true`.
- The bridges still install (a plain reload re-runs document-start scripts) and `confirm_bridge_alive` still verifies it — only the redundant cold re-fetch of Meet's SPA bundle is dropped.

## Problem

`install_audio_bridge` registers the audio + captions bridges via `Page.addScriptToEvaluateOnNewDocument`, then calls `Page.reload({ignoreCache: true})` so they run at document-start. This reload runs **concurrently** with the join scanner on the same Meet page. The `ignoreCache: true` flag forced CEF to re-fetch and re-parse Meet's multi-MB SPA bundle from cold on this second reload — so even after warming the scanner's own reload, a cold load remained on the join hot path.

The cold flag was justified in a comment as "defeating the bfcache so we get a real document-start hook". But that conflates two things: `Page.reload` **always** performs a fresh document load (which re-runs every `addScriptToEvaluateOnNewDocument` hook); the back-forward cache only applies to history navigation (back/forward), never to an explicit reload. So `ignoreCache` was never needed for the bridge to install — it only added a cold network fetch.

## Solution

- Reload with `audio_bridge_reload_params()` (an empty params object) instead of `{ignoreCache: true}`, keeping the HTTP cache warm.
- The existing `confirm_bridge_alive` probe still confirms the bridge booted post-reload, and the speak pump already retries if it somehow didn't — so the safety net is unchanged.
- New `audio_bridge_reload_params()` helper documents the warm-reload decision; its unit test asserts no `ignoreCache`, guarding against a regression.

This mirrors the same fix already applied to the scanner's reload, so after both, neither concurrent reload on the join path forces a cold Meet load.

## Note for manual testing

This touches the **audio/captions path** (speak + caption listen), so it's worth a manual smoke: join a Meet, confirm the bot still speaks and still picks up captions. If a warm reload ever failed to install the bridge on some CEF build, `confirm_bridge_alive` would log `[meet-audio] bridge readiness probe timed out` and the speak pump would retry — but the expectation is no behavioural change, just a faster reload.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `audio_bridge_reload_keeps_cache_warm` (regression guard on the reload params).
- [x] **Diff coverage ≥ 80%** — the only added executable line is `audio_bridge_reload_params()`, covered by the new test; the rest is the reload-call edit + comments.
- [x] Coverage matrix updated — `N/A: behaviour-preserving performance change, no new feature row.`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A.`
- [x] No new external network dependencies introduced — removes a cold re-fetch; adds none.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A to docs; see "Note for manual testing" — bot speak + caption listen should be smoke-checked, behaviour unchanged.`
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue.`

## Impact

- **Platform**: desktop (Tauri CEF) only.
- **Performance**: removes the remaining cold Meet SPA re-fetch from the join hot path (the audio-bridge reload).
- **Behaviour**: bridges still install + verified; bot speak/caption-listen unchanged.
- **Security/Migration**: none.

## Related

- Closes:
- Follow-up PR(s)/TODOs: collapse the initial navigation + the two concurrent reloads (scanner + audio) into a single navigation with bridges pre-registered — eliminates the reloads entirely, but needs scanner/audio attach-ordering coordination; deferred as a larger restructure.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/meet-audio-warm-reload`
- Commit SHA: _set on push_

### Validation Run

- [ ] `pnpm --filter openhuman-app format:check` — N/A: no frontend change.
- [ ] `pnpm typecheck` — N/A: no TypeScript change.
- [ ] Focused tests: `cargo test -p OpenHuman meet_audio::inject`
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean.
- [x] Tauri fmt/check (if changed): `cargo check --manifest-path app/src-tauri/Cargo.toml`

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: audio-bridge reload no longer forces a cold cache fetch.
- User-visible effect: faster join; bot speak/caption-listen unchanged.

### Parity Contract

- Legacy behavior preserved: bridges still registered + reloaded + verified via `confirm_bridge_alive`; speak-pump retry unchanged.
- Guard/fallback/dispatch parity checks: reload still best-effort with the readiness probe as the safety net.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A
