### PR TITLE
fix(orchestration): don't abort first agent link on 404 contact status

### DIFF
--- a/src/openhuman/agent_orchestration/pairing.rs
+++ b/src/openhuman/agent_orchestration/pairing.rs
@@ -243,12 +243,25 @@ pub async fn block_request(config: &Config, agent_id: &str) -> Result<PairingAct
 
 async fn contact_status(agent_id: &str) -> Result<String, String> {
     let client = tinyplace_state().client().await?;
-    let remote: Value = client
+    match client
         .http()
         .get_agent_auth::<Value>(&contact_path(agent_id, Some("status")), &[])
         .await
-        .map_err(map_err)?;
-    Ok(remote_status(&remote).unwrap_or_else(|| "none".to_string()))
+    {
+        Ok(remote) => Ok(remote_status(&remote).unwrap_or_else(|| "none".to_string())),
+        // A 404 from /contacts/{id}/status means "no contact relationship yet" —
+        // the normal state before you've ever linked this agent. Treat it as
+        // `none` (not an error) so `link_session` proceeds to send the request
+        // instead of surfacing a false "not found" and aborting the first link.
+        Err(e) if e.status() == Some(404) => {
+            log::debug!(
+                target: LOG_TARGET,
+                "[orchestration_pairing] contact_status.none agent_id={agent_id} (404 = no relationship yet)"
+            );
+            Ok("none".to_string())
+        }
+        Err(e) => Err(map_err(e)),
+    }
 }
 
 fn remote_status(value: &Value) -> Option<String> {


### PR DESCRIPTION
## Problem

Linking a new agent for the first time is impossible from the UI. In **Orchestration → Discover → "Link a new agent"**, pasting any valid agent ID and clicking **Link** fails with:

```
HTTP 404: /contacts/<id>/status: not found
```

This happens for every agent you have not already linked — i.e. the normal first-contact case.

## Root cause

`link_session` (`src/openhuman/agent_orchestration/pairing.rs`) pre-checks the relationship via `contact_status`, which calls `GET /contacts/{id}/status`. The backend returns **404** when there is no contact relationship yet. `contact_status` ran that response through `map_err(map_err)?`, turning the 404 into a hard error that propagated out of `link_session` **before** it ever reached the `POST /contacts/{id}` that sends the request.

Verified against staging: `GET /contacts/{id}/status` returns `404` pre-link and flips to `200 pending` only *after* a request is sent — so the 404 is expected state, not a failure.

## Fix

Treat a 404 from the status pre-check as `"none"` (no relationship yet) so `link_session` proceeds to send the request. Other HTTP/transport errors still propagate unchanged. `tinyplace::Error::status()` returns `Option<u16>`, so the 404 is matched precisely rather than by string-sniffing.

```rust
match client.http().get_agent_auth::<Value>(&contact_path(agent_id, Some("status")), &[]).await {
    Ok(remote) => Ok(remote_status(&remote).unwrap_or_else(|| "none".to_string())),
    Err(e) if e.status() == Some(404) => Ok("none".to_string()), // no relationship yet
    Err(e) => Err(map_err(e)),
}
```

## Testing

- Reproduced the 404 on `main` in the desktop app against staging.
- Confirmed the contact lifecycle on staging out-of-band (`request → pending → accept → accepted`), proving the backend path is healthy and the 404 is purely the pre-check.
- With the fix built into the app, the **Link** action sends the request instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact linking by treating contacts without an existing relationship as having a neutral status.
  * Prevented unnecessary errors when no relationship status is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->