### PR TITLE
fix(flows): keep seeded build turn propose-only (#4596)

### DIFF
--- a/app/src/components/flows/WorkflowCopilotPanel.test.tsx
+++ b/app/src/components/flows/WorkflowCopilotPanel.test.tsx
@@ -229,13 +229,11 @@ describe('WorkflowCopilotPanel', () => {
     );
     expect(hookState.send).toHaveBeenCalledTimes(1);
     const arg = hookState.send.mock.calls[0][0];
-    // The user's description reads as their own first turn in the transcript,
-    // while the real prompt injects the blank graph + flow id and asks for the
-    // full build → dry-run → save arc onto the already-created flow.
+    // The user's description reads as their own first turn in the transcript;
+    // the structured build request carries the blank graph + flow id so the
+    // server's brief asks for a build → dry-run → propose arc (propose-only —
+    // see #4596; persistence still waits on Accept + Save).
     expect(arg.displayText).toBe('digest my Slack every morning');
-    // The user's description reads as their own first turn; the structured
-    // build request carries the blank graph + flow id so the server's brief
-    // asks for the full build → dry-run → save arc onto the created flow.
     expect(arg.request.mode).toBe('build');
     expect(arg.request.instruction).toBe('digest my Slack every morning');
     expect(arg.request.graph).toEqual(baseGraph);

--- a/app/src/components/flows/WorkflowCopilotPanel.tsx
+++ b/app/src/components/flows/WorkflowCopilotPanel.tsx
@@ -153,10 +153,11 @@ export default function WorkflowCopilotPanel({
 
   // Auto-send the build turn once when opened from the prompt bar's
   // instant-create path: the user's description becomes the first user turn on
-  // this thread, and the prompt asks for the full build → dry-run → save arc
-  // against the just-created flow (its proposal still lands as the usual
-  // Accept/Reject diff preview). Falls back to a propose-only revise turn if
-  // the flow id is somehow missing (a draft canvas has nothing to save onto).
+  // this thread, and the prompt asks for the full build → dry-run → PROPOSE
+  // arc against the just-created flow. Persistence still stays behind the
+  // usual Accept + canvas Save; `mode: 'build'` intentionally does NOT save
+  // the graph (issue #4596 — a Reject used to leave the graph persisted).
+  // Falls back to a plain revise turn if the flow id is somehow missing.
   const buildSentRef = useRef(false);
   useEffect(() => {
     if (!buildSeed || buildSentRef.current) return;

--- a/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
+++ b/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
@@ -1019,14 +1019,13 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
       await waitFor(() =>
         expect(threadApi.appendMessage).toHaveBeenCalledWith(
           't-interim',
-          expect.objectContaining({
-            content: 'Let me check your calendar first.',
-            sender: 'agent',
-          })
+          expect.objectContaining({ content: 'Let me check your calendar first.', sender: 'agent' })
         )
       );
       // …and cleared from the live preview so it isn't shown twice.
-      expect(store.getState().chatRuntime.streamingAssistantByThread['t-interim']?.content).toBe('');
+      expect(store.getState().chatRuntime.streamingAssistantByThread['t-interim']?.content).toBe(
+        ''
+      );
     });
 
     it('dedupes a re-delivered interim event by round', async () => {

--- a/src/openhuman/flows/agents/workflow_builder/agent.toml
+++ b/src/openhuman/flows/agents/workflow_builder/agent.toml
@@ -1,7 +1,7 @@
 id = "workflow_builder"
 display_name = "Workflow Builder"
 delegate_name = "build_workflow"
-when_to_use = "Workflow authoring specialist — owns building tinyflows automation graphs from a natural-language description. Route any request to 'set up a workflow that…', 'automate…', 'when X happens do Y', 'build/create/edit an automation or flow', or to iterate on a proposed workflow here. It grounds nodes in real tool slugs + connections, dry-runs a draft in a sandbox to self-check, and returns a workflow PROPOSAL for review. When the host hands it an existing flow id it may also SAVE the built graph onto that flow (save_workflow) and, with the user's explicit confirmation, test-run it — but it can never create a new flow or enable/disable one. Not for running an already-saved flow (that is a direct flows_run) and not for the legacy skill 'workflows'."
+when_to_use = "Workflow authoring specialist — owns building tinyflows automation graphs from a natural-language description. Route any request to 'set up a workflow that…', 'automate…', 'when X happens do Y', 'build/create/edit an automation or flow', or to iterate on a proposed workflow here. It grounds nodes in real tool slugs + connections, dry-runs a draft in a sandbox to self-check, and returns a workflow PROPOSAL for review. Persistence stays with the user's Accept + Save; when the user explicitly asks the agent to save (or test-run) onto an existing flow id it may `save_workflow` / `run_flow` — but never on its own, and it can never create a new flow or enable/disable one. Not for running an already-saved flow (that is a direct flows_run) and not for the legacy skill 'workflows'."
 temperature = 0.2
 max_iterations = 12
 iteration_policy = "extended"

--- a/src/openhuman/flows/agents/workflow_builder/builder_prompt.rs
+++ b/src/openhuman/flows/agents/workflow_builder/builder_prompt.rs
@@ -7,12 +7,13 @@
 //! directly (like the Flow Scout), instead of the frontend crafting delegate
 //! strings and relying on the chat orchestrator to route them.
 //!
-//! Persistence contract, unchanged: `create`/`revise`/`repair` ask for a
-//! PROPOSAL only — saving stays behind the user's explicit action.
-//! [`BuildMode::Build`] is the instant-create path (the host has already made
-//! the blank flow), so its brief tells the agent to finish the job: build,
-//! dry-run, and `save_workflow` onto that flow id. Enabling/disabling a flow is
-//! never in scope here.
+//! Persistence contract: every mode is PROPOSE-ONLY — saving always stays
+//! behind the user's explicit action (the review card's Accept, then the
+//! canvas's own Save). [`BuildMode::Build`] is the instant-create path (the
+//! host already made the blank flow), so its brief injects that flow id as
+//! future-turn context but explicitly forbids `save_workflow` on this turn:
+//! rejecting the proposal must leave the flow's persisted graph untouched
+//! (see issue #4596). Enabling/disabling a flow is never in scope here.
 
 use serde::Deserialize;
 use serde_json::Value;
@@ -29,7 +30,8 @@ pub enum BuildMode {
     /// Diagnose a failed run and propose a corrected graph.
     Repair,
     /// Instant-create: the flow already exists (blank), so build → dry-run →
-    /// `save_workflow` onto `flow_id`, end to end.
+    /// propose against `flow_id`. Persistence still waits on the user's
+    /// explicit Accept + Save; the agent must NOT `save_workflow` here.
     Build,
 }
 
@@ -66,11 +68,12 @@ pub struct BuilderRequest {
 impl BuilderRequest {
     /// Validates a builder-turn request before prompt rendering.
     ///
-    /// [`BuildMode::Build`] acts on an existing saved flow — its brief tells the
-    /// agent to `save_workflow` onto `flow_id`. A missing or blank `flow_id`
-    /// would otherwise render `The flow's id is ``.` into the brief and let the
-    /// agent save onto nothing, so reject it here (the RPC path deserializes
-    /// `BuilderRequest` directly, where only `mode` is required).
+    /// [`BuildMode::Build`] injects a `flow_id` as context for future turns
+    /// (the user may later ask the agent to save/test that flow). A missing or
+    /// blank `flow_id` would render `The flow's id is ``.` into the brief and
+    /// contradict the "instant-create flow already exists" framing, so reject
+    /// it here (the RPC path deserializes `BuilderRequest` directly, where
+    /// only `mode` is required).
     pub fn validate(&self) -> Result<(), String> {
         if self.mode == BuildMode::Build
             && self
@@ -96,10 +99,11 @@ const DIRECTIVE_REVISE: &str = "Revise this tinyflows automation and return the 
      disable anything. You may run_flow the SAVED flow to test it, but ONLY if I ask and only after you \
      confirm with me first.";
 
-const DIRECTIVE_BUILD_AND_SAVE: &str = "Build this tinyflows automation END-TO-END. The flow already exists \
-     (created blank just now) — design the graph, verify it with dry_run_workflow, return the workflow \
-     proposal, then SAVE it onto the flow id below with save_workflow. Do not enable or disable anything, and \
-     do not run_flow a real test unless I explicitly confirm first. Tell me what you saved when you are done.";
+const DIRECTIVE_BUILD_PROPOSE_ONLY: &str = "Build this tinyflows automation END-TO-END and return the workflow \
+     proposal. The flow already exists (created blank just now) — design the graph and verify it with \
+     dry_run_workflow, then return the proposal for me to review. Do NOT save_workflow in this turn: I will \
+     Accept the proposal explicitly and the canvas's Save persists it. Do not enable, disable, or run_flow \
+     anything unless I explicitly confirm first.";
 
 /// Serialize a graph compactly for injection as agent context.
 fn serialize_graph(graph: &Value) -> String {
@@ -142,9 +146,12 @@ pub fn render_prompt(req: &BuilderRequest) -> String {
         BuildMode::Build => {
             let flow_id = req.flow_id.as_deref().unwrap_or("");
             [
-                DIRECTIVE_BUILD_AND_SAVE,
+                DIRECTIVE_BUILD_PROPOSE_ONLY,
                 "",
-                &format!("The flow's id is `{flow_id}`. Its current (blank) graph is:"),
+                &format!(
+                    "The flow's id is `{flow_id}` (kept for future turns — do not save_workflow it here). \
+                     Its current (blank) graph is:"
+                ),
                 "```json",
                 &req.graph
                     .as_ref()
@@ -241,12 +248,37 @@ mod tests {
     }
 
     #[test]
-    fn build_asks_to_save_onto_flow_id() {
+    fn build_is_propose_only_and_injects_flow_id_as_context() {
+        // Regression for #4596: the instant-create build turn must NOT
+        // instruct the agent to `save_workflow`. Rejecting the proposal has
+        // to leave the created-blank flow's persisted graph untouched, so
+        // persistence stays behind the user's explicit Accept + Save. The
+        // flow id is still injected as context for future turns.
         let mut r = req(BuildMode::Build);
         r.flow_id = Some("flow_9".into());
         r.graph = Some(json!({ "nodes": [], "edges": [] }));
         let p = render_prompt(&r);
-        assert!(p.contains("save_workflow"));
+        // Positive: the new directive explicitly forbids save_workflow on
+        // this turn.
+        assert!(
+            p.contains("Do NOT save_workflow"),
+            "build directive must forbid save_workflow explicitly (#4596)"
+        );
+        // Negative: none of the old imperative-save phrasings survive
+        // (any of them would put us back in the auto-save bug).
+        for banned in [
+            "then SAVE",
+            "with save_workflow",
+            "SAVE it onto",
+            "save_workflow onto",
+        ] {
+            assert!(
+                !p.contains(banned),
+                "build directive must not carry auto-save phrasing `{banned}` (#4596)"
+            );
+        }
+        // Context is still injected so the user can later ask the agent to
+        // save/test that specific flow.
         assert!(p.contains("flow_9"));
         assert!(p.contains("END-TO-END"));
     }

--- a/src/openhuman/flows/agents/workflow_builder/prompt.md
+++ b/src/openhuman/flows/agents/workflow_builder/prompt.md
@@ -24,24 +24,31 @@ click in the review card persists a flow (via `flows_create`, which
 re-validates server-side). If a user says "just turn it on for me", explain
 that enabling stays in their hands.
 
-## Saving your work: `save_workflow` (finish the job — don't hand it back)
+## Saving your work: `save_workflow` (only on the user's explicit ask)
 
-When the request gives you a **flow id to build into** (the Flows page's prompt
-bar creates the flow first and delegates with its id; the canvas copilot passes
-the saved flow's id), the user expects you to **finish**: build, verify, and
-**save** — not to tell them to go save it themselves. The arc:
+Every authoring turn — including a **build** turn seeded from the Flows
+prompt bar (which creates the flow first and delegates with its id) and every
+**revise** turn on the canvas copilot — is **propose-only** by default. Your
+arc is:
 
 1. Ground + build the graph (below), `dry_run_workflow` until it's clean.
 2. `revise_workflow` / `propose_workflow` so the user gets the reviewable
-   proposal card.
-3. **`save_workflow { flow_id, graph, name? }`** to persist it onto that flow,
-   then tell the user plainly what you saved (trigger, steps, and — if the flow
-   is enabled with a schedule/app_event trigger — that it is now live and will
-   fire on its own).
+   proposal card. **Stop there** and hand back — the user's Accept + the
+   canvas's Save persist the graph, not you.
 
-Never `save_workflow` onto a flow the user did NOT ask you to build/update —
-editing some other saved flow requires their explicit ask naming it. It cannot
-create flows, and it never changes `enabled` or the approval gate.
+**Do NOT auto-`save_workflow` when the request carries a `flow_id`.** The id
+is context — the user may later ask you to save/test that flow — but the
+persistence gate stays with the user. Auto-saving would leave the flow's
+graph persisted even if the user Rejects the proposal.
+
+Use **`save_workflow { flow_id, graph, name? }`** only when the user
+**explicitly asks** you to save it ("save this", "yes save it onto flow_X").
+When you do, tell them plainly what you saved (trigger, steps, and — if the
+flow is enabled with a schedule/app_event trigger — that it is now live and
+will fire on its own). Never `save_workflow` onto a flow the user did NOT
+ask you to build/update — editing some other saved flow requires their
+explicit ask naming it. It cannot create flows, and it never changes
+`enabled` or the approval gate.
 
 ## Testing a saved flow: `run_flow` (ask first!)
 

--- a/src/openhuman/flows/schemas.rs
+++ b/src/openhuman/flows/schemas.rs
@@ -748,12 +748,13 @@ pub fn schemas(function: &str) -> ControllerSchema {
             description: "Run the workflow_builder agent for one authoring turn. `mode` selects \
                           create (first draft from `instruction`), revise (refine the injected \
                           `graph`), repair (diagnose a failed `run_id` and fix), or build \
-                          (instant-create: build + dry-run + save_workflow onto `flow_id`). The \
-                          server renders the agent's brief — the frontend no longer crafts prompts. \
-                          Returns `{ proposal, assistant_text, error }`, where `proposal` is the \
-                          `{ type: 'workflow_proposal', name, graph, require_approval, summary, \
-                          warnings }` the agent produced (or null). Only `build` may persist (via \
-                          save_workflow onto an existing flow); it never enables or runs a flow.",
+                          (instant-create: build + dry-run + propose against `flow_id`; \
+                          propose-only, see #4596). The server renders the agent's brief — the \
+                          frontend no longer crafts prompts. Returns `{ proposal, assistant_text, \
+                          error }`, where `proposal` is the `{ type: 'workflow_proposal', name, \
+                          graph, require_approval, summary, warnings }` the agent produced (or \
+                          null). No mode auto-persists a graph; save/enable/run stay behind the \
+                          user's explicit action.",
             inputs: vec![
                 FieldSchema {
                     name: "mode",

--- a/src/openhuman/tools/ops.rs
+++ b/src/openhuman/tools/ops.rs
@@ -295,10 +295,10 @@ pub fn all_tools_with_runtime(
         // workflow-builder prompt requires it to ask the user for confirmation
         // first, and the flow's own approval gate still pauses outbound nodes.
         Box::new(RunFlowTool::new(config.clone())),
-        // Persist a built graph onto an EXISTING saved flow (Write). The one
-        // deliberate carve-out from the belt's propose-only origin: the Flows
-        // prompt bar creates the flow first and hands the agent its id, so the
-        // copilot can finish the "build → dry-run → save" arc itself. It can
+        // Persist a built graph onto an EXISTING saved flow (Write). Used only
+        // when the USER explicitly asks the agent to save; the seeded build
+        // turn from the Flows prompt bar is propose-only (see #4596) — Accept
+        // + the canvas's own Save persist the graph. The tool itself can
         // never create a flow or change enabled/require_approval.
         Box::new(SaveWorkflowTool::new(config.clone())),
         // Flow Scout discovery: the `flow_discovery` agent's terminal emit


### PR DESCRIPTION
## Summary

- Restores the "copilot only PROPOSES" invariant for the Flows prompt-bar seeded build turn, so rejecting the proposal no longer leaves a persisted graph behind.
- Rewrites the `workflow_builder` build directive to explicitly forbid `save_workflow` on the seeded turn; realigns the system prompt, agent descriptor, RPC schema description, and `save_workflow` tool comment so every doc surface says the same thing.
- No frontend behavior change — `mode: 'build'` still fires; the server just no longer asks the agent to persist.
- Adds a regression test (`build_is_propose_only_and_injects_flow_id_as_context`) that guards against every historical auto-save phrasing coming back.

## Problem

Flagged as P1 by `chatgpt-codex-connector` on PR #4578 and filed as #4596.

The Flows prompt bar's instant-create path did **two** real writes:

1. `WorkflowPromptBar.tsx` calls `createFlow(...)` (persists a blank flow), then navigates to `/flows/:id` with `state.copilotBuild`.
2. `WorkflowCopilotPanel.tsx:161-169` sees `buildSeed` and sends `mode: 'build'`. `builder_prompt.rs`'s old `DIRECTIVE_BUILD_AND_SAVE` explicitly told the agent to `save_workflow` onto that flow id after dry-run. `save_workflow` → `flows_update` → **the graph is persisted before Accept/Reject ever renders.**

Reject (`WorkflowCopilotPanel.tsx:214-218`) only did `onReject()` + `clearProposal()` — pure local overlay state; no RPC. So a user who rejected or closed the panel was left with a persisted flow they never approved. If the graph carried a schedule / app_event trigger and the user later enabled the flow, that trigger would arm.

The invariant on `WorkflowCopilotPanel.tsx:19-20` — *"the copilot only PROPOSES. Accept applies to the UNSAVED local draft (no `flows_update`); persistence stays behind the canvas's own Save"* — had already been silently violated by the `build` mode addition.

## Solution

Bring `build` mode back inside the propose-only invariant. Persistence stays a user-explicit action (Accept in the review card, then the canvas's own Save). Two options were considered:

- **A. Make `build` propose-only (chosen)** — small footprint, restores the stated invariant, matches every other authoring turn.
- **B. Add a revert path on Reject/close** — would need snapshot-of-blank tracking, disarm-triggers RPC, cover close-tab / route-away / lost-socket edge cases. Materially more code + more failure modes for a UX win the invariant explicitly rejected.

Chose A.

### Changes

- `src/openhuman/flows/agents/workflow_builder/builder_prompt.rs`
  - Rename `DIRECTIVE_BUILD_AND_SAVE` → `DIRECTIVE_BUILD_PROPOSE_ONLY`. New directive explicitly says *"Do NOT save_workflow in this turn: I will Accept the proposal explicitly and the canvas's Save persists it."*
  - `BuildMode::Build` branch of `render_prompt` still injects `flow_id` as future-turn context (user may later ask "save it" / "run it"), but the injection line now labels it: *"kept for future turns — do not save_workflow it here"*.
  - Updated module-level doc + `BuildMode::Build` variant doc to reference #4596 and the propose-only contract.
  - Test `build_asks_to_save_onto_flow_id` → **`build_is_propose_only_and_injects_flow_id_as_context`**. Asserts (a) `Do NOT save_workflow` appears; (b) none of the four historical auto-save phrasings (`then SAVE`, `with save_workflow`, `SAVE it onto`, `save_workflow onto`) survive; (c) `flow_9` + `END-TO-END` still land.
- `src/openhuman/flows/agents/workflow_builder/prompt.md`
  - Rewrote the "Saving your work" section. Old header (*"finish the job — don't hand it back"*) is replaced with *"only on the user's explicit ask"*. New body: every authoring turn is propose-only; `save_workflow` runs only when the user explicitly asks ("save this"); explains **why** auto-saving on a flow_id would leave the graph persisted even on Reject.
- `src/openhuman/flows/agents/workflow_builder/agent.toml`
  - `when_to_use` no longer tells the router the agent *"may also SAVE the built graph"* on flow-id delegation. Persistence stays with the user's Accept + Save; `save_workflow` / `run_flow` are on explicit user ask only.
- `src/openhuman/flows/schemas.rs`
  - `flows.build` RPC controller description: *"build (instant-create: build + dry-run + propose against `flow_id`; propose-only, see #4596)"* instead of *"…save_workflow onto flow_id"*. Adds *"No mode auto-persists a graph."*
- `src/openhuman/tools/ops.rs`
  - Comment on `SaveWorkflowTool` registration was defending an auto-save carve-out for the prompt bar. Rewrote to reflect explicit-ask usage.
- `app/src/components/flows/WorkflowCopilotPanel.tsx`
  - Comment on the auto-`send` for `buildSeed` (~line 154) now describes a *"build → dry-run → PROPOSE"* arc and points at #4596. `mode: 'build'` still fires (naming preserved) so the server can still distinguish "seeded from prompt bar" from a plain revise and inject the flow_id as context. No API break.
- `app/src/components/flows/WorkflowCopilotPanel.test.tsx`
  - Comment-only update. Existing `arg.request.mode === 'build'` assertion still holds.

### What was deliberately not changed

- `save_workflow` remains in the agent's `named` tools list — revise mode legitimately uses it on user ask.
- No new revert RPC, no snapshot-of-blank tracking, no trigger-disarm logic — Option B was rejected.
- No frontend behavior change.

## Submission Checklist

- [x] Tests added or updated — Rust regression test `build_is_propose_only_and_injects_flow_id_as_context` covers both the happy path (directive still injects flow_id and END-TO-END framing) and the failure path (four historical auto-save phrasings are asserted absent).
- [x] **Diff coverage ≥ 80%** — the only executable-code change is the directive/text rendering in `BuildMode::Build`, fully covered by the new + existing `builder_prompt` tests. `cargo test --lib openhuman::flows::agents::workflow_builder` — 9 passed. Frontend edits are comment-only.
- [x] Coverage matrix updated — `N/A: behavior-only change restoring a documented invariant; no new feature row.`
- [x] All affected feature IDs listed under `## Related` — `N/A: behavior-only change, no matrix rows added/removed/renamed.`
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — `N/A: bug fix restoring propose-only; the Flows seeded-build path smoke step is unchanged from the reviewer's perspective (Accept still applies, Save still persists).`
- [x] Linked issue closed via `Closes #4596` in `## Related`.

## Impact

- **Runtime/platform:** desktop only (Flows canvas + prompt bar). Backend directive change affects the workflow_builder agent's turn behavior. No mobile/CLI impact.
- **Performance:** none.
- **Security:** removes an auto-persistence path the user did not explicitly consent to — small positive.
- **Migration/compat:** none. No schema, RPC surface, or wire-format change. `mode: 'build'` still accepted; only its rendered directive changes.
- **UX:** users who prompt-bar-seed a flow now see a proposal only; they must click Accept + Save to persist, exactly like every other copilot turn.

## Related

- Closes #4596
- Found in #4578 (chatgpt-codex-connector P1)
- Follow-up PR(s)/TODOs: This PR carries one incidental **chore(format)** commit — a Prettier autofix on `app/src/providers/__tests__/ChatRuntimeProvider.test.tsx` (2 mechanical wraps, no code change) that landed unformatted via #4604 and was blocking `pr-quality.yml`'s `format:check` job on this PR. Called out separately in the commit history so it's easy to review. The blank flow created by the prompt bar remains listed if the user Rejects; that's a first-class saved-but-empty flow they can delete or build up manually, which matches "Start from scratch" today.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A (tracked as GitHub issue #4596)
- URL: N/A

### Commit & Branch

- Branch: `fix/4596-seeded-build-propose-only`
- Commit SHA: `44f459007` (rebased onto latest `origin/main` and includes one incidental Prettier autofix — see Follow-up TODOs below).

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — Prettier clean on touched frontend files (`WorkflowCopilotPanel.tsx`, `WorkflowCopilotPanel.test.tsx`).
- [x] `pnpm typecheck` — `N/A: no TS surface changed (only comments); frontend tests compile + pass via vitest run.`
- [x] Focused tests:
  - Rust: `cargo test --lib openhuman::flows::agents::workflow_builder` → 9 passed.
  - Rust: `cargo test --lib openhuman::flows::schemas` → 19 passed (no cascade from schema description edit).
  - Vitest: all 129 tests in `app/src/components/flows/*` pass (`WorkflowCopilotPanel.test.tsx`, `WorkflowPromptBar.test.tsx`, and 14 more).
- [x] Rust fmt/check — `cargo fmt --check` clean; `cargo check` clean (no new warnings introduced).
- [x] Tauri fmt/check — `N/A: no Tauri host code changed.`

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- **Intended behavior change:** the workflow_builder agent no longer auto-`save_workflow`s onto the prompt-bar-seeded flow. `mode: 'build'` becomes propose-only, matching `create`/`revise`/`repair`.
- **User-visible effect:** rejecting or closing a seeded build proposal now leaves the flow's persisted graph untouched (blank, as created). Accepting still applies the diff to the local draft; the canvas's Save still persists. One extra click (Save) after Accept for users who want to keep the built graph — matching the rest of the canvas.

### Parity Contract

- **Legacy behavior preserved:** `mode: 'build'` still accepted at the RPC surface with the same request shape (`{ mode, instruction, graph, flow_id }`) and `validate()` still rejects a missing/blank `flow_id`. `save_workflow` tool is still registered and still callable when the user explicitly asks the agent to save.
- **Guard/fallback/dispatch parity checks:** the frontend `mode: 'revise'` fallback in `WorkflowCopilotPanel.tsx:168` (used when `flowId` is somehow missing) is unchanged.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none found.
- Canonical PR: this one.
- Resolution: N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow building guidance now keeps new builds proposal-only until you explicitly **Accept** and then **Save**.
  * Build and instant-create now follow a **build → dry-run → propose** arc; persistence requires explicit user action.

* **Bug Fixes**
  * Prevented workflows from being auto-saved during the initial build flow, reducing unintended persistence.
  * Improved clarity of fallback behavior when no flow ID is available.

* **Tests**
  * Updated and extended tests to verify the “do not auto-save” contract and related runtime expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->