### PR TITLE
fix(observability): demote composio set-key invalid-key rejection (TAURI-RUST-K27)

### DIFF
--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -1698,6 +1698,26 @@ fn is_provider_user_state_message(lower: &str) -> bool {
         return true;
     }
 
+    // TAURI-RUST-K27 — the set-key sibling of X9. `composio_set_api_key`'s
+    // validate-before-store probe (added in #4318) rejects an obviously invalid
+    // BYO key *before* persisting it and returns its own user-facing prose,
+    // `COMPOSIO_INVALID_API_KEY_USER_MESSAGE` ("Invalid Composio API key. Re-enter
+    // a valid key in Settings > Connections > Composio."). That string carries
+    // neither the `[composio-direct]` prefix nor an `HTTP 401` token, and the word
+    // "Composio" splits the `invalid … api key` sequence — so the X9 arm above
+    // never claims it and the RPC-boundary `report_error` leaked as a Sentry error
+    // (473 events / 53 users, starting ~5 h after #4318 merged). Same user-state as
+    // X9: an invalid/revoked BYO key with zero client-side lever to make it valid;
+    // the Settings UI already surfaces the actionable re-entry copy. Anchor on the
+    // distinctive `"invalid composio api key"` phrase — it can only be produced by
+    // our own const (a genuine set-path defect renders a different `store_…
+    // failed` / `save config failed` body that still pages). Coupled to the typed
+    // source by `demotes_composio_set_key_invalid_key_rejection` so a reword that
+    // drops the phrase fails CI instead of silently re-opening the leak.
+    if lower.contains("invalid composio api key") {
+        return true;
+    }
+
     // TAURI-RUST-34H — composio backend endpoint (e.g.
     // `/agent-integrations/composio/connections`) wraps an upstream
     // Cloudflare anti-bot challenge as `Backend returned 500 Internal
@@ -5637,6 +5657,43 @@ mod tests {
             Some(ExpectedErrorKind::ProviderUserState),
             "unrelated 401 (no [composio-direct] anchor) must NOT match the composio-direct arm"
         );
+    }
+
+    // ── TAURI-RUST-K27: composio set-key validation prose (sibling of X9) ──
+
+    #[test]
+    fn demotes_composio_set_key_invalid_key_rejection() {
+        // Drift coupler: assert the classifier demotes the EXACT const the
+        // `composio_set_api_key` validate-before-store probe returns. Keying
+        // off the shared const (not a copied literal) means any reword that
+        // drops the `"Invalid Composio API key"` anchor fails this test in CI
+        // instead of silently re-opening the TAURI-RUST-K27 leak.
+        assert_eq!(
+            expected_error_kind(
+                crate::openhuman::composio::direct_auth::COMPOSIO_INVALID_API_KEY_USER_MESSAGE
+            ),
+            Some(ExpectedErrorKind::ProviderUserState),
+            "composio_set_api_key invalid-key rejection must demote to ProviderUserState"
+        );
+    }
+
+    #[test]
+    fn does_not_classify_composio_set_key_store_failure_as_user_state() {
+        // Discrimination: a genuine defect on the set path — the key validated
+        // but persistence/config-save failed — renders a different body and
+        // MUST still page. The K27 arm keys on "invalid composio api key",
+        // which these do not contain, so they fall through to `None`.
+        let store_fail = "[composio-direct] store_composio_api_key failed: \
+                          keyring write denied (os error 5)";
+        let save_fail = "[composio-direct] save config failed: \
+                         config file is read-only";
+        for msg in [store_fail, save_fail] {
+            assert_eq!(
+                expected_error_kind(msg),
+                None,
+                "genuine composio set-path failure must still reach Sentry: {msg}"
+            );
+        }
     }
 
     #[test]

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -1709,12 +1709,13 @@ fn is_provider_user_state_message(lower: &str) -> bool {
     // (473 events / 53 users, starting ~5 h after #4318 merged). Same user-state as
     // X9: an invalid/revoked BYO key with zero client-side lever to make it valid;
     // the Settings UI already surfaces the actionable re-entry copy. Anchor on the
-    // distinctive `"invalid composio api key"` phrase — it can only be produced by
-    // our own const (a genuine set-path defect renders a different `store_…
-    // failed` / `save config failed` body that still pages). Coupled to the typed
-    // source by `demotes_composio_set_key_invalid_key_rejection` so a reword that
-    // drops the phrase fails CI instead of silently re-opening the leak.
-    if lower.contains("invalid composio api key") {
+    // distinctive `COMPOSIO_INVALID_API_KEY_ANCHOR` phrase — it can only be produced
+    // by our own const (a genuine set-path defect renders a different `store_…
+    // failed` / `save config failed` body that still pages). Keyed off the shared
+    // anchor const (not a copied literal) and coupled to the typed source by
+    // `demotes_composio_set_key_invalid_key_rejection` so a reword that drops the
+    // phrase fails CI instead of silently re-opening the leak.
+    if lower.contains(crate::openhuman::composio::direct_auth::COMPOSIO_INVALID_API_KEY_ANCHOR) {
         return true;
     }
 
@@ -5674,6 +5675,23 @@ mod tests {
             ),
             Some(ExpectedErrorKind::ProviderUserState),
             "composio_set_api_key invalid-key rejection must demote to ProviderUserState"
+        );
+    }
+
+    #[test]
+    fn composio_set_key_anchor_is_substring_of_message() {
+        // Contract coupler: the classifier keys on the shared
+        // `COMPOSIO_INVALID_API_KEY_ANCHOR`; it is only correct if that anchor is a
+        // genuine lowercase substring of the message the probe returns. Assert the
+        // two consts stay in sync so neither can be reworded independently.
+        use crate::openhuman::composio::direct_auth::{
+            COMPOSIO_INVALID_API_KEY_ANCHOR, COMPOSIO_INVALID_API_KEY_USER_MESSAGE,
+        };
+        assert!(
+            COMPOSIO_INVALID_API_KEY_USER_MESSAGE
+                .to_lowercase()
+                .contains(COMPOSIO_INVALID_API_KEY_ANCHOR),
+            "the K27 anchor must be a lowercase substring of the user message"
         );
     }
 

--- a/src/openhuman/composio/direct_auth/messages.rs
+++ b/src/openhuman/composio/direct_auth/messages.rs
@@ -1,0 +1,26 @@
+//! User-facing message contract for the direct-mode Composio set-key path,
+//! and the lowercase anchor the observability classifier keys on. Kept in one
+//! place so the message ([`COMPOSIO_INVALID_API_KEY_USER_MESSAGE`]) and the
+//! substring the TAURI-RUST-K27 demotion arm matches on
+//! ([`COMPOSIO_INVALID_API_KEY_ANCHOR`]) are a single, drift-guarded contract.
+
+/// User-facing rejection returned by `composio_set_api_key`'s validate-before-store
+/// probe (`ops/direct_mode.rs`) when the entered BYO key fails Composio's v3 auth
+/// wall. This is the **single source of truth** for that string: the
+/// `expected_error_kind` classifier (TAURI-RUST-K27 arm in `core::observability`)
+/// keys on [`COMPOSIO_INVALID_API_KEY_ANCHOR`] within it to demote the RPC-boundary
+/// `report_error` to `ProviderUserState`. Unlike the runtime
+/// `[composio-direct] … HTTP 401: Invalid API key` wire body (TAURI-RUST-X9), this
+/// prose carries no `[composio-direct]` prefix and — because the word `Composio`
+/// splits `Invalid … api key` — does not match the X9 anchor, so it needs its own
+/// arm. Reword the tail freely, but keep the anchor phrase or the drift-coupling
+/// test `demotes_composio_set_key_invalid_key_rejection` fails CI.
+pub(crate) const COMPOSIO_INVALID_API_KEY_USER_MESSAGE: &str =
+    "Invalid Composio API key. Re-enter a valid key in Settings > Connections > Composio.";
+
+/// Lowercase substring the observability classifier's TAURI-RUST-K27 arm matches
+/// on to demote the set-key rejection. Shared with the runtime matcher so the
+/// classifier keys off this named contract rather than a copied literal; the
+/// `composio_set_key_anchor_is_substring_of_message` test asserts it stays a
+/// lowercase substring of [`COMPOSIO_INVALID_API_KEY_USER_MESSAGE`].
+pub(crate) const COMPOSIO_INVALID_API_KEY_ANCHOR: &str = "invalid composio api key";

--- a/src/openhuman/composio/direct_auth/mod.rs
+++ b/src/openhuman/composio/direct_auth/mod.rs
@@ -11,6 +11,20 @@ use std::sync::{LazyLock, Mutex, MutexGuard};
 
 pub(crate) const DIRECT_INVALID_API_KEY_THRESHOLD: u32 = 3;
 
+/// User-facing rejection returned by `composio_set_api_key`'s validate-before-store
+/// probe (`ops/direct_mode.rs`) when the entered BYO key fails Composio's v3 auth
+/// wall. This is the **single source of truth** for that string: the
+/// `expected_error_kind` classifier (TAURI-RUST-K27 arm in `core::observability`)
+/// keys on the distinctive `"invalid composio api key"` phrase within it to demote
+/// the RPC-boundary `report_error` to `ProviderUserState`. Unlike the runtime
+/// `[composio-direct] … HTTP 401: Invalid API key` wire body (TAURI-RUST-X9), this
+/// prose carries no `[composio-direct]` prefix and — because the word `Composio`
+/// splits `Invalid … api key` — does not match the X9 anchor, so it needs its own
+/// arm. Reword the tail freely, but keep the `"Invalid Composio API key"` phrase or
+/// the drift-coupling test `demotes_composio_set_key_invalid_key_rejection` fails CI.
+pub(crate) const COMPOSIO_INVALID_API_KEY_USER_MESSAGE: &str =
+    "Invalid Composio API key. Re-enter a valid key in Settings > Connections > Composio.";
+
 static DIRECT_AUTH_FAILURES: LazyLock<Mutex<HashMap<u64, u32>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 

--- a/src/openhuman/composio/direct_auth/mod.rs
+++ b/src/openhuman/composio/direct_auth/mod.rs
@@ -9,21 +9,10 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::sync::{LazyLock, Mutex, MutexGuard};
 
-pub(crate) const DIRECT_INVALID_API_KEY_THRESHOLD: u32 = 3;
+mod messages;
+pub(crate) use messages::{COMPOSIO_INVALID_API_KEY_ANCHOR, COMPOSIO_INVALID_API_KEY_USER_MESSAGE};
 
-/// User-facing rejection returned by `composio_set_api_key`'s validate-before-store
-/// probe (`ops/direct_mode.rs`) when the entered BYO key fails Composio's v3 auth
-/// wall. This is the **single source of truth** for that string: the
-/// `expected_error_kind` classifier (TAURI-RUST-K27 arm in `core::observability`)
-/// keys on the distinctive `"invalid composio api key"` phrase within it to demote
-/// the RPC-boundary `report_error` to `ProviderUserState`. Unlike the runtime
-/// `[composio-direct] … HTTP 401: Invalid API key` wire body (TAURI-RUST-X9), this
-/// prose carries no `[composio-direct]` prefix and — because the word `Composio`
-/// splits `Invalid … api key` — does not match the X9 anchor, so it needs its own
-/// arm. Reword the tail freely, but keep the `"Invalid Composio API key"` phrase or
-/// the drift-coupling test `demotes_composio_set_key_invalid_key_rejection` fails CI.
-pub(crate) const COMPOSIO_INVALID_API_KEY_USER_MESSAGE: &str =
-    "Invalid Composio API key. Re-enter a valid key in Settings > Connections > Composio.";
+pub(crate) const DIRECT_INVALID_API_KEY_THRESHOLD: u32 = 3;
 
 static DIRECT_AUTH_FAILURES: LazyLock<Mutex<HashMap<u64, u32>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));

--- a/src/openhuman/composio/ops/direct_mode.rs
+++ b/src/openhuman/composio/ops/direct_mode.rs
@@ -28,7 +28,7 @@ async fn validate_direct_api_key_before_store(config: &Config, api_key: &str) ->
                 tracing::warn!(
                     "[composio-direct] validate_api_key: rejected invalid API key before storage"
                 );
-                Err("Invalid Composio API key. Re-enter a valid key in Settings > Connections > Composio.".into())
+                Err(direct_auth::COMPOSIO_INVALID_API_KEY_USER_MESSAGE.into())
             } else {
                 tracing::warn!(
                     error = %rendered,


### PR DESCRIPTION
## Summary

- Demote the `composio_set_api_key` invalid-BYO-key rejection from a Sentry error to `ProviderUserState`, stopping a flood of **473 events / 53 users** (Sentry `TAURI-RUST-K27`).
- Extract the rejection prose into a shared const so the classifier keys on a single source of truth (drift-guarded by a test).
- No user-facing behavior change — the Settings UI still blocks storage and shows the re-entry message; only the telemetry tag changes.

## Problem

- `Sentry-Issue: TAURI-RUST-K27` — "Invalid Composio API key. Re-enter a valid key in Settings > Connections > Composio." First seen 2026-06-30, still ongoing.
- The validate-before-store probe added in #4318 returns its own user-facing prose when a BYO key fails Composio's v3 auth wall. That `Err` propagates to the RPC boundary (`jsonrpc` → `report_error_or_expected`) and fires a full `report_error`.
- The existing X9 demotion arm (`[composio-direct]` + `HTTP 401`/`Invalid API key`) never matched it: the set-path prose carries no `[composio-direct]` prefix, no `HTTP 401`, and the word "Composio" splits the `invalid … api key` sequence. K27 first-seen is ~5h **after** #4318 merged — it is a leak the fix introduced, not a regression of the old polling flood.
- **S3.5 bucket: unpreventable user-state** — an invalid/revoked BYO key has zero client-side lever to make it valid; the probe *is* the prevention and the UI already surfaces the actionable re-entry copy. RCA: none owed — completing the X9 demotion for the sibling wording is the fix, not a new suppression.

## Solution

- Extract the message to `direct_auth::COMPOSIO_INVALID_API_KEY_USER_MESSAGE` (single source of truth); `composio_set_api_key` returns the const.
- Add a K27 arm in `is_provider_user_state_message` anchored on the distinctive `"invalid composio api key"` phrase → `ProviderUserState`. The anchor can only be produced by our own const; genuine set-path defects (store/config-save failures) render different bodies and still page.
- Couple the arm to the const with a drift test — a reword that drops the phrase fails CI instead of silently re-opening the leak.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — drift-coupling demote test + negative store/save-failure-still-pages test
- [x] **Diff coverage ≥ 80%** — changed lines are the const + classifier arm, both exercised by the new + existing X9 classifier tests
- [x] Coverage matrix updated — `N/A: observability classification change, no feature row`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A` (none)
- [x] No new external network dependencies introduced — pure in-process string classification
- [x] Manual smoke checklist updated — `N/A: does not touch a release-cut surface`
- [x] Linked issue closed via `Closes #NNN` — `N/A: Sentry-only, no GitHub issue (see Sentry-Issue below)`

## Impact

- Desktop (all platforms). Removes ~473 events/53 users of Sentry noise on the Composio direct-mode set-key path.
- No performance, migration, or compatibility implications. Genuine set-path faults remain a Sentry signal.

## Related

- Closes: N/A — Sentry-only
- Sentry-Issue: TAURI-RUST-K27
- Sibling of #1166 (X9 runtime-poll demotion); follow-up leak from #4318

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/composio-set-key-demote-k27
- Commit SHA: ea491f50e

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend change
- [x] `pnpm typecheck` — N/A: no frontend change
- [x] Focused tests: `cargo test --lib observability::tests` (230 passed) incl. new K27 demote + negative tests
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean, `cargo check` clean
- [x] Tauri fmt/check (if changed): N/A: core-crate-only change

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: invalid-key set rejection no longer captured as a Sentry error (demoted to ProviderUserState)
- User-visible effect: none — UI still blocks + prompts re-entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Composio direct-mode API key validation with a clear message when an invalid key is entered.
  * The message directs users to **Settings > Connections > Composio** to re-enter a valid key.
  * Improved handling of validation errors so invalid credentials are reported appropriately without incorrectly treating genuine key-storage failures as credential issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
