### PR TITLE
fix(tinyagents): keep attempted tool name in the timeline for unavailable tools

### DIFF
--- a/src/openhuman/tinyagents/observability.rs
+++ b/src/openhuman/tinyagents/observability.rs
@@ -259,7 +259,19 @@ impl EventListener for OpenhumanEventBridge {
             // exactly once per model call; prefer it over `ModelCompleted`'s
             // optional usage to avoid double counting.
             AgentEvent::UsageRecorded { usage } => self.record_usage(usage),
-            AgentEvent::ToolStarted { call_id, tool_name } => {
+            AgentEvent::ToolStarted { call_id, tool_name }
+                if tool_name.as_str() != super::tools::UNKNOWN_TOOL_SENTINEL =>
+            {
+                // Skip the sentinel Started event. When the model calls a tool the
+                // agent can't see, `UnknownToolRewriteMiddleware` rewrites the name
+                // to `UNKNOWN_TOOL_SENTINEL` *before* this event fires. The frontend
+                // keys tool-timeline rows by `call_id` and overwrites the name on
+                // Started, so a real streamed `web_fetch` row would be clobbered to
+                // the sentinel — dropping the attempted tool name from the timeline
+                // (regression vs. the pre-tinyagents engine, which emitted the real
+                // name before the availability block). The streamed
+                // `tool_args_delta` row (carrying the attempted name) survives, and
+                // the sentinel `ToolCompleted` only updates status by `call_id`.
                 let iteration = self.iteration();
                 match &self.scope {
                     None => self.send(AgentProgress::ToolCallStarted {
@@ -359,6 +371,40 @@ mod tests {
 
         let (input, output, _) = bridge.totals();
         assert_eq!((input, output), (100, 40));
+    }
+
+    #[tokio::test]
+    async fn sentinel_tool_started_is_not_forwarded() {
+        // #4249 regression guard: a `ToolStarted` for the unknown-tool sentinel
+        // must NOT emit a `ToolCallStarted`. The frontend keys tool-timeline rows
+        // by `call_id` and overwrites the name on Started, so forwarding the
+        // sentinel would clobber the real streamed row (e.g. `web_fetch`) and drop
+        // the attempted tool from the UI timeline. A real tool name still forwards.
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let bridge = OpenhumanEventBridge::new(Some(tx), "mock-model", 10);
+        let sink = EventSink::new();
+        sink.subscribe(bridge.clone());
+
+        sink.emit(AgentEvent::ToolStarted {
+            call_id: "c1".into(),
+            tool_name: crate::openhuman::tinyagents::tools::UNKNOWN_TOOL_SENTINEL.to_string(),
+        });
+        sink.emit(AgentEvent::ToolStarted {
+            call_id: "c2".into(),
+            tool_name: "web_fetch".to_string(),
+        });
+
+        let mut started_names = Vec::new();
+        while let Ok(p) = rx.try_recv() {
+            if let AgentProgress::ToolCallStarted { tool_name, .. } = p {
+                started_names.push(tool_name);
+            }
+        }
+        assert_eq!(
+            started_names,
+            vec!["web_fetch".to_string()],
+            "sentinel Started must be skipped; the real tool name must still forward"
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes a **repo-wide Playwright regression**: the chat tool-call specs (`chat-tool-call-flow`, `chat-multi-tool-round`) fail on every open PR because the tool timeline drops the *attempted* tool name for a tool the agent can't see.

## Problem

The tinyagents harness (#4249) now routes every chat turn. When the model calls a tool that isn't in the agent's visible set — e.g. `web_fetch`, `web_search_tool`, `file_read`, which the E2E specs deliberately force via the mock — `UnknownToolRewriteMiddleware` rewrites the call name to `UNKNOWN_TOOL_SENTINEL` (`__openhuman_unknown_tool__`) *before* the progress event fires.

The observability bridge then emitted `AgentProgress::ToolCallStarted { tool_name: sentinel }` with the **same `call_id`**. The frontend keys tool-timeline rows by `call_id` and overwrites the name on Started (`ChatRuntimeProvider.tsx`), so the real streamed `web_fetch` row was clobbered to the sentinel. `toolTimelineNames(...).some(n => n.includes('web_fetch'))` then returns `false`, and the specs time out after 20s.

The pre-tinyagents engine emitted the real tool name *before* the availability block, so the timeline showed the attempted tool even for a blocked call — hence green before #4249. This now fails on **#4388, #4389, #4390, and #4393**, confirming it's a `main` regression, not any single PR.

## Fix

Skip forwarding the sentinel `ToolStarted` in the observability bridge (`src/openhuman/tinyagents/observability.rs`) via a match guard. The streamed `tool_args_delta` row keeps the attempted tool name, and the sentinel `ToolCompleted` only updates status by `call_id` — so the timeline once again shows the tool the model attempted, matching the pre-#4249 behaviour. No test is weakened.

## Tests

- New `sentinel_tool_started_is_not_forwarded` unit test: a sentinel `ToolStarted` emits **no** `ToolCallStarted`, while a real tool name still forwards.
- Restores the Playwright `chat-tool-call-flow` / `chat-multi-tool-round` specs (validated in CI's web lane).

## Submission Checklist

- [x] Tests added or updated (happy path + failure/edge case) — unit test above + the restored Playwright specs.
- [x] **Diff coverage ≥ 80%** — the changed lines (the guard) are exercised by the new unit test.
- [x] Coverage matrix updated — N/A: behaviour-only observability fix, no feature row changed.
- [x] All affected feature IDs listed under `## Related` — N/A: no coverage-matrix feature ID applies.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A.
- [x] Linked issue closed via `Closes #NNN` — N/A: regression fix for #4249; no separate tracking issue.

## Impact

- Runtime impact: agent tool-timeline UI on the tinyagents path. No behaviour change for tools the agent *can* see.
- Unblocks the `E2E (Playwright / web lane)` check across all open PRs.
- No persistence, migration, security, or network changes.

## Related

- Regression introduced by #4249 (tinyagents state-machine harness).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented placeholder tool-start events from appearing in the activity timeline, so only real tool calls are shown.
  * Improved event handling to avoid overwriting or clobbering visible progress updates.
* **Tests**
  * Added regression coverage to ensure placeholder tool events are ignored while valid tool names still appear correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->