### PR TITLE
test(e2e): convert chat-harness-subagent to llmKeywordRules (#4517)

### DIFF
--- a/app/test/e2e/specs/chat-harness-subagent.spec.ts
+++ b/app/test/e2e/specs/chat-harness-subagent.spec.ts
@@ -10,12 +10,24 @@
  * to a sub-agent which runs the agent harness loop a level deeper —
  * which means the LLM gets hit at least once more for the sub-agent.
  *
+ * Scripting: `llmKeywordRules` (content-addressed, never depleted).
+ * A prior version of this spec used the `llmForcedResponses` FIFO but
+ * that queue drains one entry per `/chat/completions` regardless of who
+ * called (#4517): the sub-agent's own harness loop plus any ancillary
+ * summarisation/memory-prep call shifts responses out of order and the
+ * scripted final canary lands on the wrong turn (or never renders).
+ * Keyword rules route each call by a substring of its latest
+ * user/tool message, so extra calls that don't match any rule fall
+ * through to the mock's dynamic default — the scripted turns are never
+ * consumed by an off-turn caller.
+ *
  * What this spec scripts and verifies:
  *
- *   1. Configure `llmForcedResponses` with THREE responses in order:
- *        A) orchestrator turn — emits `research` tool_call
- *        B) researcher turn   — answers with a plain text finding
- *        C) orchestrator turn — final synthesis text (canary marker)
+ *   1. Configure `llmKeywordRules` with three rules keyed on
+ *      per-turn-unique tokens:
+ *        A) orchestrator turn (user PROMPT)   — emits `research` tool_call
+ *        B) researcher turn (delegate prompt) — plain text finding
+ *        C) orchestrator turn (tool result)   — final synthesis (canary)
  *
  *   2. Send the user prompt and watch the runtime:
  *        UI:
@@ -52,27 +64,41 @@ import { navigateViaHash } from '../helpers/shared-flows';
 import { getRequestLog, setMockBehavior, startMockServer, stopMockServer } from '../mock-server';
 
 const USER_ID = 'e2e-chat-harness-subagent';
-const PROMPT = 'Research the answer to life and tell me a marker phrase.';
+// Per-turn tokens chosen so pickProbeText's substring match routes each
+// call to exactly one rule regardless of any extra ancillary
+// tool/context/summary call the harness may issue on top of the three
+// happy-path turns.
+const PROMPT = 'Please delegate a llama-research task and return the marker.';
+const DELEGATE_PROMPT = 'Return the coded marker phrase.';
+const RESEARCHER_REPLY = 'The researcher trace signal is FORTY-TWO.';
 const CANARY_FINAL = 'subagent-canary-final-7afe2';
-const RESEARCHER_REPLY = 'The researcher answer is 42.';
 
-// Three forced responses, popped in order by the mock LLM streamer.
-const FORCED_RESPONSES = [
-  // 1. Orchestrator: emit a research tool call.
+// Content-addressed keyword rules — never depleted, immune to extra
+// ancillary /chat/completions calls (#4517).
+const KEYWORD_RULES = [
+  // Sub-agent turn — dispatch_subagent renders the arg as "Task:\n<arg>"
+  // (archetype_delegation.rs render_structured_handoff), so DELEGATE_PROMPT
+  // surfaces verbatim in the researcher's user message.
+  { keyword: 'coded marker phrase', content: RESEARCHER_REPLY },
+  // Orchestrator's post-delegation turn — the sub-agent's output is handed
+  // back as the `role: tool` message content
+  // (dispatch.rs `ToolResult::success(outcome.output)`).
+  { keyword: 'researcher trace signal', content: `Done. The result is: ${CANARY_FINAL}` },
+  // Orchestrator's initial turn — the fire-and-forget thread-title-gen
+  // call (threadSlice.ts, tools: None) sees the same probe, but
+  // chat_with_system consumes `content` and ignores unexpected tool_calls,
+  // so a delegation-triggering rule here is safe for both callers.
   {
-    content: '',
+    keyword: 'llama-research',
+    content: 'Delegating to researcher.',
     toolCalls: [
       {
         id: 'call_research_1',
         name: 'research',
-        arguments: JSON.stringify({ prompt: 'Tell me a marker phrase' }),
+        arguments: JSON.stringify({ prompt: DELEGATE_PROMPT }),
       },
     ],
   },
-  // 2. Researcher sub-agent: produces a text answer.
-  { content: RESEARCHER_REPLY },
-  // 3. Orchestrator final synthesis containing the canary.
-  { content: `Done. The result is: ${CANARY_FINAL}` },
 ];
 
 interface RuntimeSnapshot {
@@ -132,14 +158,14 @@ describe('Chat harness — orchestrator → subagent flow', () => {
       '[chat-harness-subagent] Disabled super context for deterministic scripted LLM calls'
     );
 
-    setMockBehavior('llmForcedResponses', JSON.stringify(FORCED_RESPONSES));
+    setMockBehavior('llmKeywordRules', JSON.stringify(KEYWORD_RULES));
     // Faster streaming for non-tool-call responses so this spec doesn't
     // need 30s of patience for three full streams.
     setMockBehavior('llmStreamChunkDelayMs', '10');
   });
 
   after(async () => {
-    setMockBehavior('llmForcedResponses', '');
+    setMockBehavior('llmKeywordRules', '');
     setMockBehavior('llmStreamChunkDelayMs', '');
     await stopMockServer();
   });


### PR DESCRIPTION
## Summary

- Convert `chat-harness-subagent.spec.ts` from the shared `llmForcedResponses` FIFO to `llmKeywordRules` — content-addressed, never depleted.
- Rename per-turn tokens (`llama-research` / `coded marker phrase` / `researcher trace signal`) so each of the 3 turns routes to exactly one rule via `pickProbeText`'s substring match.
- No product/runtime change; E2E-mock fixture only.

## Problem

Follow-up to #4519 for #4517. #4519 stopped the fire-and-forget thread-title-gen call (`chat_with_system`, `tools: None`) from draining the FIFO queue, but the orchestrator→researcher fan-out spec was left as its own known follow-up (see #4519 body: *"the genuinely multi-agent spec `chat-harness-subagent` (orchestrator→researcher) additionally needs its `FORCED_RESPONSES` to cover the sub-agent's own model calls (or convert to `llmKeywordRules`, which are content-addressed and never shifted)"*).

The residual failure mechanism: the delegated researcher runs its own agent-harness loop, so the mock's global FIFO can still be shifted by an off-turn call. The scripted final canary then lands on the wrong turn (or never renders). Keyword rules are matched by a case-insensitive substring of the latest user/tool message per call and are never consumed, so any extra ancillary call that doesn't match a rule falls through to the mock's dynamic default and leaves the scripted turns intact.

## Solution

`app/test/e2e/specs/chat-harness-subagent.spec.ts`:

- Swap `llmForcedResponses` → `llmKeywordRules` in the `before`/`after` hooks.
- Three content-addressed rules keyed on tokens that are disjoint across the three probe surfaces:

| Turn                        | Probe (latest user/tool msg)                                                                                                                | Keyword                    |
| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
| Orchestrator turn 1         | user `PROMPT` = *"Please delegate a llama-research task and return the marker."*                                                            | `llama-research`           |
| Sub-agent (researcher)      | `"Task:\n" + DELEGATE_PROMPT` (rendered by `render_structured_handoff` in `src/openhuman/agent_orchestration/tools/archetype_delegation.rs`) | `coded marker phrase`      |
| Orchestrator turn 2 (final) | `role: tool` msg content = `RESEARCHER_REPLY` (via `ToolResult::success(outcome.output)` in `src/openhuman/agent_orchestration/tools/dispatch.rs`) | `researcher trace signal` |

The title-gen call from `app/src/store/threadSlice.ts` shares the turn-1 probe; it matches the `llama-research` rule and gets both `content` and `tool_calls` back. `chat_with_system` (no tools) consumes `content` (`"Delegating to researcher."`) as the title and ignores unexpected `tool_calls` — benign for both callers.

**Validated against the mock in isolation** (in-process, non-stream and stream): each of the three turn shapes routes to its intended rule and returns the expected content/tool_calls; the final canary lands as the turn-2 response.

## Submission Checklist

- [x] Tests added or updated — this PR *is* the E2E fixture correction; the happy path (single-turn tool-round → final canary) is exercised by the existing 3 `it` blocks (canary in DOM, IN_FLIGHT drains after `chat_done`, persisted thread JSONL contains the canary); failure-path signal is preserved via `expect(content).toContain(CANARY_FINAL)` and the ≥2 mock-hit count check.
- [x] **Diff coverage ≥ 80%** — N/A: change is E2E test-fixture TS in `app/test/e2e/specs/`, no product `src` lines under coverage.
- [x] Coverage matrix updated — N/A: test-infra only, no feature IDs change.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no feature IDs affected.
- [x] No new external network dependencies introduced — mock backend only.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: does not touch release-cut UX.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: this PR only fixes one of the two specs #4517 tracks; leaving the issue open for the sibling `chat-harness-subagent-continue.spec.ts` follow-up (details below).

## Impact

- E2E mock only. Deterministically fixes the orchestrator→researcher fan-out spec (`chat-harness-subagent.spec.ts`) that #4519 flagged as still-failing after its own mock-side gating landed. No runtime, product, or platform behavior change.

## Related

- Refs #4517 (does **not** close — see follow-up below).
- Follows #4519 (the FIFO gating for ancillary no-tools calls that fixed the single-turn specs).
- Follow-up PR(s)/TODOs: `chat-harness-subagent-continue.spec.ts` shares the same FIFO pattern *and* has an unresolved `{{DYNAMIC_TASK_ID}}` literal placeholder in the scripted `continue_subagent` tool-call args (spec line 86). Converting it to keyword rules alone won't make it pass — `continue_subagent` needs a real `task_id: sub-<uuid>` from the last `[SUBAGENT_AWAITING_USER]` envelope. Options for a follow-up: extend the mock to substitute template placeholders from a message-history parse, or rework the spec to drive the resume via a different mechanism.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/4517-harness-subagent-keyword-rules`
- Commit SHA: `0308a6cd1`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — prettier ✓ (spec re-formatted; no other files touched)
- [x] `pnpm typecheck` — `tsc --noEmit` on `app/tsconfig.json` ✓ 0 errors
- [x] Focused tests: in-process mock probe (non-stream + streaming) for all three turn probes and the title-gen collision — see the *Solution* section above
- [x] Rust fmt/check (if changed): N/A — no Rust changes
- [x] Tauri fmt/check (if changed): N/A — no Tauri changes

### Validation Blocked

- `command:` `pnpm debug e2e app/test/e2e/specs/chat-harness-subagent.spec.ts`
- `error:` Full WDIO/CEF chain needs a built Tauri bundle + Appium XCUITest (macOS) or `tauri-driver` (Linux); not runnable in this session's environment.
- `impact:` Runtime side of the fix (real agent harness making the /chat/completions calls) will be exercised by Release CI on this PR; in-process mock probes above prove the routing side.

### Behavior Changes

- Intended behavior change: none in shipped product; corrects an E2E fixture that was still red after #4519.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: yes — the three `it` assertions (canary in DOM, `IN_FLIGHT` drains, thread JSONL persists canary) are unchanged; only the scripting mechanism swaps FIFO → content-addressed rules.
- Guard/fallback/dispatch parity checks: the mock's `defaultStreamScript` handles `{content, toolCalls}` identically whether it came from the FIFO or from a keyword rule (`scripts/mock-api/routes/llm.mjs:249-253` and `:264-268`); the non-stream path likewise (`:622-639` vs `:642-668`).

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated chat flow coverage to better simulate multi-step assistant handoffs.
  * Improved test reliability by matching scripted responses to specific conversation content instead of relying on response order.
  * Kept existing checks for subagent activity, final output, and workspace persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->