### PR TITLE
fix(memory): classify cloud embedding auth absence

### DIFF
--- a/src/openhuman/memory_queue/handlers/mod.rs
+++ b/src/openhuman/memory_queue/handlers/mod.rs
@@ -738,7 +738,9 @@ fn try_mark_summary_reembed_skipped(
 /// Failure semantics are preserved verbatim from #1574 §6:
 /// - body read failure → log + persistent tombstone (`"body read failed: {e}"`)
 /// - embed wrong dim → log + tombstone (`"embed wrong dim"`)
-/// - embed error → log + tombstone (`"embed failed: {e}"`)
+/// - per-row unrecoverable embed error → log + tombstone (`"embed failed: {e}"`)
+/// - global cloud-auth absence → fail the backfill without tombstoning rows, so
+///   signing in later can re-embed the same signature.
 ///
 /// The single difference vs the old code is the embed call shape: one
 /// `embed_batch` (which collapses N provider round-trips into one for batch-
@@ -809,6 +811,19 @@ async fn reembed_collect(
             }
             Err(e) => {
                 let failure = crate::openhuman::memory_tree::health::classify_embed_error(&e);
+                if matches!(
+                    failure.code,
+                    crate::openhuman::memory_tree::health::FailureCode::AuthMissing
+                ) {
+                    log::warn!(
+                        "[memory::jobs] reembed_backfill: {label} {id} embed failed with \
+                         global auth-missing error; failing backfill without tombstone \
+                         so rows stay re-embeddable (sig={active_sig}): {e:#}"
+                    );
+                    return Err(anyhow::Error::new(failure).context(format!(
+                        "reembed_backfill: {label} {id} cloud auth missing (sig={active_sig}): {e:#}"
+                    )));
+                }
                 if !failure.is_unrecoverable() {
                     return Err(anyhow::Error::new(failure).context(format!(
                         "reembed_backfill: {label} {id} transient embed failed (sig={active_sig}): {e:#}"
@@ -910,14 +925,18 @@ async fn handle_reembed_backfill(config: &Config, job: &Job) -> Result<JobOutcom
     // errors are skipped (logged) so a single bad row can't strand memory.
     //
     // #1574 §6 fix: terminal failures (body file missing on disk, embed
-    // wrong dim, embed unrecoverable error) are *persistently* tombstoned
-    // via `mark_chunk_reembed_skipped` / `mark_summary_reembed_skipped`.
+    // wrong dim, per-row unrecoverable embed error) are *persistently*
+    // tombstoned via `mark_chunk_reembed_skipped` /
+    // `mark_summary_reembed_skipped`.
     // The worklist queries above exclude these tombstones, so a single
     // unembeddable row is attempted at most ONCE per signature instead of
     // re-selected on every batch forever (the original bug: 16 orphans
     // generating ~128k warns across ~8k defers, observed in the wild).
     // Tombstone writes are best-effort: failures are logged so the row can
     // be retried on a later batch instead of spinning forever.
+    // Global cloud-auth absence is not row-specific and returns a typed
+    // `AuthMissing` failure without tombstoning, preserving the fail-fast
+    // banner while leaving rows re-embeddable after sign-in.
     // #002 (FR-002): use the WRITE-path factory. Re-embed is a write path, so a
     // missing/unusable provider must SKIP rather than fall back to an
     // `InertEmbedder` whose all-zero vectors would pass `pack_checked` and get

--- a/src/openhuman/memory_queue/handlers/mod_tests.rs
+++ b/src/openhuman/memory_queue/handlers/mod_tests.rs
@@ -8,6 +8,10 @@ use crate::openhuman::memory_tree::tree::bucket_seal::{append_leaf_deferred, Lea
 use crate::openhuman::memory_tree::tree::store as src_store;
 use chrono::TimeZone;
 use rusqlite::params;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
 use tempfile::TempDir;
 
 fn test_config() -> (TempDir, Config) {
@@ -429,6 +433,57 @@ async fn reembed_backfill_tombstones_orphan_and_terminates() {
     assert!(
         !probe_uncovered,
         "after tombstoning the only orphan, the ensure_reembed_backfill probe must report covered"
+    );
+}
+
+struct MissingSessionEmbedder;
+
+#[async_trait::async_trait]
+impl crate::openhuman::memory_tree::score::embed::Embedder for MissingSessionEmbedder {
+    fn name(&self) -> &'static str {
+        "missing-session"
+    }
+
+    async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+        anyhow::bail!(
+            "No backend session for cloud embeddings: log in to OpenHuman, or set \
+             memory.embedding_provider to \"ollama\" / \"none\" in config.toml"
+        )
+    }
+}
+
+#[tokio::test]
+async fn reembed_backfill_auth_missing_fails_without_tombstone() {
+    use crate::openhuman::memory_tree::health::{FailureCode, PipelineFailure};
+
+    let (_tmp, cfg) = test_config();
+    let ids = vec!["chunk-auth-missing".to_string()];
+    let skipped = Arc::new(AtomicUsize::new(0));
+    let skipped_for_mark = Arc::clone(&skipped);
+
+    let err = reembed_collect(
+        &cfg,
+        &MissingSessionEmbedder,
+        "provider=cloud;model=embedding-v1;dims=1024",
+        &ids,
+        "chunk",
+        |_cfg, id| Ok(format!("body for {id}")),
+        move |_cfg, _id, _sig, _reason| {
+            skipped_for_mark.fetch_add(1, Ordering::SeqCst);
+        },
+    )
+    .await
+    .expect_err("missing cloud auth should fail the backfill without tombstoning rows");
+
+    let failure = err
+        .downcast_ref::<PipelineFailure>()
+        .expect("auth-missing backfill error should carry typed PipelineFailure");
+    assert_eq!(failure.code, FailureCode::AuthMissing);
+    assert!(failure.is_unrecoverable());
+    assert_eq!(
+        skipped.load(Ordering::SeqCst),
+        0,
+        "global missing-session failures must leave rows re-embeddable"
     );
 }
 

--- a/src/openhuman/memory_tree/health/mod.rs
+++ b/src/openhuman/memory_tree/health/mod.rs
@@ -242,6 +242,15 @@ pub fn classify_embed_error_str(msg: &str) -> PipelineFailure {
             .with_detail(truncate_detail(msg));
     }
 
+    // Cloud embeddings require the desktop/backend session bearer before any
+    // provider round-trip. Without this explicit match, a logged-out app is
+    // treated like a retryable transport error and the worker keeps retrying
+    // instead of surfacing the login remediation.
+    if lower.contains("no backend session") {
+        log::debug!("[memory_tree] classified cloud embedding auth state as auth_missing");
+        return PipelineFailure::new(FailureCode::AuthMissing).with_detail(truncate_detail(msg));
+    }
+
     // Dimension mismatch — the trait validator / CloudEmbedder rejects a
     // vector whose length isn't EMBEDDING_DIM. Check before status parsing:
     // it's a 2xx-but-wrong-shape case with no HTTP status to match.
@@ -674,6 +683,18 @@ mod tests {
             assert_eq!(f.code, FailureCode::AuthInvalid, "status {status}");
             assert!(f.is_unrecoverable());
         }
+    }
+
+    #[test]
+    fn classify_cloud_backend_session_missing_as_auth_missing() {
+        let f = classify_embed_error_str(
+            "No backend session for cloud embeddings: log in to OpenHuman, or set \
+             memory.embedding_provider to \"ollama\" / \"none\" in config.toml",
+        );
+        assert_eq!(f.code, FailureCode::AuthMissing);
+        assert_eq!(f.class, FailureClass::Unrecoverable);
+        assert_eq!(f.remediation_key, "memory.health.remediation.auth_missing");
+        assert!(f.is_unrecoverable());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Classifies cloud embedding "No backend session" failures as `auth_missing` instead of `transient`.
- Keeps the failure unrecoverable so the memory queue can fail fast instead of retrying a logged-out state.
- Adds a regression test covering the exact cloud embedding session-missing message and remediation key.
- Adds a debug log for this auth-state classification path without logging secrets.

## Problem

- Cloud embeddings fail before any provider request when no OpenHuman backend session bearer is available.
- The existing embedding error classifier did not recognize `No backend session`, so it fell through to `FailureCode::Transient`.
- That made Memory Tree surface retry-oriented state instead of the login remediation, and workers could keep retrying a non-recoverable auth absence.

## Solution

- Match `no backend session` in `classify_embed_error_str` before HTTP status and budget parsing.
- Return `PipelineFailure::new(FailureCode::AuthMissing)` with the existing truncated detail, preserving the current failure wire shape.
- Cover the path with a unit test asserting `AuthMissing`, `Unrecoverable`, and `memory.health.remediation.auth_missing`.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines are covered by the new focused Rust regression test; CI cargo-llvm-cov will enforce the gate.
- [x] Coverage matrix updated — N/A: behavior-only classifier fix, no feature row added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no coverage-matrix feature ID applies.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: Rust classifier-only fix.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime impact: Rust core memory/embedding health classification only.
- User-visible effect: logged-out cloud embedding failures now surface auth/login remediation and fail fast instead of retry wording.
- No migration, config, or external dependency changes.

## Related

- Fixes #4359
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/GH-4359-cloud-embedding-auth-missing`
- Commit SHA: `73740e2791243440f893fd8da510cd0dc629e4e9`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: frontend not touched.
- [x] `pnpm typecheck` — N/A: frontend not touched.
- [x] Focused tests:
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib classify_transport_error_is_transient -- --nocapture`
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib classify_cloud_backend_session_missing_as_auth_missing -- --nocapture` (RED before fix, GREEN after fix)
  - `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml --lib classify_ -- --nocapture`
- [x] Rust fmt/check (if changed):
  - `cargo fmt --all -- --check`
  - `git diff --check`
  - `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml`
- [x] Tauri fmt/check (if changed): N/A: Tauri not touched.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: cloud embedding auth absence is classified as `auth_missing` and unrecoverable.
- User-visible effect: Memory Tree can show login remediation instead of retry-only transient state.

### Parity Contract

- Legacy behavior preserved: existing HTTP status, budget/quota, dimension mismatch, empty-input refusal, and transport-error classifications are unchanged.
- Guard/fallback/dispatch parity checks: `classify_` filtered Rust tests cover existing classifier branches alongside the new auth-missing case.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for scenarios where cloud login/session is missing, now clearly classified as an authentication failure.
  * Updated the failure details to be shorter and more actionable.
  * Added regression test coverage to ensure the backfill fails fast in this case and does not trigger tombstoning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->