### PR TITLE
fix(conversations): stop the thread-goal footer text from auto-scrolling

### DIFF
--- a/app/src/features/conversations/components/ThreadGoalChip.tsx
+++ b/app/src/features/conversations/components/ThreadGoalChip.tsx
@@ -213,7 +213,12 @@ export function ThreadGoalFooterTrigger({
         className={`shrink-0 rounded px-1 py-0.5 text-[10px] font-medium uppercase tracking-wide ${statusClasses(ctl.goal.status)}`}>
         {t(`conversations.threadGoal.status.${ctl.goal.status}`)}
       </span>
-      <MarqueeText text={ctl.goal.objective} className="max-w-[18rem] text-content-secondary" />
+      {/* Truncate long objectives instead of scrolling them. The full text is
+          reachable via the button's `title` tooltip (hover) and by clicking to
+          open the editor, so a moving label would only distract. */}
+      <span className="block min-w-0 max-w-[18rem] truncate text-content-secondary">
+        {ctl.goal.objective}
+      </span>
     </button>
   );
 }
@@ -302,44 +307,6 @@ export function ThreadGoalEditorPanel({
         className="w-full border-0 bg-transparent text-sm text-content outline-none focus:outline-none focus:ring-0 placeholder:text-stone-400"
       />
     </div>
-  );
-}
-
-/**
- * Single-line label that gently marquees (ping-pong scroll) only when the text
- * overflows its max width; otherwise it truncates. The scroll distance is
- * measured and fed to the `goal-marquee` keyframe via a CSS variable.
- */
-function MarqueeText({
-  text,
-  className = '',
-}: {
-  text: string;
-  className?: string;
-}): React.ReactElement {
-  const outerRef = useRef<HTMLSpanElement>(null);
-  const innerRef = useRef<HTMLSpanElement>(null);
-  const [shift, setShift] = useState(0);
-
-  useEffect(() => {
-    const outer = outerRef.current;
-    const inner = innerRef.current;
-    if (!outer || !inner) return;
-    const overflow = inner.scrollWidth - outer.clientWidth;
-    setShift(overflow > 4 ? overflow + 8 : 0);
-  }, [text]);
-
-  return (
-    <span ref={outerRef} className={`relative block min-w-0 overflow-hidden ${className}`}>
-      <span
-        ref={innerRef}
-        className={`block whitespace-nowrap ${shift > 0 ? 'animate-goal-marquee' : 'truncate'}`}
-        style={
-          shift > 0 ? ({ '--goal-marquee-shift': `-${shift}px` } as React.CSSProperties) : undefined
-        }>
-        {text}
-      </span>
-    </span>
   );
 }
 

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -271,10 +271,6 @@ module.exports = {
         'float': 'float 3s ease-in-out infinite',
         'ticker': 'ticker 30s linear infinite',
         'wiggle': 'wiggle 0.5s ease-in-out',
-        // Gentle ping-pong scroll for overflowing single-line labels (e.g. a
-        // long thread-goal objective). Distance is supplied per-element via the
-        // `--goal-marquee-shift` CSS var; `alternate` returns it to the start.
-        'goal-marquee': 'goalMarquee 6s ease-in-out infinite alternate',
       },
 
       keyframes: {
@@ -318,10 +314,6 @@ module.exports = {
           '0%, 100%': { transform: 'rotate(0deg)' },
           '25%': { transform: 'rotate(-9deg)' },
           '75%': { transform: 'rotate(9deg)' },
-        },
-        goalMarquee: {
-          '0%, 18%': { transform: 'translateX(0)' },
-          '82%, 100%': { transform: 'translateX(var(--goal-marquee-shift, 0px))' },
         },
       },
 


### PR DESCRIPTION
## Summary

- The per-thread **goal chip** in the composer footer scrolls its objective text back and forth (a ping-pong marquee) whenever the text overflows. This change stops that: the label now sits still and truncates with an ellipsis.
- Removes the now-unused `goal-marquee` animation + `goalMarquee` keyframe from the Tailwind config (grep-confirmed used nowhere else).
- Pure presentational change — no behavior, API, or i18n changes.

## Problem

When a thread goal is set, a long objective in the footer continuously animates left-and-right. It's visually distracting and pulls the eye during normal chat use, yet adds no information: the full objective is already reachable two other ways —

- **hover** shows the complete text via the button's native `title` tooltip, and
- **click** opens the goal editor, which shows the full objective in an input.

So the moving text is redundant motion with no upside, and continuous animation is an accessibility/motion concern.

## Solution

- In `ThreadGoalFooterTrigger`, replace the animated `<MarqueeText>` with a plain truncating `<span>` (`truncate`, same `max-w-[18rem]`), and delete the now-unused `MarqueeText` component.
- Delete the `goal-marquee` animation entry and the `goalMarquee` keyframe from `app/tailwind.config.js`.
- The tooltip (`title`) and click-to-open editor were already present and are unchanged, so no discoverability is lost.

## Submission Checklist

- [x] Tests added or updated — `N/A`: no new behavior. Existing `ThreadGoalChip.test.tsx` (5 tests) asserts the objective renders and remains reachable via title/click, and continues to pass. A marquee-vs-truncate distinction is a visual/animation detail not meaningfully unit-testable in jsdom.
- [x] **Diff coverage ≥ 80%** — changed lines are a JSX element swap + deletions; the rendered objective span is exercised by the existing footer-trigger tests. No Rust touched.
- [x] Coverage matrix updated — `N/A: behaviour-only (visual) change`, no feature rows added/removed/renamed.
- [x] All affected feature IDs listed under `## Related` — `N/A`: no matrix feature affected.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A`: cosmetic tweak to an existing control.
- [x] Linked issue closed via `Closes #NNN` — `N/A`: no tracking issue.

## Impact

- **Platforms:** desktop UI only (React). No CLI/core/mobile impact.
- **Performance:** slightly less — one fewer running CSS animation in the footer.
- **Security/migration/compat:** none.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `claude/remove-goal-scroll-animation-d2f43d`
- Commit SHA: 0d4726369

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — prettier clean on changed files
- [x] `pnpm typecheck` — passes
- [x] Focused tests: `vitest run ThreadGoalChip.test.tsx` — 5/5 pass
- [x] Rust fmt/check (if changed): `N/A` — no Rust changed
- [x] Tauri fmt/check (if changed): `N/A` — no Rust changed

### Validation Blocked

- `command:` `git push` (pre-push hook)
- `error:` pre-push hook reported `lint:commands-tokens` (ripgrep) and a Rust check failing with "No such file or directory"
- `impact:` Environment/hook-PATH artifacts only — `rg` and `cargo` are installed but not on the hook subshell PATH; neither check covers this TypeScript + Tailwind diff (no `src/components/commands/` tokens, no Rust). Pushed with `--no-verify` per AGENTS.md guidance for unrelated pre-existing breakage. TS/lint/test/format were all run manually and pass.

### Behavior Changes

- Intended behavior change: footer goal objective no longer auto-scrolls; it truncates instead.
- User-visible effect: the goal text in the composer footer is static; full text still available on hover (tooltip) and on click (editor).

### Parity Contract

- Legacy behavior preserved: tooltip + click-to-open editor unchanged; truncation replaces marquee only when text overflows.
- Guard/fallback/dispatch parity checks: N/A.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Goal objectives now remain on a single line without animated scrolling.
  - Long objective text is truncated for a cleaner footer layout.
  - Hovering over truncated objectives displays the full text in a tooltip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->