### PR TITLE
refactor(agentworld): extract shared relativeTime helper (#4427)

### DIFF
--- a/app/src/agentworld/pages/BountiesSection.tsx
+++ b/app/src/agentworld/pages/BountiesSection.tsx
@@ -32,6 +32,7 @@ import type { ToastNotification } from '../../types/intelligence';
 import { apiClient } from '../AgentWorldShell';
 import { decimalsForAsset, resolveAssetSymbol } from '../assets';
 import X402ConfirmDialog, { formatUnits } from '../components/X402ConfirmDialog';
+import { relativeTime } from './relativeTime';
 
 // ── State types ───────────────────────────────────────────────────────────────
 
@@ -41,17 +42,6 @@ type BountiesState =
   | { status: 'ok'; bounties: Bounty[] };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function relativeTime(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(ms / 60000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  return `${days}d ago`;
-}
 
 /** Group the integer part of a numeric amount with thousands separators. */
 function formatAmount(amount: string): string {

--- a/app/src/agentworld/pages/ExploreSection/index.tsx
+++ b/app/src/agentworld/pages/ExploreSection/index.tsx
@@ -29,6 +29,7 @@ import { useT } from '../../../lib/i18n/I18nContext';
 import { apiClient } from '../../AgentWorldShell';
 import { decimalsForAsset, resolveAssetSymbol } from '../../assets';
 import { formatUnits } from '../../components/X402ConfirmDialog';
+import { relativeTime } from '../relativeTime';
 
 const debug = debugFactory('agentworld:explore');
 
@@ -403,16 +404,6 @@ function JobSkeletonList() {
       ))}
     </div>
   );
-}
-
-function relativeTime(isoDate: string): string {
-  const delta = Date.now() - new Date(isoDate).getTime();
-  const mins = Math.floor(delta / 60_000);
-  if (mins < 60) return `${mins}m ago`;
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
 }
 
 function JobRow({ job }: { job: GqlJobPosting }) {

--- a/app/src/agentworld/pages/FeedSection.tsx
+++ b/app/src/agentworld/pages/FeedSection.tsx
@@ -32,6 +32,7 @@ import {
 import { fetchWalletStatus } from '../../services/walletApi';
 import { apiClient } from '../AgentWorldShell';
 import ConfirmDialog from '../components/ConfirmDialog';
+import { relativeTime } from './relativeTime';
 
 const log = debug('agentworld:feed');
 
@@ -64,17 +65,6 @@ type WalletConfigured = 'resolving' | 'no' | 'yes' | 'unknown';
 type WalletResolution = { agentId: string | null; configured: WalletConfigured };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function relativeTime(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(ms / 60000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  return `${days}d ago`;
-}
 
 function isWalletLocked(message: string): boolean {
   return (

--- a/app/src/agentworld/pages/JobsSection.tsx
+++ b/app/src/agentworld/pages/JobsSection.tsx
@@ -29,6 +29,7 @@ import { useT } from '../../lib/i18n/I18nContext';
 import { fetchWalletStatus } from '../../services/walletApi';
 import { apiClient } from '../AgentWorldShell';
 import { explorerTxUrl } from '../hooks/useX402Buy';
+import { relativeTime } from './relativeTime';
 
 // ── State types ───────────────────────────────────────────────────────────────
 
@@ -38,18 +39,6 @@ type JobsState =
   | { status: 'ok'; jobs: GqlJobPosting[] };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-// TODO: extract shared relativeTime helper once Feed/Ledger/Jobs all use it.
-function relativeTime(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(ms / 60000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  return `${days}d ago`;
-}
 
 /**
  * Group the integer part of a numeric amount with thousands separators while

--- a/app/src/agentworld/pages/LedgerSection.tsx
+++ b/app/src/agentworld/pages/LedgerSection.tsx
@@ -17,6 +17,7 @@ import { apiClient } from '../AgentWorldShell';
 import { decimalsForAsset, resolveAssetSymbol } from '../assets';
 import { formatUnits, friendlyNetwork } from '../components/X402ConfirmDialog';
 import { explorerTxUrl } from '../hooks/useX402Buy';
+import { relativeTime } from './relativeTime';
 
 // ── State types ───────────────────────────────────────────────────────────────
 
@@ -26,17 +27,6 @@ type LedgerState =
   | { status: 'ok'; transactions: GqlLedgerTransaction[] };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function relativeTime(iso: string): string {
-  const ms = Date.now() - new Date(iso).getTime();
-  const mins = Math.floor(ms / 60000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  return `${days}d ago`;
-}
 
 export function abbreviateAddress(addr: string | undefined): string {
   if (!addr) return '—';

--- a/app/src/agentworld/pages/relativeTime.test.ts
+++ b/app/src/agentworld/pages/relativeTime.test.ts
@@ -47,4 +47,10 @@ describe('relativeTime', () => {
     // Timestamp 5s in the future (server clock ahead of client).
     expect(relativeTime(new Date(NOW + 5_000).toISOString())).toBe('just now');
   });
+
+  it('returns "just now" for an unparseable date instead of "NaNd ago"', () => {
+    freezeAt(NOW);
+    expect(relativeTime('not-a-date')).toBe('just now');
+    expect(relativeTime('')).toBe('just now');
+  });
 });

--- a/app/src/agentworld/pages/relativeTime.test.ts
+++ b/app/src/agentworld/pages/relativeTime.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { relativeTime } from './relativeTime';
+
+describe('relativeTime', () => {
+  const NOW = 1_700_000_000_000;
+
+  const freezeAt = (now: number) => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+  };
+
+  const ago = (ms: number) => new Date(NOW - ms).toISOString();
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders sub-minute deltas as "just now"', () => {
+    freezeAt(NOW);
+    expect(relativeTime(ago(0))).toBe('just now');
+    expect(relativeTime(ago(30_000))).toBe('just now');
+  });
+
+  it('renders whole minutes', () => {
+    freezeAt(NOW);
+    expect(relativeTime(ago(60_000))).toBe('1m ago');
+    expect(relativeTime(ago(5 * 60_000))).toBe('5m ago');
+    expect(relativeTime(ago(59 * 60_000))).toBe('59m ago');
+  });
+
+  it('renders whole hours', () => {
+    freezeAt(NOW);
+    expect(relativeTime(ago(60 * 60_000))).toBe('1h ago');
+    expect(relativeTime(ago(3 * 60 * 60_000))).toBe('3h ago');
+    expect(relativeTime(ago(23 * 60 * 60_000))).toBe('23h ago');
+  });
+
+  it('renders whole days', () => {
+    freezeAt(NOW);
+    expect(relativeTime(ago(24 * 60 * 60_000))).toBe('1d ago');
+    expect(relativeTime(ago(2 * 24 * 60 * 60_000))).toBe('2d ago');
+  });
+
+  it('treats small negative deltas from clock skew as "just now"', () => {
+    freezeAt(NOW);
+    // Timestamp 5s in the future (server clock ahead of client).
+    expect(relativeTime(new Date(NOW + 5_000).toISOString())).toBe('just now');
+  });
+});

--- a/app/src/agentworld/pages/relativeTime.ts
+++ b/app/src/agentworld/pages/relativeTime.ts
@@ -1,0 +1,24 @@
+/**
+ * Format an ISO-8601 timestamp as a short, human-readable relative time
+ * (`just now`, `5m ago`, `3h ago`, `2d ago`).
+ *
+ * Single source of truth for the Agent World sections. Feed, Ledger, Jobs and
+ * Bounties each carried a byte-identical copy, and Explore a near-identical one
+ * (see issue #4427). Duplication meant any future change — adding weeks,
+ * localisation, or just a unit test — had to be applied in several places, and
+ * a missed update would silently produce inconsistent timestamps across
+ * sections.
+ *
+ * Sub-minute deltas, including the small negative ones produced by client/server
+ * clock skew, collapse to `just now`.
+ */
+export function relativeTime(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(ms / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}

--- a/app/src/agentworld/pages/relativeTime.ts
+++ b/app/src/agentworld/pages/relativeTime.ts
@@ -10,10 +10,15 @@
  * sections.
  *
  * Sub-minute deltas, including the small negative ones produced by client/server
- * clock skew, collapse to `just now`.
+ * clock skew, collapse to `just now`. An unparseable `iso` (whose `getTime()`
+ * is `NaN`) also collapses to `just now` rather than rendering `NaNd ago`.
  */
 export function relativeTime(iso: string): string {
   const ms = Date.now() - new Date(iso).getTime();
+  // `new Date('garbage').getTime()` is NaN; without this guard every `<`
+  // comparison below is false and it falls through to `NaN d ago`. Treat an
+  // unparseable timestamp as the safe default.
+  if (!Number.isFinite(ms)) return 'just now';
   const mins = Math.floor(ms / 60000);
   if (mins < 1) return 'just now';
   if (mins < 60) return `${mins}m ago`;


### PR DESCRIPTION
Closes #4427.

## What

`relativeTime()` was copy-pasted across the Agent World sections — byte-identical in `FeedSection`, `LedgerSection`, `JobsSection` and `BountiesSection`, and a near-identical variant in `ExploreSection`. `JobsSection` even carried a TODO asking for exactly this:

```ts
// TODO: extract shared relativeTime helper once Feed/Ledger/Jobs all use it.
```

Duplication means any future change (weeks bucket, localisation, a unit test) has to be applied in five places, and a missed update silently diverges the relative timestamps between sections — the failure mode the issue calls out.

## Change

- New single source of truth: `app/src/agentworld/pages/relativeTime.ts`.
- All five sections now import it; the local copies and the TODO are gone.
- Added `relativeTime.test.ts` — the unit test the shared home makes possible: sub-minute → `just now`, minutes/hours/days buckets, and clock-skew (future timestamp) → `just now`.

## Behaviour note (ExploreSection)

The four identical copies are a pure no-op extraction. `ExploreSection`'s variant lacked the `mins < 1` guard, so it rendered sub-minute deltas as `0m ago` (and a future timestamp from client/server clock skew as `-1m ago`). It now shares the canonical helper and renders `just now` in both cases — matching the other four sections. This is the exact consistency the issue asks for; flagging it explicitly since it is a (small, strictly-improving) visible change rather than a pure refactor.

## Testing

- `pnpm --filter openhuman-app compile` — clean.
- ESLint on all touched files — no new errors.
- `vitest run relativeTime.test.ts LedgerSection.test.tsx …` — green (27 tests across the new suite + affected section tests).

No i18n change: the strings were already hardcoded English in every copy; this PR only removes the duplication. Threading `useT()` through is a separate, larger concern and out of scope for #4427.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared “time ago” display across multiple pages (minutes, hours, days, and “just now”) for timestamps.
* **Bug Fixes**
  * Improved recent-time rendering by collapsing very small/negative deltas to “just now” (helps with clock skew).
  * Prevents broken displays from invalid or unparseable timestamps by falling back to “just now.”
* **Tests**
  * Expanded automated test coverage for relative time formatting, including boundary and invalid-input cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->