### PR TITLE
fix(tests): restore test-module imports broken by recent refactors

### DIFF
--- a/src/openhuman/channels/providers/web/mod.rs
+++ b/src/openhuman/channels/providers/web/mod.rs
@@ -50,6 +50,25 @@ pub(crate) use ops::{event_session_id_for, key_for};
 pub(crate) use progress_bridge::spawn_progress_bridge;
 
 // Schema field helpers re-exported for tests
+#[cfg(any(test, debug_assertions))]
+#[allow(unused_imports)]
+pub(crate) use schemas::{
+    json_output, optional_bool, optional_f64, optional_string, optional_u64, required_string,
+};
+#[cfg(any(test, debug_assertions))]
+#[allow(unused_imports)]
+pub(crate) use session::{
+    compose_system_prompt_suffix, locale_reply_directive, normalize_model_override,
+    provider_role_for_model_override,
+};
+#[cfg(any(test, debug_assertions))]
+#[allow(unused_imports)]
+pub(crate) use types::WebChatParams;
+#[cfg(any(test, debug_assertions))]
+#[allow(unused_imports)]
+pub(crate) use web_errors::{
+    inference_budget_exceeded_user_message, is_inference_budget_exceeded_error,
+};
 
 // Test helpers (debug/test builds only)
 #[cfg(any(test, debug_assertions))]

--- a/src/openhuman/config/schema/load_tests.rs
+++ b/src/openhuman/config/schema/load_tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use super::dirs::{ACTION_DIR_ENV_VAR, MEMORY_SYNC_INTERVAL_SECS_ENV_VAR};
+use super::env::EnvLookup;
 use crate::openhuman::config::schema::{StreamMode, TelegramConfig};
 
 #[test]

--- a/src/openhuman/config/schema/load_tests.rs
+++ b/src/openhuman/config/schema/load_tests.rs
@@ -1,6 +1,6 @@
-use super::*;
 use super::dirs::{ACTION_DIR_ENV_VAR, MEMORY_SYNC_INTERVAL_SECS_ENV_VAR};
 use super::env::EnvLookup;
+use super::*;
 use crate::openhuman::config::schema::{StreamMode, TelegramConfig};
 
 #[test]

--- a/src/openhuman/config/schemas/mod.rs
+++ b/src/openhuman/config/schemas/mod.rs
@@ -11,6 +11,8 @@ use crate::core::TypeSchema;
 #[cfg(test)]
 use crate::rpc::RpcOutcome;
 #[cfg(test)]
+use schema_defs::schemas;
+#[cfg(test)]
 use controllers::{
     handle_get_agent_paths, handle_get_autonomy_settings, handle_update_autonomy_settings,
 };

--- a/src/openhuman/config/schemas/mod.rs
+++ b/src/openhuman/config/schemas/mod.rs
@@ -11,8 +11,6 @@ use crate::core::TypeSchema;
 #[cfg(test)]
 use crate::rpc::RpcOutcome;
 #[cfg(test)]
-use schema_defs::schemas;
-#[cfg(test)]
 use controllers::{
     handle_get_agent_paths, handle_get_autonomy_settings, handle_update_autonomy_settings,
 };
@@ -28,6 +26,8 @@ use helpers::{
     VoiceServerSettingsUpdate, WorkspaceOnboardingFlagParams, WorkspaceOnboardingFlagSetParams,
     DEFAULT_ONBOARDING_FLAG_NAME,
 };
+#[cfg(test)]
+use schema_defs::schemas;
 #[cfg(test)]
 use serde_json::{Map, Value};
 

--- a/src/openhuman/inference/local/service/ollama_admin_tests.rs
+++ b/src/openhuman/inference/local/service/ollama_admin_tests.rs
@@ -1,4 +1,4 @@
-use super::interrupted_pull_settle_window_secs;
+use super::util::interrupted_pull_settle_window_secs;
 
 #[test]
 fn interrupted_pull_waits_when_bytes_were_observed() {

--- a/src/openhuman/inference/provider/reliable_tests.rs
+++ b/src/openhuman/inference/provider/reliable_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::openhuman::inference::provider::traits::StreamError;
 use std::sync::Arc;
 
 struct MockProvider {

--- a/src/openhuman/mcp_server/tools_tests.rs
+++ b/src/openhuman/mcp_server/tools_tests.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::specs::list_tools_result_for_config;
+use super::*;
 
 #[test]
 fn list_tools_exposes_base_mcp_surface_when_searxng_disabled() {

--- a/src/openhuman/mcp_server/tools_tests.rs
+++ b/src/openhuman/mcp_server/tools_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use super::specs::list_tools_result_for_config;
 
 #[test]
 fn list_tools_exposes_base_mcp_surface_when_searxng_disabled() {

--- a/src/openhuman/memory/chat.rs
+++ b/src/openhuman/memory/chat.rs
@@ -266,6 +266,7 @@ pub mod test_override {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::openhuman::config::schema::DEFAULT_CLOUD_LLM_MODEL;
 
     #[test]
     fn build_provider_returns_inference_wrapper_when_default() {

--- a/src/openhuman/memory/schema_tests.rs
+++ b/src/openhuman/memory/schema_tests.rs
@@ -1,5 +1,5 @@
-use super::*;
 use super::definitions::NAMESPACE;
+use super::*;
 
 #[test]
 fn all_controller_schemas_and_registered_controllers_stay_in_sync() {

--- a/src/openhuman/memory/schema_tests.rs
+++ b/src/openhuman/memory/schema_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use super::definitions::NAMESPACE;
 
 #[test]
 fn all_controller_schemas_and_registered_controllers_stay_in_sync() {

--- a/src/openhuman/memory/tree_source/file.rs
+++ b/src/openhuman/memory/tree_source/file.rs
@@ -134,6 +134,7 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::openhuman::memory_store::trees::types::{TreeKind, TreeStatus};
     use chrono::TimeZone;
     use tempfile::TempDir;
 

--- a/src/openhuman/sandbox/docker.rs
+++ b/src/openhuman/sandbox/docker.rs
@@ -288,6 +288,7 @@ pub fn validate_docker_policy(policy: &SandboxPolicy) -> Result<(), Vec<String>>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::openhuman::sandbox::types::DockerOverrides;
     use std::path::PathBuf;
 
     fn test_policy() -> SandboxPolicy {


### PR DESCRIPTION
## Summary

- Fixes the **red `Rust Core Coverage` lane on `main`** — the crate's lib-test target currently fails to compile (38 errors: `E0405/E0425/E0432/E0433`), so `Rust Core Coverage` fails on `main` HEAD and, via the PR merge-ref, on **every open PR's** coverage gate.
- The breakage is pure **test-module import drift**: recent refactors moved helpers into submodules (or dropped the `pub(crate) use` re-exports the tests rely on) without updating the test modules.
- All changes are re-exports / import-path fixes. **No test logic and no production behaviour changes.**

## Problem

`cargo llvm-cov ... -p openhuman --lib` compiles the whole lib-test target, which no longer builds on `main`. The 38 errors cluster into 8 modules whose `*_tests.rs` reference symbols that still exist but are no longer in the test module's scope:

| Module | Unresolved symbols | Root cause |
|--------|--------------------|-----------|
| `channels/providers/web` | `WebChatParams`, `required_string`, `optional_bool/f64/string/u64`, `json_output`, `compose_system_prompt_suffix`, `normalize_model_override`, `locale_reply_directive`, `provider_role_for_model_override`, `inference_budget_exceeded_user_message`, `is_inference_budget_exceeded_error` (13) | #4722 chat rework moved these into `web/{schemas,session,types}.rs` + `web_errors.rs`; the `// Schema field helpers re-exported for tests` block in `web/mod.rs` was left **empty** |
| `config/schemas` | `schemas` (×4) | lives in `schema_defs.rs`, not re-exported into the `schemas` test scope |
| `config/schema/load` | `EnvLookup`, `ACTION_DIR_ENV_VAR`, `MEMORY_SYNC_INTERVAL_SECS_ENV_VAR` | now in `load/{env,dirs}.rs` submodules |
| `inference/provider` | `StreamError` | in `provider/traits.rs` |
| `mcp_server/tools` | `list_tools_result_for_config` | in `tools/specs.rs` |
| `memory/schema` | `NAMESPACE` | in `schema/definitions.rs` |
| `memory/chat` | `DEFAULT_CLOUD_LLM_MODEL` | in `config::schema` |
| `inference/.../ollama_admin` | `interrupted_pull_settle_window_secs` | in `ollama_admin/util.rs` |

Introduced by #4720 / #4722 / #4738. `clippy` doesn't catch it (`cargo clippy -p openhuman` skips test targets), so it only surfaces in the coverage lane — which is why it slipped onto `main`.

## Solution

Restore the missing scope, matching each module's existing pattern:

- **web/mod.rs** — fill in the empty "Schema field helpers re-exported for tests" block: `pub(crate) use` the 13 helpers from `schemas` / `session` / `types` / `web_errors`, gated `#[cfg(any(test, debug_assertions))]` with `#[allow(unused_imports)]` (identical to the adjacent `web_errors` re-export block).
- **config/schemas/mod.rs** — add `#[cfg(test)] use schema_defs::schemas;` alongside the existing test re-exports.
- **the six remaining `*_tests.rs`** — qualify each import to the submodule that now owns the symbol (e.g. `use super::env::EnvLookup;`, `use super::specs::list_tools_result_for_config;`).

No test bodies were changed; no tests removed.

## Submission Checklist

- [x] Tests added or updated — N/A: this **repairs** the existing test suite so it compiles; no behaviour under test changes. The `Rust Core Coverage` lane going green is the verification.
- [x] **Diff coverage ≥ 80%** — N/A: changes are `use`/re-export statements (non-executable), excluded by `diff-cover`.
- [x] Coverage matrix updated — N/A: no feature added/removed/renamed.
- [x] All affected feature IDs listed — N/A.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — N/A: no user-facing change.
- [x] Linked issue closed — N/A: no tracking issue; this unblocks CI on `main` + the open PR queue.

## Impact

- Greens `Rust Core Coverage` on `main`, unblocking the coverage gate for all open PRs (immediately relevant to #4748, #4751, #4752, whose own checks are already green).
- No runtime/behaviour/perf/security impact — test-scope imports only.

## Related

- Closes: N/A
- Root-cause refactors: #4720, #4722, #4738
- Unblocks: #4748, #4751, #4752

---

## AI Authored PR Metadata

### Commit & Branch
- Branch: `fix/lib-test-compile-drift`
- Base: `main`

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — N/A: Rust-only change
- [x] `pnpm typecheck` — N/A: Rust-only change
- [x] Focused tests: N/A — import-only fix; verified by the CI `Rust Core Coverage` lane compiling the lib-test target
- [x] Rust fmt/check (if changed): see Validation Blocked
- [x] Tauri fmt/check (if changed): N/A — root core crate only

### Validation Blocked
- `command:` `cargo test -p openhuman --lib` / `cargo llvm-cov`
- `error:` local builds are disabled on this worker (disk pressure); the fix is verified by inspection (every restored symbol's definition location is cited above) and by CI.
- `impact:` low — re-export / import statements only; each restored name resolves to a confirmed `pub`/`pub(crate)` definition in the cited submodule.

### Behavior Changes
- Intended behavior change: none (test compile fix).
- User-visible effect: none.

### Parity Contract
- Legacy behavior preserved: yes — no test bodies changed, no production code touched beyond adding `#[cfg(test)]`/`#[cfg(any(test, debug_assertions))]` re-exports.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit tests for OpenHuman memory schema behavior, including namespace consistency and validation of unknown function and ingest schema inputs.
  * Improved test reliability by adding targeted imports across config loading, inference streaming, MCP tool listing, sandbox Docker policy checks, and local service helpers.
  * Added test/debug-only access to additional web-channel utilities and error helpers to support assertions around prompt/session behavior and inference-budget handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->