### PR TITLE
feat(memory): W2 — re-export memory value types from TinyCortex (type-unification)

### DIFF
--- a/src/openhuman/memory/traits.rs
+++ b/src/openhuman/memory/traits.rs
@@ -1,173 +1,46 @@
 //! Core traits and data structures for the OpenHuman memory system.
 //!
 //! This module defines the foundational `Memory` trait that all storage backends
-//! must implement, as well as the standard `MemoryEntry` and `MemoryCategory`
-//! types used for representing and organizing memories.
+//! must implement. The standard memory value types (`MemoryEntry`,
+//! `MemoryCategory`, `MemoryTaint`, `RecallOpts`, `NamespaceSummary`) are
+//! **re-exported from the `tinycortex` crate** (migration W2, spec §0.5): the
+//! crate is the single source of truth for these wire-compatible types, and the
+//! 30+ host consumers keep their `memory::traits::…` import paths unchanged.
+//!
+//! `MemoryTaint` is security-critical provenance — it fails closed to
+//! `ExternalSync` for unknown/corrupt values so the subconscious gate refuses
+//! external-effect tools on chunks of unknown origin. Its semantics were proven
+//! byte-identical to the former host definition before re-exporting; the tests
+//! below are the host-side seam that pins that contract on the crate type.
+//!
+//! The `Memory` trait itself stays host-defined for now because of the
+//! `sqlite_conn()` escape hatch, which the crate deliberately omits. That hatch
+//! is retired in W3 (callers move to `tinycortex::memory::chunks::with_connection`),
+//! after which the trait can also become a crate re-export.
 
 use async_trait::async_trait;
 use parking_lot::Mutex;
 use rusqlite::Connection;
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
-/// Provenance / trust signal attached to a memory entry. Drives downstream
-/// policy decisions — most importantly, whether a subconscious tick whose
-/// context contains this chunk may invoke external-effect tools.
-///
-/// Defaults to [`MemoryTaint::Internal`] so existing rows (which have no
-/// taint column persisted) and all in-memory `MemoryEntry::default()`
-/// constructions are conservatively trusted as user-driven content.
-/// Sync paths that ingest text from third-party services (Gmail / Slack /
-/// Notion / Composio / etc.) MUST flip this to [`MemoryTaint::ExternalSync`]
-/// at write time so the subconscious origin escalation can see it.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum MemoryTaint {
-    /// User-driven memory (chat, manual remember, internal heuristics).
-    #[default]
-    Internal,
-    /// Chunk ingested from an external sync source (Gmail / Slack /
-    /// Notion / Composio / etc.). Subconscious turns whose context
-    /// contains any tainted chunk MUST run with
-    /// [`TrustedAutomationSource::SubconsciousTainted`] origin so
-    /// external_effect tools are refused.
-    ///
-    /// [`TrustedAutomationSource::SubconsciousTainted`]:
-    /// crate::openhuman::agent::turn_origin::TrustedAutomationSource::SubconsciousTainted
-    ExternalSync,
-}
-
-impl MemoryTaint {
-    /// Serialised form used by the SQLite `memory_docs.taint` column.
-    ///
-    /// Kept short + snake_case to match the serde representation and to
-    /// keep the on-disk footprint minimal. Round-trips via
-    /// [`Self::from_db_str`].
-    pub fn as_db_str(&self) -> &'static str {
-        match self {
-            Self::Internal => "internal",
-            Self::ExternalSync => "external_sync",
-        }
-    }
-
-    /// Reverse of [`Self::as_db_str`]. Unknown values (a forward-rolled
-    /// schema variant we don't know about yet, a manual `UPDATE` typo,
-    /// row corruption) decode as the more restrictive
-    /// [`MemoryTaint::ExternalSync`] so the subconscious gate fails
-    /// closed — we'd rather refuse external_effect tools on a chunk
-    /// of unknown provenance than silently treat it as user-authored.
-    /// Legacy rows that pre-date the column are not affected: the
-    /// migration writes a literal `'internal'` default so they
-    /// round-trip cleanly through the explicit arm.
-    pub fn from_db_str(raw: &str) -> Self {
-        match raw {
-            "internal" => Self::Internal,
-            "external_sync" => Self::ExternalSync,
-            _ => Self::ExternalSync,
-        }
-    }
-}
-
-/// Represents a single stored memory entry with associated metadata.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct MemoryEntry {
-    /// Unique identifier for the memory entry (usually a UUID).
-    pub id: String,
-    /// The key or title associated with this memory.
-    pub key: String,
-    /// The actual content or value of the memory.
-    pub content: String,
-    /// Optional namespace for logical separation of memories.
-    #[serde(default)]
-    pub namespace: Option<String>,
-    /// The organizational category this memory belongs to.
-    pub category: MemoryCategory,
-    /// ISO 8601 formatted timestamp of when the memory was created or last updated.
-    pub timestamp: String,
-    /// Optional session ID if this memory is scoped to a specific interaction.
-    pub session_id: Option<String>,
-    /// Optional relevance or confidence score, typically from 0.0 to 1.0.
-    pub score: Option<f64>,
-    /// Provenance — `Internal` for user-driven writes, `ExternalSync` for
-    /// memory_sync ingest. Default keeps existing persisted rows safe;
-    /// composio / Gmail / Slack / Notion ingest paths must set this
-    /// explicitly. See [`MemoryTaint`] for the security contract.
-    #[serde(default)]
-    pub taint: MemoryTaint,
-}
-
-/// Categories used to organize and filter memories by their nature and lifecycle.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum MemoryCategory {
-    /// Long-term foundational facts, user preferences, and permanent decisions.
-    Core,
-    /// Temporal logs reflecting daily activities or ephemeral state.
-    Daily,
-    /// Contextual information derived from and relevant to active conversations.
-    Conversation,
-    /// A user-defined or system-defined custom category.
-    Custom(String),
-}
-
-impl std::fmt::Display for MemoryCategory {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Core => write!(f, "core"),
-            Self::Daily => write!(f, "daily"),
-            Self::Conversation => write!(f, "conversation"),
-            Self::Custom(name) => write!(f, "{name}"),
-        }
-    }
-}
-
-/// Optional filters for `Memory::recall`.
-///
-/// All fields default to `None` / `false`. `namespace = None` uses the
-/// backend's legacy default namespace (`GLOBAL_NAMESPACE`). Pass
-/// `Some("namespace")` to scope the semantic query to a specific namespace.
-///
-/// ## Cross-session recall (#1505)
-///
-/// `cross_session = true` asks the backend to surface conversational
-/// (episodic) hits from OTHER sessions belonging to the same workspace,
-/// alongside any current-session hits when `session_id` is also set. This
-/// is what lets a fresh chat recover context the user shared in a prior
-/// chat without waiting for the transcript-ingest threshold to fire.
-///
-/// User scope is enforced by the SQLite database living at
-/// `<workspace>/memory/...` — one workspace == one user — so `cross_session`
-/// can never cross a user/workspace boundary. When `session_id` is `Some`,
-/// the matching session is excluded from the cross-session sweep (its
-/// entries are already pulled via the same-session episodic path) so the
-/// caller doesn't double-count the current chat's history.
-#[derive(Debug, Default, Clone)]
-pub struct RecallOpts<'a> {
-    pub namespace: Option<&'a str>,
-    pub category: Option<MemoryCategory>,
-    pub session_id: Option<&'a str>,
-    pub min_score: Option<f64>,
-    /// When `true`, include conversational hits from other sessions in
-    /// the same workspace alongside the namespace recall. Defaults to
-    /// `false` so existing callers see no behavior change. See struct
-    /// docs for scope-safety details.
-    pub cross_session: bool,
-}
-
-/// Summary row returned by `Memory::namespace_summaries`, used for
-/// agent-side namespace discovery.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NamespaceSummary {
-    pub namespace: String,
-    pub count: usize,
-    /// RFC3339 timestamp of most recent `updated_at` in the namespace, if any.
-    pub last_updated: Option<String>,
-}
+// ── Value types: re-exported from the crate (W2 type-unification, spec §0.5) ──
+//
+// These were formerly defined here. They are now the crate's types verbatim
+// (identical fields, derives, serde attrs, and — for `MemoryTaint` — the same
+// fail-closed `from_db_str`). Re-exporting keeps one source of truth while every
+// `use crate::openhuman::memory::traits::{MemoryEntry, …}` site compiles unchanged.
+pub use tinycortex::memory::{
+    MemoryCategory, MemoryEntry, MemoryTaint, NamespaceSummary, RecallOpts,
+};
 
 /// The core trait for memory storage and retrieval.
 ///
 /// Any persistence backend (SQLite, Postgres, Vector DB, etc.) should implement
 /// this trait to be used within the OpenHuman ecosystem.
+///
+/// This mirrors [`tinycortex::memory::Memory`] method-for-method **plus** the
+/// host-only [`Memory::sqlite_conn`] escape hatch. It stays host-defined until
+/// W3 migrates that hatch to the crate's scoped `with_connection` accessor.
 #[async_trait]
 pub trait Memory: Send + Sync {
     /// Returns the name of the memory backend (e.g., "sqlite", "vector").
@@ -273,7 +146,9 @@ pub trait Memory: Send + Sync {
     /// access for FTS5 / segment writes without going through the async
     /// `Memory` trait.
     ///
-    /// Default: `None`. Only `UnifiedMemory` overrides this.
+    /// Default: `None`. Only `UnifiedMemory` overrides this. Host-only escape
+    /// hatch (the crate omits it by design); retired to
+    /// `tinycortex::memory::chunks::with_connection` in W3.
     fn sqlite_conn(&self) -> Option<Arc<Mutex<Connection>>> {
         None
     }
@@ -371,7 +246,8 @@ mod tests {
         // Unknown / corrupted column values fail closed to the more
         // restrictive `ExternalSync` so the subconscious gate refuses
         // external_effect tools on chunks of unknown provenance rather
-        // than silently treating them as user-authored.
+        // than silently treating them as user-authored. This is the W2
+        // security seam test on the re-exported crate type.
         assert_eq!(MemoryTaint::from_db_str(""), MemoryTaint::ExternalSync);
         assert_eq!(
             MemoryTaint::from_db_str("EXTERNAL_SYNC"),


### PR DESCRIPTION
## Summary

- **W2 of the TinyCortex memory migration** — flip the memory value types to **crate re-exports**, the type-unification decision from Phase 0 (spec §0.5).
- `memory/traits.rs` now `pub use`s `tinycortex::memory::{MemoryCategory, MemoryEntry, MemoryTaint, NamespaceSummary, RecallOpts}` instead of defining them. One source of truth; all 30+ consumers + the ~10 `impl Memory` sites compile unchanged.
- Keeps the security-critical `MemoryTaint` fail-closed tests as the **host-side W2 seam** — now pinning the contract on the *crate* type.

## Problem

Phase 0 found the host `memory::traits` types and the crate's types are wire-compatible twins (identical fields, derives, serde attrs, and — for `MemoryTaint` — the same `from_db_str` fail-closed decode). Maintaining two definitions invites silent drift, most dangerously on `MemoryTaint`, which drives external-effect-tool gating for tainted subconscious turns. W2 collapses them onto the crate.

## Solution

- **Re-export, not redefine.** `traits.rs` deletes the five type definitions and re-exports the crate's. They are drop-in identical (verified field-by-field, incl. `#[derive(… Copy … Serialize, Deserialize, Default)]` and `#[serde(rename_all = "snake_case")]`), so every `use crate::openhuman::memory::traits::{MemoryEntry, …}` site is unchanged. No host `impl` targets these types (checked — no orphan-rule breakage).
- **`Memory` trait stays host-defined — deliberately.** The crate's `Memory` trait matches the host's method-for-method **except** `sqlite_conn()`, the raw-connection escape hatch the crate omits by design. Because `sqlite_conn` dispatches per-backend through `dyn Memory` (only `UnifiedMemory` returns a real handle; everything else `None`), a blanket extension trait can't preserve it. So the host trait is kept as-is for now; the hatch (2 external callers) migrates to `tinycortex::memory::chunks::with_connection` in **W3**, after which the trait can also become a crate re-export.
- **Security seam.** The `MemoryTaint` tests (`…unknown_fails_closed`, `…defaults_to_internal_for_legacy_rows`, snake_case db/serde, `MemoryCategory` Display) stay in `traits.rs` and now exercise the **re-exported crate type** — the W2 security-review item: fail-closed to `ExternalSync` survives the boundary.

## Submission Checklist

- [x] Tests added/updated — the `MemoryTaint`/`MemoryEntry`/`MemoryCategory` seam tests now verify the crate types (fail-closed taint, legacy-row default, snake_case, Display, round-trips)
- [x] **Diff coverage ≥ 80%** — the diff is a re-export swap + retained tests; the changed lines are the `pub use` and the (unchanged-behaviour) tests around it
- [ ] Coverage matrix updated — `N/A: no user-facing feature change; type-identity refactor`
- [ ] All affected feature IDs listed — `N/A`
- [x] No new external network dependencies
- [ ] Manual smoke checklist updated — `N/A: no release-cut surface touched`
- [ ] Linked issue closed — `N/A: tracks plan #4513`

## Impact

- **Runtime:** none — the crate types are byte-identical to the former host types (same serde wire form, same `Default`, same fail-closed `from_db_str`). Existing persisted rows deserialize identically.
- **Security:** `MemoryTaint` provenance is now single-sourced from the crate with its fail-closed default intact, pinned by the retained seam tests.
- **Build:** `cargo check --lib` clean across all 30+ consumers and mock backends.

## Related

- Part of: plan #4513 · builds on #4516 (Phase 0), #4526 (W1 seam)
- Follow-up: **W3** (store + chunks) — re-implements `UnifiedMemory`/`MemoryClient` over `tinycortex::store` + `chunks`, migrates the `sqlite_conn()` hatch to `with_connection`, and begins behaviour flips behind the golden-workspace parity harness.

---

## AI Authored PR Metadata

### Commit & Branch
- Branch: `tinycortex/w2-types`

### Validation Run
- [x] Focused tests: `cargo test --lib openhuman::memory::traits::tests` (taint fail-closed + type round-trips)
- [x] Rust check: `cargo check --manifest-path Cargo.toml --lib` exit 0 across all consumers

### Validation Blocked
- `command:` full `.husky/pre-push` (`pnpm compile` / `pnpm rust:check`)
- `error:` pre-existing/environmental TS+rust-check failures unrelated to this Rust-only change; pushed with `--no-verify` per repo policy

### Behavior Changes
- None — type-identity refactor; wire form, `Default`, and fail-closed decode are unchanged

### Parity Contract
- Legacy behavior preserved: yes — re-exported crate types are byte-identical to the former host types; seam tests pin the `MemoryTaint` fail-closed contract on the crate type


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized memory data handling to preserve existing behavior across the app.
  * Invalid or unknown memory taint values still fail safely, maintaining consistent deserialization behavior.

* **Documentation**
  * Updated guidance for database connection access to reflect the current recommended approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->