### PR TITLE
fix(flows): default prompt-bar flows to requireApproval=true

### DIFF
--- a/app/src/components/flows/WorkflowPromptBar.test.tsx
+++ b/app/src/components/flows/WorkflowPromptBar.test.tsx
@@ -30,14 +30,30 @@ describe('WorkflowPromptBar', () => {
 
     await waitFor(() => expect(navigateMock).toHaveBeenCalledTimes(1));
     expect(createFlowMock).toHaveBeenCalledTimes(1);
-    const [name, graph] = createFlowMock.mock.calls[0];
+    const [name, graph, requireApproval] = createFlowMock.mock.calls[0];
     expect(name).toBe('digest my Slack every morning');
     // The created flow is the standard blank graph (single manual trigger).
     expect(graph.nodes).toHaveLength(1);
     expect(graph.nodes[0].kind).toBe('trigger');
+    // Parity with the proposal-card path: prompt-authored flows must default
+    // to requiring approval, matching WorkflowProposalCard's default.
+    expect(requireApproval).toBe(true);
     expect(navigateMock).toHaveBeenCalledWith('/flows/flow-1', {
       state: { copilotBuild: { description: 'digest my Slack every morning' } },
     });
+  });
+
+  it('defaults requireApproval to true so outbound side-effects need explicit approval', async () => {
+    render(<WorkflowPromptBar />);
+    fireEvent.change(screen.getByTestId('workflow-prompt-input'), {
+      target: { value: 'auto-reply to every gmail thread' },
+    });
+    fireEvent.click(screen.getByTestId('workflow-prompt-submit'));
+
+    await waitFor(() => expect(createFlowMock).toHaveBeenCalledTimes(1));
+    // Third positional arg must be `true` — flows_create's server default is
+    // `false`, so omitting it would silently disarm the approval gate.
+    expect(createFlowMock.mock.calls[0][2]).toBe(true);
   });
 
   it('submits on Enter (Shift+Enter reserved for newlines)', async () => {

--- a/app/src/components/flows/WorkflowPromptBar.tsx
+++ b/app/src/components/flows/WorkflowPromptBar.tsx
@@ -44,9 +44,13 @@ export default function WorkflowPromptBar({ variant = 'compact', autoFocus = fal
     const name = deriveWorkflowName(trimmed, t('flows.page.newWorkflow'));
     log('submit: creating flow name=%s', name);
     try {
+      // Safe default: prompt-authored flows require approval so outbound
+      // Slack/Gmail/HTTP/code nodes cannot fire unattended. Omitting this
+      // arg would fall back to the server default of `false`.
       const flow = await createFlow(
         name,
-        createBlankWorkflowGraph(name, t('flows.nodeKind.trigger'))
+        createBlankWorkflowGraph(name, t('flows.nodeKind.trigger')),
+        true
       );
       log('submit: created id=%s — opening canvas with build seed', flow.id);
       navigate(`/flows/${flow.id}`, { state: { copilotBuild: { description: trimmed } } });


### PR DESCRIPTION
## Summary

- Prompt-bar-authored flows now default to `requireApproval = true`, matching the proposal-card path and preventing outbound Slack/Gmail/HTTP/code nodes from firing unattended.
- One-line real fix at `WorkflowPromptBar.tsx:47` (pass `true` explicitly) plus two `WorkflowPromptBar.test.tsx` assertions guarding the default.
- Scope kept to the prompt-bar surface as flagged by `chatgpt-codex-connector` on #4578 (P1).

## Problem

`app/src/components/flows/WorkflowPromptBar.tsx` created flows via `createFlow(name, graph)`, omitting the optional third `requireApproval` argument. `flows_create`'s server default is `false`, so prompt-authored flows could go live with the approval gate **off** for outbound side-effect nodes. This is a posture mismatch with `WorkflowProposalCard.tsx:84`, which passes `proposal.requireApproval` (defaulting to `true`) through explicitly. The later `save_workflow` path preserves the flag but never re-enables it, so the unsafe default sticks unless the user manually flips it later.

## Solution

Pass `true` as the third argument at the prompt-bar submit site so the placeholder flow is created with the safe default from the start. Coverage:

- Extended the existing "creates a flow named from the prompt…" test to destructure `[name, graph, requireApproval]` and assert `requireApproval === true`, verifying parity with the proposal-card default.
- Added a dedicated `defaults requireApproval to true so outbound side-effects need explicit approval` regression test that asserts `createFlowMock.mock.calls[0][2] === true` in isolation, so a future refactor cannot silently swap arg positions without breaking this test.

A short "safe default" comment sits above the call to record the WHY (server default is `false`; parity with proposal-card path).

Scope note: `useCreateFlow.ts:55` (used by `NewWorkflowModal`) has the same shape but is not P1 and is intentionally out of scope for this PR; tracked as a follow-up.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/ci-lite.yml`](../.github/workflows/ci-lite.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`) — N/A: behaviour-only change, no feature rows added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature IDs affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: safe-default change, no new surface or user-visible flow.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Runtime**: Desktop only (frontend React change). No mobile/web/CLI surface touched.
- **Security posture**: Positive — closes the approval-gate bypass path for prompt-authored flows. Existing prompt-authored flows already persisted with `requireApproval = false` are unaffected; only newly created flows pick up the safe default.
- **Migration/compat**: None. `flows_create` accepts the arg today; this only flips the caller's default. No schema changes.
- **Performance**: None.

## Related

- Closes #4594
- Follow-up PR(s)/TODOs: `useCreateFlow.ts:55` (NewWorkflowModal) has the same missing third arg — should be fixed as a small separate PR to preserve parity across all placeholder-creation surfaces.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/4594-prompt-bar-require-approval`
- Commit SHA: `b42c0e480`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — prettier check on the two changed files: clean.
- [x] `pnpm typecheck` — `openhuman-app@ compile` (tsc --noEmit) exit 0.
- [x] Focused tests: `pnpm exec vitest run src/components/flows/WorkflowPromptBar.test.tsx` — 5/5 pass (~820ms).
- [x] Rust fmt/check (if changed): N/A — no Rust files changed.
- [x] Tauri fmt/check (if changed): N/A — no Tauri files changed.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: Prompt-bar-created flows are now persisted with `requireApproval = true` on the placeholder record instead of relying on `flows_create`'s `false` server default.
- User-visible effect: When a user submits the prompt bar, the resulting flow already requires approval for outbound Slack/Gmail/HTTP/code nodes; they can still toggle it off later in the canvas Save dialog if desired.

### Parity Contract

- Legacy behavior preserved: Canvas Save flow, `save_workflow` payload shape, `flows_create` RPC signature, and existing persisted flows are all unchanged.
- Guard/fallback/dispatch parity checks: The prompt-bar path now matches `WorkflowProposalCard.tsx:84`'s explicit-`requireApproval` posture. The two new/updated test assertions guard this parity going forward.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None known.
- Canonical PR: This one.
- Resolution (closed/superseded/updated): N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prompt-created workflows now default to requiring approval before they can run, adding a safer step before triggers fire.
  * Updated workflow creation behavior to keep manual review enabled when submitting a prompt.
* **Tests**
  * Added coverage to verify the approval requirement is included by default when creating a workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->