### PR TITLE
fix(tauri): deepen Windows CEF GPU fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,8 +133,10 @@ OPENHUMAN_SHELL_HIDE_WINDOW=
 # [optional] Desktop CEF startup escape hatch. Set to 1/true/yes/on only when
 # CEF fails before the app can render, for example on a GPU/driver stack where
 # startup logs show `cef::initialize returned 0`. Adds --disable-gpu and
-# --disable-gpu-compositing to the embedded CEF runtime. Leave unset otherwise;
-# this disables GPU acceleration and can break WebGL-heavy surfaces.
+# --disable-gpu-compositing to the embedded CEF runtime; on Windows it also
+# adds --disable-gpu-sandbox and --use-gl=disabled for stricter driver/runtime
+# fallback. Leave unset otherwise; this disables GPU acceleration and can break
+# WebGL-heavy surfaces.
 # OPENHUMAN_DISABLE_GPU=
 
 # ---------------------------------------------------------------------------

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -2022,16 +2022,25 @@ fn append_platform_cef_gpu_workarounds(
 ) {
     let disable_gpu = cef_disable_gpu_enabled(disable_gpu_override);
 
-    // Issue #4294: on some Windows CEF/GPU stacks, cef::initialize can fail
-    // before the app renders any UI, and user-supplied process argv switches
-    // do not reach the vendored CEF runtime. Provide a narrow, release-safe
-    // env escape hatch instead of forwarding arbitrary Chromium flags.
+    // Issues #4294/#4385: on some Windows CEF/GPU stacks, cef::initialize can
+    // fail before the app renders any UI, and user-supplied process argv
+    // switches do not reach the vendored CEF runtime. Provide a narrow,
+    // release-safe env escape hatch instead of forwarding arbitrary Chromium
+    // flags.
     if disable_gpu {
         args.push(("--disable-gpu", None));
         args.push(("--disable-gpu-compositing", None));
-        log::info!(
-            "[cef-startup] OPENHUMAN_DISABLE_GPU set: adding --disable-gpu and --disable-gpu-compositing for CEF startup compatibility (issue #4294)"
-        );
+        if os == "windows" {
+            args.push(("--disable-gpu-sandbox", None));
+            args.push(("--use-gl", Some("disabled")));
+            log::info!(
+                "[cef-startup] OPENHUMAN_DISABLE_GPU set: adding --disable-gpu, --disable-gpu-compositing, --disable-gpu-sandbox, and --use-gl=disabled for Windows CEF startup compatibility (issues #4294/#4385)"
+            );
+        } else {
+            log::info!(
+                "[cef-startup] OPENHUMAN_DISABLE_GPU set: adding --disable-gpu and --disable-gpu-compositing for CEF startup compatibility (issue #4294)"
+            );
+        }
     }
 
     // Issue #1697: on Arch/Manjaro-family Linux systems, the AppImage can

--- a/app/src-tauri/src/lib_tests.rs
+++ b/app/src-tauri/src/lib_tests.rs
@@ -458,6 +458,22 @@ fn platform_cef_gpu_workarounds_disable_windows_gpu_when_requested() {
 
     assert_eq!(
         args,
+        vec![
+            ("--disable-gpu", None),
+            ("--disable-gpu-compositing", None),
+            ("--disable-gpu-sandbox", None),
+            ("--use-gl", Some("disabled")),
+        ]
+    );
+}
+
+#[test]
+fn platform_cef_gpu_workarounds_disable_non_windows_gpu_without_windows_flags() {
+    let mut args = Vec::new();
+    append_platform_cef_gpu_workarounds(&mut args, "macos", "aarch64", None, Some("1"));
+
+    assert_eq!(
+        args,
         vec![("--disable-gpu", None), ("--disable-gpu-compositing", None)]
     );
 }
@@ -469,6 +485,14 @@ fn platform_cef_gpu_workarounds_disable_gpu_wins_over_linux_force_gpu() {
 
     assert!(args.contains(&("--disable-gpu", None)));
     assert!(args.contains(&("--disable-gpu-compositing", None)));
+    assert!(
+        !args.contains(&("--disable-gpu-sandbox", None)),
+        "OPENHUMAN_DISABLE_GPU=1 must not disable the GPU sandbox outside Windows, got: {args:?}"
+    );
+    assert!(
+        !args.contains(&("--use-gl", Some("disabled"))),
+        "OPENHUMAN_DISABLE_GPU=1 must not force use-gl=disabled outside Windows, got: {args:?}"
+    );
     assert!(
         !args.contains(&("--use-angle", Some("swiftshader"))),
         "OPENHUMAN_DISABLE_GPU=1 must not also force SwiftShader, got: {args:?}"

--- a/gitbooks/developing/cef.md
+++ b/gitbooks/developing/cef.md
@@ -121,8 +121,11 @@ an OS/runtime compatibility regression in CEF startup.
 If the logs point to a GPU-process startup failure rather than a stale CEF
 profile lock, set `OPENHUMAN_DISABLE_GPU=1` before launching OpenHuman. This
 passes `--disable-gpu` and `--disable-gpu-compositing` to the embedded CEF
-runtime without forwarding arbitrary Chromium flags. Leave it unset for normal
-use because disabling the GPU path can break WebGL-heavy surfaces.
+runtime without forwarding arbitrary Chromium flags. On Windows, the same
+opt-in path also passes `--disable-gpu-sandbox` and `--use-gl=disabled` for
+stricter driver/runtime fallback when the basic GPU-disable path is still not
+enough. Leave it unset for normal use because disabling the GPU path can break
+WebGL-heavy surfaces.
 
 ## Linux shell fallback for CEF startup crashes
 


### PR DESCRIPTION
## Summary

- Extends the explicit Windows `OPENHUMAN_DISABLE_GPU=1` CEF fallback with `--disable-gpu-sandbox` and `--use-gl=disabled`.
- Preserves the existing default launch path and the existing non-Windows disable-GPU behavior.
- Updates Rust coverage and CEF fallback docs so the documented env-var escape hatch matches the runtime flags.

## Problem

- #4385 reports `cef::initialize returned 0` on Windows 11 with RTX 5080 + Ryzen 9950X3D even though `OPENHUMAN_DISABLE_GPU=1` is active.
- The existing fallback disables GPU/compositing, but Windows CEF can still touch GPU sandbox/GL startup paths early enough to fail before the UI renders.

## Solution

- Keep the existing `--disable-gpu` and `--disable-gpu-compositing` switches whenever `OPENHUMAN_DISABLE_GPU=1` is set.
- On Windows only, append `--disable-gpu-sandbox` and `--use-gl=disabled` before CEF startup.
- Add tests for Windows and non-Windows flag parity, and update the CEF troubleshooting docs.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] N/A: Diff coverage >= 80% - focused Rust unit coverage was added for the changed startup-flag behavior; CI remains the source of truth for merged diff coverage.
- [x] N/A: Coverage matrix updated - no feature row was added/removed/renamed; this changes a CEF startup fallback path.
- [x] N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related` - no matrix feature ID applies.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: Manual smoke checklist updated if this touches release-cut surfaces - no release smoke checklist changes; Windows hardware validation is requested in the PR notes.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Desktop/Tauri startup only; default launches are unchanged.
- Windows users who explicitly set `OPENHUMAN_DISABLE_GPU=1` get a stricter CEF GPU fallback for driver stacks that still fail with the original two switches.
- Non-Windows `OPENHUMAN_DISABLE_GPU=1` behavior remains limited to `--disable-gpu` and `--disable-gpu-compositing`.
- Local validation cannot reproduce the reporter's RTX 5080 Windows environment, so reporter or maintainer validation is still requested before merge.

## Related

- Closes #4385
- Follow-up PR(s)/TODOs: Ask the reporter to test a build from this branch on the RTX 5080 + Ryzen 9950X3D Windows stack before merge.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `codex/4385-cef-disable-gpu-sandbox`
- Commit SHA: `f419b10d1`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` - passed in the repository pre-push hook.
- [x] N/A: `pnpm typecheck` - TypeScript was not changed; frontend lint ran in the pre-push hook instead.
- [x] Focused tests: `cargo test --manifest-path app/src-tauri/Cargo.toml platform_cef_gpu_workarounds --lib` - 8 passed, 0 failed.
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path app/src-tauri/Cargo.toml --all`; `cargo fmt --manifest-path app/src-tauri/Cargo.toml --all --check`; app Rust check completed in the pre-push hook with existing warnings only.
- [x] Tauri fmt/check (if changed): `cargo fmt --manifest-path app/src-tauri/Cargo.toml --all --check`; `git diff --check`; pre-push Tauri/Rust check completed with existing warnings only.

### Validation Blocked

- `command:` `node scripts/codex-pr-preflight.mjs --strict-path --lightweight`
- `error:` strict path expects `/workspace/openhuman`; this desktop checkout is `/Users/samirusani/Desktop/Codex/Contribution/AgenticFlow/openhuman`. The initial branch-name warning was resolved by creating `codex/4385-cef-disable-gpu-sandbox`.
- `impact:` Required docs/files passed; this does not block code validation. The remaining validation gap is hardware-specific Windows/RTX 5080 reproduction.

### Behavior Changes

- Intended behavior change: `OPENHUMAN_DISABLE_GPU=1` on Windows now passes `--disable-gpu`, `--disable-gpu-compositing`, `--disable-gpu-sandbox`, and `--use-gl=disabled` to CEF.
- User-visible effect: Users affected by #4385 get a deeper opt-in fallback path when CEF fails before the UI renders.

### Parity Contract

- Legacy behavior preserved: default startup is unchanged; non-Windows disable-GPU behavior remains the original two-switch fallback.
- Guard/fallback/dispatch parity checks: unit tests cover unset env, falsey env, non-Windows disable path, Windows disable path, and Windows force-enable precedence.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None found in live GitHub PR search for `#4385`, `OPENHUMAN_DISABLE_GPU`, `cef::initialize`, or `disable-gpu` before opening this PR.
- Canonical PR: this PR.
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU-disable behavior on Windows so the app can start more reliably when GPU acceleration is turned off.
  * Non-Windows platforms keep the existing GPU-disable behavior without adding Windows-only startup changes.

* **Documentation**
  * Updated guidance for the GPU-disable startup option to reflect the latest supported behavior on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->