### PR TITLE
ci: acknowledge composio/action_tool.rs in feature-gate-smoke allowlist

### DIFF
--- a/.github/workflows/ci-lite.yml
+++ b/.github/workflows/ci-lite.yml
@@ -451,6 +451,7 @@ jobs:
           openhuman/agent/harness/session/tests.rs
           openhuman/agent/harness/subagent_runner/tool_prep.rs
           openhuman/agent_registry/agents/loader.rs
+          openhuman/composio/action_tool.rs
           openhuman/inference/local/mod.rs
           openhuman/tool_registry/ops_tests.rs
           openhuman/tool_registry/schemas.rs


### PR DESCRIPTION
## Summary

Merged #4995 added a `#[cfg(feature = "flows")]` `#[tokio::test]` to `src/openhuman/composio/action_tool.rs` but did **not** add that file to the EXPECTED allowlist in the `rust-feature-gate-smoke` lane's *"Guard — new feature-gated test modules must be acknowledged"* step (`.github/workflows/ci-lite.yml`).

As a result the guard fails on **every PR branched off post-#4995 main**:

```
::error::Gated-test file set changed. ...
> openhuman/composio/action_tool.rs
```

This currently blocks otherwise-green PRs **#5064, #5066, #5067** (and any future recent-base PR). PRs on an older base (e.g. #4998) are unaffected.

## Fix

Add `openhuman/composio/action_tool.rs` to the EXPECTED allowlist — one line.

The test is properly `#[cfg(feature = "flows")]`-gated, so it compiles out entirely in the gates-off build and **cannot** carry a #5022-class ungated-assert regression. Per the guard's own guidance that means an allowlist entry **only** — no change to the scoped `cargo test` filter is needed.

## Verification

Ran the guard's own `EXPECTED` vs `ACTUAL` diff locally with this change applied: they match exactly (`gate-contract test coverage allowlist is current`). No source/behaviour change — CI-config only.

## Related

- Root cause: #4995 (`48cba1a02`)
- Unblocks: #5064, #5066, #5067
- Guard rationale: #5022 / #5021