### PR TITLE
fix(skills): thread local-http install flag as param, not process env (#4567)

### DIFF
--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -43,7 +43,7 @@
 <p align="center">
  <img src="https://img.shields.io/badge/status-early%20beta-orange" alt="Frühe Beta" />
  <a href="https://github.com/tinyhumansai/openhuman/releases/latest"><img src="https://img.shields.io/github/v/release/tinyhumansai/openhuman?label=latest" alt="Aktuellste Version" /></a>
- <a href="https://github.com/tinyhumansai/openhuman/stargazers"><img src="https://img.shields.io/github/stars/tinyhumansai/openhuman?style=flat" alt="GitHub Stars" /></a>
+ <a href="https://github.com/tinyhumansai/openhuman"><img src="https://img.shields.io/github/stars/tinyhumansai/openhuman?style=flat" alt="GitHub Stars" /></a>
  <a href="../LICENSE"><img src="https://img.shields.io/github/license/tinyhumansai/openhuman" alt="Lizenz" /></a>
 </p>
 

--- a/docs/README.ja-JP.md
+++ b/docs/README.ja-JP.md
@@ -43,7 +43,7 @@
 <p align="center">
  <img src="https://img.shields.io/badge/status-early%20beta-orange" alt="Early Beta" />
  <a href="https://github.com/tinyhumansai/openhuman/releases/latest"><img src="https://img.shields.io/github/v/release/tinyhumansai/openhuman?label=latest" alt="最新リリース" /></a>
- <a href="https://github.com/tinyhumansai/openhuman/stargazers"><img src="https://img.shields.io/github/stars/tinyhumansai/openhuman?style=flat" alt="GitHub Stars" /></a>
+ <a href="https://github.com/tinyhumansai/openhuman"><img src="https://img.shields.io/github/stars/tinyhumansai/openhuman?style=flat" alt="GitHub Stars" /></a>
  <a href="../LICENSE"><img src="https://img.shields.io/github/license/tinyhumansai/openhuman" alt="ライセンス" /></a>
 </p>
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -43,7 +43,7 @@
 <p align="center">
  <img src="https://img.shields.io/badge/status-early%20beta-orange" alt="얼리 베타" />
  <a href="https://github.com/tinyhumansai/openhuman/releases/latest"><img src="https://img.shields.io/github/v/release/tinyhumansai/openhuman?label=latest" alt="최신 릴리스" /></a>
- <a href="https://github.com/tinyhumansai/openhuman/stargazers"><img src="https://img.shields.io/github/stars/tinyhumansai/openhuman?style=flat" alt="GitHub Stars" /></a>
+ <a href="https://github.com/tinyhumansai/openhuman"><img src="https://img.shields.io/github/stars/tinyhumansai/openhuman?style=flat" alt="GitHub Stars" /></a>
  <a href="../LICENSE"><img src="https://img.shields.io/github/license/tinyhumansai/openhuman" alt="라이선스" /></a>
 </p>
 

--- a/docs/README.ur-pk.md
+++ b/docs/README.ur-pk.md
@@ -53,7 +53,7 @@
 <p align="center">
  <img src="https://img.shields.io/badge/status-early%20beta-orange" alt="ابتدائی آزمائشی نسخہ" />
  <a href="https://github.com/tinyhumansai/openhuman/releases/latest"><img src="https://img.shields.io/github/v/release/tinyhumansai/openhuman?label=latest" alt="تازہ ترین نسخہ" /></a>
- <a href="https://github.com/tinyhumansai/openhuman/stargazers"><img src="https://img.shields.io/github/stars/tinyhumansai/openhuman?style=flat" alt="ستارے" /></a>
+ <a href="https://github.com/tinyhumansai/openhuman"><img src="https://img.shields.io/github/stars/tinyhumansai/openhuman?style=flat" alt="ستارے" /></a>
  <a href="../LICENSE"><img src="https://img.shields.io/github/license/tinyhumansai/openhuman" alt="لائسنس" /></a>
 </p>
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -43,7 +43,7 @@
 <p align="center">
  <img src="https://img.shields.io/badge/status-early%20beta-orange" alt="早期测试版" />
  <a href="https://github.com/tinyhumansai/openhuman/releases/latest"><img src="https://img.shields.io/github/v/release/tinyhumansai/openhuman?label=latest" alt="最新版本" /></a>
- <a href="https://github.com/tinyhumansai/openhuman/stargazers"><img src="https://img.shields.io/github/stars/tinyhumansai/openhuman?style=flat" alt="GitHub Stars" /></a>
+ <a href="https://github.com/tinyhumansai/openhuman"><img src="https://img.shields.io/github/stars/tinyhumansai/openhuman?style=flat" alt="GitHub Stars" /></a>
  <a href="../LICENSE"><img src="https://img.shields.io/github/license/tinyhumansai/openhuman" alt="许可证" /></a>
 </p>
 

--- a/src/openhuman/skills/ops_install.rs
+++ b/src/openhuman/skills/ops_install.rs
@@ -119,7 +119,9 @@ pub async fn install_workflow_from_url(
     params: InstallWorkflowFromUrlParams,
 ) -> Result<InstallWorkflowFromUrlOutcome, String> {
     let home = dirs::home_dir();
-    install_workflow_from_url_with_home(workspace_dir, params, home.as_deref()).await
+    let allow_local_http = read_allow_local_http_env();
+    install_workflow_from_url_with_home(workspace_dir, params, home.as_deref(), allow_local_http)
+        .await
 }
 
 pub(crate) fn should_report_install_fetch_status(status: reqwest::StatusCode) -> bool {
@@ -130,9 +132,10 @@ pub(crate) async fn install_workflow_from_url_with_home(
     workspace_dir: &Path,
     params: InstallWorkflowFromUrlParams,
     home: Option<&Path>,
+    allow_local_http: bool,
 ) -> Result<InstallWorkflowFromUrlOutcome, String> {
     let raw_url = params.url.trim().to_string();
-    validate_install_url(&raw_url)?;
+    validate_install_url_with_config(&raw_url, allow_local_http)?;
 
     let timeout_secs = params
         .timeout_secs
@@ -148,7 +151,7 @@ pub(crate) async fn install_workflow_from_url_with_home(
     // resolver may see different answers than ours. Closing that gap requires
     // pinning a `SocketAddr` and passing it to reqwest via a custom resolver,
     // tracked separately.
-    if !allow_local_http_install_url(&fetch_url) {
+    if !(allow_local_http && is_loopback_http_url(&fetch_url)) {
         validate_resolved_host(&fetch_url).await?;
     }
 
@@ -698,6 +701,19 @@ pub(crate) fn derive_install_slug(fm: &WorkflowFrontmatter) -> Result<String, St
 /// * IPv6 literals in loopback (::1), unspecified (::), unique-local
 ///   (fc00::/7), link-local (fe80::/10), or multicast (ff00::/8)
 pub fn validate_install_url(raw: &str) -> Result<(), String> {
+    validate_install_url_with_config(raw, read_allow_local_http_env())
+}
+
+/// Same as [`validate_install_url`] but takes an explicit `allow_local_http`
+/// flag instead of reading `OPENHUMAN_SKILL_INSTALL_ALLOW_LOCAL_HTTP` from the
+/// process environment. Callers below the public entry point should always use
+/// this variant — the env-var read in `validate_install_url` is racy across
+/// threads under the parallel test runner (#4567), and the escape hatch is
+/// only meaningful at a single boundary.
+pub(crate) fn validate_install_url_with_config(
+    raw: &str,
+    allow_local_http: bool,
+) -> Result<(), String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return Err("url must not be empty".to_string());
@@ -710,7 +726,7 @@ pub fn validate_install_url(raw: &str) -> Result<(), String> {
     }
     let parsed = url::Url::parse(trimmed).map_err(|e| format!("invalid url {trimmed:?}: {e}"))?;
     if parsed.scheme() != "https" {
-        if allow_local_http_install_url(trimmed) {
+        if allow_local_http && is_loopback_http_url(trimmed) {
             return Ok(());
         }
         return Err(format!(
@@ -732,10 +748,15 @@ pub fn validate_install_url(raw: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn allow_local_http_install_url(raw: &str) -> bool {
-    if std::env::var(ALLOW_LOCAL_HTTP_ENV).ok().as_deref() != Some("1") {
-        return false;
-    }
+/// Reads the local-HTTP install escape hatch env var. Kept as the single
+/// boundary point where env is inspected so downstream validation never
+/// touches process-global state — required to stop the parallel-test race
+/// described in #4567.
+fn read_allow_local_http_env() -> bool {
+    std::env::var(ALLOW_LOCAL_HTTP_ENV).ok().as_deref() == Some("1")
+}
+
+fn is_loopback_http_url(raw: &str) -> bool {
     let Ok(parsed) = url::Url::parse(raw) else {
         return false;
     };
@@ -907,15 +928,12 @@ mod install_fetch_tests {
     /// for both a 4xx (which is NOT reported to Sentry) and a 5xx (which is).
     /// Exercises both branches of the non-2xx handling; the report-suppression
     /// polarity itself is asserted by `is_skills_install_client_error_event` in
-    /// observability. Uses the local-HTTP install escape hatch so the loopback
-    /// mock passes URL validation.
+    /// observability. Passes the local-HTTP install escape hatch as an
+    /// explicit param so the loopback mock passes URL validation — the env-var
+    /// path is process-global and races with other env-touching tests under
+    /// parallel execution (#4567).
     #[tokio::test]
     async fn non_2xx_install_fetch_returns_err_for_4xx_and_5xx() {
-        let _env = crate::openhuman::config::TEST_ENV_LOCK
-            .lock()
-            .unwrap_or_else(|e| e.into_inner());
-        std::env::set_var(ALLOW_LOCAL_HTTP_ENV, "1");
-
         let tmp = TempDir::new().unwrap();
 
         for status in [StatusCode::NOT_FOUND, StatusCode::INTERNAL_SERVER_ERROR] {
@@ -928,6 +946,7 @@ mod install_fetch_tests {
                     timeout_secs: Some(5),
                 },
                 None,
+                true,
             )
             .await
             .expect_err("a non-2xx fetch must return Err so the UI surfaces it");
@@ -936,7 +955,5 @@ mod install_fetch_tests {
                 "error must surface the status to the UI: {err}"
             );
         }
-
-        std::env::remove_var(ALLOW_LOCAL_HTTP_ENV);
     }
 }

--- a/src/openhuman/skills/ops_tests.rs
+++ b/src/openhuman/skills/ops_tests.rs
@@ -7,30 +7,6 @@ fn write(path: &Path, content: &str) {
     std::fs::write(path, content).unwrap();
 }
 
-struct EnvVarGuard {
-    key: &'static str,
-    previous: Option<std::ffi::OsString>,
-}
-
-impl EnvVarGuard {
-    fn set(key: &'static str, value: &str) -> Self {
-        let previous = std::env::var_os(key);
-        unsafe { std::env::set_var(key, value) };
-        Self { key, previous }
-    }
-}
-
-impl Drop for EnvVarGuard {
-    fn drop(&mut self) {
-        unsafe {
-            match &self.previous {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
-}
-
 /// Workspace-only variant of [`load_workflow_metadata`] used by tests that care only
 /// about project-scope semantics. The production [`load_workflow_metadata`] now
 /// consults `dirs::home_dir()`; in unit tests that would non-deterministically
@@ -1214,7 +1190,6 @@ async fn install_workflow_from_url_is_idempotent_when_skill_already_exists() {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    let _guard = EnvVarGuard::set("OPENHUMAN_SKILL_INSTALL_ALLOW_LOCAL_HTTP", "1");
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/SKILL.md"))
@@ -1231,15 +1206,23 @@ async fn install_workflow_from_url_is_idempotent_when_skill_already_exists() {
         timeout_secs: Some(5),
     };
 
-    let first =
-        install_workflow_from_url_with_home(workspace.path(), params.clone(), Some(home.path()))
-            .await
-            .unwrap();
+    // Pass the local-HTTP escape hatch as an explicit param — the env-var
+    // path is process-global and races other env-touching tests under
+    // parallel execution (#4567).
+    let first = install_workflow_from_url_with_home(
+        workspace.path(),
+        params.clone(),
+        Some(home.path()),
+        true,
+    )
+    .await
+    .unwrap();
     assert_eq!(first.new_skills, vec!["apple-notes"]);
 
-    let second = install_workflow_from_url_with_home(workspace.path(), params, Some(home.path()))
-        .await
-        .unwrap();
+    let second =
+        install_workflow_from_url_with_home(workspace.path(), params, Some(home.path()), true)
+            .await
+            .unwrap();
     assert!(second.new_skills.is_empty(), "{second:?}");
     assert!(second.stdout.contains("already installed"), "{second:?}");
 }


### PR DESCRIPTION
## Summary

- Kill the process-global env read that made `install_fetch_tests::non_2xx_install_fetch_returns_err_for_4xx_and_5xx` flaky under the full parallel Rust suite (#4567).
- Thread the local-HTTP install escape hatch as an explicit `allow_local_http: bool` param from the public entry point down through `install_workflow_from_url_with_home` and a new `validate_install_url_with_config`.
- Split the old combined helper into a pure `is_loopback_http_url` (no env) and a single boundary-only `read_allow_local_http_env`.
- Skills unit tests now pass `true` explicitly and no longer touch `set_var` / `remove_var` / `TEST_ENV_LOCK` for the local-HTTP flag.
- Removed the now-dead `EnvVarGuard` in `skills/ops_tests.rs`.

## Problem

`workflows::ops_install::install_fetch_tests::non_2xx_install_fetch_returns_err_for_4xx_and_5xx` (path on `main` is `skills::ops_install::install_fetch_tests::...`) flakes intermittently on the full-suite coverage run with:

```
url scheme http not allowed; https only
```

The test locks `TEST_ENV_LOCK`, does `std::env::set_var(ALLOW_LOCAL_HTTP_ENV, "1")`, then calls `install_workflow_from_url_with_home` against a loopback `http://` mock. Inside, `validate_install_url` bounces the scheme unless `allow_local_http_install_url` — which reads the same env var back — returns `true`.

Root cause: `TEST_ENV_LOCK` only serializes tests that opt in. The full-suite parallel run contains dozens of tests that mutate process env (`OPENHUMAN_WORKSPACE`, composio, approval gate, subagent orchestration, screen intelligence, …), several of which do not take the lock. `std::env::set_var` / `remove_var` are `unsafe` in modern Rust precisely because they aren't safe under concurrent readers. Between our `set_var` and the internal read, another thread's env mutation can win the race and `allow_local_http_install_url` observes a stale/unset value. In isolation the test passes because there's no concurrent env mutator.

A second test in `skills/ops_tests.rs` (`install_workflow_from_url_is_idempotent_when_skill_already_exists`) hit the same trap via `EnvVarGuard::set(...)` against a loopback wiremock.

## Solution

Remove the process-global env dependency from the hot path — the design that the issue explicitly recommended.

- `install_workflow_from_url` (the sole public entry point) reads `OPENHUMAN_SKILL_INSTALL_ALLOW_LOCAL_HTTP` **once** via new `read_allow_local_http_env()`, then threads the resolved bool into `install_workflow_from_url_with_home`.
- `install_workflow_from_url_with_home` gains an `allow_local_http: bool` param. It no longer touches env; it forwards the bool to `validate_install_url_with_config` and to the DNS-guard skip check.
- `validate_install_url` split into a public wrapper (reads env once, kept for the RPC/tests that call it from outside the crate) and `pub(crate) validate_install_url_with_config(raw, allow_local_http)` which the internal path uses.
- Old combined `allow_local_http_install_url(raw)` split into:
  - `read_allow_local_http_env()` — pure env read, called only at the boundary.
  - `is_loopback_http_url(raw)` — pure URL check, no env, no cross-thread hazards.
- Both flaky tests now pass `true` explicitly to `_with_home`. `TEST_ENV_LOCK`, `set_var`, `remove_var`, and `EnvVarGuard::set(...)` are all gone from the local-HTTP install path.

Public / RPC / CLI / docker behaviour is unchanged. The `OPENHUMAN_SKILL_INSTALL_ALLOW_LOCAL_HTTP` env var is still honoured — just read exactly once, at exactly one place. Integration tests in `tests/skill_registry_e2e.rs` (which drive the public JSON-RPC path and legitimately use `EnvVarGuard`) are unaffected: integration tests compile as their own binary and never share process state with the crate unit-test binary.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — the two existing install tests are updated to exercise the new param path; the failure path (4xx/5xx) is what the flaky test itself covers.
- [x] **Diff coverage ≥ 80%** — the two updated tests plus the existing `validate_install_url_*` suite cover every changed line; ran locally.
- [x] Coverage matrix updated — `N/A: behaviour-only change (races/flakes; no user-visible surface)`.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix rows affected`.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A: not a release-cut surface`.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform: none. Rust core only. Prod flow (`install_workflow_from_url` → RPC / CLI / docker / E2E) reads the same env var, at the same semantics, just once at the boundary. Behavioural equivalence for callers.
- Performance: negligible — one fewer `std::env::var` call per validation (was called from inside `validate_install_url` too).
- Security: the SSRF guard (`validate_resolved_host`) and loopback-block rules are unchanged. The escape hatch still requires the env var; the only path that skips DNS resolution now requires both the flag *and* a literal loopback URL, identical to before.
- Migration/compat: none — internal API only. The one internal caller of `install_workflow_from_url_with_home` (the two unit tests) is updated in this PR.

## Related

- Closes: #4567
- Follow-up PR(s)/TODOs: The audit in the issue mentions "ensure every env-touching test in the crate shares `TEST_ENV_LOCK`" as a fallback. Not done here — this PR removes the need for the local-HTTP path — but the broader crate-wide audit for other env-touching tests remains a valid separate cleanup.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/4567-install-http-env-race`
- Commit SHA: `c9c92762356578888da0d96c9c26ceed6afd8980`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A (Rust-only change)
- [x] `pnpm typecheck` — N/A (Rust-only change)
- [x] Focused tests: `cargo test --lib -p openhuman -- skills::ops_install skills::ops::tests::install_ skills::ops::tests::validate_install` — 8/8 pass. Full `skills::` suite: 176/176 pass.
- [x] Rust fmt/check (if changed): `cargo check --lib --tests` clean; `cargo fmt --check` clean on both modified files.
- [x] Tauri fmt/check (if changed): N/A (no `app/src-tauri` changes).

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none for prod callers; only the internal test-facing API is extended with an explicit `allow_local_http: bool` param.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: yes. Public `install_workflow_from_url` still reads `OPENHUMAN_SKILL_INSTALL_ALLOW_LOCAL_HTTP` at the same boundary and applies the same loopback-URL check.
- Guard/fallback/dispatch parity checks: `validate_install_url` public signature unchanged; still reads env once. `validate_resolved_host` still skipped only for the allowed loopback-HTTP case.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill installation URL handling so the “allow local HTTP” setting is applied consistently during install and validation.
  * Strengthened URL validation and network/SSRF safeguards for more reliable installs, including under parallel test execution.
  * Reduced flaky install failures caused by environment-variable race conditions.
* **Documentation**
  * Updated GitHub Stars badge links across localized README files to point to the repository root page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->