### PR TITLE
fix(embeddings): differentiate custom endpoint verification failures (#5017)

### DIFF
--- a/app/src/components/settings/panels/EmbeddingsPanel.tsx
+++ b/app/src/components/settings/panels/EmbeddingsPanel.tsx
@@ -311,15 +311,19 @@ const EmbeddingsPanel = ({ embedded = false }: EmbeddingsPanelProps = {}) => {
         confirm_wipe: false,
       });
       // Setup-time verification failed: the endpoint couldn't prove it can
-      // embed, so the config was NOT saved. Covers no `/embeddings` route
-      // (TAURI-RUST-5JR), LM Studio with no model loaded (TAURI-RUST-4P4), and
-      // any other probe failure/timeout. Keep the setup popup open and surface
-      // the actionable message so the user can fix it (load a model, correct the
-      // endpoint, …) and retry.
+      // embed, so the config was NOT saved. update_settings only ever returns an
+      // `error` for a verification failure or the dimension-wipe confirm, so any
+      // error code other than the wipe-confirm is a failed probe. Matching on the
+      // shape (rather than an explicit allow-list) means the differentiated #5017
+      // codes — EMBEDDINGS_MODEL_INCOMPATIBLE / _AUTH_FAILED / _ENDPOINT_UNREACHABLE
+      // / _DIMENSION_MISMATCH, plus _ENDPOINT_NO_API and _NO_MODEL_LOADED — all
+      // surface their actionable backend message instead of a new code being
+      // silently treated as a save. Keep the setup popup open so the user can fix
+      // it (pick an embeddings model, correct the key/endpoint, …) and retry.
       if (
-        result.error === 'EMBEDDINGS_ENDPOINT_NO_API' ||
-        result.error === 'EMBEDDINGS_NO_MODEL_LOADED' ||
-        result.error === 'EMBEDDINGS_VERIFICATION_FAILED'
+        typeof result.error === 'string' &&
+        result.error !== '' &&
+        result.error !== 'EMBEDDINGS_DIMENSION_CHANGE_REQUIRES_WIPE'
       ) {
         // `result.message`/`result.detail` are backend-emitted (already
         // context-specific); only the generic fallback is frontend-owned UI

--- a/app/src/components/settings/panels/EmbeddingsPanel.tsx
+++ b/app/src/components/settings/panels/EmbeddingsPanel.tsx
@@ -5,6 +5,7 @@
  * to enter the key, test connection, and save. Dimension changes show a
  * destructive confirm dialog since they invalidate stored vectors.
  */
+import createDebug from 'debug';
 import { useCallback, useEffect, useState } from 'react';
 
 import { useT } from '../../../lib/i18n/I18nContext';
@@ -32,6 +33,11 @@ import {
   SettingsTextField,
 } from '../controls';
 import { useSettingsNavigation } from '../hooks/useSettingsNavigation';
+
+// Grep-friendly, namespaced diagnostics for the custom-endpoint verification
+// flow. Logs only safe metadata (error classification code, state transitions) —
+// never the endpoint URL, API key, or backend-provided detail body.
+const log = createDebug('app:settings:embeddings');
 
 type Status =
   | { kind: 'idle' }
@@ -303,6 +309,7 @@ const EmbeddingsPanel = ({ embedded = false }: EmbeddingsPanelProps = {}) => {
         await setEmbeddingsApiKey('custom', setupKey.trim());
       }
       setStatus({ kind: 'saving' });
+      log('setupSaveCustom: calling update_embeddings_settings (provider=custom)');
       const result = await updateEmbeddingsSettings({
         provider: 'custom',
         model: customModel || 'embedding',
@@ -310,6 +317,12 @@ const EmbeddingsPanel = ({ embedded = false }: EmbeddingsPanelProps = {}) => {
         custom_endpoint: customEndpoint.trim(),
         confirm_wipe: false,
       });
+      // Safe to log the error *code* (an enum-like sentinel, e.g.
+      // EMBEDDINGS_AUTH_FAILED) — it carries no endpoint/key/detail content.
+      log(
+        'setupSaveCustom: rpc returned error_code=%s',
+        typeof result.error === 'string' && result.error !== '' ? result.error : 'none'
+      );
       // Setup-time verification failed: the endpoint couldn't prove it can
       // embed, so the config was NOT saved. update_settings only ever returns an
       // `error` for a verification failure or the dimension-wipe confirm, so any
@@ -340,10 +353,17 @@ const EmbeddingsPanel = ({ embedded = false }: EmbeddingsPanelProps = {}) => {
             ? `${baseMessage} (${result.detail})`
             : baseMessage
         );
+        // Verification failed: keep the setup popup open (status→idle, not error)
+        // so the user can correct the model/key/endpoint and retry.
+        log(
+          'setupSaveCustom: verification failed (code=%s) — preserving setup popup, early return',
+          result.error
+        );
         setStatus({ kind: 'idle' });
         return;
       }
       if (result.error === 'EMBEDDINGS_DIMENSION_CHANGE_REQUIRES_WIPE') {
+        log('setupSaveCustom: dimension change requires wipe — prompting confirm');
         setPendingWipe({
           provider: 'custom',
           model: customModel || 'embedding',
@@ -352,6 +372,7 @@ const EmbeddingsPanel = ({ embedded = false }: EmbeddingsPanelProps = {}) => {
         });
         setStatus({ kind: 'idle' });
       } else {
+        log('setupSaveCustom: verification passed — saved, reloading settings');
         await reload();
         setStatus({ kind: 'saved' });
       }

--- a/src/openhuman/embeddings/rpc.rs
+++ b/src/openhuman/embeddings/rpc.rs
@@ -206,8 +206,17 @@ pub async fn update_settings(
                     _ => 0,
                 };
                 if let Some(reject) = classify_embed_probe(outcome) {
+                    // Log the classified error code (never the raw detail — it can
+                    // carry endpoint response bodies) so support can distinguish
+                    // auth vs wrong-model vs unreachable failures (issue #5017).
+                    let reject_code = reject
+                        .value
+                        .get("error")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("EMBEDDINGS_VERIFICATION_FAILED");
                     tracing::warn!(
                         provider = effective_provider.as_str(),
+                        reject_code,
                         "{LOG_PREFIX} update_settings rejected — embeddings endpoint failed verification"
                     );
                     // Right-feedback (issue #3761): the probe failed. If the
@@ -666,8 +675,16 @@ fn classify_embed_probe(outcome: EmbedProbe) -> Option<RpcOutcome<serde_json::Va
         ),
         EmbedProbe::Failed(detail) => {
             let lower = detail.to_ascii_lowercase();
-            // Reachable but no model loaded (e.g. LM Studio idle).
+            // The endpoint IS reachable and correctly shaped (POST /v1/embeddings
+            // with the user's model + key — verified conformant by the mock-endpoint
+            // regression test). The failures below are all *distinct causes*; issue
+            // #5017 was that they collapsed into one generic "test embed failed"
+            // message, so a user whose endpoint works for chat couldn't tell that
+            // (e.g.) their chosen model isn't an embeddings model, their key was
+            // rejected, or the host was unreachable. Order matters: check the
+            // specific shapes before the generic fallback.
             if lower.contains("no models loaded") {
+                // Reachable but no model loaded (e.g. LM Studio idle).
                 reject(
                     "EMBEDDINGS_NO_MODEL_LOADED",
                     "Your local embeddings server (e.g. LM Studio) is running but has no \
@@ -686,8 +703,59 @@ fn classify_embed_probe(outcome: EmbedProbe) -> Option<RpcOutcome<serde_json::Va
                     "embeddings endpoint has no embeddings API — not saved",
                     Some(&detail),
                 )
+            } else if is_embedding_dimension_mismatch(&lower) {
+                // Endpoint embedded fine but returned a different vector length than
+                // the (Matryoshka) size we requested — a `text-embedding-3-*` model
+                // name pointed at a host that ignores the `dimensions` param.
+                reject(
+                    "EMBEDDINGS_DIMENSION_MISMATCH",
+                    "The endpoint returned a vector with a different length than the \
+                     dimensions you entered. Set dimensions to match the model's native \
+                     output (or clear the field to auto-detect), then save again.",
+                    "embeddings endpoint returned mismatched dimensions — not saved",
+                    Some(&detail),
+                )
+            } else if is_embedding_model_incompatible(&lower) {
+                // Reachable, authenticated embeddings API that rejected the model —
+                // the user pasted a chat/reasoning model (e.g. `gpt-5-mini`) into the
+                // embeddings model field. This is the #5017 reporter's exact case:
+                // the same model works for chat but is not an embeddings model.
+                reject(
+                    "EMBEDDINGS_MODEL_INCOMPATIBLE",
+                    "That model isn't an embeddings model on this endpoint. A chat model \
+                     (the one that works in Chat settings) can't produce embeddings — \
+                     enter an embeddings model id (e.g. text-embedding-3-small, bge-m3), \
+                     then save again.",
+                    "embeddings model is not an embeddings model — not saved",
+                    Some(&detail),
+                )
+            } else if embed_error_mentions_status(&lower, 401)
+                || embed_error_mentions_status(&lower, 403)
+            {
+                // Auth failure — key missing/wrong/lacking embeddings scope. The
+                // embeddings key is stored separately from the chat BYOK key, so
+                // "works for chat" does not imply the embeddings key is set.
+                reject(
+                    "EMBEDDINGS_AUTH_FAILED",
+                    "The endpoint rejected the API key (401/403). Enter a valid key for \
+                     this endpoint — note the embeddings key is stored separately from the \
+                     Chat provider key — then save again.",
+                    "embeddings endpoint rejected the API key — not saved",
+                    Some(&detail),
+                )
+            } else if is_embedding_endpoint_unreachable(&lower) {
+                // Transport-level failure — DNS, refused connection, TLS. The base
+                // URL is wrong or the host is down.
+                reject(
+                    "EMBEDDINGS_ENDPOINT_UNREACHABLE",
+                    "Couldn't reach the embeddings endpoint (network/DNS/connection \
+                     error). Check the base URL and that the host is reachable, then save \
+                     again.",
+                    "embeddings endpoint unreachable — not saved",
+                    Some(&detail),
+                )
             } else {
-                // Any other failure (5xx, auth, network) — didn't pass verification.
+                // Any other failure (5xx, unclassified) — didn't pass verification.
                 reject(
                     "EMBEDDINGS_VERIFICATION_FAILED",
                     "Couldn't verify the embeddings endpoint — the test embed failed. Make \
@@ -699,13 +767,60 @@ fn classify_embed_probe(outcome: EmbedProbe) -> Option<RpcOutcome<serde_json::Va
             }
         }
         EmbedProbe::TimedOut => reject(
-            "EMBEDDINGS_VERIFICATION_FAILED",
+            "EMBEDDINGS_ENDPOINT_UNREACHABLE",
             "Couldn't verify the embeddings endpoint — the test embed timed out. Make sure \
              the endpoint is running and reachable, then save again.",
             "embeddings endpoint timed out during verification — not saved",
             None,
         ),
     }
+}
+
+/// Whether a lowercased embed-error detail names the given HTTP status, tolerant
+/// of both wire shapes the embeddings stack emits:
+///   `openai embeddings returned HTTP 401 Unauthorized: …` (tinyagents adapter)
+///   `Embedding API error (401 Unauthorized): …`           (legacy / other hosts)
+fn embed_error_mentions_status(lower: &str, code: u16) -> bool {
+    let code = code.to_string();
+    lower.contains(&format!("http {code}")) || lower.contains(&format!("({code}"))
+}
+
+/// A reachable, authenticated embeddings API that **rejected the model id** — the
+/// user pointed the embeddings model field at a chat/reasoning model. Gated on a
+/// 400/422 plus a model-rejection phrase so a genuine 5xx or oversized-input 400
+/// still falls through to the generic failure (issue #5017).
+fn is_embedding_model_incompatible(lower: &str) -> bool {
+    let bad_request =
+        embed_error_mentions_status(lower, 400) || embed_error_mentions_status(lower, 422);
+    bad_request
+        && (lower.contains("does not support embeddings")
+            || lower.contains("not an embedding model")
+            || lower.contains("is not an embedding")
+            || lower.contains("does not exist")
+            || lower.contains("not supported for embeddings")
+            || lower.contains("unexpected model name format"))
+}
+
+/// The post-response length guard fired: the endpoint embedded but returned a
+/// vector whose length differs from the requested (Matryoshka) `dimensions`.
+/// Canonical shape from the tinyagents adapter:
+/// `openai embed dimension mismatch: expected 1024, got 3072`.
+fn is_embedding_dimension_mismatch(lower: &str) -> bool {
+    lower.contains("dimension mismatch")
+}
+
+/// A transport-level failure (DNS, refused connection, TLS, connect timeout) —
+/// the endpoint was never reached, so the base URL is wrong or the host is down.
+/// The tinyagents adapter wraps these as
+/// `openai embeddings request to <url> failed: <reqwest error>`.
+fn is_embedding_endpoint_unreachable(lower: &str) -> bool {
+    lower.contains("request to") && lower.contains("failed")
+        || lower.contains("connection refused")
+        || lower.contains("error sending request")
+        || lower.contains("error trying to connect")
+        || lower.contains("dns error")
+        || lower.contains("failed to lookup address")
+        || lower.contains("tcp connect error")
 }
 
 /// GET `{endpoint}/models` (OpenAI-compatible) and return the served model ids.
@@ -1048,24 +1163,202 @@ mod tests {
         }
     }
 
-    /// Any other failure (5xx/auth/network) and timeouts both reject — the
-    /// endpoint didn't prove it can embed, so we don't accept it.
+    /// An unclassified 5xx still rejects with the generic code — it's a real
+    /// server fault, not one of the actionable user-config shapes.
     #[test]
-    fn classify_embed_probe_rejects_other_failures_and_timeout() {
+    fn classify_embed_probe_rejects_unclassified_5xx_generically() {
         assert_eq!(
             reject_code(EmbedProbe::Failed(
-                "Embedding API error (500 Internal Server Error): boom".into()
+                "openai embeddings returned HTTP 500 Internal Server Error: boom".into()
             ))
             .as_deref(),
             Some("EMBEDDINGS_VERIFICATION_FAILED")
         );
-        assert_eq!(
-            reject_code(EmbedProbe::Failed("connection refused".into())).as_deref(),
-            Some("EMBEDDINGS_VERIFICATION_FAILED")
-        );
+    }
+
+    /// Issue #5017 — the #5017 reporter's exact case: a chat/reasoning model id
+    /// (`gpt-5-mini`) that works for chat is pasted into the embeddings model
+    /// field. The endpoint IS an embeddings API but rejects the model with a 400;
+    /// before the fix this collapsed into the generic "test embed failed", so the
+    /// user couldn't tell the model wasn't an embeddings model. Now it maps to a
+    /// dedicated, actionable code — across both wire shapes.
+    #[test]
+    fn classify_embed_probe_distinguishes_incompatible_model() {
+        for detail in [
+            r#"openai embeddings returned HTTP 400 Bad Request: {"error":{"message":"gpt-5-mini does not support embeddings"}}"#,
+            r#"Embedding API error (400 Bad Request): {"error":{"message":"Model gpt-5-mini does not exist"}}"#,
+            r#"openai embeddings returned HTTP 400 Bad Request: {"error":"this is not an embedding model"}"#,
+        ] {
+            assert_eq!(
+                reject_code(EmbedProbe::Failed(detail.into())).as_deref(),
+                Some("EMBEDDINGS_MODEL_INCOMPATIBLE"),
+                "detail should classify as incompatible model: {detail}"
+            );
+        }
+    }
+
+    /// Issue #5017 — a rejected/absent API key (401/403) is its own actionable
+    /// cause: the embeddings key is stored separately from the Chat BYOK key, so
+    /// "works for chat" does not imply the embeddings key is set. Both wire
+    /// shapes map to the dedicated auth code, not the generic failure.
+    #[test]
+    fn classify_embed_probe_distinguishes_auth_failure() {
+        for detail in [
+            "openai embeddings returned HTTP 401 Unauthorized: {\"error\":\"invalid api key\"}",
+            "Embedding API error (403 Forbidden): no access",
+        ] {
+            assert_eq!(
+                reject_code(EmbedProbe::Failed(detail.into())).as_deref(),
+                Some("EMBEDDINGS_AUTH_FAILED"),
+                "detail should classify as auth failure: {detail}"
+            );
+        }
+    }
+
+    /// Issue #5017 — a transport-level failure (DNS / refused connection) is a
+    /// reachability problem, distinct from a server that answered. Timeouts fall
+    /// in the same bucket.
+    #[test]
+    fn classify_embed_probe_distinguishes_unreachable() {
+        for detail in [
+            "openai embeddings request to http://127.0.0.1:9/v1/embeddings failed: connection refused",
+            "error trying to connect: dns error: failed to lookup address information",
+        ] {
+            assert_eq!(
+                reject_code(EmbedProbe::Failed(detail.into())).as_deref(),
+                Some("EMBEDDINGS_ENDPOINT_UNREACHABLE"),
+                "detail should classify as unreachable: {detail}"
+            );
+        }
+        // A timeout is a reachability problem too.
         assert_eq!(
             reject_code(EmbedProbe::TimedOut).as_deref(),
-            Some("EMBEDDINGS_VERIFICATION_FAILED")
+            Some("EMBEDDINGS_ENDPOINT_UNREACHABLE")
+        );
+    }
+
+    /// Issue #5017 — a length guard trip (endpoint ignored the `dimensions`
+    /// param and returned its native size) is a dimension problem, not a generic
+    /// failure, so the user knows to fix the dimensions field.
+    #[test]
+    fn classify_embed_probe_distinguishes_dimension_mismatch() {
+        assert_eq!(
+            reject_code(EmbedProbe::Failed(
+                "openai embed dimension mismatch: expected 1024, got 3072".into()
+            ))
+            .as_deref(),
+            Some("EMBEDDINGS_DIMENSION_MISMATCH")
+        );
+    }
+
+    /// Issue #5017 regression — the request the app sends is correct: a conformant
+    /// OpenAI-compatible `POST /v1/embeddings` host (right path, the user's model,
+    /// Bearer key, `{"input":[…],"model":…}` body) verifies successfully. Builds
+    /// the provider exactly as the save-time probe does
+    /// (`create_embedding_provider_with_credentials("custom", …, custom_endpoint)`)
+    /// and drives it against a mock that echoes the OpenAI embeddings wire shape,
+    /// asserting the captured request AND that the probe classifies it as a pass.
+    #[tokio::test]
+    async fn conformant_custom_endpoint_verifies_and_sends_expected_request() {
+        use std::sync::{Arc, Mutex};
+
+        use axum::{
+            extract::State,
+            routing::{get, post},
+            Json, Router,
+        };
+
+        #[derive(Clone, Default)]
+        struct Captured {
+            auth: Arc<Mutex<Option<String>>>,
+            body: Arc<Mutex<Option<serde_json::Value>>>,
+        }
+
+        let captured = Captured::default();
+        let app = Router::new()
+            .route(
+                "/v1/embeddings",
+                post(
+                    |State(cap): State<Captured>,
+                     headers: axum::http::HeaderMap,
+                     Json(body): Json<serde_json::Value>| async move {
+                        *cap.auth.lock().unwrap() = headers
+                            .get("authorization")
+                            .and_then(|v| v.to_str().ok())
+                            .map(str::to_owned);
+                        *cap.body.lock().unwrap() = Some(body);
+                        Json(serde_json::json!({
+                            "object": "list",
+                            "data": [{
+                                "object": "embedding",
+                                "index": 0,
+                                "embedding": [0.1_f32, 0.2, 0.3, 0.4]
+                            }],
+                            "model": "my-embed",
+                        }))
+                    },
+                ),
+            )
+            .route(
+                "/v1/models",
+                get(|| async { Json(serde_json::json!({"data": []})) }),
+            )
+            .with_state(captured.clone());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!(
+            "http://127.0.0.1:{}/v1",
+            listener.local_addr().unwrap().port()
+        );
+        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        // Same construction as the save-time probe for a non-`text-embedding-3-*`
+        // model: probe dimension-agnostically (dims = 0).
+        let embedder = create_embedding_provider_with_credentials(
+            "custom",
+            "gpt-5-mini",
+            0,
+            "sk-secret-key",
+            Some(&base),
+        )
+        .expect("provider builds");
+
+        let vectors = embedder
+            .embed(&["connection test"])
+            .await
+            .expect("conformant endpoint must verify");
+        let probe_dims = vectors.first().map(|v| v.len()).unwrap_or(0);
+        assert_eq!(
+            probe_dims, 4,
+            "auto-detected the endpoint's real vector length"
+        );
+
+        // The probe policy accepts the returned vector.
+        assert!(
+            classify_embed_probe(EmbedProbe::Returned(vectors)).is_none(),
+            "a usable vector from a conformant endpoint must pass verification"
+        );
+
+        // The exact request: user's model forwarded + Bearer key present.
+        assert_eq!(
+            captured.auth.lock().unwrap().as_deref(),
+            Some("Bearer sk-secret-key"),
+            "API key must be sent on the test-embed request"
+        );
+        let body = captured
+            .body
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("body captured");
+        assert_eq!(
+            body["model"], "gpt-5-mini",
+            "user-supplied model must be forwarded"
+        );
+        assert_eq!(
+            body["input"],
+            serde_json::json!(["connection test"]),
+            "input is the OpenAI array-of-strings shape"
         );
     }
 }

--- a/src/openhuman/embeddings/rpc.rs
+++ b/src/openhuman/embeddings/rpc.rs
@@ -711,7 +711,7 @@ fn classify_embed_probe(outcome: EmbedProbe) -> Option<RpcOutcome<serde_json::Va
                     "EMBEDDINGS_DIMENSION_MISMATCH",
                     "The endpoint returned a vector with a different length than the \
                      dimensions you entered. Set dimensions to match the model's native \
-                     output (or clear the field to auto-detect), then save again.",
+                     output, then save again.",
                     "embeddings endpoint returned mismatched dimensions — not saved",
                     Some(&detail),
                 )
@@ -777,12 +777,18 @@ fn classify_embed_probe(outcome: EmbedProbe) -> Option<RpcOutcome<serde_json::Va
 }
 
 /// Whether a lowercased embed-error detail names the given HTTP status, tolerant
-/// of both wire shapes the embeddings stack emits:
+/// of the wire shapes the embeddings stack emits:
 ///   `openai embeddings returned HTTP 401 Unauthorized: …` (tinyagents adapter)
-///   `Embedding API error (401 Unauthorized): …`           (legacy / other hosts)
+///   `Embedding API error (401 Unauthorized): …`           (parenthesized host shape)
+///   `Embedding API error 401 Unauthorized: …`             (bare-status host shape)
+/// The bare-status `Embedding API error {code}` form is the one the observability
+/// classifier in `src/core/observability.rs` covers; without it, setup-time
+/// verification for those hosts fell through to the generic failure code (#5017).
 fn embed_error_mentions_status(lower: &str, code: u16) -> bool {
     let code = code.to_string();
-    lower.contains(&format!("http {code}")) || lower.contains(&format!("({code}"))
+    lower.contains(&format!("http {code}"))
+        || lower.contains(&format!("({code}"))
+        || lower.contains(&format!("embedding api error {code}"))
 }
 
 /// A reachable, authenticated embeddings API that **rejected the model id** — the
@@ -1206,6 +1212,9 @@ mod tests {
         for detail in [
             "openai embeddings returned HTTP 401 Unauthorized: {\"error\":\"invalid api key\"}",
             "Embedding API error (403 Forbidden): no access",
+            // Bare-status host shape (no parentheses) — the form the observability
+            // classifier covers; must map to auth, not the generic failure (#5017).
+            "Embedding API error 401 Unauthorized: {\"error\":\"invalid token\"}",
         ] {
             assert_eq!(
                 reject_code(EmbedProbe::Failed(detail.into())).as_deref(),


### PR DESCRIPTION
## Summary

- Custom (OpenAI-compatible) embedding endpoints failed setup verification with one generic "test embed failed" even when the endpoint + key work for chat.
- Root cause is **not** the request: the probe sends a correct `POST /v1/embeddings` with the user's model, Bearer key, and `{"input":[…],"model":…}` body — a conformant endpoint verifies (proven by a new mock-endpoint test).
- The defect is that `classify_embed_probe` collapsed distinct failures (auth 401/403, wrong/incompatible model 400, network/DNS, dimension mismatch) into one generic message.
- Differentiate those failures into dedicated, actionable codes/messages so users know what to fix.
- Frontend now surfaces any non-wipe error code as a verification failure (fixes a latent "unknown code silently treated as a save").

## Problem

Issue #5017: a user enters a working OpenAI-compatible base URL + model + key under Connections → Vector encoding model → Custom. The same endpoint/key work for chat, but embedding verification fails with *"Couldn't verify the embeddings endpoint — the test embed failed."*

I reproduced the exact test-embed request by driving the same provider construction the save-time probe uses against a mock server. **The request is correct:**

```
POST /v1/embeddings HTTP/1.1
content-type: application/json
authorization: Bearer sk-…            ← key IS forwarded
{"input":["connection test"],"model":"gpt-5-mini"}
```

Path, method, model, key, and body are all right, and a conformant `/v1/embeddings` host verifies successfully. So the reporter's guesses (a) wrong shape, (b) `/models`/health path, (c) model not forwarded, (d) key missing, (e) dimension validation are all ruled out for this flow.

The reporter used `gpt-5-mini` — a **chat** model — which the endpoint legitimately rejects at `/v1/embeddings` (HTTP 400 "does not support embeddings"). Verification *should* fail, but the message never said the model isn't an embeddings model, so "works for chat, fails for embed" looked like a bug. Auth (401/403), network/DNS, and dimension-mismatch failures were equally indistinguishable.

## Solution

- `src/openhuman/embeddings/rpc.rs` — `classify_embed_probe` now maps failures to distinct codes/messages, tolerant of both embed-error wire shapes (`openai embeddings returned HTTP <code>…` and `Embedding API error (<code>)…`):
  - `EMBEDDINGS_MODEL_INCOMPATIBLE` — 400/422 + model-rejection body (the reporter's case: chat model in the embeddings field).
  - `EMBEDDINGS_AUTH_FAILED` — 401/403 (embeddings key is stored separately from the chat BYOK key).
  - `EMBEDDINGS_ENDPOINT_UNREACHABLE` — DNS / refused / connect / timeout.
  - `EMBEDDINGS_DIMENSION_MISMATCH` — endpoint ignored the `dimensions` param and returned a different length.
  - Existing `NO_MODEL_LOADED` / `ENDPOINT_NO_API` / generic `VERIFICATION_FAILED` preserved. Added a PII-safe log of the classified code (never the raw detail).
- `app/src/components/settings/panels/EmbeddingsPanel.tsx` — failure detection matches on shape (any error code other than the wipe-confirm) instead of an allow-list, so the new codes surface their backend message rather than a new code being silently treated as a successful save.

Design note: verification messages are backend-emitted English strings (same pattern as the existing `EMBEDDINGS_*` messages the panel already renders), so **no new frontend UI literals and no new i18n keys** are introduced.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — 4 differentiation tests (incompatible-model, auth, unreachable, dimension-mismatch) + a mock `/v1/embeddings` regression proving a conformant host verifies and the request carries the user's model + Bearer key. Pre-existing `other_failures_and_timeout` test updated to the new behavior (fail-before / pass-after).
- [x] **Diff coverage ≥ 80%** — changed Rust lines are the `classify_embed_probe` branches + helpers, each exercised by the new unit tests; the one-line frontend conditional is covered by the existing panel behavior. `openhuman::embeddings::rpc::tests` all pass (19/19).
- [x] Coverage matrix updated — `N/A: refines an existing feature's error handling; no feature row added/removed/renamed`.
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature IDs affected`.
- [x] No new external network dependencies introduced — the regression test uses an in-process `axum` mock (already a dev-dependency); no real network.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: settings-panel error messaging only, no release-cut surface change`.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- Desktop (Settings → Connections → Vector encoding model → Custom). No runtime/perf/migration impact.
- Security: the new log records only the classified error code, never the raw endpoint response body (which can carry response detail).

## Related

- Closes: #5017
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/GH-5017-custom-embed-verify-errors
- Commit SHA: dd1929d67

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — EmbeddingsPanel.tsx prettier-clean
- [x] `pnpm typecheck` — passes
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --lib openhuman::embeddings::rpc::tests` — 19 passed, 0 failed
- [x] Rust fmt/check (if changed): `rustfmt --check src/openhuman/embeddings/rpc.rs` — clean
- [x] Tauri fmt/check (if changed): N/A — no `app/src-tauri` change

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: setup-time embedding verification now returns a distinct, actionable message per failure class instead of one generic error.
- User-visible effect: a custom endpoint that works for chat but is pointed at a non-embeddings model / bad key / unreachable host now tells the user exactly which to fix; a conformant embeddings endpoint verifies unchanged.

### Parity Contract

- Legacy behavior preserved: conformant-endpoint pass, empty-vector reject, `NO_MODEL_LOADED`/`ENDPOINT_NO_API`/`DIMENSION_CHANGE_REQUIRES_WIPE` codes, and the `/models` name-mismatch guidance path are all unchanged.
- Guard/fallback/dispatch parity checks: any unclassified failure (e.g. 5xx) still falls through to the generic `EMBEDDINGS_VERIFICATION_FAILED`, so no failure is ever misreported as a success.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom embeddings setup error handling with clearer feedback for authentication, model compatibility, connectivity, and dimension mismatch issues.
  * Kept setup dialogs open when verification fails, allowing errors to be reviewed and corrected.
  * Preserved the existing confirmation flow for dimension changes that require data removal.
* **Tests**
  * Expanded coverage for embeddings verification and custom endpoint requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->