### PR TITLE
feat(meet): wire auto_summarize_policy into post-call summary (#4305)

### DIFF
--- a/src/openhuman/agent_meetings/bus.rs
+++ b/src/openhuman/agent_meetings/bus.rs
@@ -10,8 +10,13 @@ use std::sync::OnceLock;
 use async_trait::async_trait;
 
 use crate::core::event_bus::{DomainEvent, EventHandler, SubscriptionHandle};
+use crate::openhuman::notifications::bus::publish_core_notification;
+use crate::openhuman::notifications::types::{
+    CoreNotificationAction, CoreNotificationCategory, CoreNotificationEvent,
+};
 
 use super::ops::{create_meeting_thread_with_transcript, ingest_backend_meeting_transcript};
+use super::summary::{summary_action, SummaryAction};
 
 static MEETING_EVENT_HANDLE: OnceLock<SubscriptionHandle> = OnceLock::new();
 
@@ -61,6 +66,18 @@ impl EventHandler for MeetingEventSubscriber {
                     "{LOG_PREFIX} transcript received — creating meeting thread"
                 );
 
+                // Load config once so both the summary-policy gate below and the
+                // memory-ingest gate further down read a single snapshot. On a
+                // config load failure we fall back to the default policy (Ask),
+                // which never auto-summarises — safer than the old unconditional
+                // behaviour.
+                let config = crate::openhuman::config::Config::load_or_init().await.ok();
+                let policy = config
+                    .as_ref()
+                    .map(|c| c.meet.auto_summarize_policy)
+                    .unwrap_or_default();
+                let action = summary_action(policy);
+
                 // 1. Record a lean recent-calls entry (meet id, duration, owner,
                 //    participants) first — before any LLM work — so the row is on
                 //    disk by the time the panel refetches at call-end. Returns the
@@ -78,21 +95,37 @@ impl EventHandler for MeetingEventSubscriber {
                 //    detail file wouldn't exist until summarisation returned, so a
                 //    row expanded right after call-end showed "nothing captured"
                 //    even though the transcript was already in hand. The summary is
-                //    patched in by step 4 once it's ready.
+                //    patched in by step 4 once it's ready. This transcript-only
+                //    detail is also what keeps the recent-call panel working under
+                //    the Never/Ask policies (no summary, transcript intact).
                 super::recent_calls::record_backend_call_detail(&request_id, turns, None).await;
 
-                // 3. Generate the post-call summary once. Shared by the call-detail
-                //    store (step 4) and the meeting thread (step 5) so the
-                //    summarisation LLM call isn't paid for twice.
-                let generated = super::summary::generate_meeting_summary_bounded(
-                    turns,
-                    correlation_id.as_deref(),
-                )
-                .await;
+                // 3. Generate the post-call summary — but only when the user's
+                //    auto_summarize_policy says to (Always). Under Ask/Never we
+                //    skip the LLM call entirely; the Ask card below lets the user
+                //    opt in afterwards. When generated, this single summary is
+                //    shared by the call-detail store (step 4) and the meeting
+                //    thread (step 5) so it isn't paid for twice.
+                let generated = match action {
+                    SummaryAction::Generate => {
+                        super::summary::generate_meeting_summary_bounded(
+                            turns,
+                            correlation_id.as_deref(),
+                        )
+                        .await
+                    }
+                    SummaryAction::Ask | SummaryAction::Skip => {
+                        tracing::debug!(
+                            ?policy,
+                            "{LOG_PREFIX} auto-summary skipped per auto_summarize_policy"
+                        );
+                        None
+                    }
+                };
 
                 // 4. Upgrade the stored detail with the summary once it's ready.
-                //    Skipped when summarisation failed/timed out — the transcript
-                //    written in step 2 stands on its own.
+                //    Skipped when summarisation was gated off or failed/timed out —
+                //    the transcript written in step 2 stands on its own.
                 if generated.is_some() {
                     super::recent_calls::record_backend_call_detail(
                         &request_id,
@@ -103,21 +136,42 @@ impl EventHandler for MeetingEventSubscriber {
                 }
 
                 // 5. Create the meeting thread with transcript, reusing the
-                //    summary generated in step 3.
+                //    summary generated in step 3 (when any). Self-generation is
+                //    disabled here because the policy decision was already made
+                //    above — under Ask/Never the thread carries the transcript
+                //    alone.
                 if let Err(e) = create_meeting_thread_with_transcript(
                     turns,
                     *duration_ms,
                     correlation_id.clone(),
                     generated.as_ref(),
+                    false,
                 )
                 .await
                 {
                     tracing::warn!("{LOG_PREFIX} meeting thread creation failed: {e}");
                 }
 
+                // 6. Under the Ask policy, surface an approval card so the user
+                //    can opt into a summary after the call. Confirming routes
+                //    back through agent_meetings_notification_action → the
+                //    on-demand summary path, keyed by the recorded call id.
+                if matches!(action, SummaryAction::Ask) {
+                    let now_ms = chrono::Utc::now().timestamp_millis().max(0) as u64;
+                    let delivered = publish_core_notification(build_summary_ask_notification(
+                        &request_id,
+                        now_ms,
+                    ));
+                    tracing::info!(
+                        request_id = %request_id,
+                        delivered,
+                        "{LOG_PREFIX} posted post-call summary Ask card"
+                    );
+                }
+
                 // Also ingest into memory tree (existing pipeline).
-                let enabled = crate::openhuman::config::Config::load_or_init()
-                    .await
+                let enabled = config
+                    .as_ref()
                     .map(|c| c.meet.ingest_backend_transcripts)
                     .unwrap_or(false);
                 if enabled {
@@ -240,6 +294,32 @@ impl EventHandler for MeetingEventSubscriber {
     }
 }
 
+/// Build the "Meeting ended — summarise?" approval card shown when the user's
+/// `auto_summarize_policy` is `Ask`. Confirming routes back through
+/// `agent_meetings_notification_action` with `action_id = "summarize"` and the
+/// recorded call's id (`payload.meetingId`), which drives the on-demand summary
+/// path. Pure over its inputs so the card shape is unit-testable.
+fn build_summary_ask_notification(request_id: &str, now_ms: u64) -> CoreNotificationEvent {
+    let payload = serde_json::json!({ "meetingId": request_id });
+    let action = |action_id: &str, label: &str| CoreNotificationAction {
+        action_id: action_id.to_string(),
+        label: label.to_string(),
+        payload: Some(payload.clone()),
+    };
+    CoreNotificationEvent {
+        id: format!("meet-summary-ask:{request_id}"),
+        category: CoreNotificationCategory::Meetings,
+        title: "Meeting ended".to_string(),
+        body: "Want me to summarise this call?".to_string(),
+        deep_link: None,
+        timestamp_ms: now_ms,
+        actions: Some(vec![
+            action("summarize", "Summarise"),
+            action("dismiss", "No thanks"),
+        ]),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -254,5 +334,28 @@ mod tests {
     fn subscriber_domains_filter_to_agent_meetings() {
         let subscriber = MeetingEventSubscriber;
         assert_eq!(subscriber.domains(), Some(&["agent_meetings"][..]));
+    }
+
+    #[test]
+    fn summary_ask_notification_carries_summarize_and_dismiss_actions() {
+        let n = build_summary_ask_notification("call-7", 1_234);
+        assert_eq!(n.id, "meet-summary-ask:call-7");
+        assert_eq!(n.category, CoreNotificationCategory::Meetings);
+        assert_eq!(n.timestamp_ms, 1_234);
+
+        let actions = n.actions.expect("actions present");
+        let ids: Vec<&str> = actions.iter().map(|a| a.action_id.as_str()).collect();
+        assert_eq!(ids, vec!["summarize", "dismiss"]);
+
+        // Both buttons carry the recorded call id so the action handler can find
+        // the transcript to summarise.
+        for a in &actions {
+            let meeting_id = a
+                .payload
+                .as_ref()
+                .and_then(|p| p.get("meetingId"))
+                .and_then(|v| v.as_str());
+            assert_eq!(meeting_id, Some("call-7"));
+        }
     }
 }

--- a/src/openhuman/agent_meetings/ops.rs
+++ b/src/openhuman/agent_meetings/ops.rs
@@ -218,9 +218,22 @@ pub async fn ingest_backend_meeting_transcript(
     );
 
     // Create a meeting thread with the transcript for the thread system. This
-    // path has no pre-generated summary, so the thread generates its own.
-    if let Err(e) =
-        create_meeting_thread_with_transcript(&turns, duration_ms, correlation_id, None).await
+    // path has no pre-generated summary, so the thread self-generates one —
+    // but only when the user's policy permits an automatic summary, so the
+    // memory-ingest path honours `auto_summarize_policy` just like the
+    // primary call-end pipeline.
+    let allow_self_summarize = matches!(
+        super::summary::summary_action(config.meet.auto_summarize_policy),
+        super::summary::SummaryAction::Generate
+    );
+    if let Err(e) = create_meeting_thread_with_transcript(
+        &turns,
+        duration_ms,
+        correlation_id,
+        None,
+        allow_self_summarize,
+    )
+    .await
     {
         tracing::warn!("[agent_meetings] meeting thread creation failed: {e}");
     }
@@ -235,14 +248,23 @@ pub async fn ingest_backend_meeting_transcript(
 /// a new thread.
 /// `generated` lets the caller pass a summary it already produced so the
 /// call-end pipeline can share one generation across the recent-call detail
-/// store and this thread. When `None`, the summary is generated here (bounded)
-/// — preserving the behaviour of callers that don't pre-generate.
+/// store and this thread.
+///
+/// `allow_self_summarize` gates the fallback self-generation when `generated`
+/// is `None`: it must be `true` only when the user's `auto_summarize_policy`
+/// permits an automatic summary (`Always`). Under `Ask`/`Never` callers pass
+/// `false`, so the thread is created with the transcript alone and no summary
+/// LLM call is made — this is what makes the (previously dead) policy honest.
+///
+/// Returns the id of the created meeting thread so callers (e.g. the on-demand
+/// summarise RPC) can hand it back to the UI.
 pub async fn create_meeting_thread_with_transcript(
     turns: &[BackendMeetTurn],
     duration_ms: u64,
     correlation_id: Option<String>,
     generated: Option<&super::summary::GeneratedSummary>,
-) -> Result<(), String> {
+    allow_self_summarize: bool,
+) -> Result<String, String> {
     use crate::openhuman::memory::{
         AppendConversationMessageRequest, ConversationMessageRecord,
         CreateConversationThreadRequest, UpdateConversationThreadTitleRequest,
@@ -250,14 +272,19 @@ pub async fn create_meeting_thread_with_transcript(
     use crate::openhuman::threads::ops;
 
     if turns.is_empty() {
-        return Ok(());
+        return Ok(String::new());
     }
 
     // Format the transcript body first — this is the durable artifact and must
     // not depend on (or wait on) the summarisation LLM call.
     let mut body = String::new();
+    // Duration is unknown on the on-demand re-summarise path (the transcript is
+    // re-read from persisted detail, which doesn't carry it) — omit the line
+    // rather than print a misleading "Duration: 0 min".
     let duration_min = duration_ms / 60_000;
-    body.push_str(&format!("Duration: {duration_min} min\n\n"));
+    if duration_ms > 0 {
+        body.push_str(&format!("Duration: {duration_min} min\n\n"));
+    }
     if let Some(cid) = &correlation_id {
         body.push_str(&format!("Correlation ID: {cid}\n\n"));
     }
@@ -319,10 +346,11 @@ pub async fn create_meeting_thread_with_transcript(
 
     // 3. Best-effort enrichment: reuse a summary the caller already generated
     //    (the call-end pipeline shares one across the recent-call detail store
-    //    and this thread); otherwise generate one here, bounded so a slow/flaky
-    //    provider can never dominate the path. Any failure or timeout leaves the
-    //    plain-transcript thread untouched.
-    let owned_generated = if generated.is_none() {
+    //    and this thread); otherwise generate one here — but only when the
+    //    user's policy permits an automatic summary (`allow_self_summarize`).
+    //    Bounded so a slow/flaky provider can never dominate the path; any
+    //    failure/timeout leaves the plain-transcript thread untouched.
+    let owned_generated = if generated.is_none() && allow_self_summarize {
         super::summary::generate_meeting_summary_bounded(turns, correlation_id.as_deref()).await
     } else {
         None
@@ -376,7 +404,92 @@ pub async fn create_meeting_thread_with_transcript(
         summarized = generated.is_some(),
         "[agent_meetings] meeting thread created"
     );
-    Ok(())
+    Ok(thread_id)
+}
+
+/// Reconstruct summariser-shaped turns from a persisted call detail. The stored
+/// role is already normalised to "assistant"/"participant"; the summariser only
+/// distinguishes assistant vs. everything-else, so this round-trips faithfully.
+fn detail_to_turns(
+    detail: &crate::openhuman::meet_agent::store::MeetCallDetail,
+) -> Vec<BackendMeetTurn> {
+    detail
+        .transcript
+        .iter()
+        .map(|line| BackendMeetTurn {
+            role: line.role.clone(),
+            content: line.content.clone(),
+        })
+        .collect()
+}
+
+/// Generate a post-call summary on demand for a previously-recorded call,
+/// identified by its `meeting_id` (which equals the recent-call `request_id`
+/// and the join correlation id). Re-reads the persisted transcript, summarises
+/// it, patches the stored call detail so the recent-calls panel shows the
+/// summary, and posts it into a fresh meeting thread. Returns the thread id.
+///
+/// Used by both the manual `agent_meetings_generate_summary` RPC and the
+/// "Ask" approval card's confirm action, so a user who chose Ask/Never can
+/// still summarise a specific call without it happening automatically.
+pub async fn generate_summary_on_demand(meeting_id: &str) -> Result<String, String> {
+    let meeting_id = meeting_id.trim();
+    if meeting_id.is_empty() {
+        return Err("[agent_meetings] meeting_id is required".to_string());
+    }
+
+    let detail = crate::openhuman::meet_agent::store::read_detail(meeting_id)
+        .await?
+        .ok_or_else(|| format!("[agent_meetings] no recorded call for meeting_id={meeting_id}"))?;
+
+    let turns = detail_to_turns(&detail);
+    if turns.is_empty() {
+        return Err(format!(
+            "[agent_meetings] call {meeting_id} has no transcript to summarise"
+        ));
+    }
+
+    let generated = super::summary::generate_meeting_summary_bounded(&turns, Some(meeting_id))
+        .await
+        .ok_or_else(|| "[agent_meetings] summary generation failed".to_string())?;
+
+    // Patch the persisted detail so the recent-call panel surfaces the summary.
+    super::recent_calls::record_backend_call_detail(meeting_id, &turns, Some(&generated)).await;
+
+    // Post the summary into a fresh meeting thread (duration is unknown on this
+    // path → omitted from the body) and hand the id back to the caller. The
+    // summary is already in hand, so self-generation is disabled.
+    let thread_id = create_meeting_thread_with_transcript(
+        &turns,
+        0,
+        Some(meeting_id.to_string()),
+        Some(&generated),
+        false,
+    )
+    .await?;
+
+    tracing::info!(
+        meeting_id = %meeting_id,
+        thread_id = %thread_id,
+        "[agent_meetings] on-demand summary generated"
+    );
+    Ok(thread_id)
+}
+
+/// Handle `openhuman.agent_meetings_generate_summary` — generate + post a
+/// summary for a recorded call on demand. Returns `{ ok, thread_id }`.
+pub async fn handle_generate_summary(params: Map<String, Value>) -> Result<Value, String> {
+    let meeting_id = params
+        .get("meeting_id")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "[agent_meetings] meeting_id is required".to_string())?
+        .to_string();
+
+    let thread_id = generate_summary_on_demand(&meeting_id).await?;
+    let outcome = RpcOutcome::new(json!({ "ok": true, "thread_id": thread_id }), vec![]);
+    outcome.into_cli_compatible_json()
 }
 
 // ---------------------------------------------------------------------------
@@ -914,6 +1027,21 @@ pub async fn handle_notification_action(params: Map<String, Value>) -> Result<Va
             );
 
             handle_join(join).await
+        }
+        // Post-call summary "Ask" card (auto_summarize_policy = Ask). The card
+        // carries the recorded call's id as payload.meetingId.
+        "summarize" => {
+            let meeting_id = meeting_id
+                .ok_or_else(|| "[agent_meetings] payload.meetingId is required".to_string())?;
+            let thread_id = generate_summary_on_demand(&meeting_id).await?;
+            let outcome = RpcOutcome::new(json!({ "ok": true, "thread_id": thread_id }), vec![]);
+            outcome.into_cli_compatible_json()
+        }
+        "dismiss" => {
+            // User declined the summary — nothing to do; the plain transcript
+            // thread/detail already stand on their own.
+            let outcome = RpcOutcome::new(json!({ "ok": true }), vec![]);
+            outcome.into_cli_compatible_json()
         }
         other => Err(format!("[agent_meetings] unknown action_id: {other}")),
     }
@@ -1746,5 +1874,163 @@ mod tests {
             resolve_effective_join_policy(Some("evt-zoom-2"), Some("zoom"), &config),
             "auto"
         );
+    }
+
+    // ── post-call summary: on-demand generation (#4305) ─────────
+
+    struct ScriptedSummaryProvider {
+        reply: String,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::openhuman::inference::provider::Provider for ScriptedSummaryProvider {
+        async fn chat_with_system(
+            &self,
+            _system_prompt: Option<&str>,
+            _message: &str,
+            _model: &str,
+            _temperature: f64,
+        ) -> anyhow::Result<String> {
+            Ok(self.reply.clone())
+        }
+    }
+
+    /// Scoped `OPENHUMAN_WORKSPACE` override so store reads/writes land in a temp
+    /// dir. Restores the previous value on drop.
+    struct WorkspaceEnvGuard {
+        old: Option<std::ffi::OsString>,
+    }
+
+    impl WorkspaceEnvGuard {
+        fn set(path: &std::path::Path) -> Self {
+            let old = std::env::var_os("OPENHUMAN_WORKSPACE");
+            std::env::set_var("OPENHUMAN_WORKSPACE", path.as_os_str());
+            Self { old }
+        }
+    }
+
+    impl Drop for WorkspaceEnvGuard {
+        fn drop(&mut self) {
+            match &self.old {
+                Some(v) => std::env::set_var("OPENHUMAN_WORKSPACE", v),
+                None => std::env::remove_var("OPENHUMAN_WORKSPACE"),
+            }
+        }
+    }
+
+    #[test]
+    fn detail_to_turns_round_trips_transcript_lines() {
+        use crate::openhuman::meet_agent::store::{MeetCallDetail, MeetCallTranscriptLine};
+        let detail = MeetCallDetail {
+            request_id: "c1".into(),
+            summary: None,
+            transcript: vec![
+                MeetCallTranscriptLine {
+                    role: "participant".into(),
+                    content: "[00:01] [Sam] hi".into(),
+                },
+                MeetCallTranscriptLine {
+                    role: "assistant".into(),
+                    content: "[00:02] [Tiny] hello".into(),
+                },
+            ],
+        };
+        let turns = detail_to_turns(&detail);
+        assert_eq!(turns.len(), 2);
+        assert_eq!(turns[0].role, "participant");
+        assert_eq!(turns[0].content, "[00:01] [Sam] hi");
+        assert_eq!(turns[1].role, "assistant");
+    }
+
+    #[tokio::test]
+    async fn generate_summary_on_demand_rejects_blank_meeting_id() {
+        let err = generate_summary_on_demand("   ").await.unwrap_err();
+        assert!(err.contains("meeting_id is required"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn handle_generate_summary_requires_meeting_id() {
+        let err = handle_generate_summary(Map::new()).await.unwrap_err();
+        assert!(err.contains("meeting_id is required"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn notification_action_dismiss_is_ok() {
+        let mut params = Map::new();
+        params.insert("action_id".to_string(), json!("dismiss"));
+        let out = handle_notification_action(params)
+            .await
+            .expect("dismiss should succeed");
+        assert!(out.to_string().contains("\"ok\":true"), "got: {out}");
+    }
+
+    #[tokio::test]
+    async fn notification_action_summarize_requires_meeting_id() {
+        let mut params = Map::new();
+        params.insert("action_id".to_string(), json!("summarize"));
+        // No payload.meetingId → the handler can't find a call to summarise.
+        let err = handle_notification_action(params).await.unwrap_err();
+        assert!(err.contains("meetingId"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn generate_summary_on_demand_reads_detail_then_summarises() {
+        use crate::openhuman::meet_agent::store::{self, MeetCallDetail, MeetCallTranscriptLine};
+
+        // Serialise against other env-mutating tests, then point the store at a
+        // throwaway workspace.
+        let _env_lock = crate::openhuman::config::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let workspace = tempfile::tempdir().expect("workspace");
+        let _guard = WorkspaceEnvGuard::set(workspace.path());
+
+        // Nothing recorded yet → a clear, actionable error.
+        let err = generate_summary_on_demand("missing-call")
+            .await
+            .unwrap_err();
+        assert!(err.contains("no recorded call"), "got: {err}");
+
+        // Persist a transcript-only detail — exactly the state a call ends in
+        // under the Ask/Never policies.
+        let detail = MeetCallDetail {
+            request_id: "call-1".into(),
+            summary: None,
+            transcript: vec![
+                MeetCallTranscriptLine {
+                    role: "participant".into(),
+                    content: "[00:01] [Sam] let's ship Friday".into(),
+                },
+                MeetCallTranscriptLine {
+                    role: "assistant".into(),
+                    content: "[00:02] [Tiny] noted".into(),
+                },
+            ],
+        };
+        store::write_detail(&detail).await.expect("write detail");
+
+        // Scripted provider keeps summarisation network-free.
+        let reply = "{\"label\":\"Ship Plan\",\"headline\":\"Agreed to ship Friday.\",\
+            \"key_points\":[\"Ship Friday\"],\"action_items\":[]}";
+        let _provider =
+            crate::openhuman::inference::provider::factory::test_provider_override::install(
+                std::sync::Arc::new(ScriptedSummaryProvider {
+                    reply: reply.to_string(),
+                }),
+            );
+
+        let thread_id = generate_summary_on_demand("call-1")
+            .await
+            .expect("summary generated on demand");
+        assert!(!thread_id.is_empty(), "a meeting thread id is returned");
+
+        // The persisted detail is patched with the generated summary so the
+        // recent-call panel can surface it.
+        let patched = store::read_detail("call-1")
+            .await
+            .expect("read detail")
+            .expect("detail present");
+        let summary = patched.summary.expect("summary patched in");
+        assert_eq!(summary.headline, "Agreed to ship Friday.");
     }
 }

--- a/src/openhuman/agent_meetings/schemas.rs
+++ b/src/openhuman/agent_meetings/schemas.rs
@@ -42,6 +42,11 @@ const DEFS: &[BackendMeetControllerDef] = &[
         handler: handle_notification_action_wrap,
     },
     BackendMeetControllerDef {
+        function: "generate_summary",
+        schema: schema_generate_summary,
+        handler: handle_generate_summary_wrap,
+    },
+    BackendMeetControllerDef {
         function: "list_upcoming",
         schema: schema_list_upcoming,
         handler: handle_list_upcoming_wrap,
@@ -294,6 +299,43 @@ fn handle_notification_action_wrap(params: Map<String, Value>) -> ControllerFutu
     Box::pin(async move { super::ops::handle_notification_action(params).await })
 }
 
+fn schema_generate_summary() -> ControllerSchema {
+    ControllerSchema {
+        namespace: "agent_meetings",
+        function: "generate_summary",
+        description: "Generate and post a post-call summary on demand for a previously-recorded \
+                      meeting, identified by its meeting_id (the recent-call request_id / join \
+                      correlation id). Re-reads the persisted transcript, summarises it, patches \
+                      the recent-call detail, and posts the summary into a new meeting thread. \
+                      Used for manual re-summarising and to back the 'Ask' post-call card when \
+                      auto_summarize_policy is Ask.",
+        inputs: vec![FieldSchema {
+            name: "meeting_id",
+            ty: TypeSchema::String,
+            comment: "The recorded call id (recent-call request_id / join correlation id).",
+            required: true,
+        }],
+        outputs: vec![
+            FieldSchema {
+                name: "ok",
+                ty: TypeSchema::Bool,
+                comment: "True when the summary was generated and posted.",
+                required: true,
+            },
+            FieldSchema {
+                name: "thread_id",
+                ty: TypeSchema::String,
+                comment: "Id of the meeting thread the summary was posted into.",
+                required: true,
+            },
+        ],
+    }
+}
+
+fn handle_generate_summary_wrap(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move { super::ops::handle_generate_summary(params).await })
+}
+
 fn schema_list_upcoming() -> ControllerSchema {
     ControllerSchema {
         // NOTE: namespace is "meet" (not "agent_meetings") so the RPC name is
@@ -435,6 +477,7 @@ mod tests {
                 "harness_response",
                 "speak",
                 "notification_action",
+                "generate_summary",
                 "list_upcoming",
                 "set_event_policy",
                 "get_event_policies",

--- a/src/openhuman/agent_meetings/summary.rs
+++ b/src/openhuman/agent_meetings/summary.rs
@@ -14,12 +14,38 @@
 use serde::Deserialize;
 
 use crate::core::event_bus::BackendMeetTurn;
+use crate::openhuman::config::schema::AutoSummarizePolicy;
 use crate::openhuman::config::Config;
 use crate::openhuman::inference::provider::create_chat_provider;
 
 use super::types::{ActionItem, ActionItemKind, MeetingSummary};
 
 const LOG_PREFIX: &str = "[agent_meetings::summary]";
+
+/// What the call-end pipeline should do about the post-call summary, derived
+/// from the user's `auto_summarize_policy`. Centralising the mapping keeps the
+/// (previously dead) setting honest: `bus.rs` switches on this instead of
+/// summarising unconditionally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SummaryAction {
+    /// Generate + post the summary automatically (policy `Always`).
+    Generate,
+    /// Don't auto-generate; surface an approval card so the user can opt in
+    /// after the call ends (policy `Ask`).
+    Ask,
+    /// Don't generate anything — the plain transcript thread/detail stand on
+    /// their own (policy `Never`).
+    Skip,
+}
+
+/// Map the persisted [`AutoSummarizePolicy`] to the call-end [`SummaryAction`].
+pub fn summary_action(policy: AutoSummarizePolicy) -> SummaryAction {
+    match policy {
+        AutoSummarizePolicy::Always => SummaryAction::Generate,
+        AutoSummarizePolicy::Ask => SummaryAction::Ask,
+        AutoSummarizePolicy::Never => SummaryAction::Skip,
+    }
+}
 
 /// Cap on the transcript size (in **bytes**, matching `str::len`) fed to the
 /// model so a marathon call doesn't blow the context window. The tail is kept
@@ -339,6 +365,21 @@ mod tests {
             role: role.to_string(),
             content: content.to_string(),
         }
+    }
+
+    #[test]
+    fn summary_action_maps_every_policy() {
+        // The whole point of the issue: each policy drives a distinct action so
+        // Ask/Always/Never stop being a dead toggle.
+        assert_eq!(
+            summary_action(AutoSummarizePolicy::Always),
+            SummaryAction::Generate
+        );
+        assert_eq!(summary_action(AutoSummarizePolicy::Ask), SummaryAction::Ask);
+        assert_eq!(
+            summary_action(AutoSummarizePolicy::Never),
+            SummaryAction::Skip
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The **Post-call summary** setting (Ask / Always / Never) round-tripped through config but was never consulted — every meeting was summarized unconditionally (`bus.rs` called `generate_meeting_summary_bounded` with no policy check). This wires `auto_summarize_policy` into the post-call summary flow so the toggle actually behaves, and adds the manual-trigger RPC + "Ask" approval card specced in #3510.

Scope: **core** (`src/openhuman/agent_meetings/`). No frontend changes needed — the existing `CoreNotificationCard` already routes notification action buttons to `agent_meetings_notification_action` and falls back to the server-sent label for new action ids.

## Changes

- **`summary.rs`** — `summary_action(policy) -> {Generate, Ask, Skip}` centralises the policy → behaviour mapping.
- **`bus.rs`** (call-end pipeline) — gate the shared summary generation on the policy:
  - **Always** → generate + post (unchanged).
  - **Ask** → skip auto-gen; publish a "Meeting ended — want me to summarise?" `CoreNotification` card (`summarize` / `dismiss` actions carrying `payload.meetingId`).
  - **Never** → skip generation.
  - The transcript thread **and** the recent-call detail are still written under Ask/Never, so the call-detail panel never breaks (summary is `Option`, already tolerated by the UI).
- **`ops.rs`** — `generate_summary_on_demand(meeting_id)`: re-reads the persisted call detail, summarises, patches the detail, posts a meeting thread, returns the thread id. Reused by the Ask card's `summarize` action **and** the new manual RPC. `create_meeting_thread_with_transcript` now gates self-generation behind a flag, returns the `thread_id`, and omits the duration line when unknown (0).
- **`schemas.rs`** — register `openhuman.agent_meetings_generate_summary { meeting_id } -> { ok, thread_id }`.

## Acceptance criteria

- [x] **Never** — no automatic summary (policy → `Skip`; thread self-gen disabled).
- [x] **Ask** — posts an approval card; summary generated only on confirm.
- [x] **Always** — unchanged auto-generate behavior.
- [x] **Manual RPC** — `agent_meetings_generate_summary { meeting_id }` generates + posts and returns the thread id.
- [x] **No broken detail** — recent-call detail still written (transcript) under Never.
- [x] **Tests** — all three policy branches + on-demand happy path + manual RPC + notification action arms.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check`
- [x] `cargo test --lib agent_meetings` (183 passed)

Closes #4305