### PR TITLE
fix(tinyagents-audit): execute §5 fix-in-place items — provider diagnostic, anchor coupling, dead-read clarifications

### DIFF
--- a/src/openhuman/agent_orchestration/subagent_control.rs
+++ b/src/openhuman/agent_orchestration/subagent_control.rs
@@ -185,8 +185,11 @@ fn handle_subagent_steer(params: Map<String, Value>) -> ControllerFuture {
                     SteerError::Unknown => "unknown",
                     SteerError::AlreadyDone => "already_done",
                     // `steer_control` is trusted UI/RPC control and currently
-                    // does not perform parent ownership checks. Keep the arm
-                    // for future trust-model changes that may return NotOwned.
+                    // does not perform parent ownership checks, so this arm is
+                    // unreachable on THIS path. The variant is not dead overall:
+                    // the agent-tool `running_subagents::steer` path enforces
+                    // ownership and returns `NotOwned`. Kept here for the Phase 4
+                    // SteeringRegistry ownership consolidation.
                     SteerError::NotOwned => "not_owned",
                 };
                 log::debug!(

--- a/src/openhuman/inference/presets.rs
+++ b/src/openhuman/inference/presets.rs
@@ -198,6 +198,11 @@ pub fn preset_for_tier(tier: ModelTier) -> Option<ModelPreset> {
 
 /// Recommend a tier based on device capabilities.
 pub fn recommend_tier(device: &DeviceProfile) -> ModelTier {
+    // NOTE: the MVP intentionally caps every device at `MVP_MAX_TIER`
+    // regardless of installed RAM (the `recommend_tier_scales_with_ram` test
+    // pins this non-scaling contract). `ram_gb` is read only for the
+    // diagnostic log below; RAM->tier scaling is deferred until the higher
+    // tiers are productised.
     let ram_gb = device.total_ram_gb();
     let tier = MVP_MAX_TIER;
     tracing::debug!(ram_gb, ?tier, "[local_ai] recommended model tier");

--- a/src/openhuman/inference/provider/config_rejection.rs
+++ b/src/openhuman/inference/provider/config_rejection.rs
@@ -177,10 +177,10 @@ pub fn is_provider_config_rejection_message(body: &str) -> bool {
         // User-state — the remediation is "add/pick a model in Settings →
         // LLM", which the user-facing copy surfaces; Sentry has no
         // remediation. Anchored on the role/slug-interpolation-free
-        // substring, which is also `factory::NO_MODEL_CONFIGURED_ANCHOR`; a
-        // round-trip test in `factory_tests.rs` couples the two so a
-        // wording drift fails CI instead of silently re-flooding Sentry.
-        "resolved to an empty model id",
+        // substring, which IS `factory::NO_MODEL_CONFIGURED_ANCHOR` —
+        // referenced directly so the two can never drift (the round-trip
+        // test in `factory_tests.rs` remains as a belt-and-braces guard).
+        super::factory::NO_MODEL_CONFIGURED_ANCHOR,
         // TAURI-RUST-2G (~2684 events) / TAURI-RUST-2F (~950 events) —
         // thinking-mode model (DeepSeek-R1 / Moonshot K2-thinking on
         // `provider=cloud` custom_openai) rejects a follow-up turn that

--- a/src/openhuman/inference/provider/traits.rs
+++ b/src/openhuman/inference/provider/traits.rs
@@ -730,8 +730,10 @@ pub trait Provider: Send + Sync {
         _options: StreamOptions,
     ) -> stream::BoxStream<'static, StreamResult<StreamChunk>> {
         // For default implementation, we need to convert to owned strings
-        // This is a limitation of the default implementation
-        let provider_name = "unknown".to_string();
+        // This is a limitation of the default implementation. Name the real
+        // provider via its telemetry slug so the diagnostic is actionable
+        // instead of the useless literal "unknown".
+        let provider_name = self.telemetry_provider_id();
 
         // Create a single empty chunk to indicate not supported
         let chunk = StreamChunk::error(format!("{} does not support streaming", provider_name));

--- a/src/openhuman/inference/provider/traits_tests.rs
+++ b/src/openhuman/inference/provider/traits_tests.rs
@@ -448,3 +448,54 @@ async fn provider_chat_prompt_guided_rejects_non_prompt_payload() {
 
     assert!(message.contains("non-prompt-guided"));
 }
+
+// Provider that reports a real telemetry name but does not override streaming,
+// so it falls back to the default `stream_chat_with_history` implementation.
+struct NamedNoStreamProvider;
+
+#[async_trait]
+impl Provider for NamedNoStreamProvider {
+    fn telemetry_provider_id(&self) -> String {
+        "acme".to_string()
+    }
+
+    async fn chat_with_system(
+        &self,
+        _system: Option<&str>,
+        _message: &str,
+        _model: &str,
+        _temperature: f64,
+    ) -> anyhow::Result<String> {
+        Ok("ok".to_string())
+    }
+}
+
+#[tokio::test]
+async fn default_stream_chat_with_history_names_provider_when_unsupported() {
+    let provider = NamedNoStreamProvider;
+    let mut stream = provider.stream_chat_with_history(
+        &[ChatMessage::user("Hi")],
+        "model",
+        0.7,
+        StreamOptions::default(),
+    );
+
+    let chunk = stream
+        .next()
+        .await
+        .expect("one chunk")
+        .expect("chunk is Ok");
+
+    assert!(chunk.is_final);
+    assert!(
+        chunk.delta.contains("acme"),
+        "diagnostic should name the provider, got: {}",
+        chunk.delta
+    );
+    assert!(chunk.delta.contains("does not support streaming"));
+    assert!(
+        !chunk.delta.contains("unknown"),
+        "diagnostic must not use the misleading literal 'unknown', got: {}",
+        chunk.delta
+    );
+}

--- a/src/openhuman/tools/orchestrator_tools.rs
+++ b/src/openhuman/tools/orchestrator_tools.rs
@@ -589,13 +589,6 @@ mod tests {
         assert_eq!(slugs, vec!["google_calendar", "slack_bot"]);
     }
 
-    /// Two upstream toolkits whose names sanitise to the same slug
-    /// must not silently both land in the collapsed enum — the second
-    /// arrival is dropped (with a warn log) so the orchestrator's
-    /// routing handle stays unambiguous. Without this guard,
-    /// `Slack.Bot` and `Slack-Bot` would both render as `slack_bot`
-    /// in the enum and the orchestrator could no longer distinguish
-    /// them.
     /// An integration with an empty description must not render as a
     /// bare ` - slug` line in the collapsed tool description — the
     /// orchestrator LLM would have no signal about what the toolkit
@@ -631,6 +624,13 @@ mod tests {
         assert!(desc.contains("Email."));
     }
 
+    /// Two upstream toolkits whose names sanitise to the same slug
+    /// must not silently both land in the collapsed enum — the second
+    /// arrival is dropped (with a warn log) so the orchestrator's
+    /// routing handle stays unambiguous. Without this guard,
+    /// `Slack.Bot` and `Slack-Bot` would both render as `slack_bot`
+    /// in the enum and the orchestrator could no longer distinguish
+    /// them.
     #[test]
     fn duplicate_sanitised_slug_drops_later_collisions() {
         let mut orch = def("orchestrator", "t", None);

--- a/src/openhuman/tools/traits.rs
+++ b/src/openhuman/tools/traits.rs
@@ -11,8 +11,10 @@ pub use crate::openhuman::workflows::types::{ToolContent, ToolResult};
 pub enum ToolScope {
     /// Available in agent loop, CLI, and RPC.
     All,
-    /// Only available in the autonomous agent loop.
-    #[allow(dead_code)]
+    /// Intended to mark tools available only in the autonomous agent loop.
+    /// NOTE: not yet gated — no execution path filters on `AgentOnly`, so it
+    /// currently behaves like `All`. The `AgentOnly` vs `All` reconciliation is
+    /// deferred to the Phase 2 tool-model work (docs/tinyagents-port-plan.md §5).
     AgentOnly,
     /// Only available via explicit CLI/RPC invocation (not autonomous agent).
     CliRpcOnly,


### PR DESCRIPTION
## Summary

Execute the safe, behavior-preserving **§5 "bugs, gaps & improvements found during the audit"** items from `docs/tinyagents-port-plan.md` — the fix-in-place candidates independent of the port itself. Six focused commits:

- **fix(inference)**: the default `Provider::stream_chat_with_history` named its unsupported-streaming error `"unknown"` — now uses the trait's `telemetry_provider_id()` so the diagnostic names the real provider (+ test).
- **refactor(inference)**: the Sentry `before_send` rejection filter hardcoded a literal that duplicates `factory::NO_MODEL_CONFIGURED_ANCHOR` — reference the const directly so they compile-couple (was test-guarded only).
- **docs(inference)**: `recommend_tier` reads RAM but always returns `MVP_MAX_TIER` — documented as the intentional MVP cap (test already pins the non-scaling contract) so it stops reading as dead logic.
- **docs(agent_orchestration)**: clarified that `SteerError::NotOwned` is *not* dead — the agent-tool `steer` path enforces ownership and returns it; only the trusted RPC path skips the check.
- **refactor(tools)**: dropped a stale `#[allow(dead_code)]` on `ToolScope::AgentOnly` (it has three real constructors) and documented that it currently behaves like `All`.
- **docs(tools)**: re-attached a mis-placed test doc-comment in `orchestrator_tools.rs` to the slug-collision test it actually describes.

## Problem

The port-plan audit catalogued a set of localized defects and misleading/dead-reading code in `inference/`, `tools/`, and `agent_orchestration/` (plan §5). They are independent of the multi-phase crate consolidation and worth fixing in place — several would otherwise be deleted-in-place with their host anyway, but until then they mislead readers (e.g. a `"unknown does not support streaming"` diagnostic, a `recommend_tier` that looks broken, a `NotOwned` arm that looks dead).

## Solution

Only the **behavior-preserving** subset is applied here; each genuine behavior/API decision the audit raised is deliberately **deferred to its planned phase** and left documented, not guessed:

- RAM→tier scaling in `recommend_tier` (would violate the MVP cap) — not implemented.
- RPC-path ownership enforcement for `SteerError::NotOwned` (would change the JSON-RPC payload/trust model, which the plan forbids during the port) — deferred to Phase 4's `SteeringRegistry`.
- `ToolScope::AgentOnly` vs `All` reconciliation and `is_concurrency_safe` adoption (needs upstream tinyagents parallel dispatch) — deferred to Phase 2 / upstream.

The one observable change (the streaming-unsupported diagnostic text) is covered by a new co-located unit test asserting it names the provider and no longer says `"unknown"`.

## Submission Checklist

- [x] Tests added or updated — new `default_stream_chat_with_history_names_provider_when_unsupported` covers the only behavior change (diagnostic text). The remaining commits are doc/annotation/refactor with no behavior delta.
- [x] **Diff coverage ≥ 80%** — the only changed *logic* line (`provider_name = self.telemetry_provider_id()`) is directly exercised by the new test; the rest are comments/annotations. Full validation deferred to CI.
- [x] Coverage matrix updated — `N/A: no user-facing feature rows` (internal diagnostics/comments/refactors).
- [x] All affected feature IDs listed under `## Related` — `N/A`.
- [x] No new external network dependencies introduced — confirmed, none.
- [x] Manual smoke checklist updated — `N/A: no release-cut surface change`.
- [x] Linked issue closed — `N/A` (audit fix-in-place batch; see `## Related`).

## Impact

- **Runtime**: desktop core (Rust). No JSON-RPC surface, tool catalog, provider grammar, or execution-model change.
- **Observability**: the unsupported-streaming error and the `[local_ai] recommended model tier` context are now more actionable; the `config_rejection` anchor can no longer silently drift from Sentry's filter.
- **Security**: none — ownership/gating semantics are unchanged (the `NotOwned` and `AgentOnly` decisions that would touch trust/gating are deferred).

## Related

- Closes: N/A (executes §5 of the `docs/tinyagents-port-plan.md` audit; not a tracked issue)
- Follow-up PR(s)/TODOs: deferred design-calls above (Phase 2 tool-model reconciliation; Phase 4 SteeringRegistry ownership). The port itself lands separately (PR #4539, Phase 0/1).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/tinyagents-audit-fixes`
- Commit SHA: `1dfef9d963889a27ee8730a07f04d5cd612d1f20`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A (no `app/src` changes)
- [x] `pnpm typecheck` — N/A (no TypeScript changes)
- [x] Focused tests: authored a co-located unit test for the diagnostic change; `cargo fmt` applied.
- [x] Rust fmt/check (if changed): `cargo check --lib` run locally on the branch (see notes); `cargo fmt` clean.
- [x] Tauri fmt/check (if changed): N/A (core-only change); full validation on CI.

### Validation Blocked

- `command:` full `cargo test` suite
- `error:` none — deferred to GitHub runners per the requester; local validation bounded to `cargo check --lib` + `cargo fmt`.
- `impact:` CI (CI Lite on this PR) is the authoritative gate.

### Behavior Changes

- Intended behavior change: only the human-readable unsupported-streaming diagnostic (names the provider instead of "unknown").
- User-visible effect: none in normal operation (the diagnostic surfaces only when a provider without streaming support is asked to stream).

### Parity Contract

- Legacy behavior preserved: tier selection, steering/ownership semantics, tool gating, JSON-RPC surface — all unchanged.
- Guard/fallback/dispatch parity checks: `recommend_tier` non-scaling contract still pinned by its test; `config_rejection` anchor still guarded by the `factory_tests.rs` round-trip.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none.
- Canonical PR: this one.
- Resolution: N/A.
