### PR TITLE
feat(learning): surface facet provenance (cue_families, evidence_refs) in RPC

### DIFF
--- a/src/openhuman/learning/README.md
+++ b/src/openhuman/learning/README.md
@@ -62,7 +62,7 @@ Namespace `learning` (wired into `src/core/all.rs`; 11 controllers). Methods:
 | `learning.rebuild_cache` | Manually trigger a `StabilityDetector` rebuild; returns added/evicted/kept/total_size. |
 | `learning.cache_stats` | Cache totals + per-state and per-class breakdown. |
 | `learning.list_facets` | List Active + Provisional facets, optional `class` filter. |
-| `learning.get_facet` | Fetch one facet by `class` + `key` suffix. |
+| `learning.get_facet` | Fetch one facet by `class` + `key` suffix. Each returned facet carries its provenance (`evidence_refs`, `cue_families`) alongside the value/state fields. |
 | `learning.update_facet` | Set a facet value and pin it (`user_state = Pinned`). |
 | `learning.pin_facet` / `learning.unpin_facet` | Toggle `user_state` Pinned ↔ Auto. |
 | `learning.forget_facet` | Mark `Dropped` + `user_state = Forgotten` (blocks re-promotion). |

--- a/src/openhuman/learning/schemas.rs
+++ b/src/openhuman/learning/schemas.rs
@@ -476,6 +476,54 @@ mod tests {
     }
 
     #[test]
+    fn facet_to_json_includes_cue_families_and_evidence_refs() {
+        use crate::openhuman::learning::candidate::EvidenceRef;
+        use crate::openhuman::memory_store::profile::{
+            FacetState, FacetType, ProfileFacet, UserState,
+        };
+        use std::collections::HashMap;
+
+        let mut cue_families = HashMap::new();
+        cue_families.insert("explicit".to_string(), 3u32);
+        cue_families.insert("structural".to_string(), 1u32);
+
+        let facet = ProfileFacet {
+            facet_id: "f1".into(),
+            facet_type: FacetType::Preference,
+            key: "style/verbosity".into(),
+            value: "terse".into(),
+            confidence: 0.8,
+            evidence_count: 4,
+            source_segment_ids: None,
+            first_seen_at: 1000.0,
+            last_seen_at: 1200.0,
+            state: FacetState::Active,
+            stability: 0.9,
+            user_state: UserState::Auto,
+            evidence_refs: vec![EvidenceRef::Episodic { episodic_id: 42 }],
+            class: Some("style".into()),
+            cue_families: Some(cue_families),
+        };
+
+        // Populated provenance round-trips through the serializer.
+        let json = facet_to_json(&facet);
+        assert_eq!(json["cue_families"]["explicit"].as_u64(), Some(3));
+        assert_eq!(json["cue_families"]["structural"].as_u64(), Some(1));
+        assert_eq!(json["evidence_refs"][0]["type"].as_str(), Some("episodic"));
+        assert_eq!(json["evidence_refs"][0]["episodic_id"].as_i64(), Some(42));
+
+        // Empty/None provenance serializes to []/null (present, not dropped).
+        let bare = ProfileFacet {
+            evidence_refs: vec![],
+            cue_families: None,
+            ..facet
+        };
+        let json = facet_to_json(&bare);
+        assert_eq!(json["evidence_refs"].as_array().map(Vec::len), Some(0));
+        assert!(json["cue_families"].is_null());
+    }
+
+    #[test]
     fn schemas_and_controllers_match() {
         let s = all_learning_controller_schemas();
         let c = all_learning_registered_controllers();
@@ -735,6 +783,12 @@ fn facet_to_json(f: &crate::openhuman::memory_store::profile::ProfileFacet) -> s
         "first_seen_at": f.first_seen_at,
         "last_seen_at": f.last_seen_at,
         "class": f.class,
+        // Provenance the store already persists and row_to_facet hydrates, but
+        // the serializer previously dropped: the citations behind the facet and
+        // the per-cue-family evidence counts. `None`/empty serialize to
+        // `null`/`[]`.
+        "cue_families": f.cue_families,
+        "evidence_refs": f.evidence_refs,
     })
 }
 


### PR DESCRIPTION
## Summary

- Surface the two provenance fields the learning store already persists — `evidence_refs` and `cue_families` — through the facet RPC serializer, which was silently dropping them at the boundary.
- Additive-only: two keys added to `facet_to_json`, so every facet-returning controller (`list_facets`, `get_facet`, `update`/`pin`/`unpin`/`forget`) gains them at once.
- Add a unit test asserting both fields round-trip.

## Problem

`facet_to_json` is the single serializer feeding all facet-returning `learning.*` controllers. `ProfileFacet` persists (and `row_to_facet` hydrates) two provenance columns:

- `evidence_refs: Vec<EvidenceRef>` (from `evidence_refs_json`) — the citations behind a facet.
- `cue_families: Option<HashMap<String, u32>>` (from `cue_families_json`) — per-cue-family evidence counts written by the stability detector.

Both derive `Serialize` (`EvidenceRef` is a `#[serde(tag = "type")]` enum), are documented as first-class `ProfileFacet` state, and exist specifically as provenance — yet the serializer emits only 10 keys and drops both, so no RPC consumer can see the evidence behind a facet.

## Solution

Add the two fields to the `json!` macro in `facet_to_json`:

```rust
"cue_families": f.cue_families,
"evidence_refs": f.evidence_refs,
```

The controller output schemas declare `facet`/`facets` as opaque `TypeSchema::Json`, so the schema contract is unchanged; the addition is purely additive metadata. No store or query changes.

> Scope note: `evidence_refs` are keyed to a facet's `(class, key)`, not to the specific winning value (the stability detector merges every candidate's evidence for a key before persisting the single value). This PR only stops the serializer from dropping already-persisted state; it does not change what the detector stores. Value-scoped provenance would be a separate, larger change.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `facet_to_json_includes_cue_families_and_evidence_refs` builds a facet with populated and empty provenance and asserts both keys serialize correctly (present-and-populated + null/empty edge).
- [x] **Diff coverage ≥ 80%** — the two added serializer lines are exercised by the new test. `cargo test -p openhuman --lib learning::schemas` passes.
- [x] Coverage matrix updated — `N/A: additive read-only field exposure, no new controller/feature row`.
- [x] All affected feature IDs listed under `## Related` — `N/A`.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — `N/A: does not touch a release-cut surface`.
- [x] Linked issue closed via `Closes #NNN` — no existing issue; found by inspection.

## Impact

- **Desktop/CLI**: `learning.list_facets` / `get_facet` (and the mutating controllers' echoed facet) now include `cue_families` and `evidence_refs`, enabling a transparency/provenance UI to cite the evidence behind a learned facet without a second round-trip. Purely additive; no behaviour change for existing consumers.

## Related

- Closes:
- Follow-up PR(s)/TODOs: value-scoped provenance (persist/return refs per winning value) — separate change to the learning storage model.

---

## AI Authored PR Metadata

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/learning-facet-provenance-fields`
- Commit SHA: `e4f6889af`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A (no frontend change)
- [x] `pnpm typecheck` — N/A (no frontend change)
- [x] Focused tests: `cargo test -p openhuman --lib learning::schemas`
- [x] Rust fmt/check (if changed): `cargo fmt`
- [x] Tauri fmt/check (if changed): N/A (core-only change)

### Behavior Changes

- Intended behavior change: facet RPC output gains two already-persisted provenance fields.
- User-visible effect: provenance (`evidence_refs`, `cue_families`) is now retrievable via the learning facet controllers.

### Parity Contract

- Legacy behavior preserved: all existing keys unchanged; opaque-JSON output schema contract unaffected; no store/query change.
- Guard/fallback/dispatch parity checks: `None`/empty provenance serializes to `null`/`[]` (verified by the test's empty-facet case).
