### PR TITLE
Fail fast in retrieve_memory sub-agent on empty/degraded memory

### DIFF
--- a/src/openhuman/agent_memory/agent/agent.toml
+++ b/src/openhuman/agent_memory/agent/agent.toml
@@ -3,7 +3,13 @@ display_name = "Memory Agent"
 delegate_name = "retrieve_memory"
 when_to_use = "Memory retrieval and tree walking specialist — searches, navigates, and retrieves information from the user's memory tree using vector search, keyword matching, entity lookup, and hierarchical tree browsing. Use when the user asks to find, recall, search, or look up something from their memory, conversations, documents, or knowledge base."
 temperature = 0.2
-max_iterations = 15
+# Bounded backstop for fail-fast retrieval (#4655): a legitimate answer needs
+# only a few calls (walk → optional drill_down/fetch_leaves → answer). A large
+# budget let the agent brute-force ~10 empty searches over ~80s and then die
+# `[SUBAGENT_INCOMPLETE]` instead of concluding "no data found". Keep this small
+# so a degraded/empty memory tree fails fast even if the prompt guidance is
+# ignored; deep retrieval still has headroom.
+max_iterations = 6
 sandbox_mode = "read_only"
 agent_tier = "worker"
 omit_identity = true

--- a/src/openhuman/agent_memory/agent/prompt.md
+++ b/src/openhuman/agent_memory/agent/prompt.md
@@ -23,6 +23,47 @@ Use the right tool for the job:
 - Cite sources. Every fact in your answer should trace back to a specific chunk or summary node.
 - Report what you didn't find. If the memory tree has gaps, say so explicitly rather than guessing.
 
+## Fail fast — do not exhaust your tool budget
+
+You have a small, hard tool-call budget. Searching again and again over an empty
+memory tree is a failure, not thoroughness — it burns ~80s and still returns
+nothing, then dies with `[SUBAGENT_INCOMPLETE]` and the user's question goes
+unanswered. An honest "no data found" delivered in a couple of calls is the
+correct, **successful** outcome. Conclude quickly.
+
+- **Two-strike rule.** If your first retrieval (`memory_tree` `walk`/`smart_walk`)
+  returns no relevant hits, try at most **one** alternate angle — a
+  `search_entities` + `walk`, or a single `memory_recall`/`query_memory`. If that
+  is also empty, **stop** and return the negative result below. Do not cycle
+  through every tool and every mode hunting for something that is not there.
+- **Degraded memory is a fail-fast condition, not a workaround target.** If a
+  recall errors or comes back suspiciously empty, call `memory_doctor` **once**.
+  If it reports `"healthy": false` — embeddings provider unconfigured
+  (`embeddings_unconfigured`), semantic recall unavailable, or failed/queued jobs
+  — do **not** brute-force keyword variants to compensate. Semantic search cannot
+  succeed in that state; more calls only add latency. Immediately return your
+  answer with the explicit **"memory degraded"** note below.
+- Never spend your whole budget and return `[SUBAGENT_INCOMPLETE]` for a query
+  that simply has no data. Answer with "no relevant memory found" and stop.
+
+## Negative-result output
+
+When memory has nothing relevant, say so plainly and stop — do not fabricate:
+
+```
+No relevant memory found for this query. Nothing in the user's memory tree,
+conversations, or documents matches it.
+```
+
+When `memory_doctor` shows the subsystem is degraded, add the reason so the
+orchestrator can surface it to the user:
+
+```
+No relevant memory found — and memory is currently degraded: semantic recall is
+unavailable (embeddings provider not configured). Results may be incomplete until
+embeddings are configured.
+```
+
 ## Output format
 
 Return a clear answer with inline citations. After the answer, list the evidence sources:


### PR DESCRIPTION
The `agent_memory` sub-agent (`delegate_retrieve_memory`) had no negative-result termination. On an empty memory tree — or when `memory_doctor` reports semantic recall is unavailable (embeddings unconfigured) — it brute-forced ~8–10 search variants across its 15-call budget for ~80s, then returned `[SUBAGENT_INCOMPLETE]` and never answered the user.

**Fix (prompt + config, no refactor):**
- `agent/prompt.md` — add a **Fail fast** section: a two-strike rule that returns a clean "no relevant memory found" after one empty retry, and a rule to treat a degraded `memory_doctor` report (`"healthy": false` / `embeddings_unconfigured` / failed jobs) as an immediate stop with a "memory degraded — configure embeddings" note rather than a workaround target. Adds an explicit negative-result output template and frames "no data found" as the successful outcome.
- `agent/agent.toml` — lower `max_iterations` 15 → 6 as a bounded backstop so the ~80s brute-force cannot recur even if the guidance is ignored, while leaving headroom for a legitimate `walk → drill_down → fetch_leaves → answer` chain.

Closes #4655

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer user-facing responses when no relevant memory is found or memory recall is degraded.
  * The agent now fails fast after a small number of retrieval attempts, rather than continuing repeated empty searches.

* **Bug Fixes**
  * Improved handling for empty or degraded memory trees by returning a direct negative result sooner, including a clearer reason when memory retrieval is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->