### PR TITLE
perf(orchestration): batch the per-session unread_count into one query

### DIFF
--- a/src/openhuman/orchestration/ops.rs
+++ b/src/openhuman/orchestration/ops.rs
@@ -252,11 +252,12 @@ pub(super) fn gather_unread_signals(
     conn: &rusqlite::Connection,
 ) -> anyhow::Result<Vec<super::attention::UnreadSignal>> {
     let mut out: Vec<super::attention::UnreadSignal> = Vec::new();
+    let unread_counts = store::unread_counts(conn)?;
     for session in store::list_sessions(conn)? {
         if matches!(session.session_id.as_str(), "master" | "subconscious") {
             continue;
         }
-        let unread = store::unread_count(conn, &session.session_id)?;
+        let unread = unread_counts.get(&session.session_id).copied().unwrap_or(0);
         if unread > 0 {
             out.push(super::attention::UnreadSignal {
                 session_id: session.session_id,

--- a/src/openhuman/orchestration/schemas.rs
+++ b/src/openhuman/orchestration/schemas.rs
@@ -416,11 +416,12 @@ fn handle_sessions_list(_params: Map<String, Value>) -> ControllerFuture {
             let rows = store::list_sessions(conn)?;
             let visible_counts = store::visible_message_counts(conn)?;
             let pinned_visible_counts = store::visible_message_counts_by_session(conn)?;
+            let unread_counts = store::unread_counts(conn)?;
             let mut out: Vec<SessionSummary> = Vec::with_capacity(rows.len() + 2);
             let mut have_master = false;
             let mut have_subconscious = false;
             for session in rows {
-                let unread = store::unread_count(conn, &session.session_id)?;
+                let unread = unread_counts.get(&session.session_id).copied().unwrap_or(0);
                 match session.session_id.as_str() {
                     "master" => have_master = true,
                     "subconscious" => have_subconscious = true,

--- a/src/openhuman/orchestration/store.rs
+++ b/src/openhuman/orchestration/store.rs
@@ -436,6 +436,33 @@ pub fn visible_message_counts_by_session(conn: &Connection) -> Result<HashMap<St
     Ok(rows)
 }
 
+/// Unread message counts keyed by `session_id`: the batched form of
+/// [`unread_count`], collapsing its per-session cursor lookup + `COUNT(*)` into a
+/// single query so a caller iterating N sessions runs one statement instead of
+/// 2N. `LEFT JOIN kv ON kv.k = 'read:' || m.session_id` reproduces
+/// `kv_get(&read_cursor_key(..))` — `kv.k` is `PRIMARY KEY`, so the join matches
+/// at most one cursor row per session (no fan-out) — and `COALESCE(kv.v, '')`
+/// reproduces the scalar path's `.unwrap_or_default()` empty cursor, so a session
+/// that was never marked read counts all of its visible messages. Sessions with
+/// zero unread are absent from the map; callers default missing entries to 0.
+pub fn unread_counts(conn: &Connection) -> Result<HashMap<String, i64>> {
+    let mut stmt = conn.prepare(
+        "SELECT m.session_id, COUNT(*)
+           FROM messages m
+           LEFT JOIN kv ON kv.k = 'read:' || m.session_id
+          WHERE m.timestamp > COALESCE(kv.v, '')
+            AND (m.event_kind IS NULL
+                 OR m.event_kind NOT IN ('status', 'lifecycle', 'unknown', 'session_info'))
+          GROUP BY m.session_id",
+    )?;
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?
+        .collect::<std::result::Result<HashMap<_, _>, _>>()?;
+    Ok(rows)
+}
+
 /// The next monotonic per-session ingest ordinal: `MAX(seq) + 1` over the
 /// session's messages (`1` for the first message). Stamped at persist time so
 /// the wake idempotence cursor rides a strictly-increasing value instead of the
@@ -1192,6 +1219,64 @@ mod tests {
             let older = list_messages_by_session(conn, "h1", 100, Some("2026-07-02T00:05:00Z"))?;
             assert_eq!(older.len(), 1);
             assert_eq!(older[0].id, "m1");
+            Ok(())
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn unread_counts_batches_and_matches_scalar_unread_count() {
+        // The batched unread_counts() must equal the per-session scalar
+        // unread_count() for every session, across: no cursor (all unread), a
+        // mid-stream cursor (partial), fully read (zero), a hidden (excluded
+        // event_kind) row, and a session with no messages.
+        let tmp = tempfile::tempdir().unwrap();
+        with_connection(tmp.path(), |conn| {
+            // h1: two messages, never marked read -> 2 unread.
+            upsert_session(conn, &session("@a", "h1", 2))?;
+            insert_message(conn, &msg("a1", "@a", "h1", 1))?;
+            insert_message(conn, &msg("a2", "@a", "h1", 2))?;
+
+            // h2: read up to the first message, then a newer one arrives -> 1 unread.
+            upsert_session(conn, &session("@b", "h2", 2))?;
+            insert_message(conn, &msg("b1", "@b", "h2", 1))?;
+            mark_chat_read(conn, "h2")?;
+            let mut b2 = msg("b2", "@b", "h2", 2);
+            b2.timestamp = "2026-07-02T00:05:00Z".into();
+            insert_message(conn, &b2)?;
+
+            // h3: fully read -> 0 unread (absent from the map).
+            upsert_session(conn, &session("@c", "h3", 1))?;
+            insert_message(conn, &msg("c1", "@c", "h3", 1))?;
+            mark_chat_read(conn, "h3")?;
+
+            // h4: one visible + one hidden (excluded event_kind) -> 1 unread.
+            upsert_session(conn, &session("@d", "h4", 2))?;
+            insert_message(conn, &msg("d1", "@d", "h4", 1))?;
+            let hidden = OrchestrationMessage {
+                event_kind: Some("lifecycle".into()),
+                ..msg("d2", "@d", "h4", 2)
+            };
+            insert_message(conn, &hidden)?;
+
+            // h5: session with no messages -> 0 unread (absent from the map).
+            upsert_session(conn, &session("@e", "h5", 0))?;
+
+            let batched = unread_counts(conn)?;
+            for sid in ["h1", "h2", "h3", "h4", "h5"] {
+                assert_eq!(
+                    batched.get(sid).copied().unwrap_or(0),
+                    unread_count(conn, sid)?,
+                    "batched unread mismatch for {sid}"
+                );
+            }
+
+            // Concrete expectations, and zero-unread sessions dropped from the map.
+            assert_eq!(batched.get("h1").copied(), Some(2));
+            assert_eq!(batched.get("h2").copied(), Some(1));
+            assert_eq!(batched.get("h4").copied(), Some(1));
+            assert_eq!(batched.get("h3"), None);
+            assert_eq!(batched.get("h5"), None);
             Ok(())
         })
         .unwrap();


### PR DESCRIPTION
## Summary

- Collapse an N+1 in the orchestration session roster and attention queue: `unread_count` ran **2 queries per session** and was called once per session in two hot RPC paths.
- Add a batched `unread_counts(conn) -> HashMap<session_id, i64>` (one `GROUP BY` with a `LEFT JOIN` on the read-cursor kv) and consume it in `sessions_list` and `gather_unread_signals`.
- Byte-identical results; add a parity test asserting the batched map equals the scalar `unread_count` across every cursor/visibility state.

## Problem

`store::unread_count(conn, session_id)` does two round-trips — `kv_get(read_cursor_key(..))` then a `COUNT(*)` — and is called once per session in:

- `handle_sessions_list` (`schemas.rs`) — the session roster, `for session in rows { unread_count(..) }`, and `list_sessions` has **no LIMIT**, so listing N sessions is 2N queries.
- `gather_unread_signals` (`ops.rs`) — the attention queue, same per-session loop.

This is especially visible in `handle_sessions_list` because the sibling *message* count in the very same loop was already batched into `visible_message_counts` / `visible_message_counts_by_session` (consumed via `.get().copied().unwrap_or(0)`); the unread count was simply left as the lone per-row DB hit.

## Solution

Add a batched query mirroring `visible_message_counts_by_session`:

```sql
SELECT m.session_id, COUNT(*)
  FROM messages m
  LEFT JOIN kv ON kv.k = 'read:' || m.session_id
 WHERE m.timestamp > COALESCE(kv.v, '')
   AND (m.event_kind IS NULL OR m.event_kind NOT IN ('status','lifecycle','unknown','session_info'))
 GROUP BY m.session_id
```

- `kv.k` is `PRIMARY KEY`, so the `LEFT JOIN` matches at most one cursor row per session — **no fan-out**.
- `COALESCE(kv.v, '')` reproduces the scalar path's `.unwrap_or_default()` empty cursor (a never-read session counts all its visible messages).
- The `event_kind` predicate is copied verbatim from `unread_count`.
- Sessions with zero unread drop out of the `GROUP BY`; both call sites already default missing entries to `0`, so behaviour is identical.

Each call site now computes the map once before its loop and reads `map.get(&session_id).copied().unwrap_or(0)`. The scalar `unread_count` is retained (still used by existing store tests and as the parity oracle).

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `unread_counts_batches_and_matches_scalar_unread_count` asserts the batched map equals the scalar `unread_count` for every session across five states: no cursor, mid-stream cursor (partial), fully read (zero), a hidden excluded-`event_kind` row, and a session with no messages.
- [x] **Diff coverage ≥ 80%** — the new `unread_counts` query and both swapped call sites are exercised by the parity test plus existing `sessions_list` / attention coverage. `cargo test -p openhuman --lib orchestration::store` passes.
- [x] Coverage matrix updated — `N/A: internal query batching, no user-visible feature change`.
- [x] All affected feature IDs listed under `## Related` — `N/A`.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — `N/A: does not touch a release-cut surface`.
- [x] Linked issue closed via `Closes #NNN` — no existing issue; found by inspection.

## Impact

- **Desktop/CLI**: `openhuman.sessions_list` and the attention queue now issue one unread query instead of 2N. No behaviour change (verified byte-identical by the parity test); no schema/migration.
- Extends the existing `visible_message_counts` batching pattern in the same loop.

## Related

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `perf/orchestration-batch-unread-counts`
- Commit SHA: `45c2fae86`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A (no frontend change)
- [x] `pnpm typecheck` — N/A (no frontend change)
- [x] Focused tests: `cargo test -p openhuman --lib orchestration::store`
- [x] Rust fmt/check (if changed): `cargo fmt`
- [x] Tauri fmt/check (if changed): N/A (core-only change)

### Behavior Changes

- Intended behavior change: none — pure query batching.
- User-visible effect: none (fewer DB round-trips on session listing / attention).

### Parity Contract

- Legacy behavior preserved: `unread_counts` returns exactly what `unread_count` would per session; `COALESCE(kv.v,'')` = `.unwrap_or_default()`, `event_kind` predicate copied verbatim, zero-unread sessions default to 0 at both call sites.
- Guard/fallback/dispatch parity checks: parity test asserts map == scalar across all cursor/visibility states.
