### PR TITLE
fix(appimage): reject bundles missing the CEF runtime

### DIFF
--- a/scripts/release/strip-appimage-graphics-libs.sh
+++ b/scripts/release/strip-appimage-graphics-libs.sh
@@ -480,7 +480,7 @@ sanitize_elf_rpaths() {
 # binary hard-links (NEEDED) but which MUST travel inside the AppImage is absent
 # from the bundle.
 #
-# Problem (issue #3224): the app links libxdo.so.3 via enigo
+# Problem (issues #3224 and #4020): the app links libxdo.so.3 via enigo
 # (`#[link(name = "xdo")]`, used by src/openhuman/tools/impl/computer for Linux
 # mouse/keyboard control). lib4bin's ldd-walk normally bundles it into
 # shared/lib, but if a future runner image drops libxdo-dev or bumps its soname,
@@ -488,23 +488,36 @@ sanitize_elf_rpaths() {
 # on any host lacking the legacy soname (e.g. Arch, which ships libxdo.so.4). The
 # .deb path already guards this via its `depends` (libxdo3) +
 # linux_cef_deb_runtime_e2e; the AppImage path had no equivalent. This turns a
-# silent runtime segfault into a loud build failure.
+# silent runtime segfault into a loud build failure. CEF is staged separately
+# from the ldd walk, so verify its runtime library survived bundling as well.
 validate_appimage_required_libs() {
   local appdir="$1"
   if ! uses_sharun_launcher "$appdir"; then
     return 0
   fi
 
-  local root
-  for root in "$appdir/shared/lib" "$appdir/usr/lib" "$appdir/lib"; do
-    [ -d "$root" ] || continue
-    if [ -n "$(find "$root" -name 'libxdo.so*' -print -quit 2>/dev/null)" ]; then
-      return 0
-    fi
-  done
+  local root pattern found
+  for pattern in 'libxdo.so*' 'libcef.so*'; do
+    found=0
+    for root in "$appdir/shared/lib" "$appdir/usr/lib" "$appdir/lib"; do
+      [ -d "$root" ] || continue
+      if [ -n "$(find "$root" -name "$pattern" -print -quit 2>/dev/null)" ]; then
+        found=1
+        break
+      fi
+    done
+    [ "$found" -eq 1 ] && continue
 
-  echo "[strip-libs] ERROR: AppImage is missing libxdo.so.* — the enigo NEEDED dependency was not bundled (issue #3224). The app would segfault on launch on hosts without the legacy libxdo soname (e.g. Arch). Ensure libxdo-dev is installed on the build runner so lib4bin's ldd-walk bundles it." >&2
-  exit 1
+    case "$pattern" in
+      libxdo.so\*)
+        echo "[strip-libs] ERROR: AppImage is missing libxdo.so.* — the enigo NEEDED dependency was not bundled (issue #3224). The app would segfault on launch on hosts without the legacy libxdo soname (e.g. Arch). Ensure libxdo-dev is installed on the build runner so lib4bin's ldd-walk bundles it." >&2
+        ;;
+      libcef.so\*)
+        echo "[strip-libs] ERROR: AppImage is missing libcef.so — the CEF runtime was not copied into the final bundle (issue #4020). Ensure the CEF cache/prewarm step exposes the directory containing libcef.so before the Tauri AppImage build." >&2
+        ;;
+    esac
+    exit 1
+  done
 }
 
 # patch_apprun_sharun_cwd — inject `cd "$APPDIR"` into AppRun before the final

--- a/scripts/release/strip-appimage-graphics-libs.sh
+++ b/scripts/release/strip-appimage-graphics-libs.sh
@@ -516,7 +516,7 @@ validate_appimage_required_libs() {
         echo "[strip-libs] ERROR: AppImage is missing libcef.so — the CEF runtime was not copied into the final bundle (issue #4020). Ensure the CEF cache/prewarm step exposes the directory containing libcef.so before the Tauri AppImage build." >&2
         ;;
     esac
-    exit 1
+    return 1
   done
 }
 
@@ -660,7 +660,10 @@ strip_one_appimage() {
     rewrote_rpaths=1
   fi
   validate_sharun_lib_path "$appdir"
-  validate_appimage_required_libs "$appdir"
+  if ! validate_appimage_required_libs "$appdir"; then
+    rm -rf "$workdir"
+    return 1
+  fi
 
   if [ "$removed" -eq 0 ] && [ "$added_loader" -eq 0 ] && [ "$rewrote_libpath" -eq 0 ] && [ "$patched_apprun" -eq 0 ] && [ "$rewrote_rpaths" -eq 0 ]; then
     echo "[strip-libs] No graphics libs, missing sharun interpreter, or build-machine RPATHs found in $original; leaving unchanged."

--- a/scripts/release/test-strip-appimage-rpaths.sh
+++ b/scripts/release/test-strip-appimage-rpaths.sh
@@ -4,8 +4,8 @@
 #   1. sanitize_elf_rpaths        — strips /home/runner|/__w build-machine
 #                                    RPATHs from bundled ELFs, rewriting to
 #                                    $ORIGIN-relative.
-#   2. validate_appimage_required_libs — hard-fails when libxdo.so.* is missing
-#                                    from a sharun AppDir.
+#   2. validate_appimage_required_libs — hard-fails when libxdo.so.* or
+#                                    libcef.so is missing from a sharun AppDir.
 #
 # Linux-only: needs `patchelf` and a host ELF to mutate. Skips cleanly (exit 0)
 # on macOS / any host without patchelf so it is a no-op on dev boxes and a real
@@ -115,7 +115,7 @@ lib_after="$(patchelf --print-rpath "$ABS_LIB")"
   || fail "lib/ fallback wrong: expected '\$ORIGIN:\$ORIGIN/../shared/lib', got '$lib_after'"
 echo "[test-rpaths] ok: lib/ pure-absolute RPATH → depth-aware fallback '$lib_after'"
 
-# --- Case 2: validate_appimage_required_libs guards libxdo -------------------
+# --- Case 2: validate_appimage_required_libs guards runtime libraries --------
 # Build a minimal sharun AppDir. uses_sharun_launcher only inspects *ELF* entry
 # binaries (is_executable_elf) and greps them for the literal
 # "Interpreter not found!" string, mirroring the real sharun launcher binary.
@@ -136,11 +136,19 @@ if ( validate_appimage_required_libs "$GUARD_DIR" ) 2>/dev/null; then
 fi
 echo "[test-rpaths] ok: guard fails when libxdo.so.* is absent"
 
-# 2b — libxdo present → must pass.
+# 2b — libxdo present but libcef absent → must still fail.
 : > "$GUARD_DIR/shared/lib/libxdo.so.3"
-if ! ( validate_appimage_required_libs "$GUARD_DIR" ) 2>/dev/null; then
-  fail "validate_appimage_required_libs failed despite libxdo.so.3 present"
+if ( validate_appimage_required_libs "$GUARD_DIR" ) 2>/dev/null; then
+  fail "validate_appimage_required_libs passed despite missing libcef.so"
 fi
-echo "[test-rpaths] ok: guard passes when libxdo.so.3 is present"
+echo "[test-rpaths] ok: guard fails when libcef.so is absent"
+
+# 2c — both required runtime libraries present → must pass.
+mkdir -p "$GUARD_DIR/usr/lib"
+: > "$GUARD_DIR/usr/lib/libcef.so"
+if ! ( validate_appimage_required_libs "$GUARD_DIR" ) 2>/dev/null; then
+  fail "validate_appimage_required_libs failed despite libxdo.so.3 and libcef.so being present"
+fi
+echo "[test-rpaths] ok: guard passes when libxdo.so.3 and libcef.so are present"
 
 echo "[test-rpaths] PASS"

--- a/scripts/release/test-strip-appimage-rpaths.sh
+++ b/scripts/release/test-strip-appimage-rpaths.sh
@@ -145,6 +145,7 @@ echo "[test-rpaths] ok: guard fails when libcef.so is absent"
 
 # 2c — both required runtime libraries present → must pass.
 mkdir -p "$GUARD_DIR/usr/lib"
+: > "$GUARD_DIR/shared/lib/libxdo.so.3"
 : > "$GUARD_DIR/usr/lib/libcef.so"
 if ! ( validate_appimage_required_libs "$GUARD_DIR" ) 2>/dev/null; then
   fail "validate_appimage_required_libs failed despite libxdo.so.3 and libcef.so being present"


### PR DESCRIPTION
## Summary

- Extend the final AppImage runtime guard to require both `libxdo.so*` and `libcef.so*`.
- Fail release packaging with an actionable error when the CEF runtime did not survive bundling.
- Add Linux regression coverage for missing libxdo, missing libcef, and a complete bundle.

## Problem

- #4020 reports AppImages failing at launch because required runtime libraries are absent.
- The existing post-package guard covers `libxdo.so*` only. A current Fedora report shows the same release artifact missing `libcef.so`, while the earlier CEF prewarm/staging steps do not prove that the final AppDir still contains it.

## Solution

- Validate both required library patterns across the existing `shared/lib`, `usr/lib`, and `lib` roots after packaging.
- Keep the guard scoped to sharun-based AppDirs, preserving the existing non-sharun behavior.
- Preserve the existing libxdo diagnostic and add a CEF-specific diagnostic that points maintainers to the cache/prewarm path.
- Exercise every outcome in the existing release-script regression test.

## Submission Checklist

&gt; If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — all added shell validation branches are executed by the focused regression test; the CI diff gate remains authoritative.
- [x] Coverage matrix updated — N/A: release-packaging guard only; no feature row was added, removed, or renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no coverage-matrix feature ID applies.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: this automates a pre-release artifact invariant and adds no new manual flow.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Linux AppImage release path only; desktop, mobile, web, CLI, and non-sharun bundle behavior are unchanged.
- Valid artifacts have no runtime or performance change.
- An incomplete AppImage now fails before signing/upload instead of reaching users and failing at launch.

## Related



- Closes #4020
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

&gt; Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit &amp; Branch

- Branch: `fix/appimage-runtime-libraries`
- Commit SHA: `c6a2d418fbe5c5b5ed29be5f9be64c1550ead186`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — Prettier passed; the chained Rust format check is blocked by missing `cargo` and documented below.
- [x] `pnpm typecheck` — N/A: shell-only release validation change.
- [x] Focused tests: `wsl.exe -d Ubuntu-24.04 -- bash -lc &#34;bash scripts/release/test-strip-appimage-rpaths.sh&#34;`
- [x] Rust fmt/check (if changed): N/A — no Rust files changed.
- [x] Tauri fmt/check (if changed): N/A — no Tauri files changed.
- [x] Shell validation: `bash -n`, `shellcheck --severity=warning`, and `git diff --check`.

### Validation Blocked

- `command:` `pnpm --filter openhuman-app format:check` (also invoked by the pre-push hook)
- `error:` Prettier reported all matched files clean, then the chained Rust formatting step failed because `cargo` is not installed on the Windows host.
- `impact:` Rust formatting and the remaining full pre-push checks could not run locally. No Rust/TypeScript/app files changed; the Linux shell regression, syntax check, ShellCheck, and whitespace check pass.

### Behavior Changes

- Intended behavior change: reject a sharun AppImage whose final bundle lacks either libxdo or the CEF runtime.
- User-visible effect: maintainers get an actionable release failure; users no longer receive that incomplete artifact after this guard passes CI.

### Parity Contract

- Legacy behavior preserved: the existing libxdo guard, library search roots, and non-sharun early return remain intact.
- Guard/fallback/dispatch parity checks: focused test covers missing libxdo, missing libcef, and both libraries present.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): no matching open PR found for `libcef`, `AppImage runtime`, or #4020.
- Canonical PR: this PR.
- Resolution (closed/superseded/updated): N/A.




## Summary by CodeRabbit

* **Bug Fixes**
  * AppImage release validation now detects missing required graphics and runtime libraries, including CEF and enigo dependencies.
  * Builds fail with specific error messages when any required library is absent.

* **Tests**
  * Expanded release validation coverage for missing and present library combinations.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AppImage release validation is now stricter for bundles using the sharun launcher, requiring both the enigo dependency (`libxdo.so.*`) and the CEF runtime (`libcef.so*`).
  * Validation failures are reported with library-specific errors, improving clarity when required components are missing.

* **Tests**
  * Expanded release validation coverage to verify failure when only `libxdo.so.*` is present, and success when both `libxdo.so.*` and `libcef.so*` are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->