### PR TITLE
fix(flows): expose platform_user_id in flows_list_connections schema + self-DM review follow-ups

### DIFF
--- a/src/openhuman/flows/agents/workflow_builder/builder_prompt.rs
+++ b/src/openhuman/flows/agents/workflow_builder/builder_prompt.rs
@@ -376,6 +376,30 @@ mod tests {
             "standing prompt must explicitly forbid falling back to a public \
              channel (e.g. #general/#team-product) for a personal \"DM me\" request"
         );
+
+        // Positive: assert the *complete* wiring instruction, not just the
+        // presence of the `platform_user_id` keyword — a regression could
+        // drop the actual "pass it as `channel`" directive while leaving the
+        // word `platform_user_id` elsewhere in the prompt and still pass the
+        // looser check above.
+        assert!(
+            STANDING_PROMPT
+                .contains("that id verbatim as the `channel` arg on `SLACK_SEND_MESSAGE`"),
+            "standing prompt must explicitly instruct passing `platform_user_id` \
+             verbatim as the `channel` arg on `SLACK_SEND_MESSAGE` — not just \
+             mention the field name"
+        );
+
+        // Positive: the null-`platform_user_id` fallback (ask the user for
+        // their member id in one question) must survive too — this is the
+        // other half of the self-DM contract and must not be silently lost.
+        assert!(
+            STANDING_PROMPT.contains("Only if `platform_user_id` is null")
+                && STANDING_PROMPT.contains("ask the user for their member id"),
+            "standing prompt must preserve the null-`platform_user_id` fallback: \
+             ask the user for their member id in one question rather than \
+             guessing a channel"
+        );
     }
 
     #[test]

--- a/src/openhuman/flows/builder_tools.rs
+++ b/src/openhuman/flows/builder_tools.rs
@@ -1495,7 +1495,8 @@ impl Tool for GetFlowRunTool {
 
 /// `list_flow_connections`: read-only enumeration of the connection sources a
 /// node's `connection_ref` can attach to (Composio connected accounts +
-/// named HTTP credentials) — ids / display labels / kind only, never secrets.
+/// named HTTP credentials) — non-secret metadata only (ids / display labels
+/// / kind / toolkit / scheme / platform_user_id), never secrets.
 pub struct ListFlowConnectionsTool {
     config: Arc<Config>,
 }
@@ -1515,7 +1516,8 @@ impl Tool for ListFlowConnectionsTool {
     fn description(&self) -> &str {
         "List the connection sources a flow node's `connection_ref` can attach to: \
          Composio connected accounts and named HTTP credentials. Read-only; \
-         returns ids + display labels + kind ONLY (never any secret). Each \
+         returns only non-secret metadata — ids, display labels, kind, and \
+         `toolkit`/`scheme` (never any secret). Each \
          Composio entry also carries `platform_user_id` — the connected \
          account's own member id (e.g. Slack `U123ABC`) — use it to wire a \
          self-targeted action like 'DM me' to that account instead of a \

--- a/src/openhuman/flows/ops.rs
+++ b/src/openhuman/flows/ops.rs
@@ -2366,6 +2366,10 @@ pub async fn flows_list_connections(
     // connection sync. Loaded once here so `build_flow_connections` can stay
     // a pure, unit-testable matcher.
     let identities = crate::openhuman::composio::providers::profile::load_connected_identities();
+    tracing::debug!(
+        count = identities.len(),
+        "[flows] flows_list_connections: identity-cache load"
+    );
     let connections = build_flow_connections(composio_conns, http_creds, &identities);
     tracing::debug!(
         total = connections.len(),

--- a/src/openhuman/flows/schemas.rs
+++ b/src/openhuman/flows/schemas.rs
@@ -261,6 +261,16 @@ fn flow_connection_fields() -> Vec<FieldSchema> {
                       `bearer` | `basic` | `header`.",
             required: false,
         },
+        FieldSchema {
+            name: "platform_user_id",
+            ty: TypeSchema::Option(Box::new(TypeSchema::String)),
+            comment: "Connected account's own platform user id (kind `composio` only), \
+                      e.g. Slack `U123ABC`. Non-secret identity metadata — lets the \
+                      workflow builder wire a self-targeted action (e.g. \"DM me\") to \
+                      the user's own account instead of guessing a public channel. \
+                      `None` when no identity has synced yet.",
+            required: false,
+        },
     ]
 }
 
@@ -576,9 +586,11 @@ pub fn schemas(function: &str) -> ControllerSchema {
             function: "list_connections",
             description: "List the connection sources a flow node's `connection_ref` can attach \
                           to: Composio connected accounts (kind `composio`) and stored HTTP \
-                          credentials (kind `http`). Returns ids + display labels + kind ONLY — \
-                          never any secret material (OAuth/bearer tokens, passwords, and API \
-                          keys stay server-side and are injected only at execution time).",
+                          credentials (kind `http`). Returns only non-secret metadata — ids, \
+                          display labels, kind, and (for Composio) the connected account's own \
+                          `platform_user_id` — never any secret material (OAuth/bearer tokens, \
+                          passwords, and API keys stay server-side and are injected only at \
+                          execution time).",
             inputs: vec![],
             outputs: vec![FieldSchema {
                 name: "connections",
@@ -1793,7 +1805,14 @@ mod tests {
                 let names: Vec<_> = fields.iter().map(|f| f.name).collect();
                 assert_eq!(
                     names,
-                    vec!["connection_ref", "kind", "display", "toolkit", "scheme"]
+                    vec![
+                        "connection_ref",
+                        "kind",
+                        "display",
+                        "toolkit",
+                        "scheme",
+                        "platform_user_id"
+                    ]
                 );
                 for f in fields {
                     let n = f.name.to_ascii_lowercase();


### PR DESCRIPTION
## Summary

Follow-up to the merged self-DM PR #4933 (`platform_user_id` surfacing). #4933 was merged before its review round landed — this PR carries the 4 valid review findings, one a real contract gap.

## Fixes

- **Codex P2 (real gap):** `flow_connection_fields()` in `schemas.rs` never advertised `platform_user_id`, so schema-driven clients hitting `/schema` couldn't see the field the RPC actually returns. **Added the field** + fixed stale "kind ONLY" wording + updated the locking schema test.
- **CodeRabbit:** `ListFlowConnectionsTool::description()` said "kind ONLY" while documenting `platform_user_id`/`toolkit` — reworded to "only non-secret metadata."
- **CodeRabbit:** identity-cache load in `flows_list_connections` was silent — added `tracing::debug!(count = …)`.
- **CodeRabbit:** the standing-prompt test only checked keyword presence — added assertions for the actual "pass as `channel` on `SLACK_SEND_MESSAGE`" wiring instruction + the null-fallback text.

## Testing

- `cargo test --lib openhuman::flows::` → all pass (387 on the source branch); `cargo check` + `cargo fmt --check` clean.

## Acceptance criteria

- [x] `/schema` now advertises `platform_user_id` (schema-driven clients see it)
- [x] Tool description no longer self-contradictory
- [x] Prompt test asserts the real self-DM wiring instruction, not just keywords

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connection listings now include an optional, secret-free platform user ID for supported connections.
  * This metadata can support more reliable self-targeted messaging actions.

* **Documentation**
  * Connection metadata descriptions now clarify the available fields and confirm that secret information is never returned.
  * Guidance for self-messaging now explains how to use a platform user ID and what to do when it is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->