### PR TITLE
fix(flows): default require_approval to false in the builder (B3)

### DIFF
--- a/src/openhuman/flows/builder_tools.rs
+++ b/src/openhuman/flows/builder_tools.rs
@@ -114,7 +114,7 @@ impl Tool for ReviseWorkflowTool {
                 },
                 "require_approval": {
                     "type": "boolean",
-                    "description": "Force a human-approval gate on every outbound action once saved. Defaults to true for agent-proposed flows."
+                    "description": "Force a human-approval gate on every outbound action once saved. Defaults to false; set true only when the user explicitly asks for an approval step."
                 }
             },
             "required": ["name", "graph"]
@@ -146,7 +146,7 @@ impl Tool for ReviseWorkflowTool {
         let require_approval = args
             .get("require_approval")
             .and_then(Value::as_bool)
-            .unwrap_or(true);
+            .unwrap_or(false);
 
         tracing::debug!(
             target: "flows",

--- a/src/openhuman/flows/builder_tools_tests.rs
+++ b/src/openhuman/flows/builder_tools_tests.rs
@@ -58,6 +58,40 @@ async fn revise_workflow_validates_and_returns_revision_proposal() {
 }
 
 #[tokio::test]
+async fn revise_workflow_omitted_require_approval_defaults_false() {
+    let tmp = TempDir::new().unwrap();
+    let tool = ReviseWorkflowTool::new(test_config(&tmp));
+
+    let result = tool
+        .execute(json!({ "name": "Revised flow", "graph": valid_graph() }))
+        .await
+        .unwrap();
+
+    assert!(!result.is_error, "{}", result.output());
+    let parsed: Value = serde_json::from_str(&result.output()).unwrap();
+    assert_eq!(parsed["require_approval"], false);
+}
+
+#[tokio::test]
+async fn revise_workflow_explicit_require_approval_true_is_respected() {
+    let tmp = TempDir::new().unwrap();
+    let tool = ReviseWorkflowTool::new(test_config(&tmp));
+
+    let result = tool
+        .execute(json!({
+            "name": "Revised flow",
+            "graph": valid_graph(),
+            "require_approval": true
+        }))
+        .await
+        .unwrap();
+
+    assert!(!result.is_error, "{}", result.output());
+    let parsed: Value = serde_json::from_str(&result.output()).unwrap();
+    assert_eq!(parsed["require_approval"], true);
+}
+
+#[tokio::test]
 async fn revise_workflow_rejects_invalid_graph() {
     let tmp = TempDir::new().unwrap();
     let tool = ReviseWorkflowTool::new(test_config(&tmp));

--- a/src/openhuman/flows/tools.rs
+++ b/src/openhuman/flows/tools.rs
@@ -120,7 +120,7 @@ impl Tool for ProposeWorkflowTool {
                 },
                 "require_approval": {
                     "type": "boolean",
-                    "description": "Force a human-approval gate on every outbound tool/HTTP action this flow takes once saved. Defaults to true for agent-proposed flows."
+                    "description": "Force a human-approval gate on every outbound tool/HTTP action this flow takes once saved. Defaults to false; set true only when the user explicitly asks for an approval step."
                 }
             },
             "required": ["name", "graph"]
@@ -152,7 +152,7 @@ impl Tool for ProposeWorkflowTool {
         let require_approval = args
             .get("require_approval")
             .and_then(Value::as_bool)
-            .unwrap_or(true);
+            .unwrap_or(false);
 
         tracing::debug!(
             target: "flows",

--- a/src/openhuman/flows/tools_tests.rs
+++ b/src/openhuman/flows/tools_tests.rs
@@ -112,7 +112,7 @@ async fn missing_graph_is_an_error() {
 }
 
 #[tokio::test]
-async fn omitted_require_approval_defaults_true_in_result() {
+async fn omitted_require_approval_defaults_false_in_result() {
     let tmp = TempDir::new().unwrap();
     let tool = ProposeWorkflowTool::new(test_config(&tmp));
 
@@ -122,7 +122,7 @@ async fn omitted_require_approval_defaults_true_in_result() {
         .unwrap();
 
     let parsed: Value = serde_json::from_str(&result.output()).unwrap();
-    assert_eq!(parsed["require_approval"], true);
+    assert_eq!(parsed["require_approval"], false);
 }
 
 #[tokio::test]
@@ -137,6 +137,20 @@ async fn explicit_require_approval_false_is_respected() {
 
     let parsed: Value = serde_json::from_str(&result.output()).unwrap();
     assert_eq!(parsed["require_approval"], false);
+}
+
+#[tokio::test]
+async fn explicit_require_approval_true_is_respected() {
+    let tmp = TempDir::new().unwrap();
+    let tool = ProposeWorkflowTool::new(test_config(&tmp));
+
+    let result = tool
+        .execute(json!({ "name": "demo", "graph": valid_graph(), "require_approval": true }))
+        .await
+        .unwrap();
+
+    let parsed: Value = serde_json::from_str(&result.output()).unwrap();
+    assert_eq!(parsed["require_approval"], true);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Why
The `workflow_builder` defaulted `require_approval=**true**` when proposing/revising a flow. So every builder-created flow parked its first tool call for HITL approval — and for a **Run-button / scheduled** run (no `thread_id/client_id`), the approval card **can't surface → the run deadlocks** (that's B2, hit twice live). Defaulting on is the trigger for the whole class.

## Fix
Flip the builder's default to **false** — a builder-created flow no longer requires approval unless the user **explicitly** asks.
- `tools.rs` (`ProposeWorkflowTool`): schema default + `unwrap_or(true)`→`unwrap_or(false)`.
- `builder_tools.rs` (`ReviseWorkflowTool`): same.
- `SaveWorkflowTool` passes `None` (leaves the flow's existing setting) — unchanged.
- The RPC handlers + `Flow` serde default were **already** false — this was purely the builder-tool layer. An **explicit** `require_approval:true` still round-trips `true`.

(The deeper run-kind-aware approval — auto-approve manual runs / notify scheduled ones — is deferred as **B2**; this removes the deadlock-by-default that was making every flow unrunnable.)

## Verification
`cargo check`/`fmt` clean · `flows::tools` 21/21 · `flows::builder_tools` 40/41 (the 1 failure is pre-existing/unrelated — `on_error=route`, repro'd on the unmodified tip).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Changed workflow proposal defaults so approval is no longer required unless explicitly requested.
  * Preserved the approval setting when it is provided, including explicit `true` values.

* **Tests**
  * Added coverage for the new default behavior when approval is omitted.
  * Added coverage to confirm explicit approval settings continue to be respected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->