### PR TITLE
fix(connections): drop account from state before purge so disconnect can't resurrect its webview

### DIFF
--- a/app/src/components/layout/shell/SidebarAppRail.test.tsx
+++ b/app/src/components/layout/shell/SidebarAppRail.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { purgeWebviewAccount } from '../../../services/webviewAccountService';
 import SidebarAppRail from './SidebarAppRail';
 
 const mockNavigate = vi.fn();
@@ -95,6 +96,34 @@ describe('SidebarAppRail', () => {
     const addButton = screen.getByTestId('accounts-add-button');
     expect(addButton).not.toHaveTextContent('accounts.addApps');
     expect(addButton).toHaveAttribute('aria-label', 'accounts.addApps');
+  });
+
+  it('drops the account from state synchronously on disconnect, before the async purge (#4695)', () => {
+    setAccounts(['acct-whatsapp']);
+    // Hold the purge pending so we can prove `removeAccount` was dispatched
+    // *before* the purge (which triggers the app re-mount) resolves. The old
+    // order (await purge → removeAccount) let the re-mount re-open the
+    // just-purged webview because the account was still in the store.
+    let resolvePurge: () => void = () => {};
+    vi.mocked(purgeWebviewAccount).mockReturnValue(
+      new Promise<void>(res => {
+        resolvePurge = res;
+      })
+    );
+
+    renderRail('/chat');
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'WhatsApp' }));
+    fireEvent.click(screen.getByText('accounts.disconnect'));
+
+    // removeAccount is dispatched while the purge is still pending.
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'accounts/removeAccount',
+      payload: { accountId: 'acct-whatsapp' },
+    });
+    expect(purgeWebviewAccount).toHaveBeenCalledWith('acct-whatsapp');
+
+    resolvePurge();
   });
 });
 

--- a/app/src/components/layout/shell/SidebarAppRail.test.tsx
+++ b/app/src/components/layout/shell/SidebarAppRail.test.tsx
@@ -125,6 +125,29 @@ describe('SidebarAppRail', () => {
 
     resolvePurge();
   });
+
+  it('still drops the account and swallows the error when the purge rejects (#4695)', async () => {
+    setAccounts(['acct-whatsapp']);
+    // A purge failure must not leave the user with a zombie icon: the account is
+    // already removed from state before the await, and the rejection is caught
+    // and logged (not surfaced) so the disconnect handler resolves cleanly.
+    vi.mocked(purgeWebviewAccount).mockRejectedValue(new Error('purge failed'));
+
+    renderRail('/chat');
+
+    fireEvent.contextMenu(screen.getByRole('button', { name: 'WhatsApp' }));
+    fireEvent.click(screen.getByText('accounts.disconnect'));
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'accounts/removeAccount',
+      payload: { accountId: 'acct-whatsapp' },
+    });
+    expect(purgeWebviewAccount).toHaveBeenCalledWith('acct-whatsapp');
+
+    // Flush microtasks so the awaited purge rejection reaches the handler's
+    // catch (which logs and swallows it) — the disconnect must not throw.
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
 });
 
 function renderRail(route: string) {

--- a/app/src/components/layout/shell/SidebarAppRail.tsx
+++ b/app/src/components/layout/shell/SidebarAppRail.tsx
@@ -196,14 +196,23 @@ export default function SidebarAppRail() {
         account_status: account.status ?? 'unknown',
       });
     }
+    // Drop the account from state FIRST, synchronously, before the async purge
+    // (#4695). `purgeWebviewAccount` tears down the provider's backend scanners,
+    // which triggers a full app-state re-fetch and UI re-mount. If the account
+    // were still in the store at that moment, the re-mount would remount
+    // `WebviewHost` for it and re-open (reveal) the just-purged provider webview
+    // — a fresh, logged-out CEF child-view pinned over the content area,
+    // swallowing all input. Removing it first unmounts the host (whose cleanup
+    // hides the child-view) and guarantees no re-open ever targets a
+    // disconnected account.
+    dispatch(removeAccount({ accountId }));
     try {
       await purgeWebviewAccount(accountId);
     } catch {
-      // Purge failures are already logged by the service; still drop the
-      // account from the UI so the user isn't stuck with a zombie icon.
-      debug('purge failed for %s — dropping from UI anyway', accountId);
+      // Purge failures are already logged by the service; the account is
+      // already gone from the UI so the user isn't stuck with a zombie icon.
+      debug('purge failed for %s — already dropped from UI', accountId);
     }
-    dispatch(removeAccount({ accountId }));
   };
 
   // Close the context menu on Escape or any outside click.

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -205,7 +205,8 @@ const messages: TranslationMap = {
   'orchPage.discover.notDiscoverableGuide':
     'Registriere ein @handle, damit andere Agenten dich finden und dir schreiben können.',
   'orchPage.discover.linkTitle': 'Neuen Agenten verknüpfen',
-  'orchPage.discover.linkDescription': 'Füge eine Agenten-ID ein, um eine Verbindungsanfrage zu senden.',
+  'orchPage.discover.linkDescription':
+    'Füge eine Agenten-ID ein, um eine Verbindungsanfrage zu senden.',
   'orchPage.discover.noRequests': 'Keine eingehenden Anfragen.',
   'orchPage.usage.nav': 'Nutzung',
   'orchPage.usage.connections': 'Verbindungen',

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -202,7 +202,8 @@ const messages: TranslationMap = {
   'orchPage.discover.notDiscoverableGuide':
     'Registra un @handle para que otros agentes puedan encontrarte y escribirte.',
   'orchPage.discover.linkTitle': 'Vincular un nuevo agente',
-  'orchPage.discover.linkDescription': 'Pega un ID de agente para enviar una solicitud de conexión.',
+  'orchPage.discover.linkDescription':
+    'Pega un ID de agente para enviar una solicitud de conexión.',
   'orchPage.discover.noRequests': 'No hay solicitudes entrantes.',
   'orchPage.usage.nav': 'Uso',
   'orchPage.usage.connections': 'Conexiones',

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -190,7 +190,8 @@ const messages: TranslationMap = {
   'orchPage.agent.description': "Discutez avec l'agent principal et observez son subconscient",
   'orchPage.connections.nav': 'Connexions',
   'orchPage.connections.title': 'Agents liés',
-  'orchPage.connections.description': 'Pairs avec lesquels votre agent principal peut se coordonner',
+  'orchPage.connections.description':
+    'Pairs avec lesquels votre agent principal peut se coordonner',
   'orchPage.connections.empty': 'Aucune connexion pour le moment.',
   'orchPage.connections.emptyCta': 'Ajouter une connexion',
   'orchPage.connections.statContacts': 'Connexions',
@@ -202,7 +203,8 @@ const messages: TranslationMap = {
   'orchPage.discover.notDiscoverableGuide':
     "Enregistrez un @handle pour que d'autres agents puissent vous trouver et vous écrire.",
   'orchPage.discover.linkTitle': 'Lier un nouvel agent',
-  'orchPage.discover.linkDescription': "Collez un ID d'agent pour envoyer une demande de connexion.",
+  'orchPage.discover.linkDescription':
+    "Collez un ID d'agent pour envoyer une demande de connexion.",
   'orchPage.discover.noRequests': 'Aucune demande entrante.',
   'orchPage.usage.nav': 'Utilisation',
   'orchPage.usage.connections': 'Connexions',

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -202,7 +202,8 @@ const messages: TranslationMap = {
   'orchPage.discover.notDiscoverableGuide':
     'Registra un @handle così altri agenti possono trovarti e scriverti.',
   'orchPage.discover.linkTitle': 'Collega un nuovo agente',
-  'orchPage.discover.linkDescription': 'Incolla un ID agente per inviare una richiesta di connessione.',
+  'orchPage.discover.linkDescription':
+    'Incolla un ID agente per inviare una richiesta di connessione.',
   'orchPage.discover.noRequests': 'Nessuna richiesta in arrivo.',
   'orchPage.usage.nav': 'Utilizzo',
   'orchPage.usage.connections': 'Connessioni',

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -204,7 +204,8 @@ const messages: TranslationMap = {
   'orchPage.discover.notDiscoverableGuide':
     'Zarejestruj @handle, aby inni agenci mogli Cię znaleźć i napisać do Ciebie.',
   'orchPage.discover.linkTitle': 'Połącz nowego agenta',
-  'orchPage.discover.linkDescription': 'Wklej identyfikator agenta, aby wysłać prośbę o połączenie.',
+  'orchPage.discover.linkDescription':
+    'Wklej identyfikator agenta, aby wysłać prośbę o połączenie.',
   'orchPage.discover.noRequests': 'Brak przychodzących próśb.',
   'orchPage.usage.nav': 'Wykorzystanie',
   'orchPage.usage.connections': 'Połączenia',

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -201,7 +201,8 @@ const messages: TranslationMap = {
   'orchPage.discover.notDiscoverableGuide':
     'Registre um @handle para que outros agentes possam encontrá-lo e enviar mensagens.',
   'orchPage.discover.linkTitle': 'Vincular um novo agente',
-  'orchPage.discover.linkDescription': 'Cole um ID de agente para enviar uma solicitação de conexão.',
+  'orchPage.discover.linkDescription':
+    'Cole um ID de agente para enviar uma solicitação de conexão.',
   'orchPage.discover.noRequests': 'Nenhuma solicitação recebida.',
   'orchPage.usage.nav': 'Uso',
   'orchPage.usage.connections': 'Conexões',

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -192,7 +192,8 @@ const messages: TranslationMap = {
   'orchPage.agent.description': 'Общайтесь с главным агентом и наблюдайте за его подсознанием',
   'orchPage.connections.nav': 'Связи',
   'orchPage.connections.title': 'Связанные агенты',
-  'orchPage.connections.description': 'Партнёры, с которыми может координироваться ваш главный агент',
+  'orchPage.connections.description':
+    'Партнёры, с которыми может координироваться ваш главный агент',
   'orchPage.connections.empty': 'Пока нет связей.',
   'orchPage.connections.emptyCta': 'Добавить связь',
   'orchPage.connections.statContacts': 'Связи',


### PR DESCRIPTION
Disconnecting a provider (Discord) left its CEF webview pinned over the whole content area, swallowing all input until restart.

**Root cause:** the Disconnect CTA (`handleLogout` in `SidebarAppRail.tsx`) `await`ed `purgeWebviewAccount` **before** dispatching `removeAccount`. `purgeWebviewAccount` tears down the provider's backend scanners, which triggers a full app-state re-fetch + UI re-mount. During that await the account was **still in Redux**, so the re-mount remounted `WebviewHost` for it and re-opened/**revealed** a fresh, logged-out provider webview — never concealed (`2 reveals, 0 conceals` in the log). `webview_account_purge` itself does close the native view; the resurrection was frontend-driven.

**Fix (minimal, frontend-only):** dispatch `removeAccount` **first, synchronously**, then run the async purge. The account leaves state immediately → `WebviewHost` unmounts (its cleanup hides the child-view) and any purge-triggered re-mount sees no account, so it can't re-open a disconnected provider. Purge still closes the native view + wipes its data dir. Conceal-on-navigate-away already exists in `App.tsx`; no Rust change is needed (core `webview_accounts/mod.rs` is only cookie detection — the reveal/conceal lifecycle lives in the Tauri host).

**Checks:** `vitest` SidebarAppRail suite passes (5, incl. a new regression test asserting `removeAccount` fires while the purge is still pending); `tsc` clean for the touched files (remaining errors are pre-existing missing-dep issues in unrelated files). Full runtime verification needs the desktop app (connect+disconnect Discord).

Closes #4695

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured logout/disconnect removes the account from the sidebar before background webview cleanup completes.
  * Adjusted cleanup failure handling so errors don’t disrupt UI state after the account is already gone.
* **Tests**
  * Added disconnect coverage to verify dispatch/cleanup ordering and that purge failures are swallowed.
* **Documentation**
  * Reformatted i18n translation string formatting for German, Spanish, French, Italian, Polish, Portuguese, and Russian (no text changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->