### PR TITLE
fix(cron): stop one-shot At jobs from re-firing every poll

### DIFF
--- a/src/openhuman/cron/scheduler.rs
+++ b/src/openhuman/cron/scheduler.rs
@@ -1186,13 +1186,21 @@ async fn persist_job_result(
         duration_ms,
     );
 
-    if is_one_shot_auto_delete(job) {
-        if success {
+    // A fixed-instant (`Schedule::At`) job is inherently one-shot: its `at` is in
+    // the past the moment it runs, so `reschedule_after_run` (which writes
+    // next_run = at for an `At` schedule) leaves next_run <= now and the job is
+    // re-selected by `due_jobs` on every poll, re-executing forever. Terminate
+    // every `At` job after a single run, regardless of `delete_after_run`. Only an
+    // auto-delete job that succeeded is removed; everything else is kept disabled
+    // so its run history stays inspectable. (Inside this `At` branch
+    // `is_one_shot_auto_delete` reduces to `job.delete_after_run`.)
+    if matches!(job.schedule, Schedule::At { .. }) {
+        if is_one_shot_auto_delete(job) && success {
             if let Err(e) = remove_job(config, &job.id) {
                 tracing::warn!("Failed to remove one-shot cron job after success: {e}");
             }
         } else {
-            let _ = record_last_run(config, &job.id, finished_at, false, output);
+            let _ = record_last_run(config, &job.id, finished_at, success, output);
             if let Err(e) = update_job(
                 config,
                 &job.id,
@@ -1201,7 +1209,7 @@ async fn persist_job_result(
                     ..CronJobPatch::default()
                 },
             ) {
-                tracing::warn!("Failed to disable failed one-shot cron job: {e}");
+                tracing::warn!("Failed to disable one-shot cron job: {e}");
             }
         }
         return success;

--- a/src/openhuman/cron/scheduler_tests.rs
+++ b/src/openhuman/cron/scheduler_tests.rs
@@ -1144,6 +1144,46 @@ async fn persist_job_result_failure_disables_one_shot() {
 }
 
 #[tokio::test]
+async fn persist_job_result_disables_at_job_without_delete_flag() {
+    // Regression: an `At` job created without delete_after_run (the RPC default,
+    // and every shell `At` job) must not be rescheduled after it runs. Its `at`
+    // is a fixed instant, so reschedule_after_run would write next_run = at
+    // (now in the past) and due_jobs would re-select it on every poll, re-firing
+    // the job forever.
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp).await;
+    let at = Utc::now() + ChronoDuration::minutes(10);
+    let job = cron::add_agent_job(
+        &config,
+        Some("at-no-delete".into()),
+        crate::openhuman::cron::Schedule::At { at },
+        "Hello",
+        SessionTarget::Isolated,
+        None,
+        None,
+        false, // delete_after_run = false — the previously-buggy case
+    )
+    .unwrap();
+    let started = Utc::now();
+    let finished = started + ChronoDuration::milliseconds(10);
+
+    let success = persist_job_result(&config, &job, true, "ok", started, finished).await;
+    assert!(success);
+
+    // The row is kept (not auto-deleted) but disabled, and its run is recorded.
+    let updated = cron::get_job(&config, &job.id).unwrap();
+    assert!(!updated.enabled, "At job must be disabled after one run");
+    assert_eq!(updated.last_status.as_deref(), Some("ok"));
+
+    // It is never due again — even at a time past its `at` instant.
+    let due = cron::due_jobs(&config, at + ChronoDuration::minutes(1)).unwrap();
+    assert!(
+        !due.iter().any(|j| j.id == job.id),
+        "disabled At job must not be re-selected by due_jobs"
+    );
+}
+
+#[tokio::test]
 async fn deliver_if_configured_skips_non_announce_mode() {
     let tmp = TempDir::new().unwrap();
     let config = test_config(&tmp).await;


### PR DESCRIPTION
## Summary

- Fix a runaway-execution bug: one-shot `Schedule::At` cron jobs re-fire on **every** poll interval forever when `delete_after_run` is not set.
- Treat any `At` job as inherently one-shot in the scheduler, so it terminates after a single run regardless of the flag or entry point (agent **and** shell RPC).
- Add a regression test asserting an `At` job with `delete_after_run=false` is disabled after one run and is never re-selected by `due_jobs`.

## Problem

`Schedule::At` is a fixed instant. When such a job runs, `persist_job_result` decides whether to finish it (one-shot) or reschedule it:

- `is_one_shot_auto_delete(job)` is `job.delete_after_run && matches!(schedule, At)`.
- The agent **tool** defaults `delete_after_run` to `matches!(schedule, At{..})` (`tools/add.rs`), so tool-created `At` jobs are correctly one-shot.
- The **RPC** handler defaults it to `false` (`schemas.rs` `handle_add`), and `add_shell_job` never sets it at all (column default `0`).

So an `At` job created over RPC is **not** `is_one_shot_auto_delete`, and falls through to `reschedule_after_run`, which writes `next_run = next_run_for_schedule(&At, now)` = the (now past) instant. `due_jobs` selects `enabled = 1 AND next_run <= now`, so the past `at` stays perpetually due and the job re-executes on every poll — burning model cost and repeating external side effects for agent jobs.

## Solution

Fix at the scheduler rather than mirroring the RPC default (a default-mirror would miss `add_shell_job`). A fixed-instant job can never have a legitimate *future* occurrence, so terminate every `At` job after a single run:

- Auto-delete job that **succeeded** → removed (unchanged).
- Every other `At` job → kept **disabled** (`enabled = false`) with its last run recorded, so history stays inspectable and it never re-fires.
- Non-`At` schedules are unaffected — they still `reschedule_after_run`.

Inside the new `At` branch, `is_one_shot_auto_delete(job)` reduces to `job.delete_after_run`, so the existing helper and its unit tests remain valid.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `persist_job_result_disables_at_job_without_delete_flag` covers the previously-buggy `delete_after_run=false` path; existing `..._success_deletes_one_shot` / `..._failure_disables_one_shot` cover the auto-delete arms, which now route through the same `At` branch.
- [x] **Diff coverage ≥ 80%** — the changed scheduler lines (the `At` branch: `remove_job`, `record_last_run` + disable, and the guard) are all exercised by the three one-shot tests. `cargo test -p openhuman --lib cron::scheduler` passes (one unrelated pre-existing failure noted under Impact).
- [x] Coverage matrix updated — `N/A: behaviour-only bug fix, no new/renamed feature`.
- [x] All affected feature IDs listed under `## Related` — `N/A: no matrix feature touched`.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — `N/A: does not touch a release-cut surface`.
- [x] Linked issue closed via `Closes #NNN` — no existing issue; this was found by inspection.

## Impact

- **CLI/desktop cron**: fixes unbounded re-execution of `At` jobs created via `cron.add` RPC (agent and shell). No migration; existing rescheduled-to-past `At` rows stop re-firing the next time they run (they get disabled) — or can be deleted normally.
- No performance or security implications beyond stopping the wasteful re-runs.
- Note: `cargo test -p openhuman --lib cron::scheduler` shows one **pre-existing, unrelated** failure — `run_agent_job_returns_error_without_provider_key` overflows the debug thread stack (deep agent async state machine); it reproduces identically on clean `main` with this change stashed, and does not touch the scheduler reschedule path.

## Related

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/cron-at-oneshot-refire`
- Commit SHA: `90c1a16e8`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A (no frontend change)
- [x] `pnpm typecheck` — N/A (no frontend change)
- [x] Focused tests: `cargo test -p openhuman --lib cron::scheduler` (new + one-shot family pass)
- [x] Rust fmt/check (if changed): `cargo fmt`
- [x] Tauri fmt/check (if changed): N/A (core-only change)

### Behavior Changes

- Intended behavior change: `At` jobs no longer reschedule after running; they terminate (remove-on-success for auto-delete, else disable).
- User-visible effect: a one-time scheduled job runs once instead of repeating forever.

### Parity Contract

- Legacy behavior preserved: auto-delete-on-success and disable-on-failure for `delete_after_run=true` `At` jobs; all non-`At` schedules reschedule exactly as before.
- Guard/fallback/dispatch parity checks: `is_one_shot_auto_delete` semantics unchanged; the new branch is gated strictly on `matches!(schedule, At{..})`.
