### PR TITLE
fix(webview-accounts): remount provider WebviewHost on account switch to stop cross-account bleed (#4421)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -295,7 +295,15 @@ export function AppShellDesktop() {
       <AppRoutes location={baseLocation} />
       {activeProviderAccount && !accountsOverlayOpen && (
         <div className="absolute inset-0 z-30">
+          {/* key on the account id so switching provider accounts fully
+              unmounts the previous host (running its cleanup → hideWebviewAccount)
+              and mounts a fresh one, instead of React reusing one instance with
+              new props. Guarantees deterministic hide-old-before-show-new
+              ordering and stops a deselected provider's CEF view from bleeding
+              into the newly-selected account's slot on rapid rail switches
+              (#4421). */}
           <WebviewHost
+            key={activeProviderAccount.id}
             accountId={activeProviderAccount.id}
             provider={activeProviderAccount.provider}
           />

--- a/app/src/__tests__/App.webviewOverlay.test.tsx
+++ b/app/src/__tests__/App.webviewOverlay.test.tsx
@@ -5,10 +5,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AppShellDesktop } from '../App';
 
-const { hideWebviewAccountMock, mockDispatch } = vi.hoisted(() => ({
-  hideWebviewAccountMock: vi.fn().mockResolvedValue(undefined),
-  mockDispatch: vi.fn(),
-}));
+const { hideWebviewAccountMock, mockDispatch, webviewMountSpy, webviewUnmountSpy } = vi.hoisted(
+  () => ({
+    hideWebviewAccountMock: vi.fn().mockResolvedValue(undefined),
+    mockDispatch: vi.fn(),
+    // Fired from the mocked WebviewHost's mount/unmount only (empty-deps
+    // effect) so a real remount is observable and distinguishable from a
+    // same-instance prop update. See the #4421 regression test below.
+    webviewMountSpy: vi.fn(),
+    webviewUnmountSpy: vi.fn(),
+  })
+);
 
 const baseState = {
   accounts: {
@@ -71,11 +78,21 @@ vi.mock('../store/hooks', () => ({
   useAppDispatch: () => mockDispatch,
   useAppSelector: (selector: (state: typeof baseState) => unknown) => selector(mockState),
 }));
-vi.mock('../components/accounts/WebviewHost', () => ({
-  default: ({ accountId }: { accountId: string }) => (
-    <div data-testid="webview-host">{accountId}</div>
-  ),
-}));
+vi.mock('../components/accounts/WebviewHost', () => {
+  // Empty deps: the spies fire only on a genuine mount/unmount, not on a prop
+  // change. If App reuses one host instance across account switches (no `key`),
+  // switching accounts is a prop update and neither spy fires for the new
+  // account — which is exactly the desync #4421 guards against.
+  const MockWebviewHost = ({ accountId }: { accountId: string }) => {
+    useEffect(() => {
+      webviewMountSpy(accountId);
+      return () => webviewUnmountSpy(accountId);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return <div data-testid="webview-host">{accountId}</div>;
+  };
+  return { default: MockWebviewHost };
+});
 vi.mock('../AppRoutes', () => ({ default: () => <main data-testid="routes" /> }));
 vi.mock('../components/AppBackground', () => ({ default: () => null }));
 vi.mock('../components/layout/shell/AppSidebar', () => ({ default: () => <aside /> }));
@@ -127,6 +144,29 @@ describe('AppShellDesktop provider webview visibility', () => {
     expect(screen.queryByTestId('webview-host')).not.toBeInTheDocument();
   });
 
+  it('remounts a fresh host when the active provider account changes — no cross-account webview bleed (#4421)', () => {
+    mockState = stateWithActive('acct-whatsapp');
+    const { rerender } = renderShell();
+
+    expect(webviewMountSpy).toHaveBeenCalledWith('acct-whatsapp');
+    expect(screen.getByTestId('webview-host')).toHaveTextContent('acct-whatsapp');
+
+    // Rapid rail switch to a different provider account. With `key={id}` on
+    // <WebviewHost>, React tears down the WhatsApp host (unmount) and mounts a
+    // fresh Slack host rather than reusing the instance with new props — so the
+    // previous provider's webview can't linger in the new account's slot.
+    mockState = stateWithActive('acct-slack');
+    rerender(
+      <MemoryRouter initialEntries={['/chat/thread-1']}>
+        <RouteChangeHarness />
+      </MemoryRouter>
+    );
+
+    expect(webviewUnmountSpy).toHaveBeenCalledWith('acct-whatsapp');
+    expect(webviewMountSpy).toHaveBeenCalledWith('acct-slack');
+    expect(screen.getByTestId('webview-host')).toHaveTextContent('acct-slack');
+  });
+
   it('hides the active provider and restores the agent selection on route changes', async () => {
     renderShell('/chat/thread-1', '/settings');
 
@@ -137,6 +177,26 @@ describe('AppShellDesktop provider webview visibility', () => {
     });
   });
 });
+
+function stateWithActive(activeAccountId: string) {
+  return {
+    ...baseState,
+    accounts: {
+      ...baseState.accounts,
+      accounts: {
+        ...baseState.accounts.accounts,
+        'acct-slack': {
+          id: 'acct-slack',
+          provider: 'slack',
+          label: 'Slack',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          status: 'open',
+        },
+      },
+      activeAccountId,
+    },
+  };
+}
 
 function renderShell(initialPath = '/chat/thread-1', nextPath?: string) {
   return render(


### PR DESCRIPTION
## Summary

- Key the provider `<WebviewHost>` in `App.tsx` on the active account id so switching provider accounts on the rail fully remounts the host instead of reusing one React instance with new props.
- Fixes the rapid-switch desync: the previous provider's embedded CEF webview bleeding into the newly-selected account's slot (wrong webview) and the blank/black content panel during the switch.
- Adds a regression test that fails without the `key` (old host never unmounts) and passes with it.

## Problem

`App.tsx` rendered the embedded provider webview as `<WebviewHost accountId=… provider=… />` **without a `key`**. When a user switches provider accounts on the rail (`SidebarAppRail.selectAccount` → `setActiveAccount`), React reuses the single `WebviewHost` fiber and only swaps props. Its `[accountId, provider]` effect then fires cleanup → `hideWebviewAccount(old)` and re-run → `openWebviewAccount(new)` — both **async native IPC into Rust**. On rapid switches these race:

- the new CEF view composites before the old is hidden → **wrong webview** (e.g. Slack over Telegram);
- the new view is still parked off-screen mid-load while the old is gone → **blank/black panel**.

`WebviewHost` already documents this instance reuse (`"React reuses this component instance when only props change"`) and hand-rolls `openedRef`/`lastBoundsRef` resets to compensate — a workaround for the missing remount.

## Solution

Add `key={activeProviderAccount.id}` to `<WebviewHost>`. A switch now fully unmounts the old host (its cleanup runs `hideWebviewAccount(old)` deterministically **before** the new host mounts) and mounts a fresh one for the new account — no instance reuse, deterministic hide-old-before-show-new ordering, no cross-account bleed. This is exactly the remedy the issue's hypothesis and acceptance criteria call for ("webviews unmounted on deselect; force remount on switch").

Scope is intentionally limited to the CEF `WebviewHost` surface (the actual source of the black-panel / wrong-webview symptoms). The `/channels` config-form page the issue cited as the likely fix area was not modified — those panels are plain forms whose OAuth opens the external browser, so they cannot render a black panel or an embedded provider login webview.

Note: the existing claim PR #4423 for this issue is off-target — it only edits an unrelated `src/openhuman/telegram/bot.rs` (12 lines) and is already `CHANGES_REQUESTED`; it does not touch the tab-switch/webview path.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — extended `App.webviewOverlay.test.tsx` with a remount-on-switch regression test (verified red without the `key`, green with it).
- [x] **Diff coverage ≥ 80%** — the one changed source line (`key={…}` in `App.tsx`) is exercised by the new test and the existing overlay-render tests. `@xyflow/react`/markdown-plugin deps are absent in the fresh worktree so the full `pnpm test:coverage` was not run locally; CI runs it with full deps.
- [x] Coverage matrix updated — `N/A: behaviour-only bug fix`, no feature rows added/removed/renamed.
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: behaviour-only bug fix`.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)).
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: one-line React key change, no new smoke surface`.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- **Platform:** desktop only (embedded CEF provider webviews). No mobile/web/CLI impact.
- **Behaviour:** rapid provider-account switching on the rail is now stable — the content area always shows the selected account's webview; deselected providers no longer bleed in.
- **Performance:** a switch now unmounts/remounts one host component (React-cheap) and issues the same native hide/open IPC it already did, just in deterministic order. No new native cost.
- **Security/migration/compat:** none.

## Related

- Closes: #4421
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A (GitHub issue #4421, no Linear issue)
- URL: N/A

### Commit & Branch

- Branch: `fix/4421-webview-host-remount-on-switch`
- Commit SHA: 39df53d05

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — Prettier clean on changed files.
- [x] `pnpm typecheck` — zero errors in changed files (unrelated pre-existing errors are missing optional deps in the fresh worktree, e.g. `@xyflow/react`).
- [x] Focused tests: `vitest run src/__tests__/App.webviewOverlay.test.tsx src/components/accounts/__tests__/WebviewHost.test.tsx` — 14/14 pass.
- [x] Rust fmt/check (if changed): `N/A: no Rust changed`.
- [x] Tauri fmt/check (if changed): `N/A: no Tauri Rust changed`.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: switching provider accounts remounts the embedded webview host instead of reusing one instance.
- User-visible effect: no more blank/black panel or wrong-provider webview after a rapid rail switch.

### Parity Contract

- Legacy behavior preserved: single-account and route-change hide/restore behaviour unchanged (existing overlay tests still pass).
- Guard/fallback/dispatch parity checks: `activeProviderAccount && !accountsOverlayOpen` render guard and route-change `hideWebviewAccount` effect are untouched.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): #4423 (off-target — edits unrelated `telegram/bot.rs`, `CHANGES_REQUESTED`).
- Canonical PR: this PR.
- Resolution: this PR supersedes #4423 for issue #4421.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Switching between active provider accounts now fully refreshes the embedded webview, preventing content from carrying over between accounts.
  * Improved cleanup so the previous webview is closed before the new one appears.
* **Tests**
  * Added regression coverage for account switching to verify the old webview unmounts and the new one mounts correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->