### PR TITLE
fix(memory): demote local-model-unreachable ingestion errors (#4735)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -7213,6 +7213,29 @@ mod tests {
     }
 
     #[test]
+    fn memory_ingestion_extract_localhost_refused_classifies_as_loopback_unavailable() {
+        // Regression guard for the memory-ingestion call site (queue.rs), which
+        // now reports extraction failures through `report_error_or_expected`.
+        // When the configured LLM is a local server the user isn't running
+        // (LM Studio on localhost:1234), memory-tree extraction fails with the
+        // connect-refused body wrapped in the extraction error chain
+        // (TAURI-RUST-12K: 3071 events). The flattened `{err:#}` message must
+        // classify as an expected loopback-unavailable condition so it demotes
+        // to a breadcrumb instead of an error event — matching the agent chat
+        // paths. A stopped local model is user-state, not a defect.
+        let raw = "memory graph extraction failed for doc_id=abc123: \
+                   error sending request for url \
+                   (http://localhost:1234/v1/chat/completions): client error (Connect): \
+                   tcp connect error: No connection could be made because the target \
+                   machine actively refused it. (os error 10061)";
+        assert_eq!(
+            expected_error_kind(raw),
+            Some(ExpectedErrorKind::LoopbackUnavailable),
+            "memory ingestion loopback connect-refused must demote as LoopbackUnavailable"
+        );
+    }
+
+    #[test]
     fn does_not_classify_loopback_timeout_as_loopback() {
         // A loopback *timeout* (WSAETIMEDOUT os error 10060, not the
         // connect-refused 10061) shares the `tcp connect error` marker but is

--- a/src/openhuman/memory/ingestion/queue.rs
+++ b/src/openhuman/memory/ingestion/queue.rs
@@ -259,7 +259,18 @@ async fn ingestion_worker(
                 true
             }
             Err(e) => {
-                crate::core::observability::report_error(
+                // Graph extraction calls the configured LLM. When that provider
+                // is a local server the user isn't running (e.g. LM Studio on
+                // localhost:1234), the call fails with a connect-refused
+                // transport error the user alone can fix — the same expected
+                // condition the agent chat paths already demote. Route through
+                // `report_error_or_expected` so a stopped local model produces a
+                // breadcrumb, not a Sentry error (TAURI-RUST-12K: 3071 events).
+                // Genuine extraction bugs don't match the expected classifier
+                // and are still reported. The document is durably persisted and
+                // the failed job is re-runnable via "Retry failed", so no data
+                // is lost by demoting the noise.
+                crate::core::observability::report_error_or_expected(
                     &e,
                     "memory",
                     "ingestion_extract",


### PR DESCRIPTION
## Summary

- Memory graph-extraction failures now route through `report_error_or_expected`, so a **stopped local model** (e.g. LM Studio on `localhost:1234`) produces a Sentry breadcrumb instead of an error event.
- Kills 3071 events / 24 users of pure user-state noise (`TAURI-RUST-12K`) with a one-line call swap, reusing the classifier already built for this exact body.

## Problem

The background memory-ingestion worker calls the configured LLM to extract the memory graph. When that provider is a local server the user isn't running, the call fails with a connect-refused transport error:

```
error sending request for url (http://localhost:1234/v1/chat/completions):
  client error (Connect): tcp connect error:
  No connection could be made because the target machine actively refused it. (os error 10061)
```

The agent chat paths (`agent.run_single`, `agent.provider_chat`) already recognise this as an expected user-state condition and demote it — the codebase even has a purpose-built `LoopbackUnavailable` classifier for the `localhost:` + connect-refused-errno body (added for `TAURI-RUST-12K`). But the ingestion worker reported extraction failures with **raw** `report_error()`, bypassing the classifier entirely, so a user with LM Studio closed flooded Sentry — 3071 events, 24 users, zero real impact.

## Solution

Swap the single `report_error(...)` call at the ingestion failure site to `report_error_or_expected(...)` (identical signature). The existing `expected_error_kind` → `LoopbackUnavailable` classifier then demotes a stopped-local-model failure to a `warn` breadcrumb, exactly like the agent paths. Adds a regression test coupling the memory-ingestion error envelope to the classifier.

**Not a blindfold:** `report_error_or_expected` only demotes errors matching the expected classifier (loopback-unavailable, network-unreachable, api-key-missing, …). A genuine extraction bug produces a non-matching message and is **still reported**. And no data is lost by quieting this: the source document is durably persisted before extraction (`memory_store::upsert_document`), the failed job is recorded (`mem_tree_jobs status='failed'`), and it is re-runnable via the existing "Retry failed" lever (`memory_tree_retry_failed`).

**RCA-vs-suppress:** Bucket = **genuinely unpreventable** — the user's local server being down is an external condition with zero local lever, and the identical error is already demoted elsewhere. *Flagged follow-up (not owed here):* auto-requeue failed extractions once the provider recovers + a "N failed, retry" badge so the outage is discoverable rather than silent.

## Submission Checklist

- [x] Tests added or updated — regression test asserts the memory-ingestion localhost connect-refused envelope classifies as `LoopbackUnavailable` (demoted); existing classifier tests cover the cross-platform / localized bodies + the negative timeout case
- [x] **Diff coverage ≥ 80%** — verified locally via `cargo-llvm-cov` + `diff-cover --compare-branch=upstream/main`: **90%** on changed lines (9/10; the one uncovered line is the `report_error_or_expected` call in `queue.rs`, exercised in production via the ingestion worker's error branch — the classifier decision it delegates to is covered 100%)
- [x] Coverage matrix updated — `N/A: observability-routing change, no feature row`
- [x] All affected feature IDs listed under `## Related` — `N/A`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if release-cut surfaces touched — `N/A: internal error-reporting routing`
- [x] Linked issue closed via `Closes #NNN` in `## Related`

## Impact

- **Platform**: desktop (all) — background memory ingestion with a local model provider.
- **Observability**: a stopped local model no longer floods Sentry; genuine extraction bugs still report.
- **Data**: none dropped — document persisted, job re-runnable.
- No schema/API/migration change. One-line routing swap + test.

## Related

- Closes: #4735
- Sentry-Issue: TAURI-RUST-12K
- Follow-up PR(s)/TODOs: auto-requeue after local-provider recovery + failed-extraction UI badge (discoverability) — not owed by this noise fix.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A (GitHub issue #4735; sourced from Sentry TAURI-RUST-12K)

### Commit & Branch

- Branch: `fix/4735-memory-ingest-network-unreachable` (rebased onto current `main`, past the #4759 libtest fix)
- Commit SHA: b66f7847e

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A (no `app/` changes)
- [x] `pnpm typecheck` — N/A (no TS changes)
- [x] Focused tests: `memory_ingestion_extract_localhost_refused_classifies_as_loopback_unavailable` — **passes** (`test result: ok. 1 passed`)
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean, `cargo check --lib` clean, `cargo clippy --lib` clean on both changed files
- [x] Tauri fmt/check (if changed): N/A

### Behavior Changes

- Intended behavior change: memory-ingestion extraction failures go through the expected-error classifier.
- User-visible effect: a stopped local model no longer generates Sentry error spam; nothing else changes.

### Parity Contract

- Legacy behavior preserved: non-expected extraction errors still reach Sentry via the same code path; only classifier-matched user-state conditions are demoted, matching the agent chat paths.
- Guard/fallback/dispatch parity checks: reuses the shared `expected_error_kind` classifier — no new matching logic, no data-path change.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A
