### PR TITLE
fix(core): seed tool-execution timeout on the always-on boot path (#5027)

### DIFF
--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -1882,6 +1882,31 @@ fn register_domain_subscribers(
             .insert(group)
     }
 
+    // Seed the live tool-execution timeout from the persisted `[agent]` config
+    // so a user-configured value (Settings → Agent OS access → Action timeout)
+    // is in effect from the first tool call. `OPENHUMAN_TOOL_TIMEOUT_SECS`, when
+    // set, still overrides this inside `set_tool_timeout_secs`. This lives on
+    // the always-on boot path (not `channels::runtime::startup::start_channels`,
+    // which is skipped for channel-less / web-chat-only cores) so the timeout
+    // seeds for every install regardless of DomainSet — it is DomainSet-
+    // independent process-global state, not a gated subscriber (#5027).
+    //
+    // Deliberately OUTSIDE the `INFRA: Once` below: `bootstrap_core_runtime`
+    // re-runs on an in-process core restart (`CoreProcessHandle::restart` →
+    // `ensure_running`, and `reset_local_data`/Clear-Local-Data) with a freshly
+    // reloaded `Config`, but `INFRA` is already consumed — so a seed gated by it
+    // would leave the process-global timeout pinned to the previous config's
+    // value until Settings is re-saved. `set_tool_timeout_secs` is idempotent
+    // (a plain atomic store honouring the env override), so re-seeding on every
+    // call is correct and cheap and re-applies the current config each boot.
+    let effective_timeout =
+        crate::openhuman::tool_timeout::set_tool_timeout_secs(config.agent.agent_timeout_secs);
+    log::debug!(
+        "[tool_timeout] seeded tool-execution timeout from config: configured={}s effective={}s",
+        config.agent.agent_timeout_secs,
+        effective_timeout
+    );
+
     // Ungated core/platform infra — health, scheduler-gate, TokenJuice
     // content-router, session-token seeding, the SessionExpired handler, and
     // service restart/shutdown. These are DomainSet-independent, so they run
@@ -1905,22 +1930,6 @@ fn register_domain_subscribers(
         // every agent's tool output, so this must be set before any agent loop
         // executes a tool.
         crate::openhuman::tokenjuice::install_from_config(&config);
-
-        // Seed the live tool-execution timeout from the persisted `[agent]` config
-        // so a user-configured value (Settings → Agent OS access → Action timeout)
-        // is in effect from the first tool call. `OPENHUMAN_TOOL_TIMEOUT_SECS`, when
-        // set, still overrides this inside `set_tool_timeout_secs`. This lives on
-        // the always-on boot path (not `channels::runtime::startup::start_channels`,
-        // which is skipped for channel-less / web-chat-only cores) so the timeout
-        // seeds for every install regardless of DomainSet — it is DomainSet-
-        // independent process-global state, not a gated subscriber (#5027).
-        let effective_timeout =
-            crate::openhuman::tool_timeout::set_tool_timeout_secs(config.agent.agent_timeout_secs);
-        log::debug!(
-            "[tool_timeout] seeded tool-execution timeout from config: configured={}s effective={}s",
-            config.agent.agent_timeout_secs,
-            effective_timeout
-        );
 
         // Seed the scheduler-gate signed-out override from the on-disk session.
         // Without this, a sidecar that boots with no stored JWT would happily

--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -1906,6 +1906,22 @@ fn register_domain_subscribers(
         // executes a tool.
         crate::openhuman::tokenjuice::install_from_config(&config);
 
+        // Seed the live tool-execution timeout from the persisted `[agent]` config
+        // so a user-configured value (Settings → Agent OS access → Action timeout)
+        // is in effect from the first tool call. `OPENHUMAN_TOOL_TIMEOUT_SECS`, when
+        // set, still overrides this inside `set_tool_timeout_secs`. This lives on
+        // the always-on boot path (not `channels::runtime::startup::start_channels`,
+        // which is skipped for channel-less / web-chat-only cores) so the timeout
+        // seeds for every install regardless of DomainSet — it is DomainSet-
+        // independent process-global state, not a gated subscriber (#5027).
+        let effective_timeout =
+            crate::openhuman::tool_timeout::set_tool_timeout_secs(config.agent.agent_timeout_secs);
+        log::debug!(
+            "[tool_timeout] seeded tool-execution timeout from config: configured={}s effective={}s",
+            config.agent.agent_timeout_secs,
+            effective_timeout
+        );
+
         // Seed the scheduler-gate signed-out override from the on-disk session.
         // Without this, a sidecar that boots with no stored JWT would happily
         // spin up cron / channel loops and fire LLM requests that all 401.

--- a/src/core/jsonrpc_tests.rs
+++ b/src/core/jsonrpc_tests.rs
@@ -78,6 +78,62 @@ fn domain_subscriber_plan_harness_gates_by_owning_group() {
     assert!(!plan.mcp, "harness must skip mcp_registry bus init");
 }
 
+/// #5027 — the tool-execution timeout must be seeded on the always-on core boot
+/// path (`register_domain_subscribers`, inside the ungated `INFRA: Once` block),
+/// NOT inside `channels::runtime::startup::start_channels`, which is skipped for
+/// channel-less / web-chat-only cores (and when `OPENHUMAN_DISABLE_CHANNEL_LISTENERS`
+/// is set). A minimal `DomainSet::none()` must still seed, because the INFRA block
+/// is DomainSet-independent.
+///
+/// The timeout atomic and the `INFRA: Once` are process-global, so this is the
+/// SOLE `register_domain_subscribers` seed assertion in the binary: a second caller
+/// would find `INFRA` already consumed and observe no re-seed, so a second such test
+/// would be order-dependent and flaky. Serialized via `TEST_ENV_LOCK` with
+/// `OPENHUMAN_TOOL_TIMEOUT_SECS` cleared so the operator env override cannot mask the
+/// config-derived value. Runs under a tokio runtime like the real boot paths — the
+/// INFRA block calls `subscribe_global`, which `tokio::spawn`s when the global bus is
+/// already initialized by another test in the binary.
+#[tokio::test]
+async fn tool_timeout_seeds_on_channelless_core_boot() {
+    let _lock = crate::openhuman::config::TEST_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let restore = std::env::var_os("OPENHUMAN_TOOL_TIMEOUT_SECS");
+    std::env::remove_var("OPENHUMAN_TOOL_TIMEOUT_SECS");
+
+    // Distinctive, in-range (1..=3600) value so the assertion can only pass on a
+    // real seed, never on the default. Channel-less: `channels_config` stays empty,
+    // which is exactly the config for which `start_channels` is skipped.
+    let mut config = crate::openhuman::config::Config::default();
+    config.agent.agent_timeout_secs = 1234;
+    assert!(
+        config.channels_config.active_channel.is_none(),
+        "test premise: channel-less config, so start_channels would be skipped"
+    );
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // Minimal DomainSet — INFRA (and thus the timeout seed) is DomainSet-independent,
+    // so even `none()` must seed. `embedded_core = true` skips the standalone
+    // process-exit shutdown subscriber.
+    super::register_domain_subscribers(
+        tmp.path().to_path_buf(),
+        config,
+        true,
+        crate::core::runtime::DomainSet::none(),
+    );
+
+    assert_eq!(
+        crate::openhuman::tool_timeout::tool_execution_timeout_secs(),
+        1234,
+        "channel-less core boot must seed the tool-execution timeout from [agent].agent_timeout_secs"
+    );
+
+    match restore {
+        Some(v) => std::env::set_var("OPENHUMAN_TOOL_TIMEOUT_SECS", v),
+        None => std::env::remove_var("OPENHUMAN_TOOL_TIMEOUT_SECS"),
+    }
+}
+
 struct EnvVarGuard {
     old_values: Vec<(&'static str, Option<OsString>)>,
     _lock: MutexGuard<'static, ()>,

--- a/src/core/jsonrpc_tests.rs
+++ b/src/core/jsonrpc_tests.rs
@@ -79,27 +79,27 @@ fn domain_subscriber_plan_harness_gates_by_owning_group() {
 }
 
 /// #5027 — the tool-execution timeout must be seeded on the always-on core boot
-/// path (`register_domain_subscribers`, inside the ungated `INFRA: Once` block),
-/// NOT inside `channels::runtime::startup::start_channels`, which is skipped for
+/// path (`register_domain_subscribers`), NOT inside
+/// `channels::runtime::startup::start_channels`, which is skipped for
 /// channel-less / web-chat-only cores (and when `OPENHUMAN_DISABLE_CHANNEL_LISTENERS`
-/// is set). A minimal `DomainSet::none()` must still seed, because the INFRA block
-/// is DomainSet-independent.
+/// is set). A minimal `DomainSet::none()` must still seed, because the seed is
+/// DomainSet-independent.
 ///
-/// The timeout atomic and the `INFRA: Once` are process-global, so this is the
-/// SOLE `register_domain_subscribers` seed assertion in the binary: a second caller
-/// would find `INFRA` already consumed and observe no re-seed, so a second such test
-/// would be order-dependent and flaky. Serialized via `TEST_ENV_LOCK` with
-/// `OPENHUMAN_TOOL_TIMEOUT_SECS` cleared so the operator env override cannot mask the
-/// config-derived value. Runs under a tokio runtime like the real boot paths — the
-/// INFRA block calls `subscribe_global`, which `tokio::spawn`s when the global bus is
-/// already initialized by another test in the binary.
+/// The seed sits just *before* the ungated `INFRA: Once` block, so it re-runs on
+/// every `register_domain_subscribers` call (each `bootstrap_core_runtime`),
+/// re-applying the freshly reloaded config on an in-process restart — a seed gated
+/// by the process-global `Once` would only fire on the first boot. `TEST_ENV_LOCK`
+/// (via `EnvVarGuard`) serializes with `OPENHUMAN_TOOL_TIMEOUT_SECS` cleared so the
+/// operator env override cannot mask the config-derived value. Runs under a tokio
+/// runtime like the real boot paths — the INFRA block calls `subscribe_global`,
+/// which `tokio::spawn`s when the global bus is already initialized by another test
+/// in the binary.
 #[tokio::test]
 async fn tool_timeout_seeds_on_channelless_core_boot() {
-    let _lock = crate::openhuman::config::TEST_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|e| e.into_inner());
-    let restore = std::env::var_os("OPENHUMAN_TOOL_TIMEOUT_SECS");
-    std::env::remove_var("OPENHUMAN_TOOL_TIMEOUT_SECS");
+    // Clear the operator override behind a panic-safe RAII guard: if any assertion
+    // below panics, `Drop` still restores the previous value, so sibling tests that
+    // share `TEST_ENV_LOCK` never inherit the cleared var.
+    let _env = EnvVarGuard::remove_many(vec!["OPENHUMAN_TOOL_TIMEOUT_SECS"]);
 
     // Distinctive, in-range (1..=3600) value so the assertion can only pass on a
     // real seed, never on the default. Channel-less: `channels_config` stays empty,
@@ -127,11 +127,6 @@ async fn tool_timeout_seeds_on_channelless_core_boot() {
         1234,
         "channel-less core boot must seed the tool-execution timeout from [agent].agent_timeout_secs"
     );
-
-    match restore {
-        Some(v) => std::env::set_var("OPENHUMAN_TOOL_TIMEOUT_SECS", v),
-        None => std::env::remove_var("OPENHUMAN_TOOL_TIMEOUT_SECS"),
-    }
 }
 
 struct EnvVarGuard {
@@ -148,6 +143,25 @@ impl EnvVarGuard {
         for (key, value) in vars {
             let old = std::env::var_os(key);
             std::env::set_var(key, value);
+            old_values.push((key, old));
+        }
+        Self {
+            old_values,
+            _lock: lock,
+        }
+    }
+
+    /// Remove the named vars (capturing their prior values) for the guard's
+    /// lifetime, restoring each on `Drop`. Mirrors [`set_many`] for tests that
+    /// need an env var *absent* rather than set to a fixed value.
+    fn remove_many(keys: Vec<&'static str>) -> Self {
+        let lock = crate::openhuman::config::TEST_ENV_LOCK
+            .lock()
+            .expect("test env lock poisoned");
+        let mut old_values = Vec::with_capacity(keys.len());
+        for key in keys {
+            let old = std::env::var_os(key);
+            std::env::remove_var(key);
             old_values.push((key, old));
         }
         Self {

--- a/src/openhuman/channels/runtime/startup.rs
+++ b/src/openhuman/channels/runtime/startup.rs
@@ -276,17 +276,12 @@ pub async fn start_channels(mut config: Config) -> Result<()> {
         config.workspace_dir.clone(),
         config.action_dir.clone(),
     );
-    // Seed the live tool-execution timeout from the persisted `[agent]` config so
-    // a user-configured value (Settings → Agent OS access → Action timeout) is in
-    // effect from the first tool call. `OPENHUMAN_TOOL_TIMEOUT_SECS`, when set,
-    // still overrides this inside `set_tool_timeout_secs`.
-    let effective_timeout =
-        crate::openhuman::tool_timeout::set_tool_timeout_secs(config.agent.agent_timeout_secs);
-    tracing::debug!(
-        configured = config.agent.agent_timeout_secs,
-        effective = effective_timeout,
-        "[startup] seeded tool-execution timeout from config"
-    );
+    // NOTE: the live tool-execution timeout seed is done in
+    // `core::jsonrpc::register_domain_subscribers` (unconditional core boot), NOT
+    // here — `start_channels` is skipped when no channel is configured or
+    // `OPENHUMAN_DISABLE_CHANNEL_LISTENERS` is set, which would otherwise leave
+    // channel-less / web-chat-only cores running the default timeout instead of the
+    // user-configured `[agent].agent_timeout_secs` (#5027).
     // Phase 1 of #1401: audit logger is wired with defaults so emission paths
     // are exercised at runtime. A follow-up promotes `SecurityConfig` (and
     // therefore the `audit` knob) onto the runtime `Config` schema so users

--- a/src/openhuman/channels/runtime/startup.rs
+++ b/src/openhuman/channels/runtime/startup.rs
@@ -156,7 +156,6 @@ pub async fn start_channels(mut config: Config) -> Result<()> {
     let bus = event_bus::init_global(DEFAULT_CAPACITY);
     let _tracing_handle = bus.subscribe(Arc::new(TracingSubscriber));
     crate::openhuman::health::bus::register_health_subscriber();
-    crate::openhuman::skills::bus::register_workflow_cleanup_subscriber();
     crate::openhuman::memory_conversations::register_conversation_persistence_subscriber(
         config.workspace_dir.clone(),
     );

--- a/src/openhuman/skills/bus.rs
+++ b/src/openhuman/skills/bus.rs
@@ -255,10 +255,6 @@ pub fn ensure_triggered_workflow_subscriber(workspace: &std::path::Path) {
     });
 }
 
-/// Legacy no-op retained while call-sites migrate to
-/// [`register_triggered_workflow_subscriber`]. Safe to call multiple times.
-pub fn register_workflow_cleanup_subscriber() {}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -445,11 +441,5 @@ mod tests {
             component: "core".into(),
         };
         assert!(idx.matching_workflows(&event).is_empty());
-    }
-
-    #[test]
-    fn register_skill_cleanup_subscriber_is_a_safe_noop() {
-        register_workflow_cleanup_subscriber();
-        register_workflow_cleanup_subscriber();
     }
 }

--- a/src/openhuman/skills/stub.rs
+++ b/src/openhuman/skills/stub.rs
@@ -82,7 +82,7 @@ pub mod registry {
 }
 
 // ---------------------------------------------------------------------------
-// bus::{ensure_triggered_workflow_subscriber, register_workflow_cleanup_subscriber}
+// bus::ensure_triggered_workflow_subscriber
 // ---------------------------------------------------------------------------
 
 pub mod bus {
@@ -90,9 +90,6 @@ pub mod bus {
     pub fn ensure_triggered_workflow_subscriber(_workspace: &std::path::Path) {
         log::debug!("[skills-stub] ensure_triggered_workflow_subscriber skipped (skills disabled)");
     }
-
-    /// No-op: no skill run directories exist to clean up.
-    pub fn register_workflow_cleanup_subscriber() {}
 }
 
 // NOTE: no `tools` module here. The `pub use skills::tools::*` glob in

--- a/src/openhuman/tool_timeout/README.md
+++ b/src/openhuman/tool_timeout/README.md
@@ -7,7 +7,7 @@ Process-wide wall-clock timeout policy for tool execution (the node/tool runtime
 Highest precedence first:
 
 1. `OPENHUMAN_TOOL_TIMEOUT_SECS` environment variable — operator override. When set to a valid value (`1..=3600`) it always wins; config pushes are ignored while it is present.
-2. The persisted config value (`[agent].agent_timeout_secs`), pushed in via `set_tool_timeout_secs` at startup and on every `config.update_agent_settings` RPC.
+2. The persisted config value (`[agent].agent_timeout_secs`), pushed in via `set_tool_timeout_secs` at startup (from `core::jsonrpc::register_domain_subscribers`, the always-on core boot path) and on every `config.update_agent_settings` RPC.
 3. The built-in `DEFAULT_TIMEOUT_SECS` (`120`) default.
 
 ## Responsibilities
@@ -54,7 +54,7 @@ The global timeout governs **non-scripting** tools only — a hung network/MCP c
 - `src/openhuman/tools/impl/system/{shell,node_exec,npm_exec}.rs` — scripting tools: unbounded by default, explicit `timeout_secs` via `explicit_call_timeout_*`.
 - `src/openhuman/agent/tools/delegate.rs` — bounds the delegated provider chat call with `tool_execution_timeout_secs`.
 - `src/openhuman/config/ops.rs` — `apply_agent_settings` calls `set_tool_timeout_secs` after persisting; `get_agent_settings` reports `effective_timeout_secs` / `env_override`.
-- `src/openhuman/channels/runtime/startup.rs` — seeds the runtime value from config at core boot.
+- `src/core/jsonrpc.rs` — `register_domain_subscribers` seeds the runtime value from config on the always-on core boot path (its ungated `INFRA: Once` block), so channel-less / web-chat-only cores get the configured timeout too (#5027).
 - `src/openhuman/agent/harness/harness_gap_tests.rs` — pins `parse_tool_timeout_secs` default/boundary behaviour.
 
 ## Notes / gotchas


### PR DESCRIPTION
## Summary

- Moves the tool-execution timeout seed off the chat-channel startup path onto the always-on boot path, so a user's configured `[agent].agent_timeout_secs` takes effect on **every** boot — not only when a chat channel is connected.
- Retires a dead legacy no-op (`register_workflow_cleanup_subscriber`) whose real successor is already registered on the always-on path.
- Core-only; desktop behaviour unchanged.

## Problem

`start_channels` is skipped entirely when no chat integration is configured (`spawn_channels_service` early-returns on `!has_listening_integrations()`, and also under `OPENHUMAN_DISABLE_CHANNEL_LISTENERS=1`). Two things were still wired inside it:

1. **The tool-timeout seed** — the only boot-time call of `set_tool_timeout_secs`. On channel-less installs the persisted `[agent].agent_timeout_secs` was silently ignored and tools ran on the built-in default until a Settings save happened to re-seed it.
2. **`register_workflow_cleanup_subscriber`** — a documented legacy no-op (`pub fn …() {}`); its successor `ensure_triggered_workflow_subscriber` is already registered on the always-on boot path. Moving a no-op would only mislead readers.

Same coupling class as #5003 (learning subscribers), which this file already carries a NOTE about.

## Solution

- **Seed on the always-on path.** The seed moves into the ungated `INFRA: Once` block of `register_domain_subscribers`, right after `tokenjuice::install_from_config`. That block is the file's home for config-derived process-global boot seeds, is `DomainSet`-independent (so the timeout seeds even under `harness()`/`none()`), runs exactly once with `config` in scope, and runs earlier than `start_channels` did — so the configured timeout is live strictly sooner.
- **Delete the seed from `start_channels`**, leaving a #5003-style NOTE pointing at the new home and why.
- **Retire the no-op**: delete the call site, the `pub fn`, its doc, its `_is_a_safe_noop` test, and the matching stub fn (keeping `ensure_triggered_workflow_subscriber`). Post-change `git grep register_workflow_cleanup_subscriber` is empty.
- **Doc sweep**: `tool_timeout/README.md` now names `core::jsonrpc::register_domain_subscribers` as the seed site.

## Submission Checklist

- [x] Tests added: `tool_timeout_seeds_on_channelless_core_boot` — channel-less `Config` (`agent_timeout_secs = 1234`), minimal `DomainSet::none()`, asserts the effective timeout is seeded (the failure the fix targets: without the move, a channel-less boot leaves the default). ENV_LOCK-serialized, `OPENHUMAN_TOOL_TIMEOUT_SECS` cleared.
- [x] **Diff coverage ≥ 80%** — the added seed line is exercised by the new test; the rest of the diff is deletions (dead no-op + moved seed). Enforced on merge by CI.
- [x] N/A: behaviour-only change — no coverage-matrix feature rows added/removed/renamed.
- [x] No matrix feature IDs affected — see `## Related`.
- [x] No new external network dependencies introduced.
- [x] N/A: does not touch a release-cut manual-smoke surface (internal boot wiring; desktop path byte-identical).
- [x] Linked issue closed via `Closes #5027` in `## Related`.

## Impact

- **Platform**: core only. Desktop (channel-configured) behaviour unchanged — same seed value, now applied on a path that also runs channel-less.
- **User-visible**: channel-less users get their configured action-timeout honoured from the first tool call instead of after a Settings re-save.
- **Binary size / migration**: none.
- **Risk**: low. Seed is an idempotent atomic store under `Once`; the settings-update RPC path still re-seeds on change. Verified: `cargo check` (default + gates-off), `fmt`/`clippy -D warnings` clean, `tool_timeout` 14 passed, `core::jsonrpc` 94 passed (incl. new test), `skills::bus` 16 passed.

## Related

- Closes #5027
- Follow-up of #5003 (same start_channels coupling class) and epic #4795 (channels feature gate)
- Independent of #5029 (channels gate) — disjoint files (`startup.rs`/`skills` vs #5029's channels cfg); not stacked. Landing this first makes #5029's channels-off build correct for free (the seed lives in always-compiled code rather than being compiled out).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A — GitHub-issue driven (#5027)
- URL: N/A

### Commit & Branch

- Branch: `fix/5027-tool-timeout-seed-decouple`
- Commit SHA: `11394080f`

### Validation Run

- [x] N/A: `pnpm typecheck` / `format:check` — no TypeScript or frontend files changed
- [x] `cargo fmt --check` clean; `cargo check` (default) clean; `cargo clippy -- -D warnings` clean
- [x] Gates-off compiles: `GGML_NATIVE=OFF cargo check --no-default-features --features tokenjuice-treesitter`
- [x] Focused tests: `cargo test --lib openhuman::tool_timeout` (14) + `core::jsonrpc` (94, incl. new) + `skills::bus` (16)

### Behavior Changes

- Intended behavior change: the configured tool-execution timeout is seeded on every core boot, including channel-less installs.
- User-visible effect: channel-less users' `[agent].agent_timeout_secs` is honoured from the first tool call.

### Parity Contract

- Legacy behavior preserved: channel-configured desktop boots seed the same value as before; the settings-update RPC still re-seeds on change.
- Guard/fallback/dispatch parity checks: `register_workflow_cleanup_subscriber` was a no-op; its successor `ensure_triggered_workflow_subscriber` remains registered on the always-on path.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Tool-execution timeouts are now seeded from saved agent settings during core startup, including channel-less and web-chat-only configurations.
  - Updated startup behavior ensures the live timeout source is consistent across initialization paths.
- **Documentation**
  - Clarified tool-timeout resolution order and the exact startup location responsible for runtime seeding.
- **Tests**
  - Added a regression test to verify timeout seeding when running without channels.
- **Maintenance**
  - Removed the obsolete workflow-cleanup subscriber registration from channel/skills startup paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->