### PR TITLE
fix(memory): exclude same-session docs from recall so agents don't retrieve their own request

### DIFF
--- a/src/openhuman/agent/harness/session/turn/core.rs
+++ b/src/openhuman/agent/harness/session/turn/core.rs
@@ -585,8 +585,21 @@ impl Agent {
             let user_msg = user_message.to_string();
             let autosave_key = format!("user_msg:{}", uuid::Uuid::new_v4());
             let chars = user_msg.chars().count();
+            // Captured *before* `tokio::spawn` — the ambient thread id is a
+            // `tokio::task_local` (see `inference::provider::thread_context`)
+            // and does not propagate into a spawned task, so it must be read
+            // on this (still-scoped) task and moved in explicitly. Tagging
+            // this document with the live chat thread id is what lets the
+            // same-session exclusion filter (`UnifiedMemory::recall` /
+            // `memory_hybrid_search`) recognize and drop it later this same
+            // turn, so the agent's own on-demand memory search doesn't echo
+            // its own triggering request back as a "relevant" result.
+            let session_id_for_autosave =
+                crate::openhuman::inference::provider::thread_context::current_thread_id();
             log::debug!(
-                "[agent_autosave] enqueue user-message store key={autosave_key} chars={chars}"
+                "[agent_autosave] enqueue user-message store key={autosave_key} chars={chars} \
+                 session_id={}",
+                session_id_for_autosave.as_deref().unwrap_or("<none>")
             );
             tokio::spawn(async move {
                 match memory
@@ -595,7 +608,7 @@ impl Agent {
                         &autosave_key,
                         &user_msg,
                         MemoryCategory::Conversation,
-                        None,
+                        session_id_for_autosave.as_deref(),
                     )
                     .await
                 {

--- a/src/openhuman/memory_search/tools/hybrid_search.rs
+++ b/src/openhuman/memory_search/tools/hybrid_search.rs
@@ -146,8 +146,25 @@ impl Tool for MemoryHybridSearchTool {
         )
         .map_err(|e| anyhow::anyhow!("memory_hybrid_search: open store failed: {e}"))?;
 
+        // Self-echo guard (agent-agnostic, mirrors `UnifiedMemory::recall`):
+        // exclude documents auto-saved for the ambient chat thread (set by
+        // the web channel around the turn) so a search issued mid-turn
+        // never retrieves the very request that triggered it. `None`
+        // outside a chat turn — unchanged behavior for cron/CLI/tests.
+        let exclude_session_id =
+            crate::openhuman::inference::provider::thread_context::current_thread_id();
+        if let Some(ref excluded) = exclude_session_id {
+            log::debug!(
+                "[tool][memory_hybrid_search] applying same-session exclusion exclude_session_id={excluded}"
+            );
+        }
         let hits = memory
-            .query_namespace_hits(&parsed.namespace, &parsed.query, limit)
+            .query_namespace_hits_excluding_session(
+                &parsed.namespace,
+                &parsed.query,
+                limit,
+                exclude_session_id.as_deref(),
+            )
             .await
             .map_err(|e| anyhow::anyhow!("memory_hybrid_search: query failed: {e}"))?;
 

--- a/src/openhuman/memory_store/memory_trait.rs
+++ b/src/openhuman/memory_store/memory_trait.rs
@@ -133,8 +133,31 @@ impl Memory for UnifiedMemory {
     ) -> anyhow::Result<Vec<MemoryEntry>> {
         let namespace = normalize_namespace(opts.namespace);
 
+        // Self-echo guard (agent-agnostic): when this recall runs inside a
+        // live chat turn, the harness has an ambient "current thread" id
+        // (set by the web channel around `agent.run_single`, see
+        // `inference::provider::thread_context`) and the turn's own user
+        // message was just auto-saved as a `[conversation]` document tagged
+        // with that same id (`agent::harness::session::turn::core`). Exclude
+        // it here so the agent's own on-demand `memory_recall` never surfaces
+        // the very request that triggered it. Outside a chat turn (cron,
+        // CLI, tests, standalone) the ambient id is `None` and this is a
+        // no-op — behavior is byte-for-byte unchanged.
+        let exclude_session_id =
+            crate::openhuman::inference::provider::thread_context::current_thread_id();
+        if let Some(ref excluded) = exclude_session_id {
+            tracing::debug!(
+                "[memory-trait] recall applying same-session exclusion namespace={namespace} \
+                 exclude_session_id={excluded}"
+            );
+        }
         let ranked = self
-            .query_namespace_ranked(namespace, query, limit as u32)
+            .query_namespace_ranked_excluding_session(
+                namespace,
+                query,
+                limit as u32,
+                exclude_session_id.as_deref(),
+            )
             .await
             .map_err(anyhow::Error::msg)?;
 
@@ -890,6 +913,106 @@ mod tests {
         assert!(
             any_internal,
             "user-driven row must keep its Internal label so mixed contexts don't over-escalate"
+        );
+    }
+
+    // ── Same-session self-echo exclusion, via the ambient thread scope ────
+    //
+    // `Memory::recall` (backing the agent's `memory_recall` tool) reads the
+    // ambient chat-thread id set by `inference::provider::thread_context`
+    // around a live turn, and excludes documents tagged with that same id —
+    // guarding against the harness's own `user_msg:<uuid>` autosave being
+    // recalled as the top "relevant" result for the very request that
+    // triggered the search. See `agent::harness::session::turn::core`
+    // (autosave tagging) and `query::query_namespace_hits_excluding_session`
+    // (the exclusion mechanism).
+
+    #[tokio::test]
+    async fn recall_excludes_document_from_ambient_current_thread() {
+        use crate::openhuman::inference::provider::thread_context::with_thread_id;
+
+        let (_tmp, mem) = fresh_mem();
+        mem.store(
+            "global",
+            "user_msg:current-turn",
+            "Please look up Jordan Rivera's chat platform user ID for me.",
+            MemoryCategory::Conversation,
+            Some("thread-current"),
+        )
+        .await
+        .unwrap();
+        mem.store(
+            "global",
+            "fact:jordan-rivera-platform-id",
+            "Jordan Rivera's chat platform user ID is U0000042.",
+            MemoryCategory::Conversation,
+            Some("thread-other"),
+        )
+        .await
+        .unwrap();
+
+        let entries = with_thread_id("thread-current", async {
+            mem.recall(
+                "Jordan Rivera chat platform user ID",
+                10,
+                RecallOpts {
+                    namespace: Some("global"),
+                    min_score: Some(0.0),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap()
+        })
+        .await;
+
+        assert!(
+            !entries.iter().any(|e| e.key == "user_msg:current-turn"),
+            "recall inside the ambient current-thread scope must exclude that thread's own \
+             autosaved request, got {entries:#?}"
+        );
+        assert!(
+            entries
+                .iter()
+                .any(|e| e.key == "fact:jordan-rivera-platform-id"),
+            "an unrelated document from a different session must still be recalled, got {entries:#?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn recall_outside_any_thread_scope_is_unaffected() {
+        let (_tmp, mem) = fresh_mem();
+        mem.store(
+            "global",
+            "user_msg:current-turn",
+            "Please look up Jordan Rivera's chat platform user ID for me.",
+            MemoryCategory::Conversation,
+            Some("thread-current"),
+        )
+        .await
+        .unwrap();
+
+        // No `with_thread_id(...)` scope active — mirrors cron, CLI,
+        // standalone, and any pre-existing caller. `current_thread_id()`
+        // returns `None`, so no exclusion applies and behavior is
+        // byte-for-byte the same as before this fix.
+        let entries = mem
+            .recall(
+                "Jordan Rivera chat platform user ID",
+                10,
+                RecallOpts {
+                    namespace: Some("global"),
+                    min_score: Some(0.0),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            entries.iter().any(|e| e.key == "user_msg:current-turn"),
+            "with no ambient thread scope, recall must return the document exactly as before \
+             this fix, got {entries:#?}"
         );
     }
 }

--- a/src/openhuman/memory_store/unified/query.rs
+++ b/src/openhuman/memory_store/unified/query.rs
@@ -81,7 +81,23 @@ impl UnifiedMemory {
         query: &str,
         limit: u32,
     ) -> Result<Vec<NamespaceQueryResult>, String> {
-        let hits = self.query_namespace_hits(namespace, query, limit).await?;
+        self.query_namespace_ranked_excluding_session(namespace, query, limit, None)
+            .await
+    }
+
+    /// Same as [`Self::query_namespace_ranked`], but excludes same-session
+    /// documents — see [`Self::query_namespace_hits_excluding_session`] for
+    /// the exact semantics and backward-compatibility guarantee.
+    pub async fn query_namespace_ranked_excluding_session(
+        &self,
+        namespace: &str,
+        query: &str,
+        limit: u32,
+        exclude_session_id: Option<&str>,
+    ) -> Result<Vec<NamespaceQueryResult>, String> {
+        let hits = self
+            .query_namespace_hits_excluding_session(namespace, query, limit, exclude_session_id)
+            .await?;
         let mut out = Vec::new();
         for hit in hits {
             if hit.kind != MemoryItemKind::Document {
@@ -107,8 +123,49 @@ impl UnifiedMemory {
         query: &str,
         limit: u32,
     ) -> Result<Vec<NamespaceMemoryHit>, String> {
+        self.query_namespace_hits_excluding_session(namespace, query, limit, None)
+            .await
+    }
+
+    /// Same as [`Self::query_namespace_hits`], but drops any document-kind
+    /// hit whose stored `session_id` matches `exclude_session_id`.
+    ///
+    /// This is the self-echo guard for agent-invoked search (`memory_recall`,
+    /// `memory_hybrid_search`): the harness auto-saves the user's own turn as
+    /// a `[conversation]` document tagged with the ambient chat thread id
+    /// (see `agent::harness::session::turn::core`), so without this filter a
+    /// search issued *during that same turn* can retrieve its own triggering
+    /// request as the top "relevant" result. Only documents are
+    /// session-filtered — KV rows carry no session concept, and
+    /// episodic/event hits already have their own dedicated session-scoping
+    /// (`RecallOpts::session_id` / `cross_session`).
+    ///
+    /// `exclude_session_id = None` (or an empty/whitespace string) is
+    /// identical to [`Self::query_namespace_hits`] — no filtering is
+    /// applied, so every existing caller (and every caller with no ambient
+    /// session context) keeps its exact prior behavior.
+    pub async fn query_namespace_hits_excluding_session(
+        &self,
+        namespace: &str,
+        query: &str,
+        limit: u32,
+        exclude_session_id: Option<&str>,
+    ) -> Result<Vec<NamespaceMemoryHit>, String> {
         let ns = Self::sanitize_namespace(namespace);
-        let docs = self.load_documents_for_scope(&ns).await?;
+        let exclude_session_id = exclude_session_id
+            .map(str::trim)
+            .filter(|id| !id.is_empty());
+        let mut docs = self.load_documents_for_scope(&ns).await?;
+        if let Some(exclude) = exclude_session_id {
+            let before = docs.len();
+            docs.retain(|doc| doc.session_id.as_deref() != Some(exclude));
+            let dropped = before - docs.len();
+            tracing::debug!(
+                "[query] session-exclusion filter namespace={ns} exclude_session_id={exclude} \
+                 dropped={dropped} remaining={}",
+                docs.len()
+            );
+        }
         let kvs = self.kv_records_for_scope(&ns).await?;
 
         let graph_relations = self

--- a/src/openhuman/memory_store/unified/query_tests.rs
+++ b/src/openhuman/memory_store/unified/query_tests.rs
@@ -847,3 +847,154 @@ async fn recall_relevant_by_vector_gates_on_similarity() {
         "an unrelated message must surface no situational preferences"
     );
 }
+
+// ── Same-session self-echo exclusion (memory-search self-echo fix) ─────────
+//
+// Regression coverage for the workflow_builder self-echo bug: the harness
+// auto-saves the user's own turn as a `[conversation]` document tagged with
+// the live chat thread id, and without a filter a search issued mid-turn
+// could retrieve that very request as its own top "relevant" result. See
+// `UnifiedMemory::query_namespace_hits_excluding_session`.
+
+fn conversation_doc_with_session(
+    key: &str,
+    content: &str,
+    session_id: Option<&str>,
+) -> NamespaceDocumentInput {
+    NamespaceDocumentInput {
+        namespace: "global".to_string(),
+        key: key.to_string(),
+        title: key.to_string(),
+        content: content.to_string(),
+        source_type: "chat".to_string(),
+        priority: "medium".to_string(),
+        tags: vec![],
+        metadata: json!({}),
+        category: "conversation".to_string(),
+        session_id: session_id.map(str::to_string),
+        document_id: None,
+        taint: crate::openhuman::memory::MemoryTaint::Internal,
+    }
+}
+
+#[tokio::test]
+async fn excludes_same_session_document_but_keeps_unrelated_useful_doc() {
+    let tmp = TempDir::new().unwrap();
+    let memory = UnifiedMemory::new(tmp.path(), Arc::new(NoopEmbedding), None).unwrap();
+
+    // (a) The current turn's own auto-saved request — tagged with the live
+    // session/thread id, exactly like `agent::harness::session::turn::core`
+    // tags the `user_msg:<uuid>` autosave.
+    memory
+        .upsert_document(conversation_doc_with_session(
+            "user_msg:current-turn",
+            "Please look up Jordan Rivera's chat platform user ID for me.",
+            Some("thread-current"),
+        ))
+        .await
+        .unwrap();
+
+    // (b) An unrelated, genuinely useful fact from a prior turn/session that
+    // actually answers the query.
+    memory
+        .upsert_document(conversation_doc_with_session(
+            "fact:jordan-rivera-platform-id",
+            "Jordan Rivera's chat platform user ID is U0000042.",
+            Some("thread-other"),
+        ))
+        .await
+        .unwrap();
+
+    let query = "Jordan Rivera chat platform user ID";
+
+    // Sanity check: without exclusion, both documents are lexically relevant
+    // and both come back (this is the pre-fix, buggy shape).
+    let unfiltered = memory
+        .query_namespace_hits("global", query, 10)
+        .await
+        .unwrap();
+    assert!(
+        unfiltered.iter().any(|h| h.key == "user_msg:current-turn"),
+        "sanity check: the self-request doc must be lexically relevant without a filter, got {unfiltered:#?}"
+    );
+
+    // With the current-session exclusion applied, the self-echo document is
+    // dropped and the useful fact survives.
+    let filtered = memory
+        .query_namespace_hits_excluding_session("global", query, 10, Some("thread-current"))
+        .await
+        .unwrap();
+
+    assert!(
+        !filtered.iter().any(|h| h.key == "user_msg:current-turn"),
+        "same-session self-request document must be excluded, got {filtered:#?}"
+    );
+    assert!(
+        filtered
+            .iter()
+            .any(|h| h.key == "fact:jordan-rivera-platform-id"),
+        "unrelated useful document from another session must still be returned, got {filtered:#?}"
+    );
+}
+
+#[tokio::test]
+async fn no_session_context_leaves_results_unchanged() {
+    let tmp = TempDir::new().unwrap();
+    let memory = UnifiedMemory::new(tmp.path(), Arc::new(NoopEmbedding), None).unwrap();
+
+    memory
+        .upsert_document(conversation_doc_with_session(
+            "user_msg:current-turn",
+            "Please look up Jordan Rivera's chat platform user ID for me.",
+            Some("thread-current"),
+        ))
+        .await
+        .unwrap();
+    memory
+        .upsert_document(conversation_doc_with_session(
+            "fact:jordan-rivera-platform-id",
+            "Jordan Rivera's chat platform user ID is U0000042.",
+            Some("thread-other"),
+        ))
+        .await
+        .unwrap();
+
+    let query = "Jordan Rivera chat platform user ID";
+
+    let baseline = memory
+        .query_namespace_hits("global", query, 10)
+        .await
+        .unwrap();
+
+    // `None` exclusion (no ambient session context — cron, CLI, standalone,
+    // or a caller with no `exclude_session_id` to give) must behave
+    // identically to the pre-existing `query_namespace_hits` entry point:
+    // same hit count, same keys, in the same order.
+    let explicit_none = memory
+        .query_namespace_hits_excluding_session("global", query, 10, None)
+        .await
+        .unwrap();
+
+    let baseline_keys: Vec<&str> = baseline.iter().map(|h| h.key.as_str()).collect();
+    let explicit_none_keys: Vec<&str> = explicit_none.iter().map(|h| h.key.as_str()).collect();
+    assert_eq!(
+        baseline_keys, explicit_none_keys,
+        "no session context must be a no-op vs. the unfiltered entry point"
+    );
+    assert!(
+        explicit_none_keys.contains(&"user_msg:current-turn"),
+        "without any exclusion, the self-request document must still be present"
+    );
+
+    // An empty/whitespace exclude id must also be treated as "no filter",
+    // not accidentally matched against a document with `session_id: None`.
+    let empty_string = memory
+        .query_namespace_hits_excluding_session("global", query, 10, Some("   "))
+        .await
+        .unwrap();
+    let empty_string_keys: Vec<&str> = empty_string.iter().map(|h| h.key.as_str()).collect();
+    assert_eq!(
+        baseline_keys, empty_string_keys,
+        "a blank exclude_session_id must not filter anything"
+    );
+}


### PR DESCRIPTION
## Bug

When an agent (e.g. `workflow_builder`) runs `memory_recall` / `memory_hybrid_search` mid-turn, the results were dominated by echoes of its own current request. Root cause: the harness auto-saves every user turn as a `[conversation]` document (`user_msg:<uuid>`) via `agent::harness::session::turn::core`, and lexical/graph search then matches on shared tokens in that same document — so a query like "Alan Johnson Slack user ID" retrieved the request itself as the top "relevant" result, drowning out any real facts.

## Fix

Agent-agnostic, additive, no vendored-crate changes:

1. **Tag the autosave doc with the live chat-thread id.** `agent/harness/session/turn/core.rs` now captures `inference::provider::thread_context::current_thread_id()` (an existing `tokio::task_local` the web channel already scopes around every turn — see `channels/providers/web/run_task.rs`) *before* the `tokio::spawn` that persists the message, and passes it as `session_id` instead of the previous hardcoded `None`.
2. **Thread an opt-in `exclude_session_id` filter through search.** `UnifiedMemory::query_namespace_hits` / `query_namespace_ranked` (`memory_store/unified/query.rs`) keep their exact existing public signatures — zero behavior change for any existing caller (autocomplete, RPC recall handlers, cron, CLI, tests). New sibling entry points `query_namespace_hits_excluding_session` / `query_namespace_ranked_excluding_session` accept `Option<&str>` and drop any *document*-kind hit whose stored `session_id` matches. KV rows have no session concept and are untouched; episodic/event hits keep their own existing session-scoping (`RecallOpts::session_id` / `cross_session`).
3. **Apply the exclusion generically at the two call sites that matter:**
   - `UnifiedMemory::recall()` (`memory_store/memory_trait.rs`, the impl backing the `Memory` trait and thus the `memory_recall` tool) reads the ambient `current_thread_id()` and passes it as the exclusion — so *any* consumer of `Memory::recall()` gets the guard, not just `workflow_builder`.
   - `memory_hybrid_search` (`memory_search/tools/hybrid_search.rs`) does the same directly, mirroring the existing `memory::source_scope` ambient-scope pattern already used by its sibling `memory_vector_search` tool.

Outside a live web-channel chat turn (cron, CLI, standalone, tests, or any caller with no ambient thread) `current_thread_id()` is `None`, so no filtering is applied — behavior is byte-for-byte identical to before this change.

### Why not thread it through `RecallOpts`/the `Memory` trait instead?

`RecallOpts` and the `Memory` trait are owned by the vendored `tinycortex` crate (`vendor/tinycortex`, git submodule). Adding a field there would require a separate upstream PR to that repo before it could land here. The ambient `thread_context` task-local is an established host-side pattern for exactly this class of "current turn" cross-cutting concern (see `memory::source_scope`, used by the sibling `memory_vector_search`/`memory_chunk_context` tools) — reusing it keeps the whole fix host-only and additive.

## Testing

- `src/openhuman/memory_store/unified/query_tests.rs`:
  - `excludes_same_session_document_but_keeps_unrelated_useful_doc` — seeds a same-session self-request doc + an unrelated useful doc, asserts the exclusion drops only the former.
  - `no_session_context_leaves_results_unchanged` — asserts `None`/blank `exclude_session_id` is a byte-for-byte no-op vs. the pre-existing `query_namespace_hits`.
- `src/openhuman/memory_store/memory_trait.rs`:
  - `recall_excludes_document_from_ambient_current_thread` — exercises `Memory::recall()` inside a `with_thread_id(...)` scope end-to-end.
  - `recall_outside_any_thread_scope_is_unaffected` — same setup with no ambient scope, asserts the document is still returned.
- `GGML_NATIVE=OFF cargo check` — clean.
- `GGML_NATIVE=OFF cargo test --lib` on `openhuman::memory_store::`, `openhuman::memory_search::`, `openhuman::memory::tools::recall::`, `openhuman::inference::provider::thread_context::` — all pass (276+ tests, no regressions).
- `cargo fmt` — clean (no diff).

## Deviations / notes

- Out of scope per the issue: the separate cloud-embeddings auth issue that keeps vector search dead was **not** touched.
- `openhuman::agent::harness::session::tests::turn_dispatches_spawn_subagent_through_full_path` stack-overflows under the default test-thread stack size — confirmed **pre-existing** on `upstream/main` without this change (reproduced via `git stash`), unrelated to this fix.

## Acceptance checklist

- [x] `memory_recall` / `memory_hybrid_search` no longer surface the current turn's own autosaved request as a result once the ambient thread id is set.
- [x] Exclusion is scoped to the caller's own current-session documents only — no cross-user/cross-session leakage risk (exact `session_id` match required).
- [x] No ambient session context ⇒ identical behavior to before (verified by test + existing `query_namespace_hits`/`query_namespace_ranked` signatures being untouched).
- [x] Debug logging added on the filter path (`tracing::debug!`/`log::debug!` with dropped/remaining counts).
- [x] `cargo check` clean, relevant tests pass, `cargo fmt` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory search now avoids returning conversation entries from the current chat session, reducing repetitive self-references.
  * Automatically saved messages are associated with their active chat session.

* **Bug Fixes**
  * Improved memory recall to exclude the current conversation’s automatically saved request while preserving relevant results from other sessions.
  * Memory searches without an active session continue to behave as before.

* **Tests**
  * Added coverage for session filtering and unchanged behavior outside a chat session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->