### PR TITLE
ci(coverage): raise RUST_MIN_STACK so llvm-cov coverage runs don't stack-overflow

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -336,7 +336,11 @@ jobs:
     needs: [changes, rust-quality]
     if: always() && needs.changes.outputs['rust-core'] == 'true' && needs['rust-quality'].result == 'success'
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    # 30 min was only ever enough because a stack overflow aborted the run early
+    # (see RUST_MIN_STACK below). With the overflow fixed the job runs the full
+    # instrumented suite (~13.6k tests, single-threaded build) end-to-end, which
+    # needs more wall-time.
+    timeout-minutes: 50
     container:
       image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
     env:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -349,6 +349,13 @@ jobs:
       # the maximum-shrink setting; line-tables-only was still too large for the
       # instrumented build.
       CARGO_PROFILE_DEV_DEBUG: "0"
+      # cargo-llvm-cov instrumentation inflates per-frame stack usage, so deep
+      # async tests (e.g. cron::scheduler agent-job tests that drive the full
+      # harness) overflow the default ~2 MB test-thread stack and SIGABRT the
+      # whole run with "stack overflow". Give libtest's per-test threads a large
+      # stack so coverage runs don't abort. (Virtual reservation only — no real
+      # memory cost.)
+      RUST_MIN_STACK: "67108864"
     steps:
       - name: Free disk space
         run: |
@@ -425,6 +432,9 @@ jobs:
       # __llvm_covmap/__llvm_covfun sections, NOT from DWARF, so coverage
       # numbers are unaffected. Mirrors rust-core-coverage.
       CARGO_PROFILE_DEV_DEBUG: "0"
+      # Large test-thread stack so coverage instrumentation's inflated frames
+      # don't overflow deep async tests. Mirrors rust-core-coverage.
+      RUST_MIN_STACK: "67108864"
     steps:
       - name: Free disk space
         run: |


### PR DESCRIPTION
## Summary

The **Rust Core Coverage (cargo-llvm-cov)** lane is currently red on `main` — it SIGABRTs with a **stack overflow**:

```
thread 'openhuman::cron::scheduler::tests::run_agent_job_returns_error_without_provider_key' has overflowed its stack
fatal runtime error: stack overflow, aborting
```

That test (added by #4166) drives the full agent harness. Under `cargo-llvm-cov`, coverage **instrumentation inflates per-frame stack usage**, which blows libtest's default ~2 MB per-test-thread stack and aborts the *entire* coverage run — so the lane fails repo-wide, not just on one PR.

## Fix

Set `RUST_MIN_STACK=67108864` (64 MB) on both the **Rust Core Coverage** and **Rust Tauri Coverage** jobs, so libtest's per-test threads get enough headroom under instrumentation. It's a virtual address reservation only (no real memory cost), and **CI-only — no source or test changes**.

## Why this approach

- The overflow is an artifact of coverage instrumentation, not a real bug in the test or `run_agent_job`, so bumping the stack for the instrumented run is the correct, minimal fix (vs. refactoring the harness or the test).
- Applying it to both coverage jobs prevents the same class of failure on the Tauri shell.

## Test plan
- [x] Workflow YAML validates
CI verification: this PR's Rust Core Coverage lane should no longer stack-overflow (watching this run).

Surfaced while landing the Meetings redesign (#4308); that PR's own lanes were green — this unrelated coverage breakage was blocking the gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated coverage job settings to allow larger thread stack sizes during test coverage runs, helping prevent stack-related failures and improving CI reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
