### PR TITLE
fix(memory): stop Vault checklist reporting healthy while Sync shows Degraded (#4691)

### DIFF
--- a/src/openhuman/memory/read_rpc/vault.rs
+++ b/src/openhuman/memory/read_rpc/vault.rs
@@ -74,7 +74,7 @@ pub async fn vault_health_check_rpc(
         .map_err(|e| format!("vault_health_check pipeline_status: {e}"))?;
 
     let (content_root_abs, exists, readable, writable, obsidian_registered) = fs_probe;
-    let pipeline_healthy = pipeline.value.status != "error" && !pipeline.value.is_paused;
+    let pipeline_healthy = pipeline_is_healthy(&pipeline.value.status);
     let last_sync_ms = pipeline.value.last_sync_ms.max(0);
 
     let resp = VaultHealthCheckResponse {
@@ -101,6 +101,23 @@ pub async fn vault_health_check_rpc(
     Ok(RpcOutcome::single_log(resp, log))
 }
 
+/// Whether the memory pipeline status counts as "healthy" for the Vault setup
+/// checklist.
+///
+/// #4691: the Vault checklist and the Memory Sync panel read the SAME signal
+/// (`pipeline_status_rpc` → `derive_pipeline_status`), so they must never
+/// disagree. The prior denylist (`status != "error" && !is_paused`) let
+/// `"degraded"` slip through as healthy, so the Vault surface reported
+/// "Memory pipeline is healthy" while Memory Sync reported "Degraded".
+///
+/// This is an allowlist of the fully-operational states so any future
+/// non-operational status added to `derive_pipeline_status` defaults to
+/// unhealthy rather than silently reading as healthy. `paused`/`error`/
+/// `degraded` are all excluded.
+fn pipeline_is_healthy(status: &str) -> bool {
+    matches!(status, "idle" | "running" | "syncing")
+}
+
 fn probe_directory_writable(dir: &std::path::Path) -> bool {
     use std::io::Write;
     let ts = std::time::SystemTime::now()
@@ -124,5 +141,52 @@ fn probe_directory_writable(dir: &std::path::Path) -> bool {
             write_ok
         }
         Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pipeline_is_healthy;
+
+    // The full set of statuses `derive_pipeline_status` can return. Kept in sync
+    // with `memory_tree::tree::rpc::derive_pipeline_status` so a new status forces
+    // an explicit decision here.
+    const OPERATIONAL: &[&str] = &["idle", "running", "syncing"];
+    const NON_OPERATIONAL: &[&str] = &["paused", "error", "degraded"];
+
+    #[test]
+    fn operational_statuses_are_healthy() {
+        for status in OPERATIONAL {
+            assert!(
+                pipeline_is_healthy(status),
+                "expected `{status}` to be healthy"
+            );
+        }
+    }
+
+    #[test]
+    fn non_operational_statuses_are_not_healthy() {
+        for status in NON_OPERATIONAL {
+            assert!(
+                !pipeline_is_healthy(status),
+                "expected `{status}` to be unhealthy"
+            );
+        }
+    }
+
+    #[test]
+    fn degraded_is_not_healthy_regression_4691() {
+        // #4691: "degraded" previously leaked through the denylist and made the
+        // Vault checklist report "Memory pipeline is healthy" while Memory Sync
+        // reported "Degraded". It must read as unhealthy.
+        assert!(!pipeline_is_healthy("degraded"));
+    }
+
+    #[test]
+    fn unknown_status_defaults_to_unhealthy() {
+        // Allowlist semantics: any future/unexpected status is treated as
+        // unhealthy rather than silently reported as healthy.
+        assert!(!pipeline_is_healthy("boom"));
+        assert!(!pipeline_is_healthy(""));
     }
 }

--- a/src/openhuman/memory/read_rpc_tests.rs
+++ b/src/openhuman/memory/read_rpc_tests.rs
@@ -902,6 +902,11 @@ async fn obsidian_status_blank_override_is_treated_as_none() {
 
 #[tokio::test]
 async fn vault_health_check_reports_missing_content_root_for_fresh_workspace() {
+    // `pipeline_healthy` reads the process-global degraded flags (via
+    // `pipeline_status_rpc` → `current_degraded_state`), which sibling
+    // `memory_tree` tests set and never clear. Serialise + reset to a clean
+    // baseline so the assertion is deterministic. See #4691.
+    let _g = crate::openhuman::memory_tree::health::test_guard();
     let (_tmp, cfg) = test_config();
     let outcome = vault_health_check_rpc(&cfg, None).await.unwrap();
 
@@ -957,7 +962,15 @@ async fn vault_health_check_reports_writable_and_obsidian_registered_when_ready(
     assert!(outcome.value.readable);
     assert!(outcome.value.writable);
     assert!(outcome.value.obsidian_registered);
-    assert!(outcome.value.pipeline_healthy);
+    // Intentionally NOT asserting `pipeline_healthy` here: with a seeded chunk
+    // (total_chunks > 0) the derived status depends on the process-global
+    // degraded flags, which unguarded parallel `memory_tree` extraction/pipeline
+    // tests set and never clear (structure degrades only clears on a *successful*
+    // extraction, which never happens under test). Post-#4691 a leaked "degraded"
+    // correctly reads as unhealthy, so asserting healthy here would be flaky.
+    // The health mapping is covered deterministically by the `pipeline_is_healthy`
+    // unit tests in `read_rpc/vault.rs`; this test covers the filesystem readiness
+    // wiring. See also `memory_tree::tree::rpc::pipeline_status_reports_chunk_aggregates_after_ingest`.
     assert!(outcome.value.last_sync_ms > 0);
     assert!(
         !outcome.logs[0].contains(content_root.to_str().unwrap()),


### PR DESCRIPTION
## Summary

- Fix the Vault setup checklist reporting **"Memory pipeline is healthy"** at the same moment the Memory Sync panel reports **"Degraded"** (#4691).
- Root cause: both surfaces read the **same** signal (`pipeline_status_rpc` → `derive_pipeline_status`), but the Vault surface collapsed it into a boolean with a denylist that forgot the `degraded` state.
- Replace the denylist with an allowlist of fully-operational statuses in a pure, unit-tested helper.

## Problem

`Brain > Knowledge & Memory > Vault setup` and `Brain > Memory > Sync` are **not** independent health models — they both derive from `derive_pipeline_status()` (`src/openhuman/memory_tree/tree/rpc.rs`), which returns one of: `paused`, `error`, `degraded`, `syncing`, `running`, `idle`.

- The **Sync panel** renders the status verbatim → correctly shows `Degraded` + "wiki structure incomplete" + extraction-coverage %.
- The **Vault checklist** rendered a boolean `pipeline_healthy` computed at `vault.rs:77`:
  ```rust
  let pipeline_healthy = pipeline.value.status != "error" && !pipeline.value.is_paused;
  ```
  This denylist excluded `error` and `paused` but **not `degraded`**, so a `degraded` pipeline evaluated to `true` → "Memory pipeline is healthy". That is the entire contradiction reported in #4691.

## Solution

- Extract the health decision into a pure helper `pipeline_is_healthy(status)` and switch from a denylist to an **allowlist** of the fully-operational states:
  ```rust
  fn pipeline_is_healthy(status: &str) -> bool {
      matches!(status, "idle" | "running" | "syncing")
  }
  ```
- `degraded`/`paused`/`error` now all read as unhealthy, so the Vault checklist flips to "Needs attention" exactly when the Sync panel shows a non-operational state — the two surfaces can no longer disagree (AC #1). Aggregation to the worst layer already happens upstream in `derive_pipeline_status` (AC #2), and "healthy" is now shown only for operational states (AC #4).
- **Design decision:** an allowlist (not a longer denylist) future-proofs the mapping — any new status added to `derive_pipeline_status` defaults to unhealthy rather than silently reading as healthy.
- Scope is intentionally Rust-only; the AC #3 copy/cross-reference enhancement (Vault text mirroring the Sync status) was deferred as optional polish. The existing recovery copy already points users to "Memory Tree status".

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) — 4 unit tests in `vault.rs`: operational→healthy, non-operational→unhealthy, `degraded` regression (#4691), and unknown-status→unhealthy.
- [x] **Diff coverage ≥ 80%** — the changed line and the new helper are directly exercised by the new unit tests (`cargo test read_rpc::vault::tests` → 4 passed).
- [x] Coverage matrix updated — `N/A: behaviour-only fix to an existing health mapping; no feature added/removed/renamed.`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix rows affected.`
- [x] No new external network dependencies introduced — pure in-process string check; no I/O added.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: does not change a release-cut smoke surface.`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- Desktop UI only: the Vault setup checklist now shows "Needs attention" (instead of a false "healthy") whenever the memory pipeline is `degraded`/`paused`/`error`, matching the Memory Sync panel.
- No performance, migration, or compatibility implications — single pure-function change on an existing RPC field.

## Related

- Closes: #4691
- Follow-up PR(s)/TODOs: optional AC #3 polish — make the Vault checklist recovery copy explicitly mirror/link the Memory Sync status (frontend + i18n across all locales).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A (GitHub issue #4691)
- URL: https://github.com/tinyhumansai/openhuman/issues/4691

### Commit & Branch

- Branch: `fix/4691-vault-health-degraded-mismatch`
- Commit SHA: c03ada67bdafc16928178cc22fe178bf0942408a

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend files changed (Rust-only).
- [x] `pnpm typecheck` — N/A: no TypeScript changed.
- [x] Focused tests: `cargo test --lib read_rpc::vault::tests` → 4 passed, 0 failed.
- [x] Rust fmt/check (if changed): `cargo fmt --check src/openhuman/memory/read_rpc/vault.rs` clean.
- [x] Tauri fmt/check (if changed): N/A: no `app/src-tauri` changes.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: Vault setup checklist no longer reports "Memory pipeline is healthy" when the pipeline status is `degraded`.
- User-visible effect: Vault and Memory Sync surfaces now show consistent health; a degraded pipeline surfaces as "Needs attention" in both.

### Parity Contract

- Legacy behavior preserved: `error` and `paused` still read as unhealthy exactly as before; only the previously-missed `degraded` state changes.
- Guard/fallback/dispatch parity checks: allowlist covers all operational statuses emitted by `derive_pipeline_status`; unknown statuses fail closed (unhealthy).

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pipeline health checks to use a stricter status allowlist, making health results more accurate.
  * Ensured degraded, paused, error, and unknown statuses are treated as unhealthy.
  * Fixed an issue where some non-healthy pipeline states could be reported incorrectly. 

* **Tests**
  * Added coverage to verify healthy status handling and protect against regressions for degraded and unknown states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->