### PR TITLE
fix(flows): update stale on_error:route dry-run test for tinyflows 0.5.1 validation (B14)

### DIFF
--- a/src/openhuman/flows/builder_tools_tests.rs
+++ b/src/openhuman/flows/builder_tools_tests.rs
@@ -658,6 +658,15 @@ async fn dry_run_flags_tool_call_error_when_on_error_is_route() {
     // got far enough to trace an `=`-expression before the preflight error).
     // Seed the same schema as `dry_run_catches_unwired_required_composio_arg`
     // (process-global cache; keep the arg list identical across tests).
+    //
+    // The graph must give `post`'s `error` port a real destination: vendored
+    // tinyflows' author-time `validate()` (added alongside per-node error
+    // handling — a graph with `on_error: "route"` but no outgoing `error`-port
+    // edge is now rejected up front, since a route with nowhere to go is
+    // always a dead-end) would otherwise reject this graph before the sandbox
+    // run ever starts, which is a different failure mode than the one this
+    // test targets. `recover` is a no-op sink, same convention as
+    // `dry_run_passes_when_tool_call_binds_to_upstream_tool_output` above.
     seed_live_catalog_cache("gmail", vec![seeded_gmail_send_contract()]);
 
     let tool = DryRunWorkflowTool::new(
@@ -669,9 +678,14 @@ async fn dry_run_flags_tool_call_error_when_on_error_is_route() {
             { "id": "t", "kind": "trigger", "name": "Manual" },
             { "id": "post", "kind": "tool_call", "name": "Send email",
               "config": { "slug": "GMAIL_SEND_EMAIL", "on_error": "route",
-                "args": { "to": "=item.email", "body": "hello" } } }
+                "args": { "to": "=item.email", "body": "hello" } } },
+            { "id": "recover", "kind": "tool_call", "name": "Recover",
+              "config": { "slug": "oh:noop", "args": {} } }
         ],
-        "edges": [ { "from_node": "t", "to_node": "post" } ]
+        "edges": [
+            { "from_node": "t", "to_node": "post" },
+            { "from_node": "post", "from_port": "error", "to_node": "recover" }
+        ]
     });
 
     // `to` misses (trigger input has no `email`) — a real run would fail the


### PR DESCRIPTION
## Why the coverage lane was red on every PR
`flows::builder_tools::tests::dry_run_flags_tool_call_error_when_on_error_is_route` has **failed on clean `main`** since #4608 bumped vendored tinyflows to 0.5.1 — reddening **Rust Core Coverage → PR CI Gate** on every open PR (repeatedly waved off as "pre-existing").

## Root cause — a stale test, NOT an enforcement hole
tinyflows 0.5.1 (commit `a6860bc`) added a **correct** author-time rule: a node with `on_error:"route"` but **no outgoing edge on its `error` port** is rejected as an invalid graph (a route with nowhere to route is a dead end — tinyflows ships `rejects/accepts_on_error_route_without/with_error_edge` for it).

The test was written in #4586, *before* that rule, with an `on_error:"route"` node and **no** error-port edge. So `validate_and_migrate_graph` now rejects it up front and `DryRunWorkflowTool` maps the `Err` to `ToolResult::error` → the test's first `assert!(!result.is_error)` fails, never reaching the `ok`/`node_errors` assertions. **The enforcement is fine (better, even).**

## Fix (test-only)
Give the test graph a real error-port destination — a no-op `oh:noop` `recover` sink + a `from_port:"error"` edge (the same convention as the neighboring `dry_run_passes_when_tool_call_binds_to_upstream_tool_output`). The graph is now valid → the dry-run runs → the missing required `to` arg is detected as intended (`ok:false`, `node_errors:[post]`). **No production code changed.**

## Verification
`flows::` **369 pass** · `tinyflows::` 95 pass · `cargo check`/`fmt` clean. This gets the coverage/PR-CI gate green again for all open PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for routed error handling in dry-run flows.
  * Added a routed recovery path to validate behavior when a tool call sends errors to a follow-up step.
  * Clarified expected validation behavior for graphs that route errors without a valid outgoing error connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->