### PR TITLE
chore(flows): bump vendored tinyflows → 0.5.1 (dotted-path split_out)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6889,7 +6889,7 @@ dependencies = [
 
 [[package]]
 name = "tinyflows"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -8268,7 +8268,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -9238,7 +9238,7 @@ dependencies = [
 
 [[package]]
 name = "tinyflows"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "futures-timer",


### PR DESCRIPTION
Bumps the vendored `tinyflows` submodule to **0.5.1** (tinyhumansai/tinyflows#4): `split_out` now resolves **dotted paths**, so a fan-out can reach an array **nested inside a tool_call's `{json,text,raw}` envelope** — `path="json.data.messages"` walks envelope → tool result → the array (e.g. `GMAIL_FETCH_EMAILS`'s list at `data.messages`).

**Pairs with #4605** (live tool-contract grounding): #4605 teaches the builder to *write* the correct `json.<primary_array_path>` via the tool's real output schema; this bump makes the engine *traverse* it. Together, `fetch → split_out → per-item agent` finally passes real data (fixes the null-cascade in the classify-emails flow).

Backward compatible: single-segment paths (`path="items"`) unchanged. `cargo check` clean with 0.5.1.

⚠️ Depends on tinyhumansai/tinyflows#4 merging first (submodule pin).