### PR TITLE
fix(tauri): resolve macOS-gated clippy -D warnings blocking pre-push (#5018)

### DIFF
--- a/app/src-tauri/src/claude_code.rs
+++ b/app/src-tauri/src/claude_code.rs
@@ -43,7 +43,7 @@ end tell"#;
             .args(["-e", script])
             .spawn()
             .map_err(|e| format!("failed to open Terminal.app: {e}"))?;
-        return Ok("Terminal.app".into());
+        Ok("Terminal.app".into())
     }
 
     #[cfg(target_os = "linux")]

--- a/app/src-tauri/src/imessage_scanner/mod.rs
+++ b/app/src-tauri/src/imessage_scanner/mod.rs
@@ -372,7 +372,7 @@ fn extract_text_from_attributed_body(blob: &[u8]) -> Option<String> {
         .filter_map(|r| String::from_utf8(r).ok())
         .filter(|s| {
             let trimmed = s.trim();
-            trimmed.len() >= 2 && !ignored_markers.iter().any(|m| trimmed == *m)
+            trimmed.len() >= 2 && !ignored_markers.contains(&trimmed)
         })
         .max_by_key(|s| s.len())
         .map(|s| s.trim().to_string())

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1195,7 +1195,7 @@ fn mascot_window_show(app: AppHandle<AppRuntime>) -> Result<(), String> {
     log::info!("[mascot-window] show requested");
     #[cfg(target_os = "macos")]
     {
-        return mascot_native_window::show(&app);
+        mascot_native_window::show(&app)
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -1258,11 +1258,11 @@ fn notch_window_show(app: AppHandle<AppRuntime>) -> Result<(), String> {
     log::info!("[notch-window] show requested");
     #[cfg(target_os = "macos")]
     {
-        return dispatch_notch_on_main(app, |app| {
+        dispatch_notch_on_main(app, |app| {
             if let Err(e) = notch_window::show(app) {
                 log::warn!("[notch-window] show failed: {e}");
             }
-        });
+        })
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -1277,7 +1277,7 @@ fn notch_window_hide(app: AppHandle<AppRuntime>) -> Result<(), String> {
     log::info!("[notch-window] hide requested");
     #[cfg(target_os = "macos")]
     {
-        return dispatch_notch_on_main(app, |_app| notch_window::hide());
+        dispatch_notch_on_main(app, |_app| notch_window::hide())
     }
     #[cfg(not(target_os = "macos"))]
     {

--- a/app/src-tauri/src/mascot_native_window.rs
+++ b/app/src-tauri/src/mascot_native_window.rs
@@ -52,6 +52,9 @@ const DRAG_POLL_SECONDS: f64 = 0.016;
 /// dropped webview.
 struct MascotPanel {
     panel: Retained<NSPanel>,
+    // RAII keep-alive: never read, but dropping it deallocates the WKWebView and
+    // blanks the panel. Must outlive the show/hide cycle — do not remove.
+    #[allow(dead_code)]
     webview: Retained<WKWebView>,
     drag_timer: Retained<NSTimer>,
 }
@@ -389,7 +392,7 @@ unsafe fn build_webview(
         let _: () = msg_send![&*webview, setAutoresizingMask: 18u64]; // width|height
 
         // Make the webview the panel's content view so it fills the frame.
-        let webview_ref: &objc2::runtime::AnyObject = &*webview;
+        let webview_ref: &objc2::runtime::AnyObject = &webview;
         let webview_view: *mut objc2::runtime::AnyObject =
             webview_ref as *const _ as *mut objc2::runtime::AnyObject;
         let _: () = msg_send![panel, setContentView: webview_view];

--- a/app/src-tauri/src/native_notifications/mod.rs
+++ b/app/src-tauri/src/native_notifications/mod.rs
@@ -37,7 +37,7 @@ use crate::AppRuntime;
 pub fn notification_permission_state() -> Result<String, String> {
     #[cfg(target_os = "macos")]
     {
-        return macos::permission_state();
+        macos::permission_state()
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -51,7 +51,7 @@ pub fn notification_permission_state() -> Result<String, String> {
 pub fn notification_permission_request() -> Result<String, String> {
     #[cfg(target_os = "macos")]
     {
-        return macos::request_permission();
+        macos::request_permission()
     }
     #[cfg(not(target_os = "macos"))]
     {

--- a/app/src-tauri/src/notch_window.rs
+++ b/app/src-tauri/src/notch_window.rs
@@ -61,10 +61,6 @@ thread_local! {
     static NOTCH: RefCell<Option<NotchPanel>> = const { RefCell::new(None) };
 }
 
-pub(crate) fn is_open() -> bool {
-    NOTCH.with(|cell| cell.borrow().is_some())
-}
-
 pub(crate) fn hide() {
     NOTCH.with(|cell| {
         if let Some(existing) = cell.borrow_mut().take() {
@@ -262,7 +258,7 @@ unsafe fn build_webview(
         // Auto-resize to fill the panel content view.
         let _: () = msg_send![&*webview, setAutoresizingMask: 18u64]; // width|height
 
-        let webview_ref: &objc2::runtime::AnyObject = &*webview;
+        let webview_ref: &objc2::runtime::AnyObject = &webview;
         let webview_view = webview_ref as *const _ as *mut objc2::runtime::AnyObject;
         let _: () = msg_send![panel, setContentView: webview_view];
 


### PR DESCRIPTION
## 🥞 Stacked PR — merge order (bottom → top)

1. **#5020 — macOS clippy fix** (base `main`) ← **this PR**, unblocks all macOS pushes
2. #5004 — web_chat conduit relocation
3. gates-off smoke lane — voice asserts + test-exec step (to be opened)
4. #5003 — learning channels-coupling fix (to be opened)
5. #4801 — channels feature gate (top, last child of epic #4795)

**This is position 1/5 — the base of the stack.** Merge first; everything above carries these commits.

---

## Summary

Fixes the 11 clippy `-D warnings` errors in the macOS-gated Tauri shell code that block `git push` on every macOS dev machine since #4872 wired `pnpm rust:clippy` into the pre-push hook. Six mechanical lint fixes, one commit per file.

## Problem

#4872 (`chore(rust): enforce warning-free clippy`, merged 2026-07-16) switched `.husky/pre-push` from `rust:check` to `rust:clippy`, linting both crates with `-D warnings`. The `app/src-tauri` (shell) crate carries 11 pre-existing clippy errors, all inside `#[cfg(target_os = "macos")]` code.

The `Rust Quality` CI job runs on `ubuntu-22.04`, where every macOS-gated region is configured out before clippy sees it — so these errors are invisible to CI. Main is green; every macOS contributor is hard-blocked at push. (The CI blind-spot itself is tracked in #5019.)

The errors are pre-existing, not introduced here: this branch is cut fresh from `upstream/main` and every fix targets code untouched since #4872.

## Solution

| File | Lint | Fix |
|------|------|-----|
| `lib.rs:1198,1261,1280` | `needless_return` ×3 | Drop `return`/`;` in the `cfg(macos)` command tails (the `cfg(not(macos))` sibling is stripped on macOS, so the block is the tail expression) |
| `claude_code.rs:46` | `needless_return` | Same, in the macOS Terminal-launch arm |
| `native_notifications/mod.rs:40,54` | `needless_return` ×2 | Same, in the macOS permission commands |
| `imessage_scanner/mod.rs:375` | `manual_contains` | `!ignored_markers.iter().any(\|m\| trimmed == *m)` → `!ignored_markers.contains(&trimmed)` |
| `mascot_native_window.rs:55` | `dead_code` | `#[allow(dead_code)]` + comment on the `webview` field — **not** deletion |
| `mascot_native_window.rs:392` | `explicit_auto_deref` | `&*webview` → `&webview` (explicit `&AnyObject` annotation kept) |
| `notch_window.rs:64` | `dead_code` | Delete `is_open` — zero callers |
| `notch_window.rs:265` | `explicit_auto_deref` | `&*webview` → `&webview` |

**Two judgment calls, flagged for review:**

- **`MascotPanel.webview` — allow, not delete.** The struct doc says it "holds the panel + webview together so we keep both alive." The field is an RAII keep-alive; dropping it deallocates the `WKWebView` and blanks the mascot panel. Deleting it would be a real behaviour bug, so it gets `#[allow(dead_code)]` and a comment saying why.
- **`notch_window::is_open` — delete.** Zero callers (only `mascot_native_window::is_open` is used, at `lib.rs:1226`). `pub(crate)` and trivially re-addable. Keeping dead code "for symmetry" is how it accretes.

The vendored `tauri-runtime-cef` crate's 13 warnings are **out of scope** — `-D warnings` applies only to the selected package, not path dependencies, so they do not block the push and are not regressions.

## Submission Checklist

- [x] N/A: no new behaviour — these are mechanical lint fixes to existing code paths, so there is no new happy or failure path to cover. The two `explicit_auto_deref` and one `manual_contains` fixes are semantically identical to the originals.
- [x] N/A: no executable logic changed — every edit removes a diagnostic (`return` keyword, redundant deref, dead fn) or swaps an equivalent idiom. `diff-cover` has no new behaviour to measure.
- [x] N/A: no feature rows added, removed, or renamed.
- [x] N/A: no matrix feature IDs affected.
- [x] No new external network dependencies introduced.
- [x] N/A: no release-cut surface behaviour changes — macOS runtime behaviour is byte-identical (RAII keep-alive preserved, tail expressions return the same values).
- [x] Linked issue closed via `Closes` in `## Related`.

## Impact

- **Platform**: macOS shell only. Runtime behaviour identical — the fixes remove diagnostics, not logic.
- **User-visible**: none.
- **Binary size**: unchanged.
- **Migration/compat**: none.
- **Observability**: none.
- **Security**: none.
- **Risk**: low. Verified by `pnpm rust:clippy` exiting 0 on macOS (was 11 errors) and `cargo fmt --check` clean. The `explicit_auto_deref` fixes touch objc2 coercion feeding raw-pointer `msg_send!` casts — mitigated by keeping the explicit `&AnyObject` type annotation so the coercion target is unchanged, plus a runtime smoke of the mascot/notch windows.

## Related

- Closes #5018
- #5019 — the Linux-CI-cannot-lint-macOS gap that let these 11 through (recommend piggybacking clippy on CI Full's macOS build job)
- #4872 — introduced `-D warnings` enforcement

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A — GitHub-issue driven (#5018)
- URL: N/A

### Commit & Branch

- Branch: `fix/5018-macos-clippy-warnings`

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend files changed
- [x] N/A: `pnpm typecheck` — no TypeScript changed
- [x] Rust clippy (the acceptance test): `GGML_NATIVE=OFF pnpm rust:clippy` → exit 0 (was 11 errors on `upstream/main`)
- [x] Rust fmt: `cargo fmt --manifest-path app/src-tauri/Cargo.toml --check` clean
- [x] Pre-existing proof: `git diff upstream/main..HEAD --name-only` on the base contains none of the 6 lint files; introducing commit `d320c4382` (#4872) predates this branch
