### PR TITLE
fix(announcements): degrade best-effort latest fetch to null, stop Sentry flood (#4401)

### DIFF
--- a/src/api/rest.rs
+++ b/src/api/rest.rs
@@ -94,6 +94,17 @@ fn parse_message_path(path: &str) -> Option<(&str, &str)> {
     None
 }
 
+/// True when `path` addresses the announcements endpoint family
+/// (`/announcements/…`), tolerant of base-path prefixes such as
+/// `/api/v1/announcements/latest`. Segment-aware, so a substring like
+/// `/foo/announcementsxyz` does not match. Used to scope the best-effort 404
+/// suppression to this cosmetic endpoint (see `authed_json`).
+fn is_announcements_path(path: &str) -> bool {
+    path.split('/')
+        .filter(|s| !s.is_empty())
+        .any(|segment| segment == "announcements")
+}
+
 const CLIENT_VERSION_HEADER_MAX_LEN: usize = 64;
 
 /// Max bytes of the `body_shape` key-name list echoed into the `authed_json`
@@ -698,6 +709,35 @@ impl BackendOAuthClient {
                     );
                     anyhow::bail!(
                         "channel message not found (404) on {} {}",
+                        method.as_str(),
+                        url.path(),
+                    );
+                }
+
+                // 404 on the announcements endpoint is an expected state under
+                // staged backend deploys / rollback — the route
+                // (tinyhumansai/backend#1064) may not be shipped yet.
+                // Announcements-on-init (#4125) is a best-effort, fire-once,
+                // cosmetic feature, so a missing announcement is never worth a
+                // Sentry event. Suppress the report and bail with an
+                // announcements-scoped message; the caller degrades to "no
+                // announcement". Collapses the double-report at
+                // OPENHUMAN-TAURI-HW0 / KHX (~452 events). Non-404 errors on
+                // this path still report below, so this is not a blindfold.
+                if is_announcements_path(url.path()) {
+                    tracing::info!(
+                        domain = "backend_api",
+                        operation = "authed_json",
+                        method = method.as_str(),
+                        path = url.path(),
+                        status = status_code,
+                        failure = "non_2xx",
+                        "[backend_api] announcements 404 on {} {} — cosmetic best-effort endpoint, suppressing Sentry",
+                        method.as_str(),
+                        url.path(),
+                    );
+                    anyhow::bail!(
+                        "announcements not found (404) on {} {}",
                         method.as_str(),
                         url.path(),
                     );

--- a/src/api/rest_tests.rs
+++ b/src/api/rest_tests.rs
@@ -1,6 +1,7 @@
 use super::{
-    backend_api_body_shape, flatten_authed_error, key_bytes_from_string, parse_message_path,
-    sanitize_client_version, BackendApiError, BackendOAuthClient, BACKEND_API_BODY_SHAPE_MAX_BYTES,
+    backend_api_body_shape, flatten_authed_error, is_announcements_path, key_bytes_from_string,
+    parse_message_path, sanitize_client_version, BackendApiError, BackendOAuthClient,
+    BACKEND_API_BODY_SHAPE_MAX_BYTES,
 };
 use axum::extract::State;
 use axum::http::HeaderMap;
@@ -356,6 +357,74 @@ async fn authed_json_surfaces_message_not_found_on_404() {
     };
     assert_eq!(provider, "discord");
     assert_eq!(message_id, "abc");
+}
+
+#[tokio::test]
+async fn authed_json_suppresses_announcements_404() {
+    // #4401 (OPENHUMAN-TAURI-HW0 / KHX): a 404 on the cosmetic announcements
+    // endpoint (route may not be shipped under a staged deploy / rollback) must
+    // be suppressed — no `report_error` — so the caller degrades to "no
+    // announcement". It takes the announcements-scoped bail branch (distinct
+    // message) rather than the generic report_error + bail path, and is NOT
+    // classified as the typed channel-message state.
+    let app = Router::new().route(
+        "/announcements/latest",
+        get(|| async { (axum::http::StatusCode::NOT_FOUND, "Not Found") }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let base_url = format!("http://{addr}");
+    let client = BackendOAuthClient::new(&base_url).unwrap();
+
+    let err = client
+        .authed_json("mock-jwt", Method::GET, "/announcements/latest", None)
+        .await
+        .unwrap_err();
+
+    // Not the typed channel-message state.
+    assert!(
+        err.downcast_ref::<BackendApiError>().is_none(),
+        "announcements 404 must not be classified as a typed channel error"
+    );
+    // Took the announcements suppression branch: its message is distinct from
+    // the generic report_error + bail path ("… failed (404): …").
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("announcements not found"),
+        "expected the announcements-scoped suppression message, got: {msg}"
+    );
+}
+
+// ── is_announcements_path unit tests (TAURI-HW0/KHX #4401 scoping guard) ──────
+
+#[test]
+fn announcements_path_canonical_form() {
+    assert!(is_announcements_path("/announcements/latest"));
+}
+
+#[test]
+fn announcements_path_tolerates_base_prefix() {
+    assert!(is_announcements_path("/api/v1/announcements/latest"));
+}
+
+#[test]
+fn announcements_path_tolerates_trailing_slash() {
+    assert!(is_announcements_path("/announcements/latest/"));
+}
+
+#[test]
+fn announcements_path_rejects_non_announcement_paths() {
+    // A substring that is not a whole path segment must not match — the
+    // suppression stays scoped to the real endpoint, never a code bug elsewhere.
+    assert!(!is_announcements_path("/foo/announcementsxyz"));
+    assert!(!is_announcements_path("/channels/telegram/messages/1"));
+    assert!(!is_announcements_path("/auth/profile"));
+    assert!(!is_announcements_path("/"));
+    assert!(!is_announcements_path(""));
 }
 
 #[tokio::test]

--- a/src/openhuman/announcements/ops.rs
+++ b/src/openhuman/announcements/ops.rs
@@ -46,11 +46,16 @@ async fn get_authed_value(config: &Config, method: Method, path: &str) -> Result
 pub async fn get_latest_announcement(config: &Config) -> Result<RpcOutcome<Value>, String> {
     match get_authed_value(config, Method::GET, "/announcements/latest").await {
         Ok(data) => Ok(RpcOutcome::single_log(data, "latest announcement fetched")),
-        Err(e) => {
+        Err(_e) => {
+            // Deliberately do NOT log the raw error: for a non-404 failure
+            // `authed_json` formats it as "GET /announcements/latest failed
+            // (…): {body}", so `%e` could write a raw upstream response body
+            // (potential PII) to the logs. The REST layer already reports the
+            // real error with a PII-safe `body_shape`; here we only note that
+            // the cosmetic fetch degraded.
             tracing::info!(
                 domain = "announcements",
                 operation = "get_latest_announcement",
-                error = %e,
                 "[announcements] latest fetch failed — degrading to no announcement (null)"
             );
             Ok(RpcOutcome::single_log(

--- a/src/openhuman/announcements/ops.rs
+++ b/src/openhuman/announcements/ops.rs
@@ -33,7 +33,30 @@ async fn get_authed_value(config: &Config, method: Method, path: &str) -> Result
 /// Fetch the latest active announcement for the signed-in user.
 /// Maps to `GET /announcements/latest`. The backend returns the announcement
 /// object or `null` when nothing qualifies; both pass through verbatim.
+///
+/// Announcements-on-init (#4125) is a best-effort, fire-once, cosmetic feature:
+/// a missing or unavailable announcement is never worth surfacing an error for.
+/// Any fetch failure — a 404 under a staged backend deploy / rollback
+/// (tinyhumansai/backend#1064), a lapsed session, transient infra — degrades to
+/// "no announcement" (`null`) instead of propagating an `Err` that the RPC layer
+/// would re-wrap into a second Sentry event (OPENHUMAN-TAURI-KHX). The frontend
+/// service documents the same intent. The REST layer still reports genuinely
+/// unexpected (non-404) errors to Sentry, so this is graceful degradation, not a
+/// blindfold. See #4401.
 pub async fn get_latest_announcement(config: &Config) -> Result<RpcOutcome<Value>, String> {
-    let data = get_authed_value(config, Method::GET, "/announcements/latest").await?;
-    Ok(RpcOutcome::single_log(data, "latest announcement fetched"))
+    match get_authed_value(config, Method::GET, "/announcements/latest").await {
+        Ok(data) => Ok(RpcOutcome::single_log(data, "latest announcement fetched")),
+        Err(e) => {
+            tracing::info!(
+                domain = "announcements",
+                operation = "get_latest_announcement",
+                error = %e,
+                "[announcements] latest fetch failed — degrading to no announcement (null)"
+            );
+            Ok(RpcOutcome::single_log(
+                Value::Null,
+                "no announcement (fetch failed, degraded to null)",
+            ))
+        }
+    }
 }


### PR DESCRIPTION
Closes #4401.

## What

`GET /announcements/latest` currently 404s in prod (backend route merged but not shipped — tinyhumansai/backend#1064), and the client turns that into a Sentry flood: ~452 events / 19 users, escalating. One failure is reported **twice** — once by `authed_json`'s `report_error` (OPENHUMAN-TAURI-HW0), then again when the RPC dispatch re-wraps the propagated `Err` (OPENHUMAN-TAURI-KHX).

Announcements-on-init (#4125) is a best-effort, fire-once, **cosmetic** feature. The frontend service already documents the intent — *"Network/auth failures resolve to null — a missing announcement is never worth surfacing an error for"* — but the Rust path didn't honor it.

## Change

Two scoped layers, mirroring the existing expected-404 suppression precedent for `/channels/*/messages/*` (`BackendApiError::MessageNotFound`, TAURI-2Y):

1. **`src/api/rest.rs::authed_json`** — a 404 on the announcements endpoint is an expected state under staged deploy / rollback. Suppress `report_error` and bail with an announcements-scoped message. New segment-aware `is_announcements_path` helper keeps the scope tight (tolerates base-path prefixes like `/api/v1/announcements/latest`; a substring like `/foo/announcementsxyz` does **not** match). Kills HW0.

2. **`src/openhuman/announcements/ops.rs::get_latest_announcement`** — any fetch failure degrades to `null` ("no announcement") instead of propagating `Err`, so the RPC layer never sees an error to re-wrap. Kills KHX and gives the correct UX for a cosmetic endpoint.

## Not a blindfold

The suppression is deliberately narrow. Only the **404** is silenced at the REST layer; a genuinely unexpected non-404 (e.g. a 500) on the announcements path still flows through `report_error`, so real backend breakage stays visible in Sentry. The ops-layer degradation only affects the user-facing surface (no error shown for a cosmetic feature), not Sentry visibility for non-404s. The backend deploy gap itself is tracked separately (tinyhumansai/backend#1064), so the "feature actually works" path stays honest.

## Tests (`src/api/rest_tests.rs`)

- `authed_json_suppresses_announcements_404` — a 404 on `/announcements/latest` bails via the announcements-scoped branch (distinct message) and is not classified as the typed channel-message error.
- `is_announcements_path` unit tests: canonical path, base-path prefix, trailing slash, and negatives (substring-not-segment, channel-message path, auth path, `/`, empty) — mirrors the `parse_message_path` regression-guard style.

`cargo test --lib api::rest` green locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Missing announcements now fail gracefully instead of surfacing an error to the app.
  * Requests to the announcements area that return “not found” are handled quietly, reducing unnecessary error noise.
  * When announcement data can’t be fetched, the app now treats it as “no announcement” rather than a failure.

* **Tests**
  * Added coverage for announcement path handling and the 404-suppression behavior to ensure missing announcements don’t trigger error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->