### PR TITLE
fix(memory): classify 'No backend session' embed error as AuthMissing

### DIFF
--- a/src/openhuman/memory_tree/health/mod.rs
+++ b/src/openhuman/memory_tree/health/mod.rs
@@ -262,6 +262,21 @@ pub fn classify_embed_error_str(msg: &str) -> PipelineFailure {
             .with_detail(truncate_detail(msg));
     }
 
+    // OpenHumanCloudEmbedding::resolve_bearer() bails *before any HTTP call*
+    // when there is no backend session (user not logged in), with the
+    // literal phrase "No backend session for cloud embeddings" (see
+    // src/openhuman/embeddings/cloud.rs). Like the #13021 pre-flight guard
+    // above, this carries no `Embedding API error (<status>)` shape, so
+    // without an explicit match it falls through to `Transient` — the
+    // Memory Tree then shows "temporary error… will retry automatically"
+    // and the worker retries an unrecoverable auth failure forever instead
+    // of surfacing the existing AuthMissing → "log in to OpenHuman"
+    // remediation. Fixes #4359.
+    if lower.contains("no backend session") {
+        return PipelineFailure::new(FailureCode::AuthMissing)
+            .with_detail(truncate_detail(msg));
+    }
+
     // Parse the HTTP status out of the `Embedding API error (<status>): ...`
     // shape. reqwest renders e.g. `402 Payment Required`, so the first
     // 3-digit run after the opening paren is the code.
@@ -720,6 +735,49 @@ mod tests {
             .context("reembed_backfill chunk_id=c");
         let f = classify_embed_error(&wrapped);
         assert_eq!(f.code, FailureCode::EmptyInputRefused);
+        assert!(f.is_unrecoverable());
+    }
+
+    /// Issue #4359: `OpenHumanCloudEmbedding::resolve_bearer()` bails with
+    /// "No backend session for cloud embeddings: log in to OpenHuman, or
+    /// set memory.embedding_provider to ..." *before any HTTP call* when
+    /// the user isn't logged in. This must classify as `AuthMissing`
+    /// (unrecoverable, prompts "log in to OpenHuman") rather than falling
+    /// through to `Transient` ("will retry automatically" — which loops
+    /// forever on an auth failure retrying can never fix).
+    #[test]
+    fn classify_no_backend_session_as_auth_missing() {
+        let msg = "No backend session for cloud embeddings: log in to OpenHuman, or set \
+                    memory.embedding_provider to \"ollama\" / \"none\" in config.toml";
+        let f = classify_embed_error_str(msg);
+        assert_eq!(
+            f.code,
+            FailureCode::AuthMissing,
+            "expected AuthMissing for {msg:?}"
+        );
+        assert!(
+            f.is_unrecoverable(),
+            "AuthMissing must be unrecoverable so the worker stops retrying \
+             and the Memory Tree prompts login instead of showing \
+             'temporary error… will retry automatically'"
+        );
+    }
+
+    /// The match must be case-insensitive and survive anyhow context
+    /// wrapping, matching the same pattern as the #13021 empty-input test
+    /// above — resolve_bearer's bail gets `.context()`-wrapped by callers
+    /// on the way up through the embed pipeline.
+    #[test]
+    fn classify_no_backend_session_through_anyhow_context_chain() {
+        let base = anyhow::anyhow!(
+            "No backend session for cloud embeddings: log in to OpenHuman, or set \
+             memory.embedding_provider to \"ollama\" / \"none\" in config.toml"
+        );
+        let wrapped = base
+            .context("embed summary during seal tree_id=t level=0")
+            .context("reembed_backfill chunk_id=c");
+        let f = classify_embed_error(&wrapped);
+        assert_eq!(f.code, FailureCode::AuthMissing);
         assert!(f.is_unrecoverable());
     }
 

--- a/src/openhuman/memory_tree/health/mod.rs
+++ b/src/openhuman/memory_tree/health/mod.rs
@@ -273,8 +273,7 @@ pub fn classify_embed_error_str(msg: &str) -> PipelineFailure {
     // of surfacing the existing AuthMissing → "log in to OpenHuman"
     // remediation. Fixes #4359.
     if lower.contains("no backend session") {
-        return PipelineFailure::new(FailureCode::AuthMissing)
-            .with_detail(truncate_detail(msg));
+        return PipelineFailure::new(FailureCode::AuthMissing).with_detail(truncate_detail(msg));
     }
 
     // Parse the HTTP status out of the `Embedding API error (<status>): ...`


### PR DESCRIPTION
## Problem

`classify_embed_error_str()` does not recognize the cloud embedder's "No backend session for cloud embeddings" bail, so it falls through to the default `FailureCode::Transient`. The Memory Tree then shows "A temporary error… will retry automatically" and the worker keeps retrying an unrecoverable auth failure, even though an `AuthMissing` → "log in to OpenHuman" classification already exists for exactly this case.

`OpenHumanCloudEmbedding::resolve_bearer()` (`src/openhuman/embeddings/cloud.rs:89-92`) bails with this message **before any HTTP call** when the user isn't logged in:

```
No backend session for cloud embeddings: log in to OpenHuman, or set
memory.embedding_provider to "ollama" / "none" in config.toml
```

Like the existing #13021 pre-flight-guard case just above it in the same function, this message carries no `Embedding API error (<status>)` shape, so it falls through every status-parsing branch straight to `Transient`.

Fixes #4359.

## Fix

One new early-return branch, placed after the budget/quota check and before HTTP-status parsing (same position pattern as the existing #13021 `EmptyInputRefused` branch): match `"no backend session"` case-insensitively and classify as `FailureCode::AuthMissing`.

## Tests

Two new unit tests following the exact pattern of the adjacent #13021 `EmptyInputRefused` tests:
- `classify_no_backend_session_as_auth_missing` — direct string match
- `classify_no_backend_session_through_anyhow_context_chain` — survives `.context()` wrapping, matching how `resolve_bearer`'s bail actually flows up through the embed pipeline in production

## ⚠️ Honest disclosure on verification

I don't have a Rust toolchain available in my environment (rustup install is blocked by network egress rules, no cargo/rustc present), so **I was not able to run `cargo test` for this change.**

What I did verify instead:
- Reproduced the exact string-matching logic (`lower.contains("no backend session")` against the literal bail message) in Python, confirming both the pre-fix fallthrough to `Transient` and the post-fix match to `AuthMissing`, with no keyword collision against the earlier budget/quota/dims/refusing-empty branches for this message.
- The new branch's structure (`if lower.contains(...) { return PipelineFailure::new(...).with_detail(truncate_detail(msg)); }`) is byte-for-byte the same pattern as the three existing branches immediately above it, which already compile and pass in this codebase.
- The two new tests mirror `classify_empty_input_refusal_as_unrecoverable` / `classify_empty_input_refusal_through_anyhow_context_chain` in the same file line-for-line in structure, substituting only the message string and expected `FailureCode`.

Given the size and pattern-matching nature of this change I'm reasonably confident it's correct, but **please let CI/a maintainer confirm the compile and test pass** rather than take my word for it — I'd rather flag this limitation upfront than claim a test result I couldn't actually produce.

## Files changed

```
src/openhuman/memory_tree/health/mod.rs — 1 file, +58 lines (1 fix branch + 2 tests + doc comments)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud embedding error classification for the “no backend session” message using an early, case-insensitive match.
  * Authentication-related errors are now reported as unrecoverable (instead of transient).
* **Tests**
  * Added regression tests to verify correct mapping for both direct error strings and errors wrapped with additional context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->