### PR TITLE
perf(meet): pre-warm orchestrator agent at session start

### DIFF
--- a/src/openhuman/meet_agent/brain/llm.rs
+++ b/src/openhuman/meet_agent/brain/llm.rs
@@ -137,7 +137,9 @@ pub(super) async fn llm_meeting_agentic(prompt: &str, request_id: &str) -> Resul
 /// Get the cached orchestrator for this meet, or build it on first
 /// call. Returns an `Arc<TokioMutex<Agent>>` so the caller can lock
 /// across the run_single().await.
-async fn get_or_build_agent_for_meet(request_id: &str) -> Result<Arc<TokioMutex<Agent>>, String> {
+pub(super) async fn get_or_build_agent_for_meet(
+    request_id: &str,
+) -> Result<Arc<TokioMutex<Agent>>, String> {
     {
         let cache = agent_cache().lock().await;
         if let Some(existing) = cache.get(request_id) {

--- a/src/openhuman/meet_agent/brain/mod.rs
+++ b/src/openhuman/meet_agent/brain/mod.rs
@@ -50,6 +50,26 @@ pub(crate) use text::strip_for_speech;
 
 use constants::agent_cache;
 
+/// Build + cache the orchestrator Agent for a meet session ahead of the
+/// first wake. The cold build (memory tree + MCP clients + tool registry)
+/// costs 5-10s; running it here — kicked off at `start_session`, while the
+/// CEF webview is still joining the call — means it overlaps the join
+/// instead of stalling the first reply. Fire-and-forget: on failure (or if
+/// the wake fires before it finishes) the first turn falls back to the
+/// lazy build in `llm_meeting_agentic`, so behaviour is unchanged, just
+/// slower in that case.
+pub async fn prewarm_session_agent(request_id: &str) {
+    match llm::get_or_build_agent_for_meet(request_id).await {
+        Ok(_) => {
+            log::info!("[meet-agent] pre-warmed orchestrator for request_id={request_id}")
+        }
+        Err(err) => log::warn!(
+            "[meet-agent] orchestrator pre-warm failed request_id={request_id} \
+             (first wake will build lazily): {err}"
+        ),
+    }
+}
+
 /// Drop the cached orchestrator for a meet session. Called from
 /// `handle_stop_session` so a finished call doesn't leak the Agent
 /// (each one carries memory tree + tool registry handles).

--- a/src/openhuman/meet_agent/rpc.rs
+++ b/src/openhuman/meet_agent/rpc.rs
@@ -58,6 +58,18 @@ pub async fn handle_start_session(params: Map<String, Value>) -> Result<Value, S
         req.bot_display_name.chars().count()
     );
 
+    // Pre-warm the orchestrator Agent now so its 5-10s cold build
+    // (memory tree + MCP + tool registry) overlaps the CEF join window
+    // instead of stalling the first wake's reply. Fire-and-forget: the
+    // first caption turn falls back to the lazy build if this hasn't
+    // finished or failed, so the RPC reply is never blocked on it.
+    {
+        let request_id = req.request_id.clone();
+        tokio::spawn(async move {
+            brain::prewarm_session_agent(&request_id).await;
+        });
+    }
+
     RpcOutcome::new(
         json!({
             "ok": true,


### PR DESCRIPTION
## Summary

- Pre-warm the meeting agent's orchestrator Agent at `start_session` (call join) instead of lazily on the first wake.
- The 5–10s cold build (memory tree + MCP clients + tool registry) now overlaps the CEF join window, so the first question doesn't pay it.

## Problem

The meeting agent builds its orchestrator Agent lazily, inside `llm_meeting_agentic` on the **first** wake (`get_or_build_agent_for_meet`). That cold build is 5–10s (memory tree load + MCP attach + tool registry). So the very first question of a call eats the entire build latency before the LLM even starts — on top of the LLM + TTS time. Meanwhile, during the ~several-second CEF join (window build, scanner, bridges), the core is idle with respect to the agent.

## Solution

- Add `brain::prewarm_session_agent(request_id)` — a thin wrapper over the existing `get_or_build_agent_for_meet` that builds + caches the Agent and logs the outcome.
- `handle_start_session` spawns it **fire-and-forget** right after the session is created, so the cold build runs concurrently with the call join. The RPC reply is never blocked on it.
- Fully backward-compatible: if the build fails, or the first wake somehow fires before it finishes, the first turn falls back to the existing lazy build in `llm_meeting_agentic` — identical behaviour, just without the pre-warm speedup in that case.

`get_or_build_agent_for_meet` is made `pub(super)` so `brain/mod.rs` can call it; no other surface changes.

## Notes / limits

- **Rare double-build:** `get_or_build_agent_for_meet` checks the cache under a lock, releases it, then builds, then re-inserts. If a wake fires *during* the pre-warm build (i.e. the user speaks within the first ~10s, before pre-warm completes), both paths can build once — wasteful but not incorrect (last insert wins, both yield a valid Agent). In practice the first wake lands well after the build, so pre-warm wins. A build-once guard is a possible follow-up if this matters.
- **LLM→TTS sentence streaming (from the audit) intentionally not included:** meet replies are already capped to a single short sentence (`REPLY_MAX_TOKENS=80`, `MAX_TTS_CHARS=400`, and the "Output ONE sentence" system prompt), so there is nothing to pipeline at sentence granularity. Streaming the single sentence's *audio* is the backend ElevenLabs-streaming change, tracked separately.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [ ] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `prewarm_session_agent` is fire-and-forget plumbing over `get_or_build_agent_for_meet`, which performs a live config-load + Agent build (memory tree / MCP / registry) with no offline seam, so it has no clean unit test. Flagging rather than adding a slow/flaky build-invoking test; a build seam to cover both the lazy and pre-warm entry points is a reasonable follow-up before un-drafting.
- [ ] **Diff coverage ≥ 80%** — see above; the new lines are the visibility change, the wrapper, and the spawn — all plumbing over an existing (separately exercised) build path. Flagged, not asserted.
- [x] Coverage matrix updated — `N/A: latency-only change, no new user-facing feature row.`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A.`
- [x] No new external network dependencies introduced — same Agent build, just earlier.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: first-reply latency improvement, behaviour unchanged; smoke = join a Meet, confirm first answer is faster and correct.`
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue.`

## Impact

- **Platform**: desktop core (meeting agent only).
- **Performance**: hides the 5–10s cold orchestrator build behind the call-join window, so the first question's reply lands sooner.
- **Behaviour**: unchanged — same Agent, same cache, same lazy fallback.
- **Security/Migration**: none.

## Related

- Closes:
- Follow-up PR(s)/TODOs: build-once guard to eliminate the rare pre-warm/first-wake double build; build seam for unit coverage of the agent-build entry points.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/meet-prewarm-agent`
- Commit SHA: _set on push_

### Validation Run

- [ ] `pnpm --filter openhuman-app format:check` — N/A: no frontend change.
- [ ] `pnpm typecheck` — N/A: no TypeScript change.
- [ ] Focused tests: N/A — see coverage note (no offline seam for the build path).
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo check --lib` builds.
- [ ] Tauri fmt/check (if changed): N/A: core crate only.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: orchestrator Agent built at session start instead of first wake.
- User-visible effect: faster first reply in a meeting; identical thereafter.

### Parity Contract

- Legacy behavior preserved: lazy build in `llm_meeting_agentic` remains the fallback; cache keyed by `request_id` unchanged; `forget_session_agent` teardown unchanged.
- Guard/fallback/dispatch parity checks: pre-warm is fire-and-forget; RPC reply path unchanged.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A
