### PR TITLE
feat(rewards): surface the Rewards page via a cloud-gated sidebar footer entry

### DIFF
--- a/app/src/components/layout/shell/AppSidebar.test.tsx
+++ b/app/src/components/layout/shell/AppSidebar.test.tsx
@@ -54,6 +54,17 @@ describe('AppSidebar — Rewards footer entry', () => {
     );
   });
 
+  it('normalizes from_path to a route template so entity IDs never reach analytics', () => {
+    renderWithProviders(<AppSidebar />, { initialEntries: ['/chat/thread-abc123'] });
+
+    fireEvent.click(screen.getByTitle('nav.rewards'));
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      'tab_bar_change',
+      expect.objectContaining({ from_path: '/chat/:threadId', to_path: '/rewards' })
+    );
+  });
+
   it('hides the Rewards row for a local session but keeps Feedback', () => {
     mockCoreState = { snapshot: { sessionToken: 'header.payload.local' }, isReady: true };
     renderWithProviders(<AppSidebar />, { initialEntries: ['/chat'] });

--- a/app/src/components/layout/shell/AppSidebar.test.tsx
+++ b/app/src/components/layout/shell/AppSidebar.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from '../../../test/test-utils';
+import AppSidebar from './AppSidebar';
+
+const mockNavigate = vi.fn();
+const mockTrackEvent = vi.fn();
+// Mutable so each test can pick the session kind. Must be `mock`-prefixed so the
+// hoisted vi.mock factory below is allowed to close over it.
+let mockSessionToken: string | null = 'cloud.session.token';
+
+vi.mock('react-router-dom', async importOriginal => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+// Render i18n keys verbatim so assertions don't depend on locale copy.
+vi.mock('../../../lib/i18n/I18nContext', () => ({ useT: () => ({ t: (k: string) => k }) }));
+vi.mock('../../../services/analytics', () => ({
+  trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
+}));
+vi.mock('../../../providers/CoreStateProvider', () => ({
+  useCoreState: () => ({ snapshot: { sessionToken: mockSessionToken } }),
+}));
+// Keep the mount light: the footer affordance rows are the unit under test, not
+// the header/nav/rail children (SidebarHeader in particular needs the
+// RootShellLayout context the test harness doesn't provide). SidebarSlot is left
+// real on purpose — the harness itself imports SidebarSlotProvider from it.
+vi.mock('./SidebarHeader', () => ({ default: () => null }));
+vi.mock('./SidebarNav', () => ({ default: () => null }));
+vi.mock('./SidebarAppRail', () => ({ default: () => null }));
+vi.mock('../../ConnectionIndicator', () => ({ default: () => null }));
+
+describe('AppSidebar — Rewards footer entry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSessionToken = 'cloud.session.token';
+  });
+
+  it('shows the Rewards row for a cloud session and navigates + tracks on click', () => {
+    renderWithProviders(<AppSidebar />, { initialEntries: ['/chat'] });
+
+    const rewards = screen.getByTitle('nav.rewards');
+    expect(rewards).toBeInTheDocument();
+
+    fireEvent.click(rewards);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/rewards');
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      'tab_bar_change',
+      expect.objectContaining({ to_tab: 'rewards', to_path: '/rewards' })
+    );
+  });
+
+  it('hides the Rewards row for a local session but keeps Feedback', () => {
+    mockSessionToken = 'header.payload.local';
+    renderWithProviders(<AppSidebar />, { initialEntries: ['/chat'] });
+
+    expect(screen.queryByTitle('nav.rewards')).not.toBeInTheDocument();
+    expect(screen.getByTitle('nav.feedback')).toBeInTheDocument();
+  });
+
+  it('marks the Rewards row active on the /rewards route', () => {
+    renderWithProviders(<AppSidebar />, { initialEntries: ['/rewards'] });
+
+    expect(screen.getByTitle('nav.rewards')).toHaveAttribute('aria-current', 'page');
+  });
+});

--- a/app/src/components/layout/shell/AppSidebar.test.tsx
+++ b/app/src/components/layout/shell/AppSidebar.test.tsx
@@ -6,9 +6,13 @@ import AppSidebar from './AppSidebar';
 
 const mockNavigate = vi.fn();
 const mockTrackEvent = vi.fn();
-// Mutable so each test can pick the session kind. Must be `mock`-prefixed so the
-// hoisted vi.mock factory below is allowed to close over it.
-let mockSessionToken: string | null = 'cloud.session.token';
+// Mutable so each test can pick the session kind. `isReady` sits alongside
+// `snapshot` on the core-state value (not inside the snapshot). Must be
+// `mock`-prefixed so the hoisted vi.mock factory below may close over it.
+let mockCoreState: { snapshot: { sessionToken: string | null }; isReady: boolean } = {
+  snapshot: { sessionToken: 'cloud.session.token' },
+  isReady: true,
+};
 
 vi.mock('react-router-dom', async importOriginal => {
   const actual = await importOriginal<typeof import('react-router-dom')>();
@@ -19,9 +23,7 @@ vi.mock('../../../lib/i18n/I18nContext', () => ({ useT: () => ({ t: (k: string) 
 vi.mock('../../../services/analytics', () => ({
   trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
 }));
-vi.mock('../../../providers/CoreStateProvider', () => ({
-  useCoreState: () => ({ snapshot: { sessionToken: mockSessionToken } }),
-}));
+vi.mock('../../../providers/CoreStateProvider', () => ({ useCoreState: () => mockCoreState }));
 // Keep the mount light: the footer affordance rows are the unit under test, not
 // the header/nav/rail children (SidebarHeader in particular needs the
 // RootShellLayout context the test harness doesn't provide). SidebarSlot is left
@@ -34,10 +36,10 @@ vi.mock('../../ConnectionIndicator', () => ({ default: () => null }));
 describe('AppSidebar — Rewards footer entry', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSessionToken = 'cloud.session.token';
+    mockCoreState = { snapshot: { sessionToken: 'cloud.session.token' }, isReady: true };
   });
 
-  it('shows the Rewards row for a cloud session and navigates + tracks on click', () => {
+  it('shows the Rewards row for a resolved cloud session and navigates + tracks on click', () => {
     renderWithProviders(<AppSidebar />, { initialEntries: ['/chat'] });
 
     const rewards = screen.getByTitle('nav.rewards');
@@ -53,7 +55,18 @@ describe('AppSidebar — Rewards footer entry', () => {
   });
 
   it('hides the Rewards row for a local session but keeps Feedback', () => {
-    mockSessionToken = 'header.payload.local';
+    mockCoreState = { snapshot: { sessionToken: 'header.payload.local' }, isReady: true };
+    renderWithProviders(<AppSidebar />, { initialEntries: ['/chat'] });
+
+    expect(screen.queryByTitle('nav.rewards')).not.toBeInTheDocument();
+    expect(screen.getByTitle('nav.feedback')).toBeInTheDocument();
+  });
+
+  it('hides the Rewards row until core state has bootstrapped (no flash)', () => {
+    // Initial snapshot before the first refresh: not ready, null token.
+    // isLocalSessionToken(null) is false, so gating on the token alone would
+    // briefly show Rewards here — the isReady guard prevents that flash.
+    mockCoreState = { snapshot: { sessionToken: null }, isReady: false };
     renderWithProviders(<AppSidebar />, { initialEntries: ['/chat'] });
 
     expect(screen.queryByTitle('nav.rewards')).not.toBeInTheDocument();

--- a/app/src/components/layout/shell/AppSidebar.tsx
+++ b/app/src/components/layout/shell/AppSidebar.tsx
@@ -1,8 +1,10 @@
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { useT } from '../../../lib/i18n/I18nContext';
+import { useCoreState } from '../../../providers/CoreStateProvider';
 import { trackEvent } from '../../../services/analytics';
 import { APP_VERSION } from '../../../utils/config';
+import { isLocalSessionToken } from '../../../utils/localSession';
 import ConnectionIndicator from '../../ConnectionIndicator';
 import { NavIcon } from './navIcons';
 import SidebarAppRail from './SidebarAppRail';
@@ -33,7 +35,14 @@ export default function AppSidebar() {
   const { t } = useT();
   const location = useLocation();
   const navigate = useNavigate();
+  const { snapshot: coreSnapshot } = useCoreState();
+  // Rewards is a cloud-only surface (credits/referrals/coupons live behind the
+  // backend rewards API); the page itself renders an "unavailable" state for
+  // local sessions, so there's no point offering the entry there. Mirrors the
+  // `cloudOnly` intent recorded for rewards in navConfig's AVATAR_MENU_ITEMS.
+  const isLocalSession = isLocalSessionToken(coreSnapshot.sessionToken);
   const feedbackActive = location.pathname === '/feedback';
+  const rewardsActive = location.pathname === '/rewards';
 
   const handleFeedbackClick = () => {
     if (!feedbackActive) {
@@ -45,6 +54,18 @@ export default function AppSidebar() {
       });
     }
     navigate('/feedback');
+  };
+
+  const handleRewardsClick = () => {
+    if (!rewardsActive) {
+      trackEvent('tab_bar_change', {
+        from_tab: 'unknown',
+        to_tab: 'rewards',
+        from_path: location.pathname,
+        to_path: '/rewards',
+      });
+    }
+    navigate('/rewards');
   };
 
   return (
@@ -66,9 +87,26 @@ export default function AppSidebar() {
             app rail above its thread list) can order them via Tailwind `order-*`. */}
         <SidebarSlotOutlet className="flex h-full flex-col" />
       </div>
-      {/* Slim feedback row — pinned just above the status bar. Kept thin and
-          low-profile so it reads as a footer affordance, not a primary nav tab
-          (it used to live in SidebarNav). */}
+      {/* Slim account affordances pinned above the status bar — Rewards then
+          Feedback. Kept thin and low-profile so they read as footer entries,
+          not primary nav tabs. Rewards is hidden on local sessions (cloud-only
+          surface). */}
+      {!isLocalSession && (
+        <button
+          type="button"
+          data-walkthrough="tab-rewards"
+          onClick={handleRewardsClick}
+          title={t('nav.rewards')}
+          aria-current={rewardsActive ? 'page' : undefined}
+          className={`group flex flex-shrink-0 items-center justify-center gap-2 border-t border-line/70 px-3 py-1 text-[11px] transition-colors cursor-pointer dark:border-line/70 ${
+            rewardsActive
+              ? 'bg-surface text-content font-medium'
+              : 'text-content-muted hover:bg-surface-strong/70 hover:text-content-secondary dark:hover:bg-surface-muted/60'
+          }`}>
+          <NavIcon id="rewards" className="h-3.5 w-3.5 flex-shrink-0" />
+          <span className="min-w-0 truncate">{t('nav.rewards')}</span>
+        </button>
+      )}
       <button
         type="button"
         data-walkthrough="tab-feedback"

--- a/app/src/components/layout/shell/AppSidebar.tsx
+++ b/app/src/components/layout/shell/AppSidebar.tsx
@@ -12,6 +12,47 @@ import SidebarHeader from './SidebarHeader';
 import SidebarNav from './SidebarNav';
 import { SidebarSlotOutlet } from './SidebarSlot';
 
+interface FooterNavButtonProps {
+  /** `NavTab.id`-style icon key resolved by {@link NavIcon}. */
+  iconId: string;
+  /** Already-translated label (also used as the `title`). */
+  label: string;
+  /** Whether the current route matches this entry. */
+  active: boolean;
+  /** `data-walkthrough` attribute for the walkthrough tour. */
+  walkthroughAttr: string;
+  onClick: () => void;
+}
+
+/**
+ * Slim footer affordance button shared by the Rewards and Feedback rows. Kept
+ * thin and low-profile so it reads as a footer entry, not a primary nav tab.
+ */
+function FooterNavButton({
+  iconId,
+  label,
+  active,
+  walkthroughAttr,
+  onClick,
+}: FooterNavButtonProps) {
+  return (
+    <button
+      type="button"
+      data-walkthrough={walkthroughAttr}
+      onClick={onClick}
+      title={label}
+      aria-current={active ? 'page' : undefined}
+      className={`group flex flex-shrink-0 items-center justify-center gap-2 border-t border-line/70 px-3 py-1 text-[11px] transition-colors cursor-pointer dark:border-line/70 ${
+        active
+          ? 'bg-surface text-content font-medium'
+          : 'text-content-muted hover:bg-surface-strong/70 hover:text-content-secondary dark:hover:bg-surface-muted/60'
+      }`}>
+      <NavIcon id={iconId} className="h-3.5 w-3.5 flex-shrink-0" />
+      <span className="min-w-0 truncate">{label}</span>
+    </button>
+  );
+}
+
 /**
  * The root-shell sidebar, split top-to-bottom into:
  *
@@ -35,37 +76,33 @@ export default function AppSidebar() {
   const { t } = useT();
   const location = useLocation();
   const navigate = useNavigate();
-  const { snapshot: coreSnapshot } = useCoreState();
+  const { snapshot: coreSnapshot, isReady } = useCoreState();
   // Rewards is a cloud-only surface (credits/referrals/coupons live behind the
   // backend rewards API); the page itself renders an "unavailable" state for
   // local sessions, so there's no point offering the entry there. Mirrors the
   // `cloudOnly` intent recorded for rewards in navConfig's AVATAR_MENU_ITEMS.
-  const isLocalSession = isLocalSessionToken(coreSnapshot.sessionToken);
+  //
+  // Show it only once core state has bootstrapped to a real, non-local session.
+  // The initial snapshot is `{ isReady: false, sessionToken: null }`, and
+  // `isLocalSessionToken(null)` is `false`, so gating on the token alone would
+  // briefly flash Rewards for a local session until the first refresh resolves.
+  const showRewards =
+    isReady &&
+    Boolean(coreSnapshot.sessionToken) &&
+    !isLocalSessionToken(coreSnapshot.sessionToken);
   const feedbackActive = location.pathname === '/feedback';
   const rewardsActive = location.pathname === '/rewards';
 
-  const handleFeedbackClick = () => {
-    if (!feedbackActive) {
+  const handleFooterNav = (tab: string, path: string, active: boolean) => {
+    if (!active) {
       trackEvent('tab_bar_change', {
         from_tab: 'unknown',
-        to_tab: 'feedback',
+        to_tab: tab,
         from_path: location.pathname,
-        to_path: '/feedback',
+        to_path: path,
       });
     }
-    navigate('/feedback');
-  };
-
-  const handleRewardsClick = () => {
-    if (!rewardsActive) {
-      trackEvent('tab_bar_change', {
-        from_tab: 'unknown',
-        to_tab: 'rewards',
-        from_path: location.pathname,
-        to_path: '/rewards',
-      });
-    }
-    navigate('/rewards');
+    navigate(path);
   };
 
   return (
@@ -88,39 +125,23 @@ export default function AppSidebar() {
         <SidebarSlotOutlet className="flex h-full flex-col" />
       </div>
       {/* Slim account affordances pinned above the status bar — Rewards then
-          Feedback. Kept thin and low-profile so they read as footer entries,
-          not primary nav tabs. Rewards is hidden on local sessions (cloud-only
-          surface). */}
-      {!isLocalSession && (
-        <button
-          type="button"
-          data-walkthrough="tab-rewards"
-          onClick={handleRewardsClick}
-          title={t('nav.rewards')}
-          aria-current={rewardsActive ? 'page' : undefined}
-          className={`group flex flex-shrink-0 items-center justify-center gap-2 border-t border-line/70 px-3 py-1 text-[11px] transition-colors cursor-pointer dark:border-line/70 ${
-            rewardsActive
-              ? 'bg-surface text-content font-medium'
-              : 'text-content-muted hover:bg-surface-strong/70 hover:text-content-secondary dark:hover:bg-surface-muted/60'
-          }`}>
-          <NavIcon id="rewards" className="h-3.5 w-3.5 flex-shrink-0" />
-          <span className="min-w-0 truncate">{t('nav.rewards')}</span>
-        </button>
+          Feedback. Rewards is shown only for a resolved cloud session. */}
+      {showRewards && (
+        <FooterNavButton
+          iconId="rewards"
+          label={t('nav.rewards')}
+          active={rewardsActive}
+          walkthroughAttr="tab-rewards"
+          onClick={() => handleFooterNav('rewards', '/rewards', rewardsActive)}
+        />
       )}
-      <button
-        type="button"
-        data-walkthrough="tab-feedback"
-        onClick={handleFeedbackClick}
-        title={t('nav.feedback')}
-        aria-current={feedbackActive ? 'page' : undefined}
-        className={`group flex flex-shrink-0 items-center justify-center gap-2 border-t border-line/70 px-3 py-1 text-[11px] transition-colors cursor-pointer dark:border-line/70 ${
-          feedbackActive
-            ? 'bg-surface text-content font-medium'
-            : 'text-content-muted hover:bg-surface-strong/70 hover:text-content-secondary dark:hover:bg-surface-muted/60'
-        }`}>
-        <NavIcon id="feedback" className="h-3.5 w-3.5 flex-shrink-0" />
-        <span className="min-w-0 truncate">{t('nav.feedback')}</span>
-      </button>
+      <FooterNavButton
+        iconId="feedback"
+        label={t('nav.feedback')}
+        active={feedbackActive}
+        walkthroughAttr="tab-feedback"
+        onClick={() => handleFooterNav('feedback', '/feedback', feedbackActive)}
+      />
       {/* App-wide footer: connectivity status + build/version, pinned to the
           bottom of the sidebar. */}
       <div className="flex flex-shrink-0 flex-wrap items-center justify-center gap-x-2 gap-y-0.5 border-t border-line px-2 py-0.5">

--- a/app/src/components/layout/shell/AppSidebar.tsx
+++ b/app/src/components/layout/shell/AppSidebar.tsx
@@ -1,8 +1,11 @@
+import debugFactory from 'debug';
+import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 
 import { useT } from '../../../lib/i18n/I18nContext';
 import { useCoreState } from '../../../providers/CoreStateProvider';
 import { trackEvent } from '../../../services/analytics';
+import { normalizeAnalyticsPagePath } from '../../../services/analyticsRoutes';
 import { APP_VERSION } from '../../../utils/config';
 import { isLocalSessionToken } from '../../../utils/localSession';
 import ConnectionIndicator from '../../ConnectionIndicator';
@@ -11,6 +14,8 @@ import SidebarAppRail from './SidebarAppRail';
 import SidebarHeader from './SidebarHeader';
 import SidebarNav from './SidebarNav';
 import { SidebarSlotOutlet } from './SidebarSlot';
+
+const log = debugFactory('sidebar');
 
 interface FooterNavButtonProps {
   /** `NavTab.id`-style icon key resolved by {@link NavIcon}. */
@@ -93,12 +98,27 @@ export default function AppSidebar() {
   const feedbackActive = location.pathname === '/feedback';
   const rewardsActive = location.pathname === '/rewards';
 
+  // Log the gate outcome whenever it resolves/flips. Booleans only — never the
+  // session token or a raw path.
+  useEffect(() => {
+    log(
+      'rewards footer entry visibility resolved: visible=%s isReady=%s hasSession=%s local=%s',
+      showRewards,
+      isReady,
+      Boolean(coreSnapshot.sessionToken),
+      isLocalSessionToken(coreSnapshot.sessionToken)
+    );
+  }, [showRewards, isReady, coreSnapshot.sessionToken]);
+
   const handleFooterNav = (tab: string, path: string, active: boolean) => {
+    log('footer nav click: tab=%s active=%s', tab, active);
     if (!active) {
       trackEvent('tab_bar_change', {
         from_tab: 'unknown',
         to_tab: tab,
-        from_path: location.pathname,
+        // Normalize to a route template so route-scoped entity IDs (thread,
+        // flow, team, …) never leave the app via analytics.
+        from_path: normalizeAnalyticsPagePath(location.pathname),
         to_path: path,
       });
     }

--- a/app/src/components/layout/shell/navIcons.tsx
+++ b/app/src/components/layout/shell/navIcons.tsx
@@ -193,6 +193,19 @@ export function NavIcon({ id, className = 'w-5 h-5' }: NavIconProps) {
           />
         </svg>
       );
+    case 'rewards':
+      // Gift box — mirrors the glyph the Rewards page uses for its own header
+      // and welcome icon, so the sidebar entry reads as the same destination.
+      return (
+        <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.8}
+            d="M12 8v8m0-8l-3-3m3 3l3-3M8 14H6a2 2 0 01-2-2V7a2 2 0 012-2h2m8 9h2a2 2 0 002-2V7a2 2 0 00-2-2h-2M7 19h10"
+          />
+        </svg>
+      );
     default:
       return null;
   }


### PR DESCRIPTION
## Summary

- Add a labeled **Rewards** row to the sidebar footer (above Feedback) so the `/rewards` page has a real, discoverable entry point.
- The entry is cloud-gated — hidden on local (no-login) sessions, matching the page's own cloud-only behavior.
- Register a `rewards` gift glyph in the sidebar icon set, reusing the icon the Rewards page already uses for itself.

## Problem

The `/rewards` route was fully implemented but unreachable from the UI — the only way to open it was `window.location.hash = '/rewards'`. The intended navigation was never wired:

- `AVATAR_MENU_ITEMS` in `app/src/config/navConfig.ts` (Account → Billing → Rewards → Invites → Wallet, `cloudOnly`) is dead config — it is not consumed by any rendered component.
- The only other link (an "Earn rewards" button in `Home.tsx`) is commented out, and `Home` itself is unreachable (`/home` redirects to `/chat`).

Result: the page was invisible to users.

## Solution

- Rewards is an account/monetization surface (credits, referrals, coupons), not a workflow destination like Chat/Brain/Flows, so it does not belong in the primary `NAV_TABS` rail. It is placed in the sidebar footer affordance zone alongside Feedback: labeled (fixes discoverability) but low-profile (correct altitude).
- The row mirrors the existing Feedback row's styling, active-state handling, and `trackEvent('tab_bar_change', …)` analytics for consistency.
- Cloud gating reuses the proven `isLocalSessionToken(coreSnapshot.sessionToken)` pattern from `Rewards.tsx`. On local sessions the Rewards page renders an "unavailable" state, so the entry is hidden there rather than leading users to a dead end. This honors the `cloudOnly` intent recorded for rewards in `navConfig`.
- Tradeoff: like Feedback, the entry is expanded-sidebar only (not shown in the collapsed rail). Collapsed-rail parity can be added as a follow-up if desired.

Files:
- `app/src/components/layout/shell/AppSidebar.tsx` — cloud-gated Rewards footer row.
- `app/src/components/layout/shell/navIcons.tsx` — `rewards` gift icon.
- `app/src/components/layout/shell/AppSidebar.test.tsx` — new tests.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — new `AppSidebar.test.tsx`: renders + navigates + tracks on cloud session (happy path); hides row on local session (gate/edge case); active-state on `/rewards`.
- [x] **Diff coverage ≥ 80%** — the added branch (render / click→navigate / local-session gate / active-state) is exercised by the new tests. Run `pnpm test:coverage` to confirm the merged gate before merge.
- [x] Coverage matrix updated — `N/A: navigation wiring for an existing feature (Rewards); no new feature ID introduced`.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix feature ID affected`.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — UI-only change, no new network calls.
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A: adds a nav entry to an existing page; no release-cut surface behavior changed`.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — fill in below.

## Impact

- Runtime/platform impact: desktop UI only. No core/Rust, RPC, or backend changes.
- Performance: negligible — one extra conditional footer button; reads an already-available session token from CoreState.
- Security/migration/compatibility: none. Route, page, and rewards API are unchanged; this only adds a navigation affordance to them.

## Related

- Closes: #NNN  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a cloud-only “Rewards” entry to the sidebar footer with a gift-box icon.
  - Updated footer tab active-state so “Rewards” highlights on the /rewards page (and “Feedback” remains available).
  - Enhanced footer navigation to emit tab-change analytics when switching to “Rewards”.
- **Bug Fixes**
  - Prevented “Rewards” from showing during local sessions and while cloud session data is still loading, avoiding any initial UI flash.
- **Tests**
  - Expanded coverage for “Rewards” visibility rules, navigation, analytics event payloads, and active-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->