### PR TITLE
fix(orchestration): repair TinyAgents-migration build break (main does not compile)

### DIFF
--- a/src/openhuman/agent_registry/agents/loader.rs
+++ b/src/openhuman/agent_registry/agents/loader.rs
@@ -291,13 +291,13 @@ pub const BUILTINS: &[BuiltinAgent] = &[
         id: "frontend_agent",
         toml: include_str!("../../orchestration/frontend_agent/agent.toml"),
         prompt_fn: crate::openhuman::orchestration::frontend_agent::prompt::build,
-        graph_fn: crate::openhuman::orchestration::frontend_agent::graph::graph,
+        graph_fn: Some(crate::openhuman::orchestration::frontend_agent::graph::graph),
     },
     BuiltinAgent {
         id: "reasoning_agent",
         toml: include_str!("../../orchestration/reasoning_agent/agent.toml"),
         prompt_fn: crate::openhuman::orchestration::reasoning_agent::prompt::build,
-        graph_fn: crate::openhuman::orchestration::reasoning_agent::graph::graph,
+        graph_fn: Some(crate::openhuman::orchestration::reasoning_agent::graph::graph),
     },
 ];
 

--- a/src/openhuman/orchestration/graph/mod.rs
+++ b/src/openhuman/orchestration/graph/mod.rs
@@ -39,7 +39,7 @@ use tinyagents::graph::{
 
 use crate::openhuman::config::Config;
 use crate::openhuman::tinyagents::observability::GraphTracingSink;
-use crate::openhuman::tinyagents::SqlRunLedgerCheckpointer;
+use tinyagents::graph::checkpoint::SqliteCheckpointer;
 
 pub use state::{CompressedEntry, OrchestrationState, WorldDiff, WorldDiffEntry};
 
@@ -381,7 +381,12 @@ pub async fn run_orchestration_graph(
     let threshold = config.orchestration.effective_evict_threshold();
     let thread_id = format!("orchestration:{}", state.session_id);
     let label = thread_id.clone();
-    let checkpointer = Arc::new(SqlRunLedgerCheckpointer::<OrchestrationState>::new(config));
+    let checkpointer = Arc::new(
+        SqliteCheckpointer::<OrchestrationState>::open(
+            config.workspace_dir.join("graph_checkpoints.db"),
+        )
+        .map_err(|e| anyhow::anyhow!("open orchestration graph checkpointer: {e}"))?,
+    );
 
     tracing::debug!(
         target: LOG, session_id = %state.session_id, %thread_id,

--- a/src/openhuman/orchestration/graph/state.rs
+++ b/src/openhuman/orchestration/graph/state.rs
@@ -3,7 +3,7 @@
 //! `OrchestrationState` is the spec's single `StateGraph` state object: one
 //! value flows through the whole wake path (normalize → frontend → execute →
 //! frontend → send_dm → context_guard → END) and is checkpointed at every
-//! super-step boundary by [`SqlRunLedgerCheckpointer`](crate::openhuman::tinyagents::SqlRunLedgerCheckpointer)
+//! super-step boundary by [`SqliteCheckpointer`](tinyagents::graph::checkpoint::SqliteCheckpointer)
 //! under the thread id `orchestration:<session_id>`.
 //!
 //! Every field is serde-serializable so a mid-cycle crash can resume from the

--- a/src/openhuman/orchestration/ops.rs
+++ b/src/openhuman/orchestration/ops.rs
@@ -727,9 +727,9 @@ impl OrchestrationRuntime for ProductionRuntime {
 mod tests {
     use super::*;
     use crate::openhuman::orchestration::types::OrchestrationMessage;
-    use crate::openhuman::tinyagents::SqlRunLedgerCheckpointer;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tinyagents::graph::checkpoint::Checkpointer;
+    use tinyagents::graph::checkpoint::SqliteCheckpointer;
 
     fn test_config(tmp: &tempfile::TempDir) -> Config {
         Config {
@@ -910,7 +910,10 @@ mod tests {
         .unwrap();
 
         // Checkpoints persisted → kill/restart could resume without re-sending.
-        let cp = SqlRunLedgerCheckpointer::<OrchestrationState>::new(config);
+        let cp = SqliteCheckpointer::<OrchestrationState>::open(
+            config.workspace_dir.join("graph_checkpoints.db"),
+        )
+        .expect("open checkpointer");
         let list = cp.list("orchestration:h1").await.expect("list checkpoints");
         assert!(!list.is_empty(), "wake cycle persisted checkpoints");
     }


### PR DESCRIPTION
## Summary

- Repairs the `cargo build` break left on `main` by #4399 (the TinyAgents harness migration): a dangling `SqlRunLedgerCheckpointer` import and a `graph_fn` type mismatch. The core lib currently does not compile.

## Problem

#4399 deleted the `SqlRunLedgerCheckpointer` adapter and made `BuiltinAgent.graph_fn` optional (`Option<fn() -> AgentGraph>`), but left live references behind:

- `orchestration/graph/mod.rs` + `orchestration/ops.rs` still import the removed `SqlRunLedgerCheckpointer` → **E0432**.
- `agent_registry/agents/loader.rs` passes bare `fn` items to the now-`Option` `graph_fn` field → **E0308** (×2).

Net: `main` does not build.

## Solution

- Repoint orchestration graph checkpointing onto the crate's `SqliteCheckpointer` at `{workspace}/graph_checkpoints.db` — the direction #4399 intended (it enabled `features = ["sqlite"]` and pinned the toolchain precisely for this).
- Wrap the two `graph_fn` call sites in `Some(...)`.
- Fix the stale intra-doc link in `graph/state.rs`.

Minimal, mechanical, behavior-preserving.

## Submission Checklist

- [x] Tests — covered by the existing orchestration regression test `full_cycle_persists_one_dm_one_compressed_one_diff_and_checkpoints` (drives a real wake cycle and asserts checkpoints persist via the crate `SqliteCheckpointer`); passes.
- [x] N/A: Diff coverage — build-fix / mechanical repoint of a deleted type; no new logic.
- [x] N/A: Coverage matrix — no feature rows change.
- [x] N/A: Affected feature IDs — none.
- [x] No new external network dependencies introduced.
- [x] N/A: Manual smoke checklist — build fix, no release-cut surface change.

## Impact

- Runtime/platform: desktop/CLI Rust core. Orchestration durable checkpoints now use the crate `SqliteCheckpointer` (`{workspace}/graph_checkpoints.db`), completing the #4399 migration direction. No frontend change.

## Related

- Follow-up: carved out of #4434 so it can merge fast and unblock CI for the harness PRs that rebase onto `main`.

---

## AI Authored PR Metadata

### Validation Run

- [x] Rust fmt/check: `GGML_NATIVE=OFF cargo check` green (Rust 1.96.1); `cargo fmt` clean.
- [x] N/A: frontend `format:check` / `typecheck` — no frontend changes.
