### PR TITLE
fix(flows): force HITL on nested agent-node harness runs (#4595)

### DIFF
--- a/src/openhuman/tinyflows/caps.rs
+++ b/src/openhuman/tinyflows/caps.rs
@@ -198,6 +198,51 @@ fn escalated_origin_for_prompt(
     }
 }
 
+/// Pure decision core of the nested agent-node harness escalation (issue
+/// #4595): when the flow run's origin is a `Workflow { require_approval: false }`
+/// trust root, returns a clone with `require_approval` flipped to `true` so the
+/// [`ApprovalGate`](crate::openhuman::approval::ApprovalGate)'s pre-declared-
+/// action shortcut (`gate.rs::intercept_audited`, `Workflow { require_approval:
+/// false }` → `Allow` without prompt) does NOT apply to tool calls the nested
+/// harness picks at runtime.
+///
+/// **Why this is different from [`escalated_origin_for_prompt`].** That helper
+/// escalates a *single* flow-node acting tool dispatch when the tier decision
+/// is `Prompt`. This helper escalates the *entire nested harness turn*
+/// unconditionally, because the flow author never pre-declared which tools the
+/// referenced agent's LLM will pick — the graph only names the `agent_ref`, and
+/// the definition's `ToolScope` is the runtime pool. So the "trust root =
+/// static action" invariant that justifies the `intercept_audited` shortcut
+/// simply doesn't hold across the `Agent::run_single` boundary.
+///
+/// `Workflow { require_approval: true }` passes through unchanged (already
+/// user-forced HITL); other origins pass through unchanged (Cron / Web chat
+/// / etc. don't route through this call site today, but if they ever do the
+/// shortcut is safe or already covered by that origin's own gate branch).
+/// Split out as a free function over plain values so the escalation policy is
+/// unit-testable without a live `ApprovalGate`.
+fn escalated_origin_for_nested_harness(
+    origin: Option<crate::openhuman::agent::turn_origin::AgentTurnOrigin>,
+) -> Option<crate::openhuman::agent::turn_origin::AgentTurnOrigin> {
+    use crate::openhuman::agent::turn_origin::{AgentTurnOrigin, TrustedAutomationSource};
+
+    match origin {
+        Some(AgentTurnOrigin::TrustedAutomation {
+            job_id,
+            source:
+                TrustedAutomationSource::Workflow {
+                    require_approval: false,
+                },
+        }) => Some(AgentTurnOrigin::TrustedAutomation {
+            job_id,
+            source: TrustedAutomationSource::Workflow {
+                require_approval: true,
+            },
+        }),
+        _ => None,
+    }
+}
+
 /// Cap on the serialized `input_context` block size (bytes of the pretty-
 /// printed JSON) before truncation. Keeps a huge upstream payload (e.g. a
 /// large fan-in `=items` array) from blowing the completion's context window;
@@ -815,12 +860,45 @@ impl OpenHumanAgentRunner {
             "[flows] agent_runner: dispatching full harness turn"
         );
 
-        // No origin wrapper: the engine future already runs under the flow's
-        // Workflow origin, so the inner turn inherits the autonomy tier +
-        // approval gate; the definition's ToolScope/sandbox is the inner gate.
+        // Nested-harness HITL escalation (issue #4595): the engine future runs
+        // under the flow's Workflow origin, but the flow author only pre-
+        // declared `agent_ref` — not the concrete tools the harness LLM will
+        // pick from the definition's `ToolScope`. If we let the inner turn
+        // inherit a `Workflow { require_approval: false }` origin,
+        // `ApprovalGate::intercept_audited` treats it as a trust root and
+        // auto-`Allow`s external_effect tools (see
+        // `src/openhuman/approval/gate.rs` `Workflow { require_approval: false }`
+        // branch), which would let a scheduled / app-event flow reach out to
+        // Slack / email / desktop control with no HITL. We force
+        // `require_approval: true` around `run_single` so external_effect tools
+        // park for a real decision the same way flow acting nodes escalated by
+        // [`gate_call_for_tier`] do. Read-only tools (no `external_effect`)
+        // aren't gated by `intercept_audited` at all, so this doesn't add noise
+        // for pure-read nested agents.
+        //
         // Cancellation: the run_registry token aborts the engine future, and the
-        // inner turn drops with it.
-        let run = agent.run_single(&prompt);
+        // inner turn drops with it (task-local scope unwinds cleanly).
+        use crate::openhuman::agent::turn_origin;
+        let escalated_origin = escalated_origin_for_nested_harness(turn_origin::current());
+        if let Some(ref escalated) = escalated_origin {
+            tracing::debug!(
+                target: "flows",
+                agent_ref,
+                origin = ?escalated,
+                "[flows] agent_runner: escalating nested harness turn to Workflow{{require_approval:true}} \
+                 so external_effect tools park for HITL (issue #4595)"
+            );
+        }
+        let run: std::pin::Pin<
+            Box<dyn std::future::Future<Output = anyhow::Result<String>> + Send>,
+        > = if let Some(escalated) = escalated_origin {
+            Box::pin(turn_origin::with_origin(
+                escalated,
+                agent.run_single(&prompt),
+            ))
+        } else {
+            Box::pin(agent.run_single(&prompt))
+        };
         let final_text =
             match tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), run).await {
                 Ok(Ok(text)) => text,
@@ -3336,6 +3414,68 @@ mod tests {
     #[test]
     fn prompt_decision_does_not_escalate_without_a_workflow_origin() {
         assert!(escalated_origin_for_prompt(GateDecision::Prompt, None).is_none());
+    }
+
+    // ── Nested agent-node harness escalation (issue #4595) ─────────────────
+    //
+    // The `agent` node's harness turn runs the full agent tool loop, and the
+    // flow author never pre-declared the tool selection (only the `agent_ref`).
+    // So `escalated_origin_for_nested_harness` must escalate a default
+    // `Workflow { require_approval: false }` origin so
+    // `ApprovalGate::intercept_audited` can't apply its
+    // pre-declared-action `Allow` shortcut to tools the nested LLM picks at
+    // runtime.
+
+    /// A default `require_approval: false` workflow origin unconditionally
+    /// escalates: the nested harness's tool selection was not pre-declared, so
+    /// the trust-root shortcut in `ApprovalGate` must not apply. `job_id` is
+    /// preserved so the parked approval is still attributable to the flow run.
+    #[test]
+    fn nested_harness_escalates_default_workflow_origin_and_preserves_job_id() {
+        let escalated =
+            escalated_origin_for_nested_harness(Some(workflow_origin("flow-42", false)))
+                .expect("a default require_approval=false workflow must escalate");
+        match escalated {
+            AgentTurnOrigin::TrustedAutomation {
+                job_id,
+                source:
+                    TrustedAutomationSource::Workflow {
+                        require_approval: true,
+                    },
+            } => assert_eq!(job_id, "flow-42"),
+            other => panic!("expected escalated Workflow origin, got {other:?}"),
+        }
+    }
+
+    /// A flow that already opted into `require_approval: true` needs no
+    /// escalation — the parking branch already applies.
+    #[test]
+    fn nested_harness_does_not_re_escalate_already_gated_workflow() {
+        assert!(
+            escalated_origin_for_nested_harness(Some(workflow_origin("flow-42", true,))).is_none()
+        );
+    }
+
+    /// A non-Workflow origin (Cron, Cli, WebChat, Unknown, …) passes through
+    /// unchanged: their own gate branches already make the right decision.
+    #[test]
+    fn nested_harness_does_not_escalate_non_workflow_origin() {
+        assert!(
+            escalated_origin_for_nested_harness(Some(AgentTurnOrigin::TrustedAutomation {
+                job_id: "cron-1".into(),
+                source: TrustedAutomationSource::Cron,
+            }))
+            .is_none()
+        );
+        assert!(escalated_origin_for_nested_harness(Some(AgentTurnOrigin::Cli)).is_none());
+    }
+
+    /// No scoped origin (unlabelled caller) passes through: the gate maps it
+    /// to `Unknown` and fails closed on external_effect tools already, so we
+    /// don't invent an escalation.
+    #[test]
+    fn nested_harness_does_not_escalate_without_an_origin() {
+        assert!(escalated_origin_for_nested_harness(None).is_none());
     }
 
     // ── Phase 7: sub_workflow-by-id resolver ───────────────────────────────


### PR DESCRIPTION
## Summary

- Fix P1 approval-gate bypass: nested agent-node harness runs inside a `Workflow { require_approval: false }` flow no longer auto-`Allow` external_effect tools — they park for HITL like the outer flow's acting tools already do.
- New pure helper `escalated_origin_for_nested_harness` mirrors the shape of `escalated_origin_for_prompt` (co-located in `caps.rs`); wraps `Agent::run_single` in `run_via_harness` with `turn_origin::with_origin(escalated, ...)` when the origin needs escalation.
- 4 unit tests covering every branch of the helper (escalate default / don't re-escalate already-gated / non-Workflow passthrough / `None` passthrough).

## Problem

A flow `agent` node whose `agent_ref` names a harness definition (e.g. `desktop_control_agent`) drives the full agent tool loop via `Agent::run_single` under the flow's `TrustedAutomation::Workflow { require_approval: false }` origin. `ApprovalGate::intercept_audited` (`src/openhuman/approval/gate.rs` L458–472) treats that origin as a pre-declared trust root and returns `Allow` for every `external_effect` tool with no prompt — a shortcut that's correct when flow nodes are statically-typed acting tools (`http_request`, `code`, connector actions) but wrong across the nested harness boundary: the flow author only pre-declared `agent_ref`, never the concrete tools the harness LLM will pick from the definition's `ToolScope`. Result: a schedule- or app-event-triggered flow using an agent with external-effect tools reaches out to Slack / email / desktop control with no HITL. Flagged as **P1** by `chatgpt-codex-connector` on PR #4578.

The existing tier-`Prompt` → forced-approval escalation for flow acting nodes (`gate_call_for_tier` + `escalated_origin_for_prompt` in `caps.rs` L139-200) does NOT reach the nested harness — those helpers wrap flow-node dispatch only, not `run_single`.

## Solution

**Escalate the entire nested harness turn to `Workflow { require_approval: true }`** so `ApprovalGate::intercept_audited` takes its parking branch (the same one the outer flow uses when the user explicitly enabled `require_approval`) and prompts on every external_effect tool the nested LLM picks.

- New pure helper `escalated_origin_for_nested_harness(origin) -> Option<AgentTurnOrigin>` in `src/openhuman/tinyflows/caps.rs` (~L200): clones a `Workflow { require_approval: false }` origin into `Workflow { require_approval: true }` (preserving `job_id`), passes every other origin through unchanged. Free function over plain values so the escalation policy is unit-testable without a live `ApprovalGate`, matching how `escalated_origin_for_prompt` is factored.
- In `run_via_harness` (~L860) read `turn_origin::current()`, call the helper, and wrap `agent.run_single(&prompt)` with `turn_origin::with_origin(escalated, ...)` when it returns `Some`. `Box::pin` on both `if let Some / else` arms because the wrapped and unwrapped futures have distinct concrete types but a shared `anyhow::Result<String>` output.
- Grep-friendly `[flows] agent_runner: escalating nested harness turn to Workflow{require_approval:true} …` debug log at the wrap site per the debug-logging rule.
- Read-only tools (no `external_effect`) never hit `intercept_audited` at all, so this doesn't add prompt noise for pure-read nested agents.

**Rejected alternatives:**
- *Conditional escalation on `ToolScope`-has-external-effect*: adds complexity for a marginal noise saving; a nested agent's scope can also gain external-effect tools later without the wrap being reconsidered.
- *Whitelist which `AgentDefinition`s can be referenced from flow nodes*: doesn't close the underlying gate hole (allowlisted-but-still-external-effect agents still bypass), and blocks legitimate user-defined agents from flows.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/ci-lite.yml`](../.github/workflows/ci-lite.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`) — **N/A: behaviour-only change (single-file fix, no new feature row)**
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — **N/A: no matrix feature ID for `flows::caps::run_via_harness`; behaviour lives inside the existing flows/agent-node coverage**
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — **N/A: does not touch a release-cut surface (server-side security gate only)**
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Runtime**: desktop (any platform running the core). Behavioural change is confined to `TrustedAutomation::Workflow { require_approval: false }` runs that include an `agent` node routing to `AgentRoute::Harness`. Under an autonomy tier where `intercept_audited`'s parking path applies, external_effect tools inside nested agent turns now block for HITL rather than firing silently.
- **Security**: closes a P1 auto-`Allow` bypass. Fail-closed direction — user sees more prompts, never fewer.
- **Performance / migration / compatibility**: none. No schema changes, no config changes, no API changes; the helper is internal.
- **User-visible**: scheduled / app-event flows using an `agent` node with external-effect tools will now trip HITL prompts. If a user actually wants unattended execution they can set the flow's own `require_approval: true` — which already parks — or migrate the action to a statically-declared node (`http_request`, connector action) which remains under the pre-declared trust root.

## Related

- Closes: #4595
- Found in: #4578 (P1 finding by `chatgpt-codex-connector`)
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/4595-flow-agent-nested-hitl`
- Commit SHA: `78e3f4d00103543089d4977144a94d982213b863`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — **N/A: no `app/` changes in this PR (Rust-only)**
- [x] `pnpm typecheck` — **N/A: no `app/` changes in this PR (Rust-only)**
- [x] Focused tests: `GGML_NATIVE=OFF cargo test -p openhuman --lib -- openhuman::tinyflows::caps::tests::` → **58 passed / 0 failed** (54 pre-existing + 4 new nested-harness tests)
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path Cargo.toml --check` pass · `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml` pass (53 pre-existing warnings, no new ones)
- [x] Tauri fmt/check (if changed): `GGML_NATIVE=OFF cargo check --manifest-path app/src-tauri/Cargo.toml` pass

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: Nested agent-node harness turns inside `Workflow { require_approval: false }` flows now escalate to `Workflow { require_approval: true }` so `ApprovalGate::intercept_audited` parks external_effect tools for HITL instead of auto-allowing them.
- User-visible effect: Scheduled / app-event flows containing an `agent` node whose harness picks external_effect tools will now trigger an approval prompt for each such tool call. Read-only tools unaffected (they never reach `intercept_audited`).

### Parity Contract

- Legacy behavior preserved: Flows that already set `require_approval: true` are unchanged (helper returns `None`, no double-wrap). Non-Workflow origins (Cron, Cli, WebChat, Unknown, ExternalChannel, GoalContinuation, Subconscious*) are unchanged (helper returns `None`). Non-nested-harness flow paths (statically-typed acting nodes) still go through `escalated_origin_for_prompt` + `gate_call_for_tier` exactly as before — this PR adds a sibling escalation, it does not modify the existing one.
- Guard/fallback/dispatch parity checks: The `AgentRoute::RegistryFallback` path (custom persona-completion, no harness tool loop) is intentionally unchanged — a single `OpenHumanLlm::complete` never dispatches an external_effect tool, so there's nothing for `intercept_audited` to auto-allow.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nested harness runs now inherit a safer approval state when launched from a workflow that does not already require approval.
  * The original job context is preserved during this escalation.

* **Bug Fixes**
  * Prevented unnecessary approval escalation for workflows that already require approval.
  * Kept non-workflow and unauthenticated runs unchanged.
  * Added coverage for the new nested-run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->