### PR TITLE
fix(learning): dedup evidence_refs across the full merged list, not just neighbours

### DIFF
--- a/src/openhuman/learning/stability_detector.rs
+++ b/src/openhuman/learning/stability_detector.rs
@@ -31,7 +31,7 @@
 //! rows by stability. Excess Active rows are demoted to Provisional. A cross-class
 //! overflow pool holds up to `BUDGET_OVERFLOW` extra Provisional rows.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::core::event_bus;
 use crate::core::event_bus::DomainEvent;
@@ -262,13 +262,10 @@ impl StabilityDetector {
             let new_refs: Vec<crate::openhuman::learning::candidate::EvidenceRef> =
                 cands.iter().map(|c| c.evidence.clone()).collect();
 
-            let mut all_refs = existing
-                .map(|f| f.evidence_refs.clone())
-                .unwrap_or_default();
-            all_refs.extend(new_refs);
-            // Deduplicate refs by serialised form (cheap for small vecs).
-            all_refs
-                .dedup_by(|a, b| serde_json::to_string(a).ok() == serde_json::to_string(b).ok());
+            let all_refs = merge_evidence_refs(
+                existing.map(|f| f.evidence_refs.as_slice()).unwrap_or(&[]),
+                new_refs,
+            );
 
             // Build cue-families counts from this cycle's candidates.
             let mut cue_counts: HashMap<String, u32> = HashMap::new();
@@ -491,6 +488,27 @@ fn dominant_cue(cands: &[LearningCandidate], _existing: Option<&ProfileFacet>) -
         })
         .map(|c| c.cue_family)
         .unwrap_or(CueFamily::Behavioral)
+}
+
+/// Merge the existing row's evidence refs with this cycle's new refs,
+/// deduplicating while preserving first-seen order.
+///
+/// `Vec::dedup_by` only collapses *consecutive* equal elements, so a ref that
+/// recurs non-adjacently — present in the existing row and re-emitted by a new
+/// candidate, or repeated within one cycle — would slip through and accumulate
+/// without bound across rebuilds. `EvidenceRef: Eq + Hash`, so tracking seen
+/// refs in a set removes every duplicate exactly and cheaply.
+fn merge_evidence_refs(
+    existing_refs: &[candidate::EvidenceRef],
+    new_refs: Vec<candidate::EvidenceRef>,
+) -> Vec<candidate::EvidenceRef> {
+    let mut seen: HashSet<candidate::EvidenceRef> = HashSet::new();
+    existing_refs
+        .iter()
+        .cloned()
+        .chain(new_refs)
+        .filter(|r| seen.insert(r.clone()))
+        .collect()
 }
 
 /// Total evidence count from candidates + existing row.
@@ -880,5 +898,75 @@ mod tests {
             most_recent_reinforcement(&[], None, now, FacetClass::Goal),
             most_recent_reinforcement(&[], None, now, FacetClass::Style),
         );
+    }
+
+    // ── merge_evidence_refs deduplication ─────────────────────────────────────
+
+    #[test]
+    fn merge_evidence_refs_removes_non_consecutive_duplicates() {
+        // The bug this guards: a ref already in the existing row (Episodic 1)
+        // that is re-emitted by a new candidate lands non-adjacent to its twin
+        // once the two lists are concatenated ([1, 2, 1]). `Vec::dedup_by` only
+        // collapses *consecutive* equals, so it would leave the duplicate in and
+        // the refs list would grow every rebuild cycle. The set-based merge must
+        // drop it, keeping the first occurrence and preserving order.
+        let existing = vec![EvidenceRef::Episodic { episodic_id: 1 }];
+        let new = vec![
+            EvidenceRef::Episodic { episodic_id: 2 },
+            EvidenceRef::Episodic { episodic_id: 1 },
+        ];
+        let merged = merge_evidence_refs(&existing, new);
+        assert_eq!(
+            merged,
+            vec![
+                EvidenceRef::Episodic { episodic_id: 1 },
+                EvidenceRef::Episodic { episodic_id: 2 },
+            ],
+            "non-consecutive duplicate must be removed, first-seen order preserved"
+        );
+    }
+
+    #[test]
+    fn merge_evidence_refs_dedups_within_a_single_cycle() {
+        // Two candidates in the same cycle can reference the same evidence with
+        // an unrelated ref between them; that also defeats consecutive-only dedup.
+        let new = vec![
+            EvidenceRef::TreeTopic {
+                topic_id: "a".into(),
+            },
+            EvidenceRef::Episodic { episodic_id: 7 },
+            EvidenceRef::TreeTopic {
+                topic_id: "a".into(),
+            },
+        ];
+        let merged = merge_evidence_refs(&[], new);
+        assert_eq!(
+            merged,
+            vec![
+                EvidenceRef::TreeTopic {
+                    topic_id: "a".into(),
+                },
+                EvidenceRef::Episodic { episodic_id: 7 },
+            ],
+        );
+    }
+
+    #[test]
+    fn merge_evidence_refs_is_idempotent_across_rebuilds() {
+        // Re-running with the merged result as the new existing row and the same
+        // candidates must not grow the list — the core invariant that the old
+        // consecutive-only dedup violated.
+        let existing = vec![
+            EvidenceRef::Episodic { episodic_id: 1 },
+            EvidenceRef::Episodic { episodic_id: 2 },
+        ];
+        let cands = vec![
+            EvidenceRef::Episodic { episodic_id: 2 },
+            EvidenceRef::Episodic { episodic_id: 1 },
+        ];
+        let first = merge_evidence_refs(&existing, cands.clone());
+        let second = merge_evidence_refs(&first, cands);
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 2);
     }
 }


### PR DESCRIPTION
## What

`StabilityDetector::rebuild` merges the existing facet row's `evidence_refs` with the current cycle's new refs and is meant to deduplicate the result — the comment literally says *"Deduplicate refs by serialised form"*. It used `Vec::dedup_by`, which only collapses **consecutive** equal elements.

Once the existing refs and the new refs are concatenated, a ref that recurs is almost never adjacent to its twin. Concrete case: existing row has `[Episodic{1}]`, a new candidate re-emits the same evidence alongside a fresh one → `[Episodic{1}, Episodic{2}, Episodic{1}]`. `dedup_by` leaves it untouched because the two `Episodic{1}` entries aren't neighbours. The duplicate is persisted and the list grows every rebuild cycle, unbounded, since the same evidence keeps supporting the same facet across cycles. Two candidates within a single cycle sharing evidence with anything between them hit the same hole.

## Fix

Extract the merge into a small pure helper `merge_evidence_refs` that deduplicates with a `HashSet` while preserving first-seen order. `EvidenceRef` already derives `Eq + Hash`, so membership is exact and cheap — and this drops the per-element `serde_json::to_string` the old path allocated on every comparison.

`evidence_count` is computed independently (`existing_count + cands.len()`), so this changes only the provenance list, not scoring — but it stops the `evidence_refs` audit trail from ballooning with repeats.

## Tests

Three regression tests on the helper:
- non-consecutive duplicate across existing + new is removed, order preserved
- duplicate within a single cycle (with an unrelated ref between the twins) is removed
- idempotence across rebuilds — feeding the merged result back in with the same candidates does not grow the list (the invariant the old code violated)

All `learning::stability_detector` tests pass locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability tracking so repeated rebuilds no longer accumulate duplicate evidence entries.
  * Deduplication now handles both adjacent and non-adjacent duplicates while keeping the original order.

* **Tests**
  * Added coverage for non-consecutive duplicate removal, single-cycle deduplication, and rebuild idempotence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->