### PR TITLE
refactor: extract shared relativeTime() helper from Feed/Ledger/Jobs

### DIFF
--- a/app/src/agentworld/pages/BountiesSection.tsx
+++ b/app/src/agentworld/pages/BountiesSection.tsx
@@ -32,6 +32,7 @@ import type { ToastNotification } from '../../types/intelligence';
 import { apiClient } from '../AgentWorldShell';
 import { decimalsForAsset, resolveAssetSymbol } from '../assets';
 import X402ConfirmDialog, { formatUnits } from '../components/X402ConfirmDialog';
+import { relativeTime } from '../utils/relativeTime';
 
 // ── State types ───────────────────────────────────────────────────────────────
 
@@ -39,19 +40,6 @@ type BountiesState =
   | { status: 'loading' }
   | { status: 'error'; message: string }
   | { status: 'ok'; bounties: Bounty[] };
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-function relativeTime(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(ms / 60000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  return `${days}d ago`;
-}
 
 /** Group the integer part of a numeric amount with thousands separators. */
 function formatAmount(amount: string): string {

--- a/app/src/agentworld/pages/FeedSection.tsx
+++ b/app/src/agentworld/pages/FeedSection.tsx
@@ -32,6 +32,7 @@ import {
 import { fetchWalletStatus } from '../../services/walletApi';
 import { apiClient } from '../AgentWorldShell';
 import ConfirmDialog from '../components/ConfirmDialog';
+import { relativeTime } from '../utils/relativeTime';
 
 const log = debug('agentworld:feed');
 
@@ -64,17 +65,6 @@ type WalletConfigured = 'resolving' | 'no' | 'yes' | 'unknown';
 type WalletResolution = { agentId: string | null; configured: WalletConfigured };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function relativeTime(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(ms / 60000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  return `${days}d ago`;
-}
 
 function isWalletLocked(message: string): boolean {
   return (

--- a/app/src/agentworld/pages/JobsSection.tsx
+++ b/app/src/agentworld/pages/JobsSection.tsx
@@ -29,6 +29,7 @@ import { useT } from '../../lib/i18n/I18nContext';
 import { fetchWalletStatus } from '../../services/walletApi';
 import { apiClient } from '../AgentWorldShell';
 import { explorerTxUrl } from '../hooks/useX402Buy';
+import { relativeTime } from '../utils/relativeTime';
 
 // ── State types ───────────────────────────────────────────────────────────────
 
@@ -38,18 +39,6 @@ type JobsState =
   | { status: 'ok'; jobs: GqlJobPosting[] };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-// TODO: extract shared relativeTime helper once Feed/Ledger/Jobs all use it.
-function relativeTime(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(ms / 60000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  return `${days}d ago`;
-}
 
 /**
  * Group the integer part of a numeric amount with thousands separators while

--- a/app/src/agentworld/pages/LedgerSection.tsx
+++ b/app/src/agentworld/pages/LedgerSection.tsx
@@ -17,6 +17,7 @@ import { apiClient } from '../AgentWorldShell';
 import { decimalsForAsset, resolveAssetSymbol } from '../assets';
 import { formatUnits, friendlyNetwork } from '../components/X402ConfirmDialog';
 import { explorerTxUrl } from '../hooks/useX402Buy';
+import { relativeTime } from '../utils/relativeTime';
 
 // ── State types ───────────────────────────────────────────────────────────────
 
@@ -26,17 +27,6 @@ type LedgerState =
   | { status: 'ok'; transactions: GqlLedgerTransaction[] };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function relativeTime(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(ms / 60000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  return `${days}d ago`;
-}
 
 export function abbreviateAddress(addr: string | undefined): string {
   if (!addr) return '—';

--- a/app/src/agentworld/utils/relativeTime.ts
+++ b/app/src/agentworld/utils/relativeTime.ts
@@ -1,0 +1,10 @@
+export function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(ms / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}


### PR DESCRIPTION
Closes #4427

Extracts the duplicated relativeTime() function across three files into a single shared helper at app/src/agentworld/utils/relativeTime.ts.

- New file: app/src/agentworld/utils/relativeTime.ts
- FeedSection.tsx, LedgerSection.tsx, JobsSection.tsx: removed local copies, added import from shared util
- Removed resolved TODO in JobsSection.tsx

Zero runtime behaviour change. Pure refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent human-readable relative time labels across feed, jobs, ledger, and bounties (e.g., “just now”, “5m ago”, “2h ago”, “3d ago”).

* **Bug Fixes**
  * Standardized timestamp display so all sections render relative times using the same formatting rules.

* **Refactor**
  * Consolidated duplicated time-formatting logic into a shared utility to reduce repetition and keep behavior aligned across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->