### PR TITLE
fix(tinyplace): handle DM to a non-contact gracefully (Closes #4921)

### DIFF
--- a/app/src/agentworld/pages/MessagingSection.test.tsx
+++ b/app/src/agentworld/pages/MessagingSection.test.tsx
@@ -135,6 +135,17 @@ vi.mock('../AgentWorldShell', () => ({
       stop: vi.fn().mockResolvedValue(undefined),
       list: vi.fn().mockResolvedValue({ streams: [] }),
     },
+    contacts: {
+      request: vi
+        .fn()
+        .mockResolvedValue({
+          agentId: 'resolved-crypto-id',
+          requester: 'test-agent',
+          status: 'pending',
+        }),
+      accept: vi.fn().mockResolvedValue(undefined),
+      block: vi.fn().mockResolvedValue(undefined),
+    },
   },
 }));
 
@@ -302,6 +313,56 @@ describe('DMs panel (E2E enabled)', () => {
     ).toBeInTheDocument();
     expect(screen.queryByText(/CoreRpcError/)).not.toBeInTheDocument();
     expect(screen.queryByText(/\/keys\//)).not.toBeInTheDocument();
+  });
+
+  test('surfaces a friendly not_a_contact message instead of the raw 403 body', async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiClient.messages.list).mockResolvedValue({ messages: [] });
+    vi.mocked(apiClient.signal.sendMessage).mockRejectedValueOnce(
+      new Error('CoreRpcError: HTTP 403: HTTP 403: /messages/send: not_a_contact')
+    );
+
+    render(<MessagingSection />);
+    const peerInput = screen.getByPlaceholderText(/Recipient @handle/);
+    await user.type(peerInput, 'peer456');
+    await user.click(screen.getByRole('button', { name: 'Open DM' }));
+
+    const composeInput = await screen.findByPlaceholderText(/Type a message/);
+    await user.type(composeInput, 'secret');
+    await user.click(screen.getByRole('button', { name: 'Send' }));
+
+    // Friendly, actionable copy — not the raw relay body.
+    expect(await screen.findByText(/until they're a contact/i)).toBeInTheDocument();
+    expect(screen.queryByText(/not_a_contact/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/HTTP 403/)).not.toBeInTheDocument();
+    // And the actionable affordance is offered.
+    expect(screen.getByTestId('dm-contact-request')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Send contact request' })).toBeInTheDocument();
+  });
+
+  test('the not_a_contact affordance sends a contact request and confirms it', async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiClient.messages.list).mockResolvedValue({ messages: [] });
+    vi.mocked(apiClient.signal.sendMessage).mockRejectedValueOnce(
+      new Error('CoreRpcError: HTTP 403: HTTP 403: /messages/send: not_a_contact')
+    );
+
+    render(<MessagingSection />);
+    const peerInput = screen.getByPlaceholderText(/Recipient @handle/);
+    await user.type(peerInput, 'peer456');
+    await user.click(screen.getByRole('button', { name: 'Open DM' }));
+
+    const composeInput = await screen.findByPlaceholderText(/Type a message/);
+    await user.type(composeInput, 'secret');
+    await user.click(screen.getByRole('button', { name: 'Send' }));
+
+    const requestButton = await screen.findByRole('button', { name: 'Send contact request' });
+    await user.click(requestButton);
+
+    // Requests the edge for the RESOLVED crypto id, then confirms in-place.
+    expect(vi.mocked(apiClient.contacts.request)).toHaveBeenCalledWith('resolved-crypto-id');
+    expect(await screen.findByText(/Contact request sent/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Send contact request' })).not.toBeInTheDocument();
   });
 
   test('normalizes the core mapped missing encrypted messaging setup error', async () => {

--- a/app/src/agentworld/pages/MessagingSection.tsx
+++ b/app/src/agentworld/pages/MessagingSection.tsx
@@ -10,7 +10,7 @@
  * E2E_MESSAGING_ENABLED gate so users can set up keys before 0C ships.
  */
 import debug from 'debug';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import ChipTabs from '../../components/layout/ChipTabs';
 import Button from '../../components/ui/Button';
@@ -1018,29 +1018,59 @@ interface DecryptedMessage {
   outgoing?: boolean;
 }
 
-function formatDirectMessageError(err: unknown, missingBundleMessage: string): string {
-  const message = String(err);
-  const rawBundle404 = /http\s*404/i.test(message) && /\/keys\/[^/\s]+\/bundle\b/i.test(message);
-  const mappedMissingBundle =
-    /recipient/i.test(message) &&
-    /not\s+set\s+up/i.test(message) &&
-    /encrypted\s+messaging/i.test(message);
-  if (rawBundle404 || mappedMissingBundle) {
-    log('[agentworld:dm] recipient key bundle missing');
-    return missingBundleMessage;
-  }
-  return message;
+/**
+ * Kind of DM send/refresh failure, so the UI can render an actionable
+ * affordance (e.g. a "Send contact request" button) instead of only a message.
+ * `generic` means we surfaced the raw backend string with no friendly mapping.
+ */
+type DmErrorKind = 'missing_bundle' | 'not_a_contact' | 'generic';
+
+interface DmErrorMessages {
+  missingBundle: string;
+  notAContact: string;
 }
 
-function useDirectMessages(peerId: string, missingBundleMessage: string) {
+/**
+ * Classify a DM error into a friendly, translated message plus a `kind` the UI
+ * can branch on. Both the raw-`404 /keys/…/bundle` case and the core-mapped
+ * "recipient has not set up encrypted messaging" case fold into `missing_bundle`.
+ * A relay `403 … not_a_contact` (see `map_err` in
+ * `src/openhuman/tinyplace/ops.rs`) is an *expected* rejection — the peer edge
+ * has to be accepted first — so we treat it like `wallet-not-configured`: a
+ * known, actionable state, never a raw error dump.
+ */
+function classifyDirectMessageError(
+  err: unknown,
+  messages: DmErrorMessages
+): { message: string; kind: DmErrorKind } {
+  const raw = String(err);
+  const rawBundle404 = /http\s*404/i.test(raw) && /\/keys\/[^/\s]+\/bundle\b/i.test(raw);
+  const mappedMissingBundle =
+    /recipient/i.test(raw) && /not\s+set\s+up/i.test(raw) && /encrypted\s+messaging/i.test(raw);
+  if (rawBundle404 || mappedMissingBundle) {
+    log('[agentworld:dm] recipient key bundle missing');
+    return { message: messages.missingBundle, kind: 'missing_bundle' };
+  }
+  // Relay surfaces the reason token as `…: not_a_contact`; also tolerate a
+  // spaced "not a contact" phrasing in case the body is ever humanized.
+  if (/not[_\s]?a[_\s]?contact/i.test(raw)) {
+    log('[agentworld:dm] send blocked: recipient is not a contact');
+    return { message: messages.notAContact, kind: 'not_a_contact' };
+  }
+  return { message: raw, kind: 'generic' };
+}
+
+function useDirectMessages(peerId: string, errorMessages: DmErrorMessages) {
   const [messages, setMessages] = useState<DecryptedMessage[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [errorKind, setErrorKind] = useState<DmErrorKind | null>(null);
   const [sending, setSending] = useState(false);
 
   const refresh = useCallback(async () => {
     setLoading(true);
     setError(null);
+    setErrorKind(null);
     try {
       const response = await apiClient.messages.list({ limit: 50 });
       const fromPeer = response.messages.filter(m => m.from === peerId);
@@ -1069,16 +1099,19 @@ function useDirectMessages(peerId: string, missingBundleMessage: string) {
         return merged.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
       });
     } catch (err) {
-      setError(formatDirectMessageError(err, missingBundleMessage));
+      const classified = classifyDirectMessageError(err, errorMessages);
+      setError(classified.message);
+      setErrorKind(classified.kind);
     } finally {
       setLoading(false);
     }
-  }, [missingBundleMessage, peerId]);
+  }, [errorMessages, peerId]);
 
   const send = useCallback(
     async (plaintext: string) => {
       setSending(true);
       setError(null);
+      setErrorKind(null);
       try {
         const result = await apiClient.signal.sendMessage({ recipient: peerId, plaintext });
         // Optimistically show our own message: the relay won't return it and we
@@ -1096,19 +1129,21 @@ function useDirectMessages(peerId: string, missingBundleMessage: string) {
         );
         await refresh();
       } catch (err) {
-        setError(formatDirectMessageError(err, missingBundleMessage));
+        const classified = classifyDirectMessageError(err, errorMessages);
+        setError(classified.message);
+        setErrorKind(classified.kind);
       } finally {
         setSending(false);
       }
     },
-    [missingBundleMessage, peerId, refresh]
+    [errorMessages, peerId, refresh]
   );
 
   useEffect(() => {
     void refresh();
   }, [refresh]);
 
-  return { messages, loading, error, sending, send, refresh };
+  return { messages, loading, error, errorKind, sending, send, refresh };
 }
 
 function ActiveDmView({
@@ -1123,14 +1158,49 @@ function ActiveDmView({
   setComposeText: (v: string) => void;
 }) {
   const { t } = useT();
-  const missingBundleMessage = t(
-    'agentworld.messaging.missingSignalBundle',
-    "This user hasn't enabled encrypted messaging yet. Ask them to open Agent World and enable secure DMs before sending a message."
+  // Memoized so its identity is stable across renders — `useDirectMessages`
+  // threads it into `refresh`/`send` (and the mount effect), so a fresh object
+  // every render would retrigger the refresh loop.
+  const errorMessages = useMemo(
+    () => ({
+      missingBundle: t(
+        'agentworld.messaging.missingSignalBundle',
+        "This user hasn't enabled encrypted messaging yet. Ask them to open Agent World and enable secure DMs before sending a message."
+      ),
+      notAContact: t(
+        'agentworld.messaging.notAContact',
+        "You can't message this person until they're a contact. Send a contact request and try again once they accept."
+      ),
+    }),
+    [t]
   );
-  const { messages, loading, error, sending, send } = useDirectMessages(
+  const { messages, loading, error, errorKind, sending, send } = useDirectMessages(
     peerId,
-    missingBundleMessage
+    errorMessages
   );
+
+  // Inline "Send contact request" affordance shown when a send is rejected
+  // because the recipient isn't an accepted contact yet.
+  const [contactRequest, setContactRequest] = useState<'idle' | 'sending' | 'sent' | 'failed'>(
+    'idle'
+  );
+  // Reset the affordance when the error clears or we switch peers, so a stale
+  // "sent" state never lingers over a fresh conversation.
+  useEffect(() => {
+    if (errorKind !== 'not_a_contact') setContactRequest('idle');
+  }, [errorKind, peerId]);
+  const sendContactRequest = useCallback(async () => {
+    setContactRequest('sending');
+    try {
+      log('[agentworld:dm] sending contact request to recipient');
+      await apiClient.contacts.request(peerId);
+      log('[agentworld:dm] contact request sent');
+      setContactRequest('sent');
+    } catch (err) {
+      log('[agentworld:dm] contact request failed: %s', String(err));
+      setContactRequest('failed');
+    }
+  }, [peerId]);
 
   const handleSend = useCallback(async () => {
     if (!composeText.trim()) return;
@@ -1168,7 +1238,41 @@ function ActiveDmView({
         {loading && messages.length === 0 ? (
           <p className="text-xs text-content-faint animate-pulse">Loading encrypted messages...</p>
         ) : null}
-        {error ? <p className="text-xs text-red-500">{error}</p> : null}
+        {error ? (
+          <div className="space-y-2" data-testid="dm-error">
+            <p className="text-xs text-red-500">{error}</p>
+            {errorKind === 'not_a_contact' ? (
+              <div data-testid="dm-contact-request">
+                {contactRequest === 'sent' ? (
+                  <p className="text-xs text-content-muted">
+                    {t(
+                      'agentworld.messaging.contactRequestSent',
+                      'Contact request sent. You can message them once they accept.'
+                    )}
+                  </p>
+                ) : (
+                  <Button
+                    variant="secondary"
+                    size="xs"
+                    disabled={contactRequest === 'sending'}
+                    onClick={() => void sendContactRequest()}>
+                    {contactRequest === 'sending'
+                      ? t('agentworld.messaging.contactRequestSending', 'Sending request…')
+                      : t('agentworld.messaging.sendContactRequest', 'Send contact request')}
+                  </Button>
+                )}
+                {contactRequest === 'failed' ? (
+                  <p className="mt-1 text-xs text-red-500">
+                    {t(
+                      'agentworld.messaging.contactRequestFailed',
+                      "Couldn't send the contact request. Please try again."
+                    )}
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
         {!loading && !error && messages.length === 0 ? (
           <div
             data-testid="dm-empty-state"

--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -7038,6 +7038,13 @@ const messages: TranslationMap = {
   'agentworld.jobs.applyModal.submitting': 'جارٍ التقديم…',
   'agentworld.messaging.missingSignalBundle':
     'لم يفعّل هذا المستخدم الرسائل المشفرة بعد. اطلب منه فتح Agent World وتفعيل الرسائل المباشرة الآمنة قبل إرسال رسالة.',
+  'agentworld.messaging.notAContact':
+    'لا يمكنك مراسلة هذا الشخص حتى يصبح جهة اتصال. أرسل طلب جهة اتصال وحاول مرة أخرى بعد قبوله.',
+  'agentworld.messaging.sendContactRequest': 'إرسال طلب جهة اتصال',
+  'agentworld.messaging.contactRequestSending': 'جارٍ إرسال الطلب…',
+  'agentworld.messaging.contactRequestSent': 'تم إرسال طلب جهة الاتصال. يمكنك مراسلته بعد قبوله.',
+  'agentworld.messaging.contactRequestFailed':
+    'تعذّر إرسال طلب جهة الاتصال. يُرجى المحاولة مرة أخرى.',
 
   // User-actionable runtime errors (#3931)
   'userErrors.title': 'إجراء مطلوب',

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -7204,6 +7204,13 @@ const messages: TranslationMap = {
   'agentworld.jobs.applyModal.submitting': 'আবেদন করা হচ্ছে…',
   'agentworld.messaging.missingSignalBundle':
     'এই ব্যবহারকারী এখনো এনক্রিপ্টেড মেসেজিং চালু করেননি। বার্তা পাঠানোর আগে তাকে Agent World খুলে নিরাপদ DM চালু করতে বলুন।',
+  'agentworld.messaging.notAContact':
+    'এই ব্যক্তি পরিচিতি না হওয়া পর্যন্ত আপনি তাকে বার্তা পাঠাতে পারবেন না। একটি পরিচিতি অনুরোধ পাঠান এবং তিনি গ্রহণ করার পর আবার চেষ্টা করুন।',
+  'agentworld.messaging.sendContactRequest': 'পরিচিতি অনুরোধ পাঠান',
+  'agentworld.messaging.contactRequestSending': 'অনুরোধ পাঠানো হচ্ছে…',
+  'agentworld.messaging.contactRequestSent':
+    'পরিচিতি অনুরোধ পাঠানো হয়েছে। তিনি গ্রহণ করলে আপনি তাকে বার্তা পাঠাতে পারবেন।',
+  'agentworld.messaging.contactRequestFailed': 'পরিচিতি অনুরোধ পাঠানো যায়নি। আবার চেষ্টা করুন।',
 
   // User-actionable runtime errors (#3931)
   'userErrors.title': 'পদক্ষেপ প্রয়োজন',

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -7415,6 +7415,14 @@ const messages: TranslationMap = {
   'agentworld.jobs.applyModal.submitting': 'Wird eingereicht…',
   'agentworld.messaging.missingSignalBundle':
     'Dieser Benutzer hat verschlüsselte Nachrichten noch nicht aktiviert. Bitte ihn, Agent World zu öffnen und sichere DMs zu aktivieren, bevor du eine Nachricht sendest.',
+  'agentworld.messaging.notAContact':
+    'Du kannst dieser Person erst schreiben, wenn sie ein Kontakt ist. Sende eine Kontaktanfrage und versuche es erneut, sobald sie angenommen wurde.',
+  'agentworld.messaging.sendContactRequest': 'Kontaktanfrage senden',
+  'agentworld.messaging.contactRequestSending': 'Anfrage wird gesendet…',
+  'agentworld.messaging.contactRequestSent':
+    'Kontaktanfrage gesendet. Sobald sie angenommen wird, kannst du schreiben.',
+  'agentworld.messaging.contactRequestFailed':
+    'Kontaktanfrage konnte nicht gesendet werden. Bitte versuche es erneut.',
 
   // User-actionable runtime errors (#3931)
   'userErrors.title': 'Aktion erforderlich',

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -7577,6 +7577,14 @@ const en: TranslationMap = {
   'agentworld.jobs.applyModal.submitting': 'Applying…',
   'agentworld.messaging.missingSignalBundle':
     "This user hasn't enabled encrypted messaging yet. Ask them to open Agent World and enable secure DMs before sending a message.",
+  'agentworld.messaging.notAContact':
+    "You can't message this person until they're a contact. Send a contact request and try again once they accept.",
+  'agentworld.messaging.sendContactRequest': 'Send contact request',
+  'agentworld.messaging.contactRequestSending': 'Sending request…',
+  'agentworld.messaging.contactRequestSent':
+    'Contact request sent. You can message them once they accept.',
+  'agentworld.messaging.contactRequestFailed':
+    "Couldn't send the contact request. Please try again.",
 
   // Code block chrome
   'codeBlock.copy': 'Copy',

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -7354,6 +7354,14 @@ const messages: TranslationMap = {
   'agentworld.jobs.applyModal.submitting': 'Enviando…',
   'agentworld.messaging.missingSignalBundle':
     'Este usuario aún no ha activado la mensajería cifrada. Pídele que abra Agent World y active los DM seguros antes de enviarle un mensaje.',
+  'agentworld.messaging.notAContact':
+    'No puedes enviar mensajes a esta persona hasta que sea un contacto. Envía una solicitud de contacto e inténtalo de nuevo cuando la acepte.',
+  'agentworld.messaging.sendContactRequest': 'Enviar solicitud de contacto',
+  'agentworld.messaging.contactRequestSending': 'Enviando solicitud…',
+  'agentworld.messaging.contactRequestSent':
+    'Solicitud de contacto enviada. Podrás enviarle mensajes cuando la acepte.',
+  'agentworld.messaging.contactRequestFailed':
+    'No se pudo enviar la solicitud de contacto. Inténtalo de nuevo.',
 
   // User-actionable runtime errors (#3931)
   'userErrors.title': 'Acción necesaria',

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -7388,6 +7388,14 @@ const messages: TranslationMap = {
   'agentworld.jobs.applyModal.submitting': 'Envoi en cours…',
   'agentworld.messaging.missingSignalBundle':
     "Cet utilisateur n'a pas encore activé la messagerie chiffrée. Demandez-lui d'ouvrir Agent World et d'activer les messages privés sécurisés avant d'envoyer un message.",
+  'agentworld.messaging.notAContact':
+    "Vous ne pouvez pas écrire à cette personne tant qu'elle n'est pas un contact. Envoyez une demande de contact et réessayez une fois qu'elle l'a acceptée.",
+  'agentworld.messaging.sendContactRequest': 'Envoyer une demande de contact',
+  'agentworld.messaging.contactRequestSending': 'Envoi de la demande…',
+  'agentworld.messaging.contactRequestSent':
+    "Demande de contact envoyée. Vous pourrez lui écrire une fois qu'elle l'aura acceptée.",
+  'agentworld.messaging.contactRequestFailed':
+    "Impossible d'envoyer la demande de contact. Veuillez réessayer.",
 
   // User-actionable runtime errors (#3931)
   'userErrors.title': 'Action requise',

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -7199,6 +7199,14 @@ const messages: TranslationMap = {
   'agentworld.jobs.applyModal.submitting': 'आवेदन हो रहा है…',
   'agentworld.messaging.missingSignalBundle':
     'इस उपयोगकर्ता ने अभी तक एन्क्रिप्टेड मैसेजिंग चालू नहीं की है। संदेश भेजने से पहले उनसे Agent World खोलकर सुरक्षित DM चालू करने को कहें।',
+  'agentworld.messaging.notAContact':
+    'जब तक यह व्यक्ति संपर्क नहीं बन जाता, आप उसे संदेश नहीं भेज सकते। एक संपर्क अनुरोध भेजें और उनके स्वीकार करने के बाद फिर से प्रयास करें।',
+  'agentworld.messaging.sendContactRequest': 'संपर्क अनुरोध भेजें',
+  'agentworld.messaging.contactRequestSending': 'अनुरोध भेजा जा रहा है…',
+  'agentworld.messaging.contactRequestSent':
+    'संपर्क अनुरोध भेज दिया गया। उनके स्वीकार करने पर आप उन्हें संदेश भेज सकते हैं।',
+  'agentworld.messaging.contactRequestFailed':
+    'संपर्क अनुरोध नहीं भेजा जा सका। कृपया फिर से प्रयास करें।',
 
   // User-actionable runtime errors (#3931)
   'userErrors.title': 'कार्रवाई आवश्यक',

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -7236,6 +7236,14 @@ const messages: TranslationMap = {
   'agentworld.jobs.applyModal.submitting': 'Melamar…',
   'agentworld.messaging.missingSignalBundle':
     'Pengguna ini belum mengaktifkan pesan terenkripsi. Minta mereka membuka Agent World dan mengaktifkan DM aman sebelum Anda mengirim pesan.',
+  'agentworld.messaging.notAContact':
+    'Anda tidak dapat mengirim pesan ke orang ini sampai menjadi kontak. Kirim permintaan kontak dan coba lagi setelah mereka menerimanya.',
+  'agentworld.messaging.sendContactRequest': 'Kirim permintaan kontak',
+  'agentworld.messaging.contactRequestSending': 'Mengirim permintaan…',
+  'agentworld.messaging.contactRequestSent':
+    'Permintaan kontak terkirim. Anda dapat mengirim pesan setelah mereka menerimanya.',
+  'agentworld.messaging.contactRequestFailed':
+    'Tidak dapat mengirim permintaan kontak. Silakan coba lagi.',
 
   // User-actionable runtime errors (#3931)
   'userErrors.title': 'Tindakan diperlukan',

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -7341,6 +7341,14 @@ const messages: TranslationMap = {
   'agentworld.jobs.applyModal.submitting': 'Candidatura in corso…',
   'agentworld.messaging.missingSignalBundle':
     'Questo utente non ha ancora attivato la messaggistica crittografata. Chiedigli di aprire Agent World e attivare i DM sicuri prima di inviare un messaggio.',
+  'agentworld.messaging.notAContact':
+    "Non puoi inviare messaggi a questa persona finché non è un contatto. Invia una richiesta di contatto e riprova dopo che l'ha accettata.",
+  'agentworld.messaging.sendContactRequest': 'Invia richiesta di contatto',
+  'agentworld.messaging.contactRequestSending': 'Invio della richiesta…',
+  'agentworld.messaging.contactRequestSent':
+    "Richiesta di contatto inviata. Potrai scrivere quando l'avrà accettata.",
+  'agentworld.messaging.contactRequestFailed':
+    'Impossibile inviare la richiesta di contatto. Riprova.',
 
   // User-actionable runtime errors (#3931)
   'userErrors.title': 'Azione necessaria',

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -7116,6 +7116,14 @@ const messages: TranslationMap = {
   'agentworld.jobs.applyModal.submitting': '지원 중…',
   'agentworld.messaging.missingSignalBundle':
     '이 사용자는 아직 암호화 메시지를 활성화하지 않았습니다. 메시지를 보내기 전에 Agent World를 열고 보안 DM을 활성화해 달라고 요청하세요.',
+  'agentworld.messaging.notAContact':
+    '이 사람이 연락처가 되기 전까지는 메시지를 보낼 수 없습니다. 연락처 요청을 보내고 상대방이 수락하면 다시 시도하세요.',
+  'agentworld.messaging.sendContactRequest': '연락처 요청 보내기',
+  'agentworld.messaging.contactRequestSending': '요청 보내는 중…',
+  'agentworld.messaging.contactRequestSent':
+    '연락처 요청을 보냈습니다. 상대방이 수락하면 메시지를 보낼 수 있습니다.',
+  'agentworld.messaging.contactRequestFailed':
+    '연락처 요청을 보내지 못했습니다. 다시 시도해 주세요.',
 
   // User-actionable runtime errors (#3931)
   'userErrors.title': '조치 필요',

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -7312,6 +7312,14 @@ const messages: TranslationMap = {
   'agentworld.jobs.applyModal.submitting': 'Wysyłanie…',
   'agentworld.messaging.missingSignalBundle':
     'Ten użytkownik nie włączył jeszcze szyfrowanych wiadomości. Poproś go, aby otworzył Agent World i włączył bezpieczne DM przed wysłaniem wiadomości.',
+  'agentworld.messaging.notAContact':
+    'Nie możesz napisać do tej osoby, dopóki nie stanie się kontaktem. Wyślij prośbę o kontakt i spróbuj ponownie, gdy ją zaakceptuje.',
+  'agentworld.messaging.sendContactRequest': 'Wyślij prośbę o kontakt',
+  'agentworld.messaging.contactRequestSending': 'Wysyłanie prośby…',
+  'agentworld.messaging.contactRequestSent':
+    'Prośba o kontakt wysłana. Będziesz mógł napisać, gdy ją zaakceptuje.',
+  'agentworld.messaging.contactRequestFailed':
+    'Nie udało się wysłać prośby o kontakt. Spróbuj ponownie.',
 
   // User-actionable runtime errors (#3931)
   'userErrors.title': 'Wymagane działanie',

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -7322,6 +7322,14 @@ const messages: TranslationMap = {
   'agentworld.jobs.applyModal.submitting': 'A enviar…',
   'agentworld.messaging.missingSignalBundle':
     'Este utilizador ainda não ativou as mensagens encriptadas. Peça-lhe para abrir o Agent World e ativar DMs seguras antes de enviar uma mensagem.',
+  'agentworld.messaging.notAContact':
+    'Não podes enviar mensagens a esta pessoa até ela ser um contacto. Envia um pedido de contacto e tenta novamente depois de ela aceitar.',
+  'agentworld.messaging.sendContactRequest': 'Enviar pedido de contacto',
+  'agentworld.messaging.contactRequestSending': 'A enviar pedido…',
+  'agentworld.messaging.contactRequestSent':
+    'Pedido de contacto enviado. Poderás enviar mensagens quando ela aceitar.',
+  'agentworld.messaging.contactRequestFailed':
+    'Não foi possível enviar o pedido de contacto. Tenta novamente.',
 
   // User-actionable runtime errors (#3931)
   'userErrors.title': 'Ação necessária',

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -7286,6 +7286,14 @@ const messages: TranslationMap = {
   'agentworld.jobs.applyModal.submitting': 'Отправка…',
   'agentworld.messaging.missingSignalBundle':
     'Этот пользователь еще не включил зашифрованные сообщения. Попросите его открыть Agent World и включить безопасные личные сообщения перед отправкой.',
+  'agentworld.messaging.notAContact':
+    'Вы не можете писать этому человеку, пока он не станет контактом. Отправьте запрос в контакты и повторите попытку после того, как он его примет.',
+  'agentworld.messaging.sendContactRequest': 'Отправить запрос в контакты',
+  'agentworld.messaging.contactRequestSending': 'Отправка запроса…',
+  'agentworld.messaging.contactRequestSent':
+    'Запрос в контакты отправлен. Вы сможете написать, когда он его примет.',
+  'agentworld.messaging.contactRequestFailed':
+    'Не удалось отправить запрос в контакты. Попробуйте ещё раз.',
 
   // User-actionable runtime errors (#3931)
   'userErrors.title': 'Требуется действие',

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -6809,6 +6809,12 @@ const messages: TranslationMap = {
   'agentworld.jobs.applyModal.submitting': '申请中…',
   'agentworld.messaging.missingSignalBundle':
     '此用户尚未启用加密消息。发送消息前，请让对方打开 Agent World 并启用安全私信。',
+  'agentworld.messaging.notAContact':
+    '在对方成为联系人之前，你无法向其发送消息。请发送联系人请求，待对方接受后再试。',
+  'agentworld.messaging.sendContactRequest': '发送联系人请求',
+  'agentworld.messaging.contactRequestSending': '正在发送请求…',
+  'agentworld.messaging.contactRequestSent': '联系人请求已发送。对方接受后你即可发送消息。',
+  'agentworld.messaging.contactRequestFailed': '无法发送联系人请求，请重试。',
 
   // User-actionable runtime errors (#3931)
   'userErrors.title': '需要操作',


### PR DESCRIPTION
## Summary

- Agent World DMs to a peer who isn't an accepted contact now show a friendly, actionable message instead of the raw `HTTP 403 … not_a_contact` relay body.
- Added an inline **Send contact request** button in the DM view that calls `apiClient.contacts.request(peerId)`, with in-place sending / sent / failed feedback.
- Classified `not_a_contact` as an *expected* rejection in `classifyDirectMessageError`, mirroring the existing "wallet-not-configured is an expected error" precedent.
- New `agentworld.messaging.*` i18n keys added to `en.ts` and all 13 locale files (no em dashes in values).
- Regression tests cover both the friendly-message mapping and the contact-request action.

## Problem

Sending a DM to a peer with no accepted contact edge returned a raw, un-actionable error string. `formatDirectMessageError` (`app/src/agentworld/pages/MessagingSection.tsx`) only mapped the 404 missing-key-bundle case; a relay `403 not_a_contact` fell through to `return String(err)`, so the UI showed e.g. `CoreRpcError: HTTP 403: … not_a_contact` verbatim. The backend surfaces the reason token via `map_err` in `src/openhuman/tinyplace/ops.rs:71` as `"{e}: not_a_contact"`. This left the #4776 §3 audit checkbox *"403 not_a_contact error handled gracefully"* unsatisfied. PR #4773 fixed a different orchestration agent-link path, not the interactive DM UX.

## Solution

- Replaced `formatDirectMessageError` with `classifyDirectMessageError`, which returns `{ message, kind }` where `kind ∈ { missing_bundle, not_a_contact, generic }`. It matches the `not_a_contact` token (tolerating a spaced "not a contact" phrasing) and returns the friendly translated copy.
- `useDirectMessages` now tracks `errorKind` alongside `error` and clears both on each refresh/send.
- `ActiveDmView` renders the **Send contact request** affordance only when `errorKind === 'not_a_contact'`, wired to `apiClient.contacts.request`. The error-message object is `useMemo`-stabilized so the hook's `refresh`/`send` callbacks (and the mount effect) don't re-fire every render.
- Debug logs use grep-friendly `[agentworld:dm]` prefixes and never log the peer id / any PII.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — two new Vitest cases: friendly-message mapping (no raw `not_a_contact`/`HTTP 403` leaks) and the contact-request action.
- [x] **Diff coverage ≥ 80%** — changed lines are frontend-only and exercised by the new tests. `pnpm test:coverage` not run locally (machine constraint); CI enforces the gate.
- [x] Coverage matrix updated — `N/A: behaviour-only bugfix, no new feature row.`
- [x] All affected feature IDs from the matrix are listed under `## Related`.
- [x] No new external network dependencies introduced — uses existing `apiClient.contacts.request` RPC; tests mock the client.
- [x] Manual smoke checklist updated — `N/A: does not touch a release-cut surface.`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- Desktop UI only (Agent World → Messages → DMs). No Rust/core, schema, or network changes.
- No migration or security implications. Strictly improves error UX; the `generic` branch preserves prior behavior for all other errors.

## Related

- Closes: #4921
- Part of #4776 (§3 Messages/DMs audit).
- Follow-up PR(s)/TODOs: none.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/GH-4921-tinyplace-dm-403`
- Commit SHA: `05d45641574bbde61e352bbf1c57264118a6767e`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — ran targeted `prettier --write` on touched files instead.
- [x] `pnpm typecheck` — passed clean.
- [x] Focused tests: two new cases in `app/src/agentworld/pages/MessagingSection.test.tsx` (not run locally; CI verifies).
- [x] Rust fmt/check (if changed): N/A — no Rust changes.
- [x] Tauri fmt/check (if changed): N/A — no Tauri changes.

### Validation Blocked

- `command:` `pnpm test:coverage` / `pnpm test`
- `error:` intentionally not run — local full test/build is disabled on this machine (fills disk).
- `impact:` CI is the authority for full test + coverage verification.

### Behavior Changes

- Intended behavior change: a DM to a non-contact shows friendly copy + a contact-request action instead of a raw 403 body.
- User-visible effect: actionable message and one-click **Send contact request** button in the DM view.

### Parity Contract

- Legacy behavior preserved: the missing-key-bundle mapping and all other errors (`generic`) are unchanged.
- Guard/fallback/dispatch parity checks: `classifyDirectMessageError` returns `generic` for any unmatched error, identical to the prior `return String(err)`.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none.
- Canonical PR: this.
- Resolution: N/A.

