### PR TITLE
fix(approval): redact non-canonically-cased home paths in scrub_paths

### DIFF
--- a/src/openhuman/approval/redact.rs
+++ b/src/openhuman/approval/redact.rs
@@ -130,9 +130,13 @@ fn scrub_paths(input: &str) -> String {
     // via `eq_ignore_ascii_case`. A case-sensitive check let non-canonical
     // casings like `c:\users\alice` or `/HOME/alice` short-circuit here and get
     // returned verbatim, leaking the OS username into the durable approval audit
-    // row instead of redacting it to `<HOME>`.
-    let lower = input.to_ascii_lowercase();
-    if !lower.contains("users") && !lower.contains("home") {
+    // row instead of redacting it to `<HOME>`. Scan the bytes in place with a
+    // sliding window rather than allocating a full lowercase copy — tool args can
+    // be large (source/file contents), and the common case bails without a match.
+    let bytes = input.as_bytes();
+    let has_users = bytes.windows(5).any(|w| w.eq_ignore_ascii_case(b"users"));
+    let has_home = bytes.windows(4).any(|w| w.eq_ignore_ascii_case(b"home"));
+    if !has_users && !has_home {
         return input.to_string();
     }
     let mut out = String::with_capacity(input.len());

--- a/src/openhuman/approval/redact.rs
+++ b/src/openhuman/approval/redact.rs
@@ -124,7 +124,15 @@ fn redact_value(value: &Value) -> Value {
 /// would miss the Windows case in a Unix-built artifact looking at
 /// log payloads that originated on Windows, or vice versa.
 fn scrub_paths(input: &str) -> String {
-    if !input.contains("Users") && !input.contains("home") {
+    // Fast-path bailout: if `input` contains neither "users" nor "home" it holds
+    // no home prefix for `match_home_prefix` to find, so skip the walk. This
+    // guard MUST be case-insensitive to match the matcher below, which folds case
+    // via `eq_ignore_ascii_case`. A case-sensitive check let non-canonical
+    // casings like `c:\users\alice` or `/HOME/alice` short-circuit here and get
+    // returned verbatim, leaking the OS username into the durable approval audit
+    // row instead of redacting it to `<HOME>`.
+    let lower = input.to_ascii_lowercase();
+    if !lower.contains("users") && !lower.contains("home") {
         return input.to_string();
     }
     let mut out = String::with_capacity(input.len());
@@ -417,6 +425,47 @@ mod tests {
         assert!(!cwd.contains("jane"), "got {cwd}");
         assert!(cwd.contains("<HOME>"));
         assert!(cwd.ends_with("/project"));
+    }
+
+    #[test]
+    fn lowercase_windows_home_path_is_scrubbed() {
+        // Regression: the fast-path guard was case-sensitive while the matcher is
+        // case-insensitive, so a lowercase drive/`users` casing slipped through
+        // unredacted and leaked the username.
+        let args = json!({ "action": "list", "cwd": "c:\\users\\alice\\work" });
+        let red = redact_args(&args);
+        let cwd = red["cwd"].as_str().unwrap();
+        assert!(!cwd.contains("alice"), "got {cwd}");
+        assert!(cwd.contains("<HOME>"));
+        assert!(cwd.ends_with("\\work"));
+    }
+
+    #[test]
+    fn uppercase_linux_home_path_is_scrubbed() {
+        let args = json!({ "action": "list", "cwd": "/HOME/alice/work" });
+        let red = redact_args(&args);
+        let cwd = red["cwd"].as_str().unwrap();
+        assert!(!cwd.contains("alice"), "got {cwd}");
+        assert!(cwd.contains("<HOME>"));
+        assert!(cwd.ends_with("/work"));
+    }
+
+    #[test]
+    fn mixed_case_home_path_is_scrubbed() {
+        let args = json!({ "action": "list", "cwd": "/Home/alice/work" });
+        let red = redact_args(&args);
+        let cwd = red["cwd"].as_str().unwrap();
+        assert!(!cwd.contains("alice"), "got {cwd}");
+        assert!(cwd.contains("<HOME>"));
+        assert!(cwd.ends_with("/work"));
+    }
+
+    #[test]
+    fn non_path_string_without_home_marker_is_unchanged() {
+        // The guard's fast-path must still return unrelated strings verbatim.
+        let args = json!({ "action": "run", "command": "echo hello world" });
+        let red = redact_args(&args);
+        assert_eq!(red["command"].as_str().unwrap(), "echo hello world");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fix a PII leak: `scrub_paths` returned non-canonically-cased home paths (e.g. `c:\users\alice\…`, `/HOME/alice/…`) **verbatim**, leaking the OS username into the durable approval audit surface.
- Make the fast-path bailout guard case-insensitive so it matches the (already case-insensitive) `match_home_prefix` matcher it guards.
- Add regression tests for lowercase / uppercase / mixed-case home paths and a non-path string.

## Problem

`scrub_paths` redacts absolute home paths to `<HOME>` before an approval summary is persisted into the durable `pending_approvals` table and broadcast on the event bus (`DomainEvent::ApprovalRequested`). The module docstring promises this output cannot leak the user's username on multi-tenant log shipping.

It opens with a fast-path bailout:

```rust
if !input.contains("Users") && !input.contains("home") {
    return input.to_string();
}
```

This guard is **case-sensitive**, but the matcher it guards (`match_home_prefix`) is deliberately **case-insensitive** (`eq_ignore_ascii_case`). So a path like `c:\users\alice\work` (lowercase `users`) or `/HOME/alice/work` (uppercase) contains neither `"Users"` nor `"home"` literally, hits the early return, and is emitted **unredacted** — leaking the username into a surface the module guarantees is username-free. Path-bearing keys (`cwd`/`path`/`dir`/`command`/`file`) are not in `SENSITIVE_KEYS`, so `scrub_paths` is their only redaction boundary. The existing tests only cover canonical `C:\Users\` / `/Users/` / `/home/`, so the gap was untested.

## Solution

Lower-case the input once and test the guard against it, so the fast-path can only skip strings the matcher genuinely could not redact:

```rust
let lower = input.to_ascii_lowercase();
if !lower.contains("users") && !lower.contains("home") {
    return input.to_string();
}
```

`match_home_prefix` only ever matches strings containing `users` or `home` (case-insensitively), so this guard is now exactly as permissive as the matcher — no false bailout, and unrelated strings still return verbatim (one allocation on the common no-path path). Canonical casings that already redacted are unaffected.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `lowercase_windows_home_path_is_scrubbed`, `uppercase_linux_home_path_is_scrubbed`, `mixed_case_home_path_is_scrubbed` (the previously-leaking cases), and `non_path_string_without_home_marker_is_unchanged` (guard still bails correctly).
- [x] **Diff coverage ≥ 80%** — the changed guard line is exercised by both the new leak-path tests and the unchanged-string test. `cargo test -p openhuman --lib approval::redact` passes.
- [x] Coverage matrix updated — `N/A: security bug fix, no user-visible feature change`.
- [x] All affected feature IDs listed under `## Related` — `N/A`.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — `N/A: does not touch a release-cut surface`.
- [x] Linked issue closed via `Closes #NNN` — no existing issue; found by inspection.

## Impact

- **Security / privacy**: stops the OS username leaking into the durable `pending_approvals` audit row and the `ApprovalRequested` event for non-canonically-cased home paths. No behaviour change for canonical paths or non-path strings; no schema/migration.

## Related

- Closes:
- Follow-up PR(s)/TODOs:

---

## AI Authored PR Metadata

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/approval-redact-case-insensitive-home`
- Commit SHA: `a0ea9cb4c`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A (no frontend change)
- [x] `pnpm typecheck` — N/A (no frontend change)
- [x] Focused tests: `cargo test -p openhuman --lib approval::redact`
- [x] Rust fmt/check (if changed): `cargo fmt`
- [x] Tauri fmt/check (if changed): N/A (core-only change)

### Behavior Changes

- Intended behavior change: non-canonically-cased home paths are now redacted to `<HOME>` like their canonical forms.
- User-visible effect: none beyond stronger redaction (no username leak).

### Parity Contract

- Legacy behavior preserved: canonical `/Users/`, `/home/`, `C:\Users\` paths redact exactly as before; non-path strings still return verbatim via the (now case-insensitive) fast-path guard.
- Guard/fallback/dispatch parity checks: guard permissiveness now matches `match_home_prefix` exactly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redaction of home-directory paths regardless of capitalization.
  * Fixed cases where Windows and Linux paths with mixed-case home markers could be exposed.
  * Preserved unrelated text that does not contain a home-directory path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->