### PR TITLE
fix(orchestration): key inbound DMs on the shared per-pair session id

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -70,6 +70,8 @@ jobs:
             --exclude '^https://github\.com/tinyhumansai/homebrew-openhuman'
             --exclude '^https://www\.reddit\.com/r/tinyhumansai/?$'
             --exclude '^https://www\.star-history\.com/#tinyhumansai/openhuman&type=date&legend=top-left$'
+            --exclude '^https://github\.com/tinyhumansai/openhuman/stargazers'
+            --exclude '^https://api\.star-history\.com/'
             'docs/**/*.md'
             'src/**/README.md'
             '.github/PULL_REQUEST_TEMPLATE.md'

--- a/src/openhuman/orchestration/ingest.rs
+++ b/src/openhuman/orchestration/ingest.rs
@@ -42,6 +42,9 @@ fn is_dm_stream(kind: &str, stream_id: &str) -> bool {
 fn classify_message(plaintext: String, fallback_timestamp: &str) -> ClassifiedMessage {
     match SessionEnvelopeV1::parse(&plaintext) {
         Some(env) => {
+            // Compute the session key while `env` is still fully intact (before any
+            // field moves below), since `session_key` borrows `&env`.
+            let session_id = env.session_key();
             let label = (env.scope.scope_type == "folder").then(|| env.scope.key.clone());
             let workspace = (!env.scope.cwd.is_empty()).then(|| env.scope.cwd.clone());
             let timestamp = if env.message.timestamp.is_empty() {
@@ -51,7 +54,11 @@ fn classify_message(plaintext: String, fallback_timestamp: &str) -> ClassifiedMe
             };
             ClassifiedMessage {
                 chat_kind: ChatKind::Session,
-                session_id: env.scope.harness_session_id,
+                // Key on the single per-pair session id (the shared `wrapper_session_id`
+                // both peers put on every message for a thread), so a reply threads back
+                // into the same session. Falls back to `harness_session_id` for a legacy
+                // envelope with no per-pair id. See `SessionEnvelopeV1::session_key`.
+                session_id,
                 role: env.message.role,
                 source: env.harness.provider,
                 label,
@@ -273,7 +280,7 @@ mod tests {
     fn classifies_harness_envelope_as_session() {
         let c = classify_message(ENVELOPE.to_string(), "2026-07-02T09:00:00Z");
         assert_eq!(c.chat_kind, ChatKind::Session);
-        assert_eq!(c.session_id, "h1");
+        assert_eq!(c.session_id, "w1"); // keyed on the shared per-pair wrapper_session_id
         assert_eq!(c.role, "user");
         assert_eq!(c.source, "codex");
         assert_eq!(c.label.as_deref(), Some("my-repo")); // folder scope → label
@@ -307,7 +314,7 @@ mod tests {
         assert!(persist_message(tmp.path(), "m2", "@peer", &master, "now").unwrap());
 
         store::with_connection(tmp.path(), |c| {
-            assert_eq!(store::count_messages(c, "@peer", "h1")?, 1);
+            assert_eq!(store::count_messages(c, "@peer", "w1")?, 1); // per-pair wrapper id
             assert_eq!(store::count_messages(c, "@peer", "master")?, 1);
             Ok(())
         })

--- a/src/openhuman/orchestration/ingest.rs
+++ b/src/openhuman/orchestration/ingest.rs
@@ -92,6 +92,27 @@ fn persist_message(
     now: &str,
 ) -> Result<bool, String> {
     store::with_connection(workspace_dir, |c| {
+        // Invariant guard (session windows only): the wake cursor keys on `session_id`
+        // while `seq` (= `env.message.line`) is monotonic only within one emitting
+        // harness. `upsert_session` clamps `last_seq` with `MAX(..)` and the wake fires
+        // only on `last_seq > cursor`, so a non-monotonic inbound `seq` (a peer reusing
+        // one `wrapper_session_id` across harness sessions, or a plugin-composed message
+        // whose line is 0) is persisted + acked but can SILENTLY skip the graph. Log it
+        // so the break surfaces in prod instead of dropping quietly. Robust fix (a
+        // per-wrapper monotonic ingest cursor) tracked in #4583.
+        if classified.chat_kind == ChatKind::Session {
+            if let Ok(Some(existing_last_seq)) =
+                store::session_last_seq(c, agent_id, &classified.session_id)
+            {
+                if classified.seq <= existing_last_seq {
+                    log::warn!(
+                        target: LOG,
+                        "[orchestration] wrapper session {} got seq {} <= last_seq {} — possible cross-harness reuse; wake may skip",
+                        classified.session_id, classified.seq, existing_last_seq
+                    );
+                }
+            }
+        }
         store::upsert_session(
             c,
             &OrchestrationSession {
@@ -316,6 +337,30 @@ mod tests {
         store::with_connection(tmp.path(), |c| {
             assert_eq!(store::count_messages(c, "@peer", "w1")?, 1); // per-pair wrapper id
             assert_eq!(store::count_messages(c, "@peer", "master")?, 1);
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn persist_still_stores_a_lower_seq_in_the_same_wrapper_session() {
+        // The non-monotonic-seq guard only WARNS — it must never block persistence.
+        // A later message on the same wrapper session with a LOWER seq (e.g. a
+        // plugin-composed line 0, or a different emitting harness) still lands.
+        let tmp = tempfile::tempdir().unwrap();
+        let hi = classify_message(ENVELOPE.to_string(), "2026-07-02T09:00:00Z"); // seq 7
+        assert!(persist_message(tmp.path(), "m1", "@peer", &hi, "now").unwrap());
+
+        let lo = classify_message(
+            ENVELOPE.replace("\"line\": 7", "\"line\": 3"),
+            "2026-07-02T09:00:00Z",
+        );
+        assert_eq!(lo.session_id, "w1");
+        assert_eq!(lo.seq, 3); // lower than the stored last_seq (7) → guard warns
+        assert!(persist_message(tmp.path(), "m9", "@peer", &lo, "now").unwrap());
+
+        store::with_connection(tmp.path(), |c| {
+            assert_eq!(store::count_messages(c, "@peer", "w1")?, 2); // both stored despite the warn
             Ok(())
         })
         .unwrap();

--- a/src/openhuman/orchestration/store.rs
+++ b/src/openhuman/orchestration/store.rs
@@ -213,6 +213,22 @@ pub fn count_messages(conn: &Connection, agent_id: &str, session_id: &str) -> Re
     )?)
 }
 
+/// The current `last_seq` for a session, or `None` if the session row does not
+/// exist yet. Used to detect a non-monotonic inbound `seq` before the upsert
+/// clamps it away via `MAX(...)`.
+pub fn session_last_seq(
+    conn: &Connection,
+    agent_id: &str,
+    session_id: &str,
+) -> Result<Option<i64>> {
+    conn.query_row(
+        "SELECT last_seq FROM sessions WHERE agent_id = ?1 AND session_id = ?2",
+        params![agent_id, session_id],
+        |row| row.get(0),
+    )
+    .optional()
+}
+
 /// List every persisted session row, newest activity first (stage-7 read surface).
 pub fn list_sessions(conn: &Connection) -> Result<Vec<OrchestrationSession>> {
     let mut stmt = conn.prepare(

--- a/src/openhuman/orchestration/store.rs
+++ b/src/openhuman/orchestration/store.rs
@@ -221,12 +221,13 @@ pub fn session_last_seq(
     agent_id: &str,
     session_id: &str,
 ) -> Result<Option<i64>> {
-    conn.query_row(
-        "SELECT last_seq FROM sessions WHERE agent_id = ?1 AND session_id = ?2",
-        params![agent_id, session_id],
-        |row| row.get(0),
-    )
-    .optional()
+    Ok(conn
+        .query_row(
+            "SELECT last_seq FROM sessions WHERE agent_id = ?1 AND session_id = ?2",
+            params![agent_id, session_id],
+            |row| row.get(0),
+        )
+        .optional()?)
 }
 
 /// List every persisted session row, newest activity first (stage-7 read surface).

--- a/src/openhuman/orchestration/types.rs
+++ b/src/openhuman/orchestration/types.rs
@@ -109,6 +109,19 @@ impl SessionEnvelopeV1 {
         envelope.is_valid_v1().then_some(envelope)
     }
 
+    /// The single per-pair session id to bucket an inbound message under. Every
+    /// message — whoever sent it — carries exactly one id: the shared conversation
+    /// id in `scope.wrapper_session_id`. Both peers put the SAME id there for a given
+    /// thread (the peer reuses it on reply), so it is the sole routing key. Falls
+    /// back to `harness_session_id` only for a legacy envelope that predates the
+    /// per-pair id.
+    pub fn session_key(&self) -> String {
+        if !self.scope.wrapper_session_id.is_empty() {
+            return self.scope.wrapper_session_id.clone();
+        }
+        self.scope.harness_session_id.clone()
+    }
+
     /// Build an outgoing v1 session envelope carrying `body` under `session_id`,
     /// so a compliant peer harness threads its reply under the same session.
     pub fn outgoing(session_id: &str, body: &str, message_id: &str, timestamp: &str) -> Self {
@@ -239,5 +252,23 @@ mod tests {
             r#"{"envelope_version":"tinyplace.harness.session.v1","scope":{"harness_session_id":""}}"#
         )
         .is_none());
+    }
+
+    #[test]
+    fn session_key_is_the_shared_wrapper_id_then_harness_fallback() {
+        // The single per-pair id lives in `wrapper_session_id`.
+        assert_eq!(
+            SessionEnvelopeV1::parse(SAMPLE).unwrap().session_key(),
+            "w1"
+        );
+        // Legacy envelope with no per-pair id: fall back to the harness id.
+        let env = SessionEnvelopeV1::parse(
+            r#"{
+                "envelope_version": "tinyplace.harness.session.v1",
+                "scope": { "harness_session_id": "h-only" }
+            }"#,
+        )
+        .expect("valid v1");
+        assert_eq!(env.session_key(), "h-only");
     }
 }


### PR DESCRIPTION
## Summary

- Key inbound harness DMs on the **shared per-pair session id** (`scope.wrapper_session_id`) instead of `harness_session_id`, via a new `SessionEnvelopeV1::session_key()`.
- Pairs with the tiny.place plugin change (tinyhumansai/tiny.place#227) so a reply threads back into the session that *originated* the conversation — in both directions.

## Problem

- `classify_message` bucketed inbound harness DMs on `harness_session_id`. The plugin now emits one shared conversation id per thread in `wrapper_session_id` (and reuses it on reply), so keying on `harness_session_id` means an OpenHuman-initiated conversation never threads the peer's reply back into the originating session.

## Solution

- Add `SessionEnvelopeV1::session_key()` → returns `wrapper_session_id` (the shared id), falling back to `harness_session_id` only for a legacy envelope with no per-pair id.
- `classify_message` uses it (computed before field moves, since it borrows `&env`).
- Verified live: OpenHuman-initiated DM under a session id `S` → the claude session's reply reused `S` → OpenHuman ingested it back under `S` and ran its orchestration graph on that session.

## Submission Checklist

- [x] Tests added or updated — `session_key_is_the_shared_wrapper_id_then_harness_fallback` (types.rs) + updated ingest `classifies_harness_envelope_as_session` / `persist_message_is_idempotent_and_buckets_by_session` to assert the shared id (`w1`) and its failure/fallback path.
- [x] **Diff coverage ≥ 80%** — every changed line (`session_key` + the classify assignment) is exercised by the new/updated unit tests.
- [x] N/A — Coverage matrix: behaviour-only change to an existing ingest path; no feature rows added/removed/renamed.
- [x] N/A — no matrix feature IDs affected (behaviour-only change).
- [x] No new external network dependencies introduced.
- [x] N/A — does not touch release-cut / manual-smoke surfaces (internal DM routing key only).
- [x] N/A — no linked issue; follow-up to the A2A shared-session-id work (plugin PR tinyhumansai/tiny.place#227).

## Impact

- Desktop core only (Rust). Inbound harness DMs now bucket under the shared per-pair id; a legacy envelope with no `wrapper_session_id` still falls back to `harness_session_id`, so there is no regression for older peers.

## Related

- Closes: N/A (follow-up to tinyhumansai/tiny.place#227)
- Follow-up PR(s)/TODOs: pairs with tinyhumansai/tiny.place#227

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/orchestration-shared-session-key`
- Commit SHA: `e966b7667`

### Validation Run

- [x] N/A `pnpm --filter openhuman-app format:check` — no frontend/TS changes
- [x] N/A `pnpm typecheck` — no frontend/TS changes
- [x] Focused tests: `cargo test --lib openhuman::orchestration::` passes (54 tests) in a sibling worktree carrying the byte-identical change (types + ingest)
- [x] Rust fmt/check: `cargo fmt --check` clean on both files; full `cargo check` blocked in a clean `upstream/main` worktree (see Validation Blocked) — verified via sibling worktree + CI
- [x] N/A Tauri fmt/check — no Tauri code changed

### Validation Blocked

- `command:` `cargo check`/`cargo test` in a fresh worktree off `upstream/main`
- `error:` missing vendored submodules (`vendor/tinyagents`, `vendor/tinyplace`) — a clean worktree can't complete the build locally
- `impact:` compilation + the full orchestration suite (54 tests) verified in a sibling worktree with the identical change; CI has the submodules and will validate authoritatively.

### Behavior Changes

- Intended behavior change: inbound harness DMs bucket on the shared per-pair session id.
- User-visible effect: replies to OpenHuman-initiated agent conversations thread back into the same session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session messages now use a more precise per-session identifier for routing and persistence, improving consistency across related conversations.
  * Legacy session envelopes are still supported via automatic fallback to the older session identifier format.
* **Bug Fixes**
  * Added a warning when messages arrive with non-monotonic sequence numbers for the same session, highlighting potential ordering/reuse issues while still saving data.
  * Lower-sequence messages continue to be saved to prevent unintended loss.
* **Chores**
  * Updated CI link checking to exclude additional external URLs from validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->