### PR TITLE
feat(inference): adopt crate ModelRouter for host workload-tier routing (Phase 3)

### DIFF
--- a/docs/tinyagents-drift-ledger.md
+++ b/docs/tinyagents-drift-ledger.md
@@ -146,6 +146,28 @@ it still serves every Bearer cloud slug, `openai_codex`, and the `create_chat_pr
 callers that have not moved to `create_chat_model` — and cannot be deleted until
 Phase 3 completes.
 
+## Phase 3 — RouterProvider → crate registry (host-only)
+
+Per `docs/tinyagents-phase3-router-registry-design.md` §1, Phase 3 is **host-only**
+— the crate `ModelRegistry` projection is already wired in `assemble_turn_harness`,
+so there is **no upstream gap** (this corrects the earlier "upstream-gated" reading
+of P1-9). Two sub-motions:
+
+- **P3-A** (harness holds `TurnModels`, not `Provider`): effectively complete —
+  `agent/harness/graph.rs` holds the seam `TurnModelSource` (names no `Provider`
+  trait) and `TurnModels` carries the `provider_id`/`context_window`/`native_tools`/
+  `supports_vision` accessors; the per-turn route re-projection that needs the raw
+  `Provider` is confined inside the seam newtype.
+- **P3-B** (registered tier models become crate-native, deletes `compatible*.rs`):
+  the hot turn path still builds `ProviderModel`-over-`Provider` via
+  `build_turn_models`/`build_route_models`. Cutting it to crate-native tiered
+  models from config is the remaining work.
+
+| Step | Status | Evidence |
+| --- | --- | --- |
+| Crate high-level router | **DONE** | [tinyagents#54](https://github.com/tinyhumansai/tinyagents/pull/54) `registry::router::{ModelRouter, WorkloadRoute}` (merged `4fc8cd8`) — declarative workload-tier table (alias→model, `CapabilitySet` gate, same-family fallbacks) filling the long-declared `ComponentKind::Router`; holds no models, no I/O. |
+| Host adopts `ModelRouter` for fallback + capability | **IN PROGRESS** | `tinyagents/routes.rs`: `OH_WORKLOAD_ROUTER` (`LazyLock<ModelRouter>`) now backs `route_fallback_policy` + `turn_required_capabilities`; deleted the hand-rolled `same_family_fallbacks`. Behavior-neutral (parity tests pin the exact chains + vision gate incl. `hint:vision`). `build_route_models`' per-tier `ProviderModel` construction (the P3-B client swap) is untouched. Host pin bumped `8e57665` → `4fc8cd8` (adds #53 langfuse run-tree + #54 router). |
+
 ## Host Validation Notes
 
 Local host validation is intentionally bounded because full suites are deferred

--- a/src/openhuman/tinyagents/routes.rs
+++ b/src/openhuman/tinyagents/routes.rs
@@ -17,7 +17,7 @@
 //! the turn's effective model, so nothing dispatches to these entries until a
 //! future fallback/selection step chooses them.
 
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use async_trait::async_trait;
 use tinyagents::harness::context::RunContext;
@@ -25,6 +25,7 @@ use tinyagents::harness::events::AgentEvent;
 use tinyagents::harness::middleware::{MiddlewareModelOutcome, ModelHandler, ModelMiddleware};
 use tinyagents::harness::model::{CapabilitySet, ModelRequest};
 use tinyagents::harness::retry::FallbackPolicy;
+use tinyagents::registry::{ModelRouter, WorkloadRoute};
 
 use crate::openhuman::config::{
     MODEL_AGENTIC_V1, MODEL_BURST_V1, MODEL_CHAT_V1, MODEL_CODING_V1, MODEL_REASONING_V1,
@@ -54,6 +55,61 @@ pub(super) const WORKLOAD_ROUTE_TIERS: &[&str] = &[
     MODEL_SUMMARIZATION_V1,
     MODEL_VISION_V1,
 ];
+
+/// The OpenHuman workload-tier routing table as a crate
+/// [`ModelRouter`](tinyagents::registry::ModelRouter) — the single declarative
+/// source for cross-route **fallback chains** and per-tier **required-capability
+/// gates** (issue #4249, Phase 3: RouterProvider → crate registry projection).
+///
+/// This does not move tier→provider/model *resolution* into the crate —
+/// `provider/router.rs` stays the product source of truth for what each tier
+/// name resolves to, and [`build_route_models`] still registers the per-tier
+/// [`ProviderModel`] with its real profile. The router owns only the *policy*
+/// this module previously open-coded as `same_family_fallbacks` +
+/// `turn_required_capabilities`: it answers [`route_fallback_policy`] and
+/// [`turn_required_capabilities`] from one declarative table.
+///
+/// Built once — the tier set + fallback ordering + vision gate are static:
+/// - light/fast conversational siblings `chat-v1 ⇄ burst-v1`;
+/// - heavy reasoning/agentic siblings `reasoning-v1 ⇄ agentic-v1`;
+/// - `coding-v1 → agentic-v1` (coding is tool-heavy, agentic-adjacent);
+/// - `summarization-v1 → chat-v1` (summarization rides a general chat model);
+/// - `vision-v1` is `image_in`-gated and primary-only — a text fallback cannot
+///   satisfy the gate — and its `hint:vision` form carries the same gate.
+static OH_WORKLOAD_ROUTER: LazyLock<ModelRouter> = LazyLock::new(|| {
+    let vision_gate = CapabilitySet {
+        image_in: true,
+        ..CapabilitySet::default()
+    };
+    ModelRouter::new()
+        .with_route(
+            WorkloadRoute::new(MODEL_CHAT_V1, MODEL_CHAT_V1).with_fallbacks([MODEL_BURST_V1]),
+        )
+        .with_route(
+            WorkloadRoute::new(MODEL_BURST_V1, MODEL_BURST_V1).with_fallbacks([MODEL_CHAT_V1]),
+        )
+        .with_route(
+            WorkloadRoute::new(MODEL_REASONING_V1, MODEL_REASONING_V1)
+                .with_fallbacks([MODEL_AGENTIC_V1]),
+        )
+        .with_route(
+            WorkloadRoute::new(MODEL_AGENTIC_V1, MODEL_AGENTIC_V1)
+                .with_fallbacks([MODEL_REASONING_V1]),
+        )
+        .with_route(
+            WorkloadRoute::new(MODEL_CODING_V1, MODEL_CODING_V1).with_fallbacks([MODEL_AGENTIC_V1]),
+        )
+        .with_route(
+            WorkloadRoute::new(MODEL_SUMMARIZATION_V1, MODEL_SUMMARIZATION_V1)
+                .with_fallbacks([MODEL_CHAT_V1]),
+        )
+        .with_route(
+            WorkloadRoute::new(MODEL_VISION_V1, MODEL_VISION_V1).requiring(vision_gate.clone()),
+        )
+        // The hint form resolves to the same vision tier and carries the same gate,
+        // with no fallback (primary-only), matching the legacy static gate.
+        .with_route(WorkloadRoute::new("hint:vision", MODEL_VISION_V1).requiring(vision_gate))
+});
 
 /// Whether a workload tier emits reasoning/thinking output.
 ///
@@ -149,13 +205,7 @@ pub(super) fn build_route_models(
 /// (needs `Config` + `model_registry.vision`), and true per-message image
 /// presence rather than the tier proxy.
 pub(super) fn turn_required_capabilities(model: &str) -> Option<CapabilitySet> {
-    if model == MODEL_VISION_V1 || model == "hint:vision" {
-        return Some(CapabilitySet {
-            image_in: true,
-            ..CapabilitySet::default()
-        });
-    }
-    None
+    OH_WORKLOAD_ROUTER.required_capabilities(model)
 }
 
 /// Around-model middleware that stamps the turn's required [`CapabilitySet`] onto
@@ -195,67 +245,33 @@ impl ModelMiddleware<()> for RequiredCapabilitiesMiddleware {
     }
 }
 
-/// The ordered same-family fallback **alternates** for a workload tier (issue
-/// #4249, Workstream 02.2). Each primary tier falls back to a single sibling in
-/// the same workload family so the harness can retry a different registered route
-/// when the primary route errors — bounding the cross-route fan-out to one extra
-/// call per turn (mirroring the single-alternate spirit of `ReliableProvider`'s
-/// `model_fallbacks`, so this does not regress failure latency/cost).
-///
-/// Ordering rationale (derived from `provider/router.rs` tier families):
-/// - `chat-v1` ⇄ `burst-v1` — the two light/fast conversational tiers.
-/// - `reasoning-v1` ⇄ `agentic-v1` — the two heavy reasoning/agentic tiers.
-/// - `coding-v1` → `agentic-v1` — coding is agentic-adjacent (tool-heavy).
-/// - `summarization-v1` → `chat-v1` — summarization rides a general chat model.
-/// - `vision-v1` → **none**: a non-vision route cannot satisfy the `image_in`
-///   capability the [`RequiredCapabilitiesMiddleware`] stamps on a vision turn, so
-///   falling back to a text tier would only be rejected pre-dispatch. There is a
-///   single vision tier, so vision turns are primary-only.
-///
-/// A model that is not one of the recognized tiers (a raw provider model string)
-/// returns an empty slice → no fallback chain is installed for that turn.
-fn same_family_fallbacks(model: &str) -> &'static [&'static str] {
-    match model {
-        MODEL_CHAT_V1 => &[MODEL_BURST_V1],
-        MODEL_BURST_V1 => &[MODEL_CHAT_V1],
-        MODEL_REASONING_V1 => &[MODEL_AGENTIC_V1],
-        MODEL_AGENTIC_V1 => &[MODEL_REASONING_V1],
-        MODEL_CODING_V1 => &[MODEL_AGENTIC_V1],
-        MODEL_SUMMARIZATION_V1 => &[MODEL_CHAT_V1],
-        MODEL_VISION_V1 => &[],
-        _ => &[],
-    }
-}
-
 /// Build the [`FallbackPolicy`] for a turn whose effective/primary model is
 /// `model` (issue #4249, Workstream 02.2). The returned chain is `[primary,
 /// alternate…]` — the crate's [`FallbackPolicy::next_after`] traversal expects the
 /// current (primary) name as the first entry and yields each subsequent alternate.
 ///
-/// Every alternate is a distinct workload tier that
+/// The chain now comes straight from the declarative [`OH_WORKLOAD_ROUTER`]
+/// (`fallback_policy` leads with the primary, then the tier's same-family
+/// alternates). Every alternate is a distinct workload tier that
 /// [`build_route_models`] has already registered in the harness model registry
 /// (the primary tier itself is skipped there, since the caller registers it as the
 /// default), so the harness can resolve each fallback name to its capability-carrying
 /// route adapter. Returns `None` when no same-family alternate exists (vision, or a
 /// raw non-tier model string), leaving the turn primary-only.
 pub(super) fn route_fallback_policy(model: &str) -> Option<FallbackPolicy> {
-    let alternates = same_family_fallbacks(model);
-    if alternates.is_empty() {
-        tracing::debug!(
+    let policy = OH_WORKLOAD_ROUTER.fallback_policy(model);
+    match &policy {
+        Some(p) => tracing::debug!(
+            route = model,
+            chain = ?p.models,
+            "[fallback] configured SDK-owned cross-route fallback chain"
+        ),
+        None => tracing::debug!(
             route = model,
             "[fallback] no same-family fallback route; turn is primary-only"
-        );
-        return None;
+        ),
     }
-    let mut models = Vec::with_capacity(alternates.len() + 1);
-    models.push(model.to_string());
-    models.extend(alternates.iter().map(|s| s.to_string()));
-    tracing::debug!(
-        route = model,
-        chain = ?models,
-        "[fallback] configured SDK-owned cross-route fallback chain"
-    );
-    Some(FallbackPolicy { models })
+    policy
 }
 
 /// Around-model middleware that makes the crate's registry-backed
@@ -365,5 +381,82 @@ impl ModelMiddleware<()> for UsageCarryMiddleware {
                 .push_back(usage);
         }
         Ok(MiddlewareModelOutcome::from(response))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The fallback chain for every tier must lead with the primary and carry the
+    /// single same-family alternate the legacy static table encoded — the crate
+    /// `ModelRouter` projection is exactly behavior-neutral.
+    #[test]
+    fn route_fallback_policy_matches_legacy_chains() {
+        let cases: &[(&str, Option<&[&str]>)] = &[
+            (MODEL_CHAT_V1, Some(&[MODEL_CHAT_V1, MODEL_BURST_V1])),
+            (MODEL_BURST_V1, Some(&[MODEL_BURST_V1, MODEL_CHAT_V1])),
+            (
+                MODEL_REASONING_V1,
+                Some(&[MODEL_REASONING_V1, MODEL_AGENTIC_V1]),
+            ),
+            (
+                MODEL_AGENTIC_V1,
+                Some(&[MODEL_AGENTIC_V1, MODEL_REASONING_V1]),
+            ),
+            (MODEL_CODING_V1, Some(&[MODEL_CODING_V1, MODEL_AGENTIC_V1])),
+            (
+                MODEL_SUMMARIZATION_V1,
+                Some(&[MODEL_SUMMARIZATION_V1, MODEL_CHAT_V1]),
+            ),
+            // Vision is primary-only (an image_in gate no text tier can satisfy).
+            (MODEL_VISION_V1, None),
+            ("hint:vision", None),
+            // A raw non-tier model installs no chain.
+            ("gpt-4o", None),
+        ];
+        for (model, expected) in cases {
+            let got = route_fallback_policy(model).map(|p| p.models);
+            let want =
+                expected.map(|chain| chain.iter().map(|s| s.to_string()).collect::<Vec<_>>());
+            assert_eq!(got, want, "fallback chain mismatch for {model}");
+        }
+    }
+
+    /// Only the vision tier (and its hint form) imposes an `image_in` gate; the
+    /// common text turn stays ungated.
+    #[test]
+    fn turn_required_capabilities_gates_only_vision() {
+        let vision = turn_required_capabilities(MODEL_VISION_V1).expect("vision is gated");
+        assert!(vision.image_in);
+        let hint = turn_required_capabilities("hint:vision").expect("hint:vision is gated");
+        assert!(hint.image_in);
+        for model in [
+            MODEL_CHAT_V1,
+            MODEL_REASONING_V1,
+            MODEL_AGENTIC_V1,
+            MODEL_CODING_V1,
+            MODEL_BURST_V1,
+            MODEL_SUMMARIZATION_V1,
+            "gpt-4o",
+        ] {
+            assert!(
+                turn_required_capabilities(model).is_none(),
+                "{model} must not be capability-gated"
+            );
+        }
+    }
+
+    /// The router covers exactly the projected tier inventory (plus the hint:vision
+    /// gate alias), so the fallback/capability source of truth stays aligned with
+    /// `WORKLOAD_ROUTE_TIERS`.
+    #[test]
+    fn router_covers_the_workload_tier_inventory() {
+        for tier in WORKLOAD_ROUTE_TIERS {
+            assert!(
+                OH_WORKLOAD_ROUTER.route(tier).is_some(),
+                "router missing tier {tier}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## What

Phase 3 (issue #4249) host adoption of the crate-side high-level router
(**tinyagents#54**, merged `4fc8cd8`). The OpenHuman **workload-tier fallback +
required-capability** policy that `tinyagents/routes.rs` open-coded now lives in
one declarative `OH_WORKLOAD_ROUTER` (`LazyLock<tinyagents::registry::ModelRouter>`):

- `route_fallback_policy(model)` → `router.fallback_policy(model)` — the
  `[primary, same-family alternate]` chain (or `None` for a primary-only tier).
- `turn_required_capabilities(model)` → `router.required_capabilities(model)` —
  `vision-v1` + `hint:vision` gate `image_in`; everything else ungated.
- Deleted the hand-rolled `same_family_fallbacks` static (folded into the table).

## Behavior-neutral

- `build_route_models`' per-tier `ProviderModel` construction (the P3-B client
  swap that eventually deletes `compatible*.rs`) is **untouched**.
- `provider/router.rs` stays the tier→provider/model source of truth.
- Parity tests pin the exact fallback chains, the vision gate (incl. the `hint`
  form), and that the router covers `WORKLOAD_ROUTE_TIERS`.

## Pin bump

`vendor/tinyagents` `8e57665` → `4fc8cd8` — adds **#53** (langfuse run-tree +
scores API) and **#54** (`registry::router::{ModelRouter, WorkloadRoute}`). Host
lib compiles clean against the new pin; #53 needs no host changes.

## Testing

Full-suite test **runs** defer to CI (local builds OOM on the shared box — a
documented constraint). The lib + nearly all test files compiled with zero errors
before the local run hit OOM at link. The crate `ModelRouter` is unit-tested
upstream in #54 (9 tests + doctest); this PR adds host parity tests for the
projection.

Phase 3 is host-only (the crate `ModelRegistry` projection is already wired in
`assemble_turn_harness`). Next P3-B slices: config-driven `create_turn_models`
builder → wire into the turn path → delete `compatible*.rs`.

https://claude.ai/code/session_01U8NDGbt9tKj443VquzycLB
