### PR TITLE
fix(conversations): key the proactive-thread insights fallback (disclosure state leak)

### DIFF
--- a/app/src/features/conversations/Conversations.tsx
+++ b/app/src/features/conversations/Conversations.tsx
@@ -2017,6 +2017,22 @@ const Conversations = ({
       </>
     ) : null;
 
+  // Standalone fallback slot (rendered once, below all messages) for the
+  // rare thread with no user message at all (e.g. a proactive-only run), so
+  // `agentInsights` is never unreachable. This slot sits at a fixed JSX
+  // position with no per-thread key of its own, so switching directly
+  // between two threads that both hit this fallback (e.g. two proactive-only
+  // threads) would otherwise reuse the same `ToolTimelineBlock` instance
+  // instead of remounting it — leaking its sticky `userOverrideOpen`
+  // disclosure state from the old thread into the new one (flagged in
+  // review on #4942). Keying on thread id forces a clean remount on every
+  // thread switch, matching the `key={msg.id}` pattern used for the in-flow
+  // timeline above.
+  const proactiveInsightsFallback = (() => {
+    if (lastUserMessageId) return null;
+    return <Fragment key={selectedThreadId ?? 'none'}>{agentInsights}</Fragment>;
+  })();
+
   const filteredThreads = useMemo(() => {
     return threads.filter(t => isThreadVisibleInTab(t, selectedLabel));
   }, [threads, selectedLabel]);
@@ -2695,26 +2711,11 @@ const Conversations = ({
               )}
             {/* The "Agentic task insights" panel is rendered inline *above* the
                 latest answer (right after the latest turn's user message) so
-                processing reads before the result. This fallback only fires for
-                the rare thread with no user message (e.g. a proactive-only
-                thread) so the recorded steps are never unreachable. The cancel
-                control + view-process-source opener now live in `agentInsights`
-                and the floating footer respectively (upstream relocated the
-                in-flow cancel button below the composer).
-
-                Keyed by `selectedThreadId`: this slot sits at a fixed JSX
-                position with no per-thread key of its own, so switching
-                directly between two threads that both hit this fallback (e.g.
-                two proactive-only threads) would otherwise reuse the same
-                `ToolTimelineBlock` instance instead of remounting it — leaking
-                its sticky `userOverrideOpen` disclosure state from the old
-                thread into the new one (flagged in review on #4942). Keying
-                on thread id forces a clean remount on every thread switch,
-                matching the `key={msg.id}` pattern used for the in-flow
-                timeline above. */}
-            {!lastUserMessageId && (
-              <Fragment key={selectedThreadId ?? 'none'}>{agentInsights}</Fragment>
-            )}
+                processing reads before the result. `proactiveInsightsFallback`
+                (defined above, near `agentInsights`) covers the rare thread
+                with no user message at all — see its doc comment for the
+                per-thread keying that fix keeps this remount-safe. */}
+            {proactiveInsightsFallback}
             <div ref={messagesEndRef} />
           </div>
         ) : isNewWindow ? (

--- a/app/src/features/conversations/Conversations.tsx
+++ b/app/src/features/conversations/Conversations.tsx
@@ -2700,8 +2700,21 @@ const Conversations = ({
                 thread) so the recorded steps are never unreachable. The cancel
                 control + view-process-source opener now live in `agentInsights`
                 and the floating footer respectively (upstream relocated the
-                in-flow cancel button below the composer). */}
-            {!lastUserMessageId && agentInsights}
+                in-flow cancel button below the composer).
+
+                Keyed by `selectedThreadId`: this slot sits at a fixed JSX
+                position with no per-thread key of its own, so switching
+                directly between two threads that both hit this fallback (e.g.
+                two proactive-only threads) would otherwise reuse the same
+                `ToolTimelineBlock` instance instead of remounting it — leaking
+                its sticky `userOverrideOpen` disclosure state from the old
+                thread into the new one (flagged in review on #4942). Keying
+                on thread id forces a clean remount on every thread switch,
+                matching the `key={msg.id}` pattern used for the in-flow
+                timeline above. */}
+            {!lastUserMessageId && (
+              <Fragment key={selectedThreadId ?? 'none'}>{agentInsights}</Fragment>
+            )}
             <div ref={messagesEndRef} />
           </div>
         ) : isNewWindow ? (

--- a/app/src/pages/__tests__/Conversations.render.test.tsx
+++ b/app/src/pages/__tests__/Conversations.render.test.tsx
@@ -2379,6 +2379,71 @@ describe('Conversations — agent task insights panel anchoring (#3717 Bug 2)', 
     });
     expect(await screen.findByTestId('agent-task-insights')).toBeInTheDocument();
   });
+
+  it('remounts the standalone insights fallback (resetting its sticky disclosure) when switching between two proactive-only threads (#4944)', async () => {
+    // Neither thread has a user message (e.g. a proactive-only run), so the
+    // panel renders through the standalone fallback slot at the bottom of the
+    // message list — not the per-message anchor keyed by `msg.id` — which is
+    // the exact slot that previously had no key of its own.
+    const threadA = makeThread({ id: 'proactive-a', title: 'Proactive A' });
+    const threadB = makeThread({ id: 'proactive-b', title: 'Proactive B' });
+    mockGetThreads.mockResolvedValue({ threads: [threadA, threadB], count: 2 });
+
+    let store: ReturnType<typeof buildStore> | undefined;
+    await act(async () => {
+      store = await renderConversations({
+        thread: {
+          ...emptyThreadState,
+          threads: [threadA, threadB],
+          selectedThreadId: threadA.id,
+          messagesByThreadId: { [threadA.id]: [], [threadB.id]: [] },
+        },
+        socket: socketState('connected'),
+      });
+    });
+
+    // Thread A: a settled (non-running) timeline, so the group defaults to
+    // collapsed.
+    await act(async () => {
+      store!.dispatch(
+        setToolTimelineForThread({
+          threadId: threadA.id,
+          entries: [{ id: 'a-1', name: 'web_fetch', round: 1, status: 'success' }],
+        })
+      );
+    });
+
+    const panelA = await screen.findByTestId('agent-task-insights');
+    expect((panelA as HTMLDetailsElement).open).toBe(false);
+
+    // The user manually expands it — this is the sticky per-instance
+    // `userOverrideOpen` state from #4942 that must not leak across threads.
+    const summaryA = panelA.querySelector('summary');
+    expect(summaryA).not.toBeNull();
+    await act(async () => {
+      fireEvent.click(summaryA!);
+    });
+    expect((panelA as HTMLDetailsElement).open).toBe(true);
+
+    // Switch straight to a second proactive-only thread with its own settled
+    // timeline.
+    await act(async () => {
+      store!.dispatch(setSelectedThread(threadB.id));
+      store!.dispatch(
+        setToolTimelineForThread({
+          threadId: threadB.id,
+          entries: [{ id: 'b-1', name: 'send_email', round: 1, status: 'success' }],
+        })
+      );
+    });
+
+    const panelB = await screen.findByTestId('agent-task-insights');
+    // Keyed by `selectedThreadId ?? 'none'`: switching threads remounts the
+    // `ToolTimelineBlock` instead of reusing the same instance, so thread B's
+    // panel starts collapsed again rather than inheriting thread A's
+    // manually-opened disclosure state.
+    expect((panelB as HTMLDetailsElement).open).toBe(false);
+  });
 });
 
 describe('Conversations — open-session resume (View work)', () => {


### PR DESCRIPTION
## Summary

Follow-up to #4942 (merged). #4942 added a sticky `userOverrideOpen` to the "Agentic task insights" disclosure so it persists across turns. Codex flagged a state-leak on review; the general claim was overstated (the main timeline + past-turn trail are keyed via `<Fragment key={msg.id}>`, and `WorkflowCopilotPanel` is isolated via `<FlowEditor key={flow.id}>`), but there's a **real narrow gap**: the no-user-message fallback in `Conversations.tsx` (proactive-only threads) rendered `ToolTimelineBlock` at a fixed JSX position with **no key**, so switching between two proactive-only threads reused the same instance and leaked the disclosure open/collapse state.

## Fix

Key that fallback `ToolTimelineBlock` by `selectedThreadId ?? 'none'`, so each proactive thread gets its own instance (state resets on thread switch, consistent with the keyed main/past-turn paths).

## Testing

- `typecheck` clean; `ToolTimelineBlock.test.tsx` 37/37; `conversations` dir 233/233.

## Acceptance criteria

- [x] Insights disclosure state no longer leaks between two proactive-only threads
- [x] Keyed consistently with the main-timeline / past-turn paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent insights display when switching between conversation threads.
  * Prevented disclosure state from carrying over from one thread to another.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->