### PR TITLE
fix(flows): copilot chat stays scrollable (auto-scroll only when pinned to bottom)

### DIFF
--- a/app/src/components/flows/WorkflowCopilotPanel.test.tsx
+++ b/app/src/components/flows/WorkflowCopilotPanel.test.tsx
@@ -282,6 +282,134 @@ describe('WorkflowCopilotPanel', () => {
     expect(screen.queryByTestId('workflow-copilot-thinking')).not.toBeInTheDocument();
   });
 
+  // Regression coverage for the "copilot chat gets stuck" bug: the panel used
+  // to force-scroll to the bottom on every render of a streaming turn (an
+  // unconditional `scrollTo` effect keyed on messages/tool timeline/live
+  // text), which fought a user trying to scroll up to read. The panel now
+  // delegates to the shared `useStickToBottom` hook (same one the main chat
+  // surfaces use) — these tests exercise the REAL hook (not mocked) wired
+  // through the actual transcript container.
+  describe('transcript scroll pinning (#regression: chat gets stuck)', () => {
+    function scrollContainer() {
+      return screen.getByTestId('workflow-copilot-transcript');
+    }
+
+    // jsdom performs no real layout, so scroll metrics are inert unless
+    // defined explicitly — mirrors the approach in useStickToBottom.test.ts.
+    function mockScrollMetrics(
+      el: HTMLElement,
+      metrics: { scrollTop: number; scrollHeight: number; clientHeight: number }
+    ) {
+      Object.defineProperty(el, 'scrollHeight', {
+        configurable: true,
+        value: metrics.scrollHeight,
+      });
+      Object.defineProperty(el, 'clientHeight', {
+        configurable: true,
+        value: metrics.clientHeight,
+      });
+      Object.defineProperty(el, 'scrollTop', {
+        configurable: true,
+        writable: true,
+        value: metrics.scrollTop,
+      });
+    }
+
+    function renderPanel() {
+      return render(
+        <WorkflowCopilotPanel
+          graph={baseGraph}
+          onProposal={vi.fn()}
+          onAccept={vi.fn()}
+          onReject={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+    }
+
+    it('keeps the transcript container freely scrollable (overflow-y-auto)', () => {
+      renderPanel();
+      expect(scrollContainer()).toHaveClass('overflow-y-auto');
+    });
+
+    it('auto-scrolls to the bottom when a new message arrives while the user is pinned to the bottom', () => {
+      hookState.displayMessages = [{ id: 'm1', content: 'hi', sender: 'user' }];
+      const { rerender } = renderPanel();
+      const container = scrollContainer();
+
+      mockScrollMetrics(container, { scrollTop: 50, scrollHeight: 100, clientHeight: 50 });
+      rerender(
+        <WorkflowCopilotPanel
+          graph={baseGraph}
+          onProposal={vi.fn()}
+          onAccept={vi.fn()}
+          onReject={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      // A new agent turn lands while the user never scrolled away.
+      hookState.displayMessages = [
+        ...hookState.displayMessages,
+        { id: 'm2', content: 'Done — proposed a Slack notification.', sender: 'agent' },
+      ];
+      mockScrollMetrics(container, { scrollTop: 50, scrollHeight: 300, clientHeight: 50 });
+      rerender(
+        <WorkflowCopilotPanel
+          graph={baseGraph}
+          onProposal={vi.fn()}
+          onAccept={vi.fn()}
+          onReject={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      expect(container.scrollTop).toBe(300);
+    });
+
+    it('does NOT force-scroll the user back down once they have scrolled up to read history', () => {
+      hookState.displayMessages = [{ id: 'm1', content: 'hi', sender: 'user' }];
+      const { rerender } = renderPanel();
+      const container = scrollContainer();
+
+      mockScrollMetrics(container, { scrollTop: 50, scrollHeight: 100, clientHeight: 50 });
+      rerender(
+        <WorkflowCopilotPanel
+          graph={baseGraph}
+          onProposal={vi.fn()}
+          onAccept={vi.fn()}
+          onReject={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      // The user scrolls up to read earlier context, well past the stick
+      // threshold (400 - 0 - 50 = 350px from the bottom).
+      mockScrollMetrics(container, { scrollTop: 0, scrollHeight: 400, clientHeight: 50 });
+      fireEvent.scroll(container);
+
+      // A new agent turn streams in regardless — this is exactly the bug:
+      // the old unconditional `scrollTo` effect would yank the reader back
+      // to the bottom here. The container must stay put.
+      hookState.displayMessages = [
+        ...hookState.displayMessages,
+        { id: 'm2', content: 'Still drafting…', sender: 'agent' },
+      ];
+      mockScrollMetrics(container, { scrollTop: 0, scrollHeight: 700, clientHeight: 50 });
+      rerender(
+        <WorkflowCopilotPanel
+          graph={baseGraph}
+          onProposal={vi.fn()}
+          onAccept={vi.fn()}
+          onReject={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      expect(container.scrollTop).toBe(0);
+    });
+  });
+
   it('surfaces a new proposal to the host and shows the added/removed diff', () => {
     const onProposal = vi.fn();
     // proposed drops "b" and adds "c" vs. base [a, b].

--- a/app/src/components/flows/WorkflowCopilotPanel.tsx
+++ b/app/src/components/flows/WorkflowCopilotPanel.tsx
@@ -29,6 +29,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { BubbleMarkdown } from '../../features/conversations/components/AgentMessageBubble';
 import { ToolTimelineBlock } from '../../features/conversations/components/ToolTimelineBlock';
+import { useStickToBottom } from '../../hooks/useStickToBottom';
 import { useWorkflowBuilderChat } from '../../hooks/useWorkflowBuilderChat';
 import { unwrapToolCallEnvelope } from '../../lib/flows/copilotMessageSanitizer';
 import { diffGraphs } from '../../lib/flows/graphDiff';
@@ -177,7 +178,6 @@ export default function WorkflowCopilotPanel({
   const textInputRef = useRef<HTMLTextAreaElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const isComposingTextRef = useRef(false);
-  const scrollRef = useRef<HTMLDivElement | null>(null);
 
   // Surface each NEW proposal to the host exactly once (enter preview overlay).
   const lastSurfacedRef = useRef<WorkflowProposal | null>(null);
@@ -312,11 +312,35 @@ export default function WorkflowCopilotPanel({
     onPrefillSeedConsumed?.();
   }, [prefillSeed, onPrefillSeedConsumed]);
 
-  // Keep the transcript pinned to the newest message / streamed activity.
-  // `scrollTo` is optional-chained: jsdom (tests) doesn't implement it.
+  // Keep the transcript pinned to the newest message / streamed activity —
+  // but ONLY while the user is already at (or near) the bottom. The previous
+  // implementation here was an unconditional `scrollTo(bottom)` effect keyed
+  // on every streaming dependency (messages, tool timeline, live text, …):
+  // it fired on every streamed token and force-scrolled regardless of where
+  // the user was reading, which is what made the transcript feel "stuck" —
+  // any attempt to scroll up got yanked back down by the very next token.
+  // `useStickToBottom` is the same pinning hook the main chat surfaces use:
+  // it only auto-scrolls while `stickingRef` is true (user at/near bottom),
+  // and permanently disengages the moment the user scrolls away, so reading
+  // history is never fought. `resetKey` is a stable constant here — this
+  // panel is fully unmounted/remounted on close/reopen (see the seed refs
+  // above), so there's no in-place "navigation" case to reset for.
+  const { containerRef: scrollRef } = useStickToBottom(
+    displayMessages,
+    threadId,
+    'workflow-copilot'
+  );
   useEffect(() => {
-    scrollRef.current?.scrollTo?.({ top: scrollRef.current.scrollHeight });
-  }, [displayMessages, sending, proposal, toolTimeline, liveResponse]);
+    log(
+      'scroll: stick-to-bottom deps changed messages=%d thread=%s sending=%s hasProposal=%s timeline=%d liveTextLen=%d',
+      displayMessages.length,
+      threadId ?? 'null',
+      sending,
+      Boolean(proposal),
+      toolTimeline.length,
+      liveResponse.length
+    );
+  }, [displayMessages, threadId, sending, proposal, toolTimeline, liveResponse]);
 
   const submit = useCallback(
     async (raw?: string) => {

--- a/app/src/hooks/useStickToBottom.test.ts
+++ b/app/src/hooks/useStickToBottom.test.ts
@@ -1,0 +1,153 @@
+import { fireEvent, render } from '@testing-library/react';
+import { createElement } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { isNearBottom, useStickToBottom } from './useStickToBottom';
+
+/**
+ * jsdom performs no real layout, so `scrollHeight`/`clientHeight`/`scrollTop`
+ * are inert (always 0) unless we define them ourselves. This gives the
+ * container concrete, mutable scroll metrics so `isNearBottom` and
+ * `snapToBottom` (inside the hook) behave exactly as they would in a real
+ * browser for the geometry each test sets up.
+ */
+function mockScrollMetrics(
+  el: HTMLElement,
+  metrics: { scrollTop: number; scrollHeight: number; clientHeight: number }
+) {
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, value: metrics.scrollHeight });
+  Object.defineProperty(el, 'clientHeight', { configurable: true, value: metrics.clientHeight });
+  Object.defineProperty(el, 'scrollTop', {
+    configurable: true,
+    writable: true,
+    value: metrics.scrollTop,
+  });
+}
+
+interface HarnessProps {
+  messages: unknown[];
+  threadKey: string | null;
+  resetKey: string;
+}
+
+/** Minimal host component — the hook never touches the DOM directly, callers
+ * wire `containerRef` onto their own scroll container. */
+function Harness({ messages, threadKey, resetKey }: HarnessProps) {
+  const { containerRef } = useStickToBottom(messages, threadKey, resetKey);
+  return createElement(
+    'div',
+    { ref: containerRef, 'data-testid': 'scroll-container' },
+    messages.map((m, i) => createElement('div', { key: i }, String(m)))
+  );
+}
+
+describe('useStickToBottom', () => {
+  it('is a pure, independently-testable is-at-bottom check', () => {
+    // Exactly at the default 80px threshold: still "at bottom".
+    expect(
+      isNearBottom({ scrollHeight: 180, scrollTop: 100, clientHeight: 80 } as HTMLElement)
+    ).toBe(true);
+    // One pixel past the threshold (distance = 181 - 20 - 80 = 81): no
+    // longer "at bottom".
+    expect(
+      isNearBottom({ scrollHeight: 181, scrollTop: 20, clientHeight: 80 } as HTMLElement)
+    ).toBe(false);
+    // A custom threshold is honoured.
+    expect(
+      isNearBottom({ scrollHeight: 300, scrollTop: 100, clientHeight: 80 } as HTMLElement, 200)
+    ).toBe(true);
+  });
+
+  it('auto-scrolls to the newest content when the user is already pinned to the bottom', () => {
+    const { getByTestId, rerender } = render(
+      createElement(Harness, { messages: ['first'], threadKey: 't1', resetKey: 'k' })
+    );
+    const container = getByTestId('scroll-container');
+
+    // Establish "at the bottom" after the initial (always-snaps) mount.
+    mockScrollMetrics(container, { scrollTop: 50, scrollHeight: 100, clientHeight: 50 });
+    rerender(createElement(Harness, { messages: ['first'], threadKey: 't1', resetKey: 'k' }));
+
+    // A new message arrives — content grows (scrollHeight increases) while
+    // the user never moved away from the bottom. Because `stickingRef` is
+    // still true, the layout effect must snap to the new bottom.
+    mockScrollMetrics(container, { scrollTop: 50, scrollHeight: 300, clientHeight: 50 });
+    rerender(
+      createElement(Harness, { messages: ['first', 'second'], threadKey: 't1', resetKey: 'k' })
+    );
+
+    expect(container.scrollTop).toBe(300);
+  });
+
+  it('does NOT auto-scroll (respects the user reading history) once they scroll away from the bottom', () => {
+    const { getByTestId, rerender } = render(
+      createElement(Harness, { messages: ['first'], threadKey: 't1', resetKey: 'k' })
+    );
+    const container = getByTestId('scroll-container');
+
+    mockScrollMetrics(container, { scrollTop: 50, scrollHeight: 100, clientHeight: 50 });
+    rerender(createElement(Harness, { messages: ['first'], threadKey: 't1', resetKey: 'k' }));
+
+    // The user scrolls up, well past the stick threshold (400 - 0 - 50 =
+    // 350px from the bottom) — the `scroll` listener must disengage sticking.
+    mockScrollMetrics(container, { scrollTop: 0, scrollHeight: 400, clientHeight: 50 });
+    fireEvent.scroll(container);
+
+    // A new message arrives (content grows further) while the user is still
+    // reading up top. This is exactly the bug being fixed: the old
+    // unconditional `scrollTo` effect would yank the user back down here —
+    // the container must stay exactly where the reader left it.
+    mockScrollMetrics(container, { scrollTop: 0, scrollHeight: 700, clientHeight: 50 });
+    rerender(
+      createElement(Harness, { messages: ['first', 'second'], threadKey: 't1', resetKey: 'k' })
+    );
+
+    expect(container.scrollTop).toBe(0);
+  });
+
+  it('re-engages sticking once the user manually scrolls back to the bottom', () => {
+    const { getByTestId, rerender } = render(
+      createElement(Harness, { messages: ['first'], threadKey: 't1', resetKey: 'k' })
+    );
+    const container = getByTestId('scroll-container');
+
+    mockScrollMetrics(container, { scrollTop: 50, scrollHeight: 100, clientHeight: 50 });
+    rerender(createElement(Harness, { messages: ['first'], threadKey: 't1', resetKey: 'k' }));
+
+    // Scroll away (350px from bottom — well past the threshold).
+    mockScrollMetrics(container, { scrollTop: 0, scrollHeight: 400, clientHeight: 50 });
+    fireEvent.scroll(container);
+
+    // Scroll back within the threshold (400 - 350 - 50 = 0px from bottom).
+    mockScrollMetrics(container, { scrollTop: 350, scrollHeight: 400, clientHeight: 50 });
+    fireEvent.scroll(container);
+
+    // A new message now DOES pull the view down again.
+    mockScrollMetrics(container, { scrollTop: 350, scrollHeight: 600, clientHeight: 50 });
+    rerender(
+      createElement(Harness, { messages: ['first', 'second'], threadKey: 't1', resetKey: 'k' })
+    );
+
+    expect(container.scrollTop).toBe(600);
+  });
+
+  it('always snaps on a thread change, even mid-read (a fresh conversation should open at the bottom)', () => {
+    const { getByTestId, rerender } = render(
+      createElement(Harness, { messages: ['a1'], threadKey: 'thread-a', resetKey: 'k' })
+    );
+    const container = getByTestId('scroll-container');
+    mockScrollMetrics(container, { scrollTop: 50, scrollHeight: 100, clientHeight: 50 });
+    rerender(createElement(Harness, { messages: ['a1'], threadKey: 'thread-a', resetKey: 'k' }));
+
+    // Scroll away on thread A.
+    mockScrollMetrics(container, { scrollTop: 0, scrollHeight: 400, clientHeight: 50 });
+    fireEvent.scroll(container);
+
+    // Switch to a different thread entirely — must snap regardless of the
+    // stale `stickingRef` from thread A.
+    mockScrollMetrics(container, { scrollTop: 0, scrollHeight: 250, clientHeight: 50 });
+    rerender(createElement(Harness, { messages: ['b1'], threadKey: 'thread-b', resetKey: 'k' }));
+
+    expect(container.scrollTop).toBe(250);
+  });
+});

--- a/app/src/hooks/useStickToBottom.ts
+++ b/app/src/hooks/useStickToBottom.ts
@@ -1,3 +1,4 @@
+import createDebug from 'debug';
 import { useEffect, useLayoutEffect, useRef } from 'react';
 
 /**
@@ -17,12 +18,23 @@ import { useEffect, useLayoutEffect, useRef } from 'react';
  * If the user manually scrolls up past the threshold we stop sticking, so they
  * can read history without being yanked down. Scrolling back to the bottom
  * re-engages stickiness on the next render.
+ *
+ * Root-cause note (copilot "chat gets stuck" bug): a naive `useEffect` that
+ * unconditionally calls `scrollTo(bottom)` on every dependency change (new
+ * message, streamed token, tool-timeline entry, …) fights a user who has
+ * scrolled up to read — it snaps them back down mid-read, which reads as the
+ * scroll container "locking up". This hook is the fix for that pattern:
+ * auto-scroll only fires while `stickingRef` is true (i.e. the user was
+ * already at/near the bottom), so scrolling up always disengages it.
  */
+
+const log = createDebug('app:hooks:stick-to-bottom');
 
 const STICK_THRESHOLD_PX = 80;
 
-function isNearBottom(el: HTMLElement): boolean {
-  return el.scrollHeight - el.scrollTop - el.clientHeight <= STICK_THRESHOLD_PX;
+/** Pure, independently-testable "is this container at/near the bottom?" check. */
+export function isNearBottom(el: HTMLElement, thresholdPx: number = STICK_THRESHOLD_PX): boolean {
+  return el.scrollHeight - el.scrollTop - el.clientHeight <= thresholdPx;
 }
 
 function snapToBottom(el: HTMLElement) {
@@ -42,6 +54,12 @@ export function useStickToBottom(
   // Tracks whether we should keep auto-scrolling. Flips to false when the user
   // scrolls up away from the bottom; flips back when they return.
   const stickingRef = useRef(true);
+  // Mirrors `threadKey` for the mount-only resize-observer effect's log lines
+  // below — kept current every render so the logs stay accurate even though
+  // that effect itself intentionally doesn't re-run on a thread change (the
+  // MutationObserver already re-binds the ResizeObserver on subtree swaps).
+  const threadKeyRef = useRef(threadKey);
+  threadKeyRef.current = threadKey;
 
   // ── Snap on message / thread / route changes ─────────────────────────────
   useLayoutEffect(() => {
@@ -51,18 +69,40 @@ export function useStickToBottom(
     }
     // Record the active thread on every render (including empty ones) so
     // the A → empty B → A navigation pattern is recognised as a thread
-    // change when A's messages re-arrive.
+    // change when A's messages re-arrive. Normalize `undefined` to `null`
+    // on BOTH sides of the comparison below — comparing the normalized
+    // previous value against a raw `threadKey` that happens to be
+    // `undefined` (rather than `null`) would make `threadChanged` true on
+    // every single run (`null !== undefined`), forcing an unwanted snap on
+    // every re-render for any caller whose "no thread yet" state is
+    // `undefined` instead of `null`. The param type explicitly allows
+    // `undefined`, so this normalization has to be symmetric.
     const previousThread = lastScrolledThreadRef.current;
-    lastScrolledThreadRef.current = threadKey ?? null;
+    const normalizedThreadKey = threadKey ?? null;
+    lastScrolledThreadRef.current = normalizedThreadKey;
     if (messages.length === 0) return;
     const container = containerRef.current;
     if (!container) return;
 
-    const threadChanged = previousThread !== threadKey;
+    const threadChanged = previousThread !== normalizedThreadKey;
     const firstScroll = !didInitialScrollRef.current;
     if (firstScroll || threadChanged || stickingRef.current) {
+      log(
+        'layout-effect: snap fired (firstScroll=%s threadChanged=%s sticking=%s) count=%d thread=%s',
+        firstScroll,
+        threadChanged,
+        stickingRef.current,
+        messages.length,
+        normalizedThreadKey ?? 'null'
+      );
       snapToBottom(container);
       stickingRef.current = true;
+    } else {
+      log(
+        'layout-effect: snap skipped (user scrolled up) count=%d thread=%s',
+        messages.length,
+        normalizedThreadKey ?? 'null'
+      );
     }
     didInitialScrollRef.current = true;
   }, [messages, threadKey, resetKey]);
@@ -72,7 +112,11 @@ export function useStickToBottom(
     const container = containerRef.current;
     if (!container) return;
     const onScroll = () => {
-      stickingRef.current = isNearBottom(container);
+      const atBottom = isNearBottom(container);
+      if (atBottom !== stickingRef.current) {
+        log('scroll: sticking %s -> %s (isNearBottom=%s)', stickingRef.current, atBottom, atBottom);
+      }
+      stickingRef.current = atBottom;
     };
     container.addEventListener('scroll', onScroll, { passive: true });
     return () => container.removeEventListener('scroll', onScroll);
@@ -91,7 +135,13 @@ export function useStickToBottom(
 
     const resizeObserver = new ResizeObserver(() => {
       if (stickingRef.current) {
+        log('resize-observer: snap fired (sticking) thread=%s', threadKeyRef.current ?? 'null');
         snapToBottom(container);
+      } else {
+        log(
+          'resize-observer: snap skipped (user scrolled up) thread=%s',
+          threadKeyRef.current ?? 'null'
+        );
       }
     });
 


### PR DESCRIPTION
## Summary

- Fixes a bug where the Workflows canvas copilot chat becomes un-scrollable / "gets stuck". Root cause: `WorkflowCopilotPanel`'s transcript had an unconditional `scrollTo(bottom)` effect keyed on every streaming dependency (`displayMessages`, `sending`, `proposal`, `toolTimeline`, `liveResponse`) — it fired on every streamed token and force-scrolled to the bottom regardless of where the user was reading, so any attempt to scroll up mid-turn got yanked back down by the very next token.
- Delegates the copilot transcript to the existing shared `useStickToBottom` hook (`app/src/hooks/useStickToBottom.ts`) — the same pinning logic the main chat surfaces (`Conversations.tsx`, `AgentChatPanel.tsx`) already use. It only auto-scrolls while the user is at/near the bottom and permanently disengages the moment they scroll away (re-engaging once they scroll back within the threshold).
- While reproducing the fix with an accurate `threadKey` value in tests, found and fixed a latent bug in `useStickToBottom` itself: `lastScrolledThreadRef.current` normalizes `undefined` → `null`, but the `threadChanged` comparison compared that normalized value against the *raw* `threadKey` — so any caller whose thread id was genuinely `undefined` (rather than `null`) got `threadChanged === true` on **every** render, forcing an unwanted snap regardless of scroll position. Fixed by normalizing both sides of the comparison.
- Added verbose, namespaced debug logging (`debug('app:hooks:stick-to-bottom')`) at the scroll decision points (layout-effect snap fired/skipped, scroll-driven sticking toggle, resize-observer snap fired/skipped) per the project's debug-logging convention, plus a lightweight `debug('app:flows:copilot-panel')` log at the panel's scroll-dependency-changed point.
- Exported `isNearBottom` from the hook as a small, independently-testable pure helper (`el, thresholdPx? -> boolean`).

## Root cause

`app/src/components/flows/WorkflowCopilotPanel.tsx` (previously around line 315-319):

```tsx
useEffect(() => {
  scrollRef.current?.scrollTo?.({ top: scrollRef.current.scrollHeight });
}, [displayMessages, sending, proposal, toolTimeline, liveResponse]);
```

This force-scrolled to the bottom on every render triggered by any streaming dependency, with no check for whether the user had scrolled away — the exact anti-pattern that makes a chat transcript feel "stuck" while the agent is talking.

## Files changed

- `app/src/components/flows/WorkflowCopilotPanel.tsx` — swap the manual scroll effect for `useStickToBottom`; add scroll-decision debug logging.
- `app/src/hooks/useStickToBottom.ts` — add debug logging at all three scroll-decision points; export `isNearBottom` as a testable pure helper; fix the `threadKey` `null`/`undefined` normalization bug in the `threadChanged` check.
- `app/src/hooks/useStickToBottom.test.ts` (new) — unit tests: pure `isNearBottom` boundary behavior; auto-scrolls when pinned + new content arrives; does NOT auto-scroll once the user scrolls away; re-engages sticking on scroll-back; always snaps on a thread change.
- `app/src/components/flows/WorkflowCopilotPanel.test.tsx` — new `transcript scroll pinning (#regression: chat gets stuck)` suite exercising the real (unmocked) hook through the actual panel: transcript stays `overflow-y-auto`, auto-scrolls when pinned + a new message arrives, does NOT force-scroll after the user scrolls up to read.

## Test plan

- [x] `corepack pnpm typecheck` — clean
- [x] `corepack pnpm lint` — 0 errors (pre-existing unrelated warnings only, none in changed files)
- [x] `corepack pnpm format` / `format:check` — clean
- [x] `corepack pnpm test --config app/test/vitest.config.ts app/src/hooks/useStickToBottom.test.ts app/src/components/flows/WorkflowCopilotPanel.test.tsx` — 41/41 passing
- [x] Full `app/src/components/flows/` suite (198 tests) — passing
- [x] Other `useStickToBottom` consumers (`AgentChatPanel.test.tsx`, `Conversations.render.test.tsx`) — passing, no regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow transcript scrolling so new messages keep the view at the bottom when already there.
  * Preserved the reader’s position when scrolling up to review earlier messages.
  * Re-engaged automatic scrolling when returning near the bottom of the transcript.
  * Ensured switching threads displays the latest content from the bottom.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->