### PR TITLE
fix(conversations): add required seq to ToolTimelineEntry test fixtures (fixes red main, #4948)

### DIFF
--- a/app/src/pages/__tests__/Conversations.render.test.tsx
+++ b/app/src/pages/__tests__/Conversations.render.test.tsx
@@ -2411,7 +2411,7 @@ describe('Conversations — agent task insights panel anchoring (#3717 Bug 2)', 
       store!.dispatch(
         setToolTimelineForThread({
           threadId: threadA.id,
-          entries: [{ id: 'a-1', name: 'web_fetch', round: 1, status: 'success' }],
+          entries: [{ id: 'a-1', name: 'web_fetch', round: 1, seq: 0, status: 'success' }],
         })
       );
     });
@@ -2435,7 +2435,7 @@ describe('Conversations — agent task insights panel anchoring (#3717 Bug 2)', 
       store!.dispatch(
         setToolTimelineForThread({
           threadId: threadB.id,
-          entries: [{ id: 'b-1', name: 'send_email', round: 1, status: 'success' }],
+          entries: [{ id: 'b-1', name: 'send_email', round: 1, seq: 0, status: 'success' }],
         })
       );
     });


### PR DESCRIPTION
## Summary

- **`main` is currently RED** — the `Frontend Checks (quality, i18n, docs, coverage)` lane fails to typecheck, which hard-blocks every open PR. This restores it.
- Adds the now-required `seq: 0` field to the two `ToolTimelineEntry` test fixtures in `app/src/pages/__tests__/Conversations.render.test.tsx` (lines 2414 and 2438).
- Test-fixture-only change — **no production code and no behavior change**.

## Problem

`main` fails `tsc --noEmit` with two `TS2741` errors:

```
src/pages/__tests__/Conversations.render.test.tsx(2414,21): Property 'seq' is missing in type
  '{ id: string; name: string; round: number; status: string; }' but required in type 'ToolTimelineEntry'.
src/pages/__tests__/Conversations.render.test.tsx(2438,21): (same)
```

**Root cause — a semantic conflict between two individually-green PRs:**

- #4944 (`b48b62327`) added two new `ToolTimelineEntry` fixtures to `Conversations.render.test.tsx`.
- #4945 (`4a68fd727`) made `seq: number` **required** on `ToolTimelineEntry` (`app/src/store/chatRuntimeSlice.ts:286`) and updated 12 test files to add `seq` — but it was authored against a base predating #4944, so it never saw these two fixtures.

Both passed CI in isolation; once both landed on `main`, the two fixtures lack the newly-required `seq` and the typecheck lane breaks. Full writeup in #4948.

## Solution

- Added `seq: 0` to each of the two fixtures, placed after `round` and before `status` — matching #4945's own convention for every comparable single-entry fixture it updated (`timeline/selectors.test.ts`, `SubMascotLayer.test.tsx`, `ToolTimelineBlock.test.tsx`).
- **Repo-wide verification that #4945 didn't miss any others:** grepped every `ToolTimelineEntry`-shaped object literal in `app/src` and confirmed the only strictly-typed ones missing `seq` were these two. All other `round:`+`status:` literals surfaced by the sweep are either `as`-cast to a looser param type (`ChatRuntimeProvider.test.tsx`, `WorkflowCopilotPanel.test.tsx`) or belong to loosely-typed mock/snapshot fields, so they do not require `seq`. Definitively confirmed by a clean full `tsc --noEmit` after the fix (0 errors).

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — updates existing test fixtures so the suite compiles; no new behavior to cover.
- [x] **Diff coverage ≥ 80%** — changed lines are within existing, executed test bodies; N/A for new production lines (none added).
- [x] Coverage matrix updated — `N/A: test-fixture-only change, no feature rows affected`.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no feature behavior changed`.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: test-only`.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- **CI/build only.** Restores the `Frontend Checks` typecheck lane on `main`, unblocking every open PR (notably #4912, #4913, #4914, #4934).
- No runtime, platform, performance, security, migration, or compatibility impact — the change is confined to a `*.test.tsx` fixture.

## Related

- Closes: #4948
- Unblocks: #4912, #4913, #4914, #4934 (all blocked by red `main`)
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/GH-4948-tooltimeline-seq-fixtures`
- Commit SHA: `1e43cc4182d3643e59b37f46f38eb61767d9c89e`

### Validation Run

- [ ] `pnpm --filter openhuman-app format:check` — not run (two-line fixture edit; keys placed to match surrounding style).
- [x] `pnpm typecheck` — **passes clean** (0 errors); this is the exact lane that was red on `main`.
- [ ] Focused tests: not run locally (test-fixture-only, type-level fix); CI runs the affected suite.
- [ ] Rust fmt/check (if changed): N/A — no Rust changed.
- [ ] Tauri fmt/check (if changed): N/A — no Tauri changed.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none.
- User-visible effect: none — restores CI only.

### Parity Contract

- Legacy behavior preserved: yes — fixtures assert identical runtime behavior; only the required `seq` field was added.
- Guard/fallback/dispatch parity checks: N/A.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none.
- Canonical PR: this PR.
- Resolution: N/A.
