### PR TITLE
fix(voice): import hotkey symbols in dictation_listener so non-macOS clippy compiles

### DIFF
--- a/src/openhuman/voice/dictation_listener.rs
+++ b/src/openhuman/voice/dictation_listener.rs
@@ -14,6 +14,13 @@ use tokio::task::JoinHandle;
 
 use crate::openhuman::config::Config;
 
+// The `hotkey` submodule (`ActivationMode`, `HotkeyEvent`, `parse_hotkey`,
+// `start_listener`) is only used by `start_rdev_listener`, which is itself
+// gated on non-macOS. Gate the import identically to avoid an unused-import
+// warning on macOS, where the CoreGraphics-based path is used instead.
+#[cfg(not(target_os = "macos"))]
+use super::hotkey::{self, ActivationMode, HotkeyEvent};
+
 const LOG_PREFIX: &str = "[dictation_listener]";
 
 // ── Listener task handle (for stop support) ─────────────────────────


### PR DESCRIPTION
## Summary

- Adds the missing `use super::hotkey::{self, ActivationMode, HotkeyEvent}` (cfg-gated to non-macOS) to `src/openhuman/voice/dictation_listener.rs` so its `start_rdev_listener` compiles on Linux and Windows.
- Unblocks main `CI Lite` (currently red on 8 × `E0433` in this file) and every open PR that has merged the affected main commit — notably #4600.

## Problem

`start_rdev_listener` (gated on `#[cfg(not(target_os = "macos"))]`) references `ActivationMode::Push`, `ActivationMode::Tap`, `HotkeyEvent::Pressed`, `HotkeyEvent::Released`, and calls `hotkey::parse_hotkey` / `hotkey::start_listener`, but the file has no matching `use` for the sibling `super::hotkey` module. `rustc` on macOS never compiles that path so the omission slipped through local dev; every Linux build fails with 8 × `E0433`:

```
error[E0433]: cannot find type `ActivationMode` in this scope
   --> src/openhuman/voice/dictation_listener.rs:135:68
error[E0433]: cannot find module or crate `hotkey` in this scope
   --> src/openhuman/voice/dictation_listener.rs:146:23
error[E0433]: cannot find type `HotkeyEvent` in this scope
   --> src/openhuman/voice/dictation_listener.rs:176:17
```

Repro on main HEAD: [`Rust Quality (fmt, clippy)` failure](https://github.com/tinyhumansai/openhuman/actions/runs/29002613890/job/86066528388) and identical failures on the last several main pushes.

## Solution

Add `use super::hotkey::{self, ActivationMode, HotkeyEvent}` gated on the same `#[cfg(not(target_os = "macos"))]` as the sole caller. Matching the caller's cfg keeps the macOS build clean (no `unused_imports` warning) and pairs the import with the code that actually needs it.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — N/A: this is an import-only fix to make an already-existing code path compile on non-macOS. `dictation_listener` behavior on Linux/Windows is exercised by `voice/` integration paths already; there is nothing to unit-test about a `use` statement. CI going from 8× `E0433` → 0 errors is the authoritative test.
- [x] **Diff coverage ≥ 80%** — N/A: single-line `use` addition — diff-cover excludes bare `use` statements from executable coverage.
- [x] Coverage matrix updated — N/A: no user-facing feature added / removed / renamed. `docs/TEST-COVERAGE-MATRIX.md` doesn't map to this file.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: bug fix, no feature-ID rows change.
- [x] No new external network dependencies introduced — no new deps at all.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: the fix restores an existing (broken on Linux) code path; behavior is unchanged from what main was intended to be shipping.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: no tracking issue; discovered while investigating PR #4600 CI red after fetching main.

## Impact

- **Platform:** Linux + Windows only — macOS wasn't affected because `start_rdev_listener` is `#[cfg(not(target_os = "macos"))]`. macOS builds are byte-for-byte unchanged.
- **Behaviour:** none — the `use` statement just makes an existing code path compile.
- **Performance / security / migration:** none.

## Related

- Fixes: main CI regression introduced in `088102386` (`feat(orchestration): chat rework, Agent graph, global Kanban, presence (#4722)`), which added the sibling `voice/hotkey.rs` module but didn't wire the import into `dictation_listener.rs`.
- Unblocks PR #4600 (Emergency Stop) — its `Rust Quality` + `Rust Core Coverage` lanes will pass on next rebase/merge from main.
- Follow-up PR(s)/TODOs: none.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A (GitHub-only)
- URL: N/A

### Commit & Branch

- Branch: `fix/voice-dictation-imports`
- Commit SHA: `a40ee2e29`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend files changed.
- [x] `pnpm typecheck` — N/A: no TS/TSX changes.
- [x] Focused tests: `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml --lib` → clean on macOS (import is cfg-gated so no unused-import warning). CI Linux clippy is the authoritative test.
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean.
- [x] Tauri fmt/check (if changed): N/A: no `app/src-tauri` changes.

### Validation Blocked

- `command:` full Linux clippy locally
- `error:` no Linux target installed on this macOS host
- `impact:` low — the `use` mirrors the sole caller's cfg exactly, so the imports are present on precisely the platforms where the symbols are referenced. CI (Linux) will confirm.

### Behavior Changes

- Intended behavior change: none. Import-only fix so non-macOS builds compile.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: yes — the code path being fixed is already `#[cfg(not(target_os = "macos"))]`. macOS is unchanged; Linux/Windows previously failed to build and now build.
- Guard/fallback/dispatch parity checks: N/A.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility on macOS by avoiding an unnecessary import path, reducing build warnings and keeping the app’s voice dictation behavior consistent across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->