### PR TITLE
fix(voice): import hotkey types in non-macOS dictation listener (release hotfix)

### DIFF
--- a/src/openhuman/voice/dictation_listener.rs
+++ b/src/openhuman/voice/dictation_listener.rs
@@ -14,6 +14,12 @@ use tokio::task::JoinHandle;
 
 use crate::openhuman::config::Config;
 
+// The rdev-based listener path only compiles on non-macOS (macOS skips rdev,
+// see `start_rdev_listener` below), so gate the hotkey imports to match — on
+// macOS these symbols are unused and would warn.
+#[cfg(not(target_os = "macos"))]
+use super::hotkey::{self, ActivationMode, HotkeyEvent};
+
 const LOG_PREFIX: &str = "[dictation_listener]";
 
 // ── Listener task handle (for stop support) ─────────────────────────


### PR DESCRIPTION
## Summary

- **Targets `release`** — hotfix for the broken **Release Staging** build ([run 29017097307](https://github.com/tinyhumansai/openhuman/actions/runs/29017097307)).
- Adds a `cfg`-gated import of `hotkey::{self, ActivationMode, HotkeyEvent}` to `src/openhuman/voice/dictation_listener.rs`.
- Fixes a compile break (`E0433`) on every non-macOS target (Linux + Windows); macOS was unaffected.
- Same one-line fix as the `main`-targeted #4743 (cherry-picked). Opened directly on `release` because `release`'s CI Full is blocked by exactly this bug, whereas `main`'s merge gate is currently blocked by unrelated pre-existing test-compile breakage.

## Problem

`start_rdev_listener` in `dictation_listener.rs` is gated `#[cfg(not(target_os = "macos"))]` and references `hotkey::parse_hotkey`, `hotkey::start_listener`, `ActivationMode`, and `HotkeyEvent` without importing them. Because the function is compiled out on macOS, macOS builds (and macOS-only local/CI compiles) never exercised it — so the missing imports slipped through. Every Linux/Windows target fails with:

```
error[E0433]: cannot find module or crate `hotkey` in this scope
error[E0433]: cannot find type `ActivationMode` in this scope
error[E0433]: cannot find type `HotkeyEvent` in this scope
error: could not compile `openhuman` (lib) due to 8 previous errors
```

This broke the **Release Staging** run across **Docker: build** and **Desktop: ubuntu / ubuntu-arm64 / windows** (both macOS desktop jobs passed — the fingerprint of a non-macOS-only break). It also fails `release`'s **CI Full** — both `Build (Linux full)` and `Rust Core Tests + Quality` die at `could not compile openhuman (lib) due to 8 previous errors` on these same 8 errors. Introduced by #2735, which split the listener into a macOS / non-macOS path.

## Solution

Add the missing import, gated to the same `cfg` as its only use site so macOS does not warn on unused symbols:

```rust
#[cfg(not(target_os = "macos"))]
use super::hotkey::{self, ActivationMode, HotkeyEvent};
```

`super::hotkey` resolves to `voice::hotkey` (`pub mod hotkey;` in `voice/mod.rs`), which exports all four symbols. Resolves all 8 `E0433` errors; nothing on the macOS path changes. Already validated on `main`'s #4743 — the Linux **Rust Quality (fmt, clippy)** and **AppImage RPATH + libxdo guard** lanes pass with this change applied.

## Submission Checklist

- [x] Tests added or updated — N/A: compile-only fix (a missing `use`). The build is the test; CI Full's Linux/Windows build + Rust Core lanes are the regression guard.
- [x] **Diff coverage ≥ 80%** — N/A: the sole changed line is a `use` statement (non-executable), excluded by `diff-cover`.
- [x] Coverage matrix updated — N/A: behaviour-only change (no feature added/removed/renamed).
- [x] All affected feature IDs listed — N/A: no matrix feature affected.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — N/A: no user-facing behavior change.
- [x] Linked issue closed via `Closes #NNN` — N/A: hotfix for CI run 29017097307; no separate tracking issue filed.

## Impact

- **Platform**: fixes the build on Linux and Windows (desktop + Docker/`openhuman-core`). No change to macOS behavior — the macOS path already skips the rdev listener (handled by `tauri-plugin-global-shortcut`, #2677).
- No runtime behavior change: only makes existing non-macOS code compile.
- Unblocks the staging release cut.

## Related

- Closes: N/A (hotfix for Release Staging run 29017097307)
- Sibling PR: #4743 (same fix, base `main`) — kept open until `main`'s unrelated pre-existing lib-test-compile errors are resolved so its coverage gate can go green.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/dictation-hotkey-imports-release`
- Commit SHA: da2dba659 (cherry-pick of 261798c37)

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: Rust-only change, no `app/` files touched
- [x] `pnpm typecheck` — N/A: Rust-only change, no TypeScript touched
- [x] Focused tests: N/A — compile-only fix; validated on #4743 by the Linux clippy + AppImage lanes.
- [x] Rust fmt/check (if changed): `cargo fmt --check` passes locally; `cargo clippy` (Rust Quality lane on #4743) passes.
- [x] Tauri fmt/check (if changed): N/A — root core crate only, `app/src-tauri` untouched.

### Validation Blocked

- `command:` `cargo check --target x86_64-unknown-linux-gnu`
- `error:` cross-compiling the non-macOS target from a macOS host is not feasible (whisper-rs/ggml NEON fp16 + cross linker); verified by inspection and by CI Full / release build lanes.
- `impact:` low — a single `use` line resolving the exact 8 `E0433` names at their only (cfg-matched) use site.

### Behavior Changes

- Intended behavior change: none (compile fix only).
- User-visible effect: Linux/Windows release builds succeed again.

### Parity Contract

- Legacy behavior preserved: yes — non-macOS listener logic unchanged; only its imports are now in scope.
- Guard/fallback/dispatch parity checks: import is `cfg`-gated to match the `#[cfg(not(target_os = "macos"))]` use site, preserving the macOS skip path (#2677).

### Duplicate / Superseded PR Handling

- Duplicate PR(s): #4743 (same fix, base `main`)
- Canonical PR: this one for `release`; #4743 for `main`
- Resolution: both intentionally open — different base branches
