### PR TITLE
fix(agent): arm harness wall-clock ceiling so a wedged turn can't ship an empty reply

### DIFF
--- a/src/openhuman/channels/providers/web/mod.rs
+++ b/src/openhuman/channels/providers/web/mod.rs
@@ -79,6 +79,8 @@ pub(crate) use web_errors::{
 #[cfg(any(test, debug_assertions))]
 pub use ops::set_test_forced_run_chat_task_error;
 #[cfg(any(test, debug_assertions))]
+pub use ops::RUN_CHAT_TASK_TEST_LOCK;
+#[cfg(any(test, debug_assertions))]
 pub use ops::{set_test_run_chat_task_block, TestRunChatTaskBlock};
 
 #[cfg(any(test, debug_assertions))]

--- a/src/openhuman/channels/providers/web/mod.rs
+++ b/src/openhuman/channels/providers/web/mod.rs
@@ -46,6 +46,9 @@ pub use schemas::{
 };
 
 // Helpers re-exported for tests
+#[cfg(any(test, debug_assertions))]
+#[allow(unused_imports)]
+pub(crate) use ops::sentry_suppression_reason;
 pub(crate) use ops::{event_session_id_for, key_for};
 pub(crate) use progress_bridge::spawn_progress_bridge;
 

--- a/src/openhuman/channels/providers/web/ops.rs
+++ b/src/openhuman/channels/providers/web/ops.rs
@@ -113,6 +113,40 @@ where
     }
 }
 
+/// Run a chat-turn future under the two standard web-channel guards, inside the
+/// shared origin + approval-context scope: the cooperative cancel token
+/// (interrupt/cancel paths tear the turn down at its next await point) and the
+/// wall-clock backstop ([`drive_turn_with_deadline`]).
+///
+/// Returns `None` when the turn was cancelled cooperatively before producing a
+/// result — the cancelling side already emitted the user-facing `chat_error`,
+/// so the caller just unwinds quietly. Otherwise `Some(res)` carries the turn's
+/// `Result`. Extracted so `start_chat` and `spawn_parallel_turn` share one copy
+/// of this wiring and can't drift apart (issue #4746 review); the only per-site
+/// differences are the `fork` flag and run-queue handle passed to
+/// `run_chat_task` when building `fut`.
+async fn run_turn_under_cancel_and_deadline<F>(
+    cancel_token: CancellationToken,
+    origin: crate::openhuman::agent::turn_origin::AgentTurnOrigin,
+    approval_ctx: crate::openhuman::approval::ApprovalChatContext,
+    fut: F,
+) -> Option<Result<super::types::WebChatTaskResult, String>>
+where
+    F: std::future::Future<Output = Result<super::types::WebChatTaskResult, String>>,
+{
+    tokio::select! {
+        biased;
+        _ = cancel_token.cancelled() => None,
+        res = drive_turn_with_deadline(
+            web_turn_deadline(),
+            crate::openhuman::agent::turn_origin::with_origin(
+                origin,
+                crate::openhuman::approval::APPROVAL_CHAT_CONTEXT.scope(approval_ctx, fut),
+            ),
+        ) => Some(res),
+    }
+}
+
 /// What the budget-correlator should do with a terminated turn (#3386).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum BudgetCorrelation {
@@ -609,32 +643,25 @@ pub async fn start_chat(
         // `None` => the turn was cancelled cooperatively before producing a
         // result; the interrupting/cancelling side already emitted the
         // user-facing `chat_error`, so we just unwind quietly here.
-        let result = tokio::select! {
-            biased;
-            _ = task_cancel_token.cancelled() => None,
-            res = drive_turn_with_deadline(
-                web_turn_deadline(),
-                crate::openhuman::agent::turn_origin::with_origin(
-                    origin,
-                    crate::openhuman::approval::APPROVAL_CHAT_CONTEXT.scope(
-                        approval_ctx,
-                        run_chat_task(
-                            &client_id_task,
-                            &thread_id_task,
-                            &request_id_task,
-                            &user_message,
-                            model_override,
-                            temperature,
-                            profile_id,
-                            locale,
-                            turn_run_queue_task,
-                            metadata,
-                            /* fork */ false,
-                        ),
-                    ),
-                ),
-            ) => Some(res),
-        };
+        let result = run_turn_under_cancel_and_deadline(
+            task_cancel_token,
+            origin,
+            approval_ctx,
+            run_chat_task(
+                &client_id_task,
+                &thread_id_task,
+                &request_id_task,
+                &user_message,
+                model_override,
+                temperature,
+                profile_id,
+                locale,
+                turn_run_queue_task,
+                metadata,
+                /* fork */ false,
+            ),
+        )
+        .await;
 
         let result = match result {
             Some(res) => res,
@@ -840,32 +867,25 @@ async fn spawn_parallel_turn(
             client_id: client_id_task.clone(),
             request_id: Some(request_id_task.clone()),
         };
-        let result = tokio::select! {
-            biased;
-            _ = task_cancel_token.cancelled() => None,
-            res = drive_turn_with_deadline(
-                web_turn_deadline(),
-                crate::openhuman::agent::turn_origin::with_origin(
-                    origin,
-                    crate::openhuman::approval::APPROVAL_CHAT_CONTEXT.scope(
-                        approval_ctx,
-                        run_chat_task(
-                            &client_id_task,
-                            &thread_id_task,
-                            &request_id_task,
-                            &user_message,
-                            model_override,
-                            temperature,
-                            profile_id,
-                            locale,
-                            run_queue,
-                            metadata,
-                            /* fork */ true,
-                        ),
-                    ),
-                ),
-            ) => Some(res),
-        };
+        let result = run_turn_under_cancel_and_deadline(
+            task_cancel_token,
+            origin,
+            approval_ctx,
+            run_chat_task(
+                &client_id_task,
+                &thread_id_task,
+                &request_id_task,
+                &user_message,
+                model_override,
+                temperature,
+                profile_id,
+                locale,
+                run_queue,
+                metadata,
+                /* fork */ true,
+            ),
+        )
+        .await;
 
         match result {
             Some(Ok(chat_result)) => {

--- a/src/openhuman/channels/providers/web/ops.rs
+++ b/src/openhuman/channels/providers/web/ops.rs
@@ -61,15 +61,17 @@ const BUDGET_SIGNAL_TTL: Duration = Duration::from_secs(5 * 60);
 
 /// Default wall-clock backstop for a single web chat turn, in seconds.
 ///
-/// A turn still running past this without producing a terminal event is treated
-/// as wedged — a stuck main-agent tool call, or a delegated sub-agent that
-/// never returned — and stopped with a graceful `chat_error`, so the client
-/// never receives an empty reply / spins on `inference_heartbeat` until the
-/// socket dies (issue #4746). Deliberately generous: normal turns, even slow
-/// reasoning-tier ones that buffer output for minutes, finish well under it —
-/// this is a hang backstop, not a UX deadline. Override via
-/// `OPENHUMAN_WEB_TURN_TIMEOUT_SECS`; set it to `0` to disable the backstop.
-const DEFAULT_WEB_TURN_TIMEOUT_SECS: u64 = 600;
+/// This is the OUTER safety net (issue #4746). The primary, root-cause guard is
+/// the harness policy's `max_wall_clock_ms` (`tinyagents::run_policy_for`,
+/// default 600s), which interrupts a hung/slow model or tool/sub-agent call
+/// mid-flight and returns a proper `Timeout` → `chat_error`. This channel-level
+/// backstop sits ABOVE that (900s) and only fires if a turn wedges OUTSIDE the
+/// harness run entirely (e.g. session assembly / persistence plumbing), so the
+/// client still always gets a terminal event instead of an empty reply / an
+/// endless `inference_heartbeat` stream. Deliberately generous — a hang
+/// backstop, not a UX deadline. Override via `OPENHUMAN_WEB_TURN_TIMEOUT_SECS`;
+/// set it to `0` to disable the backstop.
+const DEFAULT_WEB_TURN_TIMEOUT_SECS: u64 = 900;
 
 /// Resolve the per-turn wall-clock backstop. Returns `None` when disabled
 /// (env `OPENHUMAN_WEB_TURN_TIMEOUT_SECS=0`).

--- a/src/openhuman/channels/providers/web/ops.rs
+++ b/src/openhuman/channels/providers/web/ops.rs
@@ -309,6 +309,21 @@ pub struct TestRunChatTaskBlock {
 pub(super) static TEST_RUN_CHAT_TASK_BLOCK: Lazy<Mutex<Option<TestRunChatTaskBlock>>> =
     Lazy::new(|| Mutex::new(None));
 
+/// Process-wide lock serializing every test that drives the global
+/// `run_chat_task` test hooks (`set_test_run_chat_task_block`,
+/// `set_test_forced_run_chat_task_error`) or the `OPENHUMAN_WEB_TURN_TIMEOUT_SECS`
+/// turn-timeout override.
+///
+/// All of those toggles are process-global, so a `start_chat` / `run_chat_task`
+/// call in ANY test — not just those in `web_tests.rs` — can observe another
+/// test's forced block/error/timeout unless every such test holds this one lock
+/// for its whole body. It lives here at the hook boundary (rather than as a
+/// file-local lock in `web_tests.rs`) precisely so tests in other modules that
+/// exercise `start_chat`/`run_chat_task` can serialize against the same lock
+/// (CodeRabbit review on #4746).
+#[cfg(any(test, debug_assertions))]
+pub static RUN_CHAT_TASK_TEST_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
 /// Cooperatively cancel an in-flight turn, with a hard `abort()` backstop.
 ///
 /// Cancelling the token makes the turn's `tokio::select!` arm fire, dropping

--- a/src/openhuman/channels/providers/web/ops.rs
+++ b/src/openhuman/channels/providers/web/ops.rs
@@ -147,6 +147,32 @@ where
     }
 }
 
+/// Reason a terminal `run_chat_task` error should be kept OUT of Sentry, or
+/// `None` when it is a genuine defect that must page.
+///
+/// Both suppressed cases are deterministic, user-surfaced, retryable
+/// agent-loop outcomes — a terminal `chat_error` already reaches the client, so
+/// a Sentry event is pure noise (same tier as `MaxIterationsExceeded` /
+/// `EmptyProviderResponse`, which are demoted the same way):
+///
+/// - the max-iteration cap (`is_max_iterations_error`), and
+/// - the turn wall-clock backstop / harness `Timeout` (`is_turn_timeout_error`,
+///   issue #4746) — without this arm every wedged turn that trips the ceiling
+///   would emit a spurious Sentry event, contradicting the graceful
+///   `turn_timeout` framing.
+///
+/// Kept as a pure predicate over the already-formatted error string so the
+/// suppression policy is unit-testable without a Sentry harness.
+pub(crate) fn sentry_suppression_reason(detailed: &str) -> Option<&'static str> {
+    if crate::openhuman::agent::error::is_max_iterations_error(detailed) {
+        Some("max-iteration cap")
+    } else if super::web_errors::is_turn_timeout_error(detailed) {
+        Some("turn wall-clock backstop")
+    } else {
+        None
+    }
+}
+
 /// What the budget-correlator should do with a terminated turn (#3386).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum BudgetCorrelation {
@@ -713,11 +739,12 @@ pub async fn start_chat(
                 let classified = classify_inference_error(&err);
                 let classified_type = classified.error_type;
                 let classified_type_string = classified_type.to_string();
-                if crate::openhuman::agent::error::is_max_iterations_error(&detailed) {
+                if let Some(reason) = sentry_suppression_reason(&detailed) {
                     log::info!(
                         target: "web_channel",
-                        "[web_channel.run_chat_task] suppressed Sentry emission for max-iteration \
-                         cap client_id={} thread_id={} request_id={} error_type={} message={}",
+                        "[web_channel.run_chat_task] suppressed Sentry emission for {} \
+                         client_id={} thread_id={} request_id={} error_type={} message={}",
+                        reason,
                         client_id_task,
                         thread_id_task,
                         request_id_task,

--- a/src/openhuman/channels/providers/web/ops.rs
+++ b/src/openhuman/channels/providers/web/ops.rs
@@ -59,6 +59,58 @@ static THREAD_BUDGET_SIGNALS: Lazy<Mutex<HashMap<String, BudgetSignal>>> =
 /// the signal regardless (the balance is evidently usable again). See #3386.
 const BUDGET_SIGNAL_TTL: Duration = Duration::from_secs(5 * 60);
 
+/// Default wall-clock backstop for a single web chat turn, in seconds.
+///
+/// A turn still running past this without producing a terminal event is treated
+/// as wedged — a stuck main-agent tool call, or a delegated sub-agent that
+/// never returned — and stopped with a graceful `chat_error`, so the client
+/// never receives an empty reply / spins on `inference_heartbeat` until the
+/// socket dies (issue #4746). Deliberately generous: normal turns, even slow
+/// reasoning-tier ones that buffer output for minutes, finish well under it —
+/// this is a hang backstop, not a UX deadline. Override via
+/// `OPENHUMAN_WEB_TURN_TIMEOUT_SECS`; set it to `0` to disable the backstop.
+const DEFAULT_WEB_TURN_TIMEOUT_SECS: u64 = 600;
+
+/// Resolve the per-turn wall-clock backstop. Returns `None` when disabled
+/// (env `OPENHUMAN_WEB_TURN_TIMEOUT_SECS=0`).
+fn web_turn_deadline() -> Option<Duration> {
+    let secs = std::env::var("OPENHUMAN_WEB_TURN_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_WEB_TURN_TIMEOUT_SECS);
+    (secs > 0).then(|| Duration::from_secs(secs))
+}
+
+/// Drive a chat-turn future under the wall-clock backstop.
+///
+/// On elapse the inner future is dropped (cooperative teardown at its next
+/// await point) and a synthetic `turn_timeout` error is returned, so the
+/// caller's existing `chat_error` emission path fires. This is the outermost
+/// guarantee that a wedged turn always ends in a terminal event rather than an
+/// empty reply / an endless `inference_heartbeat` stream (issue #4746).
+async fn drive_turn_with_deadline<F>(
+    deadline: Option<Duration>,
+    fut: F,
+) -> Result<super::types::WebChatTaskResult, String>
+where
+    F: std::future::Future<Output = Result<super::types::WebChatTaskResult, String>>,
+{
+    match deadline {
+        Some(d) => match tokio::time::timeout(d, fut).await {
+            Ok(res) => res,
+            Err(_elapsed) => {
+                log::warn!(
+                    "[web-channel] turn wall-clock backstop fired after {}s with no terminal event; \
+                     emitting graceful turn_timeout chat_error (issue #4746)",
+                    d.as_secs()
+                );
+                Err(super::web_errors::turn_timeout_error_message(d.as_secs()))
+            }
+        },
+        None => fut.await,
+    }
+}
+
 /// What the budget-correlator should do with a terminated turn (#3386).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum BudgetCorrelation {
@@ -558,22 +610,25 @@ pub async fn start_chat(
         let result = tokio::select! {
             biased;
             _ = task_cancel_token.cancelled() => None,
-            res = crate::openhuman::agent::turn_origin::with_origin(
-                origin,
-                crate::openhuman::approval::APPROVAL_CHAT_CONTEXT.scope(
-                    approval_ctx,
-                    run_chat_task(
-                        &client_id_task,
-                        &thread_id_task,
-                        &request_id_task,
-                        &user_message,
-                        model_override,
-                        temperature,
-                        profile_id,
-                        locale,
-                        turn_run_queue_task,
-                        metadata,
-                        /* fork */ false,
+            res = drive_turn_with_deadline(
+                web_turn_deadline(),
+                crate::openhuman::agent::turn_origin::with_origin(
+                    origin,
+                    crate::openhuman::approval::APPROVAL_CHAT_CONTEXT.scope(
+                        approval_ctx,
+                        run_chat_task(
+                            &client_id_task,
+                            &thread_id_task,
+                            &request_id_task,
+                            &user_message,
+                            model_override,
+                            temperature,
+                            profile_id,
+                            locale,
+                            turn_run_queue_task,
+                            metadata,
+                            /* fork */ false,
+                        ),
                     ),
                 ),
             ) => Some(res),
@@ -786,22 +841,25 @@ async fn spawn_parallel_turn(
         let result = tokio::select! {
             biased;
             _ = task_cancel_token.cancelled() => None,
-            res = crate::openhuman::agent::turn_origin::with_origin(
-                origin,
-                crate::openhuman::approval::APPROVAL_CHAT_CONTEXT.scope(
-                    approval_ctx,
-                    run_chat_task(
-                        &client_id_task,
-                        &thread_id_task,
-                        &request_id_task,
-                        &user_message,
-                        model_override,
-                        temperature,
-                        profile_id,
-                        locale,
-                        run_queue,
-                        metadata,
-                        /* fork */ true,
+            res = drive_turn_with_deadline(
+                web_turn_deadline(),
+                crate::openhuman::agent::turn_origin::with_origin(
+                    origin,
+                    crate::openhuman::approval::APPROVAL_CHAT_CONTEXT.scope(
+                        approval_ctx,
+                        run_chat_task(
+                            &client_id_task,
+                            &thread_id_task,
+                            &request_id_task,
+                            &user_message,
+                            model_override,
+                            temperature,
+                            profile_id,
+                            locale,
+                            run_queue,
+                            metadata,
+                            /* fork */ true,
+                        ),
                     ),
                 ),
             ) => Some(res),

--- a/src/openhuman/channels/providers/web_errors.rs
+++ b/src/openhuman/channels/providers/web_errors.rs
@@ -163,10 +163,11 @@ pub(crate) fn with_provider_detail(summary: &str, err: &str) -> String {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ClassifiedError {
     /// Stable token: `rate_limited`, `action_budget_exceeded`,
-    /// `max_iterations`, `timeout`, `auth_error`, `budget_exhausted`,
-    /// `provider_error`, `context_overflow`, `model_unavailable`,
-    /// `payload_too_large`, `provider_request_rejected`,
-    /// `capability_unsupported`, `empty_response`, `turn_timeout`, `inference`.
+    /// `max_iterations`, `turn_timeout`, `timeout`, `auth_error`,
+    /// `session_expired`, `budget_exhausted`, `provider_error`,
+    /// `context_overflow`, `model_unavailable`, `payload_too_large`,
+    /// `provider_request_rejected`, `capability_unsupported`,
+    /// `empty_response`, `network`, `inference`.
     pub(crate) error_type: &'static str,
     /// User-facing copy (already includes provider detail block and the
     /// retry-after countdown sentence when available).

--- a/src/openhuman/channels/providers/web_errors.rs
+++ b/src/openhuman/channels/providers/web_errors.rs
@@ -67,10 +67,19 @@ pub(crate) fn turn_timeout_error_message(secs: u64) -> String {
     )
 }
 
-/// True when `err` is the synthetic wall-clock-timeout error raised by the web
-/// turn driver — matched on the stable [`TURN_TIMEOUT_MARKER`] anchor.
+/// True when `err` is a turn wall-clock timeout — either the synthetic marker
+/// raised by the web turn driver's outer backstop ([`TURN_TIMEOUT_MARKER`]), or
+/// the tinyagents harness's own `TinyAgentsError::Timeout` (issue #4746). The
+/// harness renders that as `run timed out: <model|tool> call for run `..`
+/// exceeded its remaining wall-clock budget (.. ms)` / `.. exceeded its
+/// wall-clock deadline`, so both wall-clock phrasings are anchored here. This
+/// routes the loop's graceful budget-exhaustion terminal event to the dedicated
+/// `turn_timeout` copy instead of the generic catch-all.
 pub(crate) fn is_turn_timeout_error(err: &str) -> bool {
     err.contains(TURN_TIMEOUT_MARKER)
+        || err.contains("run timed out:")
+        || err.contains("exceeded its remaining wall-clock budget")
+        || err.contains("exceeded its wall-clock deadline")
 }
 
 /// Pull the structured provider error message out of a raw error string.

--- a/src/openhuman/channels/providers/web_errors.rs
+++ b/src/openhuman/channels/providers/web_errors.rs
@@ -50,6 +50,29 @@ pub(crate) fn generic_inference_error_user_message() -> &'static str {
     "Something went wrong. Please try again.\nThis error has been reported. You can also report it on Discord.\n<openhuman-link path=\"community/discord-report\">Report on Discord</openhuman-link>"
 }
 
+/// Stable marker embedded in the synthetic error a web turn raises when it
+/// exceeds its wall-clock backstop (`OPENHUMAN_WEB_TURN_TIMEOUT_SECS`). Kept as
+/// a grep-friendly anchor so [`classify_inference_error`] routes it to the
+/// dedicated `turn_timeout` branch instead of the generic catch-all.
+pub(crate) const TURN_TIMEOUT_MARKER: &str = "openhuman_turn_wall_clock_timeout";
+
+/// Build the synthetic error string a wedged web turn raises when its
+/// wall-clock backstop fires. Carries [`TURN_TIMEOUT_MARKER`] so the error
+/// classifier surfaces a graceful, retryable `turn_timeout` chat_error rather
+/// than letting the turn hang forever with no terminal event (issue #4746).
+pub(crate) fn turn_timeout_error_message(secs: u64) -> String {
+    format!(
+        "{TURN_TIMEOUT_MARKER}: agent turn exceeded its {secs}s wall-clock budget \
+         without producing a terminal event (a tool or delegated sub-agent likely stalled)"
+    )
+}
+
+/// True when `err` is the synthetic wall-clock-timeout error raised by the web
+/// turn driver — matched on the stable [`TURN_TIMEOUT_MARKER`] anchor.
+pub(crate) fn is_turn_timeout_error(err: &str) -> bool {
+    err.contains(TURN_TIMEOUT_MARKER)
+}
+
 /// Pull the structured provider error message out of a raw error string.
 ///
 /// Provider error chains from OpenAI/Anthropic/OpenRouter/etc. arrive looking
@@ -134,7 +157,7 @@ pub(crate) struct ClassifiedError {
     /// `max_iterations`, `timeout`, `auth_error`, `budget_exhausted`,
     /// `provider_error`, `context_overflow`, `model_unavailable`,
     /// `payload_too_large`, `provider_request_rejected`,
-    /// `capability_unsupported`, `empty_response`, `inference`.
+    /// `capability_unsupported`, `empty_response`, `turn_timeout`, `inference`.
     pub(crate) error_type: &'static str,
     /// User-facing copy (already includes provider detail block and the
     /// retry-after countdown sentence when available).
@@ -564,6 +587,28 @@ pub(crate) fn classify_inference_error(err: &str) -> ClassifiedError {
             retryable: true,
             retry_after_ms: None,
             provider,
+            fallback_available: None,
+        }
+    } else if is_turn_timeout_error(err) {
+        // The web turn driver's wall-clock backstop fired: the turn ran past its
+        // time budget without ever producing a terminal event — a wedged main
+        // agent (stuck mid tool-call) or a delegated sub-agent that never
+        // returned. Surface a graceful, retryable chat_error so the client stops
+        // "processing" instead of receiving an empty reply / spinning on
+        // `inference_heartbeat` until the socket dies (issue #4746). Anchored
+        // next to max_iterations — both are deterministic agent-loop outcomes
+        // that must not be shadowed by the broad provider-429 / 5xx arms below.
+        // No `with_provider_detail`: the marker string carries no provider body.
+        ClassifiedError {
+            error_type: "turn_timeout",
+            message: "This turn ran past its time budget without finishing and was \
+                 stopped so it wouldn't hang. This usually means a tool call or a \
+                 delegated sub-agent stalled. You can retry your question in this thread."
+                .to_string(),
+            source: "agent_loop",
+            retryable: true,
+            retry_after_ms: None,
+            provider: None,
             fallback_available: None,
         }
     } else if is_empty_provider_response_text(&lower) {

--- a/src/openhuman/channels/providers/web_tests.rs
+++ b/src/openhuman/channels/providers/web_tests.rs
@@ -2010,8 +2010,18 @@ async fn cancel_chat_cooperatively_stops_in_flight_turn() {
 #[tokio::test]
 async fn wedged_turn_hits_wall_clock_backstop_and_emits_turn_timeout_chat_error() {
     let _serial = FORCED_ERROR_TEST_LOCK.lock().await;
+    // Panic-safe teardown of the process-global env override: if any assertion
+    // below unwinds, this guard still clears `OPENHUMAN_WEB_TURN_TIMEOUT_SECS` so
+    // a 1s backstop can't leak into unrelated tests sharing this process.
+    struct EnvGuard;
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            std::env::remove_var("OPENHUMAN_WEB_TURN_TIMEOUT_SECS");
+        }
+    }
+    let _env_guard = EnvGuard;
     // Tight 1s backstop so the parked (30s) turn trips it quickly. Scoped to this
-    // serialized test and cleared below.
+    // serialized test and cleared by `EnvGuard` on drop (even on unwind).
     std::env::set_var("OPENHUMAN_WEB_TURN_TIMEOUT_SECS", "1");
     let block = make_block();
     set_test_run_chat_task_block(Some(block.clone())).await;
@@ -2063,7 +2073,7 @@ async fn wedged_turn_hits_wall_clock_backstop_and_emits_turn_timeout_chat_error(
     wait_for_flag(&block.dropped, "wedged turn future dropped by backstop").await;
 
     set_test_run_chat_task_block(None).await;
-    std::env::remove_var("OPENHUMAN_WEB_TURN_TIMEOUT_SECS");
+    // `OPENHUMAN_WEB_TURN_TIMEOUT_SECS` is cleared by `_env_guard`'s Drop.
 }
 
 /// Helper: poll the parallel in-flight lane until `pred` holds (or time out).

--- a/src/openhuman/channels/providers/web_tests.rs
+++ b/src/openhuman/channels/providers/web_tests.rs
@@ -430,6 +430,29 @@ fn classify_inference_error_turn_timeout_gets_dedicated_branch() {
 }
 
 #[test]
+fn classify_inference_error_harness_wall_clock_timeout_is_turn_timeout() {
+    // Issue #4746: the root-cause guard is the tinyagents harness policy
+    // wall-clock ceiling. When it fires the loop returns TinyAgentsError::Timeout,
+    // rendered `run timed out: <model|tool> call for run `..` exceeded its
+    // remaining wall-clock budget (.. ms)`. That terminal error must classify to
+    // the graceful `turn_timeout` bucket, not the generic catch-all, so the user
+    // sees actionable copy instead of "something went wrong".
+    for raw in [
+        "run timed out: model call for run `abc123` exceeded its remaining wall-clock budget (600000 ms)",
+        "run timed out: tool call for run `abc123` exceeded its remaining wall-clock budget (12345 ms)",
+        "run `abc123` exceeded its wall-clock deadline",
+    ] {
+        let ClassifiedError {
+            error_type: category,
+            retryable,
+            ..
+        } = classify_inference_error(raw);
+        assert_eq!(category, "turn_timeout", "must classify as turn_timeout: {raw}");
+        assert!(retryable, "a wall-clock timeout is retryable: {raw}");
+    }
+}
+
+#[test]
 fn classify_inference_error_rate_limited_surfaces_retry_after_seconds() {
     let raw = "openrouter API error (429 Too Many Requests): Retry-After: 30";
     let ClassifiedError {

--- a/src/openhuman/channels/providers/web_tests.rs
+++ b/src/openhuman/channels/providers/web_tests.rs
@@ -399,6 +399,37 @@ fn classify_inference_error_max_iterations_gets_dedicated_branch() {
 }
 
 #[test]
+fn classify_inference_error_turn_timeout_gets_dedicated_branch() {
+    // Issue #4746: the web turn driver's wall-clock backstop raises a synthetic
+    // error carrying a stable marker when a wedged turn is stopped. It must
+    // classify to a dedicated, retryable `turn_timeout` bucket with graceful
+    // copy — never the generic catch-all, and the internal marker must not leak.
+    let raw = super::web_errors::turn_timeout_error_message(600);
+    let ClassifiedError {
+        error_type: category,
+        message,
+        source,
+        retryable,
+        ..
+    } = classify_inference_error(&raw);
+    assert_eq!(category, "turn_timeout");
+    assert_eq!(source, "agent_loop");
+    assert!(retryable, "a wedged-turn timeout is safe to retry in-thread");
+    assert!(
+        message.contains("past its time budget"),
+        "must explain the turn was stopped: {message}"
+    );
+    assert!(
+        message.contains("retry your question in this thread"),
+        "must reassure same-thread recovery: {message}"
+    );
+    assert!(
+        !message.contains("openhuman_turn_wall_clock_timeout"),
+        "internal marker must not leak into user copy: {message}"
+    );
+}
+
+#[test]
 fn classify_inference_error_rate_limited_surfaces_retry_after_seconds() {
     let raw = "openrouter API error (429 Too Many Requests): Retry-After: 30";
     let ClassifiedError {
@@ -1940,6 +1971,73 @@ async fn cancel_chat_cooperatively_stops_in_flight_turn() {
     wait_for_flag(&block.dropped, "turn future dropped by cooperative cancel").await;
 
     set_test_run_chat_task_block(None).await;
+}
+
+/// Issue #4746: a turn that never produces a terminal event on its own — a
+/// wedged main agent stuck mid tool-call, or a delegated sub-agent that never
+/// returns (modeled here by the parked test block) — must still end in a
+/// terminal `chat_error`, never an empty reply / an endless `inference_heartbeat`
+/// stream until the socket dies. The web turn driver's wall-clock backstop fires
+/// and emits a graceful, retryable `turn_timeout` chat_error, and tears the
+/// wedged future down cooperatively (its `Drop` guard flips well before the 30s
+/// test sleep would elapse).
+#[tokio::test]
+async fn wedged_turn_hits_wall_clock_backstop_and_emits_turn_timeout_chat_error() {
+    let _serial = FORCED_ERROR_TEST_LOCK.lock().await;
+    // Tight 1s backstop so the parked (30s) turn trips it quickly. Scoped to this
+    // serialized test and cleared below.
+    std::env::set_var("OPENHUMAN_WEB_TURN_TIMEOUT_SECS", "1");
+    let block = make_block();
+    set_test_run_chat_task_block(Some(block.clone())).await;
+
+    let mut rx = subscribe_web_channel_events();
+    let request_id = start_chat(
+        "backstop-client",
+        "backstop-thread",
+        "park me until the wall-clock backstop fires",
+        None,
+        None,
+        None,
+        None,
+        None,
+        ChatRequestMetadata::default(),
+    )
+    .await
+    .expect("turn should start");
+
+    let recv = timeout(Duration::from_secs(20), async move {
+        loop {
+            let event = rx.recv().await.expect("event stream should stay open");
+            if event.event == "chat_error" && event.request_id == request_id {
+                return event;
+            }
+        }
+    })
+    .await
+    .expect("a wedged turn must still emit a terminal chat_error (issue #4746)");
+
+    assert_eq!(
+        recv.error_type.as_deref(),
+        Some("turn_timeout"),
+        "the backstop must surface a graceful turn_timeout, not a generic error"
+    );
+    assert_eq!(
+        recv.error_retryable,
+        Some(true),
+        "a turn_timeout is safe to retry in the same thread"
+    );
+    let message = recv.message.unwrap_or_default();
+    assert!(
+        !message.contains("openhuman_turn_wall_clock_timeout"),
+        "internal marker must not leak into user copy: {message}"
+    );
+
+    // The wedged future is torn down cooperatively when the backstop drops it
+    // (the Drop guard flips), not left sleeping to its 30s test wall.
+    wait_for_flag(&block.dropped, "wedged turn future dropped by backstop").await;
+
+    set_test_run_chat_task_block(None).await;
+    std::env::remove_var("OPENHUMAN_WEB_TURN_TIMEOUT_SECS");
 }
 
 /// Helper: poll the parallel in-flight lane until `pred` holds (or time out).

--- a/src/openhuman/channels/providers/web_tests.rs
+++ b/src/openhuman/channels/providers/web_tests.rs
@@ -11,21 +11,24 @@ use super::{
     WebChatParams,
 };
 use crate::core::TypeSchema;
-use once_cell::sync::Lazy;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use tokio::sync::Mutex as TokioMutex;
 use tokio::time::{timeout, Duration};
 
-/// Serializes every test that drives `start_chat` with a
-/// `TEST_FORCED_RUN_CHAT_TASK_ERROR` toggle. The toggle and the
-/// per-thread session cache are process-global, so two such tests
-/// running concurrently can clobber each other's forced error before
-/// `run_chat_task` reads it — leading to flaky asserts where one test
-/// observes another test's error string. Holding this mutex for the
-/// duration of each test body restores isolation without disabling
-/// `cargo test`'s default parallelism for the rest of the suite.
-static FORCED_ERROR_TEST_LOCK: Lazy<TokioMutex<()>> = Lazy::new(|| TokioMutex::new(()));
+// Serializes every test that drives `start_chat` with the process-global
+// `run_chat_task` test hooks (forced error / forced block) or the
+// `OPENHUMAN_WEB_TURN_TIMEOUT_SECS` override. Those toggles and the per-thread
+// session cache are process-global, so two such tests running concurrently can
+// clobber each other before `run_chat_task` reads them — leading to flaky
+// asserts where one test observes another test's state. Holding this mutex for
+// the duration of each test body restores isolation without disabling
+// `cargo test`'s default parallelism for the rest of the suite.
+//
+// This is the *shared* lock defined at the hook boundary
+// (`web::ops::RUN_CHAT_TASK_TEST_LOCK`), not a file-local one, so tests in other
+// modules that exercise `start_chat`/`run_chat_task` serialize on the same lock
+// (CodeRabbit review on #4746).
+use super::RUN_CHAT_TASK_TEST_LOCK as FORCED_ERROR_TEST_LOCK;
 
 #[tokio::test]
 async fn start_chat_validates_required_fields() {

--- a/src/openhuman/channels/providers/web_tests.rs
+++ b/src/openhuman/channels/providers/web_tests.rs
@@ -5,7 +5,7 @@ use super::{
     in_flight_entries_for_test, inference_budget_exceeded_user_message,
     is_inference_budget_exceeded_error, json_output, key_for, locale_reply_directive,
     normalize_model_override, optional_f64, optional_string, parallel_in_flight_entries_for_test,
-    provider_role_for_model_override, required_string, schemas,
+    provider_role_for_model_override, required_string, schemas, sentry_suppression_reason,
     set_test_forced_run_chat_task_error, set_test_run_chat_task_block, start_chat,
     subscribe_web_channel_events, ChatRequestMetadata, ClassifiedError, TestRunChatTaskBlock,
     WebChatParams,
@@ -453,6 +453,40 @@ fn classify_inference_error_harness_wall_clock_timeout_is_turn_timeout() {
         assert_eq!(category, "turn_timeout", "must classify as turn_timeout: {raw}");
         assert!(retryable, "a wall-clock timeout is retryable: {raw}");
     }
+}
+
+#[test]
+fn turn_timeout_error_is_suppressed_from_sentry() {
+    // Issue #4746 (maintainer review): a wedged turn that trips the wall-clock
+    // ceiling is a deterministic, user-surfaced, retryable outcome — the client
+    // already gets a graceful `turn_timeout` chat_error, so it must NOT page
+    // Sentry (same tier as the max-iteration cap). `run_chat_task`'s emit site
+    // gates on `sentry_suppression_reason`; assert both the synthetic backstop
+    // marker and the harness `Timeout` renderings are suppressed, while a
+    // genuine provider defect still reports.
+    let detailed_marker = format!(
+        "run_chat_task failed client_id=c thread_id=t request_id=r error={}",
+        super::web_errors::turn_timeout_error_message(600)
+    );
+    assert_eq!(
+        sentry_suppression_reason(&detailed_marker),
+        Some("turn wall-clock backstop"),
+        "the synthetic backstop marker must suppress the Sentry emit"
+    );
+    assert_eq!(
+        sentry_suppression_reason(
+            "run timed out: model call for run `abc` exceeded its remaining wall-clock budget (600000 ms)"
+        ),
+        Some("turn wall-clock backstop"),
+        "the harness Timeout rendering must suppress the Sentry emit"
+    );
+    // A real provider defect is NOT a deterministic agent-loop outcome and must
+    // still page.
+    assert_eq!(
+        sentry_suppression_reason("openrouter API error (500 Internal Server Error)"),
+        None,
+        "a genuine provider error must still reach Sentry"
+    );
 }
 
 #[test]

--- a/src/openhuman/channels/providers/web_tests.rs
+++ b/src/openhuman/channels/providers/web_tests.rs
@@ -414,7 +414,10 @@ fn classify_inference_error_turn_timeout_gets_dedicated_branch() {
     } = classify_inference_error(&raw);
     assert_eq!(category, "turn_timeout");
     assert_eq!(source, "agent_loop");
-    assert!(retryable, "a wedged-turn timeout is safe to retry in-thread");
+    assert!(
+        retryable,
+        "a wedged-turn timeout is safe to retry in-thread"
+    );
     assert!(
         message.contains("past its time budget"),
         "must explain the turn was stopped: {message}"

--- a/src/openhuman/tinyagents/mod.rs
+++ b/src/openhuman/tinyagents/mod.rs
@@ -142,11 +142,59 @@ pub(crate) struct ToolPolicyEnforcement {
 /// [`routes::route_fallback_policy`]); it is safe to enable now because
 /// `ReliableProvider` does *not* fail over across the registered workload-tier
 /// routes (chat→burst, reasoning→agentic, …) the way the harness registry can.
+/// Default per-turn wall-clock ceiling for an openhuman agent turn, in seconds
+/// (issue #4746). Applied as the harness `RunLimits::max_wall_clock_ms` so the
+/// loop interrupts a hung/slow model or tool/sub-agent call instead of parking
+/// forever with no terminal event. Deliberately generous — a normal turn, even
+/// a slow multi-step reasoning one, finishes well under it; this is a hang
+/// backstop, not a UX deadline. 10 minutes.
+const DEFAULT_AGENT_TURN_TIMEOUT_SECS: u64 = 600;
+
+/// Resolve the per-turn wall-clock ceiling in milliseconds for the harness
+/// policy. Reads `OPENHUMAN_AGENT_TURN_TIMEOUT_SECS` (falling back to
+/// [`DEFAULT_AGENT_TURN_TIMEOUT_SECS`]); `0` means "no ceiling" → `None`, which
+/// restores the previous unbounded behavior for callers that deliberately opt
+/// out (e.g. very long autonomous runs).
+fn agent_turn_wall_clock_ms() -> Option<u64> {
+    parse_agent_turn_wall_clock_ms(
+        std::env::var("OPENHUMAN_AGENT_TURN_TIMEOUT_SECS")
+            .ok()
+            .as_deref(),
+    )
+}
+
+/// Pure core of [`agent_turn_wall_clock_ms`]: map an optional
+/// `OPENHUMAN_AGENT_TURN_TIMEOUT_SECS` value to a wall-clock ceiling in
+/// milliseconds. An absent/unparseable value falls back to
+/// [`DEFAULT_AGENT_TURN_TIMEOUT_SECS`]; `0` yields `None` (unbounded opt-out).
+/// Kept env-free so it is deterministically unit-testable.
+fn parse_agent_turn_wall_clock_ms(env_value: Option<&str>) -> Option<u64> {
+    let secs = env_value
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_AGENT_TURN_TIMEOUT_SECS);
+    (secs > 0).then(|| secs.saturating_mul(1_000))
+}
+
 fn run_policy_for(max_iterations: usize, response_cache_enabled: bool) -> RunPolicy {
     let mut policy = RunPolicy::default();
     policy.limits.max_model_calls = max_iterations;
     policy.limits.max_tool_calls = max_iterations.saturating_mul(8).max(8);
     policy.limits.max_depth = MAX_SPAWN_DEPTH;
+    // Wall-clock ceiling for the whole turn (issue #4746). The harness bounds
+    // every individual model AND tool call by the run's *remaining* wall-clock
+    // budget (`with_call_budget` → `tokio::time::timeout`), but ONLY when a
+    // deadline is configured — with `max_wall_clock_ms = None` (the default)
+    // `call_budget()` returns `None` and each call is awaited UNBOUNDED. That is
+    // exactly how a turn shipped an empty reply: a hung/slow model stream or a
+    // delegated sub-agent tool call that never returned left the loop parked
+    // inside an await, so the between-call deadline check never ran and no
+    // terminal event (loop `Timeout` → chat_error) ever fired. Setting the cap
+    // here arms the harness's per-call timeout so a wedged call is interrupted
+    // mid-flight and the turn degrades gracefully. It also bounds sub-agents:
+    // the parent's remaining-budget wraps the sub-agent tool call, and a child
+    // turn with no per-run timeout inherits this policy-level cap. Generous by
+    // design (a backstop, not a UX deadline); env-overridable, `0` disables.
+    policy.limits.max_wall_clock_ms = agent_turn_wall_clock_ms();
     // Crate-owned retry (Phase 3a): mirror the former `ReliableProvider` schedule
     // (2 retries, 500 ms exponential backoff). `backoff_sleep` is on so a
     // transient 429/5xx actually waits before retrying, as it did before.

--- a/src/openhuman/tinyagents/tests.rs
+++ b/src/openhuman/tinyagents/tests.rs
@@ -760,3 +760,41 @@ fn spawn_and_delegate_tools_are_never_registered_on_subagents() {
         );
     }
 }
+
+/// Issue #4746: the harness bounds each model/tool/sub-agent call by the run's
+/// remaining wall-clock budget, but ONLY when `max_wall_clock_ms` is set — with
+/// `None` a hung call is awaited unbounded and the turn can ship an empty reply
+/// with no terminal event. `run_policy_for` must arm that ceiling.
+#[test]
+fn run_policy_for_arms_the_wall_clock_ceiling() {
+    let policy = run_policy_for(10, false);
+    assert_eq!(
+        policy.limits.max_wall_clock_ms,
+        Some(DEFAULT_AGENT_TURN_TIMEOUT_SECS * 1_000),
+        "run_policy_for must set a wall-clock ceiling so hung calls are interrupted"
+    );
+}
+
+/// The `OPENHUMAN_AGENT_TURN_TIMEOUT_SECS` override maps seconds → ms, falls
+/// back to the default when absent/unparseable, and treats `0` as an explicit
+/// unbounded opt-out (`None`). Tested through the env-free pure core so it stays
+/// deterministic under parallel execution.
+#[test]
+fn agent_turn_wall_clock_ms_parses_env_override() {
+    // Absent → default.
+    assert_eq!(
+        parse_agent_turn_wall_clock_ms(None),
+        Some(DEFAULT_AGENT_TURN_TIMEOUT_SECS * 1_000)
+    );
+    // Explicit custom value → seconds converted to ms.
+    assert_eq!(parse_agent_turn_wall_clock_ms(Some("120")), Some(120_000));
+    // Whitespace tolerated.
+    assert_eq!(parse_agent_turn_wall_clock_ms(Some(" 90 ")), Some(90_000));
+    // `0` → unbounded opt-out.
+    assert_eq!(parse_agent_turn_wall_clock_ms(Some("0")), None);
+    // Garbage → default (fail safe, never unbounded by accident).
+    assert_eq!(
+        parse_agent_turn_wall_clock_ms(Some("not-a-number")),
+        Some(DEFAULT_AGENT_TURN_TIMEOUT_SECS * 1_000)
+    );
+}


### PR DESCRIPTION
## Problem (issue #4746)

A delegated turn shipped an **empty reply** with **no `chat_done` and no `chat_error`** — the client spun on `inference_heartbeat` until the socket died (~443s). Two evidence cases: a sub-agent that streamed but never emitted a completion, and a main agent wedged mid tool-call.

## Root cause — in openhuman's adapter, not the tinyagents harness

I checked `vendor/tinyagents` first. **The harness is correct and robust**: `with_call_budget` wraps *every* model call (incl. the streaming path, `agent_loop/model_call.rs`) **and** every tool/sub-agent call (`agent_loop/tools.rs`) in `tokio::time::timeout(remaining_wall_clock)`, interrupting a hung call and returning `TinyAgentsError::Timeout`.

The catch: `call_budget()` returns `None` — i.e. calls are awaited **unbounded** — when *neither* the run config's `timeout_ms` *nor* the harness policy's `max_wall_clock_ms` is set. And openhuman's `tinyagents::run_policy_for` sets the iteration caps but **never `max_wall_clock_ms`**. So the harness's per-call timeout was disabled: a hung model stream / a sub-agent that never returned parked the loop inside an `await`, the between-call deadline check never ran, and no terminal event ever fired.

**No tinyagents change needed** — the fix is a one-liner in the openhuman adapter that arms the ceiling.

## Fix

1. **`tinyagents/mod.rs` (root cause)** — `run_policy_for` now sets `policy.limits.max_wall_clock_ms` (`OPENHUMAN_AGENT_TURN_TIMEOUT_SECS`, default **600s**, `0` disables). This arms the harness's existing per-call timeout so a wedged model/tool/sub-agent call is interrupted mid-flight and the turn degrades to a graceful `Timeout → chat_error`. It also bounds sub-agents — the parent's remaining budget wraps the sub-agent tool call, and a child turn with no per-run timeout inherits this policy-level cap.
2. **`web_errors.rs`** — a dedicated, retryable `turn_timeout` classification branch matching both the harness `Timeout` message (`run timed out: … wall-clock budget/deadline`) and the outer backstop marker, so the user gets actionable copy instead of the generic "something went wrong".
3. **`web/ops.rs` (defense-in-depth)** — a channel-level wall-clock backstop around the whole turn future, as an **outer** net (raised to **900s**, above the 600s harness ceiling) so a hang *outside* the harness run (session assembly / persistence plumbing) still ends in a terminal `chat_error`. The harness ceiling is the primary mechanism and fires first.

The iteration-cap path already degrades gracefully (`core.rs` synthesizes a checkpoint/summary); this closes the remaining never-returns gap.

## Tests

- `run_policy_for_arms_the_wall_clock_ceiling` + `agent_turn_wall_clock_ms_parses_env_override` (`0`=unbounded, garbage=default).
- `classify_inference_error_turn_timeout_gets_dedicated_branch` + `classify_inference_error_harness_wall_clock_timeout_is_turn_timeout`.
- `wedged_turn_hits_wall_clock_backstop_and_emits_turn_timeout_chat_error` — parks a turn, asserts a terminal `chat_error{turn_timeout, retryable}` and cooperative teardown.

## Checks

Per an active no-local-builds directive (disk pressure on the runner), CI verifies. `cargo check --lib` passed on an earlier run of the initial change. Note: the lib **test** target has pre-existing compile errors in several unrelated domains at this base (reproduced on clean main with these changes stashed) — left to CI.

Closes #4746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added a wall-clock limit for web chat turns, ensuring stalled or unresponsive turns end with a terminal error.
  - Applied the same protection to parallel conversation branches.
  - Added a clear, retryable message when a turn exceeds its time budget.
  - Prevented internal timeout details from appearing in user-facing messages.
  - Suppressed expected timeout events from error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->