### PR TITLE
fix(people): seed people store at core boot (#4344)

### DIFF
--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -1819,6 +1819,20 @@ async fn run_server_inner(
                     ),
                     Err(e) => log::warn!("[boot] whatsapp_data::global init failed: {e}"),
                 }
+                // Seed the people store so people controllers + `people_*`
+                // tools can read/write. Without this the process-global stays
+                // empty and every call fails with "people store not
+                // initialised" (Sentry TAURI-RUST-8NM). Sits inside this
+                // Ok(cfg) arm so it inherits the wrong-workspace guard above
+                // (never seed against a Config::default fallback).
+                match crate::openhuman::people::store::init_from_workspace(&cfg.workspace_dir).await
+                {
+                    Ok(_) => log::info!(
+                        "[boot] people::store initialized (workspace={})",
+                        cfg.workspace_dir.display()
+                    ),
+                    Err(e) => log::warn!("[boot] people::store init failed: {e}"),
+                }
                 // Prune legacy bundled skills (dev-workflow / github-issue-crusher
                 // / pr-review-shepherd) that older builds seeded into
                 // <workspace>/skills/. OpenHuman no longer ships bundled defaults;

--- a/src/openhuman/people/README.md
+++ b/src/openhuman/people/README.md
@@ -58,7 +58,7 @@ Dedicated SQLite DB managed by `PeopleStore` (open via `open_at(path)` or `open_
 - `handle_aliases` — `(kind, value)` primary key → `person_id` (FK, `ON DELETE CASCADE`); `value` is the canonicalized form. This table *is* the resolver index.
 - `interactions` — `(person_id, ts, is_outbound, length)` rows the scorer aggregates; indexed by `(person_id, ts DESC)` and `ts DESC`.
 
-Migrations are tracked in `_people_migrations` and applied idempotently in a transaction. The store is exposed process-globally through a `tokio::sync::OnceCell` (`init` once at startup, `get` from controller handlers). Note: no `people::store::init` call was found outside the module — controller handlers will return "people store not initialised" until something seeds it.
+Migrations are tracked in `_people_migrations` and applied idempotently in a transaction. The store is exposed process-globally through a `tokio::sync::OnceCell` (`get` from controller handlers). Core boot seeds it via `store::init_from_workspace(workspace_dir)` (`src/core/jsonrpc.rs`, alongside `memory::global` and `whatsapp_data::global`), opening `<workspace>/people/people.db`; tests construct stores directly with `open_in_memory`.
 
 ## Dependencies
 

--- a/src/openhuman/people/store.rs
+++ b/src/openhuman/people/store.rs
@@ -29,6 +29,33 @@ pub async fn init(store: Arc<PeopleStore>) -> Result<(), &'static str> {
         .map_err(|_| "people store already initialised")
 }
 
+/// Seed the process-global store from a workspace directory, opening the
+/// on-disk db at `<workspace>/people/people.db` (schema migrations run on
+/// open). Idempotent: a second call — or a concurrent boot path — is a no-op
+/// that returns the already-seeded store rather than erroring.
+///
+/// Wired into core boot (`src/core/jsonrpc.rs`) alongside `memory::global` and
+/// `whatsapp_data::global`. Without this seed the global stays empty and every
+/// people controller / `people_*` tool fails with "people store not
+/// initialised" (Sentry TAURI-RUST-8NM).
+pub async fn init_from_workspace(
+    workspace_dir: &std::path::Path,
+) -> Result<Arc<PeopleStore>, String> {
+    if let Some(existing) = GLOBAL.get() {
+        log::debug!("[people:store] already initialised");
+        return Ok(existing.clone());
+    }
+    let db_path = workspace_dir.join("people").join("people.db");
+    let store = Arc::new(
+        PeopleStore::open_at(&db_path).map_err(|e| format!("people store open failed: {e}"))?,
+    );
+    // Race-resolve: another caller may have seeded while we were opening.
+    match GLOBAL.set(store.clone()) {
+        Ok(()) => Ok(store),
+        Err(_) => Ok(GLOBAL.get().cloned().unwrap_or(store)),
+    }
+}
+
 pub fn get() -> Result<Arc<PeopleStore>, &'static str> {
     GLOBAL
         .get()

--- a/src/openhuman/people/tests.rs
+++ b/src/openhuman/people/tests.rs
@@ -1,5 +1,7 @@
 //! Cross-file integration tests for the people domain.
 
+use std::sync::Arc;
+
 use chrono::Utc;
 
 use crate::openhuman::people::address_book;
@@ -55,6 +57,31 @@ fn schema_exposes_four_controllers() {
         "missing refresh_address_book: {names:?}"
     );
     assert_eq!(names.len(), 4);
+}
+
+/// Regression for Sentry TAURI-RUST-8NM: the process-global people store was
+/// never seeded at boot, so `store::get()` (and every `people_*` tool /
+/// controller) always failed with "people store not initialised". Boot now
+/// calls `init_from_workspace`; verify it seeds the global, creates the on-disk
+/// db, and is idempotent.
+#[tokio::test]
+async fn init_from_workspace_seeds_global_store() {
+    use crate::openhuman::people::store;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let store = store::init_from_workspace(tmp.path()).await.unwrap();
+    assert!(
+        tmp.path().join("people").join("people.db").exists(),
+        "boot seed must create <workspace>/people/people.db"
+    );
+
+    // The previously-dead global is now reachable — this is the fix.
+    let via_global = store::get().expect("people store reachable after boot seed");
+    assert!(Arc::ptr_eq(&store, &via_global));
+
+    // Idempotent: a second seed returns the same instance, never errors.
+    let again = store::init_from_workspace(tmp.path()).await.unwrap();
+    assert!(Arc::ptr_eq(&store, &again));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Seed the process-global people store at core boot — it was **never initialised in production**, so every `people_*` tool and people RPC failed with "people store not initialised".
- Add `people::store::init_from_workspace(workspace_dir)` (idempotent), wired into `core/jsonrpc.rs` boot alongside `memory::global` and `whatsapp_data::global`.
- Fixes Sentry **TAURI-RUST-8NM** (404 events / 20 users, ongoing since 2026-06-02).

## Problem

The people store is a process-global `OnceCell<Arc<PeopleStore>>` (`src/openhuman/people/store.rs`). `store::get()` errors with "people store not initialised — core startup hasn't completed" when the global is empty. Nothing ever seeded it: `people::store::init` had **zero callers** tree-wide (the module README documented the gap). Core boot seeds `memory::global` and `whatsapp_data::global` but omitted people, so:

- `PeopleListTool` (registered `src/openhuman/tools/ops.rs`) and every people controller (`src/core/all.rs`) always failed.
- Telemetry tags confirm: `tool=people_list`, `operation=execute`, `iteration=1`, `outcome=failed`.

This is **not a startup race** — startup completes fine; the global is simply never seeded. The 404 events / 20 users sustained over four weeks match a permanently-dead init path (the tool is invoked situationally, so not all users hit it). The "core startup hasn't completed" wording is misleading.

## Solution

- `people/store.rs`: add `init_from_workspace(&Path)` that opens `<workspace>/people/people.db` (schema migrations run on open) and seeds `GLOBAL`. Idempotent — a second or concurrent call returns the existing store instead of erroring.
- `core/jsonrpc.rs`: call it inside the `Ok(cfg)` boot arm, after `whatsapp_data::global::init`. Placed inside that arm deliberately so it inherits the existing wrong-workspace guard (never seeds against a `Config::default()` fallback — OPENHUMAN-CORE-48).
- `people/README.md`: replace the stale "no init call found" note with the actual boot-seeding path.
- Regression test: `init_from_workspace` seeds the global, creates the on-disk db, and is idempotent.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) — `init_from_workspace_seeds_global_store` covers seed + on-disk db + idempotency; the prior failure mode (empty global → `get()` error) is the regression target.
- [x] **Diff coverage ≥ 80%** — confirmed by CI: `Rust Core Coverage (cargo-llvm-cov)` passed on this PR. `store.rs` helper fully covered by the new test; the `core/jsonrpc.rs` boot-glue arm is the only thin uncovered surface and the merged changed-line gate still clears 80%.
- [x] Coverage matrix updated — `N/A: bug fix, no feature row added/removed/renamed`.
- [x] All affected feature IDs listed under `## Related` — `N/A: no matrix feature IDs touched`.
- [x] No new external network dependencies introduced — local SQLite only.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface changed`.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- Desktop/CLI core: people domain (contact ranking, handle resolution, interaction logging) becomes functional for the first time in production; previously every people tool/RPC errored.
- Additive only — seeds a previously-dead global. No behaviour change for any path that was not already failing. First boot creates `<workspace>/people/people.db` and runs idempotent migrations.
- No security/migration/compatibility risk; no new dependencies.

## Related

- Closes: #4344
- Sentry-Issue: TAURI-RUST-8NM
- Follow-up PR(s)/TODOs: optional — migrate the people `OnceCell` to `RwLock<Option<Arc<…>>>` for test-swap parity with `whatsapp_data::global` (not required for this fix).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/8nm-people-store-init`
- Commit SHA: `b6ae88fd2dd04d55e125c1dd4b2462caa03ced54`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend (`app/`) changes.
- [x] `pnpm typecheck` — N/A: no TypeScript changes.
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --lib openhuman::people` → 48 passed, 0 failed.
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `GGML_NATIVE=OFF cargo check` clean (only pre-existing slack_backfill warnings).
- [x] Tauri fmt/check (if changed): N/A: no `app/src-tauri` changes (root core crate only).

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: people store is seeded at boot; people tools/RPCs work.
- User-visible effect: agent `people_list` and related people features return data instead of erroring.

### Parity Contract

- Legacy behavior preserved: yes — only the previously-erroring (never-seeded) path changes; seeding sits inside the existing `Ok(cfg)` guard so the wrong-workspace protection is preserved.
- Guard/fallback/dispatch parity checks: mirrors `memory::global` / `whatsapp_data::global` boot-seed placement and idempotency.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none (searched open + 30d-merged; no people-store-init PR in flight).
- Canonical PR: this PR.
- Resolution: N/A
