### PR TITLE
feat(flows): Workflows UI redesign — tabbed Copilot|Run dock + inline node status + runs rail (DRAFT)

### DIFF
--- a/app/src/components/flows/FlowDockPanel.test.tsx
+++ b/app/src/components/flows/FlowDockPanel.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * FlowDockPanel (Workflows UI redesign, Piece 1) — asserts the tabbed dock's
+ * core contract: both tab bodies stay mounted at all times (only `display`
+ * toggles), tab clicks flip `activeTab` via the host callback, the Run tab is
+ * disabled when `runTabDisabled`, the collapse button calls `onCollapse`, and
+ * dragging the resize handle grows/shrinks the dock's width.
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import FlowDockPanel, { type FlowDockTab } from './FlowDockPanel';
+
+// A tiny stateful probe standing in for `WorkflowCopilotPanel` — a real mount
+// counter proves the component is never unmounted/remounted across a tab
+// switch (the #4942 / #5008 / #5010 regression this dock exists to avoid).
+let copilotMountCount = 0;
+function CopilotProbe() {
+  useState(() => {
+    copilotMountCount += 1;
+    return null;
+  });
+  return <div data-testid="copilot-probe">copilot content</div>;
+}
+
+function renderDock(overrides: Partial<React.ComponentProps<typeof FlowDockPanel>> = {}) {
+  const onTabChange = overrides.onTabChange ?? vi.fn();
+  const onCollapse = overrides.onCollapse ?? vi.fn();
+  const utils = render(
+    <FlowDockPanel
+      activeTab="copilot"
+      onTabChange={onTabChange}
+      copilotContent={<CopilotProbe />}
+      runContent={<div data-testid="run-probe">run content</div>}
+      onCollapse={onCollapse}
+      {...overrides}
+    />
+  );
+  return { ...utils, onTabChange, onCollapse };
+}
+
+/** A thin stateful wrapper so `activeTab` actually flips in response to `onTabChange`, mirroring how `FlowEditor` drives it. */
+function ControlledDock({ initialTab = 'copilot' as FlowDockTab } = {}) {
+  const [tab, setTab] = useState<FlowDockTab>(initialTab);
+  return (
+    <FlowDockPanel
+      activeTab={tab}
+      onTabChange={setTab}
+      copilotContent={<CopilotProbe />}
+      runContent={<div data-testid="run-probe">run content</div>}
+      onCollapse={vi.fn()}
+    />
+  );
+}
+
+describe('FlowDockPanel', () => {
+  beforeEach(() => {
+    copilotMountCount = 0;
+  });
+
+  it('renders both tab bodies in the DOM at once (only display toggles) — Copilot stays mounted across tab switches', () => {
+    render(<ControlledDock />);
+
+    expect(screen.getByTestId('copilot-probe')).toBeInTheDocument();
+    expect(screen.getByTestId('run-probe')).toBeInTheDocument();
+    expect(copilotMountCount).toBe(1);
+
+    fireEvent.click(screen.getByTestId('flow-dock-tab-run'));
+    // Both bodies are STILL in the DOM — the Run tab's body becomes visible,
+    // the Copilot's becomes `display: none`, but neither unmounts.
+    expect(screen.getByTestId('copilot-probe')).toBeInTheDocument();
+    expect(screen.getByTestId('run-probe')).toBeInTheDocument();
+    expect(copilotMountCount).toBe(1); // still exactly one mount — no remount
+
+    fireEvent.click(screen.getByTestId('flow-dock-tab-copilot'));
+    expect(copilotMountCount).toBe(1);
+  });
+
+  it('hides the inactive tab body via display:none, not by unmounting', () => {
+    render(<ControlledDock />);
+
+    expect(screen.getByTestId('flow-dock-copilot-body')).toHaveStyle({ display: 'flex' });
+    expect(screen.getByTestId('flow-dock-run-body')).toHaveStyle({ display: 'none' });
+
+    fireEvent.click(screen.getByTestId('flow-dock-tab-run'));
+
+    expect(screen.getByTestId('flow-dock-copilot-body')).toHaveStyle({ display: 'none' });
+    expect(screen.getByTestId('flow-dock-run-body')).toHaveStyle({ display: 'block' });
+  });
+
+  it('calls onTabChange with the clicked tab', () => {
+    const { onTabChange } = renderDock();
+    fireEvent.click(screen.getByTestId('flow-dock-tab-run'));
+    expect(onTabChange).toHaveBeenCalledWith('run');
+  });
+
+  it('marks the active tab aria-selected', () => {
+    renderDock({ activeTab: 'run' });
+    expect(screen.getByTestId('flow-dock-tab-run')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByTestId('flow-dock-tab-copilot')).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('disables the Run tab when runTabDisabled (a draft has no runs)', () => {
+    renderDock({ runTabDisabled: true });
+    expect(screen.getByTestId('flow-dock-tab-run')).toBeDisabled();
+  });
+
+  it('calls onCollapse when the collapse button is clicked', () => {
+    const { onCollapse } = renderDock();
+    fireEvent.click(screen.getByTestId('flow-dock-collapse'));
+    expect(onCollapse).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits the resize handle in fullWidth mode', () => {
+    renderDock({ fullWidth: true });
+    expect(screen.queryByTestId('flow-dock-resize-handle')).not.toBeInTheDocument();
+    expect(screen.getByTestId('flow-dock-panel')).toHaveAttribute('data-full-width', 'true');
+  });
+
+  it('grows the panel width when the resize handle is dragged toward the canvas (left)', () => {
+    renderDock();
+    const panel = screen.getByTestId('flow-dock-panel');
+    const initialWidth = parseInt(panel.style.width, 10);
+
+    fireEvent.pointerDown(screen.getByTestId('flow-dock-resize-handle'), { clientX: 500 });
+    fireEvent.pointerMove(window, { clientX: 400 }); // dragged 100px left -> +100px wider
+    fireEvent.pointerUp(window);
+
+    const widthAfter = parseInt(panel.style.width, 10);
+    expect(widthAfter).toBe(initialWidth + 100);
+  });
+
+  it('clamps the resized width within [320, 560]', () => {
+    renderDock();
+    const panel = screen.getByTestId('flow-dock-panel');
+
+    fireEvent.pointerDown(screen.getByTestId('flow-dock-resize-handle'), { clientX: 500 });
+    fireEvent.pointerMove(window, { clientX: -5000 }); // absurdly far left
+    fireEvent.pointerUp(window);
+    expect(parseInt(panel.style.width, 10)).toBe(560);
+
+    fireEvent.pointerDown(screen.getByTestId('flow-dock-resize-handle'), { clientX: 500 });
+    fireEvent.pointerMove(window, { clientX: 5000 }); // absurdly far right
+    fireEvent.pointerUp(window);
+    expect(parseInt(panel.style.width, 10)).toBe(320);
+  });
+});

--- a/app/src/components/flows/FlowDockPanel.tsx
+++ b/app/src/components/flows/FlowDockPanel.tsx
@@ -1,0 +1,184 @@
+/**
+ * FlowDockPanel (Workflows UI redesign, Piece 1) — the tabbed right dock on
+ * `FlowCanvasPage`, replacing the old mutually-exclusive Copilot-panel-vs-
+ * Run-inspector-overlay split. Two tabs — Copilot | Run — share one docked,
+ * resizable, collapsible panel.
+ *
+ * CRITICAL invariant: `copilotContent` (the `WorkflowCopilotPanel`) must stay
+ * MOUNTED across tab switches — this component only toggles `display:none` on
+ * the inactive tab's body, it never conditionally renders `copilotContent`
+ * itself out of the tree. The host (`FlowCanvasPage`'s `FlowEditor`) must
+ * likewise always pass the SAME element (not `activeTab === 'copilot' &&
+ * <WorkflowCopilotPanel .../>`) — that's what preserves the agentic-task
+ * panel's sticky-expand state (#4942) and the sub-agent `turnActive` flicker
+ * fix (#5008/#5010) across a switch to the Run tab and back.
+ */
+import {
+  type ReactNode,
+  type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useRef,
+  useState,
+} from 'react';
+
+import { useT } from '../../lib/i18n/I18nContext';
+import Button from '../ui/Button';
+
+export type FlowDockTab = 'copilot' | 'run';
+
+export interface FlowDockPanelProps {
+  activeTab: FlowDockTab;
+  onTabChange: (tab: FlowDockTab) => void;
+  /**
+   * Rendered inside the Copilot tab's body. Always mounted regardless of
+   * `activeTab` — see this file's doc comment.
+   */
+  copilotContent: ReactNode;
+  /** Rendered inside the Run tab's body. Also always mounted (cheap to remount, but kept consistent with the copilot side). */
+  runContent: ReactNode;
+  /** Disables (and visually dims) the Run tab — a draft flow has no runs yet. */
+  runTabDisabled?: boolean;
+  /** Collapse the whole dock (the ▸ toggle) — hands control back to the host, which hides this component entirely. */
+  onCollapse: () => void;
+  /**
+   * Render at full width with no resize handle (chat-first "graph appears
+   * later" mode — mirrors the old `WorkflowCopilotPanel`'s `fullWidth` prop).
+   */
+  fullWidth?: boolean;
+}
+
+const MIN_WIDTH = 320;
+const MAX_WIDTH = 560;
+const DEFAULT_WIDTH = 384;
+
+function ChevronRightIcon() {
+  return (
+    <svg
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+    </svg>
+  );
+}
+
+export default function FlowDockPanel({
+  activeTab,
+  onTabChange,
+  copilotContent,
+  runContent,
+  runTabDisabled = false,
+  onCollapse,
+  fullWidth = false,
+}: FlowDockPanelProps) {
+  const { t } = useT();
+  const [width, setWidth] = useState(DEFAULT_WIDTH);
+  const draggingRef = useRef(false);
+
+  const handleResizeStart = useCallback(
+    (event: ReactPointerEvent) => {
+      event.preventDefault();
+      draggingRef.current = true;
+      const startX = event.clientX;
+      const startWidth = width;
+
+      const onMove = (moveEvent: PointerEvent) => {
+        if (!draggingRef.current) return;
+        // The dock sits on the canvas's RIGHT edge — dragging its left-edge
+        // resize handle LEFT (negative clientX delta) grows the dock.
+        const delta = startX - moveEvent.clientX;
+        setWidth(Math.min(MAX_WIDTH, Math.max(MIN_WIDTH, startWidth + delta)));
+      };
+      const onUp = () => {
+        draggingRef.current = false;
+        window.removeEventListener('pointermove', onMove);
+        window.removeEventListener('pointerup', onUp);
+      };
+      window.addEventListener('pointermove', onMove);
+      window.addEventListener('pointerup', onUp);
+    },
+    [width]
+  );
+
+  const tabs: Array<{ key: FlowDockTab; label: string; testId: string }> = [
+    { key: 'copilot', label: t('flows.dock.copilotTab'), testId: 'flow-dock-tab-copilot' },
+    { key: 'run', label: t('flows.dock.runTab'), testId: 'flow-dock-tab-run' },
+  ];
+
+  return (
+    <div
+      className="relative flex h-full flex-shrink-0 border-l border-line bg-surface"
+      style={fullWidth ? undefined : { width }}
+      data-testid="flow-dock-panel"
+      data-full-width={fullWidth ? 'true' : 'false'}>
+      {!fullWidth && (
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label={t('flows.dock.resizeHandle')}
+          data-testid="flow-dock-resize-handle"
+          onPointerDown={handleResizeStart}
+          className="absolute -left-1 top-0 z-10 h-full w-2 cursor-col-resize"
+        />
+      )}
+      <div className={`flex h-full min-w-0 flex-1 flex-col ${fullWidth ? 'w-full' : ''}`}>
+        <div className="flex flex-shrink-0 items-center justify-between gap-2 border-b border-line px-2 py-1.5">
+          <div
+            role="tablist"
+            aria-label={t('flows.dock.tablistLabel')}
+            className="inline-flex items-center gap-0.5 rounded-lg bg-surface-muted p-0.5">
+            {tabs.map(tab => {
+              const disabled = tab.key === 'run' && runTabDisabled;
+              const active = activeTab === tab.key;
+              return (
+                <button
+                  key={tab.key}
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  disabled={disabled}
+                  data-testid={tab.testId}
+                  onClick={() => onTabChange(tab.key)}
+                  className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+                    active
+                      ? 'bg-surface text-content shadow-sm'
+                      : 'text-content-secondary hover:text-content'
+                  }`}>
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
+          <Button
+            type="button"
+            variant="tertiary"
+            size="xs"
+            iconOnly
+            data-testid="flow-dock-collapse"
+            aria-label={t('flows.dock.collapse')}
+            title={t('flows.dock.collapse')}
+            onClick={onCollapse}>
+            <ChevronRightIcon />
+          </Button>
+        </div>
+
+        {/* Both bodies are always in the tree — only `display` toggles — so the
+            Copilot's internal state survives switching to Run and back. */}
+        <div
+          className="min-h-0 flex-1"
+          data-testid="flow-dock-copilot-body"
+          style={{ display: activeTab === 'copilot' ? 'flex' : 'none' }}>
+          {copilotContent}
+        </div>
+        <div
+          className="min-h-0 flex-1 overflow-y-auto"
+          data-testid="flow-dock-run-body"
+          style={{ display: activeTab === 'run' ? 'block' : 'none' }}>
+          {runContent}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/flows/FlowRunInspectorDrawer.tsx
+++ b/app/src/components/flows/FlowRunInspectorDrawer.tsx
@@ -1,12 +1,16 @@
 /**
- * FlowRunInspectorDrawer (issue B3b)
- * ----------------------------------
+ * FlowRunInspectorDrawer / FlowRunInspectorPanel (issue B3b, extracted for the
+ * Workflows UI redesign's docked Run tab)
+ * ----------------------------------------------------------------------------
  *
- * Right-side drawer showing a single durable `tinyflows` run's status + step
- * timeline, opened from the "View run" action on {@link FlowApprovalCard}.
- * Drawer chrome mirrors `features/conversations/components/SubagentDrawer.tsx`
- * (fixed overlay + backdrop-click-to-close + Escape-to-close) so it renders
- * as a fixed overlay regardless of where the parent mounts it in the DOM.
+ * {@link FlowRunInspectorPanel} is a single durable `tinyflows` run's status +
+ * step timeline — the reusable BODY, with no positioning/backdrop opinion of
+ * its own. {@link FlowRunInspectorDrawer} wraps it as a right-side fixed
+ * overlay drawer (backdrop-click-to-close + Escape-to-close, chrome mirroring
+ * `features/conversations/components/SubagentDrawer.tsx`) — used by
+ * `FlowApprovalCard`'s "View run" action and the runs-list page's
+ * {@link ../flows/FlowRunsDrawer}. The Workflows UI redesign's `FlowDockPanel`
+ * Run tab instead renders the Panel directly, inline, with no overlay at all.
  *
  * Data comes from {@link useFlowRunPoller}, which polls
  * `openhuman.flows_get_run` every 2s until the run reaches a terminal status
@@ -22,6 +26,7 @@
  * dots, not progress bars (project rule).
  */
 import debug from 'debug';
+import { type ReactNode, useEffect } from 'react';
 
 import { useEscapeKey } from '../../hooks/useEscapeKey';
 import { useFlowPendingApprovals } from '../../hooks/useFlowPendingApprovals';
@@ -30,7 +35,7 @@ import { type FlowNodeRunStatus, useFlowRunProgress } from '../../hooks/useFlowR
 import { type FlowRunItem, normalizeItems } from '../../lib/flows/runItems';
 import { summarizeStep } from '../../lib/flows/runStepSummary';
 import { useT } from '../../lib/i18n/I18nContext';
-import type { FlowRunStatus, FlowRunStep } from '../../services/api/flowsApi';
+import type { FlowRun, FlowRunStatus, FlowRunStep } from '../../services/api/flowsApi';
 import Button from '../ui/Button';
 import { FlowRunPendingApprovalCard } from './FlowRunPendingApprovalCard';
 import { RunItemDataBrowser } from './RunItemDataBrowser';
@@ -140,6 +145,8 @@ function StepRow({
   index,
   liveStatus,
   inputItems,
+  isSelected = false,
+  onSelect,
 }: {
   step: FlowRunStep;
   index: number;
@@ -150,6 +157,17 @@ function StepRow({
    * Omitted for the first step, which has no upstream producer here.
    */
   inputItems?: FlowRunItem[];
+  /**
+   * Piece 2 (redesign) — true when this step is the one the canvas currently
+   * has centered/highlighted (set by a node click). Purely visual.
+   */
+  isSelected?: boolean;
+  /**
+   * Piece 2 (redesign) — fired on click with this step's node id, so the host
+   * can center/highlight the matching canvas node. Omitted (no click
+   * affordance at all) outside the dock's Run tab.
+   */
+  onSelect?: () => void;
 }) {
   const { t } = useT();
   const items = normalizeItems(step.output);
@@ -165,7 +183,24 @@ function StepRow({
   return (
     <li
       data-testid={`flow-run-step-${index}`}
-      className="rounded-lg border border-line bg-surface-muted p-2.5 text-xs">
+      role={onSelect ? 'button' : undefined}
+      tabIndex={onSelect ? 0 : undefined}
+      onClick={onSelect}
+      onKeyDown={
+        onSelect
+          ? event => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                onSelect();
+              }
+            }
+          : undefined
+      }
+      className={`rounded-lg border p-2.5 text-xs ${
+        isSelected
+          ? 'border-primary-400 bg-primary-50 dark:border-primary-500/50 dark:bg-primary-500/10'
+          : 'border-line bg-surface-muted'
+      } ${onSelect ? 'cursor-pointer hover:border-primary-300' : ''}`}>
       <div className="flex flex-wrap items-center gap-1.5">
         <span
           data-testid={`flow-run-step-dot-${index}`}
@@ -230,24 +265,59 @@ function StepRow({
   );
 }
 
-interface Props {
-  /** Run id (== thread_id) to inspect. Renders `null` (nothing) when absent. */
+export interface FlowRunInspectorPanelProps {
+  /** Run id (== thread_id) to inspect. Renders `emptyState` (or `null`) when absent. */
   runId: string | null;
-  onClose: () => void;
   /**
    * "Fix with agent" (Phase 5c) — when provided and the run failed, a repair
    * action surfaces that hands the run context up so the host can open the
    * canvas copilot preloaded. Omitted where there's no copilot to route to.
    */
   onFixWithAgent?: (request: FlowRepairRequest) => void;
+  /**
+   * Renders a close (✕) button in the header when provided (the
+   * `FlowRunInspectorDrawer` overlay use). Omitted for the dock's inline Run
+   * tab, which has no "close" concept of its own — switching tabs or picking
+   * a different run is how you leave it.
+   */
+  onClose?: () => void;
+  /**
+   * Piece 2 (redesign) — reports the fetched run (or `null`) up on every
+   * poll tick, so the host can derive a canvas overlay (`stepsToProgressMap`)
+   * from the SAME data this panel is already polling, without a second
+   * subscription.
+   */
+  onRunChange?: (run: FlowRun | null) => void;
+  /**
+   * Piece 2 (redesign) — step index to highlight (set by the host when a
+   * canvas node with a run status is clicked). `null`/absent highlights none.
+   */
+  selectedStepIndex?: number | null;
+  /**
+   * Piece 2 (redesign) — fired when a step row is clicked, with its index and
+   * node id, so the host can center/highlight the matching canvas node. Steps
+   * render as plain (non-interactive) rows when omitted.
+   */
+  onSelectStep?: (index: number, nodeId: string) => void;
+  /** Rendered instead of the run view when `runId` is `null` (dock idle state). `null` (nothing) by default. */
+  emptyState?: ReactNode;
 }
 
 /**
- * Renders `null` when `runId` is `null` so the parent can mount this
- * unconditionally and just flip `runId` (same convention as
- * `SubagentDrawer`).
+ * The run inspector's reusable body: header (title/status/ids) + timing +
+ * error banner + "Fix with agent" + pending approvals + step timeline. No
+ * positioning/backdrop/close-key handling of its own — see
+ * {@link FlowRunInspectorDrawer} for the fixed-overlay wrapper.
  */
-export function FlowRunInspectorDrawer({ runId, onClose, onFixWithAgent }: Props) {
+export function FlowRunInspectorPanel({
+  runId,
+  onFixWithAgent,
+  onClose,
+  onRunChange,
+  selectedStepIndex = null,
+  onSelectStep,
+  emptyState = null,
+}: FlowRunInspectorPanelProps) {
   const { t } = useT();
   const { run, loading, error } = useFlowRunPoller(runId);
   // Live per-node status overlay (Phase 3e): the socket feed makes the poller's
@@ -266,6 +336,13 @@ export function FlowRunInspectorDrawer({ runId, onClose, onFixWithAgent }: Props
     isActiveRun && run ? run.flow_id : null,
     isActiveRun && run ? run.thread_id : null
   );
+
+  // Piece 2 (redesign): report the fetched run up on every change so the host
+  // can derive a canvas overlay from the same poll this panel already runs.
+  useEffect(() => {
+    onRunChange?.(run ?? null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [run]);
 
   const handleFixWithAgent = () => {
     if (!run || !onFixWithAgent) return;
@@ -287,15 +364,213 @@ export function FlowRunInspectorDrawer({ runId, onClose, onFixWithAgent }: Props
     });
   };
 
+  if (!runId) return <>{emptyState}</>;
+
+  const startedAt = formatTimestamp(run?.started_at);
+  const finishedAt = formatTimestamp(run?.finished_at);
+
+  return (
+    <div className="flex h-full flex-col" data-testid="flow-run-inspector-panel">
+      {/* Header */}
+      <header className="flex items-start gap-2.5 border-b border-line px-4 py-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate font-semibold text-content">
+              {t('flowRuns.inspector.title')}
+            </span>
+            {run && (
+              <span
+                data-testid="flow-run-status-dot"
+                className={`h-2 w-2 shrink-0 rounded-full ${FLOW_RUN_STATUS_DOT[run.status]}`}
+              />
+            )}
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[11px] text-content-muted">
+            {run && (
+              <span
+                data-testid="flow-run-status-pill"
+                className={`inline-flex items-center rounded-full border px-2 py-0.5 font-medium ${FLOW_RUN_STATUS_ACCENT[run.status]}`}>
+                {t(FLOW_RUN_STATUS_KEY[run.status])}
+              </span>
+            )}
+            {/* Internal ids are dev/debug info, not primary-view content (issue
+                B20) — shown short-form only, full value on hover via `title`,
+                matching `FlowRunsDrawer`'s row-level `run.id.slice(0, 8)`. */}
+            {run && (
+              <span className="truncate font-mono" title={run.flow_id}>
+                {run.flow_id.slice(0, 8)}
+              </span>
+            )}
+            {run && (
+              <span className="truncate font-mono" title={run.thread_id}>
+                {run.thread_id.slice(0, 8)}
+              </span>
+            )}
+          </div>
+        </div>
+        {onClose && (
+          <button
+            type="button"
+            data-testid="flow-run-inspector-close"
+            onClick={onClose}
+            aria-label={t('conversations.subagent.close')}
+            className="shrink-0 rounded-full p-1.5 text-content-faint hover:bg-surface-hover hover:text-content-secondary">
+            ✕
+          </button>
+        )}
+      </header>
+
+      <div className="flex-1 space-y-3 overflow-y-auto px-4 py-4">
+        {loading && !run && (
+          <div
+            className="flex items-center gap-2 py-8 text-content-faint"
+            data-testid="flow-run-inspector-loading">
+            <div className="h-4 w-4 animate-spin rounded-full border-2 border-ocean-500 border-t-transparent" />
+            <span className="text-sm">{t('flowRuns.inspector.loading')}</span>
+          </div>
+        )}
+
+        {error && (
+          <div
+            role="alert"
+            data-testid="flow-run-inspector-error"
+            className="rounded-xl border border-coral-200 bg-coral-50 px-3 py-2 text-xs text-coral-700 dark:border-coral-500/30 dark:bg-coral-500/10 dark:text-coral-300">
+            {t('flowRuns.inspector.loadError')}: {error}
+          </div>
+        )}
+
+        {run && (
+          <>
+            {/* Timing */}
+            <div className="text-xs text-content-muted" data-testid="flow-run-timing">
+              {startedAt && (
+                <div>
+                  {t('flowRuns.inspector.startedAt')}: {startedAt}
+                </div>
+              )}
+              {finishedAt ? (
+                <div>
+                  {t('flowRuns.inspector.finishedAt')}: {finishedAt}
+                </div>
+              ) : run.status === 'running' || run.status === 'pending_approval' ? (
+                <div className="animate-pulse">{t('flowRuns.inspector.running')}</div>
+              ) : null}
+            </div>
+
+            {/* Error banner */}
+            {run.error && (
+              <div
+                role="alert"
+                data-testid="flow-run-error-banner"
+                className="rounded-xl border border-coral-200 bg-coral-50 px-3 py-2 text-xs text-coral-700 dark:border-coral-500/30 dark:bg-coral-500/10 dark:text-coral-300">
+                {t('flowRuns.inspector.error')}: {run.error}
+              </div>
+            )}
+
+            {/* Repair entry point (Phase 5c): open the canvas copilot preloaded
+                with this failed run so the workflow builder can propose a fix. */}
+            {run.status === 'failed' && onFixWithAgent && (
+              <div>
+                <Button
+                  type="button"
+                  variant="primary"
+                  size="sm"
+                  data-testid="flow-run-fix-with-agent"
+                  onClick={handleFixWithAgent}>
+                  {t('flowRuns.inspector.fixWithAgent')}
+                </Button>
+              </div>
+            )}
+
+            {/* Actionable pending-approval gates for this run (flow-approval
+                surface). Replaces the old read-only "N node(s) awaiting
+                approval" banner — Approve once / Approve always / Deny
+                resolve the gate in place via `openhuman.approval_decide`;
+                the run poller above picks up the resulting steps on its
+                own 2s cadence once the gate clears. */}
+            {isActiveRun && pendingApprovals.length > 0 && (
+              <div className="space-y-2" data-testid="flow-run-pending-approvals">
+                <h3 className="text-xs font-semibold uppercase tracking-wide text-content-muted">
+                  {t('flowRuns.inspector.pendingApprovals')}
+                </h3>
+                {pendingApprovals.map(approval => (
+                  <FlowRunPendingApprovalCard
+                    key={approval.request_id}
+                    approval={approval}
+                    deciding={decidingApprovalId === approval.request_id}
+                    onDecide={decision => decideApproval(approval.request_id, decision)}
+                  />
+                ))}
+                {pendingApprovalsError && (
+                  <p
+                    role="alert"
+                    data-testid="flow-run-pending-approvals-error"
+                    className="text-xs text-coral-600 dark:text-coral-400">
+                    {t('flowRuns.inspector.approval.loadError')}
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Steps timeline */}
+            <div>
+              <h3 className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-content-muted">
+                {t('flowRuns.inspector.steps')}
+              </h3>
+              {run.steps.length === 0 ? (
+                <p className="text-xs italic text-content-faint">
+                  {t('flowRuns.inspector.noSteps')}
+                </p>
+              ) : (
+                <ol className="space-y-2" data-testid="flow-run-steps">
+                  {run.steps.map((step, idx) => (
+                    <StepRow
+                      key={`${step.node_id}-${idx}`}
+                      step={step}
+                      index={idx}
+                      liveStatus={liveStatuses[step.node_id]}
+                      inputItems={idx > 0 ? normalizeItems(run.steps[idx - 1].output) : undefined}
+                      isSelected={selectedStepIndex === idx}
+                      onSelect={onSelectStep ? () => onSelectStep(idx, step.node_id) : undefined}
+                    />
+                  ))}
+                </ol>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface Props {
+  /** Run id (== thread_id) to inspect. Renders `null` (nothing) when absent. */
+  runId: string | null;
+  onClose: () => void;
+  /**
+   * "Fix with agent" (Phase 5c) — when provided and the run failed, a repair
+   * action surfaces that hands the run context up so the host can open the
+   * canvas copilot preloaded. Omitted where there's no copilot to route to.
+   */
+  onFixWithAgent?: (request: FlowRepairRequest) => void;
+}
+
+/**
+ * Renders `null` when `runId` is `null` so the parent can mount this
+ * unconditionally and just flip `runId` (same convention as
+ * `SubagentDrawer`). Fixed-overlay wrapper around {@link FlowRunInspectorPanel}
+ * — backdrop-click-to-close + Escape-to-close.
+ */
+export function FlowRunInspectorDrawer({ runId, onClose, onFixWithAgent }: Props) {
+  const { t } = useT();
+
   useEscapeKey(() => {
     log('escape: closing runId=%s', runId);
     onClose();
   }, runId !== null);
 
   if (!runId) return null;
-
-  const startedAt = formatTimestamp(run?.started_at);
-  const finishedAt = formatTimestamp(run?.finished_at);
 
   return (
     <div className="fixed inset-0 z-50 flex justify-end" data-testid="flow-run-inspector-drawer">
@@ -308,171 +583,7 @@ export function FlowRunInspectorDrawer({ runId, onClose, onFixWithAgent }: Props
         onClick={onClose}
       />
       <aside className="relative flex h-full w-full max-w-md flex-col bg-surface shadow-xl">
-        {/* Header */}
-        <header className="flex items-start gap-2.5 border-b border-line px-4 py-3">
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <span className="truncate font-semibold text-content">
-                {t('flowRuns.inspector.title')}
-              </span>
-              {run && (
-                <span
-                  data-testid="flow-run-status-dot"
-                  className={`h-2 w-2 shrink-0 rounded-full ${FLOW_RUN_STATUS_DOT[run.status]}`}
-                />
-              )}
-            </div>
-            <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[11px] text-content-muted">
-              {run && (
-                <span
-                  data-testid="flow-run-status-pill"
-                  className={`inline-flex items-center rounded-full border px-2 py-0.5 font-medium ${FLOW_RUN_STATUS_ACCENT[run.status]}`}>
-                  {t(FLOW_RUN_STATUS_KEY[run.status])}
-                </span>
-              )}
-              {/* Internal ids are dev/debug info, not primary-view content (issue
-                  B20) — shown short-form only, full value on hover via `title`,
-                  matching `FlowRunsDrawer`'s row-level `run.id.slice(0, 8)`. */}
-              {run && (
-                <span className="truncate font-mono" title={run.flow_id}>
-                  {run.flow_id.slice(0, 8)}
-                </span>
-              )}
-              {run && (
-                <span className="truncate font-mono" title={run.thread_id}>
-                  {run.thread_id.slice(0, 8)}
-                </span>
-              )}
-            </div>
-          </div>
-          <button
-            type="button"
-            data-testid="flow-run-inspector-close"
-            onClick={onClose}
-            aria-label={t('conversations.subagent.close')}
-            className="shrink-0 rounded-full p-1.5 text-content-faint hover:bg-surface-hover hover:text-content-secondary">
-            ✕
-          </button>
-        </header>
-
-        <div className="flex-1 space-y-3 overflow-y-auto px-4 py-4">
-          {loading && !run && (
-            <div
-              className="flex items-center gap-2 py-8 text-content-faint"
-              data-testid="flow-run-inspector-loading">
-              <div className="h-4 w-4 animate-spin rounded-full border-2 border-ocean-500 border-t-transparent" />
-              <span className="text-sm">{t('flowRuns.inspector.loading')}</span>
-            </div>
-          )}
-
-          {error && (
-            <div
-              role="alert"
-              data-testid="flow-run-inspector-error"
-              className="rounded-xl border border-coral-200 bg-coral-50 px-3 py-2 text-xs text-coral-700 dark:border-coral-500/30 dark:bg-coral-500/10 dark:text-coral-300">
-              {t('flowRuns.inspector.loadError')}: {error}
-            </div>
-          )}
-
-          {run && (
-            <>
-              {/* Timing */}
-              <div className="text-xs text-content-muted" data-testid="flow-run-timing">
-                {startedAt && (
-                  <div>
-                    {t('flowRuns.inspector.startedAt')}: {startedAt}
-                  </div>
-                )}
-                {finishedAt ? (
-                  <div>
-                    {t('flowRuns.inspector.finishedAt')}: {finishedAt}
-                  </div>
-                ) : run.status === 'running' || run.status === 'pending_approval' ? (
-                  <div className="animate-pulse">{t('flowRuns.inspector.running')}</div>
-                ) : null}
-              </div>
-
-              {/* Error banner */}
-              {run.error && (
-                <div
-                  role="alert"
-                  data-testid="flow-run-error-banner"
-                  className="rounded-xl border border-coral-200 bg-coral-50 px-3 py-2 text-xs text-coral-700 dark:border-coral-500/30 dark:bg-coral-500/10 dark:text-coral-300">
-                  {t('flowRuns.inspector.error')}: {run.error}
-                </div>
-              )}
-
-              {/* Repair entry point (Phase 5c): open the canvas copilot preloaded
-                  with this failed run so the workflow builder can propose a fix. */}
-              {run.status === 'failed' && onFixWithAgent && (
-                <div>
-                  <Button
-                    type="button"
-                    variant="primary"
-                    size="sm"
-                    data-testid="flow-run-fix-with-agent"
-                    onClick={handleFixWithAgent}>
-                    {t('flowRuns.inspector.fixWithAgent')}
-                  </Button>
-                </div>
-              )}
-
-              {/* Actionable pending-approval gates for this run (flow-approval
-                  surface). Replaces the old read-only "N node(s) awaiting
-                  approval" banner — Approve once / Approve always / Deny
-                  resolve the gate in place via `openhuman.approval_decide`;
-                  the run poller above picks up the resulting steps on its
-                  own 2s cadence once the gate clears. */}
-              {isActiveRun && pendingApprovals.length > 0 && (
-                <div className="space-y-2" data-testid="flow-run-pending-approvals">
-                  <h3 className="text-xs font-semibold uppercase tracking-wide text-content-muted">
-                    {t('flowRuns.inspector.pendingApprovals')}
-                  </h3>
-                  {pendingApprovals.map(approval => (
-                    <FlowRunPendingApprovalCard
-                      key={approval.request_id}
-                      approval={approval}
-                      deciding={decidingApprovalId === approval.request_id}
-                      onDecide={decision => decideApproval(approval.request_id, decision)}
-                    />
-                  ))}
-                  {pendingApprovalsError && (
-                    <p
-                      role="alert"
-                      data-testid="flow-run-pending-approvals-error"
-                      className="text-xs text-coral-600 dark:text-coral-400">
-                      {t('flowRuns.inspector.approval.loadError')}
-                    </p>
-                  )}
-                </div>
-              )}
-
-              {/* Steps timeline */}
-              <div>
-                <h3 className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-content-muted">
-                  {t('flowRuns.inspector.steps')}
-                </h3>
-                {run.steps.length === 0 ? (
-                  <p className="text-xs italic text-content-faint">
-                    {t('flowRuns.inspector.noSteps')}
-                  </p>
-                ) : (
-                  <ol className="space-y-2" data-testid="flow-run-steps">
-                    {run.steps.map((step, idx) => (
-                      <StepRow
-                        key={`${step.node_id}-${idx}`}
-                        step={step}
-                        index={idx}
-                        liveStatus={liveStatuses[step.node_id]}
-                        inputItems={idx > 0 ? normalizeItems(run.steps[idx - 1].output) : undefined}
-                      />
-                    ))}
-                  </ol>
-                )}
-              </div>
-            </>
-          )}
-        </div>
+        <FlowRunInspectorPanel runId={runId} onFixWithAgent={onFixWithAgent} onClose={onClose} />
       </aside>
     </div>
   );

--- a/app/src/components/flows/FlowRunsSidebar.test.tsx
+++ b/app/src/components/flows/FlowRunsSidebar.test.tsx
@@ -1,21 +1,15 @@
 /**
- * FlowRunsSidebar — the flow canvas's projected run-history sidebar. Asserts
- * the run list renders, a run row opens the {@link FlowRunInspectorDrawer},
- * and (issue B22) the drawer's "Fix with agent" action navigates to this same
- * flow's canvas seeded with a `copilotRepair` state and closes the sidebar's
- * own drawer — this sidebar is only ever mounted while the user is ALREADY on
- * the failing run's own `/flows/:id` canvas (`FlowCanvasPage` projects it into
- * the shell sidebar), so re-navigating to the SAME route with a fresh repair
- * seed is the fix (see `FlowCanvasPage.tsx`'s `locationKey`-based copilot
- * panel remount, which reacts to exactly this navigation).
+ * FlowRunsSidebar (Workflows UI redesign, Piece 3 — "runs rail") — asserts the
+ * compact rail renders one dot per run, a click calls the controlled
+ * `onSelectRun` (selection now lives in the host, not this component), the
+ * selected run's dot is visually marked, the flyout expander reveals the full
+ * list and a flyout row also calls `onSelectRun` (then auto-collapses), and
+ * the empty/loading states.
  */
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { Provider } from 'react-redux';
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { FlowRun } from '../../services/api/flowsApi';
-import { store } from '../../store';
 import FlowRunsSidebar from './FlowRunsSidebar';
 
 const listFlowRuns = vi.hoisted(() => vi.fn());
@@ -23,45 +17,6 @@ vi.mock('../../services/api/flowsApi', () => ({ listFlowRuns }));
 
 const fetchPendingApprovals = vi.hoisted(() => vi.fn());
 vi.mock('../../services/api/approvalApi', () => ({ fetchPendingApprovals }));
-
-// Capture the props handed to the drawer so "Fix with agent" can be invoked
-// directly without standing up the drawer's own run-polling machinery
-// (mirrors `FlowApprovalCard.test.tsx`'s stub pattern).
-const inspectorDrawerProps = vi.hoisted(() => ({
-  current: null as Record<string, unknown> | null,
-}));
-vi.mock('./FlowRunInspectorDrawer', () => ({
-  FLOW_RUN_STATUS_ACCENT: {
-    running: '',
-    completed: '',
-    completed_with_warnings: '',
-    pending_approval: '',
-    failed: '',
-    cancelled: '',
-  },
-  FLOW_RUN_STATUS_DOT: {
-    running: '',
-    completed: '',
-    completed_with_warnings: '',
-    pending_approval: '',
-    failed: '',
-    cancelled: '',
-  },
-  FLOW_RUN_STATUS_KEY: {
-    running: 'flowRuns.status.running',
-    completed: 'flowRuns.status.completed',
-    completed_with_warnings: 'flowRuns.status.completed_with_warnings',
-    pending_approval: 'flowRuns.status.pending_approval',
-    failed: 'flowRuns.status.failed',
-    cancelled: 'flowRuns.status.cancelled',
-  },
-  FlowRunInspectorDrawer: (props: Record<string, unknown>) => {
-    inspectorDrawerProps.current = props;
-    return props.runId ? (
-      <div data-testid="flow-run-inspector-drawer-stub">{props.runId as string}</div>
-    ) : null;
-  },
-}));
 
 function makeRun(overrides: Partial<FlowRun> = {}): FlowRun {
   return {
@@ -78,103 +33,55 @@ function makeRun(overrides: Partial<FlowRun> = {}): FlowRun {
   };
 }
 
-/** Renders whatever `location.state` a navigation landed with, for assertions. */
-function LocationStateProbe() {
-  const location = useLocation();
-  return <div data-testid="location-state-probe">{JSON.stringify(location.state)}</div>;
-}
-
-function renderSidebar(flowId = 'flow-1') {
-  return render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[`/flows/${flowId}`]}>
-        <Routes>
-          <Route path="/flows/:id" element={<FlowRunsSidebar flowId={flowId} />} />
-        </Routes>
-      </MemoryRouter>
-    </Provider>
-  );
+function renderSidebar(props: Partial<React.ComponentProps<typeof FlowRunsSidebar>> = {}) {
+  const onSelectRun = props.onSelectRun ?? vi.fn();
+  return {
+    onSelectRun,
+    ...render(
+      <FlowRunsSidebar flowId="flow-1" selectedRunId={null} onSelectRun={onSelectRun} {...props} />
+    ),
+  };
 }
 
 describe('FlowRunsSidebar', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    inspectorDrawerProps.current = null;
     fetchPendingApprovals.mockResolvedValue([]);
   });
 
-  it('lists runs and opens the inspector drawer for the clicked run', async () => {
-    listFlowRuns.mockResolvedValue([makeRun()]);
+  it('renders one dot per run in the compact rail', async () => {
+    listFlowRuns.mockResolvedValue([makeRun(), makeRun({ id: 'run-2', thread_id: 'run-2' })]);
     renderSidebar();
 
-    const row = await screen.findByTestId('flow-runs-sidebar-run-run-1');
-    expect(screen.queryByTestId('flow-run-inspector-drawer-stub')).not.toBeInTheDocument();
-
-    fireEvent.click(row);
-
-    expect(screen.getByTestId('flow-run-inspector-drawer-stub')).toHaveTextContent('run-1');
+    expect(await screen.findByTestId('flow-runs-sidebar-run-run-1')).toBeInTheDocument();
+    expect(screen.getByTestId('flow-runs-sidebar-run-run-2')).toBeInTheDocument();
   });
 
-  it('passes onFixWithAgent through to the run inspector drawer', async () => {
+  it('calls onSelectRun (controlled — no internal selection/drawer) when a dot is clicked', async () => {
     listFlowRuns.mockResolvedValue([makeRun()]);
-    renderSidebar();
+    const { onSelectRun } = renderSidebar();
 
     fireEvent.click(await screen.findByTestId('flow-runs-sidebar-run-run-1'));
 
-    expect(inspectorDrawerProps.current?.onFixWithAgent).toBeInstanceOf(Function);
+    expect(onSelectRun).toHaveBeenCalledWith('run-1');
+    // This component no longer renders any inspector/drawer itself — that's
+    // the host's job now (Piece 1: lifted `selectedRunId`).
+    expect(screen.queryByTestId('flow-run-inspector-drawer')).not.toBeInTheDocument();
   });
 
-  it('"Fix with agent" closes the drawer and navigates to the same flow seeded with the repair context (B22)', async () => {
-    listFlowRuns.mockResolvedValue([makeRun()]);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={['/flows/flow-1']}>
-          <Routes>
-            <Route
-              path="/flows/:id"
-              element={
-                <>
-                  <FlowRunsSidebar flowId="flow-1" />
-                  <LocationStateProbe />
-                </>
-              }
-            />
-          </Routes>
-        </MemoryRouter>
-      </Provider>
+  it('marks the selected run pressed via aria-pressed', async () => {
+    listFlowRuns.mockResolvedValue([makeRun(), makeRun({ id: 'run-2', thread_id: 'run-2' })]);
+    renderSidebar({ selectedRunId: 'run-2' });
+
+    await screen.findByTestId('flow-runs-sidebar-run-run-1');
+    expect(screen.getByTestId('flow-runs-sidebar-run-run-1')).toHaveAttribute(
+      'aria-pressed',
+      'false'
     );
-
-    fireEvent.click(await screen.findByTestId('flow-runs-sidebar-run-run-1'));
-    expect(screen.getByTestId('flow-run-inspector-drawer-stub')).toBeInTheDocument();
-
-    act(() => {
-      (
-        inspectorDrawerProps.current?.onFixWithAgent as (request: {
-          flowId: string;
-          runId: string;
-          error?: string | null;
-          failingNodeIds?: string[];
-        }) => void
-      )({
-        flowId: 'flow-1',
-        runId: 'run-1',
-        error: 'GMAIL_SEND_EMAIL: empty body',
-        failingNodeIds: ['send_summary'],
-      });
-    });
-
-    // The sidebar's own run-inspector drawer closes (repair takes over).
-    await waitFor(() =>
-      expect(screen.queryByTestId('flow-run-inspector-drawer-stub')).not.toBeInTheDocument()
+    expect(screen.getByTestId('flow-runs-sidebar-run-run-2')).toHaveAttribute(
+      'aria-pressed',
+      'true'
     );
-    const probe = screen.getByTestId('location-state-probe');
-    expect(JSON.parse(probe.textContent ?? 'null')).toEqual({
-      copilotRepair: {
-        runId: 'run-1',
-        error: 'GMAIL_SEND_EMAIL: empty body',
-        failingNodeIds: ['send_summary'],
-      },
-    });
   });
 
   it('shows the empty state when there are no runs', async () => {
@@ -184,7 +91,44 @@ describe('FlowRunsSidebar', () => {
     expect(await screen.findByTestId('flow-runs-sidebar-empty')).toBeInTheDocument();
   });
 
-  it('shows "Awaiting approval" for a running run halted at an approval gate', async () => {
+  it('opens a flyout with the full run list on demand, and collapses it again', async () => {
+    listFlowRuns.mockResolvedValue([makeRun()]);
+    renderSidebar();
+    await screen.findByTestId('flow-runs-sidebar-run-run-1');
+
+    expect(screen.queryByTestId('flow-runs-sidebar-flyout')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('flow-runs-sidebar-expand'));
+    expect(screen.getByTestId('flow-runs-sidebar-flyout')).toBeInTheDocument();
+    expect(screen.getByTestId('flow-runs-flyout-run-run-1')).toHaveTextContent('Failed');
+
+    fireEvent.click(screen.getByTestId('flow-runs-sidebar-expand'));
+    expect(screen.queryByTestId('flow-runs-sidebar-flyout')).not.toBeInTheDocument();
+  });
+
+  it('selecting a run from the flyout calls onSelectRun and auto-collapses the flyout', async () => {
+    listFlowRuns.mockResolvedValue([makeRun()]);
+    const { onSelectRun } = renderSidebar();
+    await screen.findByTestId('flow-runs-sidebar-run-run-1');
+
+    fireEvent.click(screen.getByTestId('flow-runs-sidebar-expand'));
+    fireEvent.click(screen.getByTestId('flow-runs-flyout-run-run-1'));
+
+    expect(onSelectRun).toHaveBeenCalledWith('run-1');
+    expect(screen.queryByTestId('flow-runs-sidebar-flyout')).not.toBeInTheDocument();
+  });
+
+  it('refetches when the refresh button is clicked', async () => {
+    listFlowRuns.mockResolvedValue([makeRun()]);
+    renderSidebar();
+    await screen.findByTestId('flow-runs-sidebar-run-run-1');
+    expect(listFlowRuns).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId('flow-runs-sidebar-refresh'));
+    await waitFor(() => expect(listFlowRuns).toHaveBeenCalledTimes(2));
+  });
+
+  it('shows an "Awaiting approval" tooltip title for a running run halted at an approval gate', async () => {
     listFlowRuns.mockResolvedValue([makeRun({ status: 'running' })]);
     fetchPendingApprovals.mockResolvedValue([
       {
@@ -200,16 +144,10 @@ describe('FlowRunsSidebar', () => {
     ]);
     renderSidebar();
 
-    const runRow = await screen.findByTestId('flow-runs-sidebar-run-run-1');
-    await waitFor(() => expect(runRow).toHaveTextContent('Awaiting approval'));
-  });
-
-  it('leaves a running run without a matching approval labeled "Running"', async () => {
-    listFlowRuns.mockResolvedValue([makeRun({ status: 'running' })]);
-    fetchPendingApprovals.mockResolvedValue([]);
-    renderSidebar();
-
-    const runRow = await screen.findByTestId('flow-runs-sidebar-run-run-1');
-    await waitFor(() => expect(runRow).toHaveTextContent('Running'));
+    const dot = await screen.findByTestId('flow-runs-sidebar-run-run-1');
+    // Tooltip label rides the native `title` fallback (see `ui/Tooltip.tsx`).
+    await waitFor(() =>
+      expect(dot).toHaveAttribute('title', expect.stringContaining('Awaiting approval'))
+    );
   });
 });

--- a/app/src/components/flows/FlowRunsSidebar.tsx
+++ b/app/src/components/flows/FlowRunsSidebar.tsx
@@ -1,18 +1,25 @@
 /**
- * FlowRunsSidebar — the workflow's recent runs, projected into the root shell's
- * dynamic left sidebar while a flow is open on the canvas (`/flows/:id`). A
- * compact, scannable run history (status dot + status + relative time); clicking
- * a run opens the full {@link FlowRunInspectorDrawer} (which polls its live
- * status). Fetches via `listFlowRuns`, with a manual refresh button plus
- * {@link useFlowRunsLiveRefresh} keeping the list itself live while any run
- * shown here is still active (no manual refresh/navigate-away required).
+ * FlowRunsSidebar (Workflows UI redesign, Piece 3 — "runs rail") — the
+ * workflow's recent runs, projected as a ~44px vertical icon+dot rail on the
+ * canvas's left edge (was a ~240px column; this reclaims most of that width
+ * for the canvas). Each dot is a color-coded run status with a hover/focus
+ * tooltip (status + relative time); clicking one calls {@link onSelectRun} so
+ * the host ({@link ../pages/FlowCanvasPage}'s `FlowEditor`) can show it in the
+ * docked Run tab — this component no longer owns selection or renders the
+ * inspector itself (both lifted to the host, Piece 1 of the redesign).
  *
- * Rendered by `FlowCanvasPage` inside a `SidebarContent` portal, so it only
- * appears for a persisted flow (a draft has no runs yet).
+ * An expander at the bottom opens a flyout with the full list (status pill +
+ * relative time per row, same visual language as before) for anyone who wants
+ * more than the compact dots. Fetches via `listFlowRuns`, with a manual
+ * refresh button plus {@link useFlowRunsLiveRefresh} keeping the list itself
+ * live while any run shown here is still active (no manual refresh/navigate-
+ * away required).
+ *
+ * Rendered directly in-page by `FlowCanvasPage` (the app sidebar is hidden
+ * entirely on this chromeless route).
  */
 import createDebug from 'debug';
 import { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 
 import { useFlowRunsLiveRefresh } from '../../hooks/useFlowRunsLiveRefresh';
 import {
@@ -21,13 +28,11 @@ import {
 } from '../../hooks/useRunsPendingApprovalSet';
 import { useT } from '../../lib/i18n/I18nContext';
 import { type FlowRun, listFlowRuns } from '../../services/api/flowsApi';
-import { CenteredLoadingState, ErrorBanner } from '../ui/LoadingState';
+import Tooltip from '../ui/Tooltip';
 import {
   FLOW_RUN_STATUS_ACCENT,
   FLOW_RUN_STATUS_DOT,
   FLOW_RUN_STATUS_KEY,
-  type FlowRepairRequest,
-  FlowRunInspectorDrawer,
 } from './FlowRunInspectorDrawer';
 
 /** Matches `useT()`'s `t` signature. */
@@ -46,43 +51,55 @@ function relativeTime(iso: string, t: TFn): string {
 
 const log = createDebug('app:flows:runs-sidebar');
 
-export interface FlowRunsSidebarProps {
-  flowId: string;
+function RefreshIcon() {
+  return (
+    <svg
+      className="h-3.5 w-3.5"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M4 4v5h5M20 20v-5h-5M4 9a8 8 0 0114-3m2 8a8 8 0 01-14 3"
+      />
+    </svg>
+  );
 }
 
-export default function FlowRunsSidebar({ flowId }: FlowRunsSidebarProps) {
+/** Chevron flipped by `expanded` — points away from the rail toward the flyout. */
+function ChevronIcon({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      className={`h-3.5 w-3.5 transition-transform ${expanded ? 'rotate-180' : ''}`}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+    </svg>
+  );
+}
+
+export interface FlowRunsSidebarProps {
+  flowId: string;
+  /** Controlled selection (Piece 1 — lifted up to `FlowEditor` so the rail and the dock's Run tab share it). */
+  selectedRunId: string | null;
+  onSelectRun: (runId: string) => void;
+}
+
+export default function FlowRunsSidebar({
+  flowId,
+  selectedRunId,
+  onSelectRun,
+}: FlowRunsSidebarProps) {
   const { t } = useT();
-  const navigate = useNavigate();
   const [runs, setRuns] = useState<FlowRun[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
-
-  // "Fix with agent" (issue B22) — this sidebar is only ever mounted while
-  // already on the failed run's own `/flows/:id` canvas (`FlowCanvasPage`
-  // projects it into the shell sidebar), so re-navigating to the SAME route
-  // with a fresh `copilotRepair` state is enough to open the canvas copilot
-  // preloaded with the failure — same mechanism `FlowsPage`'s run-history
-  // drawer uses to reach this page from elsewhere. `replace: true` avoids
-  // stacking a new history entry per click on top of the page the user is
-  // already viewing.
-  const handleFixWithAgent = useCallback(
-    (request: FlowRepairRequest) => {
-      log('fix with agent: flow=%s run=%s', request.flowId, request.runId);
-      setSelectedRunId(null);
-      navigate(`/flows/${request.flowId}`, {
-        replace: true,
-        state: {
-          copilotRepair: {
-            runId: request.runId,
-            error: request.error,
-            failingNodeIds: request.failingNodeIds,
-          },
-        },
-      });
-    },
-    [navigate]
-  );
+  const [expanded, setExpanded] = useState(false);
 
   const load = useCallback(async () => {
     log('loading runs for flow=%s', flowId);
@@ -107,90 +124,134 @@ export default function FlowRunsSidebar({ flowId }: FlowRunsSidebarProps) {
   useFlowRunsLiveRefresh(runs, load);
   const pendingRunIds = useRunsPendingApprovalSet(runs);
 
+  const selectRun = useCallback(
+    (runId: string) => {
+      onSelectRun(runId);
+      setExpanded(false);
+    },
+    [onSelectRun]
+  );
+
   return (
-    <div className="flex h-full flex-col" data-testid="flow-runs-sidebar">
-      <div className="flex flex-shrink-0 items-center justify-between gap-2 px-3 py-2">
-        <span className="text-[11px] font-semibold uppercase tracking-wide text-content-faint">
-          {t('flows.runs.sidebarTitle')}
-        </span>
+    <div
+      className="relative flex h-full w-11 flex-shrink-0 flex-col items-center border-r border-line py-2"
+      data-testid="flow-runs-sidebar">
+      <Tooltip label={t('flows.runs.refresh')} side="right">
         <button
           type="button"
           onClick={() => void load()}
           disabled={loading}
           data-testid="flow-runs-sidebar-refresh"
           aria-label={t('flows.runs.refresh')}
-          title={t('flows.runs.refresh')}
-          className="rounded-md p-1 text-content-faint transition-colors hover:bg-surface-hover hover:text-content-secondary disabled:opacity-50">
-          <svg
-            className="h-3.5 w-3.5"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M4 4v5h5M20 20v-5h-5M4 9a8 8 0 0114-3m2 8a8 8 0 01-14 3"
-            />
-          </svg>
+          className="rounded-md p-1.5 text-content-faint transition-colors hover:bg-surface-hover hover:text-content-secondary disabled:opacity-50">
+          <RefreshIcon />
         </button>
-      </div>
+      </Tooltip>
 
-      <div className="min-h-0 flex-1 overflow-y-auto px-2 pb-2">
-        {loading && runs.length === 0 && <CenteredLoadingState label={t('flows.runs.loading')} />}
-
-        {error && (
-          <div className="px-1">
-            <ErrorBanner message={error} />
-          </div>
+      <div
+        className="mt-2 flex min-h-0 flex-1 flex-col items-center gap-1.5 overflow-y-auto py-1"
+        data-testid="flow-runs-sidebar-rail">
+        {loading && runs.length === 0 && (
+          <div
+            data-testid="flow-runs-sidebar-loading"
+            className="h-2.5 w-2.5 animate-pulse rounded-full bg-content-faint/40"
+            aria-hidden="true"
+          />
         )}
 
         {!loading && !error && runs.length === 0 && (
-          <p
-            className="px-2 py-6 text-center text-xs text-content-faint"
-            data-testid="flow-runs-sidebar-empty">
-            {t('flows.runs.empty')}
-          </p>
+          <span
+            data-testid="flow-runs-sidebar-empty"
+            title={t('flows.runs.empty')}
+            aria-label={t('flows.runs.empty')}
+            className="h-2 w-2 rounded-full border border-dashed border-line"
+          />
         )}
 
-        <ul className="space-y-1">
-          {runs.map(run => {
-            const displayStatus = resolveDisplayStatus(run, pendingRunIds);
-            return (
-              <li key={run.id}>
-                <button
-                  type="button"
-                  data-testid={`flow-runs-sidebar-run-${run.id}`}
-                  onClick={() => setSelectedRunId(run.id)}
-                  className={`flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-surface-hover ${
-                    selectedRunId === run.id ? 'bg-surface-hover' : ''
-                  }`}>
-                  <span
-                    className={`h-2 w-2 shrink-0 rounded-full ${FLOW_RUN_STATUS_DOT[displayStatus]}`}
-                    aria-hidden="true"
-                  />
-                  <span className="min-w-0 flex-1">
-                    <span
-                      className={`inline-flex items-center rounded-full border px-1.5 py-0.5 text-[10px] font-medium ${FLOW_RUN_STATUS_ACCENT[displayStatus]}`}>
-                      {t(FLOW_RUN_STATUS_KEY[displayStatus])}
-                    </span>
-                    <span className="mt-0.5 block truncate text-[11px] text-content-faint">
-                      {relativeTime(run.started_at, t)}
-                    </span>
-                  </span>
-                </button>
-              </li>
-            );
-          })}
-        </ul>
+        {runs.map(run => {
+          const displayStatus = resolveDisplayStatus(run, pendingRunIds);
+          const label = `${t(FLOW_RUN_STATUS_KEY[displayStatus])} · ${relativeTime(run.started_at, t)}`;
+          const selected = selectedRunId === run.id;
+          return (
+            <Tooltip key={run.id} label={label} side="right">
+              <button
+                type="button"
+                data-testid={`flow-runs-sidebar-run-${run.id}`}
+                aria-pressed={selected}
+                onClick={() => selectRun(run.id)}
+                className={`flex h-4 w-4 flex-shrink-0 items-center justify-center rounded-full transition-shadow ${
+                  selected ? 'ring-2 ring-primary-500 ring-offset-1 ring-offset-surface' : ''
+                }`}>
+                <span
+                  className={`h-2.5 w-2.5 rounded-full ${FLOW_RUN_STATUS_DOT[displayStatus]}`}
+                  aria-hidden="true"
+                />
+              </button>
+            </Tooltip>
+          );
+        })}
       </div>
 
-      <FlowRunInspectorDrawer
-        runId={selectedRunId}
-        onClose={() => setSelectedRunId(null)}
-        onFixWithAgent={handleFixWithAgent}
-      />
+      <Tooltip label={expanded ? t('flows.runs.collapse') : t('flows.runs.expand')} side="right">
+        <button
+          type="button"
+          data-testid="flow-runs-sidebar-expand"
+          aria-expanded={expanded}
+          aria-label={expanded ? t('flows.runs.collapse') : t('flows.runs.expand')}
+          onClick={() => setExpanded(e => !e)}
+          className="mt-1 rounded-md p-1.5 text-content-faint transition-colors hover:bg-surface-hover hover:text-content-secondary">
+          <ChevronIcon expanded={expanded} />
+        </button>
+      </Tooltip>
+
+      {expanded && (
+        <div
+          data-testid="flow-runs-sidebar-flyout"
+          className="absolute left-full top-0 z-20 max-h-full w-56 overflow-y-auto rounded-xl border border-line bg-surface p-2 shadow-xl">
+          <div className="px-1 pb-1.5 text-[11px] font-semibold uppercase tracking-wide text-content-faint">
+            {t('flows.runs.sidebarTitle')}
+          </div>
+
+          {error && <p className="px-1 pb-1 text-xs text-coral-600 dark:text-coral-400">{error}</p>}
+
+          {!loading && !error && runs.length === 0 && (
+            <p className="px-2 py-4 text-center text-xs text-content-faint">
+              {t('flows.runs.empty')}
+            </p>
+          )}
+
+          <ul className="space-y-1">
+            {runs.map(run => {
+              const displayStatus = resolveDisplayStatus(run, pendingRunIds);
+              return (
+                <li key={run.id}>
+                  <button
+                    type="button"
+                    data-testid={`flow-runs-flyout-run-${run.id}`}
+                    onClick={() => selectRun(run.id)}
+                    className={`flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-surface-hover ${
+                      selectedRunId === run.id ? 'bg-surface-hover' : ''
+                    }`}>
+                    <span
+                      className={`h-2 w-2 shrink-0 rounded-full ${FLOW_RUN_STATUS_DOT[displayStatus]}`}
+                      aria-hidden="true"
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span
+                        className={`inline-flex items-center rounded-full border px-1.5 py-0.5 text-[10px] font-medium ${FLOW_RUN_STATUS_ACCENT[displayStatus]}`}>
+                        {t(FLOW_RUN_STATUS_KEY[displayStatus])}
+                      </span>
+                      <span className="mt-0.5 block truncate text-[11px] text-content-faint">
+                        {relativeTime(run.started_at, t)}
+                      </span>
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/src/components/flows/__tests__/FlowRunInspectorDrawer.test.tsx
+++ b/app/src/components/flows/__tests__/FlowRunInspectorDrawer.test.tsx
@@ -82,7 +82,10 @@ describe('FlowRunInspectorDrawer', () => {
     useFlowRunPoller.mockReturnValue({ run: null, loading: false, error: null });
     const { container } = renderDrawer(null, vi.fn());
     expect(container).toBeEmptyDOMElement();
-    expect(useFlowRunPoller).toHaveBeenCalledWith(null);
+    // The Drawer wrapper now short-circuits BEFORE mounting the extracted
+    // `FlowRunInspectorPanel` (whose `useFlowRunPoller(runId)` call this used
+    // to assert on) — with no run to show, the panel never mounts at all.
+    expect(useFlowRunPoller).not.toHaveBeenCalled();
   });
 
   it('shows a loading state before data resolves', () => {

--- a/app/src/components/flows/canvas/EditableFlowCanvas.tsx
+++ b/app/src/components/flows/canvas/EditableFlowCanvas.tsx
@@ -45,7 +45,11 @@ import {
   useState,
 } from 'react';
 
-import { FLOW_RUN_NODE_STATUS_CLASS, useFlowRunProgress } from '../../../hooks/useFlowRunProgress';
+import {
+  FLOW_RUN_NODE_STATUS_CLASS,
+  type FlowRunProgressMap,
+  useFlowRunProgress,
+} from '../../../hooks/useFlowRunProgress';
 import { erroredNodeIds } from '../../../lib/flows/flowValidation';
 import {
   createFlowNode,
@@ -145,6 +149,33 @@ export interface EditableFlowCanvasProps {
    */
   activeRunId?: string | null;
   /**
+   * Piece 2 (redesign) — a pre-computed `node_id -> status` map to overlay
+   * INSTEAD of the live `activeRunId` socket feed, for viewing a
+   * selected/completed historical run (built via `stepsToProgressMap` from
+   * its durable `steps[]`). When provided, this wins over the live overlay
+   * derived from `activeRunId` — the host is expected to pass `activeRunId`
+   * as `null`/absent in that case (no point subscribing live to a run that
+   * isn't the one being viewed). `undefined` (the default) means "no
+   * override — use the live `activeRunId` feed as before", so every existing
+   * caller is unaffected.
+   */
+  runProgressOverride?: FlowRunProgressMap;
+  /**
+   * Piece 2 (redesign) — fired when the user clicks a node that currently
+   * carries a run status (live or overridden), so the host can select the
+   * matching step in the Run tab. Never fires for a node with no status —
+   * the plain node-config-drawer click behavior is unaffected either way.
+   */
+  onNodeRunClick?: (nodeId: string) => void;
+  /**
+   * Piece 2 (redesign) — node id to visually focus (a distinct ring,
+   * `flow-node-focused`) when a step is selected from the Run tab. The host
+   * drives the actual pan/zoom via the `focusNode` imperative handle method
+   * below; this prop only controls the highlight, which must survive
+   * independent of any single `fitView` call (e.g. after further panning).
+   */
+  focusedNodeId?: string | null;
+  /**
    * Reports the canvas's live graph on every edit (Phase 5c) so the host can
    * feed the current draft to the copilot as context and diff a proposal
    * against it. Fires with the same serialization Save uses.
@@ -228,9 +259,31 @@ export interface EditableFlowCanvasHandle {
    * do that. Call this after such an out-of-band persist succeeds to sync it.
    */
   clearForcedDirty: () => void;
+  /**
+   * Piece 2 (redesign) — center the viewport on a single node by id (best-
+   * effort no-op if the node isn't in the current graph), for the Run tab's
+   * "select a step -> center the node" direction. Does not itself change
+   * selection/highlight state — pair with the `focusedNodeId` prop for the
+   * visual ring.
+   */
+  focusNode: (nodeId: string) => void;
 }
 
 const EMPTY_ID_SET: ReadonlySet<string> = new Set();
+
+/**
+ * Normalizes a raw live/overridden progress status (`FlowNodeRunStatus` —
+ * `'running' | 'success' | 'error' | (string & {})`, since the live feed's
+ * type stays forward-compatible with unrecognized values) down to the badge's
+ * closed set. `'failed'` collapses onto `'error'` — {@link FLOW_RUN_NODE_STATUS_CLASS}
+ * treats them identically for the ring class, and the badge does the same.
+ * Anything else unrecognized reads as `'not-run'` rather than throwing/blank.
+ */
+function normalizeBadgeStatus(raw: string | undefined): NonNullable<FlowNode['data']['runStatus']> {
+  if (raw === 'running' || raw === 'success') return raw;
+  if (raw === 'error' || raw === 'failed') return 'error';
+  return 'not-run';
+}
 
 function EditableFlowCanvas(
   {
@@ -241,6 +294,9 @@ function EditableFlowCanvas(
     onInvalidConnection,
     onDirtyChange,
     activeRunId = null,
+    runProgressOverride,
+    onNodeRunClick,
+    focusedNodeId = null,
     onGraphChange,
     addedNodeIds = EMPTY_ID_SET,
     removedNodeIds = EMPTY_ID_SET,
@@ -412,7 +468,12 @@ function EditableFlowCanvas(
   // each node id to a live-status ring class. This CLOSES Phase 1's deferred
   // "frontend consumes FlowRunProgress" follow-up. The 2s poller in
   // `useFlowRunPoller` stays as the durable fallback; this just makes it live.
-  const runProgress = useFlowRunProgress(activeRunId);
+  const liveRunProgress = useFlowRunProgress(activeRunId);
+  // Piece 2 (redesign): a host-supplied override (a selected/completed
+  // historical run's `stepsToProgressMap`) wins over the live feed — the host
+  // only ever supplies one or the other at a time (see `runProgressOverride`'s
+  // doc comment above).
+  const runProgress = runProgressOverride ?? liveRunProgress;
 
   // Derive the render array (never stored in draft, so it can't dirty the graph):
   // tag errored nodes with the `flow-node-error` class the canvas CSS rings, and
@@ -420,7 +481,7 @@ function EditableFlowCanvas(
   const hasRunOverlay = Object.keys(runProgress).length > 0;
   const hasDiffOverlay = addedNodeIds.size > 0 || removedNodeIds.size > 0;
   const displayNodes = useMemo(() => {
-    if (erroredIds.size === 0 && !hasRunOverlay && !hasDiffOverlay) return nodes;
+    if (erroredIds.size === 0 && !hasRunOverlay && !hasDiffOverlay && !focusedNodeId) return nodes;
     return nodes.map(n => {
       const extra: string[] = [];
       if (erroredIds.has(n.id)) extra.push('flow-node-error');
@@ -429,12 +490,31 @@ function EditableFlowCanvas(
       // Copilot diff overlay (Phase 5c): sage ring on added, ghost on removed.
       if (addedNodeIds.has(n.id)) extra.push('flow-node-added');
       if (removedNodeIds.has(n.id)) extra.push('flow-node-removed');
-      if (extra.length === 0) return n;
-      return { ...n, className: `${n.className ?? ''} ${extra.join(' ')}`.trim() };
+      // Piece 2 (redesign): a step selected in the Run tab rings its node.
+      if (focusedNodeId === n.id) extra.push('flow-node-focused');
+      const withClassName =
+        extra.length === 0
+          ? n
+          : { ...n, className: `${n.className ?? ''} ${extra.join(' ')}`.trim() };
+      // Piece 2 (redesign): while a run is being viewed (live or overridden),
+      // every node gets a badge status — 'not-run' for one with no step yet,
+      // so "hasn't executed" is as visible as "done"/"failed".
+      if (!hasRunOverlay) return withClassName;
+      const status = normalizeBadgeStatus(runProgress[n.id]);
+      return { ...withClassName, data: { ...withClassName.data, runStatus: status } };
     });
     // `runProgress` is a stable-enough dependency (new object only on a real
     // status change, see the hook's setState guard).
-  }, [nodes, erroredIds, runProgress, hasRunOverlay, hasDiffOverlay, addedNodeIds, removedNodeIds]);
+  }, [
+    nodes,
+    erroredIds,
+    runProgress,
+    hasRunOverlay,
+    hasDiffOverlay,
+    addedNodeIds,
+    removedNodeIds,
+    focusedNodeId,
+  ]);
 
   // Load the secret-free credential refs once for the node-config credential
   // picker (http_request / tool_call). Guarded: outside Tauri (or if the RPC
@@ -651,6 +731,17 @@ function EditableFlowCanvas(
         setBaseline({ nodes, edges });
         setForcedDirty(false);
       },
+      focusNode: (nodeId: string) => {
+        const instance = rfRef.current;
+        if (!instance) return;
+        const target = instance.getNode(nodeId);
+        if (!target) {
+          log('focusNode: id=%s not found in current graph — no-op', nodeId);
+          return;
+        }
+        log('focusNode: id=%s', nodeId);
+        void instance.fitView({ nodes: [{ id: nodeId }], duration: 400, maxZoom: 1.2 });
+      },
     }),
     [dirty, hasErrors, saving, saveDisabled, handleSave, handleDiscard, nodes, edges]
   );
@@ -672,10 +763,20 @@ function EditableFlowCanvas(
   // fire `onNodeClick` for a drag (dragging emits drag events instead), so
   // grabbing a node to move it no longer pops the drawer open — the fix for
   // "dragging the card opens the sidebar".
-  const onNodeClick = useCallback((_event: React.MouseEvent, node: FlowNode) => {
-    log('nodeClick: id=%s — opening config', node.id);
-    setConfigNodeId(node.id);
-  }, []);
+  const onNodeClick = useCallback(
+    (_event: React.MouseEvent, node: FlowNode) => {
+      log('nodeClick: id=%s — opening config', node.id);
+      setConfigNodeId(node.id);
+      // Piece 2 (redesign): a node carrying a run status also selects its
+      // step in the Run tab. Never fires for a node with no status (no run
+      // is being viewed, or this node hasn't executed in the one that is).
+      if (runProgress[node.id] !== undefined) {
+        log('nodeClick: id=%s has run status=%s — notifying host', node.id, runProgress[node.id]);
+        onNodeRunClick?.(node.id);
+      }
+    },
+    [runProgress, onNodeRunClick]
+  );
 
   const onSelectionChange = useCallback(
     ({ nodes: selNodes, edges: selEdges }: { nodes: FlowNode[]; edges: FlowEdge[] }) => {

--- a/app/src/components/flows/canvas/FlowCanvas.tsx
+++ b/app/src/components/flows/canvas/FlowCanvas.tsx
@@ -23,6 +23,7 @@ import {
 import '@xyflow/react/dist/style.css';
 import { forwardRef, memo, useMemo } from 'react';
 
+import type { FlowRunProgressMap } from '../../../hooks/useFlowRunProgress';
 import {
   FLOW_NODE_TYPE,
   type FlowEdge,
@@ -53,6 +54,12 @@ export interface FlowCanvasProps {
   onDirtyChange?: (dirty: boolean) => void;
   /** Active run id (== thread_id) to overlay live per-node status on the canvas (editable only, Phase 3e). */
   activeRunId?: string | null;
+  /** Overrides the live overlay with a pre-computed status map (editable only, Piece 2 redesign). See `EditableFlowCanvasProps`. */
+  runProgressOverride?: FlowRunProgressMap;
+  /** Fired when a node carrying a run status is clicked (editable only, Piece 2 redesign). */
+  onNodeRunClick?: (nodeId: string) => void;
+  /** Node id to ring-highlight as the Run tab's currently-selected step (editable only, Piece 2 redesign). */
+  focusedNodeId?: string | null;
   /** Reports the live graph on every edit so the copilot has the current draft (editable only, Phase 5c). */
   onGraphChange?: (graph: WorkflowGraph) => void;
   /** Node ids the copilot proposal adds — ringed as a diff highlight (editable only, Phase 5c). */
@@ -138,6 +145,9 @@ const FlowCanvas = forwardRef<EditableFlowCanvasHandle, FlowCanvasProps>(
       onSave,
       onDirtyChange,
       activeRunId,
+      runProgressOverride,
+      onNodeRunClick,
+      focusedNodeId,
       onGraphChange,
       addedNodeIds,
       removedNodeIds,
@@ -160,6 +170,9 @@ const FlowCanvas = forwardRef<EditableFlowCanvasHandle, FlowCanvasProps>(
           onSave={onSave}
           onDirtyChange={onDirtyChange}
           activeRunId={activeRunId}
+          runProgressOverride={runProgressOverride}
+          onNodeRunClick={onNodeRunClick}
+          focusedNodeId={focusedNodeId}
           onGraphChange={onGraphChange}
           addedNodeIds={addedNodeIds}
           removedNodeIds={removedNodeIds}

--- a/app/src/components/flows/canvas/FlowNodeComponent.tsx
+++ b/app/src/components/flows/canvas/FlowNodeComponent.tsx
@@ -21,10 +21,11 @@
 import { Handle, type NodeProps, Position } from '@xyflow/react';
 import { type CSSProperties, memo } from 'react';
 
-import type { FlowNode } from '../../../lib/flows/graphAdapter';
+import type { FlowNode, FlowNodeData } from '../../../lib/flows/graphAdapter';
 import { COLOR_CLASSES, nodeKindMeta } from '../../../lib/flows/nodeKindMeta';
 import { describeNode } from '../../../lib/flows/nodeSummary';
 import { useT } from '../../../lib/i18n/I18nContext';
+import { CheckIcon, CloseIcon, Spinner } from '../../ui/icons';
 import { useCanvasActions } from './canvasActions';
 
 /**
@@ -43,6 +44,51 @@ const INLINE_HANDLE_STYLE: CSSProperties = {
 
 /** The implicit single port; shown as a bare dot with no redundant label. */
 const IMPLICIT_PORT = 'main';
+
+/**
+ * Piece 2 (inline node run-status): background color per `data.runStatus`,
+ * for the small badge rendered on the node card's top-right corner. Distinct
+ * from — and additive to — the outline ring `EditableFlowCanvas` already
+ * applies via `flow-node-running`/`-success`/`-failed` classes; the badge
+ * gives an explicit iconographic status (done/running/failed/not-run) that
+ * reads at a glance even before the eye picks up the ring color.
+ */
+const RUN_STATUS_BADGE_CLASS: Record<NonNullable<FlowNodeData['runStatus']>, string> = {
+  running: 'bg-ocean-500',
+  success: 'bg-sage-500',
+  error: 'bg-coral-500',
+  'not-run': 'bg-content-faint/40',
+};
+
+/** i18n key per `data.runStatus`, for the badge's `aria-label`/`title`. */
+const RUN_STATUS_LABEL_KEY: Record<NonNullable<FlowNodeData['runStatus']>, string> = {
+  running: 'flows.runStatus.running',
+  success: 'flows.runStatus.success',
+  error: 'flows.runStatus.failed',
+  'not-run': 'flows.runStatus.notRun',
+};
+
+/** One badge per `data.runStatus` — check/spinner/X, or a dim dot for "not run". */
+function RunStatusBadge({
+  status,
+  label,
+}: {
+  status: NonNullable<FlowNodeData['runStatus']>;
+  label: string;
+}) {
+  return (
+    <span
+      data-testid="flow-node-status-badge"
+      data-run-status={status}
+      title={label}
+      aria-label={label}
+      className={`absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full border-2 border-surface ${RUN_STATUS_BADGE_CLASS[status]}`}>
+      {status === 'success' && <CheckIcon className="h-2.5 w-2.5 text-white" />}
+      {status === 'running' && <Spinner className="h-2.5 w-2.5 text-white" />}
+      {status === 'error' && <CloseIcon className="h-2.5 w-2.5 text-white" />}
+    </span>
+  );
+}
 
 /** Semantic colours for the well-known branch ports so routing reads at a glance. */
 function portPillClass(port: string): string {
@@ -88,6 +134,9 @@ function FlowNodeComponent({ id, data, selected }: NodeProps<FlowNode>) {
       className={`relative min-w-[180px] max-w-[240px] rounded-xl border-2 bg-surface shadow-sm ${colors.border} ${
         selected ? 'ring-2 ring-primary-500/40' : ''
       }`}>
+      {data.runStatus && (
+        <RunStatusBadge status={data.runStatus} label={t(RUN_STATUS_LABEL_KEY[data.runStatus])} />
+      )}
       <div className={`flex items-center gap-2 rounded-t-[10px] px-3 py-2 ${colors.chip}`}>
         <span className="text-base leading-none" aria-hidden="true">
           {meta.emoji}

--- a/app/src/components/flows/canvas/__tests__/EditableFlowCanvas.runOverlay.test.tsx
+++ b/app/src/components/flows/canvas/__tests__/EditableFlowCanvas.runOverlay.test.tsx
@@ -78,8 +78,28 @@ function renderCanvas(props: Partial<React.ComponentProps<typeof FlowCanvas>> = 
   );
 }
 
+function secondNode(): FlowNode {
+  return {
+    id: 'a',
+    type: 'flowNode',
+    position: { x: 200, y: 0 },
+    data: {
+      kind: 'agent',
+      name: 'Reply',
+      config: {},
+      ports: [],
+      inputPorts: ['main'],
+      outputPorts: ['main'],
+    },
+  };
+}
+
 function nodeWrapper(container: HTMLElement): Element | null {
   return container.querySelector('.react-flow__node[data-id="t"]');
+}
+
+function statusBadge(node: Element | null): Element | null | undefined {
+  return node?.querySelector('[data-testid="flow-node-status-badge"]');
 }
 
 describe('EditableFlowCanvas — live run overlay', () => {
@@ -143,5 +163,50 @@ describe('EditableFlowCanvas — live run overlay', () => {
     unmount();
     expect(socketOff).toHaveBeenCalledWith('flow:run_progress', expect.any(Function));
     expect(socketOff).toHaveBeenCalledWith('flow_run_progress', expect.any(Function));
+  });
+
+  // ── Piece 2: inline node run-status badge ─────────────────────────────────
+  describe('node status badge', () => {
+    it('renders no badge on any node when no run is being viewed', async () => {
+      const { container } = renderCanvas();
+      await waitFor(() => expect(nodeWrapper(container)).toBeInTheDocument());
+      expect(statusBadge(nodeWrapper(container))).toBeNull();
+    });
+
+    it('shows a running badge, then a done badge, then a failed badge, as progress events arrive', async () => {
+      const { container } = renderCanvas({ activeRunId: 'run_1' });
+      await waitFor(() => expect(socketOn).toHaveBeenCalled());
+
+      emitProgress({ run_id: 'run_1', node_id: 't', status: 'running' });
+      await waitFor(() =>
+        expect(statusBadge(nodeWrapper(container))).toHaveAttribute('data-run-status', 'running')
+      );
+
+      emitProgress({ run_id: 'run_1', node_id: 't', status: 'success' });
+      await waitFor(() =>
+        expect(statusBadge(nodeWrapper(container))).toHaveAttribute('data-run-status', 'success')
+      );
+
+      emitProgress({ run_id: 'run_1', node_id: 't', status: 'error' });
+      await waitFor(() =>
+        expect(statusBadge(nodeWrapper(container))).toHaveAttribute('data-run-status', 'error')
+      );
+    });
+
+    it('badges an untouched node "not-run" once ANY node in the graph has a status (a run is being viewed)', async () => {
+      const { container } = renderCanvas({
+        nodes: [triggerNode(), secondNode()],
+        activeRunId: 'run_1',
+      });
+      await waitFor(() => expect(socketOn).toHaveBeenCalled());
+
+      emitProgress({ run_id: 'run_1', node_id: 't', status: 'success' });
+
+      const untouchedWrapper = () => container.querySelector('.react-flow__node[data-id="a"]');
+      await waitFor(() =>
+        expect(statusBadge(untouchedWrapper())).toHaveAttribute('data-run-status', 'not-run')
+      );
+      expect(statusBadge(nodeWrapper(container))).toHaveAttribute('data-run-status', 'success');
+    });
   });
 });

--- a/app/src/components/flows/canvas/flowCanvasStyles.css
+++ b/app/src/components/flows/canvas/flowCanvasStyles.css
@@ -195,6 +195,19 @@
   opacity: 0.45;
 }
 
+/*
+ * Focused-step highlight (Piece 2, redesign): the node whose step is
+ * currently selected in the Run tab gets a distinct dashed primary ring, on
+ * top of whatever run/validation/diff ring it already carries, so "this is
+ * the one the Run tab is showing" reads even when the run/diff ring is
+ * already the same accent color.
+ */
+.flow-canvas .react-flow__node.flow-node-focused {
+  outline: 3px solid rgb(var(--primary-500));
+  outline-offset: 5px;
+  border-radius: 0.85rem;
+}
+
 @keyframes flow-node-run-pulse {
   0%,
   100% {

--- a/app/src/hooks/useFlowRunProgress.test.ts
+++ b/app/src/hooks/useFlowRunProgress.test.ts
@@ -9,7 +9,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useFlowRunProgress } from './useFlowRunProgress';
+import { stepsToProgressMap, useFlowRunProgress } from './useFlowRunProgress';
 
 const handlers = vi.hoisted(() => new Map<string, Set<(data: unknown) => void>>());
 const on = vi.hoisted(() =>
@@ -87,5 +87,38 @@ describe('useFlowRunProgress', () => {
     unmount();
     expect(off).toHaveBeenCalledWith('flow:run_progress', expect.any(Function));
     expect(off).toHaveBeenCalledWith('flow_run_progress', expect.any(Function));
+  });
+});
+
+// -----------------------------------------------------------------------------
+// stepsToProgressMap (Piece 2 — inline node run-status on the canvas): a
+// selected/completed durable run must overlay the canvas identically to a
+// live one, so this must produce the same shape `useFlowRunProgress` does.
+// -----------------------------------------------------------------------------
+describe('stepsToProgressMap', () => {
+  it('maps a successful step to success', () => {
+    expect(stepsToProgressMap([{ node_id: 'a', status: 'success' }])).toEqual({ a: 'success' });
+  });
+
+  it('maps a failed step to error', () => {
+    expect(stepsToProgressMap([{ node_id: 'a', status: 'error' }])).toEqual({ a: 'error' });
+  });
+
+  it('treats a step with no observed status (e.g. a reconstructed trigger) as success', () => {
+    expect(stepsToProgressMap([{ node_id: 't' }])).toEqual({ t: 'success' });
+  });
+
+  it('returns an empty map for no steps', () => {
+    expect(stepsToProgressMap([])).toEqual({});
+  });
+
+  it('keeps the LAST outcome when a node is visited more than once (loop)', () => {
+    expect(
+      stepsToProgressMap([
+        { node_id: 'a', status: 'success' },
+        { node_id: 'b', status: 'success' },
+        { node_id: 'a', status: 'error' },
+      ])
+    ).toEqual({ a: 'error', b: 'success' });
   });
 });

--- a/app/src/hooks/useFlowRunProgress.ts
+++ b/app/src/hooks/useFlowRunProgress.ts
@@ -60,6 +60,43 @@ interface FlowRunProgressPayload {
   status: string;
 }
 
+/**
+ * A single reconstructed step of a durable `FlowRun` — the subset
+ * {@link stepsToProgressMap} needs. Mirrors `FlowRunStep`
+ * (`services/api/flowsApi.ts`) without importing it here, keeping this hook
+ * dependency-free of the API client (matches the file's existing style).
+ */
+export interface FlowRunStepLike {
+  node_id: string;
+  status?: 'success' | 'error';
+}
+
+/**
+ * Derives the SAME `node_id -> status` shape {@link useFlowRunProgress} yields
+ * from live socket events, but from a durable run's already-finished
+ * `steps[]` (Piece 2 — "inline node run-status on the canvas"). Lets the
+ * canvas overlay a selected/completed historical run identically to how it
+ * overlays a live one, via {@link FLOW_RUN_NODE_STATUS_CLASS} /
+ * `EditableFlowCanvas`'s badge rendering — the caller decides which of the
+ * two maps (live vs. this one) is authoritative for the run currently being
+ * viewed.
+ *
+ * A step's `status` is only ever observed as `'success'`/`'error'`
+ * (`FlowRunStep`'s doc comment) — a step reconstructed post-hoc (e.g. the
+ * trigger) carries no `status` at all, but its mere presence in `steps[]`
+ * means it executed, so it's mapped to `'success'` too (best-effort, not a
+ * false negative). When a node id appears more than once (a loop re-visiting
+ * the same node), the LAST occurrence wins, matching how the live socket feed
+ * would have overwritten it with each subsequent event.
+ */
+export function stepsToProgressMap(steps: readonly FlowRunStepLike[]): FlowRunProgressMap {
+  const map: FlowRunProgressMap = {};
+  for (const step of steps) {
+    map[step.node_id] = step.status === 'error' ? 'error' : 'success';
+  }
+  return map;
+}
+
 function parsePayload(data: unknown): FlowRunProgressPayload | null {
   if (!data || typeof data !== 'object') return null;
   const obj = data as Record<string, unknown>;

--- a/app/src/lib/flows/graphAdapter.ts
+++ b/app/src/lib/flows/graphAdapter.ts
@@ -45,6 +45,17 @@ export interface FlowNodeData extends Record<string, unknown> {
   inputPorts: string[];
   /** Effective output port names: declared `ports` ∪ outgoing edges' `from_port` (`['main']` if neither). */
   outputPorts: string[];
+  /**
+   * Live/historical per-node run status (Piece 2 — inline node run-status on
+   * the canvas), overlaid by `EditableFlowCanvas`'s `displayNodes` derivation
+   * — NEVER set on the controlled `nodes` state itself, so it's purely
+   * cosmetic and is not read by {@link xyflowToWorkflowGraph} (it only reads
+   * `kind`/`type_version`/`name`/`config`/`ports`). `undefined` means no run
+   * is currently being viewed for this canvas at all (no badge renders);
+   * `'not-run'` means a run IS being viewed but this node has no step in it
+   * yet/at all.
+   */
+  runStatus?: 'running' | 'success' | 'error' | 'not-run';
 }
 
 export type FlowNode = Node<FlowNodeData>;

--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -4102,6 +4102,9 @@ const messages: TranslationMap = {
   'flowRuns.inspector.diagnosticResolvedNull': 'تم حله إلى null',
   'flows.runs.sidebarTitle': 'التشغيلات',
   'flows.runs.refresh': 'تحديث التشغيلات',
+  // -- Runs rail flyout (Piece 3) --
+  'flows.runs.expand': 'إظهار كل التشغيلات',
+  'flows.runs.collapse': 'إخفاء قائمة التشغيلات',
   'flows.palette.appAction': 'إجراء تطبيق',
   'flows.palette.ohTool': 'أداة',
   'flows.editor.deleteNode': 'حذف',
@@ -7144,6 +7147,19 @@ const messages: TranslationMap = {
   'flows.canvas.sidePanelToggle': 'اللوحة الجانبية',
   'flows.canvas.legendTab': 'يدوي',
 
+  // -- Docked Copilot | Run panel (Workflows UI redesign, Piece 1) --
+  'flows.dock.copilotTab': 'المساعد',
+  'flows.dock.runTab': 'تشغيل',
+  'flows.dock.collapse': 'طي اللوحة',
+  'flows.dock.expand': 'توسيع اللوحة',
+  'flows.dock.resizeHandle': 'تغيير حجم اللوحة',
+  'flows.dock.tablistLabel': 'لوحة سير العمل',
+  'flows.dock.runEmpty': 'اختر تشغيلاً من الشريط لعرض تفاصيله.',
+  // -- Node run-status badge (Piece 2) --
+  'flows.runStatus.success': 'مكتمل',
+  'flows.runStatus.failed': 'فشل',
+  'flows.runStatus.running': 'قيد التشغيل',
+  'flows.runStatus.notRun': 'لم يتم التشغيل',
   // Emergency stop (#4255)
   'safety.emergencyStop': 'إيقاف الطوارئ',
   'safety.stopFailed': 'تعذّر إيقاف الأتمتة. أعد المحاولة.',

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -4205,6 +4205,9 @@ const messages: TranslationMap = {
   'flowRuns.inspector.diagnosticResolvedNull': 'null হিসেবে সমাধান হয়েছে',
   'flows.runs.sidebarTitle': 'রান',
   'flows.runs.refresh': 'রান রিফ্রেশ করুন',
+  // -- Runs rail flyout (Piece 3) --
+  'flows.runs.expand': 'সব রান দেখান',
+  'flows.runs.collapse': 'রান তালিকা লুকান',
   'flows.palette.appAction': 'অ্যাপ অ্যাকশন',
   'flows.palette.ohTool': 'টুল',
   'flows.editor.deleteNode': 'মুছুন',
@@ -7312,6 +7315,19 @@ const messages: TranslationMap = {
   'flows.canvas.sidePanelToggle': 'সাইড প্যানেল',
   'flows.canvas.legendTab': 'ম্যানুয়াল',
 
+  // -- Docked Copilot | Run panel (Workflows UI redesign, Piece 1) --
+  'flows.dock.copilotTab': 'কো-পাইলট',
+  'flows.dock.runTab': 'চালান',
+  'flows.dock.collapse': 'প্যানেল সংকুচিত করুন',
+  'flows.dock.expand': 'প্যানেল প্রসারিত করুন',
+  'flows.dock.resizeHandle': 'প্যানেলের আকার পরিবর্তন করুন',
+  'flows.dock.tablistLabel': 'ওয়ার্কফ্লো প্যানেল',
+  'flows.dock.runEmpty': 'বিস্তারিত দেখতে রেল থেকে একটি রান নির্বাচন করুন।',
+  // -- Node run-status badge (Piece 2) --
+  'flows.runStatus.success': 'সম্পন্ন',
+  'flows.runStatus.failed': 'ব্যর্থ',
+  'flows.runStatus.running': 'চলছে',
+  'flows.runStatus.notRun': 'চালানো হয়নি',
   // Emergency stop (#4255)
   'safety.emergencyStop': 'জরুরি বন্ধ',
   'safety.stopFailed': 'অটোমেশন থামানো যায়নি। আবার চেষ্টা করুন।',

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -4325,6 +4325,9 @@ const messages: TranslationMap = {
   'flowRuns.inspector.diagnosticResolvedNull': 'wurde zu null aufgelöst',
   'flows.runs.sidebarTitle': 'Läufe',
   'flows.runs.refresh': 'Läufe aktualisieren',
+  // -- Runs rail flyout (Piece 3) --
+  'flows.runs.expand': 'Alle Läufe anzeigen',
+  'flows.runs.collapse': 'Laufliste ausblenden',
   'flows.palette.appAction': 'App-Aktion',
   'flows.palette.ohTool': 'Werkzeug',
   'flows.editor.deleteNode': 'Löschen',
@@ -7529,6 +7532,19 @@ const messages: TranslationMap = {
   'flows.canvas.sidePanelToggle': 'Seitenleiste',
   'flows.canvas.legendTab': 'Manuell',
 
+  // -- Docked Copilot | Run panel (Workflows UI redesign, Piece 1) --
+  'flows.dock.copilotTab': 'Assistent',
+  'flows.dock.runTab': 'Ausführen',
+  'flows.dock.collapse': 'Panel einklappen',
+  'flows.dock.expand': 'Panel ausklappen',
+  'flows.dock.resizeHandle': 'Panelgröße ändern',
+  'flows.dock.tablistLabel': 'Workflow-Panel',
+  'flows.dock.runEmpty': 'Wählen Sie einen Lauf aus der Leiste, um Details zu sehen.',
+  // -- Node run-status badge (Piece 2) --
+  'flows.runStatus.success': 'Abgeschlossen',
+  'flows.runStatus.failed': 'Fehlgeschlagen',
+  'flows.runStatus.running': 'Läuft',
+  'flows.runStatus.notRun': 'Nicht ausgeführt',
   // Emergency stop (#4255)
   'safety.emergencyStop': 'Notabschaltung',
   'safety.stopFailed': 'Automatisierung konnte nicht gestoppt werden – bitte erneut versuchen.',

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -4773,6 +4773,9 @@ const en: TranslationMap = {
   'flows.runs.empty': 'No runs yet',
   'flows.runs.sidebarTitle': 'Runs',
   'flows.runs.refresh': 'Refresh runs',
+  // ── Runs rail flyout (Piece 3) ─────────────────────────────────────────
+  'flows.runs.expand': 'Show all runs',
+  'flows.runs.collapse': 'Hide run list',
 
   // ── Phase 5c: prompt-first authoring + canvas copilot ────────────────────
   // The Flows prompt bar (describe a workflow → builder agent proposes it) and
@@ -4849,6 +4852,20 @@ const en: TranslationMap = {
   // The palette tab is labelled "Manual" (build by hand) as the counterpart to
   // the AI "Copilot" tab; the key name stays `legendTab` for the node palette.
   'flows.canvas.legendTab': 'Manual',
+
+  // ── Docked Copilot | Run panel (Workflows UI redesign, Piece 1) ──────────
+  'flows.dock.copilotTab': 'Copilot',
+  'flows.dock.runTab': 'Run',
+  'flows.dock.collapse': 'Collapse panel',
+  'flows.dock.expand': 'Expand panel',
+  'flows.dock.resizeHandle': 'Resize panel',
+  'flows.dock.tablistLabel': 'Workflow panel',
+  'flows.dock.runEmpty': 'Select a run from the rail to see its details.',
+  // ── Node run-status badge (Piece 2) ───────────────────────────────────────
+  'flows.runStatus.success': 'Completed',
+  'flows.runStatus.failed': 'Failed',
+  'flows.runStatus.running': 'Running',
+  'flows.runStatus.notRun': 'Not run',
   'flows.nodeKind.trigger': 'Trigger',
   'flows.nodeKind.agent': 'Agent',
   'flows.nodeKind.tool_call': 'Tool call',

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -4276,6 +4276,9 @@ const messages: TranslationMap = {
   'flowRuns.inspector.diagnosticResolvedNull': 'se resolvió como null',
   'flows.runs.sidebarTitle': 'Ejecuciones',
   'flows.runs.refresh': 'Actualizar ejecuciones',
+  // -- Runs rail flyout (Piece 3) --
+  'flows.runs.expand': 'Mostrar todas las ejecuciones',
+  'flows.runs.collapse': 'Ocultar lista de ejecuciones',
   'flows.palette.appAction': 'Acción de app',
   'flows.palette.ohTool': 'Herramienta',
   'flows.editor.deleteNode': 'Eliminar',
@@ -7465,6 +7468,19 @@ const messages: TranslationMap = {
   'flows.canvas.sidePanelToggle': 'Panel lateral',
   'flows.canvas.legendTab': 'Manual',
 
+  // -- Docked Copilot | Run panel (Workflows UI redesign, Piece 1) --
+  'flows.dock.copilotTab': 'Copiloto',
+  'flows.dock.runTab': 'Ejecutar',
+  'flows.dock.collapse': 'Contraer panel',
+  'flows.dock.expand': 'Expandir panel',
+  'flows.dock.resizeHandle': 'Cambiar tamaño del panel',
+  'flows.dock.tablistLabel': 'Panel del flujo de trabajo',
+  'flows.dock.runEmpty': 'Selecciona una ejecución en la barra para ver sus detalles.',
+  // -- Node run-status badge (Piece 2) --
+  'flows.runStatus.success': 'Completado',
+  'flows.runStatus.failed': 'Fallido',
+  'flows.runStatus.running': 'En ejecución',
+  'flows.runStatus.notRun': 'No ejecutado',
   // Emergency stop (#4255)
   'safety.emergencyStop': 'Parada de emergencia',
   'safety.stopFailed': 'No se pudo detener la automatización: inténtalo de nuevo.',

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -4304,6 +4304,9 @@ const messages: TranslationMap = {
   'flowRuns.inspector.diagnosticResolvedNull': 'résolu en null',
   'flows.runs.sidebarTitle': 'Exécutions',
   'flows.runs.refresh': 'Actualiser les exécutions',
+  // -- Runs rail flyout (Piece 3) --
+  'flows.runs.expand': 'Afficher toutes les exécutions',
+  'flows.runs.collapse': 'Masquer la liste des exécutions',
   'flows.palette.appAction': "Action d'app",
   'flows.palette.ohTool': 'Outil',
   'flows.editor.deleteNode': 'Supprimer',
@@ -7500,6 +7503,19 @@ const messages: TranslationMap = {
   'flows.canvas.sidePanelToggle': 'Panneau latéral',
   'flows.canvas.legendTab': 'Manuel',
 
+  // -- Docked Copilot | Run panel (Workflows UI redesign, Piece 1) --
+  'flows.dock.copilotTab': 'Copilote',
+  'flows.dock.runTab': 'Exécuter',
+  'flows.dock.collapse': 'Réduire le panneau',
+  'flows.dock.expand': 'Développer le panneau',
+  'flows.dock.resizeHandle': 'Redimensionner le panneau',
+  'flows.dock.tablistLabel': 'Panneau du flux de travail',
+  'flows.dock.runEmpty': 'Sélectionnez une exécution dans la barre pour voir ses détails.',
+  // -- Node run-status badge (Piece 2) --
+  'flows.runStatus.success': 'Terminé',
+  'flows.runStatus.failed': 'Échoué',
+  'flows.runStatus.running': 'En cours',
+  'flows.runStatus.notRun': 'Non exécuté',
   // Emergency stop (#4255)
   'safety.emergencyStop': "Arrêt d'urgence",
   'safety.stopFailed': "Impossible d'arrêter l'automatisation. Réessayez.",

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -4203,6 +4203,9 @@ const messages: TranslationMap = {
   'flowRuns.inspector.diagnosticResolvedNull': 'null में बदला',
   'flows.runs.sidebarTitle': 'रन',
   'flows.runs.refresh': 'रन रीफ़्रेश करें',
+  // -- Runs rail flyout (Piece 3) --
+  'flows.runs.expand': 'सभी रन दिखाएं',
+  'flows.runs.collapse': 'रन सूची छिपाएं',
   'flows.palette.appAction': 'ऐप क्रिया',
   'flows.palette.ohTool': 'टूल',
   'flows.editor.deleteNode': 'हटाएँ',
@@ -7309,6 +7312,19 @@ const messages: TranslationMap = {
   'flows.canvas.sidePanelToggle': 'साइड पैनल',
   'flows.canvas.legendTab': 'मैनुअल',
 
+  // -- Docked Copilot | Run panel (Workflows UI redesign, Piece 1) --
+  'flows.dock.copilotTab': 'सहपायलट',
+  'flows.dock.runTab': 'चलाएं',
+  'flows.dock.collapse': 'पैनल संक्षिप्त करें',
+  'flows.dock.expand': 'पैनल विस्तृत करें',
+  'flows.dock.resizeHandle': 'पैनल का आकार बदलें',
+  'flows.dock.tablistLabel': 'वर्कफ़्लो पैनल',
+  'flows.dock.runEmpty': 'विवरण देखने के लिए रेल से एक रन चुनें।',
+  // -- Node run-status badge (Piece 2) --
+  'flows.runStatus.success': 'पूर्ण',
+  'flows.runStatus.failed': 'विफल',
+  'flows.runStatus.running': 'चल रहा है',
+  'flows.runStatus.notRun': 'नहीं चला',
   // Emergency stop (#4255)
   'safety.emergencyStop': 'आपातकालीन रोक',
   'safety.stopFailed': 'स्वचालन रोका नहीं जा सका। पुनः प्रयास करें।',

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -4219,6 +4219,9 @@ const messages: TranslationMap = {
   'flowRuns.inspector.diagnosticResolvedNull': 'diselesaikan menjadi null',
   'flows.runs.sidebarTitle': 'Jalankan',
   'flows.runs.refresh': 'Segarkan daftar jalan',
+  // -- Runs rail flyout (Piece 3) --
+  'flows.runs.expand': 'Tampilkan semua proses',
+  'flows.runs.collapse': 'Sembunyikan daftar proses',
   'flows.palette.appAction': 'Aksi aplikasi',
   'flows.palette.ohTool': 'Alat',
   'flows.editor.deleteNode': 'Hapus',
@@ -7347,6 +7350,19 @@ const messages: TranslationMap = {
   'flows.canvas.sidePanelToggle': 'Panel samping',
   'flows.canvas.legendTab': 'Manual',
 
+  // -- Docked Copilot | Run panel (Workflows UI redesign, Piece 1) --
+  'flows.dock.copilotTab': 'Kopilot',
+  'flows.dock.runTab': 'Jalankan',
+  'flows.dock.collapse': 'Ciutkan panel',
+  'flows.dock.expand': 'Perluas panel',
+  'flows.dock.resizeHandle': 'Ubah ukuran panel',
+  'flows.dock.tablistLabel': 'Panel alur kerja',
+  'flows.dock.runEmpty': 'Pilih proses dari bilah untuk melihat detailnya.',
+  // -- Node run-status badge (Piece 2) --
+  'flows.runStatus.success': 'Selesai',
+  'flows.runStatus.failed': 'Gagal',
+  'flows.runStatus.running': 'Berjalan',
+  'flows.runStatus.notRun': 'Belum dijalankan',
   // Emergency stop (#4255)
   'safety.emergencyStop': 'Hentikan darurat',
   'safety.stopFailed': 'Tidak dapat menghentikan otomasi. Coba lagi.',

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -4272,6 +4272,9 @@ const messages: TranslationMap = {
   'flowRuns.inspector.diagnosticResolvedNull': 'risolto in null',
   'flows.runs.sidebarTitle': 'Esecuzioni',
   'flows.runs.refresh': 'Aggiorna esecuzioni',
+  // -- Runs rail flyout (Piece 3) --
+  'flows.runs.expand': 'Mostra tutte le esecuzioni',
+  'flows.runs.collapse': 'Nascondi elenco esecuzioni',
   'flows.palette.appAction': 'Azione app',
   'flows.palette.ohTool': 'Strumento',
   'flows.editor.deleteNode': 'Elimina',
@@ -7454,6 +7457,19 @@ const messages: TranslationMap = {
   'flows.canvas.sidePanelToggle': 'Pannello laterale',
   'flows.canvas.legendTab': 'Manuale',
 
+  // -- Docked Copilot | Run panel (Workflows UI redesign, Piece 1) --
+  'flows.dock.copilotTab': 'Copilota',
+  'flows.dock.runTab': 'Esegui',
+  'flows.dock.collapse': 'Comprimi pannello',
+  'flows.dock.expand': 'Espandi pannello',
+  'flows.dock.resizeHandle': 'Ridimensiona pannello',
+  'flows.dock.tablistLabel': 'Pannello del flusso di lavoro',
+  'flows.dock.runEmpty': "Seleziona un'esecuzione dalla barra per vederne i dettagli.",
+  // -- Node run-status badge (Piece 2) --
+  'flows.runStatus.success': 'Completato',
+  'flows.runStatus.failed': 'Non riuscito',
+  'flows.runStatus.running': 'In esecuzione',
+  'flows.runStatus.notRun': 'Non eseguito',
   // Emergency stop (#4255)
   'safety.emergencyStop': 'Arresto di emergenza',
   'safety.stopFailed': "Impossibile fermare l'automazione. Riprova.",

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -4155,6 +4155,9 @@ const messages: TranslationMap = {
   'flowRuns.inspector.diagnosticResolvedNull': 'null로 확인됨',
   'flows.runs.sidebarTitle': '실행',
   'flows.runs.refresh': '실행 새로고침',
+  // -- Runs rail flyout (Piece 3) --
+  'flows.runs.expand': '모든 실행 표시',
+  'flows.runs.collapse': '실행 목록 숨기기',
   'flows.palette.appAction': '앱 작업',
   'flows.palette.ohTool': '도구',
   'flows.editor.deleteNode': '삭제',
@@ -7224,6 +7227,19 @@ const messages: TranslationMap = {
   'flows.canvas.sidePanelToggle': '사이드 패널',
   'flows.canvas.legendTab': '수동',
 
+  // -- Docked Copilot | Run panel (Workflows UI redesign, Piece 1) --
+  'flows.dock.copilotTab': '코파일럿',
+  'flows.dock.runTab': '실행',
+  'flows.dock.collapse': '패널 접기',
+  'flows.dock.expand': '패널 펼치기',
+  'flows.dock.resizeHandle': '패널 크기 조절',
+  'flows.dock.tablistLabel': '워크플로 패널',
+  'flows.dock.runEmpty': '레일에서 실행을 선택하면 세부 정보를 볼 수 있습니다.',
+  // -- Node run-status badge (Piece 2) --
+  'flows.runStatus.success': '완료됨',
+  'flows.runStatus.failed': '실패',
+  'flows.runStatus.running': '실행 중',
+  'flows.runStatus.notRun': '실행 안 됨',
   // Emergency stop (#4255)
   'safety.emergencyStop': '긴급 정지',
   'safety.stopFailed': '자동화를 중지할 수 없습니다. 다시 시도하세요.',

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -4260,6 +4260,9 @@ const messages: TranslationMap = {
   'flowRuns.inspector.diagnosticResolvedNull': 'rozwiązano jako null',
   'flows.runs.sidebarTitle': 'Uruchomienia',
   'flows.runs.refresh': 'Odśwież uruchomienia',
+  // -- Runs rail flyout (Piece 3) --
+  'flows.runs.expand': 'Pokaż wszystkie przebiegi',
+  'flows.runs.collapse': 'Ukryj listę przebiegów',
   'flows.palette.appAction': 'Akcja aplikacji',
   'flows.palette.ohTool': 'Narzędzie',
   'flows.editor.deleteNode': 'Usuń',
@@ -7424,6 +7427,19 @@ const messages: TranslationMap = {
   'flows.canvas.sidePanelToggle': 'Panel boczny',
   'flows.canvas.legendTab': 'Ręczny',
 
+  // -- Docked Copilot | Run panel (Workflows UI redesign, Piece 1) --
+  'flows.dock.copilotTab': 'Kopilot',
+  'flows.dock.runTab': 'Uruchom',
+  'flows.dock.collapse': 'Zwiń panel',
+  'flows.dock.expand': 'Rozwiń panel',
+  'flows.dock.resizeHandle': 'Zmień rozmiar panelu',
+  'flows.dock.tablistLabel': 'Panel przepływu pracy',
+  'flows.dock.runEmpty': 'Wybierz przebieg z paska, aby zobaczyć szczegóły.',
+  // -- Node run-status badge (Piece 2) --
+  'flows.runStatus.success': 'Zakończono',
+  'flows.runStatus.failed': 'Niepowodzenie',
+  'flows.runStatus.running': 'W trakcie',
+  'flows.runStatus.notRun': 'Nie uruchomiono',
   // Emergency stop (#4255)
   'safety.emergencyStop': 'Awaryjne zatrzymanie',
   'safety.stopFailed': 'Nie udało się zatrzymać automatyzacji. Spróbuj ponownie.',

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -4265,6 +4265,9 @@ const messages: TranslationMap = {
   'flowRuns.inspector.diagnosticResolvedNull': 'resolvido como null',
   'flows.runs.sidebarTitle': 'Execuções',
   'flows.runs.refresh': 'Atualizar execuções',
+  // -- Runs rail flyout (Piece 3) --
+  'flows.runs.expand': 'Mostrar todas as execuções',
+  'flows.runs.collapse': 'Ocultar lista de execuções',
   'flows.palette.appAction': 'Ação de app',
   'flows.palette.ohTool': 'Ferramenta',
   'flows.editor.deleteNode': 'Excluir',
@@ -7434,6 +7437,19 @@ const messages: TranslationMap = {
   'flows.canvas.sidePanelToggle': 'Painel lateral',
   'flows.canvas.legendTab': 'Manual',
 
+  // -- Docked Copilot | Run panel (Workflows UI redesign, Piece 1) --
+  'flows.dock.copilotTab': 'Copiloto',
+  'flows.dock.runTab': 'Executar',
+  'flows.dock.collapse': 'Recolher painel',
+  'flows.dock.expand': 'Expandir painel',
+  'flows.dock.resizeHandle': 'Redimensionar painel',
+  'flows.dock.tablistLabel': 'Painel do fluxo de trabalho',
+  'flows.dock.runEmpty': 'Selecione uma execução na barra para ver os detalhes.',
+  // -- Node run-status badge (Piece 2) --
+  'flows.runStatus.success': 'Concluído',
+  'flows.runStatus.failed': 'Falhou',
+  'flows.runStatus.running': 'Em execução',
+  'flows.runStatus.notRun': 'Não executado',
   // Emergency stop (#4255)
   'safety.emergencyStop': 'Parada de emergência',
   'safety.stopFailed': 'Não foi possível parar a automação. Tente novamente.',

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -4243,6 +4243,9 @@ const messages: TranslationMap = {
   'flowRuns.inspector.diagnosticResolvedNull': 'разрешилось в null',
   'flows.runs.sidebarTitle': 'Запуски',
   'flows.runs.refresh': 'Обновить запуски',
+  // -- Runs rail flyout (Piece 3) --
+  'flows.runs.expand': 'Показать все запуски',
+  'flows.runs.collapse': 'Скрыть список запусков',
   'flows.palette.appAction': 'Действие приложения',
   'flows.palette.ohTool': 'Инструмент',
   'flows.editor.deleteNode': 'Удалить',
@@ -7394,6 +7397,19 @@ const messages: TranslationMap = {
   'flows.canvas.sidePanelToggle': 'Боковая панель',
   'flows.canvas.legendTab': 'Вручную',
 
+  // -- Docked Copilot | Run panel (Workflows UI redesign, Piece 1) --
+  'flows.dock.copilotTab': 'Второй пилот',
+  'flows.dock.runTab': 'Запустить',
+  'flows.dock.collapse': 'Свернуть панель',
+  'flows.dock.expand': 'Развернуть панель',
+  'flows.dock.resizeHandle': 'Изменить размер панели',
+  'flows.dock.tablistLabel': 'Панель воркфлоу',
+  'flows.dock.runEmpty': 'Выберите запуск на панели, чтобы увидеть детали.',
+  // -- Node run-status badge (Piece 2) --
+  'flows.runStatus.success': 'Завершено',
+  'flows.runStatus.failed': 'Не удалось',
+  'flows.runStatus.running': 'Выполняется',
+  'flows.runStatus.notRun': 'Не запускался',
   // Emergency stop (#4255)
   'safety.emergencyStop': 'Аварийная остановка',
   'safety.stopFailed': 'Не удалось остановить автоматизацию. Попробуйте ещё раз.',

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -3982,6 +3982,9 @@ const messages: TranslationMap = {
   'flowRuns.inspector.diagnosticResolvedNull': '解析为 null',
   'flows.runs.sidebarTitle': '运行记录',
   'flows.runs.refresh': '刷新运行记录',
+  // -- Runs rail flyout (Piece 3) --
+  'flows.runs.expand': '显示所有运行',
+  'flows.runs.collapse': '隐藏运行列表',
   'flows.palette.appAction': '应用操作',
   'flows.palette.ohTool': '工具',
   'flows.editor.deleteNode': '删除',
@@ -6911,6 +6914,19 @@ const messages: TranslationMap = {
   'flows.canvas.sidePanelToggle': '侧边栏',
   'flows.canvas.legendTab': '手动',
 
+  // -- Docked Copilot | Run panel (Workflows UI redesign, Piece 1) --
+  'flows.dock.copilotTab': '副驾驶',
+  'flows.dock.runTab': '运行',
+  'flows.dock.collapse': '收起面板',
+  'flows.dock.expand': '展开面板',
+  'flows.dock.resizeHandle': '调整面板大小',
+  'flows.dock.tablistLabel': '工作流面板',
+  'flows.dock.runEmpty': '从侧栏选择一次运行以查看详情。',
+  // -- Node run-status badge (Piece 2) --
+  'flows.runStatus.success': '已完成',
+  'flows.runStatus.failed': '失败',
+  'flows.runStatus.running': '运行中',
+  'flows.runStatus.notRun': '未运行',
   // Emergency stop (#4255)
   'safety.emergencyStop': '紧急停止',
   'safety.stopFailed': '无法停止自动化，请重试。',

--- a/app/src/pages/FlowCanvasPage.tsx
+++ b/app/src/pages/FlowCanvasPage.tsx
@@ -27,6 +27,11 @@ import type {
   EditorSaveMeta,
 } from '../components/flows/canvas/EditableFlowCanvas';
 import FlowCanvas from '../components/flows/canvas/FlowCanvas';
+import FlowDockPanel, { type FlowDockTab } from '../components/flows/FlowDockPanel';
+import {
+  type FlowRepairRequest,
+  FlowRunInspectorPanel,
+} from '../components/flows/FlowRunInspectorDrawer';
 import FlowRunsSidebar from '../components/flows/FlowRunsSidebar';
 import WorkflowCopilotPanel, {
   type RepairPromptContext,
@@ -39,12 +44,20 @@ import { ToastContainer } from '../components/intelligence/Toast';
 import PanelPage from '../components/layout/PanelPage';
 import Button from '../components/ui/Button';
 import { CenteredLoadingState, ErrorBanner } from '../components/ui/LoadingState';
+import { stepsToProgressMap } from '../hooks/useFlowRunProgress';
 import { asFlowCanvasDraftState } from '../lib/flows/canvasDraft';
 import { workflowGraphToXyflow } from '../lib/flows/graphAdapter';
 import { buildPreviewGraph, diffGraphs } from '../lib/flows/graphDiff';
 import type { WorkflowGraph } from '../lib/flows/types';
 import { useT } from '../lib/i18n/I18nContext';
-import { createFlow, type Flow, getFlow, runFlow, updateFlow } from '../services/api/flowsApi';
+import {
+  createFlow,
+  type Flow,
+  type FlowRun,
+  getFlow,
+  runFlow,
+  updateFlow,
+} from '../services/api/flowsApi';
 import type { WorkflowProposal } from '../store/chatRuntimeSlice';
 import type { ToastNotification } from '../types/intelligence';
 
@@ -309,6 +322,21 @@ function FlowEditor({
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
   const [running, setRunning] = useState(false);
   const [runError, setRunError] = useState<string | null>(null);
+
+  // ── Runs rail + docked Run tab (Workflows UI redesign, Pieces 1-3) ────────
+  // `selectedRunId` used to live inside `FlowRunsSidebar`; lifted here (Piece
+  // 1) so the rail and the dock's Run tab share it. Selecting a run from the
+  // rail shows it in the Run tab; `viewedRun` is reported up by
+  // `FlowRunInspectorPanel` (which already polls it) so the canvas can derive
+  // an identical overlay for a selected/completed historical run via
+  // `stepsToProgressMap` (Piece 2), without a second poll subscription.
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+  const [viewedRun, setViewedRun] = useState<FlowRun | null>(null);
+  // The node id whose step is centered/highlighted, synced both ways between
+  // the canvas (a click on a node with a run status) and the Run tab (a click
+  // on a step row) — see `handleNodeRunClick`/`handleSelectStep` below.
+  const [selectedStepNodeId, setSelectedStepNodeId] = useState<string | null>(null);
+  const [dockTab, setDockTab] = useState<FlowDockTab>('copilot');
 
   const { flowId, graph, requireApproval } = editorFlow;
   // Draft (unsaved) canvases have no persisted id yet; Save creates the flow
@@ -763,6 +791,84 @@ function FlowEditor({
     }
   }, [flowId]);
 
+  // Selecting a run from the rail (Piece 3) shows it in the dock's Run tab
+  // (Piece 1) — opening the dock (in case it was collapsed/on Legend) and
+  // switching to the Run tab. Resets any previously-selected step, which
+  // belonged to whatever run was viewed before.
+  const handleSelectRun = useCallback((runId: string) => {
+    log('select run from rail: %s', runId);
+    setSelectedRunId(runId);
+    setSelectedStepNodeId(null);
+    setSidePanel('copilot');
+    setDockTab('run');
+  }, []);
+
+  // "Fix with agent" (Phase 5c, moved here from `FlowRunsSidebar` — it no
+  // longer owns run selection/inspection) — re-navigates to this SAME
+  // `/flows/:id` route with a fresh `copilotRepair` state so the copilot
+  // panel (still mounted, see `FlowDockPanel`'s doc comment) picks it up via
+  // the `locationKey`-keyed remount below, same mechanism as before.
+  const handleFixWithAgent = useCallback(
+    (request: FlowRepairRequest) => {
+      log('fix with agent: flow=%s run=%s', request.flowId, request.runId);
+      setSelectedRunId(null);
+      navigate(`/flows/${request.flowId}`, {
+        replace: true,
+        state: {
+          copilotRepair: {
+            runId: request.runId,
+            error: request.error,
+            failingNodeIds: request.failingNodeIds,
+          },
+        },
+      });
+    },
+    [navigate]
+  );
+
+  // Run tab -> canvas: centering/highlighting the node a selected step
+  // belongs to (Piece 2).
+  const handleSelectStep = useCallback((_index: number, nodeId: string) => {
+    log('select step: node=%s', nodeId);
+    setSelectedStepNodeId(nodeId);
+    canvasRef.current?.focusNode(nodeId);
+  }, []);
+
+  // Canvas -> Run tab: clicking a node that currently carries a run status
+  // (live or historical) reveals it in the Run tab (Piece 2). If no run is
+  // being viewed yet (rail untouched, nothing selected), falls back to the
+  // live `activeRunId` so a click on a still-running node opens straight to
+  // it.
+  const handleNodeRunClick = useCallback(
+    (nodeId: string) => {
+      const targetRunId = selectedRunId ?? activeRunId;
+      if (!targetRunId) return;
+      log('node run click: node=%s run=%s', nodeId, targetRunId);
+      if (selectedRunId !== targetRunId) setSelectedRunId(targetRunId);
+      setSelectedStepNodeId(nodeId);
+      setSidePanel('copilot');
+      setDockTab('run');
+    },
+    [selectedRunId, activeRunId]
+  );
+
+  // Piece 2: the canvas overlays LIVE progress for `activeRunId` by default
+  // (unchanged behavior when the rail hasn't been touched). Once a DIFFERENT,
+  // historical run is selected from the rail, switch the canvas to that run's
+  // durable `stepsToProgressMap` instead — and stop the live subscription for
+  // it (there's nothing "live" about a run that isn't the active one).
+  const viewingHistoricalRun = selectedRunId !== null && selectedRunId !== activeRunId;
+  const canvasActiveRunId = viewingHistoricalRun ? null : activeRunId;
+  const runProgressOverride = useMemo(
+    () => (viewingHistoricalRun && viewedRun ? stepsToProgressMap(viewedRun.steps) : undefined),
+    [viewingHistoricalRun, viewedRun]
+  );
+  const selectedStepIndex = useMemo(() => {
+    if (!viewedRun || !selectedStepNodeId) return null;
+    const idx = viewedRun.steps.findIndex(s => s.node_id === selectedStepNodeId);
+    return idx >= 0 ? idx : null;
+  }, [viewedRun, selectedStepNodeId]);
+
   // Return to wherever the user came from rather than always the list. React
   // Router stamps the initial history entry with key 'default', so when this
   // page was the first thing loaded (deep link / fresh load) there's nothing to
@@ -937,12 +1043,17 @@ function FlowEditor({
       action={headerActions}
       contentClassName="h-full p-0">
       <div className="flex h-full w-full">
-        {/* Run history + "Fix with agent" as an inline left rail (persisted flows
-            only). The app sidebar is hidden on this route (chromeless), so this
-            can't use the shell `SidebarContent` slot — render it in-page. */}
+        {/* Runs rail (Piece 3) + "Fix with agent" reachable via a rail dot's
+            selection landing in the docked Run tab (persisted flows only). The
+            app sidebar is hidden on this route (chromeless), so this can't use
+            the shell `SidebarContent` slot — render it in-page. */}
         {!isDraft && flowId && (
-          <div className="hidden h-full w-60 flex-shrink-0 border-r border-line lg:flex">
-            <FlowRunsSidebar flowId={flowId} />
+          <div className="hidden h-full flex-shrink-0 lg:flex">
+            <FlowRunsSidebar
+              flowId={flowId}
+              selectedRunId={selectedRunId}
+              onSelectRun={handleSelectRun}
+            />
           </div>
         )}
         <div className={`relative h-full flex-1 ${hideGraph ? 'hidden' : ''}`}>
@@ -956,7 +1067,10 @@ function FlowEditor({
             onSave={onCanvasSave}
             onDirtyChange={setDirty}
             onSaveMetaChange={setSaveMeta}
-            activeRunId={activeRunId}
+            activeRunId={canvasActiveRunId}
+            runProgressOverride={runProgressOverride}
+            onNodeRunClick={handleNodeRunClick}
+            focusedNodeId={selectedStepNodeId}
             onGraphChange={handleGraphChange}
             addedNodeIds={preview?.addedNodeIds}
             removedNodeIds={preview?.removedNodeIds}
@@ -1015,29 +1129,66 @@ function FlowEditor({
         </div>
 
         {copilotOpen && (
-          <WorkflowCopilotPanel
-            // Stable ('copilot') across manual open/close and build-seed
-            // navigations (unaffected — those always land on a fresh
-            // `FlowEditor` mount already, see `locationKey`'s doc comment).
-            // Repair seeds fold in `locationKey` so a same-route "Fix with
-            // agent" click (no `FlowEditor` remount) still forces a fresh
-            // panel mount, resetting the once-per-mount `repairSentRef` guard
-            // so the repair turn actually (re)fires (issue B22).
-            key={initialCopilotSeed ? `copilot-repair-${locationKey}` : 'copilot'}
-            graph={preview?.base ?? draftGraph}
-            flowId={flowId}
-            onProposal={handleProposal}
-            onAccept={handleAcceptProposal}
-            onReject={handleRejectProposal}
-            onClose={() => setSidePanel(null)}
-            repairSeed={copilotRepairSeed}
-            buildSeed={initialBuildSeed}
-            onBuildSeedConsumed={onBuildSeedConsumed}
-            prefillSeed={initialPrefillSeed}
-            onPrefillSeedConsumed={onPrefillSeedConsumed}
-            seedThreadId={copilotThreadId}
-            onThreadIdChange={handleCopilotThreadId}
+          <FlowDockPanel
+            activeTab={dockTab}
+            onTabChange={setDockTab}
+            onCollapse={() => setSidePanel(null)}
+            runTabDisabled={isDraft}
             fullWidth={hideGraph}
+            copilotContent={
+              <WorkflowCopilotPanel
+                // Stable ('copilot') across manual open/close and build-seed
+                // navigations (unaffected — those always land on a fresh
+                // `FlowEditor` mount already, see `locationKey`'s doc comment).
+                // Repair seeds fold in `locationKey` so a same-route "Fix with
+                // agent" click (no `FlowEditor` remount) still forces a fresh
+                // panel mount, resetting the once-per-mount `repairSentRef`
+                // guard so the repair turn actually (re)fires (issue B22).
+                //
+                // CRITICAL: this element is passed down unconditionally
+                // regardless of `dockTab` — `FlowDockPanel` only toggles
+                // `display:none` on the inactive tab, never unmounts this —
+                // so the agentic-task panel's sticky expand (#4942) and the
+                // sub-agent `turnActive` flicker fix (#5008/#5010) survive
+                // switching to the Run tab and back.
+                key={initialCopilotSeed ? `copilot-repair-${locationKey}` : 'copilot'}
+                graph={preview?.base ?? draftGraph}
+                flowId={flowId}
+                onProposal={handleProposal}
+                onAccept={handleAcceptProposal}
+                onReject={handleRejectProposal}
+                onClose={() => setSidePanel(null)}
+                repairSeed={copilotRepairSeed}
+                buildSeed={initialBuildSeed}
+                onBuildSeedConsumed={onBuildSeedConsumed}
+                prefillSeed={initialPrefillSeed}
+                onPrefillSeedConsumed={onPrefillSeedConsumed}
+                seedThreadId={copilotThreadId}
+                onThreadIdChange={handleCopilotThreadId}
+                // The dock now owns overall width/border chrome; always fill
+                // it (no internal `max-w-sm` cap) rather than fighting the
+                // dock's own resize.
+                fullWidth
+              />
+            }
+            runContent={
+              !isDraft && (
+                <FlowRunInspectorPanel
+                  runId={selectedRunId}
+                  onFixWithAgent={handleFixWithAgent}
+                  onRunChange={setViewedRun}
+                  selectedStepIndex={selectedStepIndex}
+                  onSelectStep={handleSelectStep}
+                  emptyState={
+                    <div
+                      className="flex h-full flex-col items-center justify-center gap-2 p-6 text-center"
+                      data-testid="flow-dock-run-empty">
+                      <p className="text-xs text-content-muted">{t('flows.dock.runEmpty')}</p>
+                    </div>
+                  }
+                />
+              )
+            }
           />
         )}
 


### PR DESCRIPTION
## DRAFT — do not merge; awaiting design approval

This implements the locked plan for the Workflows canvas redesign, frontend-only. No screenshots yet — would help a lot for the design review; happy to add once the app is run against a live core.

### Piece 1 — Tabbed right dock (`FlowDockPanel`)
- New `FlowDockPanel` (`app/src/components/flows/FlowDockPanel.tsx`) replaces the old mutually-exclusive Copilot-panel-vs-Run-inspector-overlay on the right of `FlowCanvasPage`. Two tabs — **Copilot | Run** — in one docked, resizable (320–560px, drag the left edge), collapsible (▸) panel.
- **Critical invariant preserved**: the Copilot (`WorkflowCopilotPanel`) stays **mounted** across tab switches — `FlowDockPanel` only toggles `display:none` on the inactive tab body, it never unmounts either side. This protects the agentic-task panel's sticky expand (#4942) and the sub-agent `turnActive` flicker fix (#5008/#5010), which depend on the panel never remounting.
- The run inspector body is extracted out of its fixed overlay into a reusable `FlowRunInspectorPanel` (`FlowRunInspectorDrawer.tsx`), used inline in the Run tab. `FlowRunInspectorDrawer` itself is now a thin wrapper (backdrop + Escape-to-close) around that panel, kept as-is for the runs **list** page (`FlowRunsDrawer`/`FlowApprovalCard`) — unchanged there.
- `selectedRunId` is lifted from `FlowRunsSidebar` up to `FlowCanvasPage`'s `FlowEditor`, so the rail and the Run tab share one selection.

### Piece 2 — Inline node run-status on the canvas
- `stepsToProgressMap()` (`hooks/useFlowRunProgress.ts`) converts a durable `FlowRun.steps[]` into the identical `node_id -> status` shape the live socket hook (`useFlowRunProgress`) produces, so a selected/completed historical run overlays node status exactly like a live one.
- `FlowNodeComponent` renders a small status badge per node — done (check, sage) / running (spinner, ocean) / failed (X, coral) / not-run (dim dot) — additive to the existing outline-ring overlay.
- Selection is wired both ways: clicking a node that carries a run status selects that step in the Run tab; selecting a step in the Run tab centers the node via a new `focusNode` imperative-handle method on the canvas (`fitView` on that node).

### Piece 3 — Runs rail
- `FlowRunsSidebar` is now a ~44px icon+dot rail (was a ~240px column): a vertical strip of color-coded status dots with a hover/focus tooltip (status + relative time), plus a flyout expander for the full list on demand. Reclaims ~200px of canvas width.

### Deferred — Piece 4 (horizontal DAG layout)
Intentionally **not** touched. `autoLayout`/saved node positions/port handles have no migration path today, and repositioning risks corrupting saved graphs for existing flows. Flagged as a follow-up once a layout-migration story exists.

### Preserved (regression guards)
- #4942 — agentic-panel sticky expand: unaffected, Copilot never unmounts.
- #5008 / #5010 — sub-agent `turnActive` flicker fix: unaffected, same mounted-copilot invariant.
- #4999 / F4-F5 — canvas viewport preservation on save (`viewportRef`/`canvasVersion`): untouched.
- Run pollers (`useFlowRunPoller`/`useFlowRunsLiveRefresh`): untouched, still used by `FlowRunInspectorPanel`/the rail.

### i18n
New strings (`flows.dock.*`, `flows.runStatus.*`, `flows.runs.expand`/`collapse`) added to `en.ts` and all 13 locale files with real translations (not English placeholders) — `pnpm i18n:check` reports 0 missing/0 extra per locale.

### Status
- `pnpm typecheck` (`tsc --noEmit`): clean.
- `pnpm lint` on touched files: clean (2 pre-existing warnings unrelated to this diff, both predate this branch).
- `prettier --write` run on all touched files.
- Vitest: 491 tests passing across the touched `flows`/`hooks`/`pages`/`lib/flows` suites, including new tests for `FlowDockPanel` (tab-switch keeps Copilot mounted, disabled Run tab for drafts, resize/collapse), the node status badge, `stepsToProgressMap`, and the rewritten `FlowRunsSidebar` rail contract.

### Nothing stubbed
Everything in the three pieces is implemented against the real components — no mocked-out pieces left behind. The only intentional gap is Piece 4 (deferred, see above).