### PR TITLE
[codex] vendor tiny.place Rust SDK

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -422,7 +422,7 @@ jobs:
       # fork the core image doesn't need. The Dockerfile COPYs vendor/ because
       # [patch.crates-io] resolves Rust SDK crates from vendor/.
       - name: Init vendored Rust submodules
-        run: git submodule update --init vendor/tinyagents vendor/tinyflows vendor/tinycortex vendor/tinyjuice
+        run: git submodule update --init vendor/tinyagents vendor/tinyflows vendor/tinycortex vendor/tinyjuice vendor/tinyplace
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Log in to GHCR

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -317,7 +317,7 @@ jobs:
       # fork the core image doesn't need. The Dockerfile COPYs vendor/ because
       # [patch.crates-io] resolves Rust SDK crates from vendor/.
       - name: Init vendored Rust submodules
-        run: git submodule update --init vendor/tinyagents vendor/tinyflows vendor/tinycortex vendor/tinyjuice
+        run: git submodule update --init vendor/tinyagents vendor/tinyflows vendor/tinycortex vendor/tinyjuice vendor/tinyplace
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build image (no push)

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "vendor/tinyjuice"]
 	path = vendor/tinyjuice
 	url = https://github.com/tinyhumansai/tinyjuice
+[submodule "vendor/tinyplace"]
+	path = vendor/tinyplace
+	url = https://github.com/tinyhumansai/tiny.place.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6906,9 +6906,7 @@ dependencies = [
 
 [[package]]
 name = "tinyplace"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96c2478e3407780674721fde873ca9f188d71f507f01885eb95e9024f07ac34"
+version = "2.0.0"
 dependencies = [
  "aes",
  "async-trait",
@@ -8247,7 +8245,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,10 @@ name = "openhuman_core"
 crate-type = ["rlib"]
 
 [dependencies]
-# tiny.place A2A social network SDK — published on crates.io (tinyhumansai/tiny.place)
-tinyplace = "1.0.1"
+# tiny.place A2A social network SDK — published on crates.io and patched below
+# to the vendored tiny.place submodule so OpenHuman can test SDK changes before
+# publishing.
+tinyplace = "2.0"
 # tinyflows — host-agnostic workflow engine (typed node graph → validate → compile →
 # run on tinyagents). Powers the "Workflows" feature via the seam in
 # `src/openhuman/tinyflows/` + the `flows::` domain. Pulls tinyagents 1.7 transitively
@@ -359,6 +361,7 @@ tinyagents = { path = "vendor/tinyagents" }
 tinyflows = { path = "vendor/tinyflows" }
 tinycortex = { path = "vendor/tinycortex" }
 tinyjuice = { path = "vendor/tinyjuice" }
+tinyplace = { path = "vendor/tinyplace/sdk/rust" }
 
 # Emit just enough DWARF in release builds for Sentry to symbolicate Rust
 # panics + render surrounding source lines. `line-tables-only` keeps the

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -250,7 +250,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -2093,7 +2093,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2496,7 +2496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4136,7 +4136,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5030,7 +5030,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6726,7 +6726,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7313,7 +7313,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7372,7 +7372,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8998,7 +8998,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9252,9 +9252,7 @@ dependencies = [
 
 [[package]]
 name = "tinyplace"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96c2478e3407780674721fde873ca9f188d71f507f01885eb95e9024f07ac34"
+version = "2.0.0"
 dependencies = [
  "aes",
  "async-trait",
@@ -10614,7 +10612,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -217,6 +217,7 @@ tinyagents = { path = "../../vendor/tinyagents" }
 tinyflows = { path = "../../vendor/tinyflows" }
 tinycortex = { path = "../../vendor/tinycortex" }
 tinyjuice = { path = "../../vendor/tinyjuice" }
+tinyplace = { path = "../../vendor/tinyplace/sdk/rust" }
 
 # CEF support lives on the `feat/cef` branch of tauri-apps/tauri. We carry our
 # own fork at tinyhumansai/tauri-cef on `feat/cef-notification-intercept` which


### PR DESCRIPTION
## Summary
- vendor the tiny.place repo under `vendor/tinyplace` and patch both OpenHuman Cargo worlds to `vendor/tinyplace/sdk/rust`
- update root and Tauri lockfiles to resolve `tinyplace v2.0.0` from the vendored SDK
- update release staging/production workflows to initialize `vendor/tinyplace` with the other vendored Rust submodules

## Dependency
- Depends on tinyhumansai/tiny.place#224 so the vendored SDK commit is available upstream.

## Validation
- GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml
- GGML_NATIVE=OFF cargo check --manifest-path app/src-tauri/Cargo.toml
