### PR TITLE
test(memory): inventory guard for the protocol-mandated update_memory_md tool

### DIFF
--- a/src/openhuman/agent/harness/memory_protocol.rs
+++ b/src/openhuman/agent/harness/memory_protocol.rs
@@ -33,6 +33,17 @@
 /// recognise memory-protocol guidance in a tool result.
 pub const MEMORY_PROTOCOL_MARKER: &str = "[memory-protocol]";
 
+/// The tool that closes the write cycle: the protocol appends a "call
+/// `update_memory_md`" reminder after every durable write and only a successful
+/// call to it produces a [`MemoryOp::IndexUpdate`]. It is therefore a
+/// protocol-*mandated* tool — it MUST exist in the production registry or the
+/// model hits a permanent, unsatisfiable nag loop (unknown-tool error → the
+/// tracker never sees the index update). Naming it here gives the registry
+/// inventory test in `tools::ops_tests` a single source of truth to assert
+/// against, so a mandated tool missing from `all_tools` fails a test rather than
+/// production (#4458).
+pub const MEMORY_INDEX_UPDATE_TOOL: &str = "update_memory_md";
+
 /// Classification of a tool call for the memory protocol. Everything the model
 /// can call is one of these; non-memory tools are [`MemoryOp::Other`] and never
 /// affect protocol state.
@@ -70,7 +81,7 @@ pub fn classify_memory_op(tool_name: &str, arguments: &serde_json::Value) -> Mem
         // The index-sync step — but only for the MEMORY.md index. The same tool
         // can edit SKILL.md, which does not reconcile the memory index and so is
         // a no-op for this protocol.
-        "update_memory_md" => match arg_str("file") {
+        MEMORY_INDEX_UPDATE_TOOL => match arg_str("file") {
             Some("MEMORY.md") => MemoryOp::IndexUpdate,
             _ => MemoryOp::Other,
         },

--- a/src/openhuman/tools/ops_tests.rs
+++ b/src/openhuman/tools/ops_tests.rs
@@ -516,6 +516,50 @@ fn all_tools_default_registry_has_no_duplicate_tool_names() {
 }
 
 #[test]
+fn all_tools_registers_protocol_mandated_index_update_tool() {
+    // #4458 regression guard. The memory read→dedupe→write→update-index protocol
+    // (`agent::harness::memory_protocol`) appends a "call `update_memory_md`"
+    // reminder after every durable write and can only close its write cycle via a
+    // successful call to that tool. If the protocol-mandated tool is absent from
+    // the production registry, the model hits an unknown-tool error and a
+    // permanent, unsatisfiable nag loop. Deriving the name from
+    // `MEMORY_INDEX_UPDATE_TOOL` (the same constant `classify_memory_op` matches
+    // on) ties this inventory assertion to what the protocol actually mandates:
+    // if the protocol ever mandates a different or additional tool, this test —
+    // not production — is what fails.
+    use crate::openhuman::agent::harness::memory_protocol::MEMORY_INDEX_UPDATE_TOOL;
+
+    let tmp = TempDir::new().unwrap();
+    let security = Arc::new(SecurityPolicy::default());
+    let mem = test_memory(&tmp);
+    let browser = BrowserConfig {
+        enabled: false,
+        ..BrowserConfig::default()
+    };
+    let http = crate::openhuman::config::HttpRequestConfig::default();
+    let cfg = test_config(&tmp);
+
+    let tools = all_tools(
+        Arc::new(Config::default()),
+        &security,
+        AuditLogger::disabled(),
+        mem,
+        &browser,
+        &http,
+        tmp.path(),
+        &HashMap::new(),
+        &cfg,
+    );
+    let names = tool_names(&tools);
+    assert!(
+        names.iter().any(|n| n.as_str() == MEMORY_INDEX_UPDATE_TOOL),
+        "memory protocol mandates `{MEMORY_INDEX_UPDATE_TOOL}` after every durable \
+         write, but it is not registered in all_tools; the model would hit an \
+         unsatisfiable nag loop. Registered tools: {names:?}"
+    );
+}
+
+#[test]
 fn all_tools_excludes_browser_when_disabled() {
     let tmp = TempDir::new().unwrap();
     let security = Arc::new(SecurityPolicy::default());


### PR DESCRIPTION
Closes #4458

On current `main`, the substantive parts of #4458 are already in place: `UpdateMemoryMdTool` is registered in `all_tools_with_runtime`, its write is atomic (temp-file + rename) and serialized behind a per-workspace async lock + inter-process flock, and `remember_preference`/`save_preference` are an explicit `MemoryOp::Other` arm. The one remaining gap from the fix plan was the registry inventory assertion.

This adds a `MEMORY_INDEX_UPDATE_TOOL` constant in `memory_protocol.rs` (the single name `classify_memory_op` matches on) and a test that builds the real `all_tools` registry and asserts the protocol-mandated tool is registered. If the protocol ever mandates a tool that isn't in the registry, this test fails instead of the model hitting a permanent unsatisfiable "call update_memory_md" nag loop in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory update handling to avoid “unknown tool” failures during the memory sync flow.
  * Ensured the required memory index update action is consistently recognized when editing the memory file.
* **Tests**
  * Added a regression test to confirm the full tool set includes the required memory update action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->