### PR TITLE
feat(agent): public accessor for last-turn usage totals

### DIFF
--- a/src/openhuman/agent/harness/mod.rs
+++ b/src/openhuman/agent/harness/mod.rs
@@ -43,7 +43,7 @@ pub mod task_recency_context;
 pub(crate) mod tool_filter;
 pub(crate) mod tool_result_artifacts;
 pub mod turn_attachments_context;
-pub(crate) mod turn_subagent_usage;
+pub mod turn_subagent_usage;
 
 pub use agent_graph::{AgentGraph, AgentTurnRequest, AgentTurnResult, AgentTurnUsage};
 pub use definition::{
@@ -59,6 +59,7 @@ pub use sandbox_context::{current_sandbox_mode, with_current_sandbox_mode};
 pub(crate) use spawn_depth_context::{current_spawn_depth, with_spawn_depth, MAX_SPAWN_DEPTH};
 pub use subagent_runner::{run_subagent, SubagentRunError, SubagentRunOptions};
 pub use task_recency_context::{current_task_recency_window, with_task_recency_window};
+pub use turn_subagent_usage::{LastTurnUsage, SubagentUsageEntry};
 
 pub(crate) use graph::run_channel_turn_via_graph;
 pub(crate) use instructions::build_tool_instructions_filtered;

--- a/src/openhuman/agent/harness/session/runtime.rs
+++ b/src/openhuman/agent/harness/session/runtime.rs
@@ -378,6 +378,22 @@ impl Agent {
         std::mem::take(&mut self.last_turn_citations)
     }
 
+    /// Borrow the holistic token/cost/context totals for the latest completed
+    /// turn (parent + sub-agents) **without consuming them**. `None` until a
+    /// turn has run.
+    ///
+    /// This is the public, non-draining counterpart to
+    /// [`take_last_turn_usage_totals`](Self::take_last_turn_usage_totals): a
+    /// downstream crate embedding OpenHuman as a library (e.g. the OpenCompany
+    /// hosting platform's cost-metering hook) can read per-turn token and USD
+    /// totals after [`Agent::turn`](crate::openhuman::agent::Agent) returns,
+    /// while leaving the value in place for the web-channel drain path.
+    pub fn last_turn_usage(
+        &self,
+    ) -> Option<&crate::openhuman::agent::harness::turn_subagent_usage::LastTurnUsage> {
+        self.last_turn_usage_totals.as_ref()
+    }
+
     /// Drain and return the holistic token/cost/context totals for the latest
     /// completed turn (parent + sub-agents). `None` until a turn has run.
     /// Consumed by web-channel delivery to populate the `chat_done` usage fields.

--- a/src/openhuman/agent/harness/session/tests.rs
+++ b/src/openhuman/agent/harness/session/tests.rs
@@ -692,6 +692,84 @@ async fn turn_without_tools_returns_text() {
     assert_eq!(response, "hello");
 }
 
+/// The public [`Agent::last_turn_usage`] accessor peeks the per-turn
+/// token/cost totals **without draining** them, so a downstream crate
+/// embedding OpenHuman as a library (e.g. the OpenCompany hosting platform's
+/// cost-metering hook) can read usage after a turn while the existing
+/// web-channel `take_last_turn_usage_totals` drain path still works.
+#[tokio::test]
+async fn last_turn_usage_is_public_and_non_draining() {
+    let workspace = tempfile::TempDir::new().expect("temp workspace");
+    let workspace_path = workspace.path().to_path_buf();
+
+    let provider = Box::new(MockProvider {
+        responses: Mutex::new(vec![crate::openhuman::inference::provider::ChatResponse {
+            text: Some("hello".into()),
+            tool_calls: vec![],
+            usage: Some(crate::openhuman::inference::provider::UsageInfo {
+                input_tokens: 123,
+                output_tokens: 45,
+                context_window: 8000,
+                charged_amount_usd: 0.01,
+                ..Default::default()
+            }),
+            reasoning_content: None,
+        }]),
+    });
+
+    let memory_cfg = crate::openhuman::config::MemoryConfig {
+        backend: "none".into(),
+        ..crate::openhuman::config::MemoryConfig::default()
+    };
+    let mem: Arc<dyn Memory> = Arc::from(
+        crate::openhuman::memory_store::create_memory(&memory_cfg, &workspace_path).unwrap(),
+    );
+
+    let mut agent = Agent::builder()
+        .provider(provider)
+        .tools(vec![Box::new(MockTool)])
+        .memory(mem)
+        .tool_dispatcher(Box::new(XmlToolDispatcher))
+        .workspace_dir(workspace_path)
+        .build()
+        .unwrap();
+
+    // No turn has run yet — nothing to report.
+    assert!(agent.last_turn_usage().is_none());
+
+    let response = agent.turn("hi").await.unwrap();
+    assert_eq!(response, "hello");
+
+    // The accessor now yields totals, and the return type's fields are all
+    // publicly readable (this closure would not compile if they were not).
+    let peeked: crate::openhuman::agent::harness::LastTurnUsage = {
+        let usage = agent
+            .last_turn_usage()
+            .expect("usage should be populated after a turn");
+        crate::openhuman::agent::harness::LastTurnUsage {
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+            cached_input_tokens: usage.cached_input_tokens,
+            cost_usd: usage.cost_usd,
+            context_window: usage.context_window,
+            subagents: usage.subagents.clone(),
+        }
+    };
+
+    // Peeking must not consume: a second read returns the same snapshot.
+    assert_eq!(agent.last_turn_usage(), Some(&peeked));
+
+    // The internal web-channel drain still sees the very same value, proving
+    // the borrow accessor left it untouched.
+    let drained = agent
+        .take_last_turn_usage_totals()
+        .expect("drain should still yield the totals the borrow peeked");
+    assert_eq!(drained, peeked);
+
+    // After the drain the peek accessor reports nothing, as expected.
+    assert!(agent.last_turn_usage().is_none());
+}
+
 #[tokio::test]
 async fn turn_with_native_dispatcher_handles_tool_results_variant() {
     let workspace = tempfile::TempDir::new().expect("temp workspace");

--- a/src/openhuman/agent/harness/turn_subagent_usage.rs
+++ b/src/openhuman/agent/harness/turn_subagent_usage.rs
@@ -30,10 +30,10 @@ use super::subagent_runner::SubagentUsage;
 
 /// One sub-agent's spend, tagged with its identity for the per-child breakdown.
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct SubagentUsageEntry {
-    pub(crate) task_id: String,
-    pub(crate) agent_id: String,
-    pub(crate) usage: SubagentUsage,
+pub struct SubagentUsageEntry {
+    pub task_id: String,
+    pub agent_id: String,
+    pub usage: SubagentUsage,
 }
 
 /// Holistic token/cost accounting for a single completed turn, including any
@@ -42,22 +42,22 @@ pub(crate) struct SubagentUsageEntry {
 /// event so the UI footer can show session tokens, context-window utilisation,
 /// USD cost, and a per-sub-agent hover breakdown.
 #[derive(Debug, Clone, Default, PartialEq)]
-pub(crate) struct LastTurnUsage {
+pub struct LastTurnUsage {
     /// Input (prompt) tokens for the turn, parent + sub-agents.
-    pub(crate) input_tokens: u64,
+    pub input_tokens: u64,
     /// Output (completion) tokens for the turn, parent + sub-agents.
-    pub(crate) output_tokens: u64,
+    pub output_tokens: u64,
     /// Cached-input tokens for the turn, parent + sub-agents.
-    pub(crate) cached_input_tokens: u64,
+    pub cached_input_tokens: u64,
     /// USD cost for the turn (backend-charged where available, else estimated),
     /// parent + sub-agents.
-    pub(crate) cost_usd: f64,
+    pub cost_usd: f64,
     /// The model's context window for this turn (`0` when unknown, e.g. a cloud
     /// model whose window the core couldn't resolve). Lets the UI show real
     /// context utilisation instead of a hard-coded default.
-    pub(crate) context_window: u64,
+    pub context_window: u64,
     /// Per-sub-agent spend gathered during the turn, for the hover breakdown.
-    pub(crate) subagents: Vec<SubagentUsageEntry>,
+    pub subagents: Vec<SubagentUsageEntry>,
 }
 
 /// Shared, mutable list of sub-agent spend gathered during one parent turn.


### PR DESCRIPTION
> **Draft** — opened to unblock the downstream OpenCompany harness. Review welcome; not yet marked ready.

## Why

The [OpenCompany hosting platform](https://github.com/tinyhumansai/opencompany-microservices) embeds OpenHuman as a **library** and builds each tenant into a per-tenant container. Its cost-metering hook (WS4/WS5) needs to read the per-turn token and USD totals after `Agent::turn()` returns, to append to its billing ledger and usage meter.

Today those totals are unreachable from outside the crate:

- `Agent::take_last_turn_usage_totals()` is `pub(crate)` **and draining** — consuming it would steal the value the web-channel delivery path relies on to populate `chat_done`.
- The return type `LastTurnUsage` (and its `SubagentUsageEntry` breakdown) were `pub(crate)` with `pub(crate)` fields and lived in a `pub(crate)` module, so a downstream crate could neither name nor read the type.

## What

- Add a **public, non-draining** borrow accessor:
  ```rust
  impl Agent {
      pub fn last_turn_usage(&self) -> Option<&LastTurnUsage>;
  }
  ```
  It peeks `last_turn_usage_totals` without consuming it, so a downstream cost hook can read after a turn while the existing web-channel `take_last_turn_usage_totals()` drain path is untouched. `take_last_turn_usage_totals()` is left exactly as-is.
- Make `LastTurnUsage` and `SubagentUsageEntry` (and all their fields) `pub`, and re-export them from `crate::openhuman::agent::harness` (`turn_subagent_usage` module widened from `pub(crate)` to `pub`). Consumers can now both **call** the accessor and **name/read** the returned type (token counts, `cost_usd`, `context_window`, per-sub-agent breakdown). `SubagentUsage` was already fully public.

No behavior change to any existing call site; this is purely additive visibility plus one new accessor.

## Test

Added `last_turn_usage_is_public_and_non_draining` in the session tests: builds a minimal agent with a `MockProvider` that reports `UsageInfo`, runs a turn, and asserts the accessor
1. returns `None` before any turn,
2. returns populated totals after a turn,
3. is **non-draining** — a second peek returns the same snapshot, and the internal `take_last_turn_usage_totals()` drain still yields that same value,
4. returns `None` after the drain.

## Commands run locally

- `cargo fmt --all -- --check` — passes.
- `cargo clippy --lib --all-targets` (default features) — no warnings on the touched files. (Note: `--all-features` surfaces a large pre-existing lint backlog crate-wide, unrelated to this change.)
- `cargo check --lib` — passes.
- `cargo test --lib last_turn_usage_is_public_and_non_draining` — passes.
- `cargo test --lib turn_subagent_usage` — 4/4 pass (no regression).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added public access to per-turn usage details, including token counts, cached tokens, costs, context-window information, and sub-agent usage.
  - Added a read-only way to inspect the most recently completed turn without consuming the recorded data.
  - Usage information can now be accessed through the crate’s public API.

- **Tests**
  - Added coverage confirming usage is initially unavailable, populated after a turn, repeatably readable, and correctly cleared when explicitly consumed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->