### PR TITLE
feat(core): compile-time voice feature gate (voice + audio_toolkit) (#4803)

### DIFF
--- a/.github/workflows/ci-lite.yml
+++ b/.github/workflows/ci-lite.yml
@@ -351,6 +351,40 @@ jobs:
       - name: Run clippy (core crate)
         run: bash scripts/ci-cancel-aware.sh cargo clippy -p openhuman
 
+  # Feature-gate smoke: proves the core still compiles with a domain gate turned
+  # OFF. The disabled build is the ONLY thing that catches stub-facade signature
+  # drift (see AGENTS.md "Compile-time domain gates"), so it must run in CI, not
+  # just locally. Pathfinder lane for #4803 (voice); extend the --features list
+  # as sibling gates (#4797–#4802, #4804) land.
+  rust-feature-gate-smoke:
+    name: Rust Feature-Gate Smoke (gates off)
+    needs: [changes]
+    if: needs.changes.outputs['rust-core'] == 'true' || needs.changes.outputs['rust-tauri'] == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 25
+    container:
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+    env:
+      CARGO_INCREMENTAL: "0"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+          cache-on-failure: true
+          shared-key: pr-rust-feature-gate-smoke
+
+      - name: Check core builds with the voice gate disabled
+        run: bash scripts/ci-cancel-aware.sh cargo check --manifest-path Cargo.toml --no-default-features --features tokenjuice-treesitter
+
   rust-core-coverage:
     name: Rust Core Coverage (cargo-llvm-cov)
     needs: [changes, rust-quality]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,26 @@ Two independent runtime axes on `CoreBuilder` (`src/core/runtime/builder.rs`):
 - **`ServiceSet`** selects which *background services / transports* run (`rpc_http`, `socketio`, `cron`, `channels`, `heartbeat`, …). Presets: `desktop()` / `headless_api()` / `none()`.
 - **`DomainSet`** selects which *domain families* exist at runtime, one flag per `DomainGroup` (`src/core/all.rs`). Presets: `full()` (default — byte-identical to before #4796), `harness()` (agent + memory + threads + config + security only), `none()`. Every controller is tagged with its `DomainGroup` at the single registration site in `src/core/all.rs`; the live surface (controllers/`/schema`/dispatch, agent tools, stores, subscribers) is filtered by the ambient `CoreContext::domains()`. A gated domain's controllers become unknown-method, its agent tools absent, its stores/subscribers uninitialized. `examples/embed_headless.rs` uses `DomainSet::harness()`. Per-gate Cargo `[features]` (children #4797–#4804) narrow the compile-time surface further; `DomainSet` is the runtime axis they compose with.
 
+### Compile-time domain gates (Cargo `[features]`)
+
+Per-domain Cargo features drop whole domains **at compile time** (smaller binary, fewer deps), composing with the runtime `DomainSet` axis above. Each gate is **default-ON**, so the desktop build is byte-identical; slim builds opt out explicitly.
+
+**Slim-profile convention** (no `full` meta-feature): build slim variants with `cargo build --no-default-features --features "<explicit list of gates you want>"`. This mirrors the existing standalone-feature style (`sandbox-landlock`, `browser-native`, …). Example — everything except voice:
+
+```bash
+# check / build without the voice + audio_toolkit domains
+GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml \
+  --no-default-features --features tokenjuice-treesitter
+```
+
+| Feature | Default | Gates | Drops deps |
+| ------- | ------- | ----- | ---------- |
+| `voice` | ON | `openhuman::voice` + `openhuman::audio_toolkit` domains — STT/TTS providers, dictation server, always-on listening, podcast audio + email | `hound`, `lettre` |
+
+**Facade pattern (pathfinder for the other gates).** `pub mod voice;` is **always compiled** as a facade: the real submodules are `#[cfg(feature = "voice")]`, and a `#[cfg(not(feature = "voice"))] mod stub;` (`src/openhuman/voice/stub.rs`) re-exposes the same public surface that always-on / other-gated callers use (`server`, `dictation_listener`, `streaming`, `reply_speech`, `cloud_transcribe`, `cli`, `create_stt_provider`, `effective_stt_provider`, `publish_ptt_transcript_committed`) with no-op / `None` / disabled-error bodies. Callers therefore do **not** need per-call `#[cfg]`. When voice is off: the voice/audio controllers are unregistered (unknown-method over `/rpc`, absent from `/schema`), the `audio_generate_podcast` agent tools are absent, and `openhuman voice` returns a "voice disabled" error. Stub signatures must match the real ones exactly — the disabled build (`--no-default-features --features tokenjuice-treesitter`) is the **only** thing that catches drift, so run it before pushing any change to the voice surface.
+
+**Scope note:** the `voice` gate does **not** drop `whisper-rs` / `llama` / `cpal`. Those live in the inference domain (`src/openhuman/inference/local/service/whisper_engine.rs`; `cpal` is shared with accessibility) and await a separate future `inference` gate. The issue-level DoD line claiming whisper is dropped is superseded by this scope correction.
+
 ### Event bus (`src/core/event_bus/`)
 
 Typed pub/sub + native request/response. Both singletons — use module-level functions.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,7 +217,7 @@ sysinfo = { version = "0.33", default-features = false, features = ["system"] }
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
 clap = { version = "4.5", features = ["derive"] }
 clap_complete = "4.5"
-lettre = { version = "0.11.22", default-features = false, features = ["builder", "smtp-transport", "rustls-tls"] }
+lettre = { version = "0.11.22", default-features = false, features = ["builder", "smtp-transport", "rustls-tls"], optional = true }
 mail-parser = "0.11.2"
 async-imap = { version = "0.11", features = ["runtime-tokio"], default-features = false }
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio", "query", "ws", "macros"] }
@@ -233,7 +233,7 @@ whisper-rs = "0.16"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 tempfile = "3"
 cpal = "0.15"
-hound = "3.5"
+hound = { version = "3.5", optional = true }
 enigo = "0.3"
 arboard = "3"
 rdev = "0.5"
@@ -334,12 +334,23 @@ tokio = { version = "1", features = ["test-util"] }
 proptest = "1"
 
 [features]
-default = ["tokenjuice-treesitter"]
+default = ["tokenjuice-treesitter", "voice"]
 # AST-aware code compression (tree-sitter Rust/TS/Python grammars; C build).
 # On by default; disable to fall back to the brace-depth heuristic.
 tokenjuice-treesitter = [
     "tinyjuice/tinyjuice-treesitter",
 ]
+# Voice + audio_toolkit domains: STT/TTS providers, the standalone dictation
+# server, always-on listening, and podcast audio generation/email delivery.
+# Default-ON — the desktop app always ships with voice. Slim / headless builds
+# opt out via `--no-default-features --features "<explicit list without voice>"`,
+# which also drops the exclusive `hound` (WAV I/O) + `lettre` (podcast email)
+# dependencies. Composes with the runtime `DomainSet::voice` flag (#4796): the
+# feature narrows the compile-time surface, `DomainSet` gates it at runtime.
+# NOTE: this gate does NOT drop whisper-rs / llama / cpal — those live in the
+# inference domain (shared with accessibility for cpal) and await a separate
+# `inference` gate.
+voice = ["dep:hound", "dep:lettre"]
 sandbox-landlock = ["dep:landlock"]
 sandbox-bubblewrap = []
 peripheral-rpi = ["dep:rppal"]

--- a/src/core/all.rs
+++ b/src/core/all.rs
@@ -167,6 +167,10 @@ fn internal_registry() -> &'static [GroupedController] {
 /// Returns a reference to the global CLI adapter registry.
 fn cli_adapters() -> &'static [RegisteredCliAdapter] {
     CLI_ADAPTERS.get_or_init(|| {
+        // The `voice` namespace stays registered regardless of the `voice`
+        // feature: with the feature off, `voice::cli::run_standalone_subcommand`
+        // resolves to the facade stub, which returns a "voice disabled" error so
+        // `openhuman voice` fails gracefully instead of the subcommand vanishing.
         vec![RegisteredCliAdapter {
             namespace: "voice",
             handler: crate::openhuman::voice::cli::run_standalone_subcommand,
@@ -202,7 +206,8 @@ fn build_registered_controllers() -> Vec<GroupedController> {
         DomainGroup::Platform,
         crate::openhuman::app_state::all_app_state_registered_controllers(),
     );
-    // Audio generation + podcast-style email delivery
+    // Audio generation + podcast-style email delivery (gated with voice).
+    #[cfg(feature = "voice")]
     push(
         &mut controllers,
         DomainGroup::Voice,
@@ -632,7 +637,8 @@ fn build_registered_controllers() -> Vec<GroupedController> {
         DomainGroup::Platform,
         crate::openhuman::text_input::all_text_input_registered_controllers(),
     );
-    // Voice transcription and synthesis
+    // Voice transcription and synthesis (gated behind the `voice` feature).
+    #[cfg(feature = "voice")]
     push(
         &mut controllers,
         DomainGroup::Voice,

--- a/src/core/all_tests.rs
+++ b/src/core/all_tests.rs
@@ -201,6 +201,39 @@ fn all_controller_schemas_matches_registered_count() {
     assert_eq!(schemas.len(), controllers.len());
 }
 
+/// With the `voice` feature on (the default), the voice + audio_toolkit
+/// controllers are compiled in and registered — the desktop build is
+/// byte-identical.
+#[test]
+#[cfg(feature = "voice")]
+fn voice_and_audio_controllers_registered_when_feature_on() {
+    let schemas = all_controller_schemas();
+    assert!(
+        schemas.iter().any(|s| s.namespace == "voice"),
+        "voice controllers must be registered when the `voice` feature is on"
+    );
+    assert!(
+        schemas.iter().any(|s| s.namespace == "audio_toolkit"),
+        "audio_toolkit controllers must be registered when the `voice` feature is on"
+    );
+}
+
+/// With the `voice` feature off, both domains are compiled out: their
+/// controllers never enter the registry, so voice/audio RPC methods are
+/// unknown-method and absent from `/schema`. This is the compile-time
+/// stub-facade correctness gate (see `openhuman::voice::stub`).
+#[test]
+#[cfg(not(feature = "voice"))]
+fn voice_and_audio_controllers_absent_when_feature_off() {
+    let schemas = all_controller_schemas();
+    assert!(
+        !schemas
+            .iter()
+            .any(|s| s.namespace == "voice" || s.namespace == "audio_toolkit"),
+        "voice/audio_toolkit controllers must be compiled out when the `voice` feature is off"
+    );
+}
+
 #[test]
 fn schema_for_rpc_method_finds_known_method() {
     let schema = schema_for_rpc_method("openhuman.health_snapshot");

--- a/src/openhuman/mod.rs
+++ b/src/openhuman/mod.rs
@@ -28,6 +28,7 @@ pub mod announcements;
 pub mod app_state;
 pub mod approval;
 pub mod artifacts;
+#[cfg(feature = "voice")]
 pub mod audio_toolkit;
 pub mod autocomplete;
 pub mod billing;

--- a/src/openhuman/tools/mod.rs
+++ b/src/openhuman/tools/mod.rs
@@ -15,6 +15,7 @@ pub use crate::openhuman::agent::tools::*;
 pub use crate::openhuman::agent_memory::tools::*;
 pub use crate::openhuman::agent_orchestration::tools::*;
 pub use crate::openhuman::artifacts::tools::*;
+#[cfg(feature = "voice")]
 pub use crate::openhuman::audio_toolkit::tools::*;
 pub use crate::openhuman::billing::tools::*;
 pub use crate::openhuman::codegraph::tools::*;

--- a/src/openhuman/tools/ops.rs
+++ b/src/openhuman/tools/ops.rs
@@ -402,11 +402,17 @@ pub fn all_tools_with_runtime(
             security.clone(),
             action_dir.to_path_buf(),
         )),
+        // Audio-toolkit podcast tools — gated with the `voice` feature (they
+        // live in the `audio_toolkit` domain, which is compiled out when voice
+        // is disabled).
+        #[cfg(feature = "voice")]
         Box::new(AudioGeneratePodcastTool::new(
             config.clone(),
             security.clone(),
         )),
+        #[cfg(feature = "voice")]
         Box::new(AudioEmailPodcastTool::new(config.clone(), security.clone())),
+        #[cfg(feature = "voice")]
         Box::new(AudioGenerateAndEmailPodcastTool::new(
             config.clone(),
             security.clone(),

--- a/src/openhuman/voice/mod.rs
+++ b/src/openhuman/voice/mod.rs
@@ -8,46 +8,95 @@
 //! hallucination, streaming, postprocess) now live under
 //! `crate::openhuman::inference::voice` so all inference concerns share a
 //! single domain root.
+//!
+//! ## Compile-time gate (`voice` feature)
+//!
+//! `pub mod voice;` is ALWAYS compiled — it is a facade. The real
+//! implementation (the submodules below and the `inference::voice` re-exports)
+//! is gated behind the default-ON `voice` Cargo feature. When the feature is
+//! off, [`stub`] takes its place and exposes the same public surface that
+//! always-on / other-gated callers depend on (`server`, `dictation_listener`,
+//! `streaming`, `reply_speech`, `cloud_transcribe`, `create_stt_provider`,
+//! `effective_stt_provider`, `publish_ptt_transcript_committed`) with
+//! no-op / disabled-error bodies. Keeping the two surfaces in lockstep is
+//! enforced by the disabled-build check
+//! (`cargo check --no-default-features --features "<all-but-voice>"`): any
+//! signature drift fails that build.
 
+#[cfg(feature = "voice")]
 pub mod always_on;
+#[cfg(feature = "voice")]
 pub mod audio_capture;
+#[cfg(feature = "voice")]
 pub mod bus;
+#[cfg(feature = "voice")]
 pub use bus::publish_ptt_transcript_committed;
+#[cfg(feature = "voice")]
 pub(crate) mod cli;
+#[cfg(feature = "voice")]
 pub mod command_router;
+#[cfg(feature = "voice")]
 pub mod dictation_listener;
+#[cfg(feature = "voice")]
 pub mod factory;
+#[cfg(feature = "voice")]
 pub mod hotkey;
+#[cfg(feature = "voice")]
 mod ops;
+#[cfg(feature = "voice")]
 pub mod reply_speech;
+#[cfg(feature = "voice")]
 mod schemas;
+#[cfg(feature = "voice")]
 pub mod server;
+#[cfg(feature = "voice")]
 pub mod text_input;
+#[cfg(feature = "voice")]
 mod types;
 
 // Re-export the inference-side voice modules so `voice::local_speech`,
 // `voice::local_transcribe`, etc. continue to resolve for existing callers.
+#[cfg(feature = "voice")]
 pub use crate::openhuman::inference::voice::cloud_transcribe;
+#[cfg(feature = "voice")]
 pub use crate::openhuman::inference::voice::hallucination;
+#[cfg(feature = "voice")]
 pub use crate::openhuman::inference::voice::local_speech;
+#[cfg(feature = "voice")]
 pub use crate::openhuman::inference::voice::local_transcribe;
+#[cfg(feature = "voice")]
 pub use crate::openhuman::inference::voice::postprocess;
+#[cfg(feature = "voice")]
 pub use crate::openhuman::inference::voice::streaming;
 
+#[cfg(feature = "voice")]
 pub use factory::{
     create_stt_provider, create_tts_provider, default_stt_provider, default_tts_provider,
     effective_stt_provider, effective_tts_provider, ExternalSttProvider, ExternalTtsProvider,
     SttProvider, SttResult, TtsProvider, DEFAULT_PIPER_VOICE, DEFAULT_WHISPER_MODEL,
     WHISPER_MODEL_PRESETS,
 };
+#[cfg(feature = "voice")]
 pub use ops::*;
+#[cfg(feature = "voice")]
 pub use schemas::{all_voice_controller_schemas, all_voice_registered_controllers, voice_schemas};
+#[cfg(feature = "voice")]
 pub use types::{VoiceSpeechResult, VoiceStatus, VoiceTtsResult};
 
 /// Default Whisper-v1 model id sent to the backend cloud STT proxy. Kept
 /// here (rather than in `cloud_transcribe.rs`) so the factory module can
 /// reach it via the public `voice::` surface without re-exporting an
 /// internal constant.
+#[cfg(feature = "voice")]
 pub(crate) fn cloud_transcribe_default_model() -> &'static str {
     "whisper-v1"
 }
+
+// ---------------------------------------------------------------------------
+// Disabled facade — compiled only when the `voice` feature is OFF.
+// ---------------------------------------------------------------------------
+
+#[cfg(not(feature = "voice"))]
+mod stub;
+#[cfg(not(feature = "voice"))]
+pub use stub::*;

--- a/src/openhuman/voice/stub.rs
+++ b/src/openhuman/voice/stub.rs
@@ -1,0 +1,292 @@
+//! Disabled-voice facade.
+//!
+//! Compiled only when the `voice` Cargo feature is OFF (see the gate in
+//! [`super`]). It mirrors the subset of the real `voice` public surface that
+//! always-on / other-gated callers depend on, with no-op / disabled-error
+//! bodies so the crate still compiles, boots, and serves `/rpc` without the
+//! voice + audio_toolkit domains.
+//!
+//! The signatures here MUST match the real ones exactly (return types included).
+//! The disabled build
+//! (`cargo check --no-default-features --features "<all-but-voice>"`) is the
+//! only thing that catches drift — if a real signature changes, update the
+//! mirror below until that build is green again.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::openhuman::config::Config;
+use crate::rpc::RpcOutcome;
+
+/// Error text returned by every disabled-path operation that must yield a
+/// `Result`. Shared so callers/log-greps see one stable string.
+const DISABLED_MSG: &str = "voice feature disabled at compile time";
+
+// ---------------------------------------------------------------------------
+// Provider factory surface (mirrors `factory::*` re-exported at the voice root)
+// ---------------------------------------------------------------------------
+
+/// Common STT result shape. Mirrors [`super::factory::SttResult`] (real build).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SttResult {
+    pub text: String,
+    /// Lowercase provider id — kept for wire-shape parity with the real type.
+    pub provider: String,
+}
+
+/// Speech-to-text provider abstraction. Object-safe (via `async_trait`) so
+/// `Box<dyn SttProvider>` remains nameable at call sites; no concrete
+/// implementation exists when voice is compiled out.
+#[async_trait]
+pub trait SttProvider: Send + Sync {
+    fn name(&self) -> &'static str;
+
+    async fn transcribe(
+        &self,
+        config: &Config,
+        audio_base64: &str,
+        mime_type: Option<&str>,
+        file_name: Option<&str>,
+        language: Option<&str>,
+    ) -> Result<RpcOutcome<SttResult>, String>;
+}
+
+/// Resolve the effective STT provider string. With voice disabled the value is
+/// never used to build a real provider; the config-independent default keeps
+/// logging/telemetry callers seeing a sensible string.
+pub fn effective_stt_provider(_config: &Config) -> String {
+    "cloud".to_string()
+}
+
+/// Always errors: no STT provider can be constructed when voice is compiled
+/// out. Callers `?`-propagate the error, so the boxed provider is never used.
+pub fn create_stt_provider(
+    _provider: &str,
+    _model: &str,
+    _config: &Config,
+) -> anyhow::Result<Box<dyn SttProvider>> {
+    Err(anyhow::anyhow!(DISABLED_MSG))
+}
+
+// ---------------------------------------------------------------------------
+// Event bus surface (mirrors `bus::publish_ptt_transcript_committed`)
+// ---------------------------------------------------------------------------
+
+/// No-op: with voice disabled there is no PTT dictation path to announce.
+pub fn publish_ptt_transcript_committed(
+    _thread_id: String,
+    _session_id: u64,
+    _text_len: usize,
+    _held_ms: u64,
+    _finalized_by_watchdog: bool,
+) {
+    log::debug!("[voice-stub] publish_ptt_transcript_committed ignored (voice disabled)");
+}
+
+// ---------------------------------------------------------------------------
+// cli::run_standalone_subcommand (kept registered as a CLI adapter)
+// ---------------------------------------------------------------------------
+
+pub mod cli {
+    /// Disabled: the standalone dictation server needs the voice stack. Returns
+    /// an error so `openhuman voice` reports the feature is off instead of the
+    /// subcommand silently disappearing from the CLI registry.
+    pub fn run_standalone_subcommand(_args: &[String]) -> anyhow::Result<()> {
+        Err(anyhow::anyhow!(super::DISABLED_MSG))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// server::{start_if_enabled, try_global_server}
+// ---------------------------------------------------------------------------
+
+pub mod server {
+    use std::sync::Arc;
+
+    use crate::openhuman::config::Config;
+
+    /// Opaque handle; never actually constructed when voice is disabled, but
+    /// kept nameable so `Option<Arc<VoiceServer>>` call sites type-check.
+    pub struct VoiceServer;
+
+    impl VoiceServer {
+        /// No-op stop — unreachable (no server is ever created).
+        pub async fn stop(&self) {}
+    }
+
+    /// No-op: there is no voice server to start.
+    pub async fn start_if_enabled(_config: &Config) {}
+
+    /// Always `None`: no global voice server exists.
+    pub fn try_global_server() -> Option<Arc<VoiceServer>> {
+        None
+    }
+}
+
+// ---------------------------------------------------------------------------
+// dictation_listener::{start_if_enabled, stop, subscribe_*}
+// ---------------------------------------------------------------------------
+
+pub mod dictation_listener {
+    use once_cell::sync::Lazy;
+    use serde::Serialize;
+    use tokio::sync::broadcast;
+
+    use crate::openhuman::config::Config;
+
+    /// Mirrors the real `DictationEvent` wire shape so the Socket.IO bridge's
+    /// `serde_json::to_value(&event)` + `event.event_type` access type-check.
+    #[derive(Debug, Clone, Serialize)]
+    pub struct DictationEvent {
+        #[serde(rename = "type")]
+        pub event_type: String,
+        pub hotkey: String,
+        pub activation_mode: String,
+    }
+
+    // Senders are kept alive for the process lifetime so subscribers park
+    // (never receive) rather than seeing an immediate `Closed`, matching the
+    // real always-open broadcast bus. Nothing is ever published.
+    static DICTATION_BUS: Lazy<broadcast::Sender<DictationEvent>> =
+        Lazy::new(|| broadcast::channel(1).0);
+    static TRANSCRIPTION_BUS: Lazy<broadcast::Sender<String>> =
+        Lazy::new(|| broadcast::channel(1).0);
+
+    /// Subscribe to (never-emitting) dictation events.
+    pub fn subscribe_dictation_events() -> broadcast::Receiver<DictationEvent> {
+        DICTATION_BUS.subscribe()
+    }
+
+    /// Subscribe to (never-emitting) transcription results.
+    pub fn subscribe_transcription_results() -> broadcast::Receiver<String> {
+        TRANSCRIPTION_BUS.subscribe()
+    }
+
+    /// No-op: no hotkey listener is started.
+    pub async fn start_if_enabled(_config: &Config) {}
+
+    /// No-op: nothing to stop.
+    pub fn stop() {}
+}
+
+// ---------------------------------------------------------------------------
+// always_on::{start_if_enabled, stop}
+// ---------------------------------------------------------------------------
+
+pub mod always_on {
+    use crate::openhuman::config::Config;
+
+    /// No-op: always-on listening does not exist when voice is disabled.
+    pub async fn start_if_enabled(_config: &Config) {}
+
+    /// No-op: nothing to stop.
+    pub fn stop() {}
+}
+
+// ---------------------------------------------------------------------------
+// streaming::handle_dictation_ws (re-exported from inference::voice in real)
+// ---------------------------------------------------------------------------
+
+pub mod streaming {
+    use std::sync::Arc;
+
+    use axum::extract::ws::WebSocket;
+
+    use crate::openhuman::config::Config;
+
+    /// Drop the upgraded socket immediately — there is nothing to transcribe.
+    pub async fn handle_dictation_ws(_socket: WebSocket, _config: Arc<Config>) {}
+}
+
+// ---------------------------------------------------------------------------
+// reply_speech::{synthesize_reply, ReplySpeechOptions, ReplySpeechResult, ...}
+// ---------------------------------------------------------------------------
+
+pub mod reply_speech {
+    use serde::{Deserialize, Serialize};
+    use serde_json::Value;
+
+    use crate::openhuman::config::Config;
+    use crate::rpc::RpcOutcome;
+
+    /// One frame on the viseme timeline. Mirrors the real type.
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct VisemeFrame {
+        pub viseme: String,
+        pub start_ms: u64,
+        pub end_ms: u64,
+    }
+
+    /// Char-level timing frame. Mirrors the real type.
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct AlignmentFrame {
+        pub char: String,
+        pub start_ms: u64,
+        pub end_ms: u64,
+    }
+
+    /// Normalized TTS response. Mirrors the real type.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct ReplySpeechResult {
+        pub audio_base64: String,
+        pub audio_mime: String,
+        pub visemes: Vec<VisemeFrame>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub alignment: Option<Vec<AlignmentFrame>>,
+    }
+
+    /// Caller-tunable knobs. Mirrors the real type (fields + `Default`).
+    #[derive(Debug, Default, Clone)]
+    pub struct ReplySpeechOptions {
+        pub voice_id: Option<String>,
+        pub model_id: Option<String>,
+        pub output_format: Option<String>,
+        pub voice_settings: Option<Value>,
+    }
+
+    /// Disabled: reply-speech synthesis is unavailable when voice is compiled
+    /// out. Callers log the error and skip the spoken reply.
+    pub async fn synthesize_reply(
+        _config: &Config,
+        _text: &str,
+        _opts: &ReplySpeechOptions,
+    ) -> Result<RpcOutcome<ReplySpeechResult>, String> {
+        Err(super::DISABLED_MSG.to_string())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// cloud_transcribe::{transcribe_cloud, CloudTranscribeOptions, ...}
+// (re-exported from inference::voice in the real build)
+// ---------------------------------------------------------------------------
+
+pub mod cloud_transcribe {
+    use serde::{Deserialize, Serialize};
+
+    use crate::openhuman::config::Config;
+    use crate::rpc::RpcOutcome;
+
+    /// Caller-tunable knobs. Mirrors the real type (fields + `Default`).
+    #[derive(Debug, Default, Clone)]
+    pub struct CloudTranscribeOptions {
+        pub model: Option<String>,
+        pub language: Option<String>,
+        pub mime_type: Option<String>,
+        pub file_name: Option<String>,
+    }
+
+    /// Transcription result. Mirrors the real type.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct CloudTranscribeResult {
+        pub text: String,
+    }
+
+    /// Disabled: cloud STT is unavailable when voice is compiled out.
+    pub async fn transcribe_cloud(
+        _config: &Config,
+        _audio_base64: &str,
+        _opts: &CloudTranscribeOptions,
+    ) -> Result<RpcOutcome<CloudTranscribeResult>, String> {
+        Err(super::DISABLED_MSG.to_string())
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a compile-time Cargo **`voice`** feature (default-ON) that gates the `voice` + `audio_toolkit` domains, composing with the runtime `DomainSet.voice` flag from #4796.
- Default build is **byte-identical** — the desktop/CLI app is unchanged. A slim build drops the domains, their controllers/tools, and the `hound` + `lettre` deps.
- Uses a **stub-facade**: `pub mod voice;` stays compiled either way (real code under `#[cfg(feature="voice")]`, no-op/disabled-error stubs when off), so the ~22 always-on / other-gated callers of `voice::` need **no** per-call `#[cfg]`.
- **Pathfinder** for the sibling gates (#4797–#4802, #4804): establishes the facade+stub pattern, the slim-profile convention, and a CI smoke lane that builds with the gate OFF.

## Problem

#4795 wants one compile-time feature gate per subsystem family so slim harness builds drop code + deps; #4796 shipped the *runtime* `DomainSet` axis. This PR adds the *compile-time* half for voice. Two scope realities the issue under-stated, confirmed by a full sweep:

- **`whisper-rs` / `llama` are NOT dropped by this gate.** They live in the `inference` domain (`src/openhuman/inference/local/service/whisper_engine.rs`); `cpal` is shared with `accessibility`. Only `hound` (voice) and `lettre` (audio_toolkit) are exclusive to the gated domains. Whisper awaits a separate future `inference` gate. The issue-level DoD line claiming whisper drops is superseded (noted in AGENTS.md).
- **`voice` is widely consumed** (credentials startup, channels reply-speech/STT, dictation websocket, socketio, meet_agent, desktop_companion) — ~22 call sites — so it cannot be a clean leaf removal.

## Solution

- **`Cargo.toml`**: `hound` + `lettre` → `optional = true`; `voice = ["dep:hound", "dep:lettre"]`; `voice` added to `default`.
- **Facade** (`src/openhuman/voice/mod.rs`): real submodules + inference re-exports are `#[cfg(feature="voice")]`; new `src/openhuman/voice/stub.rs` (`#[cfg(not(feature="voice"))]`) re-exposes the exact caller surface (`server`, `dictation_listener`, `streaming`, `reply_speech`, `cloud_transcribe`, `cli`, `create_stt_provider`, `effective_stt_provider`, `publish_ptt_transcript_committed`) with no-op / `None` / disabled-error bodies matching the real signatures.
- **`audio_toolkit`**: whole module `#[cfg(feature="voice")]`; its 3 podcast agent tools + registration + the voice controller/CLI registration in `src/core/all.rs` are `#[cfg]`'d out when off.
- **CI**: new `rust-feature-gate-smoke` lane runs `cargo check --no-default-features --features tokenjuice-treesitter` — the disabled build is the only thing that catches stub-signature drift, so it must run in CI.
- **Slim-profile convention** (no `full` meta-feature): `cargo build --no-default-features --features "<explicit gates>"`. Documented in AGENTS.md.

When off: voice/audio controllers are unknown-method over `/rpc` and absent from `/schema`, the `audio_generate_podcast` tools are absent, `openhuman voice` returns a disabled error.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] N/A: no instrumented changed lines — the diff is compile-config only (`#[cfg]` attrs, optional deps, a `cfg(not(feature="voice"))` stub module not compiled in the default/coverage build, docs, CI yaml). `diff-cover` reports "no lines with coverage information"; the two new registration tests cover the on/off behavior. CI coverage-gate authoritative. — **Diff coverage ≥ 80%**
- [x] Coverage matrix updated — `N/A: compile-time build-config change, no user-facing feature row`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix rows affected`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: default build is byte-identical; the gate only removes surface when explicitly disabled — Manual smoke checklist
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Desktop / CLI / mobile / web**: no behavior change — default build keeps `voice` on and is byte-identical.
- **Slim builds**: `--no-default-features` drops the voice/audio domains + `hound`/`lettre`. Note: whisper/cpal are NOT dropped (inference-owned).
- **Soft dependency**: with `{voice: off}` but Meet/companion on, their speech paths hit the disabled stubs (transcription/synthesis no-op, not a crash). Acceptable for slim profiles; whether the Meet gate should imply `voice` is a follow-up.
- **Security / migration**: none. Additive, default-preserving.

## Related

- Closes: #4803
- Epic: #4795 (Milestone M1). Composes with the #4796 runtime `DomainSet` seam. Follow-up (per @m3ga-mind on #4808): #4821 tool/controller gating convergence.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/4803-voice-feature-gate`
- Commit SHA: `d48ae12fd17b2d07e23a26818a10e227d84681c9`

### Validation Run

- [x] N/A: no app/ (frontend) changes — `pnpm --filter openhuman-app format:check`
- [x] N/A: no TypeScript changes — `pnpm typecheck`
- [x] Focused tests: `core::all::tests::voice_and_audio_controllers_registered_when_feature_on` (default) + `..._absent_when_feature_off` (disabled), `core::all` 50 passed, `openhuman::voice`/`openhuman::audio_toolkit` green
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean · default `cargo check` exit 0 · **disabled** `cargo check --no-default-features --features tokenjuice-treesitter` exit 0 · `cargo clippy --lib` 0 warnings in changed files (both configs)
- [x] N/A: no app/src-tauri changes — Tauri fmt/check

### Validation Blocked

- `command:` `cargo test --lib` (full)
- `error:` OOM on local machine (known)
- `impact:` full matrix runs in CI; locally scoped to voice/audio_toolkit/core::all/tools::ops — all green in both feature configs

### Behavior Changes

- Intended behavior change: new default-on `voice` compile-time gate; default unchanged
- User-visible effect: none by default; slim builds omit voice/audio domains + deps
