### PR TITLE
fix(release): extend desktop build timeout

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -98,7 +98,7 @@ jobs:
   build:
     name: "Desktop: ${{ matrix.settings.artifact_suffix }}"
     runs-on: ${{ matrix.settings.platform }}
-    timeout-minutes: 70
+    timeout-minutes: 90
     environment: Production
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- Increase every reusable desktop matrix build timeout from 70 to 90 minutes.
- Apply the longer deadline to both staging and production desktop builds.
- Keep release-note generation and all other job timeouts unchanged.

## Problem

Desktop packaging can exceed the current 70-minute job deadline, especially for cold-cache CEF and cross-platform builds. The previous version of this PR mistakenly changed the release-note timeout instead of the desktop build phase.

## Solution

Update the `build` job in the shared `build-desktop.yml` reusable workflow to use `timeout-minutes: 90`. Both release workflows call this matrix, so the change covers every macOS, Linux, and Windows desktop build without duplicating configuration.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [ ] Tests added or updated (happy path + at least one failure / edge case) — N/A: declarative timeout-only workflow change.
- [ ] **Diff coverage ≥ 80%** — N/A: GitHub Actions configuration is outside the Vitest/Rust diff-coverage lanes.
- [ ] Coverage matrix updated — N/A: no product feature changed.
- [ ] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no feature IDs are affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [ ] Manual smoke checklist updated if this touches release-cut surfaces — N/A: build output and smoke procedures are unchanged.
- [ ] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: no issue was provided.

## Impact

Desktop release jobs may run for up to 90 minutes before GitHub cancels them. This affects both staging and production across the full five-platform matrix. No runtime behavior, packaging logic, or dependencies change.

## Related

<!--
Use a closing keyword so GitHub auto-closes the issue on merge. One per line.
Supported (case-insensitive): close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved.
A bare "#123" reference is just a link — it does NOT close the issue.

  Closes #123
  Fixes  #456
-->

- Closes: N/A — no linked issue.
- Follow-up PR(s)/TODOs: N/A.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `agent/release-notes-timeout`
- Commit SHA: `e46039731`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — workflow Prettier validation passed.
- [ ] `pnpm typecheck` — N/A: no application TypeScript changed.
- [x] Focused tests: `actionlint`; YAML syntax parsing; workflow Prettier check; `git diff --check`.
- [ ] Rust fmt/check (if changed): N/A — no Rust changed.
- [ ] Tauri fmt/check (if changed): N/A — no Tauri code changed.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: allow desktop build jobs to run for 90 minutes rather than 70 minutes.
- User-visible effect: release operators should see fewer timeout cancellations during long desktop builds.

### Parity Contract

- Legacy behavior preserved: the same reusable matrix, platforms, packaging, signing, uploads, and cancellation watchdog remain in place.
- Guard/fallback/dispatch parity checks: both staging and production continue to call the same reusable workflow and therefore receive the same timeout.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None found.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): Existing draft updated in place after correcting the targeted phase.
