### PR TITLE
fix(frontend): redirect pricing links to public page

### DIFF
--- a/app/src/components/home/__tests__/HomeBanners.test.tsx
+++ b/app/src/components/home/__tests__/HomeBanners.test.tsx
@@ -30,7 +30,7 @@ describe('HomeBanners', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Buy top-up credits' }));
 
-    expect(openUrl).toHaveBeenCalledWith('https://tinyhumans.ai/dashboard');
+    expect(openUrl).toHaveBeenCalledWith('https://tinyhumans.ai/pricing');
   });
 
   it('renders danger tone styles for UsageLimitBanner', () => {
@@ -53,7 +53,7 @@ describe('HomeBanners', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /get a subscription/i }));
 
-    expect(openUrl).toHaveBeenCalledWith('https://tinyhumans.ai/dashboard');
+    expect(openUrl).toHaveBeenCalledWith('https://tinyhumans.ai/pricing');
   });
 
   it('opens the Discord invite through openUrl from the Discord banner', () => {

--- a/app/src/components/settings/panels/BillingPanel.test.tsx
+++ b/app/src/components/settings/panels/BillingPanel.test.tsx
@@ -49,7 +49,7 @@ describe('<BillingPanel />', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Open billing dashboard' }));
     await waitFor(() => expect(openUrlMock).toHaveBeenCalledTimes(1));
-    expect(openUrlMock).toHaveBeenLastCalledWith('https://tinyhumans.ai/dashboard');
+    expect(openUrlMock).toHaveBeenLastCalledWith('https://tinyhumans.ai/pricing');
   });
 
   it('invokes the navigation back handler from both the header and the inline button', async () => {

--- a/app/src/config/__tests__/navConfig.test.ts
+++ b/app/src/config/__tests__/navConfig.test.ts
@@ -102,4 +102,10 @@ describe('AVATAR_MENU_ITEMS', () => {
     const openUrlItems = AVATAR_MENU_ITEMS.filter(i => i.kind === 'openUrl').map(i => i.id);
     expect(openUrlItems).toEqual(['billing']);
   });
+
+  it('opens billing on the public pricing page', () => {
+    expect(AVATAR_MENU_ITEMS.find(i => i.id === 'billing')?.target).toBe(
+      'https://tinyhumans.ai/pricing'
+    );
+  });
 });

--- a/app/src/config/navConfig.ts
+++ b/app/src/config/navConfig.ts
@@ -5,6 +5,7 @@
  * This module is pure data — no JSX, no React imports.  Icons are owned by
  * BottomTabBar.tsx and mapped from tab.id.
  */
+import { BILLING_DASHBOARD_URL } from '../utils/links';
 
 // ── Tab bar ──────────────────────────────────────────────────────────────────
 
@@ -103,8 +104,7 @@ export const AVATAR_MENU_ITEMS: AvatarMenuItem[] = [
   {
     id: 'billing',
     labelKey: 'nav.avatarMenu.billing',
-    // Resolved at runtime via BILLING_DASHBOARD_URL; placeholder keeps typing clean.
-    target: 'https://tinyhumans.ai/dashboard',
+    target: BILLING_DASHBOARD_URL,
     kind: 'openUrl',
     cloudOnly: true,
   },

--- a/app/src/utils/links.ts
+++ b/app/src/utils/links.ts
@@ -1,4 +1,4 @@
 export const DISCORD_INVITE_URL = 'https://discord.tinyhumans.ai';
-export const BILLING_DASHBOARD_URL = 'https://tinyhumans.ai/dashboard';
+export const BILLING_DASHBOARD_URL = 'https://tinyhumans.ai/pricing';
 export const PRIVACY_POLICY_URL = 'https://tinyhumans.gitbook.io/openhuman/legal/privacy-policy';
 export const TERMS_OF_USE_URL = 'https://tinyhumans.gitbook.io/openhuman/legal/terms-of-use';


### PR DESCRIPTION
## Summary

- Redirect billing, upgrade, top-up, and usage-limit links to the public TinyHumans pricing page.
- Reuse the shared billing URL constant for the avatar menu to prevent destination drift.
- Update focused frontend assertions for the new destination.

## Problem

- Pricing-related actions currently send users to the general dashboard instead of the public pricing page where plans are presented.

## Solution

- Change the shared billing destination to `https://tinyhumans.ai/pricing` and make the avatar-menu target consume that same constant.
- Keep existing navigation behavior intact while updating regression coverage for banners, billing settings, and avatar navigation.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — destination assertions updated; N/A failure path because this is a static URL change with existing browser-opening error handling unchanged.
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/ci-lite.yml`](../.github/workflows/ci-lite.yml). Focused tests exercise the changed frontend behavior; CI will enforce the merged diff-coverage threshold.
- [x] N/A: Coverage matrix update — behavior-only destination change.
- [x] N/A: Affected feature IDs — no coverage-matrix feature row changed.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)).
- [x] N/A: Manual smoke checklist — no release-cut surface or workflow changed.
- [x] N/A: Linked issue — no issue was provided for this request.

## Impact

- Desktop users who select pricing-related actions now open `https://tinyhumans.ai/pricing` in their system browser.
- No performance, security, migration, mobile, or CLI impact.

## Related

- Closes: N/A — no linked issue.
- Follow-up PR(s)/TODOs: None.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/pricing-links`
- Commit SHA: `067a89f78cb67a01fbe9a1316631a7e6ac1c7126`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` (via pre-push hook)
- [x] `pnpm typecheck`
- [x] Focused tests: `pnpm debug unit src/components/home/__tests__/HomeBanners.test.tsx src/components/settings/panels/BillingPanel.test.tsx src/config/__tests__/navConfig.test.ts` — 28 passed
- [x] Rust fmt/check (if changed): root and Tauri formatting plus clippy passed via pre-push hook; no Rust files changed
- [x] Tauri fmt/check (if changed): formatting and clippy passed via pre-push hook; no Tauri files changed

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` None

### Behavior Changes

- Intended behavior change: Pricing-related actions open the public pricing page instead of the general dashboard.
- User-visible effect: The system browser navigates to `https://tinyhumans.ai/pricing`.

### Parity Contract

- Legacy behavior preserved: Existing external-browser opening and error handling are unchanged.
- Guard/fallback/dispatch parity checks: Existing focused component tests pass; only the destination URL changed.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None found for this branch.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): N/A
