### PR TITLE
fix(learning): floor reinforcement recency by the facet's own half-life

### DIFF
--- a/src/openhuman/learning/stability_detector.rs
+++ b/src/openhuman/learning/stability_detector.rs
@@ -226,7 +226,7 @@ impl StabilityDetector {
             let final_stability = stability(
                 dominant_cue(cands, existing),
                 total_evidence_count(cands, existing),
-                most_recent_reinforcement(cands, existing, now),
+                most_recent_reinforcement(cands, existing, now, *class),
                 now,
                 *class,
                 has_explicit,
@@ -500,10 +500,18 @@ fn total_evidence_count(cands: &[LearningCandidate], existing: Option<&ProfileFa
 }
 
 /// The most recent observation timestamp across candidates and the existing row.
+///
+/// The result is floored at `now - half_life(class)` so a facet's recency decay
+/// in [`stability`] bottoms out at one (class-specific) half-life. The floor
+/// must use the facet's own `class`: every other per-group computation in
+/// `rebuild` is class-scoped, and the half-lives span 7d (Channel) to 90d
+/// (Identity), so a hardcoded class would over-retain longer-lived facets and
+/// evict shorter-lived ones too early.
 fn most_recent_reinforcement(
     cands: &[LearningCandidate],
     existing: Option<&ProfileFacet>,
     now: f64,
+    class: FacetClass,
 ) -> f64 {
     let newest_cand = cands
         .iter()
@@ -512,9 +520,7 @@ fn most_recent_reinforcement(
     let existing_ts = existing
         .map(|f| f.last_seen_at)
         .unwrap_or(f64::NEG_INFINITY);
-    newest_cand
-        .max(existing_ts)
-        .max(now - half_life(FacetClass::Style))
+    newest_cand.max(existing_ts).max(now - half_life(class))
 }
 
 /// Map a stability score + user_state to a lifecycle state.
@@ -841,5 +847,38 @@ mod tests {
         assert_eq!(class_budget(FacetClass::Veto), 3);
         assert_eq!(class_budget(FacetClass::Goal), 3);
         assert_eq!(class_budget(FacetClass::Channel), 1);
+    }
+
+    // ── most_recent_reinforcement floor ───────────────────────────────────────
+
+    #[test]
+    fn reinforcement_floor_scopes_to_facet_class() {
+        // With no candidates and no existing row, the result is purely the
+        // class-scoped floor `now - half_life(class)`. This pins that the floor
+        // tracks the facet's own class rather than a hardcoded one — the longer
+        // half-lives (Goal, Identity) must floor further in the past than Style,
+        // and Channel (shortest) closer to now.
+        let now = 10_000_000.0;
+        for class in [
+            FacetClass::Identity,
+            FacetClass::Veto,
+            FacetClass::Tooling,
+            FacetClass::Goal,
+            FacetClass::Style,
+            FacetClass::Channel,
+        ] {
+            let floor = most_recent_reinforcement(&[], None, now, class);
+            assert_eq!(
+                floor,
+                now - half_life(class),
+                "floor must use {class:?}'s own half-life"
+            );
+        }
+        // Guard against a regression to a single hardcoded class: a class with a
+        // different half-life than Style must produce a different floor.
+        assert_ne!(
+            most_recent_reinforcement(&[], None, now, FacetClass::Goal),
+            most_recent_reinforcement(&[], None, now, FacetClass::Style),
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fix a wrong-result bug in the learning stability detector: `most_recent_reinforcement` floored the most-recent-reinforcement timestamp using a hardcoded `FacetClass::Style` half-life instead of the facet's own class.
- Thread the facet `class` through and use `half_life(class)` for the floor, matching every other per-group computation in `rebuild`.
- Add a regression test asserting the floor scopes to each class's half-life.

## Problem

`rebuild` groups candidates by `(class, key)` and, for each group, computes stability with the group's `*class` — except `most_recent_reinforcement`, which ignored the class and hardcoded `Style`:

```rust
newest_cand
    .max(existing_ts)
    .max(now - half_life(FacetClass::Style)) // always Style (14d)
```

That return value is `last_reinforced_at` in `stability`, where `recency = exp(-(now - last_reinforced_at) / half_life(class))`. The floor is meant to cap the recency decay at one **class-specific** half-life (a floor of `exp(-1)`). Hardcoding Style's 14-day half-life miscalibrates that floor for every other class:

- Classes with a longer half-life than Style — Identity (90d), Veto (60d), Tooling (30d), Goal (30d): the floor sits too recent, so `dt` is too small and `recency` too high → these facets are **over-retained**, staying Active/Provisional longer than the spec intends.
- Channel (7d, shorter than Style): the floor sits too far in the past, so `recency` is too low → Channel facets are **evicted too early**.
- Style (14d): correct by coincidence — which is why the existing tests (all written against `FacetClass::Style`) never caught it.

The user-visible effect is a slowly-degrading preference profile: stale long-lived facets linger and short-lived channel facets drop prematurely.

## Solution

Add a `class: FacetClass` parameter to `most_recent_reinforcement`, use `half_life(class)` for the floor, and pass `*class` at the sole call site (the per-group loop in `rebuild`). One function, one call site, no public API change — `most_recent_reinforcement` is private to the module.

New test `reinforcement_floor_scopes_to_facet_class` calls the helper with no candidates / no existing row (so the result is purely the floor) for every class and asserts it equals `now - half_life(class)`, plus a guard that Goal and Style produce different floors so a regression to any single hardcoded class fails.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy
- [x] **Diff coverage ≥ 80%** — the changed floor line is exercised by the new `reinforcement_floor_scopes_to_facet_class` across all six classes; the threaded call site is covered by the existing `rebuild` tests.
- [x] Coverage matrix updated — `N/A: bug fix, no feature row added/removed/renamed`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature touched`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: internal learning decay math, no release-cut surface`
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue; found by code inspection`

## Impact

- Corrects per-class recency decay in the learning preference profile (desktop/CLI core). Behavior change is intentional and limited to non-Style facets: longer-lived classes decay on their true schedule instead of Style's, and Channel facets stop being evicted early. No API, schema, or migration change.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/learning-stability-floor-class-half-life
- Commit SHA: 3dfc3c968

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `cargo test --lib learning::stability_detector`
- [x] Rust fmt/check (if changed): `cargo fmt` + `pnpm rust:check`
- [x] Tauri fmt/check (if changed): N/A — no Tauri shell code changed

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: per-class recency floor now uses the facet's own half-life
- User-visible effect: preference-profile facets decay on their class's true schedule; no more over-retention of long-lived facets or early eviction of Channel facets


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stability recency limits now respect each facet class’s own decay settings instead of using a single shared floor.
  * Recent reinforcement timestamps are now calculated more consistently when no newer data is available.
  * Added coverage to ensure different facet classes keep distinct recency floors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->