### PR TITLE
spawn_parallel_agents: opt out of the 120s per-tool timeout so the fan-out isn't truncated

### DIFF
--- a/src/openhuman/agent_orchestration/tools/spawn_parallel_agents.rs
+++ b/src/openhuman/agent_orchestration/tools/spawn_parallel_agents.rs
@@ -14,7 +14,9 @@ use crate::openhuman::agent_orchestration::spawn_parallel_graph::{
     SpawnParallelGraphOutcome, SpawnParallelTaskValidationError,
 };
 use crate::openhuman::tinyagents::current_run_cancellation;
-use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, ToolResult};
+use crate::openhuman::tools::traits::{
+    PermissionLevel, Tool, ToolCallOptions, ToolResult, ToolTimeout,
+};
 use async_trait::async_trait;
 use serde_json::json;
 use tinyagents::harness::tool::ToolExecutionContext;
@@ -93,6 +95,20 @@ impl Tool for SpawnParallelAgentsTool {
 
     fn permission_level(&self) -> PermissionLevel {
         PermissionLevel::Execute
+    }
+
+    /// Run **without** the global per-tool wall-clock deadline. This is a
+    /// fan-out primitive: it spawns N independent sub-agents and awaits them
+    /// concurrently via `spawn_parallel_graph`'s bounded `map_reduce`. Under the
+    /// default `Inherit` policy the whole fan-out is hard-killed at the
+    /// single-tool timeout (120s by default) — so a group of long workers is
+    /// truncated at one worker's budget instead of running to ~the slowest, and
+    /// each worker's research is cut short. The fan-out is already bounded
+    /// internally — by `max_concurrency`, the run cancellation token, and each
+    /// sub-agent's own iteration/turn caps — so it governs its own lifetime,
+    /// like the long-running scripting tools (`shell`, `node_exec`).
+    fn timeout_policy(&self, _args: &serde_json::Value) -> ToolTimeout {
+        ToolTimeout::Unbounded
     }
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {

--- a/src/openhuman/agent_orchestration/tools/spawn_parallel_agents_tests.rs
+++ b/src/openhuman/agent_orchestration/tools/spawn_parallel_agents_tests.rs
@@ -16,6 +16,7 @@ use crate::openhuman::inference::provider::{
     ChatRequest, ChatResponse, ConversationMessage, Provider, ToolCall,
 };
 use crate::openhuman::memory::{Memory, MemoryCategory, MemoryEntry, NamespaceSummary, RecallOpts};
+use crate::openhuman::tools::traits::ToolTimeout;
 use crate::openhuman::tools::{PermissionLevel, Tool, ToolResult};
 use async_trait::async_trait;
 use parking_lot::Mutex;
@@ -897,5 +898,17 @@ async fn agent_turn_runs_long_parallel_subagent_flow_with_many_nested_tool_calls
         iterations,
         vec![4, 4],
         "each subagent should run three tool calls plus a final completion iteration"
+    );
+}
+
+#[test]
+fn spawn_parallel_agents_opts_out_of_the_global_tool_timeout() {
+    // A fan-out of N long sub-agents must not be hard-killed at the single-tool
+    // wall-clock default (120s): that truncates every worker and bounds the whole
+    // group at one worker's budget. The tool governs its own lifetime via its
+    // internal max_concurrency, cancellation token, and per-sub-agent caps.
+    assert_eq!(
+        SpawnParallelAgentsTool::new().timeout_policy(&json!({})),
+        ToolTimeout::Unbounded,
     );
 }


### PR DESCRIPTION
## Bug #2 — 120s truncation (root-caused + fixed here)
Every OpenHuman tool is wrapped in `tokio::time::timeout(deadline, exec)` (`tinyagents/tools.rs`), where `deadline` for the default `ToolTimeout::Inherit` is the global per-tool wall-clock (`tool_timeout` `DEFAULT_TIMEOUT_SECS = 120`). `SpawnParallelAgentsTool` never overrode `timeout_policy`, so the **entire fan-out was hard-killed at 120s** — the parent span's exact 120.000s — truncating every worker and bounding the group at one worker's budget instead of ~the slowest.

**Fix:** override `timeout_policy` → `ToolTimeout::Unbounded`, matching the long-running scripting tools (`shell`, `node_exec`, `rhai_workflows`). The fan-out is already bounded internally — by its `max_concurrency`, the run cancellation token, and each sub-agent's own iteration/turn caps — so it governs its own lifetime rather than the single-tool default. Adds a unit test.

## Bug #1 — serialization (investigated; not an OpenHuman fan-out bug)
The fan-out **already runs concurrently**: `run_spawn_parallel_workers` calls `tinyagents::graph::parallel::map_reduce` with `max_concurrency = prepared.len()` over `buffer_unordered` (concurrent since #4249). The serial fallback only triggers for shared-workspace **write** workers — read-only research never hits it; `run_queue` is `None`; and the managed (OpenAI-compatible) provider has no client-side concurrency semaphore. So OpenHuman does not request serial execution. The observed strict serialization isn't reproducible from any OpenHuman fan-out line — the likely causes are the 120s parent-timeout aborting the concurrent fan-out (removed by this PR) or server-side per-token serialization in the managed backend. I deliberately avoided a speculative concurrency change since concurrency is already `max_concurrency=N`.

## Note / follow-up
Each worker's *own* model call and inner tools still inherit the global 120s (`tool_timeout` + inference `request_timeout`). Making those higher or research-tier-configurable is a separate global-config/design decision, flagged rather than bundled here.

Prompt-independent from #4680 (that fix was orchestrator-prompt-only and does not touch this execution path).

Closes #4685

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for parallel agent spawning by allowing this operation to run without the standard per-tool time limit, reducing unexpected timeouts during larger fan-out tasks.

* **Tests**
  * Added coverage to verify the parallel agent spawning behavior is not constrained by the global tool timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->