### PR TITLE
fix(flows): persist agentic task insights expand state across copilot turns

### DIFF
--- a/app/src/features/conversations/components/ToolTimelineBlock.tsx
+++ b/app/src/features/conversations/components/ToolTimelineBlock.tsx
@@ -1,3 +1,6 @@
+import createDebug from 'debug';
+import { useState } from 'react';
+
 import WorktreeActions from '../../../components/worktree/WorktreeActions';
 import { useT } from '../../../lib/i18n/I18nContext';
 import type {
@@ -422,6 +425,8 @@ function RepeatCount({ count }: { count: number }) {
   );
 }
 
+const log = createDebug('app:conversations:tool-timeline');
+
 /**
  * Neutral surface tones for an expanded row's body (worker-thread card,
  * detail bubble, code block). Per the Figma "Agentic task insights"
@@ -477,6 +482,23 @@ export function ToolTimelineBlock({
 }) {
   const { t } = useT();
   const latestRunningEntryId = [...entries].reverse().find(entry => entry.status === 'running')?.id;
+
+  // Sticky override for the outer "Agentic task insights" group: `null` means
+  // the user hasn't explicitly toggled it on THIS mount yet, so the group
+  // falls back to the auto rule below (open while running, collapsed once
+  // settled). Once the user clicks the summary, this pins their choice —
+  // including across later turns that stream onto the SAME mounted block
+  // (e.g. the workflow copilot's dedicated thread, whose `ToolTimelineBlock`
+  // stays mounted for the life of the conversation while `entries` keeps
+  // growing turn over turn) — so a new turn's activity landing no longer
+  // involuntarily re-collapses (or re-expands) a choice the user already
+  // made ("Agentic task insights keeps collapsing on every new feedback").
+  // Deliberately component-local state, not lifted to Redux:
+  // the block never remounts mid-conversation in the one place this bug was
+  // reported (`WorkflowCopilotPanel` renders it at a stable JSX position
+  // with entries accumulating in `toolTimelineByThread`, not reset per
+  // turn), so a plain `useState` already survives every turn it needs to.
+  const [userOverrideOpen, setUserOverrideOpen] = useState<boolean | null>(null);
 
   if (entries.length === 0) return null;
 
@@ -629,20 +651,38 @@ export function ToolTimelineBlock({
 
   // The group header is a static section label — the live "working" state is
   // conveyed by the pulsing agent-name rows, so it never repeats a "Working…"
-  // string. The group is always collapsible: while the run is in flight it is
-  // open so the live activity is visible; once it settles it collapses to a
-  // single-line opener by default so a finished run (which can be dozens of
-  // steps) never dominates the conversation — the rows stay one click away, and
-  // the whole-run side panel is still reachable via the header link. The full
-  // "Agent Process Source" panel forces every row open via `expandAllRows`.
-  const open = isRunning || expandAllRows;
+  // string. Absent a user override, the group is auto-driven: open while the
+  // run is in flight so the live activity is visible; collapsed once it
+  // settles so a finished run (which can be dozens of steps) never dominates
+  // the conversation. The full "Agent Process Source" panel forces every row
+  // open via `expandAllRows`. Once the user has explicitly toggled the group
+  // (see `userOverrideOpen` above), THAT choice wins over the auto rule —
+  // otherwise a new turn streaming onto an already-mounted block (settling,
+  // or starting a fresh run) would silently flip `open` out from under the
+  // user's manual choice on every turn.
+  const autoOpen = isRunning || expandAllRows;
+  const open = userOverrideOpen ?? autoOpen;
+
+  // Fully own the disclosure via React state rather than letting the browser
+  // toggle the native `open` attribute itself — `preventDefault` stops the
+  // native toggle so there is exactly one source of truth (`open` above),
+  // never a race between the DOM's own uncontrolled state and the next
+  // render's `open` prop.
+  const handleSummaryClick = (event: React.MouseEvent<HTMLElement>) => {
+    event.preventDefault();
+    const next = !open;
+    log('agent-task-insights: user toggled open=%s (auto would be %s)', next, autoOpen);
+    setUserOverrideOpen(next);
+  };
 
   return (
     <details
       open={open}
       className="group/insights mb-2 px-1 py-0"
       data-testid="agent-task-insights">
-      <summary className="mb-1.5 flex cursor-pointer list-none items-center gap-1.5 select-none marker:hidden">
+      <summary
+        onClick={handleSummaryClick}
+        className="mb-1.5 flex cursor-pointer list-none items-center gap-1.5 select-none marker:hidden">
         {titleLabel}
         <span className="text-[11px] text-content-faint transition-transform group-open/insights:rotate-90">
           ▶

--- a/app/src/features/conversations/components/__tests__/ToolTimelineBlock.test.tsx
+++ b/app/src/features/conversations/components/__tests__/ToolTimelineBlock.test.tsx
@@ -358,6 +358,99 @@ describe('ToolTimelineBlock — agentic task insights surface', () => {
     expect(screen.getByTestId('agent-task-insights')).toHaveAttribute('open');
   });
 
+  // Regression coverage for "Agentic task insights keeps collapsing on every
+  // new feedback": the workflow copilot keeps ONE `ToolTimelineBlock` mounted
+  // for the life of a thread, appending each new turn's entries onto the same
+  // `entries` prop (see `WorkflowCopilotPanel`/`useWorkflowBuilderChat`) — it
+  // never remounts the block per turn. Before the fix, the outer group's
+  // `open` was driven purely by `isRunning || expandAllRows`, so every time a
+  // turn settled (running → not running) the group snapped shut regardless of
+  // anything the user had done, discarding a manual expand made moments
+  // earlier. These tests simulate that same "new turn's entries land on an
+  // already-mounted block" shape via `rerender` rather than remounting.
+  describe('agentic task insights — sticky user expand/collapse across turns', () => {
+    it('keeps an explicit user expand across a new turn that starts and settles', () => {
+      const turn1Settled: ToolTimelineEntry[] = [
+        { id: 't1', name: 'web_search', round: 1, status: 'success' },
+      ];
+      const { rerender } = renderInStore(<ToolTimelineBlock entries={turn1Settled} />);
+      // Default: settled and collapsed (unchanged behaviour).
+      expect(screen.getByTestId('agent-task-insights')).not.toHaveAttribute('open');
+
+      // The user manually expands it.
+      fireEvent.click(screen.getByText('Agentic task insights'));
+      expect(screen.getByTestId('agent-task-insights')).toHaveAttribute('open');
+
+      // A new turn/feedback starts streaming onto the SAME mounted block.
+      const turn2Running: ToolTimelineEntry[] = [
+        ...turn1Settled,
+        { id: 't2', name: 'file_read', round: 2, status: 'running' },
+      ];
+      rerender(
+        <Provider store={store}>
+          <ToolTimelineBlock entries={turn2Running} />
+        </Provider>
+      );
+      expect(screen.getByTestId('agent-task-insights')).toHaveAttribute('open');
+
+      // ...and settles. Without the fix this is exactly where it would
+      // involuntarily re-collapse, wiping out the user's choice.
+      const turn2Settled: ToolTimelineEntry[] = [
+        ...turn1Settled,
+        { id: 't2', name: 'file_read', round: 2, status: 'success' },
+      ];
+      rerender(
+        <Provider store={store}>
+          <ToolTimelineBlock entries={turn2Settled} />
+        </Provider>
+      );
+      expect(screen.getByTestId('agent-task-insights')).toHaveAttribute('open');
+    });
+
+    it('leaves the default open-while-running/collapsed-when-settled behaviour unchanged absent any user interaction', () => {
+      const running: ToolTimelineEntry[] = [
+        { id: 'r', name: 'web_search', round: 1, status: 'running' },
+      ];
+      const { rerender } = renderInStore(<ToolTimelineBlock entries={running} />);
+      expect(screen.getByTestId('agent-task-insights')).toHaveAttribute('open');
+
+      const settled: ToolTimelineEntry[] = [
+        { id: 'r', name: 'web_search', round: 1, status: 'success' },
+      ];
+      rerender(
+        <Provider store={store}>
+          <ToolTimelineBlock entries={settled} />
+        </Provider>
+      );
+      expect(screen.getByTestId('agent-task-insights')).not.toHaveAttribute('open');
+    });
+
+    it('also persists an explicit user collapse across a new turn (does not force it back open)', () => {
+      const turn1Running: ToolTimelineEntry[] = [
+        { id: 't1', name: 'web_search', round: 1, status: 'running' },
+      ];
+      const { rerender } = renderInStore(<ToolTimelineBlock entries={turn1Running} />);
+      expect(screen.getByTestId('agent-task-insights')).toHaveAttribute('open');
+
+      // The user collapses it while a turn is still running.
+      fireEvent.click(screen.getByText('Agentic task insights'));
+      expect(screen.getByTestId('agent-task-insights')).not.toHaveAttribute('open');
+
+      // A new turn starts running — the auto rule alone would force it back
+      // open, but the user's explicit collapse must win.
+      const turn2Running: ToolTimelineEntry[] = [
+        { id: 't1', name: 'web_search', round: 1, status: 'success' },
+        { id: 't2', name: 'file_read', round: 2, status: 'running' },
+      ];
+      rerender(
+        <Provider store={store}>
+          <ToolTimelineBlock entries={turn2Running} />
+        </Provider>
+      );
+      expect(screen.getByTestId('agent-task-insights')).not.toHaveAttribute('open');
+    });
+  });
+
   it('renders the tool result output inside the expanded row', () => {
     const entries: ToolTimelineEntry[] = [
       {


### PR DESCRIPTION
## Summary

- The workflow copilot's "Agentic task insights" disclosure (`ToolTimelineBlock`, embedded in `WorkflowCopilotPanel`) re-collapsed on every new copilot turn, discarding whatever expand/collapse choice the user had made.
- Root cause: the outer `<details open={...}>` computed `open` purely as `isRunning || expandAllRows` — a fully derived value with no mechanism for a user's manual toggle to persist. `WorkflowCopilotPanel` keeps a single `ToolTimelineBlock` mounted for the life of a copilot thread (`toolTimeline` accumulates turn over turn in `toolTimelineByThread`, it's never reset/remounted per turn), so every time a turn *settled* (`isRunning` flipping `true → false`), the `open` prop flipped back to `false` and forcibly collapsed the DOM — wiping out any expand the user had done, whether during that turn or a previous one.
- Fix: add a component-local "sticky" override (`userOverrideOpen: boolean | null`), set only when the user explicitly clicks the group's `<summary>`. The summary click is now fully React-controlled (`preventDefault()` on the native toggle, single source of truth via the `open` prop) instead of relying on the browser's own uncontrolled `<details>` toggling, which was racing the derived `open` prop. Absent any user interaction, behavior is unchanged: open while running, collapsed once settled — the existing default-behavior test still passes as-is.
- Scoped entirely to `ToolTimelineBlock.tsx` (the shared component also used by the main chat's timeline, the "Agent Process Source" panel, and the dev preview page) — no changes to `WorkflowCopilotPanel.tsx`, so this should merge cleanly alongside unrelated in-flight work on that file.

## Root cause detail

`ToolTimelineBlock.tsx` (before):
```tsx
const open = isRunning || expandAllRows;
...
<details open={open} data-testid="agent-task-insights">
  <summary className="...">{titleLabel}...</summary>
  {body}
</details>
```
No user-driven state existed at all — `open` was a pure function of the (streamed) `entries` prop. A new turn's tool calls arriving → `isRunning` true → forced open (fine, expected). That turn settling → `isRunning` false → forced closed, **regardless of the user's own expand/collapse choice**.

## Fix

- Added `userOverrideOpen` (`useState<boolean | null>(null)`) — `null` until the user explicitly toggles the group.
- `open = userOverrideOpen ?? (isRunning || expandAllRows)` — user choice wins once set; otherwise unchanged auto behavior.
- The `<summary>`'s click handler now `preventDefault()`s the native toggle and sets `userOverrideOpen` explicitly, so there's exactly one source of truth for the DOM's `open` attribute (no more native-vs-React race).
- Added a debug log (`app:conversations:tool-timeline`) at the toggle decision point.

## Test plan

- [x] `corepack pnpm typecheck` clean
- [x] `corepack pnpm lint` clean (0 errors; pre-existing unrelated warnings elsewhere in the repo, none in the touched files)
- [x] `corepack pnpm format` — no diff beyond the intended files
- [x] New Vitest coverage in `ToolTimelineBlock.test.tsx` (`describe('agentic task insights — sticky user expand/collapse across turns')`):
  - `keeps an explicit user expand across a new turn that starts and settles`
  - `leaves the default open-while-running/collapsed-when-settled behaviour unchanged absent any user interaction`
  - `also persists an explicit user collapse across a new turn (does not force it back open)`
- [x] Full existing `ToolTimelineBlock.test.tsx` suite green (37/37, including the pre-existing "stays open while running and collapses once settled" test — default behavior unchanged)
- [x] `WorkflowCopilotPanel.test.tsx`, `ConversationTimeline` tests, `Conversations.render.test.tsx` all green (136/136)
- [x] Broader `src/features/conversations` + `src/components/flows` sweep green (423/423)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved users’ manual expand or collapse choices for Agentic task insights across conversation turns.
  * Maintained the default behavior of expanding while tasks run and collapsing when they settle.

* **Tests**
  * Added coverage for expansion and collapse behavior during streaming and across subsequent turns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->