### PR TITLE
fix(composio): gate per-action tools on their full contract (#4853)

### DIFF
--- a/src/openhuman/agent/harness/subagent_runner/ops/provider.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops/provider.rs
@@ -247,6 +247,14 @@ pub(crate) struct LazyToolkitResolver {
 const TIER4_MIN_SLUG_LEN: usize = 8;
 
 impl LazyToolkitResolver {
+    /// NOTE (contract gate, #4853): this builds a *fresh* `ComposioActionTool`
+    /// — and therefore a fresh, empty `ContractGate` — on every call. The gate's
+    /// surface-once state lives in the tool instance, so if a future wiring
+    /// resolves a new tool per invocation the gate would surface the full
+    /// contract on every call and the retry would never see `first_time == false`
+    /// to proceed. When this path is wired to actually dispatch, cache the
+    /// resolved tool (and its gate) per turn so a given action can proceed after
+    /// its contract has been surfaced once.
     pub(super) fn resolve(&self, name: &str) -> Option<Box<dyn crate::openhuman::tools::Tool>> {
         let action = self.find_action(name)?;
         Some(Box::new(

--- a/src/openhuman/composio/action_tool.rs
+++ b/src/openhuman/composio/action_tool.rs
@@ -192,6 +192,31 @@ impl Tool for ComposioActionTool {
             }
         }
 
+        // [#1710 Wave 4 / #4853] Reload the live config snapshot ONCE, up front,
+        // and use it for BOTH the contract-gate lookup and dispatch. A mid-session
+        // `composio.mode` / credential / workspace change must route the gate's
+        // live-catalog fetch and the actual execution through the SAME config;
+        // consulting the captured spawn-time `self.config` here would let the gate
+        // resolve (or skip) a contract against stale routing while dispatch used
+        // fresh routing. Anchored to this tool's original config path rather than
+        // re-resolving process-global `OPENHUMAN_WORKSPACE` (the tool is scoped to
+        // the user/workspace it was created for).
+        let live_config =
+            match config_rpc::reload_config_snapshot_with_timeout(self.config.as_ref()).await {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(
+                        tool = %self.action_name,
+                        error = %e,
+                        "[composio] per-action execute: load_config failed"
+                    );
+                    return Ok(ToolResult::error(format!(
+                        "{}: failed to load live config: {e}",
+                        self.action_name
+                    )));
+                }
+            };
+
         // Contract gate (#4853): the per-action tool is built from the thin
         // spawn-time `list_tools` schema (often `{"type":"object"}` with no
         // field descriptions), so the model guesses argument formats — most
@@ -201,10 +226,8 @@ impl Tool for ComposioActionTool {
         // let the retry — now with the schema in context — execute. Degrades to
         // a normal execute whenever the contract can't be resolved (see
         // `contract_gate::consult`), so an unconfigured/offline client never
-        // blocks the action.
-        match super::contract_gate::consult(&self.gate, self.config.as_ref(), &self.action_name)
-            .await
-        {
+        // blocks the action. Uses `live_config` so gate routing matches dispatch.
+        match super::contract_gate::consult(&self.gate, &live_config, &self.action_name).await {
             super::contract_gate::GateDecision::Surface(contract) => {
                 tracing::info!(
                     tool = %self.action_name,
@@ -233,31 +256,11 @@ impl Tool for ComposioActionTool {
             &iana,
         );
 
-        // Resolve the client through the mode-aware factory on every
-        // call so a direct-mode toggle takes effect immediately
-        // (#1710). The pre-baked-client variant of this code routed all
-        // executions through the backend tinyhumans tenant regardless
-        // of mode — silently breaking direct mode for tool execution.
-        // [#1710 Wave 4] Reload config fresh per execute so a mid-session
-        // `composio.mode` toggle takes effect at the very next tool call.
-        // Anchor the reload to this tool's original config path rather
-        // than re-resolving process-global `OPENHUMAN_WORKSPACE`; the
-        // tool is scoped to the user/workspace it was created for.
-        let live_config =
-            match config_rpc::reload_config_snapshot_with_timeout(self.config.as_ref()).await {
-                Ok(c) => c,
-                Err(e) => {
-                    tracing::warn!(
-                        tool = %self.action_name,
-                        error = %e,
-                        "[composio] per-action execute: load_config failed"
-                    );
-                    return Ok(ToolResult::error(format!(
-                        "{}: failed to load live config: {e}",
-                        self.action_name
-                    )));
-                }
-            };
+        // Resolve the client through the mode-aware factory on every call so a
+        // direct-mode toggle takes effect immediately (#1710), reusing the
+        // `live_config` snapshot reloaded above so the gate lookup and this
+        // dispatch share identical routing. The pre-baked-client variant routed
+        // all executions through the backend tinyhumans tenant regardless of mode.
         let kind = match create_composio_client(&live_config) {
             Ok(kind) => kind,
             Err(e) => {

--- a/src/openhuman/composio/action_tool.rs
+++ b/src/openhuman/composio/action_tool.rs
@@ -67,6 +67,13 @@ pub struct ComposioActionTool {
     /// Composio connection. Used when the sub-agent is spawned for a
     /// particular account (e.g. "send from my work Gmail").
     connection_id: Option<String>,
+    /// Per-turn contract gate (#4853). On the first call to this action the
+    /// gate surfaces the action's FULL live input schema/description so the
+    /// model composes well-formed arguments (e.g. correctly-quoted Gmail
+    /// queries) instead of guessing from the thin spawn-time schema; the retry
+    /// executes normally. Held per tool instance, which lives for one
+    /// `integrations_agent` spawn, so "seen" is scoped to that turn.
+    gate: super::contract_gate::ContractGate,
 }
 
 impl ComposioActionTool {
@@ -93,6 +100,7 @@ impl ComposioActionTool {
             description,
             parameters,
             connection_id,
+            gate: super::contract_gate::ContractGate::new(),
         }
     }
 }
@@ -182,6 +190,29 @@ impl Tool for ComposioActionTool {
                     scope.as_str()
                 )));
             }
+        }
+
+        // Contract gate (#4853): the per-action tool is built from the thin
+        // spawn-time `list_tools` schema (often `{"type":"object"}` with no
+        // field descriptions), so the model guesses argument formats — most
+        // visibly sending unquoted Gmail `query` strings that return zero
+        // results. On the first call this turn, surface the action's FULL live
+        // contract (input schema + description) as a recoverable tool error and
+        // let the retry — now with the schema in context — execute. Degrades to
+        // a normal execute whenever the contract can't be resolved (see
+        // `contract_gate::consult`), so an unconfigured/offline client never
+        // blocks the action.
+        match super::contract_gate::consult(&self.gate, self.config.as_ref(), &self.action_name)
+            .await
+        {
+            super::contract_gate::GateDecision::Surface(contract) => {
+                tracing::info!(
+                    tool = %self.action_name,
+                    "[composio][contract-gate] returning full contract before first execute"
+                );
+                return Ok(ToolResult::error(contract));
+            }
+            super::contract_gate::GateDecision::Proceed => {}
         }
 
         // Inject `timeZone` / `singleEvents` defaults for Google
@@ -486,6 +517,74 @@ mod tests {
         assert!(
             !msg.contains("strict read-only"),
             "unset sandbox must never trigger the gate, got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn contract_gate_surfaces_full_contract_then_proceeds_on_retry() {
+        // Regression for #4853: the FIRST per-action execute this turn must
+        // return the action's FULL live contract (so the model composes a
+        // well-formed query) instead of running with the thin spawn-time
+        // schema; the retry then proceeds to real dispatch. A unique toolkit is
+        // seeded so this is deterministic and never touches the network.
+        use crate::openhuman::config::TEST_ENV_LOCK;
+        use crate::openhuman::tinyflows::caps::{seed_live_catalog_cache, ToolContract};
+        let _env_guard = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let toolkit = "cgateexec";
+        let slug = "CGATEEXEC_FETCH_ITEMS";
+        seed_live_catalog_cache(
+            toolkit,
+            vec![ToolContract {
+                slug: slug.to_string(),
+                toolkit: toolkit.to_string(),
+                description: Some("Search items. Quote multi-word phrases.".to_string()),
+                required_args: vec!["query".to_string()],
+                input_schema: Some(serde_json::json!({
+                    "type": "object",
+                    "properties": { "query": { "type": "string" } },
+                    "required": ["query"]
+                })),
+                output_fields: Vec::new(),
+                output_schema: None,
+                primary_array_path: None,
+                is_curated: false,
+            }],
+        );
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let _workspace_guard = WorkspaceEnvGuard::set(tmp.path());
+        let mut config = Config::default();
+        config.config_path = tmp.path().join("config.toml");
+        config.workspace_dir = tmp.path().join("workspace");
+        config.save().await.expect("save fake config to disk");
+
+        let t = ComposioActionTool::new(
+            Arc::new(config),
+            slug.to_string(),
+            "search items".to_string(),
+            None,
+        );
+
+        // First call: gate surfaces the contract (recoverable tool error).
+        let first = t.execute(serde_json::json!({})).await.unwrap();
+        assert!(
+            first.is_error,
+            "first call must surface a recoverable error"
+        );
+        let first_msg = error_text(&first);
+        assert!(
+            first_msg.contains("Input JSON schema"),
+            "first call must carry the full contract, got: {first_msg}"
+        );
+
+        // Retry: gate proceeds; dispatch fails downstream (no session token) but
+        // crucially NOT with the contract text — proving the gate did not block.
+        let second = t.execute(serde_json::json!({})).await.unwrap();
+        let second_msg = error_text(&second);
+        assert!(
+            !second_msg.contains("Input JSON schema"),
+            "retry must proceed past the gate to real dispatch, got: {second_msg}"
         );
     }
 

--- a/src/openhuman/composio/action_tool.rs
+++ b/src/openhuman/composio/action_tool.rs
@@ -520,6 +520,9 @@ mod tests {
         );
     }
 
+    // Seeds the flows/tinyflows live-catalog cache, so it only builds with the
+    // `flows` feature on (the gate degrades to a no-op when flows is off).
+    #[cfg(feature = "flows")]
     #[tokio::test]
     async fn contract_gate_surfaces_full_contract_then_proceeds_on_retry() {
         // Regression for #4853: the FIRST per-action execute this turn must

--- a/src/openhuman/composio/contract_gate.rs
+++ b/src/openhuman/composio/contract_gate.rs
@@ -28,8 +28,14 @@
 use std::collections::HashSet;
 use std::sync::Mutex;
 
-use crate::openhuman::composio::providers::toolkit_from_slug;
 use crate::openhuman::config::Config;
+// The live-contract lookup is sourced from the flows/tinyflows caps catalog,
+// which is compiled out when the `flows` feature is off (#4912). The gate then
+// simply has no fuller contract to surface and always proceeds, so the import
+// and the lookup/format helpers below are gated in lockstep.
+#[cfg(feature = "flows")]
+use crate::openhuman::composio::providers::toolkit_from_slug;
+#[cfg(feature = "flows")]
 use crate::openhuman::tinyflows::caps::{fetch_live_toolkit_catalog, ToolContract};
 
 /// Per-agent-turn record of which action contracts have already been surfaced
@@ -95,32 +101,39 @@ pub async fn consult(gate: &ContractGate, config: &Config, action_slug: &str) ->
         return GateDecision::Proceed;
     }
 
-    match lookup_contract(config, action_slug).await {
-        Some(contract) => {
-            tracing::debug!(
-                target: "composio",
-                slug = %action_slug,
-                has_input_schema = contract.input_schema.is_some(),
-                required_arg_count = contract.required_args.len(),
-                "[composio][contract-gate] surfacing full contract before first execute"
-            );
-            GateDecision::Surface(format_contract(action_slug, &contract))
-        }
-        None => {
-            tracing::debug!(
-                target: "composio",
-                slug = %action_slug,
-                "[composio][contract-gate] no live contract available; proceeding without gating"
-            );
-            GateDecision::Proceed
-        }
+    // The live catalog lives in the flows/tinyflows caps layer. With `flows`
+    // compiled out there is no catalog source, so the gate can never surface a
+    // fuller contract and always proceeds (the per-action tool still runs; it
+    // just does not get the pre-execute contract nudge).
+    #[cfg(feature = "flows")]
+    if let Some(contract) = lookup_contract(config, action_slug).await {
+        tracing::debug!(
+            target: "composio",
+            slug = %action_slug,
+            has_input_schema = contract.input_schema.is_some(),
+            required_arg_count = contract.required_args.len(),
+            "[composio][contract-gate] surfacing full contract before first execute"
+        );
+        return GateDecision::Surface(format_contract(action_slug, &contract));
     }
+
+    // `config` is only consulted through the flows-gated lookup above.
+    #[cfg(not(feature = "flows"))]
+    let _ = config;
+
+    tracing::debug!(
+        target: "composio",
+        slug = %action_slug,
+        "[composio][contract-gate] no live contract available; proceeding without gating"
+    );
+    GateDecision::Proceed
 }
 
 /// Resolve the full live contract for `action_slug` from the process-cached
 /// live toolkit catalog. Returns `None` when the toolkit can't be derived, the
 /// catalog can't be fetched (unconfigured / offline — `fetch_live_toolkit_catalog`
 /// degrades to `None`), or the action isn't in it.
+#[cfg(feature = "flows")]
 async fn lookup_contract(config: &Config, action_slug: &str) -> Option<ToolContract> {
     let toolkit = toolkit_from_slug(action_slug)?;
     let contracts = fetch_live_toolkit_catalog(config, &toolkit).await?;
@@ -131,6 +144,7 @@ async fn lookup_contract(config: &Config, action_slug: &str) -> Option<ToolContr
 
 /// Render the contract into a compact instruction for the model. Contains only
 /// the provider's own action description + JSON schema — no user data / PII.
+#[cfg(feature = "flows")]
 fn format_contract(action_slug: &str, contract: &ToolContract) -> String {
     let mut out = format!(
         "Before running `{action_slug}`, read its full contract below and then re-issue \
@@ -176,6 +190,8 @@ fn format_contract(action_slug: &str, contract: &ToolContract) -> String {
     out
 }
 
-#[cfg(test)]
+// The gate's unit tests seed the flows/tinyflows live-catalog cache, so they
+// only compile and run with the `flows` feature on.
+#[cfg(all(test, feature = "flows"))]
 #[path = "contract_gate_tests.rs"]
 mod tests;

--- a/src/openhuman/composio/contract_gate.rs
+++ b/src/openhuman/composio/contract_gate.rs
@@ -1,0 +1,181 @@
+//! Contract gate for late-bound Composio actions (#4853).
+//!
+//! Per-action Composio tools handed to `integrations_agent` are built from
+//! the lightweight `list_tools` response — a one-line description with a
+//! parameter schema that is often thin or absent (see
+//! `fetch_toolkit_actions`, consumed in the
+//! sub-agent runner). The model therefore composes calls before the action's
+//! FULL contract is in context and guesses argument formats — most visibly, it
+//! sends Gmail `query` strings without the quoting Gmail search syntax requires,
+//! so `GMAIL_FETCH_EMAILS` returns zero results.
+//!
+//! The gate makes the full contract enter context BEFORE execution: on the
+//! first call to an action this turn, if a fuller live contract is available
+//! (via the cached `fetch_live_toolkit_catalog`), it is returned as a
+//! recoverable tool error instead of executing. The retry — now with the
+//! schema/description in context — proceeds normally. This mirrors the
+//! discover-then-call discipline the generic `composio_execute` dispatcher
+//! already expects (`composio_list_tools` → `composio_execute`), but enforces
+//! it on the per-action surface where the model never sees the full schema.
+//!
+//! Scope: this pass gates the per-action Composio surface
+//! ([`super::action_tool::ComposioActionTool`]). Generalising the same gate to
+//! the `composio_execute` dispatcher, the MCP bridges, and the Workflow
+//! dispatchers — plus resetting the per-turn state on context compaction — is
+//! tracked as follow-up (a shared `ToolMiddleware` at the turn-harness seam is
+//! the natural home; see the PR description).
+
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+use crate::openhuman::composio::providers::toolkit_from_slug;
+use crate::openhuman::config::Config;
+use crate::openhuman::tinyflows::caps::{fetch_live_toolkit_catalog, ToolContract};
+
+/// Per-agent-turn record of which action contracts have already been surfaced
+/// to the model, so the gate blocks a given action at most once per turn.
+///
+/// One [`ContractGate`] is held per [`super::action_tool::ComposioActionTool`]
+/// instance; those tools are constructed fresh per `integrations_agent` spawn
+/// and live for that spawn's tool loop, so "seen" is scoped to the turn without
+/// any task-local plumbing. Interior-mutable so the gate can record state
+/// through the tool's `&self` `execute`.
+#[derive(Default)]
+pub struct ContractGate {
+    seen: Mutex<HashSet<String>>,
+}
+
+impl ContractGate {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert `slug` (normalised to upper-case) into the seen-set. Returns
+    /// `true` when it was NOT already present — i.e. this is the first time the
+    /// gate has been consulted for this action this turn.
+    ///
+    /// The lock is taken and released entirely within this call, so no guard is
+    /// held across the caller's later `await`.
+    fn mark_seen(&self, slug: &str) -> bool {
+        let mut guard = self
+            .seen
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        guard.insert(slug.to_ascii_uppercase())
+    }
+}
+
+/// Outcome of consulting the gate for one action call.
+pub enum GateDecision {
+    /// Return this text to the model as a recoverable tool error; the model
+    /// retries with the contract in context.
+    Surface(String),
+    /// Execute the action normally.
+    Proceed,
+}
+
+/// Consult the gate before executing `action_slug`.
+///
+/// On the FIRST consult for a slug this turn, if a fuller live contract can be
+/// resolved, returns [`GateDecision::Surface`] with the formatted contract and
+/// marks the slug seen. Every later consult — and any consult where no live
+/// contract is available (unconfigured client, unknown action, network miss) —
+/// returns [`GateDecision::Proceed`], so the gate never blocks an action more
+/// than once and never blocks when it cannot help.
+pub async fn consult(gate: &ContractGate, config: &Config, action_slug: &str) -> GateDecision {
+    // Mark first (releasing the lock) so the retry — and any concurrent
+    // sibling call — proceeds even if the contract lookup below is slow.
+    let first_time = gate.mark_seen(action_slug);
+    if !first_time {
+        tracing::debug!(
+            target: "composio",
+            slug = %action_slug,
+            "[composio][contract-gate] contract already surfaced this turn; proceeding"
+        );
+        return GateDecision::Proceed;
+    }
+
+    match lookup_contract(config, action_slug).await {
+        Some(contract) => {
+            tracing::debug!(
+                target: "composio",
+                slug = %action_slug,
+                has_input_schema = contract.input_schema.is_some(),
+                required_arg_count = contract.required_args.len(),
+                "[composio][contract-gate] surfacing full contract before first execute"
+            );
+            GateDecision::Surface(format_contract(action_slug, &contract))
+        }
+        None => {
+            tracing::debug!(
+                target: "composio",
+                slug = %action_slug,
+                "[composio][contract-gate] no live contract available; proceeding without gating"
+            );
+            GateDecision::Proceed
+        }
+    }
+}
+
+/// Resolve the full live contract for `action_slug` from the process-cached
+/// live toolkit catalog. Returns `None` when the toolkit can't be derived, the
+/// catalog can't be fetched (unconfigured / offline — `fetch_live_toolkit_catalog`
+/// degrades to `None`), or the action isn't in it.
+async fn lookup_contract(config: &Config, action_slug: &str) -> Option<ToolContract> {
+    let toolkit = toolkit_from_slug(action_slug)?;
+    let contracts = fetch_live_toolkit_catalog(config, &toolkit).await?;
+    contracts
+        .into_iter()
+        .find(|c| c.slug.eq_ignore_ascii_case(action_slug))
+}
+
+/// Render the contract into a compact instruction for the model. Contains only
+/// the provider's own action description + JSON schema — no user data / PII.
+fn format_contract(action_slug: &str, contract: &ToolContract) -> String {
+    let mut out = format!(
+        "Before running `{action_slug}`, read its full contract below and then re-issue \
+         the call with arguments that match it exactly.\n\n"
+    );
+
+    if let Some(desc) = contract
+        .description
+        .as_deref()
+        .map(str::trim)
+        .filter(|d| !d.is_empty())
+    {
+        out.push_str("Description:\n");
+        out.push_str(desc);
+        out.push_str("\n\n");
+    }
+
+    match contract.input_schema.as_ref() {
+        Some(schema) => {
+            let pretty =
+                serde_json::to_string_pretty(schema).unwrap_or_else(|_| schema.to_string());
+            out.push_str("Input JSON schema:\n");
+            out.push_str(&pretty);
+            out.push('\n');
+        }
+        None => out.push_str("Input JSON schema: not published by the provider for this action.\n"),
+    }
+
+    if !contract.required_args.is_empty() {
+        out.push_str(&format!(
+            "\nRequired arguments: {}\n",
+            contract.required_args.join(", ")
+        ));
+    }
+
+    out.push_str(
+        "\nCompose every argument to match this schema and any format rules in the \
+         description. Text-search fields in particular often require the provider's exact \
+         query syntax (for example, Gmail needs multi-word phrases quoted, like \
+         subject:\"quarterly report\"). Then call the action again with the corrected \
+         arguments.",
+    );
+    out
+}
+
+#[cfg(test)]
+#[path = "contract_gate_tests.rs"]
+mod tests;

--- a/src/openhuman/composio/contract_gate.rs
+++ b/src/openhuman/composio/contract_gate.rs
@@ -38,14 +38,17 @@ use crate::openhuman::composio::providers::toolkit_from_slug;
 #[cfg(feature = "flows")]
 use crate::openhuman::tinyflows::caps::{fetch_live_toolkit_catalog, ToolContract};
 
-/// Per-agent-turn record of which action contracts have already been surfaced
-/// to the model, so the gate blocks a given action at most once per turn.
+/// Record of which action contracts have already been surfaced to the model,
+/// so the gate blocks a given action at most once per gate instance.
 ///
 /// One [`ContractGate`] is held per [`super::action_tool::ComposioActionTool`]
 /// instance; those tools are constructed fresh per `integrations_agent` spawn
-/// and live for that spawn's tool loop, so "seen" is scoped to the turn without
-/// any task-local plumbing. Interior-mutable so the gate can record state
-/// through the tool's `&self` `execute`.
+/// and live for that spawn's tool loop. That loop is a single agent turn in the
+/// common case, so "seen" behaves as per-turn state without any task-local
+/// plumbing — but a long-lived spawn can span multiple turns, and this gate
+/// does NOT reset when the surfaced schema drops out of context via compaction
+/// (tracked as follow-up; see the module-level note). Interior-mutable so the
+/// gate can record state through the tool's `&self` `execute`.
 #[derive(Default)]
 pub struct ContractGate {
     seen: Mutex<HashSet<String>>,
@@ -58,7 +61,7 @@ impl ContractGate {
 
     /// Insert `slug` (normalised to upper-case) into the seen-set. Returns
     /// `true` when it was NOT already present — i.e. this is the first time the
-    /// gate has been consulted for this action this turn.
+    /// gate has been consulted for this action for this gate's lifetime.
     ///
     /// The lock is taken and released entirely within this call, so no guard is
     /// held across the caller's later `await`.

--- a/src/openhuman/composio/contract_gate_tests.rs
+++ b/src/openhuman/composio/contract_gate_tests.rs
@@ -1,0 +1,134 @@
+//! Unit tests for the Composio contract gate (#4853).
+//!
+//! These exercise the gate purely against the process-level live-catalog cache
+//! (seeded via [`seed_live_catalog_cache`]), so no Composio client is built and
+//! no network call is made. Each test uses a unique toolkit slug so the shared
+//! `LIVE_CATALOG_CACHE` can't cross-contaminate between tests.
+
+use super::{consult, ContractGate, GateDecision};
+use crate::openhuman::config::Config;
+use crate::openhuman::tinyflows::caps::{seed_live_catalog_cache, ToolContract};
+
+/// Build a full contract for `slug` in `toolkit` with a `query` input field and
+/// a description that spells out the quoting rule — the exact detail the model
+/// misses when it only sees the thin spawn-time schema.
+fn full_contract(slug: &str, toolkit: &str) -> ToolContract {
+    ToolContract {
+        slug: slug.to_string(),
+        toolkit: toolkit.to_string(),
+        description: Some(
+            "Search the mailbox. Multi-word phrases in `query` must be quoted, \
+             e.g. subject:\"quarterly report\"."
+                .to_string(),
+        ),
+        required_args: vec!["query".to_string()],
+        input_schema: Some(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Gmail search query (quote multi-word phrases)."
+                }
+            },
+            "required": ["query"]
+        })),
+        output_fields: Vec::new(),
+        output_schema: None,
+        primary_array_path: None,
+        is_curated: false,
+    }
+}
+
+#[tokio::test]
+async fn first_call_surfaces_full_contract_then_retry_proceeds() {
+    // Toolkit derived from the slug prefix: `GMAILGATE_...` -> `gmailgate`.
+    let toolkit = "gmailgate";
+    let slug = "GMAILGATE_FETCH_EMAILS";
+    seed_live_catalog_cache(toolkit, vec![full_contract(slug, toolkit)]);
+
+    let config = Config::default();
+    let gate = ContractGate::new();
+
+    // First call: the gate short-circuits execution and hands back the full
+    // contract (this is the behaviour that is ABSENT before the fix — the thin
+    // per-action tool would execute immediately with a guessed query).
+    match consult(&gate, &config, slug).await {
+        GateDecision::Surface(message) => {
+            assert!(message.contains(slug), "contract names the action slug");
+            assert!(
+                message.contains("query"),
+                "contract carries the input schema"
+            );
+            assert!(
+                message.contains("Required arguments: query"),
+                "contract lists required args"
+            );
+            assert!(
+                message.contains("quoted"),
+                "contract carries the provider description explaining quoting"
+            );
+        }
+        GateDecision::Proceed => panic!("first call must surface the contract, not execute"),
+    }
+
+    // The retry — now with the contract in context — proceeds to execution.
+    assert!(
+        matches!(consult(&gate, &config, slug).await, GateDecision::Proceed),
+        "retry must proceed once the contract has been surfaced this turn"
+    );
+}
+
+#[tokio::test]
+async fn known_toolkit_but_unknown_action_proceeds_without_blocking() {
+    // Toolkit is cached but does NOT contain the requested action, so no
+    // fuller contract can be surfaced. The gate must degrade to Proceed rather
+    // than block the call forever.
+    let toolkit = "partialkit";
+    seed_live_catalog_cache(
+        toolkit,
+        vec![full_contract("PARTIALKIT_OTHER_ACTION", toolkit)],
+    );
+
+    let config = Config::default();
+    let gate = ContractGate::new();
+
+    assert!(
+        matches!(
+            consult(&gate, &config, "PARTIALKIT_FETCH_EMAILS").await,
+            GateDecision::Proceed
+        ),
+        "an action missing from the live catalog must not be gated"
+    );
+}
+
+#[tokio::test]
+async fn distinct_actions_are_gated_independently() {
+    let toolkit = "multikit";
+    let fetch = "MULTIKIT_FETCH_EMAILS";
+    let send = "MULTIKIT_SEND_EMAIL";
+    seed_live_catalog_cache(
+        toolkit,
+        vec![full_contract(fetch, toolkit), full_contract(send, toolkit)],
+    );
+
+    let config = Config::default();
+    let gate = ContractGate::new();
+
+    // Each action surfaces its own contract exactly once, independently.
+    assert!(matches!(
+        consult(&gate, &config, fetch).await,
+        GateDecision::Surface(_)
+    ));
+    assert!(matches!(
+        consult(&gate, &config, send).await,
+        GateDecision::Surface(_)
+    ));
+    assert!(matches!(
+        consult(&gate, &config, fetch).await,
+        GateDecision::Proceed
+    ));
+    assert!(matches!(
+        consult(&gate, &config, send).await,
+        GateDecision::Proceed
+    ));
+}

--- a/src/openhuman/composio/mod.rs
+++ b/src/openhuman/composio/mod.rs
@@ -40,6 +40,7 @@ pub mod auth_retry;
 pub mod bus;
 pub mod client;
 mod connected_integrations;
+pub mod contract_gate;
 pub(crate) mod direct_auth;
 pub mod error_mapping;
 pub mod execute_dispatch;


### PR DESCRIPTION
## Summary

- Composio `GMAIL_FETCH_EMAILS` (and other per-action tools handed to `integrations_agent`) are built from the thin `list_tools` schema — often `{"type":"object"}` with no field descriptions — so the model guesses argument formats and sends unquoted Gmail queries that return zero results.
- Add a per-turn **contract gate**: on the first call to an action, surface its FULL live input schema + description (from the cached live toolkit catalog) as a recoverable tool error; the retry, now with the contract in context, executes normally.
- Gate degrades to a normal execute whenever the contract can't be resolved (unconfigured / offline client, unknown action), so it never blocks an action more than once and never blocks when it cannot help.
- New self-contained `src/openhuman/composio/contract_gate.rs` module + unit tests; wired into the per-action surface (`ComposioActionTool`).

## Problem

The per-action tools for `integrations_agent` are built by `fetch_toolkit_actions` (`src/openhuman/composio/connected_integrations.rs:1016`) from the lightweight `list_tools` response, whose `parameters` is often `None` → `ComposioActionTool` falls back to `{"type":"object"}` (`src/openhuman/composio/action_tool.rs:96`). The model therefore never sees the action's real schema/description (e.g. that Gmail `query` needs quoting for multi-word phrases) and composes zero-result calls. Telling the agent to read the contract first fixes it — because only then does the full schema enter context. The full contract already exists in-tree via `fetch_live_toolkit_catalog` (`src/openhuman/tinyflows/caps.rs:1789`), just not on this surface.

## Solution

- `contract_gate::ContractGate` records which action contracts have been surfaced this turn (interior-mutable set, one gate per `ComposioActionTool` instance, which lives for one `integrations_agent` spawn — so "seen" is scoped to the turn without task-local plumbing).
- `contract_gate::consult` (`src/openhuman/composio/contract_gate.rs`): on the first consult for a slug, resolves the full contract from the process-cached `fetch_live_toolkit_catalog` and returns `GateDecision::Surface(<formatted contract>)`; later consults, and any consult with no resolvable contract, return `GateDecision::Proceed`. No network when the catalog is cached or the client is unconfigured (fails fast).
- `ComposioActionTool::execute` consults the gate after the sandbox check and returns the contract as `ToolResult::error` before dispatch (`src/openhuman/composio/action_tool.rs`).
- Debug logging with a grep-friendly `[composio][contract-gate]` prefix; logs only action slugs and booleans/counts — no user data / PII.

### Scope note — dispatcher / MCP / Workflows / compaction-reset are follow-up

This PR gates the **per-action Composio surface**, the direct root cause of the Gmail repro. The issue also asks to generalise the gate to the `composio_execute` dispatcher, the MCP bridges (`mcp_call_tool` / `mcp_registry_tool_call`) and the Workflow dispatchers (`run_workflow`), and to reset the per-turn state on context compaction. The clean home for that is a single `ToolMiddleware` at the turn-harness seam (`assemble_turn_harness`, `src/openhuman/tinyagents/mod.rs`), where a `wrap_tool` hook can short-circuit any late-bound tool uniformly and per-turn state lives in `RunContext::stores`. That is a larger change in the agent core; it is deliberately deferred here so this fix stays contained and unit-verifiable (local cargo build/test is disabled on this machine — CI is the authority), and it builds on the reusable `ContractGate` primitive this PR adds.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `contract_gate_tests.rs` (surface-then-proceed, unknown-action degrades to proceed, independent gating) + `action_tool.rs` execute-level test covering both gate arms.
- [x] **Diff coverage ≥ 80%** — the gate module and the `execute` wiring are exercised by the new unit tests; Rust-only change, CI `rust-core-coverage` is the authority.
- [x] Coverage matrix updated — N/A: bug-fix, no new user-facing feature row.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix rows affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — tests use the seeded process cache; no client is built.
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([docs/RELEASE-MANUAL-SMOKE.md](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: internal agent-tool behaviour, no release-cut surface.
- [x] Linked issue referenced in the `## Related` section — uses `Addresses #4853` (NOT `Closes`) so the partially-resolved P1 is not auto-closed on merge, per maintainer review.

## Impact

- Runtime/platform: Rust core, all platforms. Affects the per-action Composio tools an `integrations_agent` spawns (Gmail/Notion/Slack/GitHub/Linear/etc.).
- Performance: on the first call to an action per turn the gate reads the live toolkit catalog — cached process-wide (one fetch per toolkit), so at most one extra round-trip per toolkit per process; cached and unconfigured paths do no network.
- Security: no new surface; the sandbox read-only gate still runs first, and logs carry no PII. Migration/compat: none.

## Related

- Addresses #4853 (partial — kept OPEN intentionally per maintainer review: this PR resolves the immediate Gmail-search repro on the per-action surface; unknown-id "not found + valid list", compaction-reset, and MCP/Workflow-dispatcher generalization are deferred to follow-ups)
- Follow-up PR(s)/TODOs: generalise the gate to the `composio_execute` dispatcher, the MCP bridges, and the Workflow dispatchers via a shared `ToolMiddleware`, and reset the per-turn seen-set on context compaction.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/GH-4853-composio-gmail-search`
- Commit SHA: `d80b1e3fadf8c3ab951bceb07f125f64583d5b0c`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend files changed.
- [x] `pnpm typecheck` — N/A: no TypeScript changed.
- [x] Focused tests: `cargo test -p openhuman contract_gate` — not run locally (cargo disabled on this machine per disk policy); CI is authority.
- [x] Rust fmt/check (if changed): ran standalone `rustfmt` on the changed files (clean); `cargo check`/`clippy` deferred to CI.
- [x] Tauri fmt/check (if changed): N/A: no Tauri changes.

### Validation Blocked

- `command:` `cargo test` / `cargo check` / `cargo clippy`
- `error:` local Rust builds are disabled on this machine (disk-fill policy); CI performs full verification.
- `impact:` compile + test + clippy verification deferred to CI (`rust-core-coverage`, `Rust Quality`).

### Behavior Changes

- Intended behavior change: the first per-action Composio call each turn returns the action's full contract; the retry executes with well-formed arguments.
- User-visible effect: Gmail (and other provider) searches via `integrations_agent` return results without the user first telling the agent to read the tool contract.

### Parity Contract

- Legacy behavior preserved: the sandbox read-only gate still runs before the contract gate; when no live contract can be resolved the action executes exactly as before (the gate degrades to a no-op).
- Guard/fallback/dispatch parity checks: dispatch, calendar-arg defaults, and per-call client resolution (#1710) are unchanged; only a pre-dispatch first-call gate was added.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-turn contract guidance for Composio actions by surfacing the provider description, input JSON schema (when available), and required arguments on first attempt.
  * After guidance, retry proceeds with normal dispatch on subsequent attempts (without re-surfacing the full contract).
  * Guidance is scoped per action slug and doesn’t block missing/uncached actions.

* **Bug Fixes**
  * Ensured guidance and execution share the same live config snapshot during a call to improve retry correctness.

* **Tests**
  * Added feature-gated regression tests for surface-then-proceed, missing actions, and independent per-action gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
