### PR TITLE
fix(inference): idle-timeout recovery + guaranteed terminal event on a stalled stream

### DIFF
--- a/src/openhuman/inference/provider/compatible.rs
+++ b/src/openhuman/inference/provider/compatible.rs
@@ -19,7 +19,7 @@ mod compatible_stream;
 #[path = "compatible_stream_native.rs"]
 mod compatible_stream_native;
 #[path = "compatible_timeout.rs"]
-mod compatible_timeout;
+pub(crate) mod compatible_timeout;
 #[path = "compatible_types.rs"]
 mod compatible_types;
 

--- a/src/openhuman/inference/provider/compatible_stream.rs
+++ b/src/openhuman/inference/provider/compatible_stream.rs
@@ -203,10 +203,7 @@ mod tests {
         // `None` restores the pre-#4761 unbounded wait; a ready item must still
         // be delivered (the disabled guard only removes the timeout, not data).
         let mut s = stream::iter(vec![9u8]);
-        assert_eq!(
-            read_next_or_idle(&mut s, None).await,
-            IdleRead::Item(9u8)
-        );
+        assert_eq!(read_next_or_idle(&mut s, None).await, IdleRead::Item(9u8));
         assert_eq!(read_next_or_idle(&mut s, None).await, IdleRead::Ended);
     }
 

--- a/src/openhuman/inference/provider/compatible_stream.rs
+++ b/src/openhuman/inference/provider/compatible_stream.rs
@@ -69,7 +69,12 @@ pub(crate) fn sse_bytes_to_chunks(
         // in `.env.example`) drives both this SSE path and the native stream
         // parser, so `OPENHUMAN_INFERENCE_STREAM_IDLE_TIMEOUT_SECS` means the same
         // thing everywhere and a typo can never wedge a turn indefinitely.
-        let idle_timeout = Some(super::compatible::compatible_timeout::stream_idle_timeout());
+        // Absolute path: `compatible_stream` is included as a module under both
+        // `provider` and `provider::compatible`, so a `super::`-relative path
+        // resolves differently in each and can't work in both.
+        let idle_timeout = Some(
+            crate::openhuman::inference::provider::compatible::compatible_timeout::stream_idle_timeout(),
+        );
 
         loop {
             let item = match read_next_or_idle(&mut bytes_stream, idle_timeout).await {

--- a/src/openhuman/inference/provider/compatible_stream.rs
+++ b/src/openhuman/inference/provider/compatible_stream.rs
@@ -9,27 +9,6 @@ use std::time::Duration;
 
 use super::compatible_parse::parse_sse_line;
 
-/// Default mid-stream idle timeout: if the upstream sends no bytes for this long
-/// *after the stream has been established*, we treat the connection as stalled
-/// and emit a terminal [`StreamError::IdleTimeout`] instead of blocking on
-/// `bytes_stream.next()` forever (#4761 — a stalled upstream previously orphaned
-/// the turn with no `chat_done`/`chat_error`). Generous enough to tolerate a slow
-/// first token / long silent reasoning gap on staging, but far below the ~250s
-/// point where the connection was being dropped with no terminal event.
-///
-/// Override with `OPENHUMAN_INFERENCE_STREAM_IDLE_TIMEOUT_SECS`; set it to `0` to
-/// disable the guard entirely (restores the pre-#4761 unbounded wait).
-const DEFAULT_STREAM_IDLE_TIMEOUT_SECS: u64 = 120;
-
-/// Resolve the configured mid-stream idle timeout. `None` disables the guard.
-fn stream_idle_timeout() -> Option<Duration> {
-    let secs = std::env::var("OPENHUMAN_INFERENCE_STREAM_IDLE_TIMEOUT_SECS")
-        .ok()
-        .and_then(|v| v.trim().parse::<u64>().ok())
-        .unwrap_or(DEFAULT_STREAM_IDLE_TIMEOUT_SECS);
-    (secs > 0).then(|| Duration::from_secs(secs))
-}
-
 /// Outcome of a single idle-bounded read from an item stream.
 #[derive(Debug, PartialEq, Eq)]
 enum IdleRead<T> {
@@ -85,7 +64,12 @@ pub(crate) fn sse_bytes_to_chunks(
         }
 
         let mut bytes_stream = response.bytes_stream();
-        let idle_timeout = stream_idle_timeout();
+        // Reuse the single shared per-chunk idle watchdog (#4269) rather than a
+        // second, divergent resolver: one bounded default (1..=3600s, documented
+        // in `.env.example`) drives both this SSE path and the native stream
+        // parser, so `OPENHUMAN_INFERENCE_STREAM_IDLE_TIMEOUT_SECS` means the same
+        // thing everywhere and a typo can never wedge a turn indefinitely.
+        let idle_timeout = Some(super::compatible_timeout::stream_idle_timeout());
 
         loop {
             let item = match read_next_or_idle(&mut bytes_stream, idle_timeout).await {
@@ -95,11 +79,14 @@ pub(crate) fn sse_bytes_to_chunks(
                     // The upstream established the stream but sent no bytes for
                     // `idle_timeout`. Rather than block on `next()` forever and
                     // orphan the turn with no terminal event (#4761), surface a
-                    // terminal error so the consumer fires `chat_error`.
+                    // terminal error so the consumer fires `chat_error`. Return
+                    // (not break) so the success `final_chunk()` below is NOT
+                    // emitted after the error — otherwise a stalled generation
+                    // would be reported as a normal `finish_reason: stop`.
                     if let Some(dur) = idle_timeout {
                         let _ = tx.send(Err(StreamError::IdleTimeout(dur))).await;
                     }
-                    break;
+                    return;
                 }
             };
             match item {
@@ -205,31 +192,5 @@ mod tests {
         let mut s = stream::iter(vec![9u8]);
         assert_eq!(read_next_or_idle(&mut s, None).await, IdleRead::Item(9u8));
         assert_eq!(read_next_or_idle(&mut s, None).await, IdleRead::Ended);
-    }
-
-    #[test]
-    fn idle_timeout_env_override_and_disable() {
-        // Default (var unset) is the built-in guard; `0` disables it; a positive
-        // value overrides it. Serialized within one test to avoid racing the
-        // process-global env var across the test binary.
-        let key = "OPENHUMAN_INFERENCE_STREAM_IDLE_TIMEOUT_SECS";
-        let prev = std::env::var(key).ok();
-
-        std::env::remove_var(key);
-        assert_eq!(
-            stream_idle_timeout(),
-            Some(Duration::from_secs(DEFAULT_STREAM_IDLE_TIMEOUT_SECS))
-        );
-
-        std::env::set_var(key, "0");
-        assert_eq!(stream_idle_timeout(), None, "0 disables the guard");
-
-        std::env::set_var(key, "45");
-        assert_eq!(stream_idle_timeout(), Some(Duration::from_secs(45)));
-
-        match prev {
-            Some(v) => std::env::set_var(key, v),
-            None => std::env::remove_var(key),
-        }
     }
 }

--- a/src/openhuman/inference/provider/compatible_stream.rs
+++ b/src/openhuman/inference/provider/compatible_stream.rs
@@ -69,7 +69,7 @@ pub(crate) fn sse_bytes_to_chunks(
         // in `.env.example`) drives both this SSE path and the native stream
         // parser, so `OPENHUMAN_INFERENCE_STREAM_IDLE_TIMEOUT_SECS` means the same
         // thing everywhere and a typo can never wedge a turn indefinitely.
-        let idle_timeout = Some(super::compatible_timeout::stream_idle_timeout());
+        let idle_timeout = Some(super::compatible::compatible_timeout::stream_idle_timeout());
 
         loop {
             let item = match read_next_or_idle(&mut bytes_stream, idle_timeout).await {

--- a/src/openhuman/inference/provider/compatible_stream.rs
+++ b/src/openhuman/inference/provider/compatible_stream.rs
@@ -106,7 +106,10 @@ pub(crate) fn sse_bytes_to_chunks(
                                     e
                                 ))))
                                 .await;
-                            break;
+                            // Return (not break) so the success `final_chunk()`
+                            // below is not emitted after this terminal error —
+                            // only a clean EOF (`IdleRead::Ended`) reaches it.
+                            return;
                         }
                     };
 
@@ -136,12 +139,17 @@ pub(crate) fn sse_bytes_to_chunks(
                 }
                 Err(e) => {
                     let _ = tx.send(Err(StreamError::Http(e))).await;
-                    break;
+                    // Return (not break) so a transport failure is not masked by
+                    // the success `final_chunk()` below — only a clean EOF
+                    // (`IdleRead::Ended`) emits the terminal success chunk.
+                    return;
                 }
             }
         }
 
-        // Send final chunk
+        // Reached only on a clean EOF (`IdleRead::Ended`): every error path above
+        // returns after sending its `Err(...)`, so a success `final_chunk()` can
+        // never mask a decoding/transport/idle-timeout failure as a normal stop.
         let _ = tx.send(Ok(StreamChunk::final_chunk())).await;
     });
 

--- a/src/openhuman/inference/provider/compatible_stream.rs
+++ b/src/openhuman/inference/provider/compatible_stream.rs
@@ -4,9 +4,64 @@
 //! `StreamChunk` stream via Server-Sent Events parsing.
 
 use crate::openhuman::inference::provider::traits::{StreamChunk, StreamError, StreamResult};
-use futures_util::{stream, StreamExt};
+use futures_util::{stream, Stream, StreamExt};
+use std::time::Duration;
 
 use super::compatible_parse::parse_sse_line;
+
+/// Default mid-stream idle timeout: if the upstream sends no bytes for this long
+/// *after the stream has been established*, we treat the connection as stalled
+/// and emit a terminal [`StreamError::IdleTimeout`] instead of blocking on
+/// `bytes_stream.next()` forever (#4761 — a stalled upstream previously orphaned
+/// the turn with no `chat_done`/`chat_error`). Generous enough to tolerate a slow
+/// first token / long silent reasoning gap on staging, but far below the ~250s
+/// point where the connection was being dropped with no terminal event.
+///
+/// Override with `OPENHUMAN_INFERENCE_STREAM_IDLE_TIMEOUT_SECS`; set it to `0` to
+/// disable the guard entirely (restores the pre-#4761 unbounded wait).
+const DEFAULT_STREAM_IDLE_TIMEOUT_SECS: u64 = 120;
+
+/// Resolve the configured mid-stream idle timeout. `None` disables the guard.
+fn stream_idle_timeout() -> Option<Duration> {
+    let secs = std::env::var("OPENHUMAN_INFERENCE_STREAM_IDLE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_STREAM_IDLE_TIMEOUT_SECS);
+    (secs > 0).then(|| Duration::from_secs(secs))
+}
+
+/// Outcome of a single idle-bounded read from an item stream.
+#[derive(Debug, PartialEq, Eq)]
+enum IdleRead<T> {
+    /// The stream yielded an item.
+    Item(T),
+    /// The stream ended cleanly (`next()` returned `None`).
+    Ended,
+    /// No item arrived within the idle timeout — the upstream stalled.
+    IdleTimedOut,
+}
+
+/// Read the next item from `stream`, enforcing an optional idle timeout.
+///
+/// Extracted as a small generic helper (over the concrete
+/// `reqwest::Response::bytes_stream()`) so the stall→terminal-error decision is
+/// unit-testable without standing up a live HTTP response.
+async fn read_next_or_idle<S, T>(stream: &mut S, idle: Option<Duration>) -> IdleRead<T>
+where
+    S: Stream<Item = T> + Unpin,
+{
+    match idle {
+        Some(dur) => match tokio::time::timeout(dur, stream.next()).await {
+            Ok(Some(item)) => IdleRead::Item(item),
+            Ok(None) => IdleRead::Ended,
+            Err(_elapsed) => IdleRead::IdleTimedOut,
+        },
+        None => match stream.next().await {
+            Some(item) => IdleRead::Item(item),
+            None => IdleRead::Ended,
+        },
+    }
+}
 
 /// Convert SSE byte stream to text chunks.
 pub(crate) fn sse_bytes_to_chunks(
@@ -30,8 +85,23 @@ pub(crate) fn sse_bytes_to_chunks(
         }
 
         let mut bytes_stream = response.bytes_stream();
+        let idle_timeout = stream_idle_timeout();
 
-        while let Some(item) = bytes_stream.next().await {
+        loop {
+            let item = match read_next_or_idle(&mut bytes_stream, idle_timeout).await {
+                IdleRead::Item(item) => item,
+                IdleRead::Ended => break,
+                IdleRead::IdleTimedOut => {
+                    // The upstream established the stream but sent no bytes for
+                    // `idle_timeout`. Rather than block on `next()` forever and
+                    // orphan the turn with no terminal event (#4761), surface a
+                    // terminal error so the consumer fires `chat_error`.
+                    if let Some(dur) = idle_timeout {
+                        let _ = tx.send(Err(StreamError::IdleTimeout(dur))).await;
+                    }
+                    break;
+                }
+            };
             match item {
                 Ok(bytes) => {
                     // Convert bytes to string and process line by line
@@ -88,4 +158,81 @@ pub(crate) fn sse_bytes_to_chunks(
         rx.recv().await.map(|chunk| (chunk, rx))
     })
     .boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn idle_read_times_out_on_a_stalled_stream() {
+        // #4761: a stream that yields nothing (upstream established the
+        // connection then went silent mid-generation) must resolve to
+        // `IdleTimedOut` within the idle window instead of blocking forever.
+        // Without the timeout guard this `.await` never returns and the turn is
+        // orphaned with no terminal event.
+        let mut stalled = stream::pending::<u8>();
+        let outcome = read_next_or_idle(&mut stalled, Some(Duration::from_millis(20))).await;
+        assert_eq!(outcome, IdleRead::IdleTimedOut);
+    }
+
+    #[tokio::test]
+    async fn idle_read_returns_item_when_data_arrives() {
+        let mut s = stream::iter(vec![7u8, 8u8]);
+        assert_eq!(
+            read_next_or_idle(&mut s, Some(Duration::from_secs(5))).await,
+            IdleRead::Item(7u8)
+        );
+        assert_eq!(
+            read_next_or_idle(&mut s, Some(Duration::from_secs(5))).await,
+            IdleRead::Item(8u8)
+        );
+    }
+
+    #[tokio::test]
+    async fn idle_read_reports_clean_end() {
+        let mut empty = stream::iter(Vec::<u8>::new());
+        assert_eq!(
+            read_next_or_idle(&mut empty, Some(Duration::from_secs(5))).await,
+            IdleRead::Ended
+        );
+    }
+
+    #[tokio::test]
+    async fn idle_read_with_guard_disabled_still_yields_items() {
+        // `None` restores the pre-#4761 unbounded wait; a ready item must still
+        // be delivered (the disabled guard only removes the timeout, not data).
+        let mut s = stream::iter(vec![9u8]);
+        assert_eq!(
+            read_next_or_idle(&mut s, None).await,
+            IdleRead::Item(9u8)
+        );
+        assert_eq!(read_next_or_idle(&mut s, None).await, IdleRead::Ended);
+    }
+
+    #[test]
+    fn idle_timeout_env_override_and_disable() {
+        // Default (var unset) is the built-in guard; `0` disables it; a positive
+        // value overrides it. Serialized within one test to avoid racing the
+        // process-global env var across the test binary.
+        let key = "OPENHUMAN_INFERENCE_STREAM_IDLE_TIMEOUT_SECS";
+        let prev = std::env::var(key).ok();
+
+        std::env::remove_var(key);
+        assert_eq!(
+            stream_idle_timeout(),
+            Some(Duration::from_secs(DEFAULT_STREAM_IDLE_TIMEOUT_SECS))
+        );
+
+        std::env::set_var(key, "0");
+        assert_eq!(stream_idle_timeout(), None, "0 disables the guard");
+
+        std::env::set_var(key, "45");
+        assert_eq!(stream_idle_timeout(), Some(Duration::from_secs(45)));
+
+        match prev {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+    }
 }

--- a/src/openhuman/inference/provider/compatible_timeout.rs
+++ b/src/openhuman/inference/provider/compatible_timeout.rs
@@ -109,7 +109,7 @@ pub(super) fn connect_timeout() -> Duration {
 /// long response that keeps emitting tokens is never cut — only a genuine stall
 /// (no bytes from upstream, or a wedged consumer) for the whole window trips it.
 /// Resolved once per process and cached — see [`request_timeout`].
-pub(super) fn stream_idle_timeout() -> Duration {
+pub(crate) fn stream_idle_timeout() -> Duration {
     static CACHED: OnceLock<Duration> = OnceLock::new();
     *CACHED.get_or_init(|| {
         resolve(

--- a/src/openhuman/inference/provider/error_classify.rs
+++ b/src/openhuman/inference/provider/error_classify.rs
@@ -139,6 +139,12 @@ pub(crate) fn is_stream_error_non_retryable(err: &StreamError) -> bool {
         // JSON/SSE parse errors and IO errors are generally non-retryable
         StreamError::Json(_) | StreamError::InvalidSse(_) => true,
         StreamError::Io(_) => false,
+        // A mid-stream idle timeout (#4761) is a transient upstream stall — the
+        // connection went silent, not a permanent failure — so a retry on a
+        // fresh connection may succeed. If retries are exhausted it still
+        // surfaces as a terminal error (a `chat_error`), which is the whole
+        // point: the turn can no longer hang with no terminal event.
+        StreamError::IdleTimeout(_) => false,
     }
 }
 

--- a/src/openhuman/inference/provider/traits.rs
+++ b/src/openhuman/inference/provider/traits.rs
@@ -316,6 +316,11 @@ pub enum StreamError {
     #[error("Provider error: {0}")]
     Provider(String),
 
+    #[error(
+        "inference stream idle for {0:?} with no data — treating the upstream as stalled (#4761)"
+    )]
+    IdleTimeout(std::time::Duration),
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 }


### PR DESCRIPTION
## What & why

A streaming turn with no tools/sub-agents could **freeze mid-generation and orphan itself with no terminal event** (#4761): the base inference stream streamed some text, went silent, emitted only heartbeats, and the connection was dropped ~250s later with **no `chat_done` and no `chat_error`** → empty final reply.

### Root cause

`sse_bytes_to_chunks` (`src/openhuman/inference/provider/compatible_stream.rs`) read the upstream byte stream with a bare `while let Some(item) = bytes_stream.next().await` and **no idle timeout**. When the backend established the SSE stream and then stalled (connection held open, no further bytes), `next().await` blocked **forever**:

- the read loop never exited, so the terminal `final_chunk()` never ran;
- the consumer (`compatible_provider_impl.rs`, then the tinyagents `ProviderModel` adapter that wraps openhuman's `Provider`) blocked waiting for a chunk that never came;
- **no terminal event was ever produced.**

reqwest had no read/idle timeout configured either, so nothing caught it until the far end dropped the socket much later. The harness lives in tinyagents but the actual backend byte-streaming is openhuman's `Provider`, so the gap — and the fix — are here.

### Fix

- **`compatible_stream.rs`** — a small generic helper `read_next_or_idle` wraps each byte read in `tokio::time::timeout`. On a stall it emits a **terminal** `StreamError::IdleTimeout` and **`return`s** — so the success `final_chunk()` is **not** emitted after the error and a stalled generation can no longer be masked as a normal `finish_reason: stop`. The same convergence is applied to the other terminal error branches (UTF-8 decode, HTTP transport, SSE parse): each now `return`s after sending its `Err`, so `final_chunk()` is reached **only on a clean EOF**. A terminal event is now **guaranteed** on stall/drop. The idle window reuses the single shared per-chunk inactivity watchdog (`stream_idle_timeout()`, #4269) rather than a second divergent resolver, so `OPENHUMAN_INFERENCE_STREAM_IDLE_TIMEOUT_SECS` means the same thing on both the SSE and native-stream paths: **default 90s**, bounded `1..=3600`, with a missing/non-numeric/out-of-range value (e.g. `0` or `99999`) falling back to the 90s default — the guard can't be typo'd into disabling or wedging a turn indefinitely. Every streaming method routes through `sse_bytes_to_chunks`, so this covers the whole streaming surface.
- **`traits.rs`** — new `StreamError::IdleTimeout(Duration)` variant.
- **`error_classify.rs`** — classifies `IdleTimeout` as **retryable** (a stall is a transient upstream condition): the reliable layer can retry a not-yet-committed stall on a fresh connection, and once retries are exhausted it still surfaces as a terminal `chat_error` — the whole point being that the turn can no longer hang with no terminal event.
- **`compatible.rs` / `compatible_timeout.rs`** — widen the module + `stream_idle_timeout()` getter to `pub(crate)` so the shared bounded resolver is reachable from the SSE path (`compatible_stream` is included as a module under both `provider` and `provider::compatible`, so the getter is referenced by its `crate::`-absolute path, which resolves in both inclusions).

### Tests

Four unit tests on the idle helper `read_next_or_idle`: stall → `IdleTimedOut`, data → `Item`, clean end → `Ended`, and guard-disabled (`None`) still yields items. The shared resolver's bounds/parse behaviour is covered by the existing `compatible_timeout` tests.

The `~19s` TTFT noted in the issue is upstream/staging infra (called out there as not the code gap) and is not addressed here.

Closes #4761


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an idle-timeout safeguard for OpenAI-compatible streaming to detect stalled mid-response reads and end promptly when configured.

* **Bug Fixes**
  * Introduced an `IdleTimeout` streaming error and ensured it’s classified as retryable.
  * Improved stream handling so stalled/terminal failures can’t be overridden by a later “final” chunk emission.

* **Tests**
  * Added unit coverage for item arrival, clean end-of-stream, and stalled reads (including behavior when idle-timeout is disabled).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
