### PR TITLE
fix(agent_orchestration): Unbounded timeout for delegation tools — delegate_tools_agent, run_code (#4734)

### DIFF
--- a/src/openhuman/agent_orchestration/tools/archetype_delegation.rs
+++ b/src/openhuman/agent_orchestration/tools/archetype_delegation.rs
@@ -3,7 +3,7 @@ use serde_json::json;
 use serde_json::Value;
 
 use crate::openhuman::tools::traits::{
-    PermissionLevel, Tool, ToolCallOptions, ToolCategory, ToolResult,
+    PermissionLevel, Tool, ToolCallOptions, ToolCategory, ToolResult, ToolTimeout,
 };
 use tinyagents::harness::tool::ToolExecutionContext;
 
@@ -74,6 +74,22 @@ impl Tool for ArchetypeDelegationTool {
 
     fn category(&self) -> ToolCategory {
         ToolCategory::System
+    }
+
+    /// Run **without** the global per-tool wall-clock deadline. This tool is a
+    /// delegation primitive: it hands a task to a bounded sub-agent
+    /// (`tools_agent` → `delegate_tools_agent`, `code_executor` → `run_code`,
+    /// …) and awaits that agent's full run. Under the default `Inherit` policy
+    /// the whole delegation is hard-killed at the single-tool timeout (120s) —
+    /// so any sub-agent run that legitimately exceeds two minutes is truncated
+    /// mid-flight (Sentry TAURI-RUST-K29 `delegate_tools_agent` and
+    /// TAURI-RUST-8HB `run_code`: thousands of 120.000s truncations). The
+    /// child's lifetime is already bounded internally — by its `max_iterations`,
+    /// the run cancellation token, and each inner tool's own timeout — so it
+    /// governs its own duration, exactly like the sibling `spawn_parallel_agents`
+    /// fan-out and the long-running scripting tools (`shell`, `node_exec`).
+    fn timeout_policy(&self, _args: &serde_json::Value) -> ToolTimeout {
+        ToolTimeout::Unbounded
     }
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
@@ -198,6 +214,21 @@ mod tests {
         assert_eq!(tool.description(), "Use for web and docs research.");
         assert_eq!(tool.permission_level(), PermissionLevel::Execute);
         assert_eq!(tool.category(), ToolCategory::System);
+    }
+
+    #[test]
+    fn delegation_opts_out_of_the_global_tool_timeout() {
+        // A delegated sub-agent run (delegate_tools_agent / run_code / …) can
+        // legitimately outlast the single-tool wall-clock default (120s): under
+        // `Inherit` every such run is hard-killed and truncated (Sentry
+        // TAURI-RUST-K29 / TAURI-RUST-8HB). The child bounds its own lifetime
+        // via its max_iterations, the run cancellation token, and each inner
+        // tool's own timeout — so this primitive must be Unbounded, like
+        // spawn_parallel_agents and the long-running scripting tools.
+        assert_eq!(
+            sample_tool().timeout_policy(&json!({})),
+            ToolTimeout::Unbounded,
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Delegation tools (`delegate_tools_agent`, `run_code`, and any other archetype-delegate tool) now opt out of the global 120s per-tool wall-clock, so a sub-agent run that legitimately takes longer than two minutes is no longer hard-killed mid-flight.
- Fixes two high-volume Sentry crashes with one change: `TAURI-RUST-K29` (`delegate_tools_agent`, 1236 events / 71 users) and `TAURI-RUST-8HB` (`run_code`, 755 events / 51 users).

## Problem

Both `delegate_tools_agent` and `run_code` are synthesized by the **same** type, `ArchetypeDelegationTool`. It never overrode `timeout_policy()`, so it inherited `ToolTimeout::Inherit` = the global per-tool cap (`tool_timeout::DEFAULT_TIMEOUT_SECS = 120`). Every tool call is wrapped in `tokio::time::timeout(deadline, exec)`, so a delegation whose sub-agent runs past 120s was hard-killed at exactly 120.000s and truncated — surfacing as `tool '<name>' timed out after 120 seconds`. The delegated agents are internally bounded (their `agent.toml` `max_iterations`, the run cancellation token, and each inner tool's own timeout), so the 120s cap doesn't protect against runaway work — it just truncates legitimate long-running delegation.

The sibling `spawn_parallel_agents` tool had this exact bug fixed in #4686 (`timeout_policy -> Unbounded`); the long-running scripting tools (`shell`, `node_exec`, `npm_exec`) are already Unbounded-by-default. `ArchetypeDelegationTool` was simply missed.

## Solution

Override `timeout_policy() -> ToolTimeout::Unbounded` on `ArchetypeDelegationTool`, mirroring #4686. The child agent governs its own lifetime, so the delegation primitive should not impose the single-tool wall-clock. Adds a unit test asserting the override (mirrors `spawn_parallel_agents_tests`).

Scope is deliberately narrow: `SkillDelegationTool` (→ `integrations_agent`, quick Composio actions) and the base `DelegateTool` route to short-lived agents and are intentionally left on the default — no speculative widening.

**RCA-vs-suppress:** Bucket = **real-defect** (a wrong timeout policy truncating internally-bounded work). This corrects the policy; it is not a suppression.

## Submission Checklist

- [x] Tests added or updated (happy path + edge case) — unit test asserts `timeout_policy() == Unbounded`; existing `ArchetypeDelegationTool` tests cover the delegation happy/blank-prompt paths
- [x] **Diff coverage ≥ 80%** — verified locally via `cargo-llvm-cov` + `diff-cover --compare-branch=upstream/main`: **100%** on changed lines (7/7)
- [x] Coverage matrix updated — `N/A: behaviour-only reliability change (no feature row)`
- [x] All affected feature IDs listed under `## Related` — `N/A`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if release-cut surfaces touched — `N/A: internal tool-timeout policy`
- [x] Linked issue closed via `Closes #NNN` in `## Related`

## Impact

- **Platform**: desktop (all) — agent delegation path.
- **Behavior**: long delegated sub-agent runs complete instead of dying at 120s. No change to healthy short delegations. The child is still bounded by its own iteration cap + run cancellation token, so this cannot cause an unbounded runaway.
- No schema, API, or migration change. One-line policy override + test.

## Related

- Closes: #4734
- Sentry-Issue: TAURI-RUST-K29
- Sentry-Issue: TAURI-RUST-8HB
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A (GitHub issue #4734; sourced from Sentry TAURI-RUST-K29 + TAURI-RUST-8HB)

### Commit & Branch

- Branch: `fix/4734-delegation-tool-timeout` (rebased onto current `main`, past the #4759 libtest fix)
- Commit SHA: 5df791101

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A (no `app/` changes)
- [x] `pnpm typecheck` — N/A (no TS changes)
- [x] Focused tests: `delegation_opts_out_of_the_global_tool_timeout` — **passes** (`test result: ok. 1 passed`)
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean, `cargo check --lib` clean, `cargo clippy --lib` clean on the changed file
- [x] Tauri fmt/check (if changed): N/A

### Behavior Changes

- Intended behavior change: archetype-delegation tools run without the 120s single-tool wall-clock.
- User-visible effect: long agent-delegation tasks complete instead of failing with a 120s timeout.

### Parity Contract

- Legacy behavior preserved: SkillDelegationTool / DelegateTool unchanged; child agents still bounded by their own caps + cancellation token.
- Guard/fallback/dispatch parity checks: mirrors the established #4686 `spawn_parallel_agents` pattern exactly.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none (PR #4686 is a sibling fix for a different tool, not a duplicate)
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Delegated tool operations can now run without being cut off by the global tool timeout.
  * Delegation behavior remains consistent when processing longer-running requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->