### PR TITLE
fix(tests): repair repo-wide cargo test --lib build (stale test re-exports)

### DIFF
--- a/src/openhuman/channels/providers/web/mod.rs
+++ b/src/openhuman/channels/providers/web/mod.rs
@@ -109,7 +109,22 @@ pub mod test_support {
 }
 
 #[cfg(test)]
+pub(crate) use schemas::{
+    json_output, optional_bool, optional_f64, optional_string, optional_u64, required_string,
+};
+#[cfg(test)]
+pub(crate) use session::{
+    compose_system_prompt_suffix, locale_reply_directive, normalize_model_override,
+    provider_role_for_model_override,
+};
+#[cfg(test)]
 pub(crate) use types::SessionCacheFingerprint;
+#[cfg(test)]
+pub(crate) use types::WebChatParams;
+#[cfg(test)]
+pub(crate) use web_errors::{
+    inference_budget_exceeded_user_message, is_inference_budget_exceeded_error,
+};
 
 #[cfg(test)]
 #[path = "../web_tests.rs"]

--- a/src/openhuman/config/schema/load/mod.rs
+++ b/src/openhuman/config/schema/load/mod.rs
@@ -32,7 +32,9 @@ pub(crate) use super::Config;
 #[cfg(test)]
 pub(crate) use dirs::ACTIVE_USER_STATE_FILE;
 #[cfg(test)]
-pub(crate) use env::ProcessEnvWithoutWorkspace;
+pub(crate) use dirs::{ACTION_DIR_ENV_VAR, MEMORY_SYNC_INTERVAL_SECS_ENV_VAR};
+#[cfg(test)]
+pub(crate) use env::{EnvLookup, ProcessEnvWithoutWorkspace};
 #[cfg(test)]
 pub(crate) use impl_load::parse_config_with_recovery;
 #[cfg(test)]

--- a/src/openhuman/config/schemas/mod.rs
+++ b/src/openhuman/config/schemas/mod.rs
@@ -30,5 +30,9 @@ use helpers::{
 use serde_json::{Map, Value};
 
 #[cfg(test)]
+#[cfg(test)]
+pub(crate) use schema_defs::schemas;
+
+#[cfg(test)]
 #[path = "../schemas_tests.rs"]
 mod tests;

--- a/src/openhuman/inference/local/service/ollama_admin/mod.rs
+++ b/src/openhuman/inference/local/service/ollama_admin/mod.rs
@@ -10,5 +10,8 @@ mod util;
 pub(crate) use util::test_ollama_connection;
 
 #[cfg(test)]
+pub(crate) use util::interrupted_pull_settle_window_secs;
+
+#[cfg(test)]
 #[path = "../ollama_admin_tests.rs"]
 mod tests;

--- a/src/openhuman/inference/provider/reliable.rs
+++ b/src/openhuman/inference/provider/reliable.rs
@@ -909,5 +909,8 @@ impl Provider for ReliableProvider {
 }
 
 #[cfg(test)]
+pub(crate) use super::traits::StreamError;
+
+#[cfg(test)]
 #[path = "reliable_tests.rs"]
 mod tests;

--- a/src/openhuman/mcp_server/tools/mod.rs
+++ b/src/openhuman/mcp_server/tools/mod.rs
@@ -32,5 +32,8 @@ pub use serde_json::{json, Value};
 pub use types::{DEFAULT_LIMIT, MAX_LIMIT, TREE_TAG_MAX_TAGS, TREE_TAG_MAX_TAG_LENGTH};
 
 #[cfg(test)]
+pub(crate) use specs::list_tools_result_for_config;
+
+#[cfg(test)]
 #[path = "../tools_tests.rs"]
 mod tests;

--- a/src/openhuman/memory/chat.rs
+++ b/src/openhuman/memory/chat.rs
@@ -266,6 +266,7 @@ pub mod test_override {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::openhuman::config::schema::DEFAULT_CLOUD_LLM_MODEL;
 
     #[test]
     fn build_provider_returns_inference_wrapper_when_default() {

--- a/src/openhuman/memory/schema/mod.rs
+++ b/src/openhuman/memory/schema/mod.rs
@@ -27,6 +27,8 @@ pub use registry::{all_controller_schemas, all_registered_controllers};
 
 // Re-export the NAMESPACE constant so schema_tests.rs can reference it via
 // `super::NAMESPACE` the same way the original flat module did.
+#[cfg(test)]
+pub(crate) use definitions::NAMESPACE;
 
 #[cfg(test)]
 #[path = "../schema_tests.rs"]

--- a/src/openhuman/memory/tree_source/file.rs
+++ b/src/openhuman/memory/tree_source/file.rs
@@ -134,6 +134,7 @@ fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::openhuman::memory_store::trees::types::{TreeKind, TreeStatus};
     use chrono::TimeZone;
     use tempfile::TempDir;
 

--- a/src/openhuman/sandbox/docker.rs
+++ b/src/openhuman/sandbox/docker.rs
@@ -288,6 +288,7 @@ pub fn validate_docker_policy(policy: &SandboxPolicy) -> Result<(), Vec<String>>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::openhuman::sandbox::types::DockerOverrides;
     use std::path::PathBuf;
 
     fn test_policy() -> SandboxPolicy {


### PR DESCRIPTION
## Summary

Repair the repo-wide `cargo test --lib` build. It has been **broken on `main`** — the lib `cfg(test)` build fails to compile with 38 errors across ~10 modules, which red-lines the **"Rust Core Coverage"** gate on *every* PR that touches Rust (e.g. #4753; and `main`'s own tip `e5c6507c` is red on it).

## Problem

A prior refactor split several modules into submodules and moved constants / types / helpers there (`config/schema/load` → `dirs.rs`/`env.rs`, `channels/providers/web` → `types.rs`/`session.rs`/`schemas.rs`/`web_errors.rs`, etc.), but the parent modules' `#[cfg(test)]` re-export blocks — and a few inline test imports — were left referencing the old flat locations. The symbols exist; they were just no longer in the test modules' `use super::*` scope, so the whole lib test build fails to compile.

## Solution (scope: core, test visibility only)

Restore the missing `#[cfg(test)] pub(crate) use …` re-exports on the parent modules, and add the missing test-local imports to the inline test modules. **No product code changes.**

Modules fixed:
- `config/schema/load` — `ACTION_DIR_ENV_VAR`, `MEMORY_SYNC_INTERVAL_SECS_ENV_VAR`, `EnvLookup`
- `config/schemas` — `schemas`
- `memory/schema` — `NAMESPACE`
- `memory/chat` — `DEFAULT_CLOUD_LLM_MODEL`
- `memory/tree_source/file` — `TreeKind`, `TreeStatus`
- `sandbox/docker` — `DockerOverrides`
- `mcp_server/tools` — `list_tools_result_for_config`
- `inference/provider/reliable` — `StreamError`
- `inference/local/service/ollama_admin` — `interrupted_pull_settle_window_secs`
- `channels/providers/web` — 13 helpers (`WebChatParams`, `compose_system_prompt_suffix`, schema field helpers, budget-error helpers, …)

## Acceptance criteria

- [x] **`cargo test --lib --no-run` compiles clean** — verified locally (0 errors; only pre-existing unused-import warnings).
- [x] No product-code changes — only `#[cfg(test)]` re-exports / test-local `use`s.
- [x] "Rust Core Coverage" gate can compile-and-run again for Rust PRs.

## Impact

- **Unblocks the `Rust Core Coverage` / `PR CI Gate` checks** for every Rust PR (they've been failing at compile since the refactor).
- Test-only visibility change; no runtime behavior change.

## Related

- Unblocks tinyhumansai/openhuman#4753 (its coverage gate fails only because of this repo-wide breakage).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test support across web, configuration, memory, inference, MCP tools, and sandbox areas.
  * Improved access to shared helpers and constants used in validation, model selection, environment handling, and error scenarios.
  * These updates help keep existing behaviors well covered and make future regressions easier to catch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->