### PR TITLE
fix(tauri/windows): restore minimized window on desktop shortcut/taskbar click

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1292,12 +1292,12 @@ fn set_main_window_hidden(hide: bool) {
     use std::os::windows::ffi::OsStringExt;
     use windows_sys::Win32::Foundation::{BOOL, HWND, LPARAM};
     use windows_sys::Win32::UI::WindowsAndMessaging::{
-        EnumWindows, GetClassNameW, GetWindowThreadProcessId, IsWindowVisible, ShowWindow,
+        EnumWindows, GetClassNameW, GetWindowThreadProcessId, IsIconic, IsWindowVisible, ShowWindow,
     };
 
     struct EnumCtx {
         target_pid: u32,
-        action: i32,
+        hide: bool,
         require_visible: bool,
         matched: u32,
     }
@@ -1323,15 +1323,20 @@ fn set_main_window_hidden(hide: bool) {
         if class != "Chrome_WidgetWin_1" {
             return 1;
         }
-        unsafe { ShowWindow(hwnd, ctx.action) };
+        // Choose the restore command per frame: a minimized frame needs
+        // SW_RESTORE to un-minimize, but a hidden-but-maximized frame must be
+        // shown with SW_SHOW so it stays maximized (#4818). IsIconic is only
+        // consulted on the restore path.
+        let is_iconic = !ctx.hide && unsafe { IsIconic(hwnd) } != 0;
+        let action = window_show_command(ctx.hide, is_iconic);
+        unsafe { ShowWindow(hwnd, action) };
         ctx.matched += 1;
         1
     }
 
-    let action = show_window_command(hide);
     let mut ctx = EnumCtx {
         target_pid: std::process::id(),
-        action,
+        hide,
         // Hide path: only touch currently-visible frames. Show path: also
         // pick up frames already in the SW_HIDE state.
         require_visible: hide,
@@ -1340,37 +1345,46 @@ fn set_main_window_hidden(hide: bool) {
     unsafe { EnumWindows(Some(enum_proc), &mut ctx as *mut _ as LPARAM) };
     log::info!(
         "[window-hide] EnumWindows: action={} matched={} pid={}",
-        if hide { "SW_HIDE" } else { "SW_RESTORE" },
+        if hide {
+            "SW_HIDE"
+        } else {
+            "restore(SW_RESTORE/SW_SHOW)"
+        },
         ctx.matched,
         ctx.target_pid,
     );
 }
 
-/// `ShowWindow` command for [`set_main_window_hidden`]'s restore path.
+/// `ShowWindow` command for [`set_main_window_hidden`], chosen per frame.
 ///
-/// The restore path uses `SW_RESTORE`, not `SW_SHOW`: `SW_SHOW` displays a
-/// window in its *current* state, so a **minimized** `Chrome_WidgetWin_1`
-/// frame stays minimized. That is why clicking the desktop shortcut / taskbar
-/// entry while the app was minimized did nothing — the second-instance
-/// callback ran `set_main_window_hidden(false)` (a no-op SW_SHOW) and then
-/// `WebviewWindow::unminimize()`, which the vendored CEF runtime routes to the
-/// internal `cef::Window` proxy handle rather than the visible top-level frame
-/// (#1607), so neither un-minimized the OS window (#4809).
+/// Restore is *not* a single command — it depends on whether the frame is
+/// iconic (minimized):
 ///
-/// `SW_RESTORE` un-minimizes AND un-hides the OS frame, so it fixes the
-/// minimized case while remaining correct for the hide-to-tray case (a
-/// SW_HIDE'd frame's restore state is normal, so SW_RESTORE shows + activates
-/// it exactly as SW_SHOW did).
+/// - **Minimized frame** (`is_iconic`): `SW_RESTORE`. `SW_SHOW` displays a
+///   window in its *current* state, so a minimized `Chrome_WidgetWin_1` frame
+///   stays minimized — clicking the desktop shortcut / taskbar entry while the
+///   app was minimized did nothing, because the second-instance callback ran a
+///   no-op `SW_SHOW` and then `WebviewWindow::unminimize()`, which the vendored
+///   CEF runtime routes to the internal `cef::Window` proxy handle rather than
+///   the visible top-level frame (#1607), so neither un-minimized the OS window
+///   (#4809). `SW_RESTORE` un-minimizes AND un-hides.
+/// - **Hidden-but-not-minimized frame** (the plain hide-to-tray case, which may
+///   be **maximized**): `SW_SHOW`. `SW_RESTORE` would force a maximized frame
+///   back to its normal size, so a window closed to the tray while maximized
+///   would come back un-maximized. `SW_SHOW` displays it in its current state,
+///   preserving the maximized geometry (chatgpt-codex review on #4809/#4818).
 ///
 /// Split out as a pure `i32`-returning helper so the command selection is unit
 /// testable without driving real windows.
 #[cfg(target_os = "windows")]
-const fn show_window_command(hide: bool) -> i32 {
-    use windows_sys::Win32::UI::WindowsAndMessaging::{SW_HIDE, SW_RESTORE};
+const fn window_show_command(hide: bool, is_iconic: bool) -> i32 {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{SW_HIDE, SW_RESTORE, SW_SHOW};
     if hide {
         SW_HIDE
-    } else {
+    } else if is_iconic {
         SW_RESTORE
+    } else {
+        SW_SHOW
     }
 }
 

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1292,8 +1292,7 @@ fn set_main_window_hidden(hide: bool) {
     use std::os::windows::ffi::OsStringExt;
     use windows_sys::Win32::Foundation::{BOOL, HWND, LPARAM};
     use windows_sys::Win32::UI::WindowsAndMessaging::{
-        EnumWindows, GetClassNameW, GetWindowThreadProcessId, IsWindowVisible, ShowWindow, SW_HIDE,
-        SW_SHOW,
+        EnumWindows, GetClassNameW, GetWindowThreadProcessId, IsWindowVisible, ShowWindow,
     };
 
     struct EnumCtx {
@@ -1329,7 +1328,7 @@ fn set_main_window_hidden(hide: bool) {
         1
     }
 
-    let action = if hide { SW_HIDE } else { SW_SHOW };
+    let action = show_window_command(hide);
     let mut ctx = EnumCtx {
         target_pid: std::process::id(),
         action,
@@ -1341,10 +1340,38 @@ fn set_main_window_hidden(hide: bool) {
     unsafe { EnumWindows(Some(enum_proc), &mut ctx as *mut _ as LPARAM) };
     log::info!(
         "[window-hide] EnumWindows: action={} matched={} pid={}",
-        if hide { "SW_HIDE" } else { "SW_SHOW" },
+        if hide { "SW_HIDE" } else { "SW_RESTORE" },
         ctx.matched,
         ctx.target_pid,
     );
+}
+
+/// `ShowWindow` command for [`set_main_window_hidden`]'s restore path.
+///
+/// The restore path uses `SW_RESTORE`, not `SW_SHOW`: `SW_SHOW` displays a
+/// window in its *current* state, so a **minimized** `Chrome_WidgetWin_1`
+/// frame stays minimized. That is why clicking the desktop shortcut / taskbar
+/// entry while the app was minimized did nothing — the second-instance
+/// callback ran `set_main_window_hidden(false)` (a no-op SW_SHOW) and then
+/// `WebviewWindow::unminimize()`, which the vendored CEF runtime routes to the
+/// internal `cef::Window` proxy handle rather than the visible top-level frame
+/// (#1607), so neither un-minimized the OS window (#4809).
+///
+/// `SW_RESTORE` un-minimizes AND un-hides the OS frame, so it fixes the
+/// minimized case while remaining correct for the hide-to-tray case (a
+/// SW_HIDE'd frame's restore state is normal, so SW_RESTORE shows + activates
+/// it exactly as SW_SHOW did).
+///
+/// Split out as a pure `i32`-returning helper so the command selection is unit
+/// testable without driving real windows.
+#[cfg(target_os = "windows")]
+const fn show_window_command(hide: bool) -> i32 {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{SW_HIDE, SW_RESTORE};
+    if hide {
+        SW_HIDE
+    } else {
+        SW_RESTORE
+    }
 }
 
 /// Look up the main `WebviewWindow`, optionally waiting briefly on Windows

--- a/app/src-tauri/src/lib_tests.rs
+++ b/app/src-tauri/src/lib_tests.rs
@@ -9,21 +9,30 @@ static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 // NOTE: `is_daemon_mode_detects_daemon_flag` removed (plan.md §2.1) — it
 // discarded the result with `let _` and asserted nothing.
 
-// Regression for #4809: restoring the window (desktop shortcut / taskbar /
-// tray while minimized) must un-minimize the OS frame. `SW_SHOW` leaves a
-// minimized `Chrome_WidgetWin_1` frame minimized, so the restore path must
-// use `SW_RESTORE`. Windows-only: `show_window_command` is `cfg(windows)`.
+// Regression for #4809 + #4818: the restore command is chosen per frame.
+// - A minimized frame (desktop shortcut / taskbar / tray while minimized) must
+//   un-minimize the OS frame; `SW_SHOW` leaves it minimized, so it uses
+//   `SW_RESTORE` (#4809).
+// - A hidden-but-not-minimized frame may be maximized; `SW_RESTORE` would drop
+//   it back to normal size, so it uses `SW_SHOW` to preserve the maximized
+//   geometry (#4818).
+// Windows-only: `window_show_command` is `cfg(windows)`.
 #[cfg(target_os = "windows")]
 #[test]
-fn restore_uses_sw_restore_not_sw_show() {
+fn restore_command_preserves_minimized_and_maximized_frames() {
     use windows_sys::Win32::UI::WindowsAndMessaging::{SW_HIDE, SW_RESTORE, SW_SHOW};
-    // Restore path un-minimizes AND un-hides.
-    assert_eq!(show_window_command(false), SW_RESTORE);
+    // Minimized restore un-minimizes AND un-hides.
+    assert_eq!(window_show_command(false, true), SW_RESTORE);
     // Guard against a regression back to SW_SHOW, which no-ops on a
     // minimized frame and reproduces #4809.
-    assert_ne!(show_window_command(false), SW_SHOW);
-    // Hide path is unchanged.
-    assert_eq!(show_window_command(true), SW_HIDE);
+    assert_ne!(window_show_command(false, true), SW_SHOW);
+    // Hidden-but-not-minimized restore uses SW_SHOW so a tray-hidden maximized
+    // window comes back maximized (#4818), not shrunk to normal size.
+    assert_eq!(window_show_command(false, false), SW_SHOW);
+    assert_ne!(window_show_command(false, false), SW_RESTORE);
+    // Hide path is unchanged regardless of iconic state.
+    assert_eq!(window_show_command(true, false), SW_HIDE);
+    assert_eq!(window_show_command(true, true), SW_HIDE);
 }
 
 /// Test core_rpc_url returns expected format

--- a/app/src-tauri/src/lib_tests.rs
+++ b/app/src-tauri/src/lib_tests.rs
@@ -9,6 +9,23 @@ static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 // NOTE: `is_daemon_mode_detects_daemon_flag` removed (plan.md §2.1) — it
 // discarded the result with `let _` and asserted nothing.
 
+// Regression for #4809: restoring the window (desktop shortcut / taskbar /
+// tray while minimized) must un-minimize the OS frame. `SW_SHOW` leaves a
+// minimized `Chrome_WidgetWin_1` frame minimized, so the restore path must
+// use `SW_RESTORE`. Windows-only: `show_window_command` is `cfg(windows)`.
+#[cfg(target_os = "windows")]
+#[test]
+fn restore_uses_sw_restore_not_sw_show() {
+    use windows_sys::Win32::UI::WindowsAndMessaging::{SW_HIDE, SW_RESTORE, SW_SHOW};
+    // Restore path un-minimizes AND un-hides.
+    assert_eq!(show_window_command(false), SW_RESTORE);
+    // Guard against a regression back to SW_SHOW, which no-ops on a
+    // minimized frame and reproduces #4809.
+    assert_ne!(show_window_command(false), SW_SHOW);
+    // Hide path is unchanged.
+    assert_eq!(show_window_command(true), SW_HIDE);
+}
+
 /// Test core_rpc_url returns expected format
 #[test]
 fn core_rpc_url_returns_expected_format() {


### PR DESCRIPTION
## Summary

Clicking the desktop shortcut or taskbar entry while the app was **minimized** did nothing — only the system tray could restore the window. This makes shortcut/taskbar restore behave per the standard OS convention.

## Root cause

On Windows the close/minimize-to-tray flow drives the real `Chrome_WidgetWin_1` OS frame directly via `EnumWindows` + `ShowWindow`, because the vendored CEF runtime's `WebviewWindow::{minimize,unminimize,hide,show}` only touch an internal `cef::Window` proxy handle, not the visible top-level frame (#1607).

The restore path — `set_main_window_hidden(false)`, hit by the single-instance / desktop-shortcut / taskbar relaunch **and** by the tray — issued `SW_SHOW`. `SW_SHOW` displays a window in its *current* state, so a **minimized** frame stays minimized, and the follow-up `WebviewWindow::unminimize()` is a no-op on the vendored frame. Net: the shortcut/taskbar click did nothing when minimized.

## Fix

Restore path now issues **`SW_RESTORE`** instead of `SW_SHOW`. `SW_RESTORE` un-minimizes AND un-hides the OS frame, so it fixes the minimized case while remaining correct for the hide-to-tray case (a `SW_HIDE`'d frame's restore state is normal, so `SW_RESTORE` shows + activates it exactly as `SW_SHOW` did). The command selection is extracted into a pure `show_window_command(hide) -> i32` helper.

## Test

`restore_uses_sw_restore_not_sw_show` (Windows-gated) asserts restore → `SW_RESTORE` (≠ `SW_SHOW`) and hide → `SW_HIDE`, guarding against a regression back to `SW_SHOW`.

## Notes / scope

- The changed lines are `#[cfg(target_os = "windows")]`; the unit test compiles/runs on the Windows CI target. The Linux CI-lite coverage lane does not compile these lines, so diff-coverage is unaffected.
- macOS/Linux already route restore through the working `unminimize()` plus the wired `RunEvent::Reopen` (dock) and single-instance handlers, so no change was needed there. Full cross-platform behavior is best confirmed at runtime.

Closes #4809