### PR TITLE
fix(memory): add click feedback to the Trees refresh button

### DIFF
--- a/app/src/components/intelligence/MemoryControls.test.tsx
+++ b/app/src/components/intelligence/MemoryControls.test.tsx
@@ -1,0 +1,68 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MemoryControls } from './MemoryControls';
+
+// Stub i18n and the vault sub-section so we render just the control bar.
+vi.mock('../../lib/i18n/I18nContext', () => ({ useT: () => ({ t: (k: string) => k }) }));
+vi.mock('./ObsidianVaultSection', () => ({ ObsidianVaultSection: () => null }));
+vi.mock('../../utils/tauriCommands', () => ({
+  memoryTreeFlushNow: vi.fn().mockResolvedValue({ enqueued: true, stale_buffers: 0 }),
+  memoryTreeResetTree: vi.fn().mockResolvedValue(undefined),
+  memoryTreeWipeAll: vi.fn().mockResolvedValue(undefined),
+}));
+
+const noop = () => {};
+
+describe('<MemoryControls /> refresh feedback', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('calls onRefresh and shows a busy spinner immediately on click', async () => {
+    const onRefresh = vi.fn();
+    render(<MemoryControls mode="tree" onModeChange={noop} onRefresh={onRefresh} />);
+
+    const btn = screen.getByTestId('memory-graph-refresh');
+    expect(btn).not.toBeDisabled();
+
+    fireEvent.click(btn);
+
+    // The parent re-pull fires right away…
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+    // …and the button reports a busy state so the click is visibly acknowledged.
+    expect(btn).toBeDisabled();
+    expect(btn.getAttribute('aria-busy')).toBe('true');
+    expect(btn.querySelector('.animate-spin')).not.toBeNull();
+  });
+
+  it('clears the busy state after the minimum spin window', async () => {
+    const onRefresh = vi.fn();
+    render(<MemoryControls mode="tree" onModeChange={noop} onRefresh={onRefresh} />);
+
+    const btn = screen.getByTestId('memory-graph-refresh');
+    fireEvent.click(btn);
+    expect(btn).toBeDisabled();
+
+    // Advance past the 600ms minimum spin window; the button re-enables.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+    expect(btn).not.toBeDisabled();
+    expect(btn.getAttribute('aria-busy')).toBe('false');
+  });
+
+  it('ignores re-clicks while already refreshing', async () => {
+    const onRefresh = vi.fn();
+    render(<MemoryControls mode="tree" onModeChange={noop} onRefresh={onRefresh} />);
+
+    const btn = screen.getByTestId('memory-graph-refresh');
+    fireEvent.click(btn);
+    // A disabled button shouldn't re-fire, but guard against programmatic clicks too.
+    fireEvent.click(btn);
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/components/intelligence/MemoryControls.tsx
+++ b/app/src/components/intelligence/MemoryControls.tsx
@@ -59,6 +59,7 @@ export function MemoryControls({
   const [building, setBuilding] = useState(false);
   const [wiping, setWiping] = useState(false);
   const [resetting, setResetting] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
   const busy = building || wiping || resetting;
 
   const handleWipe = useCallback(async () => {
@@ -147,6 +148,27 @@ export function MemoryControls({
     }
   }, [onToast, onRefresh]);
 
+  const handleRefresh = useCallback(async () => {
+    if (refreshing) return;
+    console.debug('[ui-flow][memory-controls] manual refresh: entry');
+    setRefreshing(true);
+    try {
+      // `onRefresh` re-pulls the graph; the parent owns the fetch and may
+      // resolve synchronously (it just bumps a version key today). Run it
+      // alongside a short minimum spin window so the click always produces
+      // perceptible feedback instead of an instant, invisible no-op.
+      await Promise.all([
+        Promise.resolve(onRefresh()),
+        new Promise(resolve => setTimeout(resolve, 600)),
+      ]);
+    } catch (err) {
+      console.error('[ui-flow][memory-controls] manual refresh failed', err);
+    } finally {
+      setRefreshing(false);
+      console.debug('[ui-flow][memory-controls] manual refresh: exit');
+    }
+  }, [onRefresh, refreshing]);
+
   return (
     <div className="flex flex-wrap items-center justify-between gap-3" data-testid="memory-actions">
       <ModeToggle mode={mode} onChange={onModeChange} />
@@ -179,11 +201,13 @@ export function MemoryControls({
         {/* Secondary actions — quiet ghost buttons. */}
         <button
           type="button"
-          onClick={onRefresh}
+          onClick={handleRefresh}
+          disabled={refreshing}
+          aria-busy={refreshing}
           data-testid="memory-graph-refresh"
           className={BTN_GHOST}
           title={t('common.refresh')}>
-          <RefreshIcon /> {t('common.refresh')}
+          {refreshing ? <Spinner /> : <RefreshIcon />} {t('common.refresh')}
         </button>
         {contentRootAbs ? (
           <ObsidianVaultSection contentRootAbs={contentRootAbs} onToast={onToast} />


### PR DESCRIPTION
## Summary

The **Refresh** button in the Trees/memory toolbar (between *Reset Memory Tree* and *View Vault*) called `onRefresh()` directly with **no local busy state**, so clicking it produced no visible reaction. Every sibling action (Reset Memory, Reset Memory Tree, Build Summary Trees) already spins a `Spinner` and disables while working — Refresh was the odd one out.

This gives Refresh the same treatment:

- On click it swaps the refresh icon for a spinner, disables the button, and sets `aria-busy` until the re-pull settles.
- A short minimum spin window (600ms) keeps the feedback perceptible even when the parent graph export resolves instantly.
- Works whether `onRefresh` is sync (current behaviour — bumps a version key) or async — `Promise.resolve(onRefresh())` wraps both. Fixes both consumers (`MemoryWorkspace`, `Brain`) in one place.

## Test plan

- [x] New unit tests in `MemoryControls.test.tsx`: fires onRefresh + shows busy spinner on click; clears busy state after the spin window; ignores re-clicks while refreshing
- [x] Existing `MemoryWorkspace.test.tsx` (refresh re-export + poll) still passes
- [x] Typecheck passes
- [x] ESLint passes (changed files)
- [x] Prettier passes (changed files)

## Acceptance criteria

- [x] **Repro gone** — clicking Refresh now produces immediate visible feedback (spinner + disabled + aria-busy).
- [x] **Regression safety** — the refresh re-pull still fires; feedback clears when done.
- [x] **Diff coverage ≥ 80%** — new behaviour covered by unit tests.

Closes #4265

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated refresh interaction state for memory controls, including a visible loading spinner and busy indicator.
  * Improved refresh behavior so repeated clicks are ignored while a refresh is in progress.
  * Ensured the refresh action stays in a loading state briefly for a smoother user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->