### PR TITLE
fix(voice): handle U16 sample format in the fallback capture path

### DIFF
--- a/src/openhuman/voice/audio_capture.rs
+++ b/src/openhuman/voice/audio_capture.rs
@@ -368,8 +368,7 @@ fn record_on_thread(
                     .build_input_stream(
                         &stream_config,
                         move |data: &[i16], _: &cpal::InputCallbackInfo| {
-                            let floats: Vec<f32> =
-                                data.iter().map(|&s| s as f32 / 32768.0).collect();
+                            let floats = i16_to_f32(data);
                             let mono = to_mono(&floats, source_channels);
                             update_peak_rms(&rms_tracker, &mono);
                             let gated = gate.lock().process(&mono);
@@ -389,10 +388,7 @@ fn record_on_thread(
                     .build_input_stream(
                         &stream_config,
                         move |data: &[u16], _: &cpal::InputCallbackInfo| {
-                            let floats: Vec<f32> = data
-                                .iter()
-                                .map(|&s| (s as f32 - 32768.0) / 32768.0)
-                                .collect();
+                            let floats = u16_to_f32(data);
                             let mono = to_mono(&floats, source_channels);
                             update_peak_rms(&rms_tracker, &mono);
                             let gated = gate.lock().process(&mono);
@@ -446,8 +442,7 @@ fn record_on_thread(
                             .build_input_stream(
                                 &sc,
                                 move |data: &[i16], _: &cpal::InputCallbackInfo| {
-                                    let floats: Vec<f32> =
-                                        data.iter().map(|&s| s as f32 / 32768.0).collect();
+                                    let floats = i16_to_f32(data);
                                     let mono = to_mono(&floats, ch);
                                     update_peak_rms(&rt, &mono);
                                     let gated = gate.lock().process(&mono);
@@ -459,7 +454,23 @@ fn record_on_thread(
                                 None,
                             )
                             .map_err(|e| format!("fallback i16 stream failed: {e}")),
-                        _ => Err(format!("unsupported fallback format: {fmt:?}")),
+                        SampleFormat::U16 => device
+                            .build_input_stream(
+                                &sc,
+                                move |data: &[u16], _: &cpal::InputCallbackInfo| {
+                                    let floats = u16_to_f32(data);
+                                    let mono = to_mono(&floats, ch);
+                                    update_peak_rms(&rt, &mono);
+                                    let gated = gate.lock().process(&mono);
+                                    if !gated.is_empty() {
+                                        sw.lock().extend_from_slice(&gated);
+                                    }
+                                },
+                                |err| error!("{LOG_PREFIX} audio stream error: {err}"),
+                                None,
+                            )
+                            .map_err(|e| format!("fallback u16 stream failed: {e}")),
+                        other => Err(format!("unsupported fallback format: {other:?}")),
                     };
                     match fallback_stream {
                         Ok(s) => (s, sr, ch),
@@ -520,6 +531,22 @@ pub fn list_input_devices() -> Result<Vec<String>, String> {
 }
 
 /// Convert interleaved multi-channel samples to mono by averaging channels.
+/// Convert interleaved signed `i16` PCM samples to normalised `f32` in
+/// `[-1.0, 1.0)` (`s / 32768`). Extracted so the preferred and fallback stream
+/// paths share one conversion instead of duplicating it inline.
+pub(crate) fn i16_to_f32(data: &[i16]) -> Vec<f32> {
+    data.iter().map(|&s| s as f32 / 32768.0).collect()
+}
+
+/// Convert interleaved unsigned `u16` PCM samples (mid-scale 32768) to
+/// normalised `f32` in `[-1.0, 1.0)` (`(s - 32768) / 32768`). Shared by the
+/// preferred and fallback stream paths.
+pub(crate) fn u16_to_f32(data: &[u16]) -> Vec<f32> {
+    data.iter()
+        .map(|&s| (s as f32 - 32768.0) / 32768.0)
+        .collect()
+}
+
 pub(crate) fn to_mono(samples: &[f32], channels: usize) -> Vec<f32> {
     if channels <= 1 {
         return samples.to_vec();

--- a/src/openhuman/voice/audio_capture.rs
+++ b/src/openhuman/voice/audio_capture.rs
@@ -530,7 +530,6 @@ pub fn list_input_devices() -> Result<Vec<String>, String> {
     Ok(names)
 }
 
-/// Convert interleaved multi-channel samples to mono by averaging channels.
 /// Convert interleaved signed `i16` PCM samples to normalised `f32` in
 /// `[-1.0, 1.0)` (`s / 32768`). Extracted so the preferred and fallback stream
 /// paths share one conversion instead of duplicating it inline.
@@ -547,6 +546,7 @@ pub(crate) fn u16_to_f32(data: &[u16]) -> Vec<f32> {
         .collect()
 }
 
+/// Convert interleaved multi-channel samples to mono by averaging channels.
 pub(crate) fn to_mono(samples: &[f32], channels: usize) -> Vec<f32> {
     if channels <= 1 {
         return samples.to_vec();

--- a/src/openhuman/voice/audio_capture_tests.rs
+++ b/src/openhuman/voice/audio_capture_tests.rs
@@ -2,6 +2,25 @@ use super::*;
 use cpal::{SampleFormat, SampleRate, SupportedBufferSize, SupportedStreamConfigRange};
 
 #[test]
+fn i16_to_f32_normalises_to_unit_range() {
+    assert_eq!(i16_to_f32(&[0]), vec![0.0]);
+    assert_eq!(i16_to_f32(&[16384]), vec![0.5]);
+    assert_eq!(i16_to_f32(&[-32768]), vec![-1.0]);
+    // Interleaved frames are converted element-wise, order preserved.
+    assert_eq!(i16_to_f32(&[0, 16384, -16384]), vec![0.0, 0.5, -0.5]);
+}
+
+#[test]
+fn u16_to_f32_centers_on_midscale() {
+    // Unsigned PCM is offset-binary: 32768 is silence (0.0), the endpoints map
+    // to the extremes. This is the conversion the fallback path was missing.
+    assert_eq!(u16_to_f32(&[32768]), vec![0.0]);
+    assert_eq!(u16_to_f32(&[49152]), vec![0.5]);
+    assert_eq!(u16_to_f32(&[0]), vec![-1.0]);
+    assert_eq!(u16_to_f32(&[32768, 49152, 16384]), vec![0.0, 0.5, -0.5]);
+}
+
+#[test]
 fn to_mono_passthrough_single_channel() {
     let input = vec![0.1, 0.2, 0.3];
     assert_eq!(to_mono(&input, 1), input);


### PR DESCRIPTION
## What

Voice capture builds the input stream for the preferred device config, and if that fails, retries with the device's **default** config. The preferred path handles three sample formats — `F32`, `I16`, **`U16`** — but the fallback path handles only `F32` and `I16`:

```rust
// fallback (src/openhuman/voice/audio_capture.rs)
let fallback_stream = match fmt {
    SampleFormat::F32 => …,
    SampleFormat::I16 => …,
    _ => Err(format!("unsupported fallback format: {fmt:?}")),  // ← U16 dies here
};
```

So when the preferred config fails **and** the device's default config is `U16` (common on some Windows drivers and older hardware), voice recording fails outright with `unsupported fallback format: U16` — even though `U16` is fully supported on the preferred path. Nothing marks the omission as intentional; it's an asymmetry between two paths that are meant to mirror each other.

## Change

- Add the missing `SampleFormat::U16` arm to the fallback match, mirroring the preferred `U16` handler.
- While here, extract the two per-format conversions that were duplicated across the preferred and fallback closures into small pure helpers `i16_to_f32` / `u16_to_f32`, and call them from all four sites. This removes the copy-paste and — unlike the inline closures, which need a live audio device — makes the conversion math unit-testable.

## Correctness

`u16_to_f32` uses the same mid-scale formula the preferred path already used (`(s - 32768) / 32768`), and `i16_to_f32` the same `s / 32768`. No behaviour change on the existing F32/I16 paths; the only new behaviour is that a `U16` fallback device now records instead of erroring.

## Tests

`i16_to_f32` / `u16_to_f32` unit tests in `audio_capture_tests.rs` pin the normalisation (mid-scale → 0.0, full-scale endpoints → ±1.0). The stream-building itself needs a real cpal device and stays uncovered, consistent with the rest of this module.

`cargo test --lib voice::audio_capture` green locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized microphone PCM-to-float conversion for signed and unsigned 16-bit audio, reducing duplicated per-sample handling while keeping normalization behavior consistent.

* **Tests**
  * Added unit tests for both signed and unsigned 16-bit sample conversions, validating midpoint (silence), endpoints, and element-wise behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->