### PR TITLE
ci: check out tinychannels submodule for Frontend Unit Tests lane

### DIFF
--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -82,6 +82,13 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 1
+      # The RPC-catalog drift-guard test (rpcMethods.test.ts) reads
+      # vendor/tinychannels/src/controllers/schemas.rs at test time. This lane
+      # otherwise checks out without submodules, so init just that one — not
+      # `submodules: recursive`, which would also pull the large tauri-cef fork
+      # this job never builds.
+      - name: Init tinychannels submodule (drift-guard test reads its schemas)
+        run: git submodule update --init vendor/tinychannels
       - name: Cache pnpm store
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
## Problem

CI Full has been red on `release` on every main→release promotion attempt today, blocking release cuts at the `Require green CI Full Gate` step. The deterministic cause is the **Frontend Unit Tests** lane:

```
FAIL src/services/__tests__/rpcMethods.test.ts > catalog canonical methods exist in core schema registry (drift guard)
Error: ENOENT: no such file or directory, open '.../vendor/tinychannels/src/controllers/schemas.rs'
```

1 test fails, 8250 pass — but vitest exits non-zero so the whole lane (and the CI Full Gate) goes red.

## Root cause

The `rpcMethods.test.ts` RPC-catalog drift guard (added for #4557, "Use tinychannels provider implementations") reads `vendor/tinychannels/src/controllers/schemas.rs` at test time. The file exists in the pinned submodule commit, but the **Frontend Unit Tests** job in `test-reusable.yml` checks out with only `ref` + `fetch-depth: 1` and **no submodules** (unlike the Rust lanes, which set `submodules: recursive`). So the file is never materialized on disk → ENOENT.

## Fix

Init just the `vendor/tinychannels` submodule for this lane — targeted rather than `submodules: recursive`, to avoid pulling the large tauri-cef fork this job never builds (matching the targeted-init pattern already used by the Docker build jobs).

## Scope

Workflow-only change; does not touch product code or the test. The flaky Rust (exit 137 / runner reap) and E2E lanes in the same CI Full run are separate, transient failures and are expected to pass on re-run once this deterministic break is cleared.