### PR TITLE
fix(tracing): link spawned sub-agent Langfuse traces to their parent turn

### DIFF
--- a/src/openhuman/agent/progress_tracing.rs
+++ b/src/openhuman/agent/progress_tracing.rs
@@ -148,6 +148,17 @@ pub struct TraceContext {
     /// Kind of run — exported as Langfuse trace tags (`run:<type>`) and the
     /// `run_type` metadata key. Defaults to interactive chat.
     pub run_type: RunType,
+    /// This run's own id (the tinyagents `RunContext` run id), exported as the
+    /// `run_id` metadata key. `None` until the run's observations are known.
+    pub run_id: Option<String>,
+    /// The spawning run's id when this run is a sub-agent/graph node, exported
+    /// as the `parent_run_id` metadata key. `None` for top-level turns. This is
+    /// what links a spawned sub-agent's trace back to its parent turn (#4657).
+    pub parent_run_id: Option<String>,
+    /// The root ancestor run id (equal to [`Self::run_id`] for top-level runs),
+    /// exported as the `root_run_id` metadata key so Langfuse can thread a whole
+    /// spawn tree under one root.
+    pub root_run_id: Option<String>,
 }
 
 impl TraceContext {
@@ -161,6 +172,9 @@ impl TraceContext {
             session_group: None,
             capture_content: false,
             run_type: RunType::default(),
+            run_id: None,
+            parent_run_id: None,
+            root_run_id: None,
         }
     }
 
@@ -198,6 +212,22 @@ impl TraceContext {
     /// Set the run type (Langfuse `run:<type>` tag / `run_type` metadata).
     pub fn with_run_type(mut self, run_type: RunType) -> Self {
         self.run_type = run_type;
+        self
+    }
+
+    /// Stamp the run lineage (`run_id` / `parent_run_id` / `root_run_id`) so a
+    /// spawned sub-agent's trace links back to its parent turn (#4657). The ids
+    /// come from the tinyagents `RunContext`, surfaced via the run's journalled
+    /// observations at export time.
+    pub fn with_run_lineage(
+        mut self,
+        run_id: Option<String>,
+        parent_run_id: Option<String>,
+        root_run_id: Option<String>,
+    ) -> Self {
+        self.run_id = run_id;
+        self.parent_run_id = parent_run_id;
+        self.root_run_id = root_run_id;
         self
     }
 }

--- a/src/openhuman/agent/progress_tracing/langfuse.rs
+++ b/src/openhuman/agent/progress_tracing/langfuse.rs
@@ -313,6 +313,31 @@ fn new_event_id() -> String {
     uuid::Uuid::new_v4().to_string()
 }
 
+/// Enrich `trace_ctx` with the run lineage (`run_id` / `parent_run_id` /
+/// `root_run_id`) carried by the run's journalled `observations` (#4657).
+///
+/// A single export corresponds to one run's observation stream (the journal is
+/// read per run id), so every observation shares the same lineage and the first
+/// is representative. For a spawned sub-agent that lineage points back at the
+/// spawning turn, which is exactly what links the sub-agent's trace to its
+/// parent. Returns the context unchanged when there are no observations.
+fn trace_ctx_with_run_lineage(
+    trace_ctx: &TraceContext,
+    observations: &[AgentObservation],
+) -> TraceContext {
+    let Some(first) = observations.first() else {
+        return trace_ctx.clone();
+    };
+    trace_ctx.clone().with_run_lineage(
+        Some(first.run_id.as_str().to_string()),
+        first
+            .parent_run_id
+            .as_ref()
+            .map(|id| id.as_str().to_string()),
+        Some(first.root_run_id.as_str().to_string()),
+    )
+}
+
 fn trace_config_from_context(trace_ctx: &TraceContext, environment: &str) -> LangfuseTraceConfig {
     let mut metadata = Map::new();
     if let Some(client_id) = &trace_ctx.client_id {
@@ -326,6 +351,18 @@ fn trace_config_from_context(trace_ctx: &TraceContext, environment: &str) -> Lan
     }
     metadata.insert("run_type".into(), json!(trace_ctx.run_type.as_str()));
     metadata.insert("app.version".into(), json!(env!("CARGO_PKG_VERSION")));
+    // Run lineage (#4657): stamp the run/parent/root ids so a spawned sub-agent's
+    // trace is navigable from — and threadable under — its parent turn. Omitted
+    // keys (e.g. `parent_run_id` for a top-level turn) simply stay absent.
+    if let Some(run_id) = &trace_ctx.run_id {
+        metadata.insert("run_id".into(), json!(run_id));
+    }
+    if let Some(parent_run_id) = &trace_ctx.parent_run_id {
+        metadata.insert("parent_run_id".into(), json!(parent_run_id));
+    }
+    if let Some(root_run_id) = &trace_ctx.root_run_id {
+        metadata.insert("root_run_id".into(), json!(root_run_id));
+    }
 
     let mut tags = vec![format!("run:{}", trace_ctx.run_type.as_str())];
     if let Some(source) = &trace_ctx.channel_source {
@@ -481,9 +518,12 @@ pub(crate) async fn push_observations(
     }
     let token = require_live_session_token(config)?;
     let environment = environment_for_base(&url);
-    let trace = trace_config_from_context(trace_ctx, environment);
+    // Stamp the run lineage from the run's own observations so a spawned
+    // sub-agent's trace links back to its parent turn (#4657).
+    let trace_ctx = trace_ctx_with_run_lineage(trace_ctx, observations);
+    let trace = trace_config_from_context(&trace_ctx, environment);
     let observation_count = observations.len();
-    let observations = observations_for_export(trace_ctx, observations);
+    let observations = observations_for_export(&trace_ctx, observations);
 
     tracing::debug!(
         target: LOG_TARGET,
@@ -680,6 +720,73 @@ mod tests {
         assert_eq!(trace.metadata["channel.source"], "chat");
         assert_eq!(trace.metadata["run_type"], "interactive_chat");
         assert_eq!(trace.metadata["app.version"], env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn trace_config_from_context_stamps_run_lineage() {
+        // A spawned sub-agent: its run has a parent (the spawning turn) and a
+        // root. Stamping these onto trace metadata is what links the sub-agent's
+        // Langfuse trace back to the parent turn (#4657).
+        let ctx = TraceContext::new("trace:req-1", None).with_run_lineage(
+            Some("sub-run".to_string()),
+            Some("parent-run".to_string()),
+            Some("root-run".to_string()),
+        );
+        let trace = trace_config_from_context(&ctx, "staging");
+        assert_eq!(trace.metadata["run_id"], "sub-run");
+        assert_eq!(trace.metadata["parent_run_id"], "parent-run");
+        assert_eq!(trace.metadata["root_run_id"], "root-run");
+    }
+
+    #[test]
+    fn trace_config_omits_parent_run_id_for_top_level_turn() {
+        // A top-level turn has no parent; the key must stay absent (root == run).
+        let ctx = TraceContext::new("trace:req-1", None).with_run_lineage(
+            Some("run-1".to_string()),
+            None,
+            Some("run-1".to_string()),
+        );
+        let trace = trace_config_from_context(&ctx, "staging");
+        assert_eq!(trace.metadata["run_id"], "run-1");
+        assert_eq!(trace.metadata["root_run_id"], "run-1");
+        assert!(
+            trace.metadata.get("parent_run_id").is_none(),
+            "top-level turn must not carry a parent_run_id"
+        );
+    }
+
+    #[test]
+    fn trace_ctx_with_run_lineage_derives_from_subagent_observations() {
+        // Sub-agent observations carry parent/root ids pointing at the spawning
+        // turn; the derived trace context stamps them so the sub-agent's trace
+        // links back instead of landing as a disconnected sibling (#4657).
+        let observations = vec![AgentObservation {
+            event_id: EventId::new("evt-1"),
+            run_id: RunId::new("sub-run"),
+            parent_run_id: Some(RunId::new("parent-run")),
+            root_run_id: RunId::new("root-run"),
+            offset: 1,
+            ts_ms: 1_000,
+            event: AgentEvent::ModelCompleted {
+                call_id: CallId::new("model-1"),
+                started_at_ms: Some(1_000),
+                usage: Some(Usage::new(1, 1)),
+                input: None,
+                output: None,
+            },
+        }];
+        let base = TraceContext::new("trace:req-1", None);
+
+        let enriched = trace_ctx_with_run_lineage(&base, &observations);
+        assert_eq!(enriched.run_id.as_deref(), Some("sub-run"));
+        assert_eq!(enriched.parent_run_id.as_deref(), Some("parent-run"));
+        assert_eq!(enriched.root_run_id.as_deref(), Some("root-run"));
+
+        // An empty stream leaves the context untouched (no lineage invented).
+        let untouched = trace_ctx_with_run_lineage(&base, &[]);
+        assert!(untouched.run_id.is_none());
+        assert!(untouched.parent_run_id.is_none());
+        assert!(untouched.root_run_id.is_none());
     }
 
     #[test]


### PR DESCRIPTION
A spawned sub-agent's real work landed as a **separate** Langfuse trace (e.g. `…:bgdeliver-…`) whose metadata had `run_id`/`parent_run_id`/`root_run_id` all null, so it was not linked to the parent turn — you couldn't navigate from the opaque spawn span to the sub-agent's detail.

**Root cause:** trace metadata is built from `TraceContext`, which carried no run-lineage fields, so `trace_config_from_context` never emitted them. But every journalled `AgentObservation` already carries the tinyagents `RunContext` lineage, and a single `push_observations` export is exactly one run's observation stream.

**Fix:** add `run_id`/`parent_run_id`/`root_run_id` to `TraceContext`; at journal export derive the lineage from the run's own observations (`trace_ctx_with_run_lineage`) and stamp it into the trace metadata. Sub-agent traces now point back at the spawning turn (`parent_run_id`/`root_run_id`), so Langfuse can thread them as a trace tree. Top-level turns get `run_id` with no parent. Added unit tests for the stamping + derivation.

Note: `cargo check --lib` can't complete in this environment (pre-existing `whisper-rs-sys` C++ build failure, unrelated); change verified statically.

Closes #4657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added run lineage metadata to traces, helping connect related sub-agent activity back to its parent and overall root run.
  * Trace details now include identifiers for the current run, parent run, and root run when available.

* **Bug Fixes**
  * Improved trace metadata propagation so lineage information is preserved for spawned sub-traces.
  * Top-level runs now avoid setting parent lineage when none exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->