### PR TITLE
fix(voice): import hotkey items in non-macOS dictation listener

### DIFF
--- a/src/openhuman/voice/dictation_listener.rs
+++ b/src/openhuman/voice/dictation_listener.rs
@@ -13,6 +13,11 @@ use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 
 use crate::openhuman::config::Config;
+// Only `start_rdev_listener` (non-macOS) touches the hotkey module — its
+// `ActivationMode`, `HotkeyEvent`, and `parse_hotkey`/`start_listener` fns — so
+// gate the import to the same cfg to avoid unused-import warnings on macOS.
+#[cfg(not(target_os = "macos"))]
+use crate::openhuman::voice::hotkey::{self, ActivationMode, HotkeyEvent};
 
 const LOG_PREFIX: &str = "[dictation_listener]";
 


### PR DESCRIPTION
## Summary

- Add a cfg-gated `use crate::openhuman::voice::hotkey::{self, ActivationMode, HotkeyEvent};` to `dictation_listener.rs` so the non-macOS `rdev` hotkey listener compiles.
- Fixes Linux-only build/clippy errors on `main` (`cannot find module hotkey` / `cannot find type ActivationMode` / `cannot find type HotkeyEvent`) that break `cargo clippy -p openhuman` — and therefore every branch merged up to `main`.

## Problem

- `start_rdev_listener` (`#[cfg(not(target_os = "macos"))]`) uses the `hotkey` module (`parse_hotkey`, `start_listener`) plus the `ActivationMode` and `HotkeyEvent` enums, but none of those items were imported into the module.
- On Linux (CI `Rust Quality (fmt, clippy)`) this fails with three `E0433` errors. macOS is unaffected because `start_rdev_listener` is `cfg`'d out there — so the gap is invisible when building locally on macOS.

## Solution

- Import the module + both enums in one `use`, gated with a matching `#[cfg(not(target_os = "macos"))]` so it exists exactly on the cfg that references them and does not become an unused-import warning on macOS.

## Submission Checklist

- [x] Tests added or updated — N/A: restores compilation of existing `cfg`-gated code; no new behavior. The proof is that the crate builds/clippies on non-macOS.
- [x] Diff coverage ≥ 80% — N/A: a single `use` import line, no executable lines to cover.
- [x] Coverage matrix updated — N/A: behaviour-only change (compilation fix, no feature added/removed/renamed).
- [x] Affected feature IDs listed — N/A: no feature rows affected.
- [x] No new external network dependencies — N/A: no dependencies changed.
- [x] Manual smoke checklist updated — N/A: no release-cut surface touched.
- [x] Linked issue closed via `Closes #NNN` — N/A: no tracked issue; found via CI failure on Linux.

## Impact

- Non-macOS (Linux/Windows) desktop/CLI builds compile again; unblocks `Rust Quality (fmt, clippy)` on `main`. No runtime behavior change. macOS unchanged.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

- N/A — human-only PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved platform-specific handling so hotkey/dictation code builds more cleanly on macOS, reducing unnecessary compiler warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->