### PR TITLE
fix(flows): flip the workflow row ⋮ menu upward when it would clip at the bottom

### DIFF
--- a/app/src/components/flows/FlowRowMenu.tsx
+++ b/app/src/components/flows/FlowRowMenu.tsx
@@ -40,9 +40,23 @@ function KebabIcon() {
 export default function FlowRowMenu({ items, rowId }: FlowRowMenuProps) {
   const { t } = useT();
   const [open, setOpen] = useState(false);
+  const [dropUp, setDropUp] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
 
   useEscapeKey(() => setOpen(false), open);
+
+  // Toggle open; when opening, flip the menu upward if there isn't room below —
+  // otherwise the last row's downward menu gets clipped by the list card.
+  const toggle = useCallback(() => {
+    setOpen(prev => {
+      if (!prev && buttonRef.current) {
+        const rect = buttonRef.current.getBoundingClientRect();
+        setDropUp(window.innerHeight - rect.bottom < 200);
+      }
+      return !prev;
+    });
+  }, []);
 
   // Close on any click outside the menu container.
   useEffect(() => {
@@ -68,7 +82,8 @@ export default function FlowRowMenu({ items, rowId }: FlowRowMenuProps) {
         aria-expanded={open}
         aria-label={t('flows.list.moreActions')}
         title={t('flows.list.moreActions')}
-        onClick={() => setOpen(o => !o)}
+        ref={buttonRef}
+        onClick={toggle}
         className="flex h-8 w-8 items-center justify-center rounded-lg border border-line text-content-muted transition-colors hover:bg-surface-hover hover:text-content-secondary">
         <KebabIcon />
       </button>
@@ -77,7 +92,9 @@ export default function FlowRowMenu({ items, rowId }: FlowRowMenuProps) {
         <div
           role="menu"
           data-testid={`flow-menu-list-${rowId}`}
-          className="absolute right-0 z-20 mt-1 min-w-[10rem] overflow-hidden rounded-xl border border-line bg-surface py-1 shadow-lg">
+          className={`absolute right-0 z-20 min-w-[10rem] overflow-hidden rounded-xl border border-line bg-surface py-1 shadow-lg ${
+            dropUp ? 'bottom-full mb-1' : 'top-full mt-1'
+          }`}>
           {items.map(item => (
             <button
               key={item.key}

--- a/app/src/components/flows/FlowRowMenu.tsx
+++ b/app/src/components/flows/FlowRowMenu.tsx
@@ -4,10 +4,16 @@
  * actions (View runs, Run) stay uncluttered, and keeps the destructive Delete
  * out of the flat button row. Closes on Escape, outside click, or item select.
  *
+ * The menu is rendered in a portal with fixed positioning so it escapes the
+ * list card's `overflow-hidden` clipping — otherwise the last row's menu would
+ * be cut off by the card edge. It flips above the button when there isn't room
+ * below in the viewport.
+ *
  * Presentational + local open state only — each item calls back up to
  * `FlowListRow`, which routes to `FlowsPage`'s handlers.
  */
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import { useEscapeKey } from '../../hooks/useEscapeKey';
 import { useT } from '../../lib/i18n/I18nContext';
@@ -37,32 +43,54 @@ function KebabIcon() {
   );
 }
 
+const MENU_WIDTH = 160; // matches min-w-[10rem]
+
 export default function FlowRowMenu({ items, rowId }: FlowRowMenuProps) {
   const { t } = useT();
   const [open, setOpen] = useState(false);
-  const [dropUp, setDropUp] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
   const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
 
   useEscapeKey(() => setOpen(false), open);
 
-  // Toggle open; when opening, flip the menu upward if there isn't room below —
-  // otherwise the last row's downward menu gets clipped by the list card.
-  const toggle = useCallback(() => {
-    setOpen(prev => {
-      if (!prev && buttonRef.current) {
-        const rect = buttonRef.current.getBoundingClientRect();
-        setDropUp(window.innerHeight - rect.bottom < 200);
-      }
-      return !prev;
+  // Position the portaled menu in viewport coords so it escapes the list card's
+  // `overflow-hidden`. Flip above the button when there isn't room below.
+  const place = useCallback(() => {
+    const btn = buttonRef.current;
+    if (!btn) return;
+    const rect = btn.getBoundingClientRect();
+    const menuH = menuRef.current?.offsetHeight ?? 8 + items.length * 30;
+    const openAbove = rect.bottom + menuH + 8 > window.innerHeight && rect.top - menuH - 4 > 0;
+    setPos({
+      top: openAbove ? rect.top - menuH - 4 : rect.bottom + 4,
+      left: Math.max(8, rect.right - MENU_WIDTH),
     });
-  }, []);
+  }, [items.length]);
 
-  // Close on any click outside the menu container.
+  useLayoutEffect(() => {
+    if (open) place();
+  }, [open, place]);
+
+  // Reposition on scroll/resize while open.
+  useEffect(() => {
+    if (!open) return;
+    const reposition = () => place();
+    window.addEventListener('resize', reposition);
+    window.addEventListener('scroll', reposition, true);
+    return () => {
+      window.removeEventListener('resize', reposition);
+      window.removeEventListener('scroll', reposition, true);
+    };
+  }, [open, place]);
+
+  // Close on any click outside the button and the (portaled) menu.
   useEffect(() => {
     if (!open) return;
     const onPointerDown = (event: MouseEvent) => {
-      if (!containerRef.current?.contains(event.target as Node | null)) setOpen(false);
+      const target = event.target as Node | null;
+      if (buttonRef.current?.contains(target) || menuRef.current?.contains(target)) return;
+      setOpen(false);
     };
     document.addEventListener('mousedown', onPointerDown);
     return () => document.removeEventListener('mousedown', onPointerDown);
@@ -74,42 +102,49 @@ export default function FlowRowMenu({ items, rowId }: FlowRowMenuProps) {
   }, []);
 
   return (
-    <div className="relative" ref={containerRef}>
+    <>
       <button
+        ref={buttonRef}
         type="button"
         data-testid={`flow-menu-${rowId}`}
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label={t('flows.list.moreActions')}
         title={t('flows.list.moreActions')}
-        ref={buttonRef}
-        onClick={toggle}
+        onClick={() => setOpen(o => !o)}
         className="flex h-8 w-8 items-center justify-center rounded-lg border border-line text-content-muted transition-colors hover:bg-surface-hover hover:text-content-secondary">
         <KebabIcon />
       </button>
 
-      {open && (
-        <div
-          role="menu"
-          data-testid={`flow-menu-list-${rowId}`}
-          className={`absolute right-0 z-20 min-w-[10rem] overflow-hidden rounded-xl border border-line bg-surface py-1 shadow-lg ${
-            dropUp ? 'bottom-full mb-1' : 'top-full mt-1'
-          }`}>
-          {items.map(item => (
-            <button
-              key={item.key}
-              type="button"
-              role="menuitem"
-              data-testid={item.testId}
-              onClick={() => select(item.onSelect)}
-              className={`block w-full px-3 py-1.5 text-left text-xs transition-colors hover:bg-surface-hover ${
-                item.danger ? 'text-coral-600 dark:text-coral-400' : 'text-content-secondary'
-              }`}>
-              {item.label}
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
+      {open &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            data-testid={`flow-menu-list-${rowId}`}
+            style={{
+              position: 'fixed',
+              top: pos?.top ?? -9999,
+              left: pos?.left ?? -9999,
+              minWidth: '10rem',
+            }}
+            className="z-50 overflow-hidden rounded-xl border border-line bg-surface py-1 shadow-lg">
+            {items.map(item => (
+              <button
+                key={item.key}
+                type="button"
+                role="menuitem"
+                data-testid={item.testId}
+                onClick={() => select(item.onSelect)}
+                className={`block w-full px-3 py-1.5 text-left text-xs transition-colors hover:bg-surface-hover ${
+                  item.danger ? 'text-coral-600 dark:text-coral-400' : 'text-content-secondary'
+                }`}>
+                {item.label}
+              </button>
+            ))}
+          </div>,
+          document.body
+        )}
+    </>
   );
 }


### PR DESCRIPTION
## Bug
The `⋮` overflow menu on a Workflows list row (`FlowRowMenu`) was absolutely positioned and **always opened downward** (`mt-1`). For the **last row**, the menu extended past the list card and got **clipped** — Export/Duplicate/Delete were unreachable on the bottom workflow.

## Fix
On open, measure the kebab button's viewport position and **flip the menu upward** (`bottom-full mb-1`) when there's <200px of room below; otherwise open downward (`top-full mt-1`) as before. Keeps the menu fully visible regardless of the row's position.

typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the overflow menu so it opens in the direction with the most available space.
  * Prevents the menu from being cut off near the bottom of the screen, making it easier to access actions in crowded views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->