### PR TITLE
Fix chat-v1 context window to 1M (DeepSeek v4 Flash backing)

### DIFF
--- a/src/openhuman/inference/model_context.rs
+++ b/src/openhuman/inference/model_context.rs
@@ -40,11 +40,15 @@ const TIER_LOCAL_CONTEXT: u64 = 8_192;
 /// instead, so we never reject a request against a guessed window the real
 /// loaded `n_ctx` would have accepted (Codex P1 review on PR #3771).
 const CONSERVATIVE_LOCAL_CONTEXT_FLOOR: u64 = 4_096;
-/// Summarization tier. `summarization-v1` resolves to a long-context flash
-/// model (currently DeepSeek v4 flash, ~1M tokens). `extract_from_result`
-/// uses this window to single-shot whole oversized payloads instead of
-/// chunking, so it must reflect the real backing model's capacity.
-const TIER_SUMMARIZATION_CONTEXT: u64 = 1_000_000;
+/// DeepSeek v4 Flash window (~1M tokens) — the shared backing for every managed
+/// "flash" tier: `chat-v1`, its legacy alias `reasoning-quick-v1`, and
+/// `summarization-v1`. Kept as a single constant so these tiers can't drift
+/// apart again (issue #4706: `chat-v1` was pinned at `TIER_STANDARD_CONTEXT`
+/// (128K) while `summarization-v1` was 1M, even though both resolve to DeepSeek
+/// v4 Flash in the backend model registry). `extract_from_result` also relies on
+/// this window to single-shot whole oversized payloads instead of chunking, so
+/// it must reflect the real backing model's capacity.
+const TIER_FLASH_CONTEXT: u64 = 1_000_000;
 
 /// Resolve the context window (in tokens) for a model id or OpenHuman tier alias.
 ///
@@ -125,11 +129,15 @@ fn tier_context_window(model: &str) -> Option<u64> {
     match model {
         MODEL_REASONING_V1 => Some(TIER_REASONING_CONTEXT),
         MODEL_AGENTIC_V1 | MODEL_CODING_V1 => Some(TIER_LARGE_CONTEXT),
-        "summarization-v1" => Some(TIER_SUMMARIZATION_CONTEXT),
+        "summarization-v1" => Some(TIER_FLASH_CONTEXT),
         // Burst tier advertises a 128k window on the managed backend. Matched on
         // the `burst-v1` alias before any substring fallbacks below.
         MODEL_BURST_V1 => Some(TIER_STANDARD_CONTEXT),
-        MODEL_CHAT_V1 | MODEL_REASONING_QUICK_V1 | "chat" => Some(TIER_STANDARD_CONTEXT),
+        // `chat-v1` (and its legacy alias `reasoning-quick-v1`) are backed by
+        // DeepSeek v4 Flash — the same ~1M model as `summarization-v1`, not a
+        // 128K model (issue #4706). Share `TIER_FLASH_CONTEXT` so the three
+        // flash tiers stay in lockstep.
+        MODEL_CHAT_V1 | MODEL_REASONING_QUICK_V1 | "chat" => Some(TIER_FLASH_CONTEXT),
         m if m.starts_with("gemma") || m.contains(":1b") || m.contains("270m") => {
             Some(TIER_LOCAL_CONTEXT)
         }
@@ -279,19 +287,28 @@ mod tests {
     fn tier_aliases_resolve() {
         assert_eq!(context_window_for_model("reasoning-v1"), Some(1_000_000));
         assert_eq!(context_window_for_model("agentic-v1"), Some(200_000));
-        assert_eq!(context_window_for_model("chat-v1"), Some(128_000));
+        // chat-v1 is backed by DeepSeek v4 Flash (~1M), the same model as
+        // summarization-v1 — not a 128K model (issue #4706).
+        assert_eq!(context_window_for_model("chat-v1"), Some(1_000_000));
         // Burst tier — 128k on the managed backend. Matched on the alias, not
         // the local-gemma 8k substring arm.
         assert_eq!(context_window_for_model("burst-v1"), Some(128_000));
+        // reasoning-quick-v1 is the legacy alias of chat-v1 (backend renamed it
+        // 2026-05), so it resolves to the same ~1M flash window.
         assert_eq!(
             context_window_for_model("reasoning-quick-v1"),
-            Some(128_000)
+            Some(1_000_000)
         );
         // summarization-v1 maps to a ~1M-token flash model so the extractor can
         // single-shot whole oversized payloads.
         assert_eq!(
             context_window_for_model("summarization-v1"),
             Some(1_000_000)
+        );
+        // The three flash-backed tiers share one window and must not drift.
+        assert_eq!(
+            context_window_for_model("chat-v1"),
+            context_window_for_model("summarization-v1")
         );
     }
 


### PR DESCRIPTION
## Problem
`tier_context_window()` in `src/openhuman/inference/model_context.rs` pinned `chat-v1` (and its legacy alias `reasoning-quick-v1`) to `TIER_STANDARD_CONTEXT` (128K). But per the backend model registry, `chat-v1` is backed by **DeepSeek v4 Flash** — the same ~1M model as `summarization-v1` (which correctly mapped to 1M). This under-reported context headroom: a 476K-token session showed **100% (476K/128K)** instead of ~48% (476K/1M), and can trigger premature compaction / pre-dispatch trimming.

## Fix
- Introduced a shared `TIER_FLASH_CONTEXT = 1_000_000` (DeepSeek v4 Flash window) and pointed **all three** flash-backed tiers at it — `chat-v1`, `reasoning-quick-v1`, `summarization-v1` — so they can't drift apart again (replaces the single-use `TIER_SUMMARIZATION_CONTEXT`).
- `chat-v1` + `reasoning-quick-v1`: 128K → 1M.
- Updated the `tier_aliases_resolve` unit test and added an assertion that `chat-v1` and `summarization-v1` resolve to the same window.

## Verified every managed tier against `tinyhumansai/backend` `modelRegistry.ts`
| Tier | Backend default binding | Window | Result |
|---|---|---|---|
| chat-v1 | `deepseek-v4-flash` | 1M | **fixed (was 128K)** |
| reasoning-quick-v1 | alias → chat-v1 | 1M | **fixed (was 128K)** |
| summarization-v1 | `deepseek-v4-flash` | 1M | unchanged; now shares the constant |
| reasoning-v1 | `deepseek-v4-pro` | 1M | already correct |
| burst-v1 | General Compute (gemma) | 128K | already correct |
| agentic-v1 / coding-v1 | paid `deepseek-v4-pro` (1M) / free GMI (128K–256K) | plan-split | **left at 200K — see below** |
| vision-v1 | `qwen3.7-plus` (1M) | resolves via cost-catalog/crate fallback | unchanged |

**Why agentic-v1 / coding-v1 are unchanged:** they plan-route between DeepSeek V4 Pro (1M, paid) and GMI (Kimi 128K / Qwen3-Coder 256K, free), so no single window is correct for all users. Raising them to 1M would risk overflowing free-plan GMI and defeating trimming — a routing-policy decision outside this bug's scope. The existing conservative 200K is left as-is.

## Checks
`GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml --lib` is blocked locally by the pre-existing `whisper-rs-sys` native C++ build failure on this macOS toolchain (the Apple-Silicon native-build issue noted in CLAUDE.md), which fails before reaching this pure-Rust change. Verified statically; the updated `model_context` unit test compiles and runs in CI (Linux).

Closes #4706

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the available context window for chat, reasoning, and summarization tiers so they now share the larger high-capacity model limit.
  * Legacy aliases for the quick reasoning tier now resolve to the same expanded window.
  * Kept the burst tier unchanged at its existing smaller context size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->