### PR TITLE
test(e2e): stop ancillary LLM calls draining the mock forced-response queue (#4517)

### DIFF
--- a/scripts/mock-api/routes/llm.mjs
+++ b/scripts/mock-api/routes/llm.mjs
@@ -9,6 +9,17 @@ import {
 import { buildDynamicCompletion } from "./llm/dynamic.mjs";
 import { headerValue, pickProbeText, resolveThreadKey } from "./llm/shared.mjs";
 
+// The scripted `llmForcedResponses` FIFO models the *interactive* agent turn,
+// which always advertises tools (the orchestrator's delegate_* tools). Ancillary
+// completions that share the endpoint but carry no tools — thread-title/summary
+// generation via `chat_with_system` (tools: None), fired fire-and-forget and
+// racing the visible turn — must NOT drain the queue, or the scripted responses
+// desync and the turn falls through to the dynamic fallback
+// (tinyhumansai/openhuman#4517).
+function isPrimaryTurn(parsedBody) {
+  return Array.isArray(parsedBody?.tools) && parsedBody.tools.length > 0;
+}
+
 function requestRuleMatches(rule, ctx) {
   if (!rule || typeof rule !== "object") return false;
   const { url, parsedBody, req } = ctx;
@@ -242,14 +253,22 @@ function handleStreamingCompletion({
 
   if (!Array.isArray(script)) {
     // 2. Forced queue: pop the next entry and convert it into a script.
-    const forced = parseBehaviorJson("llmForcedResponses", []);
-    if (Array.isArray(forced) && forced.length > 0) {
-      const next = forced.shift();
-      setMockBehavior("llmForcedResponses", JSON.stringify(forced));
-      script = defaultStreamScript({
-        content: next.content,
-        toolCalls: next.toolCalls,
-      });
+    //    Only the primary *interactive* turn drains the queue. The agent
+    //    (orchestrator) always sends a `tools` array; ancillary completions
+    //    that race the turn — notably fire-and-forget thread-title generation
+    //    (`chat_with_system`, tools: None) dispatched on send — carry no tools
+    //    and must NOT consume a scripted response, or the queue desyncs and the
+    //    turn falls through to the dynamic fallback (tinyhumansai/openhuman#4517).
+    if (isPrimaryTurn(parsedBody)) {
+      const forced = parseBehaviorJson("llmForcedResponses", []);
+      if (Array.isArray(forced) && forced.length > 0) {
+        const next = forced.shift();
+        setMockBehavior("llmForcedResponses", JSON.stringify(forced));
+        script = defaultStreamScript({
+          content: next.content,
+          toolCalls: next.toolCalls,
+        });
+      }
     }
   }
 
@@ -620,8 +639,11 @@ export function handleLlmCompletions(ctx) {
   }
 
   // 1. Forced queue — replay exact ChatResponse objects in order.
+  //    Only the primary interactive turn drains the queue; ancillary no-tools
+  //    completions (e.g. fire-and-forget thread-title generation racing the
+  //    turn) must not consume a scripted response (tinyhumansai/openhuman#4517).
   const forced = parseBehaviorJson("llmForcedResponses", []);
-  if (Array.isArray(forced) && forced.length > 0) {
+  if (isPrimaryTurn(parsedBody) && Array.isArray(forced) && forced.length > 0) {
     const next = forced.shift();
     // Persist the shrunk queue back so subsequent requests advance.
     setMockBehavior("llmForcedResponses", JSON.stringify(forced));

--- a/scripts/mock-api/routes/llm/dynamic.mjs
+++ b/scripts/mock-api/routes/llm/dynamic.mjs
@@ -137,9 +137,26 @@ function buildReasoningSummary(prompt, toolText, thread) {
   ].join(" ");
 }
 
+// Orchestration/delegate tools (analyze_image, delegate_*) require a `prompt`
+// argument (and carry `citation_requirement`). The dynamic fallback can only
+// synthesize simple worker-tool args (q/path/cmd/url), so a fabricated call to a
+// delegate tool fails schema validation with a confusing "arguments.prompt is
+// required" bubble (tinyhumansai/openhuman#4517). Treat only tools that do NOT
+// require `prompt` as fabricatable; otherwise fall through to benign text.
+function isSimpleWorkerTool(toolDef) {
+  const params = toolDef?.function?.parameters || toolDef?.parameters || {};
+  const required = Array.isArray(params.required) ? params.required : [];
+  return !required.includes("prompt");
+}
+
 function inferToolCalls(prompt, toolDefs = []) {
   const lower = String(prompt || "").toLowerCase();
-  const declared = Array.isArray(toolDefs) ? toolDefs : [];
+  const declared = (Array.isArray(toolDefs) ? toolDefs : []).filter(
+    isSimpleWorkerTool,
+  );
+  // Only delegate/orchestration tools are available — the fallback can't build a
+  // valid call, so return benign text rather than a schema-error tool call.
+  if (declared.length === 0) return [];
   const picked = (name, args) => ({
     id: createMockId("tool"),
     name,


### PR DESCRIPTION
## Summary

- Fixes the chat-shard desktop-E2E failures diagnosed in #4517: the mock's forced-response queue desyncs with the orchestrator harness, so scripted final answers never render and the agent improvises a broken `analyze_image` call.
- Mock-side only — no core/product change.

## Problem

The desktop chat agent is the **orchestrator** archetype, which always advertises `delegate_*` tools (incl. `analyze_image`, whose schema requires `prompt` + `citation_requirement`). The E2E mock's `llmForcedResponses` is a process-global one-shot FIFO consumed **one entry per `/chat/completions`**. Fire-and-forget **thread-title generation** (`chat_with_system`, `tools: None`, dispatched on user send in `app/src/store/threadSlice.ts`) races the visible turn and drains a scripted response. The queue desyncs → the turn falls through to the dynamic fallback, which fabricates a call to `declared[0]` (= `analyze_image`) with `{url}` args → `arguments.prompt is required`, and the scripted canary never renders.

Full root-cause trace in #4517.

## Solution

`scripts/mock-api/routes/llm.mjs`:
- Add `isPrimaryTurn(parsedBody)` = the request advertises tools. Only the primary interactive turn drains the forced/stream queue (both the streaming and non-stream consumption sites). Ancillary no-tools completions (title/summary) fall through to the dynamic responder and leave the queue intact.

`scripts/mock-api/routes/llm/dynamic.mjs`:
- Harden `inferToolCalls`: only fabricate tool calls for **simple worker tools** (no required `prompt`). Delegate-only turns return benign text instead of a schema-error tool call, so any residual desync is legible rather than a confusing `analyze_image` bubble.

**Validated against the running mock:** a no-tools title-gen call leaves the queue intact; consecutive tool-bearing turns receive `web_fetch` then the canary in order; a delegate-only drained turn returns text (not a broken `analyze_image` call) while simple worker tools still fabricate.

## Submission Checklist

- [x] Tests added or updated — E2E mock fixture behavior corrected; validated via direct mock exercise (happy path + delegate-only failure path).
- [ ] N/A **Diff coverage ≥ 80%** — change is E2E mock-fixture JS (no product `src` lines).
- [ ] N/A Coverage matrix — test-infra only.
- [x] No new external network dependencies — mock backend only.
- [ ] N/A release-cut manual-smoke surface.
- [ ] N/A linked issue closed — this is a partial fix; see Related.

## Impact

- E2E mock only. Deterministically fixes the single-turn forced-queue chat specs (`user-journey-full-task`, `chat-tool-call-flow`, `chat-thread-todo-strip`) and likely `chat-multi-tool-round` (local-tool, no sub-agent). No runtime/product behavior change.

## Related

- Refs #4517 — the genuinely multi-agent spec `chat-harness-subagent` (orchestrator→researcher) additionally needs its `FORCED_RESPONSES` to cover the sub-agent's own model calls (or convert to `llmKeywordRules`, which are content-addressed and never shifted); tracked there.
- Follows #4511 (release-lane unblock). Remaining Release-CI tail also in #4517: CEF shared-session instability and the `onboarding-modes` wizard (disabled-Whisper-option / vault-step), both needing app-level/harness work.

https://claude.ai/code/session_01UAetDHQCyFtWnyP7RwGdJU
