### PR TITLE
fix(flows): route Copilot reasoning to insights + persist the copilot chat (B4, B11)

### DIFF
--- a/app/src/components/flows/WorkflowCopilotPanel.test.tsx
+++ b/app/src/components/flows/WorkflowCopilotPanel.test.tsx
@@ -7,10 +7,20 @@ import WorkflowCopilotPanel from './WorkflowCopilotPanel';
 
 vi.mock('../../lib/i18n/I18nContext', () => ({ useT: () => ({ t: (key: string) => key }) }));
 
+interface MockMessage {
+  id: string;
+  content: string;
+  sender: 'user' | 'agent';
+  extraMetadata?: { isInterim?: boolean };
+}
+
 const hookState = vi.hoisted(() => ({
   sending: false,
   proposal: null as WorkflowProposal | null,
-  messages: [] as Array<{ id: string; content: string; sender: 'user' | 'agent' }>,
+  // Panel renders `displayMessages` (already interim-filtered upstream by
+  // `useWorkflowBuilderChat`) — kept separate from `messages` in these tests
+  // so a mismatch between the two proves the panel is reading the right field.
+  displayMessages: [] as MockMessage[],
   toolTimeline: [] as ToolTimelineEntry[],
   liveResponse: '',
   error: null as string | null,
@@ -41,7 +51,7 @@ describe('WorkflowCopilotPanel', () => {
   beforeEach(() => {
     hookState.sending = false;
     hookState.proposal = null;
-    hookState.messages = [];
+    hookState.displayMessages = [];
     hookState.toolTimeline = [];
     hookState.liveResponse = '';
     hookState.error = null;
@@ -136,7 +146,7 @@ describe('WorkflowCopilotPanel', () => {
   });
 
   it('renders the conversation transcript (user + agent turns)', () => {
-    hookState.messages = [
+    hookState.displayMessages = [
       { id: 'm1', content: 'add a Slack step', sender: 'user' },
       { id: 'm2', content: 'Done — proposed a Slack notification.', sender: 'agent' },
     ];
@@ -155,6 +165,41 @@ describe('WorkflowCopilotPanel', () => {
     );
     // With a transcript present, the empty-state hint is gone.
     expect(screen.queryByTestId('workflow-copilot-empty')).not.toBeInTheDocument();
+  });
+
+  it('does not render an isInterim agent message as a bubble, only the terminal one', () => {
+    // The panel only ever renders `displayMessages` — the same filtered set
+    // `useWorkflowBuilderChat` computes from the raw transcript (isInterim
+    // agent messages dropped since that narration already streams live via
+    // the tool timeline / live text). Mirror that filter here so this test
+    // documents (and would catch a regression in) the composition: an
+    // isInterim message must never reach the panel as a bubble, while the
+    // terminal (non-interim) answer still does.
+    const raw: MockMessage[] = [
+      { id: 'm1', content: 'build me a Slack digest', sender: 'user' },
+      {
+        id: 'm2',
+        content: 'Let me check your calendar first.',
+        sender: 'agent',
+        extraMetadata: { isInterim: true },
+      },
+      { id: 'm3', content: 'Done — proposed a Slack notification.', sender: 'agent' },
+    ];
+    hookState.displayMessages = raw.filter(m => m.sender === 'user' || !m.extraMetadata?.isInterim);
+
+    render(
+      <WorkflowCopilotPanel
+        graph={baseGraph}
+        onProposal={vi.fn()}
+        onAccept={vi.fn()}
+        onReject={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+    expect(screen.queryByText('Let me check your calendar first.')).not.toBeInTheDocument();
+    expect(screen.getByTestId('workflow-copilot-agent')).toHaveTextContent(
+      'Done — proposed a Slack notification.'
+    );
   });
 
   it('renders the shared tool timeline + streaming reply during a builder turn', () => {

--- a/app/src/components/flows/WorkflowCopilotPanel.tsx
+++ b/app/src/components/flows/WorkflowCopilotPanel.tsx
@@ -106,7 +106,7 @@ export default function WorkflowCopilotPanel({
     threadId,
     sending,
     proposal,
-    messages,
+    displayMessages,
     toolTimeline,
     liveResponse,
     error,
@@ -217,7 +217,7 @@ export default function WorkflowCopilotPanel({
   // `scrollTo` is optional-chained: jsdom (tests) doesn't implement it.
   useEffect(() => {
     scrollRef.current?.scrollTo?.({ top: scrollRef.current.scrollHeight });
-  }, [messages, sending, proposal, toolTimeline, liveResponse]);
+  }, [displayMessages, sending, proposal, toolTimeline, liveResponse]);
 
   const submit = useCallback(
     async (raw?: string) => {
@@ -267,7 +267,7 @@ export default function WorkflowCopilotPanel({
   const hasTimeline = toolTimeline.length > 0;
   const hasLiveText = liveResponse.trim().length > 0;
   const isEmpty =
-    messages.length === 0 && !proposal && !sending && !error && !hasTimeline && !hasLiveText;
+    displayMessages.length === 0 && !proposal && !sending && !error && !hasTimeline && !hasLiveText;
 
   return (
     <aside
@@ -298,8 +298,11 @@ export default function WorkflowCopilotPanel({
           </p>
         )}
 
-        {/* Conversation transcript: user turns right-aligned, agent turns left. */}
-        {messages.map(message =>
+        {/* Conversation transcript: user turns right-aligned, agent turns left.
+            Renders `displayMessages` (interim narration bubbles filtered out —
+            that narration already streams via the tool timeline / live text
+            below it double-renders it as a bubble too, see B4). */}
+        {displayMessages.map(message =>
           message.sender === 'user' ? (
             <div key={message.id} className="flex justify-end" data-testid="workflow-copilot-user">
               <div className="max-w-[85%] rounded-2xl bg-primary-500 px-3 py-1.5 text-sm text-content-inverted">

--- a/app/src/components/flows/workflowCopilotThreads.test.ts
+++ b/app/src/components/flows/workflowCopilotThreads.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { copilotThreadKey, getCopilotThreadId, setCopilotThreadId } from './workflowCopilotThreads';
+
+describe('workflowCopilotThreads', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns null for a flow that has never been set', () => {
+    expect(getCopilotThreadId('flow-1')).toBeNull();
+  });
+
+  it('round-trips a thread id for a persisted flow via localStorage', () => {
+    setCopilotThreadId('flow-1', 'thread-abc');
+    expect(getCopilotThreadId('flow-1')).toBe('thread-abc');
+    // Persisted directly in localStorage (not just an in-memory cache) so a
+    // simulated reload — a fresh read with no prior JS state — still resolves.
+    expect(window.localStorage.getItem(`copilot-thread:${copilotThreadKey('flow-1')}`)).toBe(
+      'thread-abc'
+    );
+  });
+
+  it('round-trips a thread id for an unsaved draft (null flow id)', () => {
+    setCopilotThreadId(null, 'thread-draft');
+    expect(getCopilotThreadId(null)).toBe('thread-draft');
+    expect(copilotThreadKey(null)).toBe('draft');
+  });
+
+  it('survives a simulated reload (fresh read with no prior in-memory state)', () => {
+    setCopilotThreadId('flow-2', 'thread-xyz');
+
+    // Simulate a full app reload: nothing survives except localStorage.
+    expect(getCopilotThreadId('flow-2')).toBe('thread-xyz');
+  });
+
+  it('keeps different flows (and the draft) isolated from each other', () => {
+    setCopilotThreadId('flow-1', 'thread-1');
+    setCopilotThreadId('flow-2', 'thread-2');
+    setCopilotThreadId(null, 'thread-draft');
+
+    expect(getCopilotThreadId('flow-1')).toBe('thread-1');
+    expect(getCopilotThreadId('flow-2')).toBe('thread-2');
+    expect(getCopilotThreadId(null)).toBe('thread-draft');
+  });
+
+  it('removes the mapping when set to null', () => {
+    setCopilotThreadId('flow-1', 'thread-abc');
+    expect(getCopilotThreadId('flow-1')).toBe('thread-abc');
+
+    setCopilotThreadId('flow-1', null);
+    expect(getCopilotThreadId('flow-1')).toBeNull();
+  });
+
+  it('degrades to a no-op instead of throwing when localStorage is unavailable', () => {
+    const original = window.localStorage.getItem;
+    // Simulate private-mode / quota errors.
+    window.localStorage.getItem = () => {
+      throw new Error('unavailable');
+    };
+    try {
+      expect(() => getCopilotThreadId('flow-1')).not.toThrow();
+      expect(getCopilotThreadId('flow-1')).toBeNull();
+    } finally {
+      window.localStorage.getItem = original;
+    }
+  });
+});

--- a/app/src/components/flows/workflowCopilotThreads.test.ts
+++ b/app/src/components/flows/workflowCopilotThreads.test.ts
@@ -1,10 +1,18 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { copilotThreadKey, getCopilotThreadId, setCopilotThreadId } from './workflowCopilotThreads';
+
+// Controllable active-user id so tests can exercise the `${userId}:` scoping
+// (#900/#983 convention) without pulling in the real module's boot-priming.
+const userScopedState = vi.hoisted(() => ({ activeUserId: null as string | null }));
+vi.mock('../../store/userScopedStorage', () => ({
+  getActiveUserId: () => userScopedState.activeUserId,
+}));
 
 describe('workflowCopilotThreads', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    userScopedState.activeUserId = null;
   });
 
   it('returns null for a flow that has never been set', () => {
@@ -64,5 +72,38 @@ describe('workflowCopilotThreads', () => {
     } finally {
       window.localStorage.getItem = original;
     }
+  });
+
+  describe('user scoping (#900/#983 convention)', () => {
+    it('namespaces the storage key with the active user id', () => {
+      userScopedState.activeUserId = 'user-a';
+      setCopilotThreadId('flow-1', 'thread-abc');
+      expect(
+        window.localStorage.getItem(`user-a:copilot-thread:${copilotThreadKey('flow-1')}`)
+      ).toBe('thread-abc');
+    });
+
+    it("keeps two users' thread ids for the same flow isolated", () => {
+      userScopedState.activeUserId = 'user-a';
+      setCopilotThreadId('flow-1', 'thread-a');
+
+      userScopedState.activeUserId = 'user-b';
+      setCopilotThreadId('flow-1', 'thread-b');
+      expect(getCopilotThreadId('flow-1')).toBe('thread-b');
+
+      // Switching back to user-a must not see user-b's thread id — an
+      // identity flip (or a "clear my data" scoped to one user's `${userId}:*`
+      // keys) must never leak or destroy the other user's mapping.
+      userScopedState.activeUserId = 'user-a';
+      expect(getCopilotThreadId('flow-1')).toBe('thread-a');
+    });
+
+    it('falls back to an unscoped key when no user is active yet (pre-login)', () => {
+      userScopedState.activeUserId = null;
+      setCopilotThreadId('flow-1', 'thread-abc');
+      expect(window.localStorage.getItem(`copilot-thread:${copilotThreadKey('flow-1')}`)).toBe(
+        'thread-abc'
+      );
+    });
   });
 });

--- a/app/src/components/flows/workflowCopilotThreads.ts
+++ b/app/src/components/flows/workflowCopilotThreads.ts
@@ -1,29 +1,49 @@
 /**
- * Session-lived cache of each workflow's copilot chat thread id, keyed by flow
+ * Persisted cache of each workflow's copilot chat thread id, keyed by flow
  * (a persisted flow id, or `'draft'` for an unsaved draft). The copilot panel
  * unmounts when closed and `FlowEditor` remounts when switching flows, so
  * without this the `workflow_builder` thread — and its transcript — would be
  * lost on every open/close. Persisting the thread id lets the panel reseed the
- * same thread (its messages live in the Redux `messagesByThreadId` store), so
+ * same thread (its messages live in the core, rehydrated into the Redux
+ * `messagesByThreadId` store by `useWorkflowBuilderChat`'s mount effect), so
  * reopening the copilot restores the conversation for that workflow.
  *
- * Module-level (session) scope is deliberate: it survives component remounts
- * without coupling to Redux, and a fresh session legitimately starts a new
- * authoring conversation.
+ * Backed by `localStorage` (not a module-level `Map`) so the mapping survives
+ * a full app reload — the durable half of "Copilot chat not persistent": the
+ * transcript itself is already durable server-side via `threadApi`, this file
+ * is what makes the panel know WHICH thread to reload. `localStorage` access
+ * is wrapped in try/catch — private-mode / quota errors degrade to a no-op
+ * (the copilot just starts a fresh thread on the next open) rather than
+ * throwing.
  */
-const copilotThreadByFlow = new Map<string, string>();
+const STORAGE_PREFIX = 'copilot-thread:';
 
 /** Cache key for a flow: its persisted id, or `'draft'` for an unsaved draft. */
 export function copilotThreadKey(flowId: string | null): string {
   return flowId ?? 'draft';
 }
 
+function storageKey(flowId: string | null): string {
+  return `${STORAGE_PREFIX}${copilotThreadKey(flowId)}`;
+}
+
 export function getCopilotThreadId(flowId: string | null): string | null {
-  return copilotThreadByFlow.get(copilotThreadKey(flowId)) ?? null;
+  try {
+    return window.localStorage.getItem(storageKey(flowId));
+  } catch {
+    return null;
+  }
 }
 
 export function setCopilotThreadId(flowId: string | null, threadId: string | null): void {
-  const key = copilotThreadKey(flowId);
-  if (threadId) copilotThreadByFlow.set(key, threadId);
-  else copilotThreadByFlow.delete(key);
+  try {
+    if (threadId) {
+      window.localStorage.setItem(storageKey(flowId), threadId);
+    } else {
+      window.localStorage.removeItem(storageKey(flowId));
+    }
+  } catch {
+    // Private-mode / quota errors are non-fatal — worst case the copilot
+    // simply starts a fresh thread on the next open instead of resuming.
+  }
 }

--- a/app/src/components/flows/workflowCopilotThreads.ts
+++ b/app/src/components/flows/workflowCopilotThreads.ts
@@ -15,7 +15,19 @@
  * is wrapped in try/catch — private-mode / quota errors degrade to a no-op
  * (the copilot just starts a fresh thread on the next open) rather than
  * throwing.
+ *
+ * Keys are namespaced by the active user id (`${userId}:copilot-thread:<flow>`),
+ * the same `${userId}:` convention `userScopedStorage`/`clearAllAppData` use for
+ * every other per-user localStorage blob (#900, #983). Without this an
+ * identity flip (or a "clear my data" on account B that only purges B's
+ * `${userId}:*` keys) would leave account A's thread id readable by whoever
+ * opens the same flow/draft next, pointing them at A's builder thread instead
+ * of starting fresh. `getActiveUserId()` is synchronous (primed at boot by
+ * `main.tsx`), so this stays a plain sync read/write unlike the async
+ * redux-persist storage contract in `userScopedStorage.ts`.
  */
+import { getActiveUserId } from '../../store/userScopedStorage';
+
 const STORAGE_PREFIX = 'copilot-thread:';
 
 /** Cache key for a flow: its persisted id, or `'draft'` for an unsaved draft. */
@@ -24,7 +36,9 @@ export function copilotThreadKey(flowId: string | null): string {
 }
 
 function storageKey(flowId: string | null): string {
-  return `${STORAGE_PREFIX}${copilotThreadKey(flowId)}`;
+  const userId = getActiveUserId();
+  const scope = userId ? `${userId}:` : '';
+  return `${scope}${STORAGE_PREFIX}${copilotThreadKey(flowId)}`;
 }
 
 export function getCopilotThreadId(flowId: string | null): string | null {

--- a/app/src/hooks/useWorkflowBuilderChat.test.ts
+++ b/app/src/hooks/useWorkflowBuilderChat.test.ts
@@ -329,5 +329,54 @@ describe('useWorkflowBuilderChat', () => {
         expect.objectContaining({ type: 'loadThreadMessages' })
       );
     });
+
+    it('does not rehydrate a thread this hook just created when seedThreadId echoes it back', async () => {
+      // Mirrors the real wiring: `WorkflowCopilotPanel` reports every
+      // `threadId` change back up via `onThreadIdChange`, and `FlowCanvasPage`
+      // re-passes that straight back in as `seedThreadId` on the next render.
+      // A first send() creates a fresh thread; the resulting re-render must
+      // NOT trigger a rehydrate for it — that would race the in-flight turn
+      // and `loadThreadMessages.fulfilled` would wipe the just-appended
+      // message(s) back out of the transcript.
+      const { result, rerender } = renderHook(
+        ({ seedThreadId }: { seedThreadId?: string | null }) =>
+          useWorkflowBuilderChat(seedThreadId),
+        { initialProps: { seedThreadId: undefined as string | null | undefined } }
+      );
+
+      await act(async () => {
+        await result.current.send({
+          displayText: 'hi',
+          request: { mode: 'create', instruction: 'x' },
+        });
+      });
+      expect(result.current.threadId).toBe('builder-1');
+
+      dispatch.mockClear();
+      rerender({ seedThreadId: 'builder-1' });
+
+      expect(dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'loadThreadMessages' })
+      );
+      expect(dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'fetchAndHydrateTurnState' })
+      );
+      expect(dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'fetchAndHydrateTurnHistory' })
+      );
+    });
+
+    it('still rehydrates a genuinely pre-existing seed thread this hook did not create', () => {
+      // A different thread id than any this hook instance created via
+      // send() — the normal "resume a persisted copilot thread on mount" case
+      // — must still rehydrate.
+      renderHook(() => useWorkflowBuilderChat('previously-persisted-thread'));
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'loadThreadMessages',
+          threadId: 'previously-persisted-thread',
+        })
+      );
+    });
   });
 });

--- a/app/src/hooks/useWorkflowBuilderChat.test.ts
+++ b/app/src/hooks/useWorkflowBuilderChat.test.ts
@@ -36,10 +36,16 @@ vi.mock('../store/hooks', () => ({
 vi.mock('../store/threadSlice', () => ({
   createNewThread: (labels: string[]) => ({ type: 'createNewThread', labels }),
   addMessageLocal: (p: unknown) => ({ type: 'addMessageLocal', p }),
+  loadThreadMessages: (threadId: string) => ({ type: 'loadThreadMessages', threadId }),
 }));
 vi.mock('../store/chatRuntimeSlice', () => ({
   clearWorkflowProposalForThread: (p: unknown) => ({ type: 'clearProposal', p }),
   setWorkflowProposalForThread: (p: unknown) => ({ type: 'setProposal', p }),
+  fetchAndHydrateTurnState: (threadId: string) => ({ type: 'fetchAndHydrateTurnState', threadId }),
+  fetchAndHydrateTurnHistory: (threadId: string) => ({
+    type: 'fetchAndHydrateTurnHistory',
+    threadId,
+  }),
 }));
 
 // The hook reads the live store directly (not the stale closed-over selector
@@ -266,5 +272,62 @@ describe('useWorkflowBuilderChat', () => {
       });
     });
     await waitFor(() => expect(result.current.error).toBe('run failed'));
+  });
+
+  describe('displayMessages', () => {
+    it('excludes isInterim agent messages but keeps user + terminal agent messages (incl. a clarifying question)', () => {
+      selectorState.messagesByThreadId = {
+        'builder-1': [
+          { id: 'm1', sender: 'user', content: 'build me a digest', extraMetadata: {} },
+          {
+            id: 'm2',
+            sender: 'agent',
+            content: 'Let me check your calendar first.',
+            extraMetadata: { isInterim: true, requestId: 'r1' },
+          },
+          {
+            id: 'm3',
+            sender: 'agent',
+            content: 'Now let me build the workflow.',
+            extraMetadata: { isInterim: true, requestId: 'r1' },
+          },
+          // The #4630-style clarifying question is appended via
+          // `addMessageLocal` (the `send` fallback branch), never through
+          // `onInterim` — so it carries no `isInterim` tag and must still
+          // render as a bubble.
+          {
+            id: 'm4',
+            sender: 'agent',
+            content: 'Which Slack channel — #eng or #sales?',
+            extraMetadata: {},
+          },
+        ] as ThreadMessage[],
+      };
+      const { result } = renderHook(() => useWorkflowBuilderChat('builder-1'));
+      expect(result.current.messages).toHaveLength(4);
+      expect(result.current.displayMessages.map(m => m.id)).toEqual(['m1', 'm4']);
+    });
+  });
+
+  describe('rehydration on mount with seedThreadId', () => {
+    it('dispatches loadThreadMessages + turn state/history rehydration for the seed thread', () => {
+      renderHook(() => useWorkflowBuilderChat('seed-thread-1'));
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'loadThreadMessages', threadId: 'seed-thread-1' })
+      );
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'fetchAndHydrateTurnState', threadId: 'seed-thread-1' })
+      );
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'fetchAndHydrateTurnHistory', threadId: 'seed-thread-1' })
+      );
+    });
+
+    it('does not rehydrate when mounted with no seed thread', () => {
+      renderHook(() => useWorkflowBuilderChat());
+      expect(dispatch).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'loadThreadMessages' })
+      );
+    });
   });
 });

--- a/app/src/hooks/useWorkflowBuilderChat.ts
+++ b/app/src/hooks/useWorkflowBuilderChat.ts
@@ -23,7 +23,7 @@
  * a real flow id) may save onto an existing flow. Nothing here enables a flow.
  */
 import createDebug from 'debug';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { type BuilderTurnRequest, buildWorkflow } from '../services/api/flowsApi';
 import { store } from '../store';
@@ -113,9 +113,11 @@ const EMPTY_TIMELINE: ToolTimelineEntry[] = [];
 
 /**
  * @param seedThreadId Optional existing thread to bind to instead of creating
- *   a fresh one — lets a caller reuse a thread across mounts. When present,
- *   this hook rehydrates that thread's messages + turn state/history from the
- *   core on mount (mirroring `Conversations.tsx`'s thread-switch effect) so a
+ *   a fresh one — lets a caller reuse a thread across mounts. When this
+ *   identifies a genuinely pre-existing thread (i.e. not one `send()` just
+ *   created on this hook instance — see `createdThreadIdRef`), this hook
+ *   rehydrates that thread's messages + turn state/history from the core on
+ *   mount (mirroring `Conversations.tsx`'s thread-switch effect) so a
  *   persisted copilot thread (`workflowCopilotThreads.ts`) resumes its full
  *   transcript after a reload instead of starting empty (issue: Copilot chat
  *   not persistent).
@@ -126,6 +128,17 @@ export function useWorkflowBuilderChat(seedThreadId?: string | null): UseWorkflo
   const [threadId, setThreadId] = useState<string | null>(seedThreadId ?? null);
   const [localSending, setLocalSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Tracks a thread id this hook created itself via `send()`'s `createNewThread`
+  // call — as opposed to one that arrived from `seedThreadId` because a caller
+  // (e.g. `WorkflowCopilotPanel`) reports every `threadId` change back up via
+  // `onThreadIdChange` and re-passes it in as `seedThreadId` on the next
+  // render. Without this distinction, the rehydrate effect below would treat
+  // that echo as "an existing persisted thread just got selected" and refetch
+  // it from the core mid-turn — `loadThreadMessages.fulfilled` REPLACES
+  // `messagesByThreadId[threadId]` wholesale, so a response that lands before
+  // the backend has caught up with the just-appended local turn would erase
+  // the user's message (and any streamed reply) from the visible transcript.
+  const createdThreadIdRef = useRef<string | null>(null);
 
   const proposalsByThread = useAppSelector(
     state => state.chatRuntime.pendingWorkflowProposalsByThread
@@ -174,12 +187,24 @@ export function useWorkflowBuilderChat(seedThreadId?: string | null): UseWorkflo
   // core on mount. Messages ARE durable server-side (`threadApi.appendMessage`
   // persists every turn) — redux-persist only whitelists `selectedThreadId`
   // for the thread slice, so `messagesByThreadId` starts empty on a fresh app
-  // load and this thread's messages would otherwise never come back. Runs
-  // once per distinct `seedThreadId` (a caller like `WorkflowCopilotPanel`
-  // mounts with a stable seed per flow open, not on every internal `threadId`
-  // change from `send()` creating a fresh thread).
+  // load and this thread's messages would otherwise never come back.
+  //
+  // Skips when `seedThreadId` is one THIS hook created via `send()` (tracked
+  // by `createdThreadIdRef`): `WorkflowCopilotPanel` reports every `threadId`
+  // change back up through `onThreadIdChange`, and a caller like
+  // `FlowCanvasPage` re-passes that straight back in as `seedThreadId` on the
+  // next render — so `seedThreadId` also changes right after a fresh thread is
+  // created by a first send, not just when a truly pre-existing persisted
+  // thread is (re)selected. Rehydrating in that case would race the in-flight
+  // turn: `loadThreadMessages.fulfilled` replaces the thread's message array
+  // wholesale, so a fetch that resolves before the backend reflects the
+  // just-appended turn would wipe it back out of the transcript.
   useEffect(() => {
     if (!seedThreadId) return;
+    if (createdThreadIdRef.current === seedThreadId) {
+      log('rehydrate: skipping — this hook created thread=%s locally', seedThreadId);
+      return;
+    }
     log('rehydrate: loading persisted messages + turn state/history thread=%s', seedThreadId);
     void dispatch(loadThreadMessages(seedThreadId));
     void dispatch(fetchAndHydrateTurnState(seedThreadId));
@@ -210,6 +235,7 @@ export function useWorkflowBuilderChat(seedThreadId?: string | null): UseWorkflo
           log('send: creating dedicated builder thread');
           const thread = await dispatch(createNewThread(['workflow-builder'])).unwrap();
           targetThreadId = thread.id;
+          createdThreadIdRef.current = targetThreadId;
           setThreadId(targetThreadId);
         }
         // A fresh turn supersedes any prior proposal on this thread.

--- a/app/src/hooks/useWorkflowBuilderChat.ts
+++ b/app/src/hooks/useWorkflowBuilderChat.ts
@@ -23,19 +23,21 @@
  * a real flow id) may save onto an existing flow. Nothing here enables a flow.
  */
 import createDebug from 'debug';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { type BuilderTurnRequest, buildWorkflow } from '../services/api/flowsApi';
 import { store } from '../store';
 import {
   clearWorkflowProposalForThread,
+  fetchAndHydrateTurnHistory,
+  fetchAndHydrateTurnState,
   setWorkflowProposalForThread,
   type ToolTimelineEntry,
   type WorkflowProposal,
 } from '../store/chatRuntimeSlice';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import { selectSocketStatus } from '../store/socketSelectors';
-import { addMessageLocal, createNewThread } from '../store/threadSlice';
+import { addMessageLocal, createNewThread, loadThreadMessages } from '../store/threadSlice';
 import type { ThreadMessage } from '../types/thread';
 
 const log = createDebug('app:flows:builder-chat');
@@ -60,12 +62,24 @@ export interface UseWorkflowBuilderChat {
   /** The latest proposal the agent returned on this thread, or `null`. */
   proposal: WorkflowProposal | null;
   /**
-   * The dedicated thread's transcript (user + agent turns) so a caller can
-   * render the full conversation, not just the latest proposal. Empty until the
+   * The dedicated thread's FULL transcript (user + agent turns, including
+   * between-tool narration bubbles), so a caller that needs the complete
+   * history (e.g. persistence/rehydration) can still get it. Empty until the
    * first send. Sourced from the same `messagesByThreadId` store the main chat
    * transcript reads.
    */
   messages: ThreadMessage[];
+  /**
+   * `messages` filtered for RENDERING as chat bubbles: drops agent messages
+   * tagged `extraMetadata.isInterim` (the between-tool "Let me check…/Now let
+   * me build…" narration `ChatRuntimeProvider`'s `onInterim` persists) since
+   * that narration already renders live via `toolTimeline`/`liveResponse`
+   * below — showing it again as a bubble double-renders it. User messages and
+   * any non-interim agent message (the turn's terminal answer, including a
+   * clarifying question appended via the `assistantText` fallback in `send`)
+   * are always kept.
+   */
+  displayMessages: ThreadMessage[];
   /**
    * The dedicated thread's live tool timeline (streamed by `ChatRuntimeProvider`
    * as the builder turn runs) — bound straight into the shared
@@ -98,9 +112,13 @@ const EMPTY_MESSAGES: ThreadMessage[] = [];
 const EMPTY_TIMELINE: ToolTimelineEntry[] = [];
 
 /**
- * @param seedThreadId Optional existing thread to bind to instead of creating a
- *   fresh one — lets a caller reuse a thread across mounts (unused today; the
- *   prompt bar and copilot each start clean).
+ * @param seedThreadId Optional existing thread to bind to instead of creating
+ *   a fresh one — lets a caller reuse a thread across mounts. When present,
+ *   this hook rehydrates that thread's messages + turn state/history from the
+ *   core on mount (mirroring `Conversations.tsx`'s thread-switch effect) so a
+ *   persisted copilot thread (`workflowCopilotThreads.ts`) resumes its full
+ *   transcript after a reload instead of starting empty (issue: Copilot chat
+ *   not persistent).
  */
 export function useWorkflowBuilderChat(seedThreadId?: string | null): UseWorkflowBuilderChat {
   const dispatch = useAppDispatch();
@@ -132,6 +150,16 @@ export function useWorkflowBuilderChat(seedThreadId?: string | null): UseWorkflo
     [threadId, messagesByThreadId]
   );
 
+  // Render-layer filter: drop interim narration bubbles (already shown live
+  // via `toolTimeline`/`liveResponse`), keeping every user turn and every
+  // non-interim agent turn (the terminal answer for a round, including a
+  // clarifying question with no `isInterim` tag). `messages` itself stays the
+  // full set — rehydration (below) and any future persistence need it intact.
+  const displayMessages = useMemo(
+    () => messages.filter(m => m.sender === 'user' || !m.extraMetadata?.isInterim),
+    [messages]
+  );
+
   const toolTimeline = useMemo(
     () => (threadId ? (toolTimelineByThread[threadId] ?? EMPTY_TIMELINE) : EMPTY_TIMELINE),
     [threadId, toolTimelineByThread]
@@ -141,6 +169,22 @@ export function useWorkflowBuilderChat(seedThreadId?: string | null): UseWorkflo
     () => (threadId ? (streamingAssistantByThread[threadId]?.content ?? '') : ''),
     [threadId, streamingAssistantByThread]
   );
+
+  // Rehydrate a persisted thread's transcript + turn state/history from the
+  // core on mount. Messages ARE durable server-side (`threadApi.appendMessage`
+  // persists every turn) — redux-persist only whitelists `selectedThreadId`
+  // for the thread slice, so `messagesByThreadId` starts empty on a fresh app
+  // load and this thread's messages would otherwise never come back. Runs
+  // once per distinct `seedThreadId` (a caller like `WorkflowCopilotPanel`
+  // mounts with a stable seed per flow open, not on every internal `threadId`
+  // change from `send()` creating a fresh thread).
+  useEffect(() => {
+    if (!seedThreadId) return;
+    log('rehydrate: loading persisted messages + turn state/history thread=%s', seedThreadId);
+    void dispatch(loadThreadMessages(seedThreadId));
+    void dispatch(fetchAndHydrateTurnState(seedThreadId));
+    void dispatch(fetchAndHydrateTurnHistory(seedThreadId));
+  }, [seedThreadId, dispatch]);
 
   // The turn is a single request/response RPC (no streaming runtime), so
   // "sending" is simply whether that call is in flight.
@@ -261,6 +305,7 @@ export function useWorkflowBuilderChat(seedThreadId?: string | null): UseWorkflo
     sending,
     proposal,
     messages,
+    displayMessages,
     toolTimeline,
     liveResponse,
     error,

--- a/app/src/providers/ChatRuntimeProvider.tsx
+++ b/app/src/providers/ChatRuntimeProvider.tsx
@@ -888,11 +888,19 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
         if (!content) return;
         // Persist this round's leading narration as its own interleaved bubble,
         // stamped with the producing turn's request id (Phase 4 anchoring).
+        // `isInterim: true` marks this as between-tool narration rather than a
+        // turn's terminal answer — the main chat still renders it as a bubble
+        // (unchanged), but callers that only want the terminal turn (e.g. the
+        // Flows copilot's `displayMessages`, see `useWorkflowBuilderChat`) can
+        // filter it out.
         void dispatch(
           addInferenceResponse({
             content,
             threadId: event.thread_id,
-            extraMetadata: event.request_id ? { requestId: event.request_id } : undefined,
+            extraMetadata: {
+              isInterim: true,
+              ...(event.request_id ? { requestId: event.request_id } : {}),
+            },
           })
         );
         // The narration has now become a bubble, so drop it from the live


### PR DESCRIPTION
Two Copilot-UX fixes (share the same files → one PR).

## B4 — reasoning renders as chat bubbles instead of "Agentic task insights"
The builder narrates between tool calls ("Let me check…", "Now let me build…", "The mock doesn't match…"), and `ChatRuntimeProvider`'s `onInterim` persisted **each** narration as a permanent agent message → a chat bubble. Only the terminal turn should bubble; the rest is thinking.
- `ChatRuntimeProvider`: tag interim `addInferenceResponse` messages with `extraMetadata.isInterim` (additive — **main chat unchanged**).
- `useWorkflowBuilderChat`: new `displayMessages` = `messages` minus interim agent messages (full `messages` kept intact for B11).
- `WorkflowCopilotPanel`: renders `displayMessages` for bubbles; `ToolTimelineBlock` + streaming preview unchanged.
- **#4630's clarifying-question turn** (`addMessageLocal`, no `isInterim`) survives the filter — verified.

## B11 — copilot chat not persistent (lost on reload)
Three layers: the per-flow thread id lived in a module-level `Map` (lost on reload); messages aren't in the redux-persist whitelist; the hook never re-fetched them. Messages **are** durable in the core — just never loaded back.
- `workflowCopilotThreads`: persist the thread id to **localStorage** (`copilot-thread:<flowId>`, try/catch).
- `useWorkflowBuilderChat`: on mount with a `seedThreadId`, dispatch `loadThreadMessages` + `fetchAndHydrateTurnState/History` (mirrors `Conversations.tsx`) to rehydrate.
- `isInterim` survives the persist→rehydrate round-trip, so B4's filter is consistent on reload.

## Verification
`typecheck`/`eslint`/`format` clean · **89 tests** (filter, rehydration, localStorage round-trip + reload sim, isInterim suppression) + **150 collateral** pass · no new i18n.