### PR TITLE
fix(meet): mint unique correlationId per upcoming-meeting join

### DIFF
--- a/app/src/components/meetings/UpcomingTable.tsx
+++ b/app/src/components/meetings/UpcomingTable.tsx
@@ -346,7 +346,20 @@ export function UpcomingTable({
   const handleJoin = async (meeting: UpcomingMeeting) => {
     if (!meeting.meet_url) return;
     const platform = meeting.platform ?? inferPlatformFromUrl(meeting.meet_url) ?? undefined;
-    log('[upcoming] joining %s platform=%s', meeting.calendar_event_id, platform);
+    // Mint a fresh correlation id per join. It becomes the call record's
+    // `request_id` (recent-calls list key + per-call detail filename), so it
+    // MUST be unique per join — reusing the deterministic `calendar_event_id`
+    // collapsed re-joins of the same event onto one request_id, overwriting the
+    // earlier call's transcript and double-highlighting the history row (#4338).
+    // `calendar_event_id` stays the dedup/policy key only (handleJoinPolicyChange,
+    // setJoiningId), mirroring the background auto-join in calendar.rs.
+    const correlationId = crypto.randomUUID();
+    log(
+      '[upcoming] joining %s platform=%s correlationId=%s',
+      meeting.calendar_event_id,
+      platform,
+      correlationId
+    );
     setJoiningId(meeting.calendar_event_id);
     try {
       await joinMeetViaBackendBot({
@@ -356,7 +369,7 @@ export function UpcomingTable({
         systemPrompt: personaDescription || undefined,
         mascotId: mascotId || undefined,
         listenOnly: true,
-        correlationId: meeting.calendar_event_id,
+        correlationId,
         riveColors,
       });
     } catch (err) {

--- a/app/src/components/meetings/__tests__/UpcomingTable.test.tsx
+++ b/app/src/components/meetings/__tests__/UpcomingTable.test.tsx
@@ -205,6 +205,10 @@ describe('UpcomingTable', () => {
     const joinBtn = await screen.findByRole('button', { name: /^join$/i });
     fireEvent.click(joinBtn);
     await waitFor(() => expect(joinMock).toHaveBeenCalledOnce());
+    // handleJoin disables the row via `joiningId` until its `finally` runs;
+    // wait for the button to re-enable before the second click so it isn't
+    // swallowed by the disabled state (timing-dependent otherwise).
+    await waitFor(() => expect((joinBtn as HTMLButtonElement).disabled).toBe(false));
     fireEvent.click(joinBtn);
     await waitFor(() => expect(joinMock).toHaveBeenCalledTimes(2));
 

--- a/app/src/components/meetings/__tests__/UpcomingTable.test.tsx
+++ b/app/src/components/meetings/__tests__/UpcomingTable.test.tsx
@@ -183,12 +183,37 @@ describe('UpcomingTable', () => {
 
     await waitFor(() => expect(joinMock).toHaveBeenCalledOnce());
     expect(joinMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        meetUrl: 'https://meet.google.com/abc-def-ghi',
-        listenOnly: true,
-        correlationId: 'evt-1',
-      })
+      expect.objectContaining({ meetUrl: 'https://meet.google.com/abc-def-ghi', listenOnly: true })
     );
+    // The correlation id MUST be a freshly-minted unique id, NOT the
+    // deterministic calendar_event_id — reusing the event id collapsed
+    // re-joins onto one request_id (#4338).
+    const { correlationId } = joinMock.mock.calls[0][0] as { correlationId: string };
+    expect(correlationId).toBeTruthy();
+    expect(correlationId).not.toBe('evt-1');
+  });
+
+  it('mints a unique correlationId per join so re-joining the same event does not collide (#4338)', async () => {
+    joinMock.mockResolvedValue({
+      meetUrl: 'https://meet.google.com/abc-def-ghi',
+      platform: 'gmeet',
+    });
+    // Same meeting (same calendar_event_id) returned across reloads.
+    listMock.mockResolvedValue([makeMeeting()]);
+    renderWithProviders(<UpcomingTable />);
+
+    const joinBtn = await screen.findByRole('button', { name: /^join$/i });
+    fireEvent.click(joinBtn);
+    await waitFor(() => expect(joinMock).toHaveBeenCalledOnce());
+    fireEvent.click(joinBtn);
+    await waitFor(() => expect(joinMock).toHaveBeenCalledTimes(2));
+
+    const first = (joinMock.mock.calls[0][0] as { correlationId: string }).correlationId;
+    const second = (joinMock.mock.calls[1][0] as { correlationId: string }).correlationId;
+    expect(first).not.toBe('evt-1');
+    expect(second).not.toBe('evt-1');
+    // Two joins of the same calendar event must yield distinct correlation ids.
+    expect(first).not.toBe(second);
   });
 
   it('does not show a join button for meetings without a conferencing URL', async () => {


### PR DESCRIPTION
## Summary

The Upcoming-meetings **Join** button passed the deterministic `calendar_event_id` (`<event_id>_<start>`, or `<meet_url>@<start_ms>` for id-less events) as the join `correlationId`. That `correlationId` is echoed back at call-end (`BackendMeetTranscript`) and copied **verbatim into `MeetCallRecord.request_id`** by `recent_calls::build_record` — which is simultaneously:
- the recent-calls list **selection key + React key**, and
- the **per-call detail filename** (`call_details/<id>.json`) that `getMeetCallDetail(request_id)` reads.

So re-joining the **same** calendar meeting produced two call records with an **identical `request_id`**: the history list highlighted both rows together, and the second call's transcript overwrote / was unreachable. Surfaced by the Meetings redesign (#4275 / #4308), but the collision was pre-existing.

`MeetComposer` and the background auto-join (`calendar.rs:404`) already mint a fresh `crypto.randomUUID()` per join — `UpcomingTable` was the lone offender.

## Fix

- `UpcomingTable.handleJoin` now mints a fresh `crypto.randomUUID()` per join and passes that as `correlationId`.
- `calendar_event_id` stays the **dedup / per-event-policy key** (`handleJoinPolicyChange` → `setEventPolicy`) and the local button-disable state (`setJoiningId`) only — never the call identity.
- No backend change: the core correctly uses `correlationId` as the call identity; the bug was a frontend misuse.

## Test plan

- [x] Updated the existing join test: asserts `correlationId` is a fresh id, **not** `calendar_event_id`.
- [x] New regression test: two joins of the **same** calendar event yield **distinct** correlation ids (#4338).
- [x] `UpcomingTable.test.tsx` — 23/23 pass; full `meetings/` suite — 173/173 pass.
- [x] Typecheck passes
- [x] Lint passes (0 errors)
- [x] Format passes

Closes #4338

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meeting join handling so each join attempt uses a unique request identifier, reducing duplicate-request issues and preventing history/transcript mix-ups when rejoining.
  * Added clearer join logging to help track individual meeting joins more reliably.

* **Tests**
  * Expanded automated coverage to verify each join attempt gets a fresh identifier, including repeated joins for the same meeting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->