### PR TITLE
fix(build): restore dropped #[cfg(test)] re-exports so the Rust libtest target compiles

### DIFF
--- a/src/openhuman/channels/providers/web/mod.rs
+++ b/src/openhuman/channels/providers/web/mod.rs
@@ -16,8 +16,10 @@ pub(crate) use web_errors::classify_inference_error;
 #[allow(unused_imports)]
 pub(crate) use web_errors::{
     extract_provider_error_detail, extract_provider_name, generic_inference_error_user_message,
-    is_action_budget_exhausted, is_fallback_chain_exhausted, is_non_retryable_rate_limit_text,
-    parse_retry_after_secs_from_str, retry_after_hint, with_provider_detail, ClassifiedError,
+    inference_budget_exceeded_user_message, is_action_budget_exhausted,
+    is_fallback_chain_exhausted, is_inference_budget_exceeded_error,
+    is_non_retryable_rate_limit_text, parse_retry_after_secs_from_str, retry_after_hint,
+    with_provider_detail, ClassifiedError,
 };
 
 // Public API — event bus
@@ -50,6 +52,20 @@ pub(crate) use ops::{event_session_id_for, key_for};
 pub(crate) use progress_bridge::spawn_progress_bridge;
 
 // Schema field helpers re-exported for tests
+#[cfg(any(test, debug_assertions))]
+#[allow(unused_imports)]
+pub(crate) use schemas::{
+    json_output, optional_bool, optional_f64, optional_string, optional_u64, required_string,
+};
+#[cfg(any(test, debug_assertions))]
+#[allow(unused_imports)]
+pub(crate) use session::{
+    compose_system_prompt_suffix, locale_reply_directive, normalize_model_override,
+    provider_role_for_model_override,
+};
+#[cfg(any(test, debug_assertions))]
+#[allow(unused_imports)]
+pub(crate) use types::WebChatParams;
 
 // Test helpers (debug/test builds only)
 #[cfg(any(test, debug_assertions))]

--- a/src/openhuman/config/schema/load/mod.rs
+++ b/src/openhuman/config/schema/load/mod.rs
@@ -32,6 +32,10 @@ pub(crate) use super::Config;
 #[cfg(test)]
 pub(crate) use dirs::ACTIVE_USER_STATE_FILE;
 #[cfg(test)]
+pub(crate) use dirs::{ACTION_DIR_ENV_VAR, MEMORY_SYNC_INTERVAL_SECS_ENV_VAR};
+#[cfg(test)]
+pub(crate) use env::EnvLookup;
+#[cfg(test)]
 pub(crate) use env::ProcessEnvWithoutWorkspace;
 #[cfg(test)]
 pub(crate) use impl_load::parse_config_with_recovery;

--- a/src/openhuman/config/schemas/mod.rs
+++ b/src/openhuman/config/schemas/mod.rs
@@ -27,6 +27,8 @@ use helpers::{
     DEFAULT_ONBOARDING_FLAG_NAME,
 };
 #[cfg(test)]
+use schema_defs::schemas;
+#[cfg(test)]
 use serde_json::{Map, Value};
 
 #[cfg(test)]

--- a/src/openhuman/inference/local/service/ollama_admin/mod.rs
+++ b/src/openhuman/inference/local/service/ollama_admin/mod.rs
@@ -9,6 +9,11 @@ mod util;
 // Re-export free functions that form the public/crate API of this module.
 pub(crate) use util::test_ollama_connection;
 
+// Test-facing re-export: `ollama_admin_tests.rs` resolves `super::…` against
+// this module. Dropped during the sub-module split; restored so libtest compiles.
+#[cfg(test)]
+pub(crate) use util::interrupted_pull_settle_window_secs;
+
 #[cfg(test)]
 #[path = "../ollama_admin_tests.rs"]
 mod tests;

--- a/src/openhuman/inference/provider/reliable.rs
+++ b/src/openhuman/inference/provider/reliable.rs
@@ -23,6 +23,11 @@
 use super::traits::{
     ChatMessage, ChatRequest, ChatResponse, StreamChunk, StreamOptions, StreamResult,
 };
+// Test-facing: `reliable_tests.rs` (included via `use super::*`) constructs
+// `StreamError::Provider(..)` directly. Prod code uses the fully-qualified
+// path, so gate this to test builds to avoid an unused-import warning.
+#[cfg(test)]
+use super::traits::StreamError;
 use super::Provider;
 use crate::openhuman::inference::provider::record_resolved_provider_route;
 use async_trait::async_trait;

--- a/src/openhuman/mcp_server/tools/mod.rs
+++ b/src/openhuman/mcp_server/tools/mod.rs
@@ -29,6 +29,8 @@ pub use params::{build_rpc_params, slug_from};
 #[cfg(test)]
 pub use serde_json::{json, Value};
 #[cfg(test)]
+pub use specs::list_tools_result_for_config;
+#[cfg(test)]
 pub use types::{DEFAULT_LIMIT, MAX_LIMIT, TREE_TAG_MAX_TAGS, TREE_TAG_MAX_TAG_LENGTH};
 
 #[cfg(test)]

--- a/src/openhuman/memory/chat.rs
+++ b/src/openhuman/memory/chat.rs
@@ -12,6 +12,10 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use crate::openhuman::config::Config;
+// Test-facing: the inline `mod tests` (via `use super::*`) asserts against the
+// managed summarization model constant. Restored after the module refactor.
+#[cfg(test)]
+use crate::openhuman::config::DEFAULT_CLOUD_LLM_MODEL;
 use crate::openhuman::inference::provider::{
     create_chat_model_with_model_id, provider_for_role, UsageInfo,
 };

--- a/src/openhuman/memory/schema/mod.rs
+++ b/src/openhuman/memory/schema/mod.rs
@@ -27,6 +27,8 @@ pub use registry::{all_controller_schemas, all_registered_controllers};
 
 // Re-export the NAMESPACE constant so schema_tests.rs can reference it via
 // `super::NAMESPACE` the same way the original flat module did.
+#[cfg(test)]
+pub(crate) use definitions::NAMESPACE;
 
 #[cfg(test)]
 #[path = "../schema_tests.rs"]

--- a/src/openhuman/memory/tree_source/file.rs
+++ b/src/openhuman/memory/tree_source/file.rs
@@ -33,6 +33,10 @@ use chrono::{DateTime, Utc};
 use crate::openhuman::config::Config;
 use crate::openhuman::memory_store::content::raw::raw_source_dir;
 use crate::openhuman::memory_store::trees::types::Tree;
+// Test-facing: the inline `mod tests` builds sample `Tree`s using these enums.
+// Restored after the tree_source refactor dropped the imports.
+#[cfg(test)]
+use crate::openhuman::memory_store::trees::types::{TreeKind, TreeStatus};
 
 /// Filename of the per-source registry mirror inside `raw/<source_slug>/`.
 pub const SOURCE_FILE_NAME: &str = "_source.md";

--- a/src/openhuman/sandbox/docker.rs
+++ b/src/openhuman/sandbox/docker.rs
@@ -16,6 +16,10 @@ use super::types::{
     SandboxBackendHandle, SandboxBackendKind, SandboxExecRequest, SandboxExecResult, SandboxPolicy,
     SandboxStatus,
 };
+// Test-facing: the inline `mod tests` builds `DockerOverrides` values. Prod code
+// here doesn't reference the type, so gate to test builds. Restored post-refactor.
+#[cfg(test)]
+use super::types::DockerOverrides;
 use std::process::Stdio;
 use tokio::process::Command;
 


### PR DESCRIPTION
## Summary

- Restores the `#[cfg(test)]` test-facing re-exports/imports that the orchestration module split (#4720 / #4722 / #4725) dropped across **10 modules**, so the Rust libtest target compiles again.
- Unblocks the coverage gate on **every open PR**: `main`'s libtest target currently fails with 37 compile errors, so `cargo-llvm-cov` (the `rust-core-coverage` job) cannot run for any PR. `main`'s CI Lite has been red for several consecutive commits.
- Pure re-export restoration — no product code changed, no tests deleted or ignored. Every referenced symbol still exists; it only moved into a sub-module during the split.

## Problem

#4720 / #4722 / #4725 restructured 10 modules into sub-modules but dropped the `#[cfg(test)]` re-export/import blocks that each module's test submodule (`#[path] mod tests` or inline `mod tests`, resolving via `use super::*` / `super::…`) depends on. The result is 37 `cargo test --lib` compile errors — e.g. in `channels/providers/web`:

```
error[E0432]: unresolved imports `super::compose_system_prompt_suffix`, `super::WebChatParams`, …
error[E0405]: cannot find trait `EnvLookup` in this scope
error[E0425]: cannot find value `MEMORY_SYNC_INTERVAL_SECS_ENV_VAR` / `ACTION_DIR_ENV_VAR`, function `schemas`
```

Because the libtest target compiles as one unit before test filtering, this blocks the `rust-core-coverage` job — and therefore the ≥80% diff-coverage merge gate — for **all** PRs, not just ones touching these modules. `cargo check --lib` (the product build) is unaffected; the breakage is test-only, which is why it slipped past the push checks (CI Full, which runs the full suite, only gates PRs targeting `release`).

## Solution

For each of the 10 modules, restore the missing test-facing re-exports/imports in the module root, pointing at the sub-module that now defines the symbol. Every re-export is gated (`#[cfg(test)]`, or `#[cfg(any(test, debug_assertions))]` + `#[allow(unused_imports)]` where a sibling uses that pattern) so nothing widens the non-test build or trips `-D warnings`.

| Module | Symbols restored | Now defined in |
|---|---|---|
| `channels/providers/web/mod.rs` | `WebChatParams`; `compose_system_prompt_suffix`, `locale_reply_directive`, `normalize_model_override`, `provider_role_for_model_override`; `required_string`, `optional_string`, `optional_bool`, `optional_f64`, `optional_u64`, `json_output`; `inference_budget_exceeded_user_message`, `is_inference_budget_exceeded_error` | `web/types.rs`, `web/session.rs`, `web/schemas.rs`, `web/web_errors.rs` |
| `config/schema/load/mod.rs` | `EnvLookup`; `ACTION_DIR_ENV_VAR`, `MEMORY_SYNC_INTERVAL_SECS_ENV_VAR` | `load/env.rs`, `load/dirs.rs` |
| `config/schemas/mod.rs` | `schemas` (fn) | `config/schemas/schema_defs.rs` |
| `inference/local/service/ollama_admin/mod.rs` | `interrupted_pull_settle_window_secs` | `ollama_admin/util.rs` |
| `inference/provider/reliable.rs` | `StreamError` | `inference/provider/traits.rs` |
| `mcp_server/tools/mod.rs` | `list_tools_result_for_config` | `mcp_server/tools/specs.rs` |
| `memory/chat.rs` | `DEFAULT_CLOUD_LLM_MODEL` | `config` (storage_memory) |
| `memory/schema/mod.rs` | `NAMESPACE` | `memory/schema/definitions.rs` |
| `memory/tree_source/file.rs` | `TreeKind`, `TreeStatus` | `memory_store/trees/types.rs` |
| `sandbox/docker.rs` | `DockerOverrides` | `sandbox/types.rs` |

No visibility changes were needed — every symbol was already `pub`/`pub(crate)`.

## Submission Checklist

- [x] Tests added or updated — `N/A: restores compilation of existing tests; no behaviour change`. The 37-error libtest target now compiles; the previously-broken web tests run (93 passed) and all restored modules' tests link again.
- [x] **Diff coverage ≥ 80%** — `N/A`: changed lines are `#[cfg(test)]` re-export statements (no executable product lines to cover). This PR is what makes the coverage job runnable again for everyone.
- [x] Coverage matrix updated — `N/A: build fix, no feature change`
- [x] All affected feature IDs listed under `## Related` — `N/A`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if release-cut surfaces touched — `N/A: test-only re-exports`
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue; fixes the main-branch libtest regression from #4720/#4722/#4725`

## Impact

- **CI**: `cargo test --lib --no-run` goes from 37 errors → clean (`Finished` in ~4m); unblocks `rust-core-coverage` / the coverage gate for every open PR.
- **Product**: none — all changes are `#[cfg(test)]`-gated re-exports; release builds are byte-identical.
- **Risk**: minimal — additive, test-gated, no product or test logic touched.

## Validation

- `cargo test --lib --no-run` → **compiles clean, 0 errors (was 37)**
- `cargo check --lib` → clean · `cargo fmt --check` → clean · `cargo clippy --lib` → no new warnings
- Ran the previously-broken web tests: **93 passed, 0 failed, 0 ignored**

## Related

- Fixes the `main` libtest regression introduced by #4720 / #4722 / #4725 (module→sub-module split dropped `#[cfg(test)]` re-export blocks).
- Follow-up PR(s)/TODOs: none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public tools helper, making it easier for clients to list available tools from the server layer.

* **Bug Fixes**
  * Improved module compatibility after refactoring by restoring several test/debug-only exports and imports.
  * Cleaned up re-export structure in the web channel provider without changing behavior.
  * Expanded test coverage support across config, memory, inference, and sandbox modules to keep validation working smoothly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->