### PR TITLE
fix(agent): default tool-calling to JSON, make P-Format opt-in

### DIFF
--- a/src/openhuman/agent/harness/session/builder/factory.rs
+++ b/src/openhuman/agent/harness/session/builder/factory.rs
@@ -1021,52 +1021,20 @@ impl Agent {
         // entry. The registry is self-contained — it doesn't hold a
         // reference back into the tools Vec.
         let pformat_registry = crate::openhuman::agent::pformat::build_registry(&tools);
+        let dispatcher_kind =
+            resolve_dispatcher_kind(&dispatcher_choice, supports_native, agent_id);
         let tool_dispatcher: Box<dyn crate::openhuman::agent::dispatcher::ToolDispatcher> =
-            match dispatcher_choice.as_str() {
-                "native" => Box::new(NativeToolDispatcher),
-                "xml" => Box::new(XmlToolDispatcher),
-                "pformat" => Box::new(PFormatToolDispatcher::new(pformat_registry.clone())),
-                _ if supports_native => Box::new(NativeToolDispatcher),
-                // Default for text-only providers: P-Format. Flip the
-                // `agent.tool_dispatcher` config to `"xml"` to revert.
-                _ => Box::new(PFormatToolDispatcher::new(pformat_registry.clone())),
-            };
-
-        // Provider-side grammar decoders (e.g. Fireworks) compile every
-        // tool JSON schema into a grammar and index its rules with a
-        // uint16_t — max 65 535 rules. Large Composio toolkits (Notion,
-        // Salesforce, Gmail) produce per-action schemas dense enough
-        // that even 16–25 of them blow past that ceiling, regardless of
-        // how aggressively the fuzzy filter in `tool_filter.rs` narrows
-        // the list. When that happens the provider rejects the request
-        // with a 400 before any generation starts, so integrations_agent can
-        // never actually invoke the toolkit.
-        //
-        // Workaround: if we're building integrations_agent and the selected
-        // dispatcher would ship `tools: [...]` in the API payload
-        // (`should_send_tool_specs() == true`, i.e. native mode), swap
-        // to XML mode. XmlToolDispatcher puts the tool catalogue inside
-        // the system prompt as prose instead — the provider never
-        // compiles a grammar for it, so the rule-count ceiling stops
-        // mattering. Downside: slightly looser tool-call formatting
-        // than native; the existing `parse_tool_calls` recovers from
-        // stray formatting and the loop retries on malformed output.
-        let tool_dispatcher: Box<dyn crate::openhuman::agent::dispatcher::ToolDispatcher> =
-            if agent_id == "integrations_agent" && tool_dispatcher.should_send_tool_specs() {
-                log::info!(
-                    "[agent::builder] integrations_agent: overriding native tool dispatcher with \
-                     PFormatToolDispatcher (native mode hits provider grammar-rule limits on \
-                     large Composio toolkits; p-format keeps the in-prompt catalogue compact \
-                     and still parses JSON-in-tag fallbacks)"
-                );
-                Box::new(PFormatToolDispatcher::new(pformat_registry.clone()))
-            } else {
-                tool_dispatcher
+            match dispatcher_kind {
+                DispatcherKind::Native => Box::new(NativeToolDispatcher),
+                DispatcherKind::Xml => Box::new(XmlToolDispatcher),
+                DispatcherKind::PFormat => {
+                    Box::new(PFormatToolDispatcher::new(pformat_registry.clone()))
+                }
             };
 
         log::debug!(
             "[agent] tool dispatcher selected: choice={dispatcher_choice} agent_id={agent_id} \
-             sends_tool_specs={} default_text_format=pformat pformat_registry_entries={}",
+             kind={dispatcher_kind:?} sends_tool_specs={} pformat_registry_entries={}",
             tool_dispatcher.should_send_tool_specs(),
             pformat_registry.len()
         );
@@ -1239,6 +1207,50 @@ fn definition_disallows_tool(disallowed: &[String], name: &str) -> bool {
     })
 }
 
+/// Which tool-call dialect a session speaks to its provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DispatcherKind {
+    /// Provider-native structured function calling (JSON tool specs on the wire).
+    Native,
+    /// JSON-in-tag: `<tool_call>{"name":…,"arguments":{…}}</tool_call>` in text.
+    Xml,
+    /// Compact positional P-Format (`tool[a|b]`) — opt-in only.
+    PFormat,
+}
+
+/// Pick the tool-call dialect from the configured `agent.tool_dispatcher`
+/// choice, the provider's native-tool support, and the agent id.
+///
+/// `"auto"` (and any unrecognized value) resolves to native when the provider
+/// supports it, otherwise JSON-in-tag — **never** P-Format, which is opt-in
+/// (`"pformat"`) because its compact positional syntax mis-parses on some
+/// models.
+///
+/// `integrations_agent` is special-cased off native: provider-side grammar
+/// decoders (e.g. Fireworks) compile every JSON tool schema into a grammar
+/// indexed by a `uint16_t` (max 65 535 rules), and large Composio toolkits
+/// (Notion, Salesforce, Gmail) blow past that ceiling, so a native request is
+/// rejected with a 400 before any generation. Falling back to JSON-in-tag puts
+/// the catalogue in the prompt as prose, so no grammar is compiled.
+fn resolve_dispatcher_kind(
+    dispatcher_choice: &str,
+    supports_native: bool,
+    agent_id: &str,
+) -> DispatcherKind {
+    let base = match dispatcher_choice {
+        "native" => DispatcherKind::Native,
+        "xml" => DispatcherKind::Xml,
+        "pformat" => DispatcherKind::PFormat,
+        _ if supports_native => DispatcherKind::Native,
+        _ => DispatcherKind::Xml,
+    };
+    if agent_id == "integrations_agent" && base == DispatcherKind::Native {
+        DispatcherKind::Xml
+    } else {
+        base
+    }
+}
+
 /// Resolve the provider/workload role for a session build.
 ///
 /// The `subconscious` workload has two entry points and both must route here:
@@ -1270,6 +1282,7 @@ pub(crate) fn provider_role_for(agent_id: &str, default_model: Option<&str>) -> 
 #[cfg(test)]
 mod provider_role_tests {
     use super::provider_role_for;
+    use super::{resolve_dispatcher_kind, DispatcherKind};
 
     #[test]
     fn orchestrator_defaults_to_chat() {
@@ -1309,5 +1322,59 @@ mod provider_role_tests {
             "subconscious"
         );
         assert_eq!(provider_role_for(" subconscious ", None), "subconscious");
+    }
+
+    #[test]
+    fn auto_prefers_native_when_supported_never_pformat() {
+        assert_eq!(
+            resolve_dispatcher_kind("auto", true, "chat"),
+            DispatcherKind::Native
+        );
+        // Text-only provider defaults to JSON-in-tag, NOT P-Format.
+        assert_eq!(
+            resolve_dispatcher_kind("auto", false, "chat"),
+            DispatcherKind::Xml
+        );
+        // An unrecognized value behaves like "auto".
+        assert_eq!(
+            resolve_dispatcher_kind("bogus", false, "chat"),
+            DispatcherKind::Xml
+        );
+    }
+
+    #[test]
+    fn explicit_choices_are_honoured_including_opt_in_pformat() {
+        assert_eq!(
+            resolve_dispatcher_kind("native", false, "chat"),
+            DispatcherKind::Native
+        );
+        assert_eq!(
+            resolve_dispatcher_kind("xml", true, "chat"),
+            DispatcherKind::Xml
+        );
+        // P-Format is only ever selected when explicitly requested.
+        assert_eq!(
+            resolve_dispatcher_kind("pformat", true, "chat"),
+            DispatcherKind::PFormat
+        );
+    }
+
+    #[test]
+    fn integrations_agent_falls_off_native_to_json_in_tag() {
+        // Native would ship JSON tool specs and blow the provider grammar-rule
+        // ceiling on large Composio toolkits → force JSON-in-tag.
+        assert_eq!(
+            resolve_dispatcher_kind("auto", true, "integrations_agent"),
+            DispatcherKind::Xml
+        );
+        assert_eq!(
+            resolve_dispatcher_kind("native", true, "integrations_agent"),
+            DispatcherKind::Xml
+        );
+        // An explicit non-native choice is left untouched for that agent.
+        assert_eq!(
+            resolve_dispatcher_kind("pformat", true, "integrations_agent"),
+            DispatcherKind::PFormat
+        );
     }
 }

--- a/src/openhuman/config/schema/agent.rs
+++ b/src/openhuman/config/schema/agent.rs
@@ -174,6 +174,13 @@ pub struct AgentConfig {
     /// Maximum number of tool calls to execute concurrently when `parallel_tools` is true.
     #[serde(default = "default_max_parallel_tools")]
     pub max_parallel_tools: usize,
+    /// How the agent formats tool calls to text-only providers.
+    /// - `"auto"` (default): native structured tool-calling when the provider
+    ///   supports it, otherwise JSON-in-tag (`<tool_call>{…}</tool_call>`).
+    /// - `"native"`: force provider-native structured tool calls.
+    /// - `"xml"`: force JSON-in-tag.
+    /// - `"pformat"`: force compact positional P-Format (`tool[a|b]`) — most
+    ///   token-efficient, but mis-parses on some models, so it is opt-in only.
     #[serde(default = "default_agent_tool_dispatcher")]
     pub tool_dispatcher: String,
     /// **Legacy** — maximum characters of memory context to inject per


### PR DESCRIPTION
## Summary

- `agent.tool_dispatcher = "auto"` (the default) now resolves to **native** structured tool calls when the provider supports them, else **JSON-in-tag** (`<tool_call>{...}</tool_call>`) — it **never** auto-selects P-Format anymore.
- The `integrations_agent` override (which sidesteps the provider grammar-rule ceiling on large Composio toolkits) now falls back to JSON-in-tag instead of P-Format, so the code finally matches its long-standing comment.
- P-Format remains available via an explicit `tool_dispatcher = "pformat"` opt-in.
- Extracted the selection into a pure `resolve_dispatcher_kind` helper with unit tests, and documented the new config field.

## Problem

P-Format's compact positional tool calls (`tool[a|b]`) mis-parse on some models, silently breaking tool invocation. Because `auto` could resolve to P-Format, agents on affected providers lost the ability to call tools with no clear signal why.

## Solution

Made dispatcher selection explicit and safe by default:

- Split the selection logic out of the builder into `resolve_dispatcher_kind(choice, supports_native, agent_id)` — a pure function that is easy to reason about and test.
- `auto` → native when supported, otherwise JSON-in-tag; unknown/`bogus` values also fall back to JSON-in-tag rather than P-Format.
- `integrations_agent` stays off native (grammar-rule ceiling) but now lands on JSON-in-tag.
- P-Format is only reachable through the explicit `"pformat"` value.

Local `~/.openhuman/config.toml` was already flipped to `"xml"` as an immediate mitigation; this PR makes the safe behavior the shipped default.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines covered by the new `provider_role_tests` unit tests (`auto` native/xml, explicit opt-in pformat, integrations fallback, unknown-value fallback).
- [x] N/A: Coverage matrix update — behaviour-only change to an internal dispatcher-selection default; no feature row added/removed/renamed.
- [x] N/A: Related feature IDs — no matrix feature IDs are affected by this internal default change.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: Manual smoke checklist — no release-cut surface touched; change is a config-default in the agent harness.
- [x] N/A: No linked issue — discovered and fixed directly from observed tool-call breakage.

## Impact

- Runtime/platform: affects the agent harness on all platforms (desktop/CLI) that build agent sessions. No UI, migration, or persistence changes.
- Behavior change: agents that previously auto-selected P-Format now use native or JSON-in-tag tool calls, restoring reliable tool invocation. P-Format users must now opt in explicitly via `tool_dispatcher = "pformat"`.
- No performance, security, or compatibility concerns beyond the intended default flip.

## Related

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/tool-dispatcher-default-json
- Commit SHA: 35495e2d026613e802340f8e640073156f5ce8ef

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend files changed
- [x] N/A: `pnpm typecheck` — no TS changed
- [x] Focused tests: `cargo test -- auto_prefers_native explicit_choices_are_honoured integrations_agent_falls_off` (3 passed)
- [x] Rust fmt/check (if changed): pre-push `pnpm rust:check` passed
- [x] N/A: Tauri fmt/check — no `app/src-tauri` files changed

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: `tool_dispatcher = "auto"` never resolves to P-Format; falls back to native or JSON-in-tag.
- User-visible effect: agents on affected models regain reliable tool calling; P-Format now requires explicit opt-in.

### Parity Contract

- Legacy behavior preserved: explicit `"pformat"` still selects P-Format; native selection when supported is unchanged.
- Guard/fallback/dispatch parity checks: `integrations_agent` still bypasses native (grammar-rule ceiling), now landing on JSON-in-tag per its documented intent.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A