### PR TITLE
orchestrator: batch independent memory lookups into one parallel fan-out

### DIFF
--- a/src/openhuman/agent_registry/agents/orchestrator/prompt.md
+++ b/src/openhuman/agent_registry/agents/orchestrator/prompt.md
@@ -192,6 +192,10 @@ User: what time is it?
 
 `retrieve_memory` walks the user's **already-ingested** email/chat/document history. It is historical, not a live API. Use it when the user asks about prior context, and cite retrieved facts with source refs. If the user asks what is in an inbox, calendar, doc, ticket, or connected service *right now*, delegate to the live integration instead.
 
+### Batch independent memory lookups
+
+Each `retrieve_memory` call runs a memory sub-agent (~30s), and calls made in separate turns run strictly one-after-another. So when a single request needs **several independent** lookups — e.g. different facets of the user for a bio, profile, or summary — do **not** fire `retrieve_memory` one at a time across turns; four serial lookups stack to ~140s. Instead batch them into **one** `spawn_parallel_agents` call with one `agent_memory` task per facet (up to `max_parallel_tools`). They run concurrently and return together in about the time of the slowest (~40s), and you synthesize from the collected results. Fall back to a single `retrieve_memory` only when there is genuinely one lookup, or when a later query's phrasing depends on an earlier result.
+
 ## Citations
 
 When your answer is informed by retrieved memory, cite it with footnote markers:


### PR DESCRIPTION
## Problem
Independent `retrieve_memory` lookups ran strictly sequentially (~141s for four in the referenced trace, zero overlap). Root cause is behavioral: the orchestrator issues them one per model iteration (the trace shows a ~4s model-decision gap between each call).

## Why not "just emit multiple calls in one turn"
That wouldn't help here. openhuman registers tool-wrap middleware, and the tinyagents loop only takes its concurrent multi-tool path when `tool_middleware_len() == 0` (`agent_loop/tools.rs:101`) — so multi-tool turns always serialize, and `is_concurrency_safe` is advisory-only today. A true harness parallel-dispatch is a larger refactor.

## Fix (minimal, uses existing infra)
`spawn_parallel_agents` already runs independent sub-agent tasks concurrently and returns their results inline as a single tool call — bypassing the serial constraint. `agent_memory` is already in the orchestrator's subagent allowlist and `spawn_parallel_agents` is already in its toolset; `max_parallel_tools` defaults to 4. This PR adds the missing prompt guidance so the orchestrator batches several independent memory needs into one `spawn_parallel_agents` fan-out (one `agent_memory` task per facet) instead of sequential `retrieve_memory` calls, with a carve-out for single/dependent lookups. Four ~30s lookups then finish in ~40s.

Prompt-only change (no code paths altered).

Closes #4680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for handling multiple independent memory lookups more efficiently.
  * Clarified when to group lookups together and when a single lookup is still the better option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->