### PR TITLE
fix(wallet): mint slash-free tiny.place identity keys

### DIFF
--- a/src/openhuman/wallet/chains/solana.rs
+++ b/src/openhuman/wallet/chains/solana.rs
@@ -655,12 +655,95 @@ pub(crate) async fn tinyplace_signer_seed() -> Result<[u8; 32], String> {
     // Extract 32-byte SLIP-0010 secret — same bytes LocalSigner::from_seed expects.
     // Never logged: the log below omits the seed.
     log::debug!("[tinyplace] signer seed derived (seed not logged)");
-    Ok(signing_key.to_bytes())
+    Ok(slash_free_identity_seed(signing_key.to_bytes()))
+}
+
+/// Return a tiny.place identity seed whose Ed25519 public key has a **slash-free**
+/// STANDARD-base64 encoding.
+///
+/// The backend serves that base64 public key as the bundle `identityKey` and keys
+/// its `/keys/{identityKey}/…` routes on it verbatim; a `/` in the key becomes
+/// `%2F` in the path and the route 404s — so a slash-bearing identity can neither
+/// publish Signal keys nor receive DMs (the same failure the tiny.place plugin
+/// avoids by regenerating slash-free wallets). Our identity is *deterministic* from
+/// the wallet key, so instead of regenerating we bump a domain-separated counter:
+///
+/// - **counter 0 = the raw wallet seed** — every already-clean identity stays
+///   byte-identical (no migration for the common case),
+/// - only when the raw key's base64 contains `/` do we deterministically derive a
+///   fresh seed from `SHA-256(domain ‖ seed ‖ counter)` until the public key is
+///   clean. Same wallet → same (lowest-counter) slash-free identity, always.
+fn slash_free_identity_seed(base: [u8; 32]) -> [u8; 32] {
+    for counter in 0u32..100_000 {
+        let seed: [u8; 32] = if counter == 0 {
+            base
+        } else {
+            let mut hasher = Sha256::new();
+            hasher.update(b"openhuman.tinyplace.identity.slashfree.v1");
+            hasher.update(base);
+            hasher.update(counter.to_le_bytes());
+            hasher.finalize().into()
+        };
+        let pub_b64 = B64.encode(SigningKey::from_bytes(&seed).verifying_key().to_bytes());
+        if !pub_b64.contains('/') {
+            if counter > 0 {
+                log::debug!(
+                    "[tinyplace] raw wallet identity key had '/'; using slash-free derivation (counter={counter})"
+                );
+            }
+            return seed;
+        }
+    }
+    // Astronomically unlikely (~1 in 2^100000 that every candidate has a '/');
+    // fall back to the raw seed rather than panic.
+    base
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn pub_b64(seed: &[u8; 32]) -> String {
+        B64.encode(SigningKey::from_bytes(seed).verifying_key().to_bytes())
+    }
+
+    #[test]
+    fn slash_free_identity_seed_cleans_slash_keys_deterministically() {
+        // Find a base seed whose raw Ed25519 pubkey base64 contains '/', and one
+        // that's already clean (roughly half of all seeds are clean).
+        let (mut slashed, mut clean): (Option<[u8; 32]>, Option<[u8; 32]>) = (None, None);
+        for i in 0u32..5000 {
+            let mut s = [0u8; 32];
+            s[..4].copy_from_slice(&i.to_le_bytes());
+            if pub_b64(&s).contains('/') {
+                slashed.get_or_insert(s);
+            } else {
+                clean.get_or_insert(s);
+            }
+            if slashed.is_some() && clean.is_some() {
+                break;
+            }
+        }
+        let clean = clean.expect("a clean seed exists");
+        let slashed = slashed.expect("a slashed seed exists");
+
+        // Clean seed passes through unchanged (counter 0 — no migration).
+        assert_eq!(slash_free_identity_seed(clean), clean);
+
+        // Slashed seed is remapped to a slash-free, deterministic result.
+        let out = slash_free_identity_seed(slashed);
+        assert_ne!(out, slashed, "slashed seed must be remapped");
+        assert!(
+            !pub_b64(&out).contains('/'),
+            "result pubkey must be slash-free"
+        );
+        assert_eq!(
+            slash_free_identity_seed(slashed),
+            out,
+            "must be deterministic"
+        );
+    }
+
     use crate::openhuman::wallet::execution::{
         insert_quote_for_test, now_ms, reset_quote_store_for_tests, PreparedKind, PreparedStatus,
         PreparedTransaction,


### PR DESCRIPTION
## Summary

- Mint **slash-free** tiny.place identity keys so newly-derived identities can actually publish Signal pre-keys and receive DMs.
- Derive the identity seed through `slash_free_identity_seed()` at the point the seed is handed to `LocalSigner`.
- **counter 0 == the raw wallet seed**, so every already-clean identity is byte-identical — no migration for the common case.
- Only slash-bearing raw keys are remapped, deterministically, via a domain-separated SHA-256 counter.

## Problem

The tiny.place backend serves the Ed25519 identity public key as the Signal bundle `identityKey` in **STANDARD base64** and keys its `/keys/{identityKey}/…` routes on that string verbatim. Standard base64's alphabet includes `/`, which becomes `%2F` in the request path — and those key routes 404 on it. So an identity whose public key's base64 contains a `/` **cannot publish its Signal pre-keys and cannot receive DMs**.

Our tiny.place identity is *deterministic* from the Solana wallet key, and roughly **half** of all Ed25519 public keys contain at least one `/` in standard base64. So ~half of new wallets mint a silently-unusable tiny.place identity (bundle publish + inbound DM both 404). This is the same class of failure the `plugin-tinyplace` SDK already sidesteps by regenerating slash-free wallets.

## Solution

`tinyplace_signer_seed()` now returns `slash_free_identity_seed(signing_key.to_bytes())`:

- **counter 0 = the raw wallet seed.** If the raw key's base64 is already slash-free (the common case), it passes through **byte-identical** — no identity change, nothing to migrate.
- Only when the raw key's base64 contains `/` do we deterministically derive a fresh seed from `SHA-256("openhuman.tinyplace.identity.slashfree.v1" ‖ seed ‖ counter)`, bumping `counter` until the resulting public key is slash-free. Same wallet always maps to the same lowest-counter slash-free identity.
- Astronomically-unlikely all-slash exhaustion falls back to the raw seed rather than panicking.

The tiny.place plugin regenerates slash-free *wallets*; here the identity must remain a pure function of the wallet key, so we remap the seed deterministically instead.

## Submission Checklist

- [x] Tests added or updated — `slash_free_identity_seed_cleans_slash_keys_deterministically` covers the clean-passthrough path (counter 0, unchanged) and the slashed→remapped path (slash-free + deterministic).
- [ ] **Diff coverage ≥ 80%** — N/A to run full merged report locally; the added `fn` + its unit test are fully exercised (both branches). Flagging for the coverage gate to confirm.
- [x] Coverage matrix updated — `N/A: internal key-derivation fix, no user-facing feature row`.
- [x] No new external network dependencies introduced — `N/A`, uses already-imported `sha2` / `ed25519_dalek` / `base64`.
- [x] Manual smoke checklist updated — `N/A: no release-cut surface touched`.
- [ ] Linked issue closed — no dedicated issue; surfaced while wiring the Cursor/Windsurf harness observer against staging.

## Impact

- **Runtime:** desktop/CLI wallet identity derivation only.
- **Security:** domain-separated SHA-256; the remapped seed is still 32 bytes of Ed25519 secret material. No key logged (existing `debug` log omits the seed).
- **⚠️ MIGRATION CAVEAT (needs a rollout decision):** for a wallet whose raw key's base64 contains `/`, this **changes that wallet's advertised tiny.place identity** to a different (slash-free) key. In practice those identities were **already non-functional** — they 404 on bundle-publish and on inbound DMs — so there is no working relay state to preserve, and remapping is strictly a repair. But if any such identity was partially advertised (e.g. published out-of-band, printed in a UI, or saved by a peer), those references will no longer resolve after upgrade. Recommend the team confirm no persisted slash-bearing identities need an explicit migration/announcement before merge. Clean identities (counter 0) are unaffected.

## Related

- Closes: _(none — no tracked issue; discovered during the Cursor/Windsurf harness observer spike)_
- Follow-up PR(s)/TODOs: base58↔base64 reply-address unification (OpenHuman→runtime reply path), tracked separately.

---

## AI Authored PR Metadata

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/tinyplace-slash-free-identity`
- Commit SHA: 010c36441

### Validation Run

- [ ] `pnpm --filter openhuman-app format:check` — N/A (no `app/` changes)
- [ ] `pnpm typecheck` — N/A (no TS changes)
- [x] Focused tests: `cargo test -p openhuman --lib slash_free_identity_seed_cleans_slash_keys_deterministically` → 1 passed
- [x] Rust fmt/check (if changed): `cargo fmt --check -- src/openhuman/wallet/chains/solana.rs` → clean
- [ ] Tauri fmt/check (if changed): N/A

### Behavior Changes

- Intended behavior change: newly-derived tiny.place identities are always slash-free and therefore able to publish pre-keys / receive DMs.
- User-visible effect: none for clean identities; for slash-bearing wallets, the tiny.place identity (not the Solana wallet address) changes to a working one.

### Parity Contract

- Legacy behavior preserved: clean identities are byte-identical (counter 0 == raw seed).
- Guard/fallback/dispatch parity checks: deterministic remap; bounded loop with raw-seed fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana wallet identity seed handling to avoid problematic slash characters in encoded identity keys.
  * Preserved existing seeds when no adjustment is needed and ensured deterministic results when remapping is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->