### PR TITLE
feat(orchestration): surface inbound relay DMs via mailbox poll-drain + fix Signal card key

### DIFF
--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -2294,6 +2294,10 @@ fn register_domain_subscribers(
         crate::openhuman::orchestration::register_orchestration_ingest_subscriber();
         // Orchestration: wake the split-brain graph on each persisted session DM.
         crate::openhuman::orchestration::register_orchestration_wake_subscriber();
+        // Orchestration: relay DMs are poll-only (`/messages`) and never traverse
+        // `/inbox/stream`, so this poller is the delivery path that surfaces
+        // inbound DMs from paired agents into the wake graph.
+        crate::openhuman::orchestration::start_message_drain_supervisor();
         // Task-sources proactive ingestion: connection-created hook + poll.
         crate::openhuman::task_sources::bus::register_task_sources_subscriber();
         crate::openhuman::task_sources::start_periodic_poll();

--- a/src/openhuman/orchestration/ingest.rs
+++ b/src/openhuman/orchestration/ingest.rs
@@ -197,6 +197,46 @@ async fn ingest_one(
     Ok(())
 }
 
+/// Poll the relay mailbox once and run every delivered envelope through the
+/// ingest pipeline.
+///
+/// The relay delivers DMs to `/messages` (poll-only) and — unlike inbox items —
+/// never publishes them to the `/inbox/stream` WebSocket, so a poller is the
+/// only way orchestration learns about inbound DMs. Envelopes from senders that
+/// are not orchestration-linked are skipped by [`ingest_one`] WITHOUT being
+/// decrypted or acknowledged, so they stay in the mailbox for the Messaging UI.
+///
+/// Returns the number of envelopes examined this pass. Best-effort per envelope:
+/// a decrypt/persist failure on one is logged and does not abort the batch.
+pub async fn drain_mailbox_once(config: &Config) -> Result<usize, String> {
+    if !config.orchestration.enabled {
+        return Ok(0);
+    }
+    let client = crate::openhuman::tinyplace::ops::global_state()
+        .client()
+        .await?;
+    let signer = client
+        .http()
+        .signer()
+        .ok_or_else(|| "no signer configured".to_string())?;
+    let agent_id = signer.agent_id();
+    let resp = client
+        .messages
+        .list(&agent_id, Some(100))
+        .await
+        .map_err(|e| format!("messages.list: {e}"))?;
+    let count = resp.messages.len();
+    if count > 0 {
+        log::debug!(target: LOG, "[orchestration] drain.fetched count={count}");
+    }
+    for envelope in resp.messages {
+        if let Err(e) = ingest_one(config, envelope).await {
+            log::warn!(target: LOG, "[orchestration] drain.ingest_error: {e}");
+        }
+    }
+    Ok(count)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -218,6 +258,15 @@ mod tests {
         assert!(is_dm_stream("DM", "x"));
         assert!(is_dm_stream("other", "conversation:abc"));
         assert!(!is_dm_stream("inbox", "inbox"));
+    }
+
+    #[tokio::test]
+    async fn drain_is_a_noop_when_orchestration_disabled() {
+        // Guard short-circuits before touching the tiny.place client, so this
+        // exercises the early return without any wallet/network.
+        let mut config = Config::default();
+        config.orchestration.enabled = false;
+        assert_eq!(drain_mailbox_once(&config).await, Ok(0));
     }
 
     #[test]

--- a/src/openhuman/orchestration/mod.rs
+++ b/src/openhuman/orchestration/mod.rs
@@ -30,4 +30,5 @@ pub use graph::{
     build_orchestration_graph, orchestration_graph_topology, run_orchestration_graph,
     OrchestrationState,
 };
+pub use ops::start_message_drain_supervisor;
 pub use schemas::{all_controller_schemas, all_registered_controllers};

--- a/src/openhuman/orchestration/ops.rs
+++ b/src/openhuman/orchestration/ops.rs
@@ -117,6 +117,33 @@ pub async fn schedule_wake(agent_id: String, session_id: String, chat_kind: Stri
     });
 }
 
+/// Periodically drain the relay mailbox through orchestration ingest.
+///
+/// tiny.place relay DMs are delivered to `/messages` (poll-only) and are NOT
+/// published to the `/inbox/stream` WebSocket — the backend only streams inbox
+/// items for payments/notifications, never `PUT /messages`. So a poller is the
+/// actual delivery path: it lists `/messages` and feeds each envelope through
+/// the same decrypt → classify → persist → acknowledge pipeline the wake graph
+/// consumes. Unlinked senders are skipped without being consumed, so their DMs
+/// remain readable by the Messaging UI.
+pub fn start_message_drain_supervisor() {
+    tokio::spawn(async {
+        loop {
+            match Config::load_or_init().await {
+                Ok(config) => match super::ingest::drain_mailbox_once(&config).await {
+                    Ok(n) if n > 0 => {
+                        log::debug!(target: LOG, "[orchestration] drain: examined {n} envelope(s)")
+                    }
+                    Ok(_) => {}
+                    Err(e) => log::debug!(target: LOG, "[orchestration] drain error: {e}"),
+                },
+                Err(e) => log::debug!(target: LOG, "[orchestration] drain config load: {e}"),
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(15)).await;
+        }
+    });
+}
+
 /// Seed a wake-cycle [`OrchestrationState`] from the store: the counterpart to
 /// reply to plus the recent-message window. Returns `None` when the session has
 /// no persisted messages (nothing to wake for).

--- a/src/openhuman/tinyplace/manifest.rs
+++ b/src/openhuman/tinyplace/manifest.rs
@@ -3609,12 +3609,13 @@ pub(crate) fn handle_tinyplace_contacts_stats(_params: Map<String, Value>) -> Co
 
 // ── Signal: encryption key registration (0D) ────────────────────────────────
 
-/// Publish the user's X25519 identity public key on their directory card as
+/// Publish the user's Ed25519 identity key (the addressable cryptoId, where the
+/// Signal prekey bundle + mailbox live) on their directory card as
 /// `metadata.encryptionPublicKey`. This makes the user discoverable for
-/// encrypted DMs via `find_agent_by_encryption_key`.
+/// encrypted DMs via `find_agent_by_encryption_key`; peers derive the X25519 DH
+/// key from the fetched bundle themselves.
 ///
-/// SECURITY: only the PUBLIC key is published. The private key never leaves
-/// the `FileSessionStore`.
+/// SECURITY: only the PUBLIC key is published.
 pub(crate) fn handle_tinyplace_signal_register_encryption_key(
     _params: Map<String, Value>,
 ) -> ControllerFuture {

--- a/src/openhuman/tinyplace/manifest.rs
+++ b/src/openhuman/tinyplace/manifest.rs
@@ -2991,13 +2991,11 @@ pub(crate) fn handle_tinyplace_signal_key_status(_params: Map<String, Value>) ->
                     .metadata
                     .as_ref()
                     .and_then(|m| m.get("encryptionPublicKey"));
-                let current_key_b64 = base64::engine::general_purpose::STANDARD.encode(
-                    store
-                        .identity_x25519_key_pair()
-                        .await
-                        .map(|kp| kp.public_key)
-                        .unwrap_or([0u8; 32]),
-                );
+                // The card advertises the Ed25519 identity key (the addressable
+                // messaging key where the bundle + mailbox live), not the X25519
+                // DH key — see `signal_register_encryption_key`. Compare against
+                // that so readiness reflects what peers actually resolve.
+                let current_key_b64 = signer.public_key_base64();
                 let matches = published_key
                     .map(|pk| pk == &current_key_b64)
                     .unwrap_or(false);
@@ -3623,20 +3621,22 @@ pub(crate) fn handle_tinyplace_signal_register_encryption_key(
     Box::pin(async move {
         log::debug!("{LOG_PREFIX} signal_register_encryption_key");
 
-        // 1. Read identity public key from the signal store.
-        let store = crate::openhuman::tinyplace::signal_store::global_signal_store().await?;
-        let identity_kp = store
-            .identity_x25519_key_pair()
-            .await
-            .map_err(|e| format!("identity key: {e}"))?;
-        let encryption_key_b64 =
-            base64::engine::general_purpose::STANDARD.encode(identity_kp.public_key);
-        log::debug!("{LOG_PREFIX} signal_register_encryption_key derived key (not logging value)");
-
-        // 2. Acquire client and signer.
+        // 1. Acquire client and signer.
         let client = global_state().client().await?;
         let signer = require_signer(client)?;
         let agent_id = signer.agent_id();
+
+        // 2. The messaging key peers resolve from this directory card must be the
+        //    wallet's **Ed25519 identity key** — that is the addressable identity
+        //    where the Signal prekey bundle is published (`/keys/<cryptoId>/bundle`)
+        //    and where the mailbox is keyed. Peers derive the X25519 DH key from
+        //    the bundle's identity key themselves (see `decode_identity_key`), so
+        //    they never need a separate X25519 key advertised here. Publishing the
+        //    X25519 key instead made every peer resolve to a *bundle-less* key and
+        //    404 on the bundle fetch — the exact reason inbound DMs never reached
+        //    this agent. Advertise the identity key so resolution + delivery align.
+        let encryption_key_b64 = signer.public_key_base64();
+        log::debug!("{LOG_PREFIX} signal_register_encryption_key advertising identity key (value not logged)");
 
         // 3. Fetch current AgentCard to preserve existing fields. A wallet that
         //    has Signal keys but no directory presence yet (e.g. it registered a

--- a/src/openhuman/tinyplace/schemas.rs
+++ b/src/openhuman/tinyplace/schemas.rs
@@ -2013,9 +2013,10 @@ fn schema_signal_register_encryption_key() -> ControllerSchema {
     ControllerSchema {
         namespace: "tinyplace",
         function: "signal_register_encryption_key",
-        description: "Publish the user's Signal X25519 identity public key on their directory \
-             card (metadata.encryptionPublicKey). Makes the user discoverable for \
-             encrypted DMs. Reads the key from the local Signal store — no params needed.",
+        description: "Publish the user's Ed25519 identity key (the addressable cryptoId, where \
+             the Signal prekey bundle + mailbox live) on their directory card \
+             (metadata.encryptionPublicKey). Peers derive the X25519 DH key from the bundle \
+             themselves. Makes the user discoverable for encrypted DMs. No params needed.",
         inputs: vec![],
         outputs: vec![json_output(
             "result",


### PR DESCRIPTION
## Summary

- **Surface inbound relay DMs.** Add a 15s orchestration poll-drain of the tiny.place `/messages` mailbox so DMs from paired agents actually reach the wake graph — previously they never surfaced.
- **Fix the Signal directory card key.** Advertise the wallet's Ed25519 identity key (not its X25519 DH key) as `encryptionPublicKey`, so peers can resolve this agent and fetch its prekey bundle.
- Both are backend-delivery correctness fixes for agent→OpenHuman DMs; no UI surface changes.

## Problem

Agents could not reliably message OpenHuman, and messages that *were* delivered never surfaced:

1. **DMs never surfaced.** Orchestration ingest was purely driven by `DomainEvent::TinyPlaceStreamMessage` (the `/inbox/stream` WebSocket). But the relay delivers DMs to `/messages` (poll-only) and **never publishes them to `/inbox/stream`** — that stream only carries inbox items for payments/notifications. So inbound DMs from paired agents piled up undrained in the mailbox while the orchestration store stayed empty. (Verified on staging: CIPHERTEXT envelopes sat in the mailbox for hours; the orchestration DB had zero inbound.)
2. **Peers couldn't resolve this agent.** `signal_register_encryption_key` published the wallet's **X25519 DH key** as the card's `metadata.encryptionPublicKey`. But Signal prekey bundles and mailboxes are keyed by the **Ed25519 identity key** (cryptoId). Peers resolve a recipient via the directory card and prefer `encryptionPublicKey` for both addressing and the bundle fetch — so they resolved to a bundle-less key and 404'd on `/keys/<key>/bundle`, unable to open a session.

## Solution

- **`feat(orchestration)`** — `start_message_drain_supervisor()` spawns a 15s loop calling `drain_mailbox_once()`, which lists `/messages` and runs each envelope through the **existing** decrypt → classify → persist → acknowledge `ingest_one` pipeline. Unlinked senders are skipped without being decrypted/consumed (the Signal ratchet is protected), so their DMs stay readable by the Messaging UI. Wired in at startup next to the existing wake/ingest subscribers.
- **`fix(tinyplace)`** — advertise `signer.public_key_base64()` (Ed25519 identity) as `encryptionPublicKey`; peers derive the X25519 DH key from the bundle themselves (`decode_identity_key`). The `signal_key_status` readiness check now compares against the identity key too.

Validated end-to-end on staging: after both fixes, a real base58 SDK-2.0 agent's messages drained → decrypted → persisted → woke the graph → produced a reply (confirmed in `world_diff`/`compressed_history`).

**Deliberately out of scope:** an inbox-stream WS-auth fix (the WS handshake 401s against the backend) — it feeds nothing into DM ingest (`is_dm_stream` excludes the `inbox` stream) and belongs in the tinyplace SDK repo, not here. Tracked as a follow-up.

## Submission Checklist

- [x] Tests added or updated — `drain_is_a_noop_when_orchestration_disabled` covers the guard early-return; the drain's happy path reuses the already-tested `ingest_one` pipeline (`persist_message`/`classify_message` tests).
- [x] **Diff coverage ≥ 80%** — `cargo test` green locally; new/changed lines are the guard (tested) + a thin poller over the covered `ingest_one` path. CI `diff-cover` is authoritative on the exact number.
- [x] Coverage matrix updated — `N/A`: internal delivery-path fix to existing orchestration ingest; no new user-facing feature row.
- [x] All affected feature IDs listed in `## Related` — `N/A`: no matrix feature IDs affected.
- [x] No new external network dependencies — uses the existing in-tree `tinyplace` client; no new deps or hosts.
- [x] Manual smoke checklist updated — `N/A`: no release-cut surface touched (headless core delivery path).
- [x] Linked issue closed via `Closes #NNN` — `N/A`: no tracked issue; found while testing the orchestration DM flow.

## Impact

- **Desktop core only.** Adds one 15s background poll of `/messages` (bounded, best-effort; silent when the mailbox is empty). No UI, migration, or schema changes.
- **Security:** unlinked senders are never decrypted or acknowledged — the Signal ratchet is only advanced for paired agents, unchanged from the existing stream path.
- The card-key change re-publishes `encryptionPublicKey`; existing agents pick up the corrected key on their next `signal_register_encryption_key` (e.g. "Make discoverable" / re-provision).

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: tinyplace SDK WS-auth fix (directory/SIWS query params for `/inbox/stream` and the other WS streams) — separate SDK-repo change.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/orchestration-dm-poll-drain`
- Commit SHA: `ce9949e0a` (card-key), `130470cfc` (poll-drain)

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no `app/` TypeScript changed.
- [x] `pnpm typecheck` — N/A: no TypeScript changed.
- [x] Focused tests: `cargo test --lib orchestration::ingest` — 5 passed.
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo check --lib` Finished, no errors.
- [x] Tauri fmt/check (if changed): N/A — no `app/src-tauri` changes.

### Validation Blocked

- `command:` full `pnpm test:coverage` / `diff-cover` not run locally
- `error:` N/A — deferred to CI
- `impact:` CI computes authoritative diff coverage; changed lines are the tested guard + a thin poller over the already-covered `ingest_one` pipeline.

### Behavior Changes

- Intended behavior change: inbound relay DMs from paired agents now surface into orchestration (and trigger the wake graph); the directory card advertises the fetchable identity key.
- User-visible effect: agents can DM OpenHuman and OpenHuman receives/acts on their messages.

### Parity Contract

- Legacy behavior preserved: the stream-driven `ingest_stream_message` path is unchanged; the poll-drain reuses the same `ingest_one` (sender gate, dedupe, ack) so semantics match.
- Guard/fallback/dispatch parity checks: unlinked senders skipped without decrypt/ack (identical to stream path); disabled-orchestration short-circuits with no client call.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a background message-polling supervisor to continuously fetch and deliver incoming relay messages for paired agents.
  * Added a batch mailbox drain operation to poll up to 100 message envelopes and process them through the existing ingest pipeline.

* **Bug Fixes**
  * Updated encryption-key publishing and readiness checks to use the wallet signer’s Ed25519 identity public key (matching what peers expect).
  * If orchestration is disabled, mailbox draining now safely returns no results.

* **Tests**
  * Added an async test verifying the disabled-orchestration mailbox drain short-circuits to `Ok(0)`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->