### PR TITLE
fix(flows): resolve a non-owner Slack DM recipient via a lookup node

### DIFF
--- a/src/openhuman/flows/agents/workflow_builder/builder_prompt.rs
+++ b/src/openhuman/flows/agents/workflow_builder/builder_prompt.rs
@@ -404,37 +404,64 @@ mod tests {
         // Positive: non-owner DM resolution — the prompt must teach the
         // builder to resolve a NAMED recipient who is NOT the connected
         // owner via a lookup node, not just the owner's own
-        // `platform_user_id`.
+        // `platform_user_id`. This guidance must be PLATFORM-AGNOSTIC (no
+        // toolkit-specific slug hardcoded) — the same shape applies to
+        // Slack, Discord, Telegram, or any other messaging toolkit.
         assert!(
             STANDING_PROMPT.contains("is NOT the connected"),
             "standing prompt must teach the non-owner DM case explicitly"
         );
         assert!(
-            STANDING_PROMPT.contains("SLACK_FIND_USERS"),
-            "standing prompt must name SLACK_FIND_USERS as the non-owner DM \
-             lookup mechanism"
+            STANDING_PROMPT.contains("platform-agnostic"),
+            "standing prompt must state the non-owner DM guidance is \
+             platform-agnostic, not tied to one toolkit"
         );
         assert!(
-            STANDING_PROMPT.contains("config.args.email")
-                && STANDING_PROMPT.contains("exact_match"),
-            "standing prompt must instruct wiring SLACK_FIND_USERS's email + \
-             exact_match args for a safe single-match lookup"
+            STANDING_PROMPT.contains("search_tool_catalog { query, toolkit }"),
+            "standing prompt must teach resolving the lookup action via \
+             search_tool_catalog scoped to the TARGET toolkit, rather than \
+             hardcoding one platform's slug"
         );
         assert!(
-            STANDING_PROMPT.contains("SLACK_LIST_ALL_USERS"),
-            "standing prompt must keep the SLACK_LIST_ALL_USERS + filter \
-             fallback for when SLACK_FIND_USERS itself can't resolve a name"
+            STANDING_PROMPT.contains("tool_call` node upstream of the send"),
+            "standing prompt must teach wiring the lookup as a tool_call \
+             node upstream of the send node"
+        );
+        assert!(
+            STANDING_PROMPT.contains("resolves to exactly one match"),
+            "standing prompt must require a name search to resolve to \
+             exactly one match before binding it without asking"
         );
         assert!(
             STANDING_PROMPT.contains("ask the user to confirm which person"),
-            "standing prompt must preserve the safety rule: never DM an \
+            "standing prompt must preserve the safety rule: never message an \
              unverified same-name match, ask instead when ambiguous"
         );
         assert!(
-            STANDING_PROMPT.contains("lookup `tool_call` node"),
-            "standing prompt must teach that a non-owner DM recipient is \
-             resolved via an upstream lookup node, not an inferred arg"
+            STANDING_PROMPT.contains("Check the send action")
+                && STANDING_PROMPT.contains("open conversation"),
+            "standing prompt must teach checking the send tool's own contract \
+             for a required open-conversation step, handled generally via the \
+             contract rather than a single-platform special case"
         );
+
+        // Negative: none of the non-owner DM guidance may hardcode a
+        // toolkit-specific action slug or arg name — the reviewer flagged an
+        // earlier draft of this guidance as Slack-only, which violates the
+        // platform-agnostic rule.
+        for banned in [
+            "SLACK_FIND_USERS",
+            "SLACK_LIST_ALL_USERS",
+            "config.args.email",
+            "exact_match",
+        ] {
+            assert!(
+                !STANDING_PROMPT.contains(banned),
+                "standing prompt's non-owner DM guidance must not hardcode \
+                 the platform-specific `{banned}` — it must stay \
+                 platform-agnostic (any messaging toolkit)"
+            );
+        }
     }
 
     #[test]

--- a/src/openhuman/flows/agents/workflow_builder/builder_prompt.rs
+++ b/src/openhuman/flows/agents/workflow_builder/builder_prompt.rs
@@ -400,6 +400,41 @@ mod tests {
              ask the user for their member id in one question rather than \
              guessing a channel"
         );
+
+        // Positive: non-owner DM resolution — the prompt must teach the
+        // builder to resolve a NAMED recipient who is NOT the connected
+        // owner via a lookup node, not just the owner's own
+        // `platform_user_id`.
+        assert!(
+            STANDING_PROMPT.contains("is NOT the connected"),
+            "standing prompt must teach the non-owner DM case explicitly"
+        );
+        assert!(
+            STANDING_PROMPT.contains("SLACK_FIND_USERS"),
+            "standing prompt must name SLACK_FIND_USERS as the non-owner DM \
+             lookup mechanism"
+        );
+        assert!(
+            STANDING_PROMPT.contains("config.args.email")
+                && STANDING_PROMPT.contains("exact_match"),
+            "standing prompt must instruct wiring SLACK_FIND_USERS's email + \
+             exact_match args for a safe single-match lookup"
+        );
+        assert!(
+            STANDING_PROMPT.contains("SLACK_LIST_ALL_USERS"),
+            "standing prompt must keep the SLACK_LIST_ALL_USERS + filter \
+             fallback for when SLACK_FIND_USERS itself can't resolve a name"
+        );
+        assert!(
+            STANDING_PROMPT.contains("ask the user to confirm which person"),
+            "standing prompt must preserve the safety rule: never DM an \
+             unverified same-name match, ask instead when ambiguous"
+        );
+        assert!(
+            STANDING_PROMPT.contains("lookup `tool_call` node"),
+            "standing prompt must teach that a non-owner DM recipient is \
+             resolved via an upstream lookup node, not an inferred arg"
+        );
     }
 
     #[test]

--- a/src/openhuman/flows/agents/workflow_builder/prompt.md
+++ b/src/openhuman/flows/agents/workflow_builder/prompt.md
@@ -623,6 +623,32 @@ into exactly one bucket before you write the node:
      `#channel` name) — no need to ask. Only if `platform_user_id` is null
      for that connection, ask the user for their member id in ONE concise
      question rather than guessing a channel.
+   - "DM `<name>`" / "message `<name>`" where `<name>` is NOT the connected
+     owner (no matching `platform_user_id`) → you don't have their member id
+     up front, and guessing one is unsafe. Wire a **lookup `tool_call` node
+     upstream of the send** instead of asking immediately:
+     - Have (or can `memory_recall`) a verified **email**? Add a `tool_call`
+       on `SLACK_FIND_USERS` with `config.args.email` set and
+       `exact_match: true` — Slack's dedicated email lookup returns at most
+       one match, so it's safe to bind without asking.
+     - Only have a **name**? `SLACK_FIND_USERS` also takes `search_query`,
+       but a name search can return multiple people. Only bind it straight
+       through when it resolves to exactly one match; otherwise this is
+       bucket 3 — **ask the user to confirm which person / their email**
+       rather than DMing an unverified same-name match. Fall back to
+       `SLACK_LIST_ALL_USERS` + a downstream `transform`/`code` filter on
+       `email`/`display_name`/`real_name` only if `SLACK_FIND_USERS` itself
+       can't resolve it.
+     - Bind the resolved id into the send node's `channel` arg with an `=`
+       expression off the lookup node (`get_tool_contract` names the exact
+       output field; confirm with `dry_run_workflow` rather than guessing),
+       same as the owner path above.
+
+     Worked example — "every Monday at 9am, DM alan@acme.com his open
+     tickets": `trigger` (schedule, Mon 09:00) → `tool_call` `find_alan`
+     (`SLACK_FIND_USERS`, `{ "email": "alan@acme.com", "exact_match": true }`)
+     → `tool_call` fetching the tickets → `tool_call` `dm_alan`
+     (`SLACK_SEND_MESSAGE`, `channel: "=nodes.find_alan.item.json.data.<id_field>"`).
    - Exactly one connected account for the toolkit the step needs → that
      account (`list_flow_connections` / `composio_list_connections` tell
      you this; don't ask "which Gmail?" when there's only one).

--- a/src/openhuman/flows/agents/workflow_builder/prompt.md
+++ b/src/openhuman/flows/agents/workflow_builder/prompt.md
@@ -624,31 +624,47 @@ into exactly one bucket before you write the node:
      for that connection, ask the user for their member id in ONE concise
      question rather than guessing a channel.
    - "DM `<name>`" / "message `<name>`" where `<name>` is NOT the connected
-     owner (no matching `platform_user_id`) → you don't have their member id
-     up front, and guessing one is unsafe. Wire a **lookup `tool_call` node
-     upstream of the send** instead of asking immediately:
-     - Have (or can `memory_recall`) a verified **email**? Add a `tool_call`
-       on `SLACK_FIND_USERS` with `config.args.email` set and
-       `exact_match: true` — Slack's dedicated email lookup returns at most
-       one match, so it's safe to bind without asking.
-     - Only have a **name**? `SLACK_FIND_USERS` also takes `search_query`,
-       but a name search can return multiple people. Only bind it straight
-       through when it resolves to exactly one match; otherwise this is
-       bucket 3 — **ask the user to confirm which person / their email**
-       rather than DMing an unverified same-name match. Fall back to
-       `SLACK_LIST_ALL_USERS` + a downstream `transform`/`code` filter on
-       `email`/`display_name`/`real_name` only if `SLACK_FIND_USERS` itself
-       can't resolve it.
-     - Bind the resolved id into the send node's `channel` arg with an `=`
-       expression off the lookup node (`get_tool_contract` names the exact
-       output field; confirm with `dry_run_workflow` rather than guessing),
-       same as the owner path above.
+     owner (no matching `platform_user_id`) → you don't have their platform
+     user id up front, and guessing one is unsafe. This shape is
+     **platform-agnostic** — it applies the same way whether the
+     destination toolkit is Slack, Discord, Telegram, or any other
+     messaging app. Don't ask immediately — resolve it:
+     1. `search_tool_catalog { query, toolkit }` scoped to the TARGET
+        toolkit to find its user-lookup action — a "find user" / "lookup by
+        email" / "list users" style action, whatever that platform exposes
+        (never assume a slug across toolkits; always search for it).
+     2. Wire that lookup as a **`tool_call` node upstream of the send**.
+     3. Prefer an **email / exact lookup** when the platform offers one —
+        that's unambiguous, so bind its result directly with no question.
+        A **name search** can return multiple people: only bind it straight
+        through when it resolves to exactly one match; otherwise this is
+        bucket 3 — **ask the user to confirm which person / their email**
+        rather than messaging an unverified same-name match. If the
+        toolkit's lookup action can't resolve the person by name or email at
+        all, fall back to its "list users" style action plus a downstream
+        `transform`/`code` filter on an identifying field (email/display
+        name/etc).
+     4. Bind the resolved id into the send node's recipient arg with an `=`
+        expression off the lookup node — use `get_tool_contract` to find the
+        exact output field and confirm with `dry_run_workflow` rather than
+        guessing — same as the owner path above.
+     5. **Check the send action's own `get_tool_contract` for a required
+        "open conversation" step first.** Some messaging toolkits require
+        opening/creating a DM conversation for a user id before you can send
+        to it; others accept a user id as the recipient directly and
+        open/reuse the DM automatically. Never assume either way — if the
+        contract names a separate open/create-conversation action as a
+        prerequisite, wire that `tool_call` too, between the lookup and the
+        send.
 
-     Worked example — "every Monday at 9am, DM alan@acme.com his open
-     tickets": `trigger` (schedule, Mon 09:00) → `tool_call` `find_alan`
-     (`SLACK_FIND_USERS`, `{ "email": "alan@acme.com", "exact_match": true }`)
-     → `tool_call` fetching the tickets → `tool_call` `dm_alan`
-     (`SLACK_SEND_MESSAGE`, `channel: "=nodes.find_alan.item.json.data.<id_field>"`).
+     Worked example (illustrative, not tied to one platform) — "every
+     Monday at 9am, message alan@acme.com his open tickets": `trigger`
+     (schedule, Mon 09:00) → `tool_call` `find_alan` (the target toolkit's
+     user-lookup action, args grounded via `get_tool_contract`, e.g. an
+     `email` arg) → `tool_call` fetching the tickets → (an
+     open-conversation `tool_call` first, only if that toolkit's contract
+     requires one) → `tool_call` `dm_alan` (the toolkit's send action,
+     recipient arg bound to `=nodes.find_alan.item.json.data.<id_field>`).
    - Exactly one connected account for the toolkit the step needs → that
      account (`list_flow_connections` / `composio_list_connections` tell
      you this; don't ask "which Gmail?" when there's only one).


### PR DESCRIPTION
## Summary

The merged self-DM fix (#4933/#4941) surfaces the connected owner's own
`platform_user_id` on `list_flow_connections`, so "DM me" wires correctly.
But when the user asks the `workflow_builder` to DM **someone else** by
name or email (a teammate, "DM Alan Johnson"), the builder had no way to
resolve that person's Slack member id — no matching `platform_user_id`
exists for a non-owner, so it either nagged the user or built a broken
graph.

This is a **prompt-only** fix — no new Composio action, no new tool code.
`SLACK_FIND_USERS` and `SLACK_LIST_ALL_USERS` were already in the curated
Slack catalog (`src/openhuman/memory_sync/composio/providers/catalogs_messaging.rs`,
lines 12-15 and 28-31), which means they already come back `featured: true`
from `search_tool_catalog` and are fully discoverable — nothing to change
there.

### Resolution mechanism (confirmed against the real Composio contract)

I pulled the live Slack tool contracts from `tests/fixtures/composio_slack.json`
(a captured Composio catalog snapshot) to confirm the exact input shape
rather than guessing:

- **`SLACK_FIND_USERS` accepts an `email` parameter directly** — "This is a
  convenience parameter that automatically performs an email-based search."
  Paired with `exact_match: true`, this uses "Slack's dedicated email lookup
  endpoint" and returns at most one match, which is what makes it safe to
  bind into the send node without asking the user anything.
- `SLACK_FIND_USERS` also accepts `search_query` for a name-based search,
  but per its own description "Name-based queries can return multiple
  matches — verify exactly one user ID before passing to downstream tools."
  So a name-only ask is only auto-wired when it resolves to exactly one
  match; otherwise the builder must ask the user to confirm (bucket-3
  ambiguity), matching the existing "never DM an unverified same-name
  person" posture.
- `SLACK_LIST_ALL_USERS` + a downstream `transform`/`code` filter on
  `email`/`display_name`/`real_name` is documented as the fallback only for
  when `SLACK_FIND_USERS` itself can't resolve the person (e.g. a workspace
  that restricts email visibility) — `SLACK_FIND_USERS` explicitly
  recommends itself over the list+filter approach ("Prefer SLACK_FIND_USERS
  for targeted lookups").

### What changed

- `src/openhuman/flows/agents/workflow_builder/prompt.md` — extended the
  existing "to me / message me / DM me" bucket-2 guidance (added by #4933)
  with a new case: a named recipient who is **not** the connected owner.
  Teaches the builder to wire a `tool_call` lookup node
  (`SLACK_FIND_USERS { email, exact_match: true }`, or the
  `SLACK_LIST_ALL_USERS` + filter fallback for a name-only ask) upstream of
  the `SLACK_SEND_MESSAGE` node, then bind the resolved id into `channel`
  via an `=` expression — plus a concise worked example (schedule →
  find-user-by-email → send-DM). The existing owner `platform_user_id` fast
  path and the "ask when ambiguous" safety rule are both preserved verbatim.
- `src/openhuman/flows/agents/workflow_builder/builder_prompt.rs` —
  extended `standing_prompt_teaches_plain_language_and_readonly_memory`
  (the existing contract test for the standing prompt) with new positive
  assertions covering the non-owner case, the `SLACK_FIND_USERS`
  email/exact_match wiring, the `SLACK_LIST_ALL_USERS` fallback, and the
  ask-when-ambiguous safety rule — mirroring the style of the existing
  self-DM assertions from #4933.

### Deviations from the brief

- No catalog change was needed — both actions were already curated/featured,
  so the "only if the catalog genuinely lacks it" branch didn't apply.
- No new tool code — this is additive prompt guidance only, per the
  "prompt-first" instruction.

## Test plan

- [x] `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml` — clean
- [x] `GGML_NATIVE=OFF cargo test --lib openhuman::flows::` — 387 passed, 0
      failed, including the extended
      `builder_prompt::tests::standing_prompt_teaches_plain_language_and_readonly_memory`
- [x] `cargo fmt --manifest-path Cargo.toml` — clean (no other diffs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved direct-message workflow setup when recipients are specified by name, including platform-agnostic recipient lookup via available search tools.
  * Added safety to ensure lookups resolve to exactly one person before sending.
  * Added ambiguity handling: when multiple matches are found, the workflow asks the user to confirm (or use email) rather than sending.
  * Enhanced validation of the send step by checking its contract for any required “open conversation/create DM” prerequisite before sending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->