### PR TITLE
test: Phase 3 P1 — TransportManager LAN/Tunnel race (verified backlog, gap filled)

### DIFF
--- a/app/src/services/transport/TransportManager.race.test.ts
+++ b/app/src/services/transport/TransportManager.race.test.ts
@@ -1,0 +1,144 @@
+/**
+ * LAN-vs-Tunnel race semantics for TransportManager.raceLanAndTunnel (plan.md
+ * §4 P1). The sibling TransportManager.test.ts covers profile *selection* but
+ * never exercises the race path, despite the docstring describing it. LAN and
+ * Tunnel transports are mocked here so each scenario controls who is healthy
+ * (and when), and asserts the winner + that the loser is closed.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ConnectionProfile } from './profileStore';
+import { TransportManager } from './TransportManager';
+
+// Mutable health/close hooks the mocked transports read at call time. Declared
+// via vi.hoisted so the vi.mock factories (hoisted above imports) can see them.
+const h = vi.hoisted(() => ({
+  lanHealthy: (): Promise<boolean> => Promise.resolve(false),
+  tunnelHealthy: (): Promise<boolean> => Promise.resolve(false),
+  lanClose: vi.fn((): Promise<void> => Promise.resolve()),
+  tunnelClose: vi.fn((): Promise<void> => Promise.resolve()),
+}));
+
+vi.mock('./LanHttpTransport', () => ({
+  LanHttpTransport: class {
+    readonly kind = 'lan-http';
+    isHealthy() {
+      return h.lanHealthy();
+    }
+    close() {
+      return h.lanClose();
+    }
+  },
+}));
+
+vi.mock('./TunnelTransport', () => ({
+  TunnelTransport: class {
+    readonly kind = 'tunnel';
+    isHealthy() {
+      return h.tunnelHealthy();
+    }
+    close() {
+      return h.tunnelClose();
+    }
+  },
+}));
+
+function tunnelProfile(overrides: Partial<ConnectionProfile> = {}): ConnectionProfile {
+  return {
+    id: 'race-profile',
+    label: 'Race',
+    kind: 'tunnel',
+    // rpcUrl present → raceLanAndTunnel actually races (not tunnel-only).
+    rpcUrl: 'http://192.168.1.5:7788/rpc',
+    channelId: 'CHANNEL001',
+    corePubkey: 'dGVzdHB1YmtleXRlc3RwdWJrZXl0ZXN0cHVia2V5',
+    sessionToken: 'tok123',
+    ...overrides,
+  };
+}
+
+function manager(profile: ConnectionProfile): TransportManager {
+  return new TransportManager(
+    profile,
+    () => Promise.resolve(''),
+    () => Promise.resolve(null),
+    'http://backend:3000'
+  );
+}
+
+const immediately = (v: boolean) => () => Promise.resolve(v);
+const after = (ms: number, v: boolean) => () =>
+  new Promise<boolean>(resolve => setTimeout(() => resolve(v), ms));
+
+describe('TransportManager.raceLanAndTunnel', () => {
+  beforeEach(() => {
+    h.lanHealthy = immediately(false);
+    h.tunnelHealthy = immediately(false);
+    h.lanClose.mockClear();
+    h.tunnelClose.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('LAN wins the race and the tunnel is closed', async () => {
+    h.lanHealthy = immediately(true);
+    h.tunnelHealthy = after(50, true);
+
+    const t = await manager(tunnelProfile()).getTransport();
+
+    expect(t.kind).toBe('lan-http');
+    expect(h.tunnelClose).toHaveBeenCalledTimes(1);
+    expect(h.lanClose).not.toHaveBeenCalled();
+  });
+
+  it('tunnel wins the race and the LAN transport is closed', async () => {
+    h.tunnelHealthy = immediately(true);
+    h.lanHealthy = after(50, true);
+
+    const t = await manager(tunnelProfile()).getTransport();
+
+    expect(t.kind).toBe('tunnel');
+    expect(h.lanClose).toHaveBeenCalledTimes(1);
+    expect(h.tunnelClose).not.toHaveBeenCalled();
+  });
+
+  it('throws when neither transport becomes healthy', async () => {
+    h.lanHealthy = immediately(false);
+    h.tunnelHealthy = immediately(false);
+
+    await expect(manager(tunnelProfile()).getTransport()).rejects.toThrow(/all transports failed/);
+  });
+
+  it('reset() re-races: LAN wins first, then after reset the tunnel wins', async () => {
+    const mgr = manager(tunnelProfile());
+
+    // First race: LAN wins.
+    h.lanHealthy = immediately(true);
+    h.tunnelHealthy = after(50, false);
+    const first = await mgr.getTransport();
+    expect(first.kind).toBe('lan-http');
+
+    // LAN later fails → caller resets, and the next race must pick the tunnel
+    // (tunnel healthy immediately; LAN's slow-unhealthy result loses the race).
+    await mgr.reset();
+    h.lanHealthy = after(50, false);
+    h.tunnelHealthy = immediately(true);
+    const second = await mgr.getTransport();
+    expect(second.kind).toBe('tunnel');
+  });
+
+  it('caches the winner: a second getTransport does not re-race', async () => {
+    h.lanHealthy = immediately(true);
+    h.tunnelHealthy = immediately(false);
+    const mgr = manager(tunnelProfile());
+
+    const a = await mgr.getTransport();
+    const b = await mgr.getTransport();
+
+    expect(a).toBe(b);
+    // Tunnel closed exactly once (from the single race), not twice.
+    expect(h.tunnelClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plan.md
+++ b/plan.md
@@ -414,10 +414,25 @@ of the five "ZERO tests" claims turned out **already covered**, so only the genu
   tests as load-bearing boot guards, so they were left intact rather than risk an unvalidated
   E2E change).
 
-**Phase 3 — P1 backlog (2–4 weeks, interleave with feature work)**
-- Approval×turn integration, TransportManager race, socket backoff, hostile webhook payloads,
-  path_scope invariant, web3 tool wiring, threadSlice/accountsSlice, journey spec, Playwright
-  approval mirror.
+**Phase 3 — P1 backlog** — ⏳ partial (PR: `test/phase3-p1-gaps`). Verification-first pass: like §4
+P0, most P1 "untested" claims were **inaccurate against current `main`**. Verified state:
+- [x] **`TransportManager.raceLanAndTunnel`** — GENUINE GAP (the sibling test only covered profile
+  *selection*, never the race). Added a dedicated `TransportManager.race.test.ts`: LAN-wins /
+  tunnel-wins (loser closed), both-fail throws, `reset()` re-race, and winner-caching. Surfaced a
+  real timing quirk: when the first `isHealthy()` to settle is `false`, the
+  `Promise.race`→`Promise.any` fallback grabs that already-fulfilled `null` and throws instead of
+  waiting for a later-healthy peer — worth a production follow-up.
+- [~] ALREADY COVERED (no gap): `composerInteractionBlocked` (ChatComposer + composerSendDecision
+  tests), `threadSlice`/`accountsSlice` (multiple `__tests__`), CustomInference/CustomSearch
+  onboarding pages, AgentAccessPanel (23 tests), and every P2 slice reducer
+  (socket/channelConnections/ptt/providerSurface) + TeamInvites. web3 tool layer has `web3_tests.rs`.
+- [~] NOT A GAP: primary socket-client backoff is delegated to socket.io
+  (`reconnectionAttempts: Infinity`), not custom logic — nothing bespoke to unit-test.
+- [ ] Genuine-but-deferred (need a full Rust build + deep store/parser fixtures, high iteration cost
+  in the authoring env): memory two-source-one-tree `path_scope` invariant; broad hostile-webhook
+  payload matrix (wrong types / deep nesting / oversized) beyond the current missing-field tests;
+  the ~20 controller domains with no `tests/` reference (the Phase 0 inventory allowlist to burn
+  down). Approval×turn integration, journey spec, and the Playwright approval mirror need WDIO/PW.
 
 **Phase 4 — new dimensions (ongoing)**
 - proptest + cargo-fuzz targets; scoped cargo-mutants; jest-axe lane; migration fixture;


### PR DESCRIPTION
## Summary

Verification-first pass over the `plan.md` §4 **P1** backlog. As with the P0 backlog, most "untested"
claims turned out **inaccurate against current `main`** — so this PR fills the one genuine,
locally-validatable gap and records the verification of the rest rather than shipping duplicates.

- **`TransportManager.raceLanAndTunnel`** — GENUINE GAP. The sibling `TransportManager.test.ts`
  covers profile *selection* but never exercised the LAN-vs-Tunnel race, despite the method's
  docstring. New `TransportManager.race.test.ts` (mocking `LanHttpTransport`/`TunnelTransport`
  health so each scenario is deterministic):
  - LAN wins → returns `lan-http`, tunnel is closed
  - Tunnel wins → returns `tunnel`, LAN is closed
  - Neither healthy → throws `all transports failed`
  - `reset()` re-races and can pick a different winner
  - The winner is cached (second `getTransport` doesn't re-race / double-close)

  Writing it surfaced a **real timing quirk** in the production code: when the first `isHealthy()`
  to settle resolves `false`, the `Promise.race`→`Promise.any` fallback grabs that already-fulfilled
  `null` and throws instead of waiting for a later-healthy peer. The tests assert the *actual*
  behaviour; the quirk is flagged in `plan.md` as a production follow-up.

## Problem — and what re-verification found

| P1 item | Verified state | Action |
|---|---|---|
| `TransportManager` race | **untested** (selection only) | ✅ added `TransportManager.race.test.ts` |
| `composerInteractionBlocked` | covered (ChatComposer + composerSendDecision tests) | skip |
| `threadSlice` / `accountsSlice` | covered (multiple `__tests__`) | skip |
| CustomInference / CustomSearch onboarding | covered (`.test.tsx` each) | skip |
| AgentAccessPanel | covered (23 tests) | skip |
| socket/channelConnections/ptt/providerSurface slices | all have reducer tests | skip |
| primary socket-client backoff | delegated to socket.io (`reconnectionAttempts: Infinity`) — no custom logic | not a gap |
| web3 tool layer | `web3_tests.rs` exists | skip |
| path_scope two-source invariant · hostile-webhook matrix · ~20 zero-`tests/` domains | genuine-but-deferred: need a full Rust build + deep fixtures (high iteration cost here) | deferred |
| approval×turn · journey spec · Playwright approval mirror | need WDIO/Playwright | deferred |

The plan's §4 backlog predates a lot of test growth on `main`; most items are already covered.
Reporting that (and not recreating the duplicates Phase 2 just removed) is part of the deliverable.

## Solution

`TransportManager.race.test.ts` mocks the two transports via `vi.hoisted` state so each test controls
who is healthy and when, and asserts the winner + that the loser is closed. It runs in the standard
frontend unit lane and is fully deterministic (no real network).

## Submission Checklist

- [x] Tests added or updated (happy path + failure/edge) — 5 new tests incl. both-fail and re-race.
- [x] **Diff coverage ≥ 80%** — `N/A`: only test code added; no product `app/src` lines changed.
- [x] Coverage matrix updated — `N/A: no feature rows added/removed/renamed`.
- [x] Affected feature IDs — `N/A: no feature behaviour change`.
- [x] No new external network dependencies — mocked transports; no real I/O.
- [x] Manual smoke checklist — `N/A: no release-cut runtime surface touched`.
- [x] Linked issue — none closed.

## Impact

- Test-only. Vitest green (5 new tests; full `services/transport` dir = 64 pass); eslint/prettier clean.

## Related

- Closes: _none_ (Phase 3 / §4 P1 of `plan.md`)
- Follow-up: production quirk in `raceLanAndTunnel`'s `Promise.any` fallback; the deferred Rust P1
  items (path_scope invariant, hostile-webhook matrix, zero-`tests/` controller domains) and the
  WDIO/Playwright items.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `test/phase3-p1-gaps`
- Commit SHA: see PR head

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — passed on the changed file
- [x] `pnpm typecheck` — the new spec compiles under the app tsconfig; eslint green
- [x] Focused tests: `vitest run src/services/transport/` → 64 pass (5 new)
- [x] Rust fmt/check — `N/A: no Rust changed`
- [x] Tauri fmt/check — `N/A: no Tauri-crate files changed`

### Validation Blocked
- `command:` none — this change is fully validated locally (Vitest).
- `error:` N/A
- `impact:` N/A

### Behavior Changes
- Intended behavior change: none (test-only).
- User-visible effect: none.

### Parity Contract
- Legacy behavior preserved: yes — additive test file only; asserts existing race behaviour.
- Guard/fallback/dispatch parity checks: N/A.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A

https://claude.ai/code/session_01Q7PNT4bLDUuZFPkV68gj4F
