### PR TITLE
fix(ci): repair build-desktop workflow parse failure + node20 action bumps

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -126,12 +126,11 @@ jobs:
             artifact_suffix: windows
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Consumed by scripts/ci-cancel-aware.sh's cancellation watchdog.
+      GH_TOKEN: ${{ github.token }}
       # Keep in sync with DEFAULT_TELEGRAM_BOT_USERNAME_* in channels/controllers/ops.rs
       OPENHUMAN_TELEGRAM_BOT_USERNAME: ${{ inputs.telegram_bot_username }}
       VITE_TELEGRAM_BOT_USERNAME: ${{ inputs.telegram_bot_username }}
-    env:
-      # Consumed by scripts/ci-cancel-aware.sh's cancellation watchdog.
-      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout build ref
         uses: actions/checkout@v5

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -71,6 +71,10 @@ jobs:
           filters: |
             frontend:
               - '.github/workflows/pr-ci.yml'
+              # The changed-files runner itself must trigger the lane that
+              # runs it (it is also in frontend-full → full-suite mode).
+              - 'scripts/ci/vitest-changed-coverage.sh'
+              - 'scripts/ci-cancel-aware.sh'
               - 'package.json'
               - 'pnpm-lock.yaml'
               - 'app/package.json'
@@ -112,6 +116,9 @@ jobs:
               - 'package.json'
             rust-core:
               - '.github/workflows/pr-ci.yml'
+              # The changed-files runner itself must trigger the lane that
+              # runs it (it is also in rust-core-full → full-suite mode).
+              - 'scripts/ci/rust-coverage-changed.sh'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Detect changed paths
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         with:
           list-files: shell
           filters: |

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -90,7 +90,7 @@ jobs:
       # Use the same GitHub App the release workflows push with.
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.XGITHUB_APP_ID }}
           private-key: ${{ secrets.XGITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -123,6 +123,11 @@ jobs:
         with:
           app-id: ${{ secrets.XGITHUB_APP_ID }}
           private-key: ${{ secrets.XGITHUB_APP_PRIVATE_KEY }}
+          # Least privilege: this job only pushes the version-bump commit and
+          # tag (and, on production, the back-merge to main) — contents: write
+          # is all it needs. Branch-protection bypass comes from the App's
+          # identity in the ruleset bypass list, not from token scopes.
+          permission-contents: write
       - name: Checkout release
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -119,7 +119,7 @@ jobs:
           exit 1
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.XGITHUB_APP_ID }}
           private-key: ${{ secrets.XGITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -94,7 +94,7 @@ jobs:
           exit 1
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.XGITHUB_APP_ID }}
           private-key: ${{ secrets.XGITHUB_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -98,6 +98,11 @@ jobs:
         with:
           app-id: ${{ secrets.XGITHUB_APP_ID }}
           private-key: ${{ secrets.XGITHUB_APP_PRIVATE_KEY }}
+          # Least privilege: this job only pushes the version-bump commit and
+          # tag (and, on production, the back-merge to main) — contents: write
+          # is all it needs. Branch-protection bypass comes from the App's
+          # identity in the ruleset bypass list, not from token scopes.
+          permission-contents: write
       - name: Checkout release
         uses: actions/checkout@v5
         with:


### PR DESCRIPTION
## Summary

- Fix the invalid `build-desktop.yml` that failed every push to main since #4486: the GH_TOKEN scoping change inserted a **second `env:` key** into the `build` job; GitHub rejects duplicate mapping keys and recorded a failed "workflow file issue" run on each push.
- Bump `actions/create-github-app-token` v2→v3 and `dorny/paths-filter` v3→v4 to move off the deprecated Node 20 runner runtime (source of the deprecation warnings in run logs).
- Incorporate the post-merge review comments from #4486: scope the release workflows' App tokens to `permission-contents: write` (CodeRabbit/zizmor), and add the changed-files runner scripts to the `frontend`/`rust-core` filters so a PR touching only those runners actually exercises them (Codex).

## Problem

- Post-merge, every push to main produced a failed run named `.github/workflows/build-desktop.yml` with zero jobs — the file no longer parsed. PyYAML's lax duplicate-key handling let it pass local validation in #4486.
- `create-github-app-token@v2` and `paths-filter@v3` declare node20, triggering the runner's deprecation warning on every use.

## Solution

- Merged `GH_TOKEN` into the `build` job's existing `env:` block.
- Local validation now uses a strict loader that rejects duplicate keys across all 20 workflow files (all pass).
- Version bumps to the node24-runtime majors; `paths-filter@v4` output/`list-files` contract is unchanged.

## Submission Checklist

- [x] Tests added or updated — `N/A: workflow-only fix; validated with strict YAML parse across all workflows`
- [x] **Diff coverage ≥ 80%** — `N/A: no app/Rust source changed`
- [x] Coverage matrix updated — `N/A: CI-only`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated — `N/A`
- [x] Linked issue closed via `Closes #NNN` — `N/A: follow-up to #4486`

## Impact

- Restores release build tooling (`build-desktop.yml` is the shared build pipeline for staging/production cuts).
- Removes node20 deprecation warnings.

## Related

- Closes:
- Follow-up PR(s)/TODOs: copy `XGITHUB_APP_ID`/`XGITHUB_APP_PRIVATE_KEY` (App: **tiny-humans-bot**) into the `Release-PR-Automation` environment so `prepare-release-pr` can mint its token.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/two-branch-ci-followups

https://claude.ai/code/session_01FsaameYvpZMKZfUeWqZi7x
