### PR TITLE
fix(voice): import hotkey types in non-macOS dictation listener

### DIFF
--- a/src/openhuman/voice/dictation_listener.rs
+++ b/src/openhuman/voice/dictation_listener.rs
@@ -14,6 +14,12 @@ use tokio::task::JoinHandle;
 
 use crate::openhuman::config::Config;
 
+// The rdev-based listener path only compiles on non-macOS (macOS skips rdev,
+// see `start_rdev_listener` below), so gate the hotkey imports to match — on
+// macOS these symbols are unused and would warn.
+#[cfg(not(target_os = "macos"))]
+use super::hotkey::{self, ActivationMode, HotkeyEvent};
+
 const LOG_PREFIX: &str = "[dictation_listener]";
 
 // ── Listener task handle (for stop support) ─────────────────────────


### PR DESCRIPTION
## Summary

- Add a `cfg`-gated import of `hotkey::{self, ActivationMode, HotkeyEvent}` to `src/openhuman/voice/dictation_listener.rs`.
- Fixes a compile break (`E0433`) on every non-macOS target (Linux + Windows); macOS was unaffected.
- Unblocks the release-staging / release-production build matrix (Docker + all desktop targets).

## Problem

`start_rdev_listener` in `dictation_listener.rs` is gated `#[cfg(not(target_os = "macos"))]` and references `hotkey::parse_hotkey`, `hotkey::start_listener`, `ActivationMode`, and `HotkeyEvent` — but the file never imports them. Because the function is compiled out on macOS, macOS builds and macOS-only local/CI compiles never exercised it, so the missing imports went unnoticed. Every Linux/Windows target fails with:

```
error[E0433]: cannot find module or crate `hotkey` in this scope
error[E0433]: cannot find type `ActivationMode` in this scope
error[E0433]: cannot find type `HotkeyEvent` in this scope
error: could not compile `openhuman` (lib) due to 8 previous errors
```

This broke the **Release Staging** run (Docker: build, Desktop: ubuntu / ubuntu-arm64 / windows all failed; both macOS desktop jobs passed — the fingerprint of a non-macOS-only break). It was introduced by #2735, which split the listener into a macOS / non-macOS path, and is present on both `main` and `release`. The per-PR CI Lite/Full gate does not compile the Linux/Windows desktop or Docker targets, so it reached the release build undetected.

## Solution

Add the missing import, gated to the same `cfg` as its only use site so macOS does not warn on unused symbols:

```rust
#[cfg(not(target_os = "macos"))]
use super::hotkey::{self, ActivationMode, HotkeyEvent};
```

`super::hotkey` resolves to `voice::hotkey` (declared `pub mod hotkey;` in `voice/mod.rs`), which exports all four symbols. This resolves all 8 `E0433` errors and touches nothing on the macOS path.

## Submission Checklist

- [x] Tests added or updated — `N/A`: compile-only fix (missing `use`). The build itself is the test; the Linux/Windows desktop + Docker build lanes in `release-*.yml` / CI Full are the regression guard.
- [x] **Diff coverage ≥ 80%** — `N/A`: the sole changed line is a `use` statement (non-executable), excluded by `diff-cover`.
- [x] Coverage matrix updated — `N/A: behaviour-only change` (no feature added/removed/renamed).
- [x] All affected feature IDs listed — `N/A`: no matrix feature affected.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — `N/A`: no user-facing behavior change.
- [x] Linked issue closed via `Closes #NNN` — `N/A`: no tracking issue filed for this build break.

## Impact

- **Platform**: fixes the build on Linux and Windows (desktop + Docker/`openhuman-core`). No change to macOS behavior — the macOS path already skips the rdev listener (handled by `tauri-plugin-global-shortcut`, #2677).
- No runtime behavior change: only makes existing non-macOS code compile.
- No performance, security, or migration implications.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: consider adding a Linux/Windows compile lane to the per-PR gate so non-macOS-only breaks are caught before the release cut.

> **CI note:** the **Rust Core Coverage** lane is red here, but the 38 `E0405/E0422/E0425/E0432/E0433` errors are a **pre-existing broken lib-test compile on `main`** — they live in unrelated `*_tests.rs` (`channels/web_tests.rs`, `config/schema/load_tests.rs`, `inference/provider/reliable_tests.rs`, `mcp_server/tools_tests.rs`, `memory/…`, etc.), **none in `voice/`**. The `ci-lite.yml` push run on `main` HEAD (`7659c75dc`, this branch's base) fails identically. This PR's 6-line diff neither causes nor fixes that; it is tracked/owned separately. clippy skips test targets, so this only surfaces in the coverage lane.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/dictation-hotkey-imports`
- Commit SHA: 261798c37

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: Rust-only change, no `app/` files touched
- [x] `pnpm typecheck` — N/A: Rust-only change, no TypeScript touched
- [x] Focused tests: N/A — compile-only fix (a missing `use`); the build is the test. Validated by CI: **Rust Quality (fmt, clippy)** and **AppImage RPATH + libxdo guard** both pass on Linux, exercising the previously-broken non-macOS path.
- [x] Rust fmt/check (if changed): `cargo fmt --check` passes locally; `cargo clippy` (Rust Quality lane) passes in CI.
- [x] Tauri fmt/check (if changed): N/A — root core crate only, `app/src-tauri` untouched.

### Validation Blocked

- `command:` `cargo check --target x86_64-unknown-linux-gnu`
- `error:` cross-compiling the non-macOS target from a macOS host is not feasible (whisper-rs/ggml NEON fp16 + cross linker); the fix is verified by inspection and by the CI Full / release build lanes.
- `impact:` low — the change is a single `use` line resolving the exact 8 `E0433` names at their only (cfg-matched) use site.

### Behavior Changes

- Intended behavior change: none (compile fix only).
- User-visible effect: Linux/Windows release builds succeed again.

### Parity Contract

- Legacy behavior preserved: yes — non-macOS listener logic is unchanged; only its imports are now in scope.
- Guard/fallback/dispatch parity checks: import is `cfg`-gated to match the `#[cfg(not(target_os = "macos"))]` use site, preserving the macOS skip path (#2677).

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A
