### PR TITLE
telegram_scanner: back-pressure bulk history ingest so it can't starve the local core RPC

### DIFF
--- a/app/src-tauri/src/telegram_scanner/mod.rs
+++ b/app/src-tauri/src/telegram_scanner/mod.rs
@@ -21,6 +21,7 @@
 //! Only built with the `cef` feature — wry has no remote-debugging port.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -37,6 +38,21 @@ mod idb;
 /// How often we walk IDB. Tune down for faster iteration during dev; the
 /// walk itself is bounded by per-store record caps in `idb.rs`.
 const IDB_SCAN_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Max concurrent `memory_doc_ingest` POSTs during a bulk-history drain. A large
+/// Telegram account is hundreds of peers; firing them all at once saturated the
+/// single local core RPC (`127.0.0.1:7788`) and starved interactive UI calls
+/// (`threads_messages_list`, …) — issue #4714. Keep only a few in flight.
+const MAX_CONCURRENT_INGESTS: usize = 3;
+/// Small pause between launching bulk writes, leaving the single local core RPC
+/// server headroom to serve interactive UI calls between ingests.
+const INGEST_PACE: Duration = Duration::from_millis(50);
+/// True while a bulk-history drain is in flight. The IDB scan loop re-emits the
+/// FULL peer set every `IDB_SCAN_INTERVAL` (30s), but a drain of a large account
+/// takes far longer than that; without this guard each cycle would stack a fresh
+/// flood on top of the previous one. We skip launching a new drain while one is
+/// running — the next cycle re-emits everything once it finishes (issue #4714).
+static INGEST_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
 
 /// Spawn a per-account CDP poller. Caller is expected to guard against
 /// double-spawning via `ScannerRegistry`.
@@ -169,6 +185,7 @@ fn emit_and_persist<R: Runtime>(app: &AppHandle<R>, account_id: &str, harvest: &
     }
 
     let mut emitted = 0usize;
+    let mut pending: Vec<Value> = Vec::new();
     for (peer_id, group) in groups {
         let mut rows = group.rows;
         rows.sort_by_key(|r| r.get("date").and_then(|v| v.as_i64()).unwrap_or(0));
@@ -220,14 +237,79 @@ fn emit_and_persist<R: Runtime>(app: &AppHandle<R>, account_id: &str, harvest: &
         } else {
             emitted += 1;
         }
+        pending.push(payload);
+    }
+    log::info!("[tg][{}] emitted {} peer doc(s)", account_id, emitted);
+
+    if pending.is_empty() {
+        return;
+    }
+    // Back-pressure the bulk ingest (issue #4714): a large account is hundreds of
+    // peers and the scan loop re-emits the full set every 30s. Skip if a previous
+    // drain is still running so cycles can't stack, then drain with bounded
+    // concurrency + pacing so interactive UI RPCs are never starved.
+    if INGEST_IN_FLIGHT
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        log::info!(
+            "[tg][{}] bulk ingest already in flight; skipping {} doc(s) this cycle",
+            account_id,
+            pending.len()
+        );
+        return;
+    }
+    let acct = account_id.to_string();
+    tokio::spawn(async move {
+        drain_ingests(&acct, pending).await;
+        INGEST_IN_FLIGHT.store(false, Ordering::SeqCst);
+    });
+}
+
+/// Drain `payloads` to `openhuman.memory_doc_ingest` with bounded concurrency
+/// and pacing, so a bulk Telegram history import cannot monopolize the single
+/// local core RPC (issue #4714).
+async fn drain_ingests(account_id: &str, payloads: Vec<Value>) {
+    let total = payloads.len();
+    bounded_drain(payloads, MAX_CONCURRENT_INGESTS, INGEST_PACE, |payload| {
         let acct = account_id.to_string();
-        tokio::spawn(async move {
+        async move {
             if let Err(e) = post_memory_doc_ingest(&acct, &payload).await {
                 log::warn!("[tg][{}] memory write failed: {}", acct, e);
             }
+        }
+    })
+    .await;
+    log::info!("[tg][{}] bulk ingest drained {} doc(s)", account_id, total);
+}
+
+/// Run `op(item)` for every item with at most `max_concurrency` futures in
+/// flight and a `pace` pause between launches. Bounds a burst of work so it
+/// can't monopolize a shared resource (here, the single local core RPC).
+/// Extracted so the concurrency bound is unit-testable without a live server.
+async fn bounded_drain<T, F, Fut>(items: Vec<T>, max_concurrency: usize, pace: Duration, op: F)
+where
+    T: Send + 'static,
+    F: Fn(T) -> Fut,
+    Fut: std::future::Future<Output = ()> + Send + 'static,
+{
+    let sem = Arc::new(tokio::sync::Semaphore::new(max_concurrency.max(1)));
+    let mut set = tokio::task::JoinSet::new();
+    for item in items {
+        // Block until a permit frees, capping the number of in-flight writes.
+        let Ok(permit) = Arc::clone(&sem).acquire_owned().await else {
+            break;
+        };
+        let fut = op(item);
+        set.spawn(async move {
+            let _permit = permit;
+            fut.await;
         });
+        if !pace.is_zero() {
+            sleep(pace).await;
+        }
     }
-    log::info!("[tg][{}] emitted {} peer doc(s)", account_id, emitted);
+    while set.join_next().await.is_some() {}
 }
 
 /// Unix seconds → UTC `YYYY-MM-DD` (Howard Hinnant civil-from-days).
@@ -585,6 +667,39 @@ mod tests {
         for task in tasks {
             assert_cancelled(task).await;
         }
+    }
+
+    #[tokio::test]
+    async fn bounded_drain_caps_concurrency_and_runs_every_item() {
+        use std::sync::atomic::AtomicUsize;
+
+        let inflight = Arc::new(AtomicUsize::new(0));
+        let max_seen = Arc::new(AtomicUsize::new(0));
+        let done = Arc::new(AtomicUsize::new(0));
+        let (inflight_c, max_c, done_c) = (inflight.clone(), max_seen.clone(), done.clone());
+
+        let items: Vec<u32> = (0..20).collect();
+        bounded_drain(items, 3, Duration::from_millis(0), move |_item| {
+            let (inflight, max_seen, done) = (inflight_c.clone(), max_c.clone(), done_c.clone());
+            async move {
+                let cur = inflight.fetch_add(1, Ordering::SeqCst) + 1;
+                max_seen.fetch_max(cur, Ordering::SeqCst);
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                inflight.fetch_sub(1, Ordering::SeqCst);
+                done.fetch_add(1, Ordering::SeqCst);
+            }
+        })
+        .await;
+
+        assert_eq!(done.load(Ordering::SeqCst), 20, "every item must run");
+        let peak = max_seen.load(Ordering::SeqCst);
+        assert!(peak >= 2, "work should actually overlap (peak {peak})");
+        assert!(peak <= 3, "concurrency must stay bounded to 3 (peak {peak})");
+        assert_eq!(
+            inflight.load(Ordering::SeqCst),
+            0,
+            "no in-flight tasks should leak"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem
Connecting a large Telegram account made `emit_and_persist` fire an **unbounded `tokio::spawn` per peer** (hundreds at once), each POSTing `memory_doc_ingest` to the single local core RPC (`127.0.0.1:7788`). The IDB scan loop also re-emits the **full** peer set every 30s, and a large-account drain takes far longer than that — so each cycle stacked another flood. The RPC saturated and went unreachable, so the frontend's interactive calls (`threads_messages_list`) failed with "Failed to load messages / Failed to fetch".

## Fix (scanner-side back-pressure, one file)
- **Bounded concurrency**: collect the per-cycle payloads and drain them through a new generic `bounded_drain` helper (`MAX_CONCURRENT_INGESTS = 3`, `Semaphore` + `JoinSet`) so at most a few ingest POSTs hit the local RPC at once.
- **Pacing**: a small `INGEST_PACE` (50ms) between launches leaves headroom for interactive UI RPCs.
- **Single-drain guard**: an `INGEST_IN_FLIGHT` atomic skips launching a new drain while one is running, so 30s scan cycles can't stack (the next cycle re-emits everything once the current drain finishes).
- **Unit test**: asserts peak in-flight ≤ the bound, every item runs, no leaked tasks.

## Notes on the compounding session-expired / retry storm
`memory_store/unified/documents.rs` already does **one batch embed per doc** and **stores-without-vectors on a failed batch** (no per-chunk retry loop), so the session-expired case needs no core change — the "batch embed failed" volume was driven by the scanner's unbounded fan-out + full re-emits, which this caps. Writes are also already **one `memory_doc_ingest` per peer** (not per-chunk), so per-peer batching is already in place.

## Validation
Standard tokio primitives only (`Semaphore`, `JoinSet`, `acquire_owned`, let-else); verified by inspection. `cargo check` on the `app/src-tauri` crate could not run in this environment (vendored path-dep submodules unavailable + CEF build). Full runtime repro needs a large Telegram account with an expired backend session.

Closes #4714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Telegram scan syncing to process records more reliably in the background.
  * Prevented overlapping sync runs, reducing duplicate work and missed updates during frequent scans.
  * Added rate-limited processing for large batches so the app stays more responsive while handling many items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->