### PR TITLE
fix(mcp): add master_agent + master_reporter to RESOURCE_CATALOG

### DIFF
--- a/src/openhuman/mcp_server/resources.rs
+++ b/src/openhuman/mcp_server/resources.rs
@@ -284,6 +284,18 @@ const RESOURCE_CATALOG: &[PromptResource] = &[
         content: include_str!("../orchestration/reasoning_agent/prompt.md"),
     },
     PromptResource {
+        uri: "openhuman://prompts/agents/master_agent",
+        name: "master_agent",
+        description: "Human-facing worker for the Master chat: OpenHuman talking directly to its human, orchestrating other agents on their behalf.",
+        content: include_str!("../orchestration/master_agent/prompt.md"),
+    },
+    PromptResource {
+        uri: "openhuman://prompts/agents/master_reporter",
+        name: "master_reporter",
+        description: "Tool-free relay that reports an external agent's reply back into the Master chat as OpenHuman's own message.",
+        content: include_str!("../orchestration/master_reporter/prompt.md"),
+    },
+    PromptResource {
         uri: "openhuman://prompts/agents/skill_setup",
         name: "skill_setup",
         description: "Worker that guides skill installation and backend configuration.",


### PR DESCRIPTION
## Summary

- Adds the missing `RESOURCE_CATALOG` entries for the `master_agent` and `master_reporter` built-ins so `src/openhuman/mcp_server/resources.rs` mirrors `src/openhuman/agent_registry/agents/loader.rs::BUILTINS` again (43 ↔ 43).
- No behaviour change beyond making the two new subagent prompts fetchable over MCP as `openhuman://prompts/agents/master_agent` and `openhuman://prompts/agents/master_reporter`.

## Problem

`catalog_mirrors_builtins` in `src/openhuman/mcp_server/resources.rs` is a parity guard: it iterates every `BUILTINS` entry and asserts a matching `openhuman://prompts/agents/<id>` catalog entry exists. When #4660 (feat(orchestration): Master chat) introduced `master_agent` and `master_reporter` in `BUILTINS`, the `RESOURCE_CATALOG` was not updated in the same commit — so `BUILTINS.len() == 43` but only 41 agent entries live in the catalog.

Main CI stayed green because the changed-files coverage lane (`scripts/ci/rust-coverage-changed.sh`) only selects tests for the domains touched by the PR. Post-#4660 pushes didn't touch `src/openhuman/mcp_server/` or `src/openhuman/mod.rs`, so `mcp_server::resources::tests::*` were never scoped. Any PR that widens the filter to a bare `openhuman` (e.g. by touching `src/openhuman/mod.rs`) surfaces the pre-existing gap. Repro on PR #4600:

```
thread '…::catalog_mirrors_builtins' panicked at src/openhuman/mcp_server/resources.rs:382:13:
RESOURCE_CATALOG is missing an entry for built-in agent `master_agent`
(expected URI `openhuman://prompts/agents/master_agent`).
```

`read_resource_returns_content_for_each_subagent` fails for the same reason (`master_agent` has no URI mapping).

## Solution

Append two `PromptResource` entries — grouped with the other `orchestration/*` subagents right after `reasoning_agent` — pointing at the existing prompt files:

- `openhuman://prompts/agents/master_agent` → `src/openhuman/orchestration/master_agent/prompt.md`
- `openhuman://prompts/agents/master_reporter` → `src/openhuman/orchestration/master_reporter/prompt.md`

The descriptions mirror each agent's `when_to_use` in the corresponding `agent.toml`. No production code changes — only the static catalog + `include_str!` bindings.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — N/A: the existing `mcp_server::resources::tests::catalog_mirrors_builtins` and `read_resource_returns_content_for_each_subagent` already cover both branches (present/absent, valid/empty content). This PR flips them from red → green; no new test needed.
- [x] **Diff coverage ≥ 80%** — the 12 changed lines are `PromptResource {…}` literals whose `uri`, `name`, and `content` fields are read by the two parity tests above, so diff-cover will attribute them.
- [x] Coverage matrix updated — N/A: behaviour-only surface (subagent prompt catalog) with no feature-ID mapping in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no feature-ID rows change.
- [x] No new external network dependencies introduced — no new deps.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: MCP static catalog is not on the release-cut smoke list.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: no tracking issue; discovered while investigating PR #4600 CI red.

## Impact

- **Platform:** all — the MCP server is embedded in the desktop core; the two new URIs are exposed to any MCP client the agent surfaces.
- **Behaviour:** MCP clients that enumerate `resources/list` now see two additional prompt resources (which they should have been seeing since #4660 merged). No existing entry changes.
- **Performance / migration / security:** none — compile-time static slice grows by two entries.

## Related

- Related PR: #4600 (Emergency Stop) — the observed failure surfaced there; this fix unblocks that PR's `Rust Core Coverage` lane once #4600 rebases on main.
- Origin of gap: #4660 (feat(orchestration): Master chat).
- Follow-up PR(s)/TODOs: none.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A (GitHub-only)
- URL: N/A

### Commit & Branch

- Branch: `fix/mcp-master-agent-catalog`
- Commit SHA: `3966d1962`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend files changed.
- [x] `pnpm typecheck` — N/A: no TS/TSX changes.
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml -p openhuman --lib openhuman::mcp_server::resources` → 9 passed, 0 failed (both previously failing tests now pass).
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean on `src/openhuman/mcp_server/resources.rs`.
- [x] Tauri fmt/check (if changed): N/A: no `app/src-tauri` changes.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: MCP clients can now fetch the `master_agent` and `master_reporter` prompt.md via the documented `openhuman://prompts/agents/<id>` scheme.
- User-visible effect: two additional entries in the MCP `resources/list` response.

### Parity Contract

- Legacy behavior preserved: yes — every previously-listed URI and its content are unchanged. Only two additions.
- Guard/fallback/dispatch parity checks: the `catalog_mirrors_builtins` guard now holds (43 == 43); `read_resource_returns_content_for_each_subagent` covers non-empty content for each new entry.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new bundled prompt resources for agent workflows.
  * New prompt URIs are now available for `master_agent` and `master_reporter`, with built-in names, descriptions, and embedded content for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->