### PR TITLE
fix(linux): link X11 for desktop error handler

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -2281,6 +2281,7 @@ fn install_silent_x_error_handler() {
     }
 
     type ErrorHandler = unsafe extern "C" fn(*mut c_void, *mut XErrorEvent) -> c_int;
+    #[link(name = "X11")]
     unsafe extern "C" {
         fn XSetErrorHandler(handler: Option<ErrorHandler>) -> Option<ErrorHandler>;
     }


### PR DESCRIPTION
## Summary

- Declare the Linux X11 native link dependency used by the Tauri shell error handler.
- Fix final-link failures on both Ubuntu x64 and Ubuntu ARM64 desktop packaging jobs.
- Preserve the existing Wayland/XWayland BadWindow suppression behavior.

## Problem

- Production run 29323020093 failed both Ubuntu desktop builds at final link.
- x86_64 failed with undefined symbol XSetErrorHandler; ARM64 reported libX11.so as DSO missing from command line.

## Solution

- Attach #[link(name = "X11")] to the Linux-only Xlib FFI block that declares XSetErrorHandler.
- The declaration remains target_os = "linux" gated through its containing function, so macOS and Windows linking are unaffected.

## Submission Checklist

> If a section does not apply to this change, mark the item as N/A with a one-line reason. Do not delete items.

- [x] N/A: native linkage correction is verified by platform builds rather than a unit-testable behavior path.
- [x] Diff coverage ≥ 80% — N/A: declarative native link attribute has no executable line coverage.
- [x] N/A: no feature row was added, removed, or renamed.
- [x] N/A: no affected feature IDs.
- [x] No new external network dependencies introduced.
- [x] N/A: no manual smoke procedure changes.
- [x] N/A: no linked issue; failure identified from production Actions run 29323020093.

## Impact

- Linux desktop packaging now links libX11 explicitly on x86_64 and ARM64.
- No runtime behavior, migration, security, or performance changes.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field N/A.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/desktop-build-matrix
- Commit SHA: 94689e390

### Validation Run

- [x] pnpm --filter openhuman-app format:check
- [x] pnpm typecheck
- [x] Focused tests: GitHub Actions desktop build matrix will validate native final linking.
- [x] Rust fmt/check (if changed): cargo fmt check passed; heavy cargo validation delegated to GitHub Actions per user request.
- [x] N/A: Tauri fmt/check is delegated to the active GitHub-hosted CI Full platform matrix per user request.

### Validation Blocked

- command: cargo check --manifest-path app/src-tauri/Cargo.toml
- error: intentionally interrupted during dependency compilation at user request; not a code failure.
- impact: GitHub Actions is the authoritative cross-platform validation.

### Behavior Changes

- Intended behavior change: Linux final links resolve XSetErrorHandler through libX11.
- User-visible effect: Ubuntu desktop packages build successfully again.

### Parity Contract

- Legacy behavior preserved: existing Linux X error handler installation and logging are unchanged.
- Guard/fallback/dispatch parity checks: native link attribute is contained by the existing Linux cfg gate.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux compatibility by ensuring the application correctly links to the required X11 system library.
  * No user-facing behavior or command functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->