### PR TITLE
fix(linux): link libX11 for XSetErrorHandler — unblock Release Production desktop build

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -2261,8 +2261,13 @@ fn strip_time_ticks_at_unix_epoch(args: &mut Vec<CefCommandLineArg>) {
 /// in PR #2032 but blocks any actual use of the app on a Wayland host).
 ///
 /// XSetErrorHandler is a process-global registration; safe to install before
-/// any X display is opened. libX11 is already a runtime dep (verified via
-/// ldd of the compiled OpenHuman binary).
+/// any X display is opened. libX11 is only pulled in transitively at *runtime*
+/// (via GTK/WebKit), so the `extern` block must carry an explicit
+/// `#[link(name = "X11")]` — otherwise `rust-lld` can't resolve the symbol at
+/// link time and the full desktop build fails with `undefined symbol:
+/// XSetErrorHandler` (only surfaces in the CI-Full / release bundle link step,
+/// not CI-Lite). libX11 is present on every Linux desktop host, so linking it
+/// directly is safe.
 #[cfg(target_os = "linux")]
 fn install_silent_x_error_handler() {
     use std::ffi::c_void;
@@ -2281,6 +2286,7 @@ fn install_silent_x_error_handler() {
     }
 
     type ErrorHandler = unsafe extern "C" fn(*mut c_void, *mut XErrorEvent) -> c_int;
+    #[link(name = "X11")]
     unsafe extern "C" {
         fn XSetErrorHandler(handler: Option<ErrorHandler>) -> Option<ErrorHandler>;
     }


### PR DESCRIPTION
## Problem
The **Release Production** build (run 29323020093, branch `release`) fails on **Desktop: ubuntu** and **Desktop: ubuntu-arm64** with:
```
rust-lld: error: undefined symbol: XSetErrorHandler
>>> referenced by lib.rs:2308
error: could not compile `OpenHuman` (bin "OpenHuman")
```

## Root cause
`app/src-tauri/src/lib.rs` (`install_silent_x_error_handler`, ~L2284) declares `extern "C" { fn XSetErrorHandler(...) }` with **no link directive**. libX11 is only pulled in transitively at **runtime** (via GTK/WebKit), so `rust-lld` cannot resolve the symbol at **link time**. This only surfaces in the CI-Full / release **bundle link step** (which actually links the `OpenHuman` bin), not CI-Lite — which is why it passed on merge but breaks the production release.

## Fix
Add `#[link(name = "X11")]` to the `extern` block so cargo passes `-lX11` to the linker. libX11 is present on every Linux desktop host, so linking it directly is safe. Updated the (previously incorrect) doc comment.

## Verification
Link-only change on the Linux desktop path; let CI's desktop matrix confirm (no local build — the full CEF desktop build is not run locally). 

## Note
`main` carries the same unlinked declaration — this fix reaches it via the standard `release`→`main` back-merge on the next cut (or cherry-pick if an earlier main fix is wanted).