### PR TITLE
fix(inference): probe /v1/models for OpenAI-compatible local runtimes (Closes #5053)

### DIFF
--- a/src/openhuman/inference/local/provider.rs
+++ b/src/openhuman/inference/local/provider.rs
@@ -48,6 +48,64 @@ pub(crate) fn provider_from_config(config: &Config) -> LocalAiProvider {
     }
 }
 
+/// How a local runtime exposes its installed-model catalog.
+///
+/// Ollama serves a native `GET /api/tags` listing; every OpenAI-compatible
+/// runtime (LM Studio, OMLX, `local-openai`, and any custom BYOK endpoint that
+/// speaks the OpenAI `/v1` surface) serves `GET /v1/models`. Sending an Ollama
+/// probe to an OpenAI-compatible server produces `GET /v1/api/tags`, which
+/// LM Studio logs as `Unexpected endpoint or method` and answers with an empty
+/// catalog — so model discovery silently fails and the model never appears as
+/// selectable (GH #5053).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ModelDiscoveryApi {
+    /// Ollama-native `/api/tags`.
+    OllamaTags,
+    /// OpenAI-compatible `/v1/models`.
+    OpenAiModels,
+}
+
+/// True when `base_url`'s path is the OpenAI-compatible `/v1` root — the
+/// canonical marker of an OpenAI-style server (LM Studio, OMLX, LiteLLM, …).
+///
+/// A genuine Ollama base URL is host-rooted (`http://localhost:11434`) with no
+/// `/v1` path segment, so this cleanly separates the two API shapes by
+/// **endpoint type**, not by "is it localhost" (which would misidentify a
+/// localhost LM Studio server as Ollama — the #5053 conflation).
+pub(crate) fn endpoint_is_openai_v1(base_url: &str) -> bool {
+    if let Ok(url) = reqwest::Url::parse(base_url.trim()) {
+        let path = url.path().trim_end_matches('/').to_ascii_lowercase();
+        return path.ends_with("/v1");
+    }
+    // Fall back to a lexical check when the URL doesn't parse cleanly.
+    base_url
+        .trim()
+        .trim_end_matches('/')
+        .to_ascii_lowercase()
+        .ends_with("/v1")
+}
+
+/// Select the model-discovery API for a local runtime from its provider slug
+/// and base URL — by provider **type**, never by "is it localhost".
+///
+/// Genuine Ollama (`provider = "ollama"` on a host-rooted base) uses
+/// `/api/tags`. Every OpenAI-compatible runtime uses `/v1/models`: an explicit
+/// `lm_studio` / `omlx` slug, OR any endpoint whose path is the OpenAI `/v1`
+/// root. The `/v1` endpoint clause is what rescues a custom BYOK localhost
+/// endpoint (e.g. LM Studio on `http://localhost:1234/v1`) whose provider tag
+/// still defaults to `ollama`: the endpoint type wins over the fallback slug
+/// (GH #5053).
+pub(crate) fn model_discovery_api(provider: &str, base_url: &str) -> ModelDiscoveryApi {
+    if endpoint_is_openai_v1(base_url) {
+        return ModelDiscoveryApi::OpenAiModels;
+    }
+    match normalize_provider(provider).as_str() {
+        "ollama" => ModelDiscoveryApi::OllamaTags,
+        // lm_studio, omlx, and any other OpenAI-compatible local runtime.
+        _ => ModelDiscoveryApi::OpenAiModels,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -70,5 +128,54 @@ mod tests {
         assert_eq!(normalize_provider("omlx"), "omlx");
         assert_eq!(normalize_provider("omlx-server"), "omlx");
         assert_eq!(normalize_provider("OMLX"), "omlx");
+    }
+
+    #[test]
+    fn endpoint_is_openai_v1_detects_v1_root() {
+        assert!(endpoint_is_openai_v1("http://localhost:1234/v1"));
+        assert!(endpoint_is_openai_v1("http://localhost:1234/v1/"));
+        assert!(endpoint_is_openai_v1("https://box.local:1234/openai/v1"));
+        // Genuine Ollama base is host-rooted with no /v1 path.
+        assert!(!endpoint_is_openai_v1("http://localhost:11434"));
+        assert!(!endpoint_is_openai_v1("http://localhost:11434/"));
+        // A `/v1` embedded mid-path is not the OpenAI root.
+        assert!(!endpoint_is_openai_v1("http://localhost:11434/v1/models"));
+    }
+
+    #[test]
+    fn model_discovery_api_uses_tags_for_genuine_ollama() {
+        // Ollama slug on its host-rooted native base -> /api/tags.
+        assert_eq!(
+            model_discovery_api("ollama", "http://localhost:11434"),
+            ModelDiscoveryApi::OllamaTags
+        );
+        assert_eq!(
+            model_discovery_api("", "http://localhost:11434"),
+            ModelDiscoveryApi::OllamaTags
+        );
+    }
+
+    #[test]
+    fn model_discovery_api_uses_v1_models_for_openai_compatible() {
+        // Explicit LM Studio / OMLX slugs are OpenAI-compatible.
+        assert_eq!(
+            model_discovery_api("lm_studio", "http://localhost:1234/v1"),
+            ModelDiscoveryApi::OpenAiModels
+        );
+        assert_eq!(
+            model_discovery_api("omlx", "http://localhost:8080/v1"),
+            ModelDiscoveryApi::OpenAiModels
+        );
+        // The #5053 case: a custom BYOK OpenAI-compatible endpoint on localhost
+        // whose provider tag still defaults to `ollama` must NOT be probed with
+        // /api/tags — the `/v1` endpoint type wins.
+        assert_eq!(
+            model_discovery_api("ollama", "http://localhost:1234/v1"),
+            ModelDiscoveryApi::OpenAiModels
+        );
+        assert_eq!(
+            model_discovery_api("custom-byok", "http://localhost:1234/v1"),
+            ModelDiscoveryApi::OpenAiModels
+        );
     }
 }

--- a/src/openhuman/inference/local/service/ollama_admin/diagnostics.rs
+++ b/src/openhuman/inference/local/service/ollama_admin/diagnostics.rs
@@ -7,7 +7,9 @@ use crate::openhuman::inference::local::ollama::{
     ollama_base_url_from_config, OllamaModelShow, OllamaModelTag, OllamaShowRequest,
     OllamaShowResponse, OllamaTagsResponse,
 };
-use crate::openhuman::inference::local::provider::{provider_from_config, LocalAiProvider};
+use crate::openhuman::inference::local::provider::{
+    model_discovery_api, provider_from_config, LocalAiProvider, ModelDiscoveryApi,
+};
 use crate::openhuman::inference::model_ids;
 use crate::openhuman::inference::presets::{self, VisionMode};
 
@@ -23,6 +25,26 @@ impl LocalAiService {
         }
 
         let base_url = ollama_base_url_from_config(config);
+
+        // Route OpenAI-compatible local runtimes to the `/v1/models` probe.
+        // `provider_from_config` collapses everything that is not literally
+        // `lm_studio` onto `Ollama`, so an OMLX / `local-openai` / custom BYOK
+        // endpoint on the OpenAI `/v1` surface (e.g. LM Studio at
+        // `http://localhost:1234/v1`) would otherwise be probed at
+        // `<base>/api/tags` -> `GET /v1/api/tags`, which LM Studio rejects as an
+        // unexpected endpoint and answers with an empty catalog — silently
+        // breaking model discovery (GH #5053). Decide by endpoint *type*, never
+        // by "is it localhost".
+        if model_discovery_api(&config.local_ai.provider, &base_url)
+            == ModelDiscoveryApi::OpenAiModels
+        {
+            log::debug!(
+                "[local_ai] diagnostics: base_url={} is OpenAI-compatible (/v1) — routing to /v1/models discovery instead of Ollama /api/tags",
+                base_url
+            );
+            return self.lm_studio_diagnostics(config).await;
+        }
+
         let healthy = self.ollama_healthy_at(&base_url).await;
         let runner_ok = if healthy {
             self.ollama_runner_ok_at(&base_url).await

--- a/src/openhuman/inference/local/service/ollama_admin_tests.rs
+++ b/src/openhuman/inference/local/service/ollama_admin_tests.rs
@@ -757,6 +757,58 @@ async fn lm_studio_diagnostics_reports_loaded_chat_model() {
     assert_eq!(diag["ok"], true);
 }
 
+/// Regression for GH #5053: a custom OpenAI-compatible BYOK endpoint on
+/// localhost (e.g. LM Studio at `http://localhost:1234/v1`) whose `provider`
+/// tag still defaults to `ollama` must be probed with `/v1/models`, NOT the
+/// Ollama-native `/api/tags`. The mock serves ONLY `/v1/models` and no
+/// `/api/tags`, so before the fix diagnostics took the Ollama branch,
+/// hit an unrouted `/v1/api/tags`, and reported the model absent; after the
+/// fix the `/v1` endpoint type routes discovery to `/v1/models` and the model
+/// is found.
+#[tokio::test]
+async fn diagnostics_openai_compatible_v1_endpoint_uses_v1_models_not_api_tags() {
+    let _guard = crate::openhuman::inference::inference_test_guard();
+
+    // OpenAI-compatible server: exposes `/v1/models` and deliberately no
+    // `/api/tags` — an Ollama probe here would 404 (silently empty discovery).
+    let app = Router::new().route(
+        "/v1/models",
+        get(|| async {
+            Json(json!({
+                "data": [
+                    { "id": "local-model", "object": "model", "owned_by": "lm-studio" }
+                ]
+            }))
+        }),
+    );
+    let base = spawn_mock(app).await;
+
+    // The #5053 config: a `/v1` OpenAI-compatible endpoint whose provider tag is
+    // the defaulted `ollama` (not `lm_studio`).
+    let mut config = lm_studio_config(&base);
+    config.local_ai.provider = "ollama".to_string();
+
+    let service = LocalAiService::new(&config);
+    let diag = service.diagnostics(&config).await.expect("diagnostics");
+
+    // `lm_studio_running` is emitted only by the OpenAI-compatible (`/v1/models`)
+    // diagnostics path — the Ollama branch reports `ollama_running` and leaves
+    // this key null. Its presence proves discovery was routed by endpoint type,
+    // not sent to `/api/tags`.
+    assert_eq!(diag["lm_studio_running"], true);
+    let installed = diag["installed_models"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        installed
+            .iter()
+            .any(|m| m["name"].as_str() == Some("local-model")),
+        "OpenAI-compatible /v1 endpoint must discover models via /v1/models, got: {:?}",
+        installed
+    );
+}
+
 #[tokio::test]
 async fn lm_studio_diagnostics_flags_missing_chat_model() {
     let _guard = crate::openhuman::inference::inference_test_guard();


### PR DESCRIPTION
## Summary

- Local-AI model discovery now selects its probe endpoint by provider **type**, not by "is it localhost": genuine Ollama uses `GET /api/tags`, every OpenAI-compatible runtime uses `GET /v1/models`.
- Fixes custom OpenAI-compatible BYOK endpoints on localhost (e.g. LM Studio at `http://localhost:1234/v1`) that were being probed with the Ollama-only `/api/tags`, producing `GET /v1/api/tags` and an empty model list.
- Adds `model_discovery_api(provider, base_url)` + `endpoint_is_openai_v1(base_url)` selectors and routes local-AI diagnostics through them.
- Adds unit coverage for the endpoint selection and a diagnostics-level regression test.

## Problem

When a custom OpenAI-compatible provider (LM Studio serving `nvidia/nemotron-3-nano-omni`) is configured as a BYOK endpoint on `http://localhost:1234/v1`, the app sends `GET /v1/api/tags` — an Ollama-specific listing endpoint — instead of the OpenAI-standard `GET /v1/models`. LM Studio logs `Unexpected endpoint or method (GET /v1/api/tags)`, returns 200 with an incompatible payload, and model discovery silently fails so the model is unavailable in the tinyagents module.

Root cause: `LocalAiService::diagnostics` gated the OpenAI-compatible `/v1/models` probe on `provider_from_config(config) == LmStudio`. But `provider_from_config` collapses **everything** that isn't literally `lm_studio` onto `Ollama` — including OMLX, `local-openai`, and any custom BYOK endpoint whose provider tag defaulted to `ollama`. Those all fell through to the Ollama branch and were probed at `<base>/api/tags`. With an OpenAI `/v1` base that yields `GET /v1/api/tags`. (The `inference_list_models` RPC path already probed `/models` correctly; the break was in the diagnostics discovery path that populates the selectable-model list.)

## Solution

- New `ModelDiscoveryApi` selector in `src/openhuman/inference/local/provider.rs`:
  - `endpoint_is_openai_v1(base_url)` — true when the URL path is the OpenAI `/v1` root. A genuine Ollama base is host-rooted (`http://localhost:11434`) with no `/v1`, so this separates the two API shapes by **endpoint type**, not by "is it localhost" (the conflation that misidentified LM Studio as Ollama).
  - `model_discovery_api(provider, base_url)` — returns `OllamaTags` only for a genuine `ollama` runtime on a host-rooted base; returns `OpenAiModels` for an explicit `lm_studio`/`omlx` slug **or** any OpenAI `/v1` endpoint. The `/v1` clause rescues a custom BYOK localhost endpoint whose provider tag still defaults to `ollama`.
- `diagnostics()` now routes any OpenAI-compatible `/v1` local endpoint to the existing `/v1/models` diagnostics path before it can reach the Ollama `/api/tags` branch. Genuine Ollama (host-rooted base) is unaffected.
- Debug logging added on the reroute (no PII).

Design notes / tradeoffs: the fix keys on the OpenAI `/v1` endpoint type in addition to the provider slug, because the saved `provider` tag is an unreliable signal (it defaults to `ollama`). This also incidentally fixes the same misrouting for OMLX/`local-openai` runtimes. Ollama's own OpenAI-compatible `/v1/models` works too, so even a hand-edited Ollama base ending in `/v1` degrades gracefully.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/ci-lite.yml`](../.github/workflows/ci-lite.yml). Changed lines are the two selectors + the diagnostics reroute, all exercised by the new unit and regression tests.
- [x] Coverage matrix updated — `N/A: behaviour-only change` (no feature row added/removed/renamed in `docs/TEST-COVERAGE-MATRIX.md`).
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix feature ID applies to this internal routing fix`.
- [x] No new external network dependencies introduced (mock backend / in-test axum mock server used; no live network).
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: does not change a release-cut surface`.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime/platform impact: desktop (and any core build) that uses a local OpenAI-compatible runtime (LM Studio, OMLX, `local-openai`, custom BYOK). No mobile/web/CLI surface change.
- Performance: none (same single probe, correct path). Security/migration/compatibility: none — genuine Ollama behaviour is byte-identical; only OpenAI-compatible `/v1` endpoints change from `/api/tags` to `/v1/models`.

## Related

- Closes: #5053
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A (GitHub-issue-driven, not Linear)
- URL: N/A

### Commit & Branch

- Branch: `fix/GH-5053-openai-compatible-model-discovery`
- Commit SHA: `117103171`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no `app/src` (frontend) files changed.
- [x] `pnpm typecheck` — N/A: no TypeScript changed (Rust-only change).
- [x] Focused tests: `cargo test --lib -- model_discovery_api endpoint_is_openai_v1 diagnostics_openai_compatible_v1_endpoint` → 4 passed.
- [x] Rust fmt/check (if changed): `cargo fmt` on touched files; `GGML_NATIVE=OFF cargo check --lib` clean.
- [x] Tauri fmt/check (if changed): N/A: no `app/src-tauri` files changed.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: OpenAI-compatible local runtimes (LM Studio/OMLX/`local-openai`/custom BYOK on a `/v1` base) are probed for models at `/v1/models` instead of `/api/tags`.
- User-visible effect: local models served by LM Studio (e.g. `nvidia/nemotron-3-nano-omni`) now appear as selectable and no `Unexpected endpoint` errors are logged.

### Parity Contract

- Legacy behavior preserved: genuine Ollama (host-rooted base, `provider = ollama`) still uses `/api/tags` — unchanged.
- Guard/fallback/dispatch parity checks: `model_discovery_api` returns `OllamaTags` for `ollama`/empty provider on a non-`/v1` base (covered by `model_discovery_api_uses_tags_for_genuine_ollama`).

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution: N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local runtime detection for OpenAI-compatible `/v1` endpoints.
  * Prevented OpenAI-compatible runtimes from being queried with Ollama-specific model APIs.
  * Improved diagnostics and installed-model detection for compatible local providers.

* **Tests**
  * Added coverage for endpoint detection, provider routing, and model discovery.
  * Added regression coverage for OpenAI-compatible endpoints using an Ollama-style provider setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->