### PR TITLE
fix(agent): prompt-dump audit — dead tools, delegate-name drift, p-format text mode

### DIFF
--- a/src/openhuman/agent/harness/session/builder/factory.rs
+++ b/src/openhuman/agent/harness/session/builder/factory.rs
@@ -1055,10 +1055,11 @@ impl Agent {
             if agent_id == "integrations_agent" && tool_dispatcher.should_send_tool_specs() {
                 log::info!(
                     "[agent::builder] integrations_agent: overriding native tool dispatcher with \
-                     XmlToolDispatcher (native mode hits provider grammar-rule limits on \
-                     large Composio toolkits)"
+                     PFormatToolDispatcher (native mode hits provider grammar-rule limits on \
+                     large Composio toolkits; p-format keeps the in-prompt catalogue compact \
+                     and still parses JSON-in-tag fallbacks)"
                 );
-                Box::new(XmlToolDispatcher)
+                Box::new(PFormatToolDispatcher::new(pformat_registry.clone()))
             } else {
                 tool_dispatcher
             };

--- a/src/openhuman/agent/harness/subagent_runner/tool_prep.rs
+++ b/src/openhuman/agent/harness/subagent_runner/tool_prep.rs
@@ -52,11 +52,14 @@ pub(super) fn top_k_for_toolkit(toolkit: &str) -> usize {
 
 // ── Text-mode protocol block ────────────────────────────────────────────
 
-/// Format an XML tool-use protocol block appended to the system prompt in text
-/// mode. Mirrors
-/// [`crate::openhuman::agent::dispatcher::XmlToolDispatcher::prompt_instructions`]
-/// — same `<tool_call>{…}</tool_call>` format so the existing
-/// `parse_tool_calls` helper understands what the model emits.
+/// Format the tool-use protocol block appended to the system prompt in text
+/// mode. Teaches **P-Format** first (the same protocol
+/// [`crate::openhuman::agent::dispatcher::PFormatToolDispatcher`] renders and
+/// the tinyagents adapter parses via `parse_tool_calls_with_pformat`), with
+/// the legacy JSON-in-tag form as the documented fallback for nested
+/// arguments. The `## Tools` catalogue already renders `Call as:` p-format
+/// signatures for every tool, so teaching JSON here contradicted the
+/// catalogue and threw away the p-format token savings.
 ///
 /// Per-parameter rendering is intentionally **compact**: name, type, a
 /// "required" marker, and a short one-line description if present. We
@@ -81,12 +84,23 @@ pub(crate) fn build_text_mode_tool_instructions() -> String {
     let mut out = String::new();
     out.push_str("## Tool Use Protocol\n\n");
     out.push_str(
-        "To use a tool, wrap a JSON object in <tool_call></tool_call> tags. \
-         Do not nest tags. Emit one tag per call; you can emit multiple tags \
-         in the same response if you need to run calls in parallel.\n\n",
+        "Tool calls use **P-Format** (Parameter-Format): compact, positional, \
+         pipe-delimited syntax wrapped in `<tool_call>` tags.\n\n",
     );
+    out.push_str("```\n<tool_call>\nGMAIL_FETCH_EMAILS[ca_123||10]\n</tool_call>\n```\n\n");
     out.push_str(
-        "```\n<tool_call>\n{\"name\": \"tool_name\", \"arguments\": {\"param\": \"value\"}}\n</tool_call>\n```\n",
+        "**Rules:**\n\
+         - Form: `name[arg1|arg2|...|argN]`. Arguments are positional and must match the \
+           order shown in each tool's `Call as:` signature in the `## Tools` section \
+           (alphabetical by parameter name). Leave a slot empty to omit that argument.\n\
+         - Empty calls: `name[]` for zero-arg tools.\n\
+         - Escapes inside argument values: `\\|` for a literal `|`, `\\]` for `]`, `\\\\` for `\\`.\n\
+         - Do not nest tags. Emit one tag per call; you can emit multiple tags in the same \
+           response to run calls in parallel.\n\
+         - When an argument needs a nested object or array that p-format cannot express, \
+           fall back to the JSON form in the same tags: \
+           `<tool_call>{\"name\": \"tool_name\", \"arguments\": {\"param\": \"value\"}}</tool_call>`. \
+           Prefer p-format for everything else.\n",
     );
     out
 }
@@ -118,10 +132,29 @@ pub(crate) fn build_text_mode_tool_instructions() -> String {
 /// this function and the corresponding generator in
 /// `orchestrator_tools.rs` together.
 pub(super) fn is_subagent_spawn_tool(name: &str) -> bool {
-    name == "spawn_subagent"
+    if name == "spawn_subagent"
         || name.starts_with("delegate_")
         || name == "use_tinyplace"
         || name == "agent_prepare_context"
+    {
+        return true;
+    }
+    // Synthesised delegation tools are named by the target agent's
+    // `delegate_name` override, which mostly does NOT carry the `delegate_`
+    // prefix (`plan`, `run_code`, `research`, `review_code`, `do_crypto`,
+    // `schedule_task`, …). The prefix check above misses every one of them,
+    // which let wildcard-scoped children inherit the orchestrator's spawn
+    // surface. Resolve the override names via the registry so the strip
+    // stays in lockstep with `collect_orchestrator_tools`'s naming.
+    if let Some(registry) =
+        crate::openhuman::agent::harness::definition::AgentDefinitionRegistry::global()
+    {
+        return registry
+            .list()
+            .iter()
+            .any(|def| def.delegate_name.as_deref() == Some(name));
+    }
+    false
 }
 
 /// Returns indices into `parent_tools` for the tools the sub-agent may
@@ -196,6 +229,45 @@ mod tests {
         // parent context. See #3949 review.
         assert!(is_subagent_spawn_tool("agent_prepare_context"));
         assert!(!is_subagent_spawn_tool("tinyplace_directory_resolve"));
+    }
+
+    #[test]
+    fn unprefixed_delegate_name_overrides_are_treated_as_spawn_tools() {
+        // Most synthesised delegation tools use an unprefixed
+        // `delegate_name` override (`plan`, `run_code`, `research`, …).
+        // They must be stripped from every sub-agent surface, exactly like
+        // the `delegate_*`-prefixed defaults.
+        let tmp = tempfile::TempDir::new().unwrap();
+        crate::openhuman::agent::harness::definition::AgentDefinitionRegistry::init_global(
+            tmp.path(),
+        )
+        .unwrap();
+        for delegate in [
+            "plan",
+            "run_code",
+            "research",
+            "review_code",
+            "do_crypto",
+            "do_prediction_markets",
+            "schedule_task",
+            "make_presentation",
+            "archive_session",
+            "use_mcp_server",
+            "setup_mcp_server",
+        ] {
+            assert!(
+                is_subagent_spawn_tool(delegate),
+                "`{delegate}` is a synthesised delegation tool and must be \
+                 stripped from sub-agent tool surfaces"
+            );
+        }
+        // Ordinary worker tools stay visible.
+        for plain in ["shell", "file_read", "web_fetch", "todo"] {
+            assert!(
+                !is_subagent_spawn_tool(plain),
+                "`{plain}` must not be classified as a spawn tool"
+            );
+        }
     }
 }
 

--- a/src/openhuman/agent_registry/agents/loader.rs
+++ b/src/openhuman/agent_registry/agents/loader.rs
@@ -708,24 +708,29 @@ mod tests {
                     "spawn_subagent must not appear — removed in #1141"
                 );
                 assert!(!tools.iter().any(|t| t == "call_memory_agent"));
-                // Shell stays out — repo-scale work (build/test/git/run)
-                // routes to `run_code`.
-                assert!(!tools.iter().any(|t| t == "shell"));
-                // Basic direct surface: quick lookups and small user-pointed
-                // edits without spawning a sub-agent per touch.
+                // Write tools and shell stay OUT — the chat-tier
+                // orchestrator must not mutate files or run commands; all
+                // modification is deferred to `run_code` / owning
+                // specialists where edits live next to build/test/verify.
+                for forbidden in ["shell", "edit", "file_write", "apply_patch"] {
+                    assert!(
+                        !tools.iter().any(|t| t == forbidden),
+                        "orchestrator must NOT have write/exec tool `{forbidden}`"
+                    );
+                }
+                // Basic READ-ONLY direct surface: quick lookups without
+                // spawning a sub-agent per touch.
                 for direct in [
                     "file_read",
                     "grep",
                     "glob",
                     "list",
-                    "edit",
-                    "file_write",
                     "web_search_tool",
                     "web_fetch",
                 ] {
                     assert!(
                         tools.iter().any(|t| t == direct),
-                        "orchestrator must have direct tool `{direct}`"
+                        "orchestrator must have read-only direct tool `{direct}`"
                     );
                 }
             }

--- a/src/openhuman/agent_registry/agents/loader.rs
+++ b/src/openhuman/agent_registry/agents/loader.rs
@@ -675,10 +675,21 @@ mod tests {
         assert!(matches!(def.model, ModelSpec::Hint(ref h) if h == "chat"));
         match def.tools {
             ToolScope::Named(tools) => {
-                // spawn_subagent was removed in #1141; spawn_worker_thread is the replacement
+                // spawn_subagent was removed in #1141. spawn_worker_thread is
+                // disabled pending its UI (#1624) and unregistered, so the
+                // named scope must not advertise it.
                 assert!(
-                    tools.iter().any(|t| t == "spawn_worker_thread"),
-                    "orchestrator must have spawn_worker_thread"
+                    !tools.iter().any(|t| t == "spawn_worker_thread"),
+                    "spawn_worker_thread is disabled (#1624) and must not be named"
+                );
+                // Async sub-agent control surface taught by prompt.md.
+                assert!(
+                    tools.iter().any(|t| t == "steer_subagent"),
+                    "orchestrator must have steer_subagent to steer async workers"
+                );
+                assert!(
+                    tools.iter().any(|t| t == "wait_subagent"),
+                    "orchestrator must have wait_subagent to collect async results"
                 );
                 assert!(
                     tools.iter().any(|t| t == "spawn_async_subagent"),
@@ -697,8 +708,26 @@ mod tests {
                     "spawn_subagent must not appear — removed in #1141"
                 );
                 assert!(!tools.iter().any(|t| t == "call_memory_agent"));
+                // Shell stays out — repo-scale work (build/test/git/run)
+                // routes to `run_code`.
                 assert!(!tools.iter().any(|t| t == "shell"));
-                assert!(!tools.iter().any(|t| t == "file_write"));
+                // Basic direct surface: quick lookups and small user-pointed
+                // edits without spawning a sub-agent per touch.
+                for direct in [
+                    "file_read",
+                    "grep",
+                    "glob",
+                    "list",
+                    "edit",
+                    "file_write",
+                    "web_search_tool",
+                    "web_fetch",
+                ] {
+                    assert!(
+                        tools.iter().any(|t| t == direct),
+                        "orchestrator must have direct tool `{direct}`"
+                    );
+                }
             }
             ToolScope::Wildcard => panic!("orchestrator must have named tool allowlist"),
         }
@@ -1367,9 +1396,11 @@ mod tests {
                     "spawn_subagent",
                     "spawn_worker_thread",
                     "delegate_to_integrations_agent",
-                    "delegate_run_code",
-                    "delegate_research",
-                    "delegate_plan",
+                    // Synthesised delegation tools use the unprefixed
+                    // `delegate_name` overrides — forbid those names too.
+                    "run_code",
+                    "research",
+                    "plan",
                 ] {
                     assert!(
                         !tools.iter().any(|t| t == forbidden),
@@ -1463,9 +1494,11 @@ mod tests {
                     "spawn_subagent",
                     "spawn_worker_thread",
                     "delegate_to_integrations_agent",
-                    "delegate_run_code",
-                    "delegate_research",
-                    "delegate_plan",
+                    // Synthesised delegation tools use the unprefixed
+                    // `delegate_name` overrides — forbid those names too.
+                    "run_code",
+                    "research",
+                    "plan",
                     "wallet_execute_prepared",
                     "wallet_prepare_transfer",
                     "web3_swap_execute",

--- a/src/openhuman/agent_registry/agents/orchestrator/agent.toml
+++ b/src/openhuman/agent_registry/agents/orchestrator/agent.toml
@@ -191,17 +191,16 @@ hint = "chat"
 named = [
     "read_workspace_state",
     "ask_user_clarification",
-    # Basic direct surface — lets the orchestrator answer small lookups and
-    # make small, user-pointed file edits itself instead of spawning a
-    # sub-agent for every touch. Deliberately NO `shell`: anything that needs
-    # a build / test / git / run cycle is repo-scale work and still routes to
-    # `run_code` (see prompt.md's code-repo rule).
+    # Basic READ-ONLY direct surface — lets the orchestrator answer small
+    # lookups itself instead of spawning a sub-agent for every touch.
+    # Deliberately NO write tools (`edit` / `file_write`) and NO `shell`:
+    # the chat-tier orchestrator must not mutate files — any modification,
+    # however small, is deferred to `run_code` (or another owning
+    # specialist) where edits live next to the build/test/verify loop.
     "file_read",
     "grep",
     "glob",
     "list",
-    "edit",
-    "file_write",
     # Quick web lookups. A single fact ("what's the capital of X", "latest
     # version of Y") is one `web_search_tool` / `web_fetch` call — spawning
     # the `research` worker for that is overkill. Multi-source crawls,

--- a/src/openhuman/agent_registry/agents/orchestrator/agent.toml
+++ b/src/openhuman/agent_registry/agents/orchestrator/agent.toml
@@ -191,11 +191,38 @@ hint = "chat"
 named = [
     "read_workspace_state",
     "ask_user_clarification",
-    "spawn_worker_thread",
+    # Basic direct surface — lets the orchestrator answer small lookups and
+    # make small, user-pointed file edits itself instead of spawning a
+    # sub-agent for every touch. Deliberately NO `shell`: anything that needs
+    # a build / test / git / run cycle is repo-scale work and still routes to
+    # `run_code` (see prompt.md's code-repo rule).
+    "file_read",
+    "grep",
+    "glob",
+    "list",
+    "edit",
+    "file_write",
+    # Quick web lookups. A single fact ("what's the capital of X", "latest
+    # version of Y") is one `web_search_tool` / `web_fetch` call — spawning
+    # the `research` worker for that is overkill. Multi-source crawls,
+    # comparisons, and doc digests still delegate to `research`.
+    "web_search_tool",
+    "web_fetch",
+    # NOTE: `spawn_worker_thread` is intentionally absent — the tool is
+    # disabled pending a worker-thread UI (#1624) and is not registered, so
+    # listing it here (and teaching it in prompt.md) only trained the model
+    # to call a tool that does not exist.
     "spawn_async_subagent",
     "spawn_parallel_agents",
     "wait",
     "wait_loop",
+    # Async sub-agent control surface. prompt.md's "Async background
+    # sub-agents" section instructs steering (`steer_subagent`) and result
+    # collection (`wait_subagent`) by `subagent_session_id` / `task_id`;
+    # both tools exist in the base registry and must be in scope here or
+    # the whole async flow dead-ends after `spawn_async_subagent`.
+    "steer_subagent",
+    "wait_subagent",
     # Resume a sub-agent that paused on `ask_user_clarification` (#4291). When
     # a delegated sub-agent (e.g. mcp_setup via `delegate_setup_mcp_server`)
     # asks the user a question, the runner checkpoints it and the orchestrator

--- a/src/openhuman/agent_registry/agents/orchestrator/prompt.md
+++ b/src/openhuman/agent_registry/agents/orchestrator/prompt.md
@@ -1,6 +1,6 @@
 # Orchestrator - Staff Engineer
 
-You are the **Orchestrator**, the senior agent in a multi-agent system. Your role is strategic: you decide when to respond directly, when to use direct tools, and when to delegate. You **never** write code, execute shell commands, or directly modify files.
+You are the **Orchestrator**, the senior agent in a multi-agent system. Your role is strategic: you decide when to respond directly, when to use direct tools, and when to delegate. You have a small direct surface for lookups and light edits (`file_read`, `grep`, `glob`, `list`, `edit`, `file_write`, `web_search_tool`, `web_fetch`), but you **never** execute shell commands, and repo-scale engineering (anything needing a build / test / git / run cycle) always goes to `run_code`.
 
 ## Core Responsibilities
 
@@ -20,27 +20,29 @@ Follow this sequence for every user message:
 2. **Does the request name (or imply) a connected external service?**
    - Words like "email/inbox/gmail", "calendar", "notion doc", "drive file", "slack/whatsapp/telegram message", "linear ticket", "send to X", "check X", etc. mean the user wants the **live** service.
    - Find the matching toolkit in the **Connected Integrations** section and call `delegate_to_integrations_agent` with that `toolkit`.
-   - **Do this even if `memory_tree` could plausibly answer.** The user wants the live source of truth, not a stale summary.
-   - If the relevant toolkit is **not** in **Connected Integrations**, call `composio_connect { toolkit: "<slug>" }` **directly** to raise an **inline connect card** so the user can authorize in one click, then continue the task once it returns `connected: true`. Do **not** refuse based on the Connected Integrations list (that is only what is *already* connected, not what is *connectable*), do **not** make "go to Settings → Connections" your first move, and do **not** silently fall back to `memory_tree` (see "Connecting external services" below).
+   - **Do this even if remembered context could plausibly answer.** The user wants the live source of truth, not a stale summary.
+   - If the relevant toolkit is **not** in **Connected Integrations**, call `composio_connect { toolkit: "<slug>" }` **directly** to raise an **inline connect card** so the user can authorize in one click, then continue the task once it returns `connected: true`. Do **not** refuse based on the Connected Integrations list (that is only what is *already* connected, not what is *connectable*), do **not** make "go to Settings → Connections" your first move, and do **not** silently fall back to memory retrieval (see "Connecting external services" below).
 3. **Can I solve this with direct tools?**
-   - Yes: use direct tools (`query_memory`, `read_workspace_state`, `composio_list_connections`, task tools, etc.).
+   - Yes: use direct tools (`retrieve_memory`, `read_workspace_state`, `composio_list_connections`, task tools, etc.).
+   - **Quick lookups are direct work.** A single web fact (a version number, a definition, one page's contents) is one `web_search_tool` or `web_fetch` call — do it yourself and answer. Reserve `research` for multi-source crawls, comparisons, or doc digests.
+   - **Small, user-pointed file work is direct work.** Reading a file the user names, grepping for a string, or making a small self-contained edit (`file_read` / `grep` / `glob` / `edit` / `file_write`) needs no sub-agent. The moment the task needs a build, test, run, git operation, or spans multiple files you haven't read, it is repo-scale — hand the whole task to `run_code` instead (see below).
    - No: continue.
 4. **Does this need other specialised execution?**
    - If the request is about OpenHuman product behavior, settings, docs, setup, or feature availability, use `ask_docs`.
    - If the request is to remind, schedule, repeat, pause, remove, or inspect jobs, use `schedule_task`.
    - If the request is to make slides, build a deck, create a pitch, cite deck sources, or attach/verify deck images, use `make_presentation`.
    - If the request is to launch an app or operate desktop UI controls, use `delegate_desktop_control`.
-   - If the request is about a **crypto wallet or market action** — balances, transfers, swaps, contract calls, on-chain positions, or trading on a connected exchange — use `delegate_do_crypto`. It enforces read → simulate → confirm → execute and refuses to fabricate chain ids, token addresses, market symbols, or unsupported tools. **Do not** route crypto write operations through `delegate_to_integrations_agent` or `delegate_run_code`.
+   - If the request is about a **crypto wallet or market action** — balances, transfers, swaps, contract calls, on-chain positions, or trading on a connected exchange — use `do_crypto`. It enforces read → simulate → confirm → execute and refuses to fabricate chain ids, token addresses, market symbols, or unsupported tools. **Do not** route crypto write operations through `delegate_to_integrations_agent` or `run_code`.
    - If the request is about **tiny.place / tinyplace** — Agent Cards, @handles, jobs, proposals, groups, messages, escrow, registration/status, or tiny.place x402 payment challenges — use `use_tinyplace`. It owns the `tinyplace_*` tools and keeps paid/irreversible actions behind confirmation.
-   - **Any task that touches a code repository — cloning, exploring, locating files, modifying, building, testing, running shell commands inside it, git operations, pushing branches, opening PRs — uses `delegate_run_code` for the entire task.** Treat "locate where to edit", "investigate the bug", "find the function", "read the file" as code-repo work the moment they're scoped to a repo: they belong inside the same `delegate_run_code` worker as the edit / build / git steps. **Never** route code-repo work through `tools_agent` / `spawn_worker_thread`; those workers lack `edit` / `apply_patch` / `file_write` / `git_operations` / `codegraph_search` and will silently stall in read-mode. `tools_agent` is for *non-repo* work only — ad-hoc shell against the host, web fetch, memory helpers, etc.
-   - **Do not stall after reading code-repo files.** If you (or a worker you spawned) have *read* files in a repo and have not yet *acted* on them — edited, built, tested, run, or pushed — and the user expects an outcome rather than a summary, that's the signal the task should have gone to `delegate_run_code` from the start. Re-issue the entire task as one `delegate_run_code` call with the full intent and let the code executor own the lifecycle. Do **not** narrate "reading the file…" / "let me check the code…" and then sit idle: in a code-repo task, reading is step zero of execution, not the deliverable. The user does not need to write "use the code executor" — infer it from the request shape (code, repo, file, build, test, run, fix, refactor, push, PR).
+   - **Any task that touches a code repository — cloning, exploring, locating files, modifying, building, testing, running shell commands inside it, git operations, pushing branches, opening PRs — uses `run_code` for the entire task.** Treat "locate where to edit", "investigate the bug", "find the function", "read the file" as code-repo work the moment they're scoped to a repo: they belong inside the same `run_code` worker as the edit / build / git steps. **Never** route code-repo work through `delegate_tools_agent`; that worker lacks `edit` / `apply_patch` / `file_write` / `git_operations` / `codegraph_search` and will silently stall in read-mode. `delegate_tools_agent` is for *non-repo* work only — ad-hoc shell against the host, web fetch, memory helpers, etc.
+   - **Do not stall after reading code-repo files.** If you (or a worker you spawned) have *read* files in a repo and have not yet *acted* on them — edited, built, tested, run, or pushed — and the user expects an outcome rather than a summary, that's the signal the task should have gone to `run_code` from the start. Re-issue the entire task as one `run_code` call with the full intent and let the code executor own the lifecycle. Do **not** narrate "reading the file…" / "let me check the code…" and then sit idle: in a code-repo task, reading is step zero of execution, not the deliverable. The user does not need to write "use the code executor" — infer it from the request shape (code, repo, file, build, test, run, fix, refactor, push, PR).
    - If the request is to find, browse, install, or manage agent skills from community registries — or to follow a SKILL.md URL — use `setup_skills`.
    - If the request is to run or execute an installed agent skill by name, use `run_skill`. The skill runs in an isolated worker, so its instructions never enter this conversation — you get back only its result. If that result contains a `## Handoff Plan` (steps the worker's narrow toolset couldn't perform — e.g. sending email, writing memory), carry out those steps yourself with your full tool set, routing each through the normal delegation path, then report the combined outcome. Treat handoff steps as *proposed* actions: never bypass the approval gate for them, especially for third-party skills.
-   - If web/doc crawling is required, use `research`.
-   - If the user asks for live/current/time-sensitive facts that are not covered by a direct tool — weather, forecasts, current temperatures, recent news, fresh web facts, or "use Grok/web/live data" — call `research` with a prompt that asks for live sources. Do **not** stop at "on it", and do **not** wait for the exact named provider if it is not wired in. Use the available research tool and then answer with the result.
-   - If complex multi-step decomposition is required, use `delegate_plan`.
-   - If code review is requested, use `delegate_critic`.
-   - If memory archiving or distillation is required, use `delegate_archivist`.
+   - If multi-source web/doc crawling is required, use `research`. For a single live fact (weather, one price, one page) prefer your direct `web_search_tool` / `web_fetch` first.
+   - If the user asks for live/current/time-sensitive facts — weather, forecasts, current temperatures, recent news, fresh web facts, or "use Grok/web/live data" — get them now: one quick fact via direct `web_search_tool`, anything broader via `research` with a prompt that asks for live sources. Do **not** stop at "on it", and do **not** wait for the exact named provider if it is not wired in. Use the available tools and then answer with the result.
+   - If complex multi-step decomposition is required, use `plan`.
+   - If code review is requested, use `review_code`.
+   - If memory archiving or distillation is required, use `archive_session`.
 5. **After delegation, distill — never forward verbatim.** A sub-agent's reply is raw material, not your answer. Extract only the parts that answer the user's question and present them in as few words as carry the meaning. Drop the sub-agent's working notes, restated context, and any detail the user already has. If the useful answer is two sentences, send two sentences, even when the sub-agent returned eight paragraphs. Never paste a sub-agent's full response back to the user.
 
 Default bias: **do not spawn a sub-agent when a direct response or direct tool call is sufficient** — but live external-service, scheduling, desktop-control, presentation, product-docs, code-repo, market, and crypto requests belong to their specialists.
@@ -51,7 +53,7 @@ You can open and operate native apps on this machine, but you do it by **delegat
 
 ## Rules
 
-- **You are the chat tier.** You run on a fast UX-focused model (TTFT > deep reasoning). When a task needs sustained multi-step thinking — planning across many steps, comparing several non-obvious options, untangling ambiguous requirements — **delegate to the reasoning tier (`delegate_plan`)** rather than reasoning through it yourself. Your job at that point is to brief the planner well and synthesise its output back to the user.
+- **You are the chat tier.** You run on a fast UX-focused model (TTFT > deep reasoning). When a task needs sustained multi-step thinking — planning across many steps, comparing several non-obvious options, untangling ambiguous requirements — **delegate to the reasoning tier (`plan`)** rather than reasoning through it yourself. Your job at that point is to brief the planner well and synthesise its output back to the user.
 - **Never spawn yourself** — You cannot delegate to another chat-tier agent (Orchestrator or otherwise). The chat tier is a leaf in its own dimension.
 - **Spawn hierarchy (hard rule).** Allowed handoffs from here: `chat → worker` (fast path) or `chat → reasoning → worker` (deep path). Never `chat → chat` and never `chat → reasoning → reasoning`. This is enforced in depth: the loader rejects same-tier delegation at boot, and the spawn chokepoint denies any tier-violating or over-deep spawn at runtime (a depth gate caps chains at 3 hops and a tier gate rejects the forbidden hops). Those gates are a safety net, not a license to mis-route — still follow the hierarchy yourself, as does the planner's matching rule.
 - **Minimise sub-agents** — Use the fewest agents necessary. Simple questions don't need a DAG.
@@ -67,19 +69,6 @@ You can open and operate native apps on this machine, but you do it by **delegat
 - **`cron_add`, `cron_list`, `cron_remove`, `current_time` are direct named tools** when they appear in your tool list. Call them by name, never via `run_workflow` (that path returns "unknown workflow" for any built-in tool name and always errors).
 - **Always get explicit user confirmation before creating any schedule** (one-shot or recurring). Propose the exact timing, wait for a yes, then act. If `cron_add` is absent from your tool list and `schedule_task` is unavailable, tell the user you can't schedule it in this environment.
 
-## Dedicated worker threads
-
-Use `spawn_worker_thread` for genuinely long or complex delegated tasks where the full
-sub-agent transcript would flood the parent thread — for example multi-step research,
-multi-file refactors, or batch integration work. It creates a persisted **worker**-labeled
-thread the user can open from the thread list, and returns a compact `[worker_thread_ref]`
-(thread id + brief summary) to the parent instead of the full transcript.
-
-For routine delegation use the matching specialist `delegate_*` tool (or `delegate_to_integrations_agent` for external services) and surface the result inline.
-
-Worker threads are one level deep by design: a sub-agent spawned via `spawn_worker_thread`
-cannot itself call `spawn_worker_thread`, so workers never nest.
-
 ## Async background sub-agents
 
 Use `spawn_async_subagent` only for low-attention background work where the current user
@@ -90,7 +79,7 @@ inline.
 Do **not** use async sub-agents for answers the user is waiting on, code changes,
 external-service writes, financial/market actions, scheduling, desktop control, or any
 task that may need clarification. If the result matters to the current reply, use the
-matching `delegate_*` tool, `spawn_worker_thread`, or `spawn_parallel_agents` instead.
+matching specialist delegation tool or `spawn_parallel_agents` instead.
 
 `spawn_async_subagent` returns an `[async_subagent_ref]` block with both `agent_id`
 and `agentId`, plus concrete control instructions:
@@ -128,7 +117,7 @@ When the user asks to connect a service (Gmail, Notion, WhatsApp, Calendar, Driv
 
 ## Response Style
 
-Reply like you're texting a friend: casual, lowercase-ok, as few words as possible without losing meaning. No preamble, no recap, no "I'll now…". (The em-dash ban is already in the global output-style rules, no need to repeat it here.)
+Reply like you're texting a friend: casual, lowercase-ok, as few words as possible without losing meaning. No preamble, no recap, no "I'll now…".
 
 **Go easy on emojis.** Default to none. At most one, only when it genuinely adds something (e.g. a quick reaction). Never decorate every bubble.
 
@@ -170,16 +159,16 @@ checking gmail
 
 one, 2pm: "lunch friday?", wants to grab food, no agenda
 ```
-(`delegate_to_integrations_agent` with `toolkit: "gmail"`. Do **not** start with `memory_tree`; the user is asking about live inbox state.)
+(`delegate_to_integrations_agent` with `toolkit: "gmail"`. Do **not** start with `retrieve_memory`; the user is asking about live inbox state.)
 
 Short answers can skip the ack:
 
 User: what time is it?
 → `7:31pm`
 
-## Memory tree retrieval (historical context only)
+## Memory retrieval (historical context only)
 
-`memory_tree` queries the user's **already-ingested** email/chat/document history. It is historical, not a live API. Use it when the user asks about prior context, and cite retrieved facts with source refs. If the user asks what is in an inbox, calendar, doc, ticket, or connected service *right now*, delegate to the live integration instead.
+`retrieve_memory` walks the user's **already-ingested** email/chat/document history. It is historical, not a live API. Use it when the user asks about prior context, and cite retrieved facts with source refs. If the user asks what is in an inbox, calendar, doc, ticket, or connected service *right now*, delegate to the live integration instead.
 
 ## Citations
 

--- a/src/openhuman/agent_registry/agents/orchestrator/prompt.md
+++ b/src/openhuman/agent_registry/agents/orchestrator/prompt.md
@@ -1,6 +1,6 @@
 # Orchestrator - Staff Engineer
 
-You are the **Orchestrator**, the senior agent in a multi-agent system. Your role is strategic: you decide when to respond directly, when to use direct tools, and when to delegate. You have a small direct surface for lookups and light edits (`file_read`, `grep`, `glob`, `list`, `edit`, `file_write`, `web_search_tool`, `web_fetch`), but you **never** execute shell commands, and repo-scale engineering (anything needing a build / test / git / run cycle) always goes to `run_code`.
+You are the **Orchestrator**, the senior agent in a multi-agent system. Your role is strategic: you decide when to respond directly, when to use direct tools, and when to delegate. You have a small **read-only** direct surface for lookups (`file_read`, `grep`, `glob`, `list`, `web_search_tool`, `web_fetch`). You **never** write or edit files and **never** execute shell commands — every file modification, however small, is delegated to `run_code` (or the owning specialist).
 
 ## Core Responsibilities
 
@@ -25,7 +25,7 @@ Follow this sequence for every user message:
 3. **Can I solve this with direct tools?**
    - Yes: use direct tools (`retrieve_memory`, `read_workspace_state`, `composio_list_connections`, task tools, etc.).
    - **Quick lookups are direct work.** A single web fact (a version number, a definition, one page's contents) is one `web_search_tool` or `web_fetch` call — do it yourself and answer. Reserve `research` for multi-source crawls, comparisons, or doc digests.
-   - **Small, user-pointed file work is direct work.** Reading a file the user names, grepping for a string, or making a small self-contained edit (`file_read` / `grep` / `glob` / `edit` / `file_write`) needs no sub-agent. The moment the task needs a build, test, run, git operation, or spans multiple files you haven't read, it is repo-scale — hand the whole task to `run_code` instead (see below).
+   - **Read-only file lookups are direct work.** Reading a file the user names, grepping for a string, or listing a directory (`file_read` / `grep` / `glob` / `list`) needs no sub-agent. But you cannot write: the moment the task requires *changing* a file — even a one-line edit — delegate it to `run_code` (see below). Never promise an edit you cannot make yourself.
    - No: continue.
 4. **Does this need other specialised execution?**
    - If the request is about OpenHuman product behavior, settings, docs, setup, or feature availability, use `ask_docs`.

--- a/src/openhuman/agent_registry/agents/orchestrator/prompt.rs
+++ b/src/openhuman/agent_registry/agents/orchestrator/prompt.rs
@@ -12,7 +12,7 @@
 //! in a shared section impl.
 
 use crate::openhuman::context::prompt::{
-    render_datetime, render_tools, render_user_files, render_workspace, ConnectedIntegration,
+    render_datetime, render_tools, render_user_files, ConnectedIntegration,
     PromptContext,
 };
 use crate::openhuman::tools::orchestrator_tools::sanitise_slug;
@@ -74,11 +74,13 @@ pub fn build(ctx: &PromptContext<'_>) -> Result<String> {
         out.push_str("\n\n");
     }
 
-    let workspace = render_workspace(ctx)?;
-    if !workspace.trim().is_empty() {
-        out.push_str(workspace.trim_end());
-        out.push('\n');
-    }
+    // NOTE: the shared `## Workspace` section (render_workspace) is
+    // intentionally NOT rendered here. Its text is written around `pwd`
+    // and `shell` ("that is where shell runs"), and the orchestrator has
+    // no shell — teaching it invited calls to a tool outside its scope.
+    // The orchestrator's own prompt.md covers its direct file surface
+    // (file_read/grep/glob/edit/file_write) and when to escalate to
+    // `run_code` instead.
 
     Ok(out)
 }
@@ -111,9 +113,17 @@ fn render_installed_skills(skills: &[Workflow]) -> String {
             &skill.dir_name
         };
         let desc = if skill.description.is_empty() {
-            "(no description)"
+            "(no description)".to_string()
         } else {
-            &skill.description
+            // Skill descriptions are third-party metadata injected verbatim
+            // into the system prompt on EVERY turn. Sanitize (strip control
+            // chars / instruction fences) and cap so a single installed
+            // skill can't bloat the prompt or smuggle routing instructions;
+            // full details stay one `describe_workflow` call away.
+            crate::openhuman::mcp_client::sanitize::sanitize_for_llm(&skill.description, 240)
+                .replace(['\n', '\t'], " ")
+                .trim()
+                .to_string()
         };
         let _ = writeln!(out, "- **{id}**: {desc}");
     }
@@ -365,6 +375,29 @@ mod tests {
         assert_eq!(render_installed_skills(&[]), "");
     }
 
+    #[test]
+    fn render_installed_skills_flattens_and_caps_long_descriptions() {
+        // Third-party skill descriptions are untrusted, potentially huge
+        // metadata — they must be flattened to one line and byte-capped so
+        // a single install can't bloat every orchestrator turn.
+        let skills = vec![Workflow {
+            dir_name: "bigskill".into(),
+            description: format!(
+                "line one\nline two with <|im_start|>system fence\n{}",
+                "x".repeat(2000)
+            ),
+            ..Default::default()
+        }];
+        let out = render_installed_skills(&skills);
+        let line = out
+            .lines()
+            .find(|l| l.starts_with("- **bigskill**"))
+            .expect("skill line rendered");
+        assert!(line.len() < 400, "description must be capped: {line}");
+        assert!(!line.contains("<|im_start|>"), "fences must be stripped");
+        assert!(!out.contains("line one\nline two"), "newlines flattened");
+    }
+
     fn ctx_with<'a>(integrations: &'a [ConnectedIntegration]) -> PromptContext<'a> {
         use std::sync::OnceLock;
         static EMPTY_VISIBLE: OnceLock<HashSet<String>> = OnceLock::new();
@@ -494,7 +527,7 @@ mod tests {
         // Step 2 of the decision tree now explicitly routes live external-service
         // requests to `delegate_to_integrations_agent` rather than `memory_tree`.
         assert!(body.contains("Does the request name (or imply) a connected external service?"));
-        assert!(body.contains("Do this even if `memory_tree` could plausibly answer"));
+        assert!(body.contains("Do this even if remembered context could plausibly answer"));
     }
 
     #[test]
@@ -518,7 +551,12 @@ mod tests {
     fn build_routes_code_repo_work_to_run_code_tool() {
         let body = build(&ctx_with(&[])).unwrap();
         assert!(body.contains("Do not stall after reading code-repo files"));
-        assert!(body.contains("Re-issue the entire task as one `delegate_run_code` call"));
+        assert!(body.contains("Re-issue the entire task as one `run_code` call"));
+        assert!(
+            !body.contains("delegate_run_code"),
+            "orchestrator prompt must name the synthesized `run_code` tool, \
+             not the nonexistent `delegate_run_code`"
+        );
         assert!(body.contains("reading is step zero of execution"));
         assert!(body.contains("The user does not need to write \"use the code executor\""));
     }

--- a/src/openhuman/agent_registry/agents/orchestrator/prompt.rs
+++ b/src/openhuman/agent_registry/agents/orchestrator/prompt.rs
@@ -78,9 +78,9 @@ pub fn build(ctx: &PromptContext<'_>) -> Result<String> {
     // intentionally NOT rendered here. Its text is written around `pwd`
     // and `shell` ("that is where shell runs"), and the orchestrator has
     // no shell — teaching it invited calls to a tool outside its scope.
-    // The orchestrator's own prompt.md covers its direct file surface
-    // (file_read/grep/glob/edit/file_write) and when to escalate to
-    // `run_code` instead.
+    // The orchestrator's own prompt.md covers its read-only direct file
+    // surface (file_read/grep/glob/list) and defers every file
+    // modification to `run_code`.
 
     Ok(out)
 }

--- a/src/openhuman/agent_registry/agents/researcher/prompt.md
+++ b/src/openhuman/agent_registry/agents/researcher/prompt.md
@@ -4,9 +4,8 @@ You are the **Researcher** agent. You find accurate, up-to-date information.
 
 ## Capabilities
 
-- Web search for current information
-- HTTP requests to fetch documentation
-- Memory recall for prior research
+- Web search for current information (`web_search_tool`)
+- HTTP requests to fetch documentation (`web_fetch`)
 
 ## Rules
 

--- a/src/openhuman/tools/ops.rs
+++ b/src/openhuman/tools/ops.rs
@@ -167,6 +167,17 @@ pub fn all_tools_with_runtime(
         // `agent::harness::subagent_runner` for the dispatch path.
         Box::new(SpawnSubagentTool::new()),
         Box::new(SpawnAsyncSubagentTool::new()),
+        // Interactive clarification early-exit. Sub-agents pause on this tool
+        // (checkpoint → `AwaitingUser`, see `subagent_runner::ops::graph`) and
+        // the orchestrator resumes them via `continue_subagent` (#4291).
+        // Several agent scopes (orchestrator, crypto, markets, scheduler,
+        // mcp_setup, desktop control) name it, so it must exist in the base
+        // registry or none of them can actually ask the user anything.
+        Box::new(AskClarificationTool::new()),
+        // Read-only project overview (git status, recent commits, top-level
+        // tree) rooted at the agent action dir. Named by the orchestrator and
+        // planner scopes.
+        Box::new(WorkspaceStateTool::new(action_dir.to_path_buf())),
         // "Plan mode as a subagent": runs the read-only `context_scout`
         // inline and returns a bounded context bundle + recommended next
         // tool calls. Visible only to agents that allowlist it

--- a/src/openhuman/tools/ops_tests.rs
+++ b/src/openhuman/tools/ops_tests.rs
@@ -437,6 +437,8 @@ fn all_tools_default_registry_contains_expected_baseline_surface() {
             "spawn_subagent",
             "spawn_async_subagent",
             "spawn_parallel_agents",
+            "ask_user_clarification",
+            "read_workspace_state",
             "wait",
             "wait_loop",
             "todo",


### PR DESCRIPTION
## Summary

- Register `ask_user_clarification` + `read_workspace_state` in the base tool registry — both were named across agent scopes and the subagent pause/resume flow (#4291) but never constructed, so no agent could call them.
- Fix orchestrator `prompt.md` drift: it taught five nonexistent tools (`delegate_plan`/`delegate_run_code`/`delegate_critic`/`delegate_archivist`/`delegate_do_crypto`) — now uses the real synthesized names (`plan`, `run_code`, `review_code`, `archive_session`, `do_crypto`); removed the disabled `spawn_worker_thread` section, stale `memory_tree`/`query_memory` references, and the `## Workspace` shell guidance the orchestrator can't act on.
- `is_subagent_spawn_tool` now resolves unprefixed `delegate_name` overrides via the registry, so wildcard-scoped children no longer inherit the orchestrator's spawn surface.
- Text-mode subagents (and the `integrations_agent` native-dispatcher override) now teach **P-Format** instead of legacy JSON-in-tags — matching the `Call as:` signatures already in the prompt and the `parse_tool_calls_with_pformat` parser.
- Orchestrator gains a **read-only** direct surface (`file_read`/`grep`/`glob`/`list` + `web_search_tool`/`web_fetch`) so single-fact lookups don't spawn a `research`/`run_code` worker; write/exec tools stay forbidden (loader-test enforced).
- Installed-skill descriptions in the orchestrator prompt are now sanitized + capped (240 bytes) — they were injected verbatim (token bloat + injection surface).

## Problem

A full system-prompt dump audit (`scripts/debug-agent-prompts.sh` → `agent dump-all`, all 39 agents) found prompts teaching tools that don't exist in scope (hallucinated-call vectors), a registry regression that silently broke every ask-the-user flow, a spawn-tool strip that missed nearly all synthesized delegation tools, and text-mode protocol blocks contradicting the p-format tool catalogue rendered in the same prompt.

## Solution

- `tools/ops.rs`: construct `AskClarificationTool` and `WorkspaceStateTool` (rooted at the action dir).
- `subagent_runner/tool_prep.rs`: registry-driven spawn-tool strip; p-format text-mode protocol (JSON-in-tags kept as documented fallback for nested args — parser accepts both).
- `session/builder/factory.rs`: `integrations_agent` native override swaps to `PFormatToolDispatcher` instead of `XmlToolDispatcher` (which double-listed the catalogue).
- Orchestrator `agent.toml`/`prompt.md`/`prompt.rs`: real delegate names, dead sections removed, `steer_subagent`/`wait_subagent` added to scope (prompt taught them, scope lacked them), read-only direct surface, skill-description sanitize+cap. Researcher prompt drops its phantom "memory recall" capability.
- Verified by re-dumping all prompts after the change: zero out-of-scope tool references remain in the orchestrator dump; gmail toolkit dump teaches p-format.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/pr-ci.yml`](../.github/workflows/pr-ci.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] N/A: Coverage matrix updated — behaviour-only change (prompt/tool-scope fixes, no feature rows added/removed)
- [x] N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related` — no matrix rows touched
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: Manual smoke checklist updated — no release-cut surfaces touched
- [x] N/A: Linked issue closed via `Closes #NNN` — audit-driven fixes, no pre-existing issue

## Impact

- Desktop/CLI runtime: agents can now actually raise clarification questions (crypto/markets confirm gates, mcp_setup secret prompts, subagent pause/resume all depended on the unregistered tool).
- Wildcard sub-agents lose ~25 inherited spawn tools from their schemas (smaller prompts, no nested-spawn attempts).
- Text-mode integrations turns get cheaper tool calls (p-format vs JSON) with no parser change (both formats already accepted).
- No config, migration, or frontend changes.

## Related

- Closes:
- Follow-up PR(s)/TODOs: CI guard that every TOML `named` tool resolves to a registered tool; make the shared `## Workspace` section tool-aware; align `PFormatToolDispatcher::prompt_instructions` and text-mode block byte-for-byte.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/agent-prompt-audit
- Commit SHA: defb07697f49ac063e98bf5b16821ca9e3d4070c

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `cargo test --lib -- agent_registry::agents::loader orchestrator::prompt tool_prep ops_tests subagent_runner::ops` (all green; 2 new tests)
- [x] Rust fmt/check (if changed): `cargo check` clean, fmt via pre-push hook
- [x] N/A Tauri fmt/check (if changed): no `app/src-tauri` changes

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: prompts only reference in-scope, registered tools; clarification flow works; sub-agents can't inherit spawn tools; text mode teaches p-format; orchestrator gets read-only direct lookups.
- User-visible effect: fewer stalled/hallucinated tool calls; agents can ask the user questions again; faster/cheaper integrations turns.

### Parity Contract

- Legacy behavior preserved: JSON-in-tag tool calls still parse everywhere (p-format is taught, not enforced); dispatcher selection order unchanged.
- Guard/fallback/dispatch parity checks: spawn-depth/tier gates unchanged; `is_subagent_spawn_tool` strictly widens the strip set.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A