### PR TITLE
fix(flows): normalize bare-scope jq in condition expressions + prompt guard (B17)

### DIFF
--- a/src/openhuman/flows/agents/workflow_builder/prompt.md
+++ b/src/openhuman/flows/agents/workflow_builder/prompt.md
@@ -307,11 +307,14 @@ the run scope (`.`):
   the first output is used; a bad program yields `null` (never an error).
 - A string **without** a leading `=` is a literal. To emit a literal `=`, don't
   start the string with it.
-- **Never mix the shorthand with jq.** If an expression uses `|`, `[`,
-  functions (`any(...)`, `length`), or any jq beyond a plain dotted path, it
-  MUST start with `.` (the jq root): write
+- **Never mix the shorthand with jq.** If an expression **begins with a bare
+  scope key** (`item`/`items`/`run`/`nodes`) and continues into jq syntax —
+  `|`, `[`, functions (`any(...)`, `length`), or anything beyond a plain
+  dotted path — it MUST start with `.` instead (the jq root): write
   `"=.item.labels | any(.name==\"x\")"`, NOT `"=item.labels | any(...)"`. The
-  plain shorthand `"=item.labels"` (no jq) is fine alone.
+  plain shorthand `"=item.labels"` (no jq) is fine alone. Expressions that
+  already start with valid jq syntax (e.g. `"=[.item.a, .item.b]"` for array
+  construction) don't need an extra leading dot — only bare scope keys do.
 
 The scope exposes:
 

--- a/src/openhuman/flows/agents/workflow_builder/prompt.md
+++ b/src/openhuman/flows/agents/workflow_builder/prompt.md
@@ -307,6 +307,11 @@ the run scope (`.`):
   the first output is used; a bad program yields `null` (never an error).
 - A string **without** a leading `=` is a literal. To emit a literal `=`, don't
   start the string with it.
+- **Never mix the shorthand with jq.** If an expression uses `|`, `[`,
+  functions (`any(...)`, `length`), or any jq beyond a plain dotted path, it
+  MUST start with `.` (the jq root): write
+  `"=.item.labels | any(.name==\"x\")"`, NOT `"=item.labels | any(...)"`. The
+  plain shorthand `"=item.labels"` (no jq) is fine alone.
 
 The scope exposes:
 


### PR DESCRIPTION
Fixes **B17** — the last hop for condition-based flows. The builder emitted `field:"=item.labels | any(.name == \"in progress\") | not"` (the simple-path shorthand `item.labels` piped into jq). `expr::run_jq` compiled bare `item` as an **undefined jq function** → `Null` → the `condition` routed **all 95 real issues to false** → 0 output. (B1→B15→B16 had gotten the real data flowing; this was the final blocker.)

## Fix
- **tinyflows** ([#6](https://github.com/tinyhumansai/tinyflows/pull/6), pin → `68590ed`): `normalize_bare_scope_ref` prepends `.` when a jq program starts with a bare **top-level scope key** (`item`/`items`/`run`/`nodes`) followed by `.`/`|`/`[`/` `/EOF — so `=item.labels | any(…)` resolves as jq field access. Leading-dot exprs and jq builtins (`any(...)` etc., followed by `(`) are untouched; only currently-`null`-returning hybrids change. 5 expr tests + a condition-node jq test.
- **`prompt.md`**: warn the builder to never mix the shorthand with jq — use a leading dot (`=.item.x | …`) for any piped/functional expression.

## Verification
tinyflows **310 pass** · openhuman `cargo check` clean · **`flows::` 413 pass**.
