### PR TITLE
fix: daemon-health identity race + Orchestration sub-tab follow-ups

### DIFF
--- a/app/src/AppRoutes.tsx
+++ b/app/src/AppRoutes.tsx
@@ -46,24 +46,40 @@ interface AppRoutesProps {
 const NETWORK_SUBS = ['connections', 'discover', 'usage'];
 const ORCH_VIEWS = ['medulla', 'agent', 'overview', 'tasks', 'network'];
 
-function OrchestrationRedirect() {
+export function OrchestrationRedirect() {
   const { search } = useLocation();
   const legacy = new URLSearchParams(search);
   const tab = legacy.get('tab');
+  // Privacy-safe: only the allowlisted branch id and whether a session param was
+  // present are logged — never the session value or any raw query string.
+  console.debug(
+    '[routes] orchestration-redirect: entry tab=%s',
+    tab && ORCH_VIEWS.includes(tab) ? tab : tab && NETWORK_SUBS.includes(tab) ? tab : '<unmapped>'
+  );
 
   const next = new URLSearchParams();
   next.set('tab', 'orchestration');
+  let branch: string;
   if (tab && NETWORK_SUBS.includes(tab)) {
     next.set('ov', 'network');
     next.set('sub', tab);
+    branch = 'network-sub';
   } else {
     if (tab && ORCH_VIEWS.includes(tab)) next.set('ov', tab);
     const sub = legacy.get('sub');
     if (sub && NETWORK_SUBS.includes(sub)) next.set('sub', sub);
+    branch = tab && ORCH_VIEWS.includes(tab) ? 'view' : 'default';
   }
   const session = legacy.get('session');
   if (session) next.set('session', session);
 
+  console.debug(
+    '[routes] orchestration-redirect: exit branch=%s ov=%s hasSub=%s hasSession=%s',
+    branch,
+    next.get('ov') ?? '<none>',
+    next.has('sub'),
+    next.has('session')
+  );
   return <Navigate to={`/brain?${next.toString()}`} replace />;
 }
 

--- a/app/src/components/LocalAIDownloadSnackbar.tsx
+++ b/app/src/components/LocalAIDownloadSnackbar.tsx
@@ -105,7 +105,14 @@ const LocalAIDownloadSnackbar = () => {
         if (downloadsRes.result) setDownloads(downloadsRes.result);
         // The download reached a terminal state — stop the fast poll early
         // rather than waiting for core state to catch up (it lags up to ~5s).
-        settled = !isDownloadInFlight(statusRes.result ?? null, downloadsRes.result ?? null);
+        // A successful response that carries no `result` (a soft failure, not a
+        // thrown error) must be treated as transient, not as "download
+        // complete" — otherwise one empty blip would permanently freeze the
+        // fast poll for the rest of the download (same failure mode the catch
+        // below guards against for thrown errors).
+        if (statusRes.result || downloadsRes.result) {
+          settled = !isDownloadInFlight(statusRes.result ?? null, downloadsRes.result ?? null);
+        }
       } catch (err) {
         // Transient RPC failure (core may be busy). Do NOT treat this as
         // settled: keep polling while core state still reports the download

--- a/app/src/hooks/__tests__/useSubconscious.test.ts
+++ b/app/src/hooks/__tests__/useSubconscious.test.ts
@@ -81,6 +81,21 @@ describe('useSubconscious', () => {
     expect(result.current.status).not.toBeNull();
   });
 
+  it('does not fetch or poll when disabled', async () => {
+    const { subconsciousStatus, openhumanHeartbeatSettingsGet } =
+      await import('../../utils/tauriCommands');
+    const { result } = renderHook(() => useSubconscious(false));
+
+    await act(async () => {
+      // Advance well past the 5s poll interval — still no RPCs.
+      await vi.advanceTimersByTimeAsync(12000);
+    });
+
+    expect(subconsciousStatus).not.toHaveBeenCalled();
+    expect(openhumanHeartbeatSettingsGet).not.toHaveBeenCalled();
+    expect(result.current.status).toBeNull();
+  });
+
   it('setMode calls heartbeat settings set', async () => {
     const { openhumanHeartbeatSettingsSet } = await import('../../utils/tauriCommands');
     const { result } = renderHook(() => useSubconscious());

--- a/app/src/hooks/useSubconscious.ts
+++ b/app/src/hooks/useSubconscious.ts
@@ -51,7 +51,15 @@ function deriveInstances(status: SubconsciousStatus | null): SubconsciousInstanc
   return [{ ...row, instance: row.instance ?? 'memory' }];
 }
 
-export function useSubconscious(): UseSubconsciousResult {
+/**
+ * @param enabled When `false`, the hook skips its initial fetch and the 5s
+ *   status poll (the imperative actions — `refresh`, `triggerTick`, `setMode`,
+ *   `setIntervalMinutes` — still work if called). Callers that only render the
+ *   subconscious surface on a specific tab pass `enabled` so opening an
+ *   unrelated view (e.g. Brain's Orchestration sub-tab) doesn't keep unrelated
+ *   heartbeat/subconscious RPCs polling. Defaults to `true` for back-compat.
+ */
+export function useSubconscious(enabled: boolean = true): UseSubconsciousResult {
   const [status, setStatus] = useState<SubconsciousStatus | null>(null);
   const [mode, setModeState] = useState<SubconsciousMode>('off');
   const [intervalMinutes, setIntervalState] = useState(30);
@@ -149,13 +157,14 @@ export function useSubconscious(): UseSubconsciousResult {
   }, []);
 
   useEffect(() => {
+    if (!enabled) return;
     refresh();
     const interval = setInterval(refresh, 5000);
     return () => {
       clearInterval(interval);
       fetchingRef.current = false;
     };
-  }, [refresh]);
+  }, [refresh, enabled]);
 
   const isTriggering = useCallback(
     (kind: TriggerKind) => triggeringKinds.has(kind),

--- a/app/src/pages/Brain.tsx
+++ b/app/src/pages/Brain.tsx
@@ -132,6 +132,15 @@ export default function Brain() {
   const refresh = useCallback(() => setRefreshKey(k => k + 1), []);
 
   useEffect(() => {
+    // Orchestration is a full-bleed sub-tab that never renders the memory graph,
+    // so skip the export RPC + memory-tree listener entirely while it's active.
+    // Without this, folding Orchestration under Brain would fire an unrelated
+    // graph load on every `/brain?tab=orchestration` (and redirected
+    // `/orchestration`) visit, which the old standalone page never did.
+    if (activeTab === 'orchestration') {
+      console.debug('[brain] graph fetch: skipped (orchestration tab)');
+      return;
+    }
     let cancelled = false;
     const load = async () => {
       console.debug('[brain] graph fetch: entry mode=%s', mode);
@@ -163,8 +172,10 @@ export default function Brain() {
     };
     // `authUserId` is a dependency so a logout→login (identity becomes
     // available again) re-pulls the persisted graph instead of leaving the
-    // signed-out empty state on screen (#4149).
-  }, [mode, refreshKey, authUserId]);
+    // signed-out empty state on screen (#4149). `activeTab` gates the fetch off
+    // on the Orchestration sub-tab (and re-runs it when returning to a
+    // graph-bearing tab).
+  }, [mode, refreshKey, authUserId, activeTab]);
 
   const cardClass = 'rounded-lg border border-line bg-surface p-4';
 

--- a/app/src/pages/Brain.tsx
+++ b/app/src/pages/Brain.tsx
@@ -121,7 +121,10 @@ export default function Brain() {
   const { snapshot } = useCoreState();
   const authUserId = snapshot.auth.userId;
 
-  const sub = useSubconscious();
+  // Only poll subconscious/heartbeat status while its own tab is showing — the
+  // data is consumed nowhere else, so other tabs (incl. the folded-in
+  // Orchestration sub-tab) shouldn't keep those RPCs running.
+  const sub = useSubconscious(activeTab === 'subconscious');
 
   const addToast = useCallback((toast: Omit<ToastNotification, 'id'>) => {
     setToasts(prev => [...prev, { ...toast, id: `toast-${Date.now()}-${Math.random()}` }]);

--- a/app/src/pages/__tests__/Brain.test.tsx
+++ b/app/src/pages/__tests__/Brain.test.tsx
@@ -195,6 +195,19 @@ describe('Brain page', () => {
     });
   });
 
+  it('does not fetch the memory graph on the orchestration tab', async () => {
+    graphExportMock.mockResolvedValue(makeGraph(0));
+    await act(async () => {
+      renderWithProviders(<Brain />, { initialEntries: ['/?tab=orchestration'] });
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('brain-orchestration')).toBeInTheDocument();
+    });
+    // Folding Orchestration under Brain must not trigger the unrelated
+    // memoryTreeGraphExport RPC that the standalone page never issued.
+    expect(graphExportMock).not.toHaveBeenCalled();
+  });
+
   it('redirects the legacy tinyplace-orchestration deep link to the orchestration tab', async () => {
     graphExportMock.mockResolvedValue(makeGraph(0));
     await act(async () => {

--- a/app/src/pages/__tests__/OrchestrationRedirect.test.tsx
+++ b/app/src/pages/__tests__/OrchestrationRedirect.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * OrchestrationRedirect maps the retired `/orchestration` route (and its legacy
+ * `?tab=`/`?sub=`/`?session=` query) onto Brain's `/brain?tab=orchestration`
+ * with the `?ov=`/`?sub=` scheme. Rendered under a MemoryRouter with a `/brain`
+ * sink route that reports the resolved URL so each mapping branch is asserted.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { OrchestrationRedirect } from '../../AppRoutes';
+
+function BrainProbe() {
+  const { pathname, search } = useLocation();
+  return <div data-testid="brain">{`${pathname}${search}`}</div>;
+}
+
+const resolve = (from: string): string => {
+  render(
+    <MemoryRouter initialEntries={[from]}>
+      <Routes>
+        <Route path="/orchestration" element={<OrchestrationRedirect />} />
+        <Route path="/brain" element={<BrainProbe />} />
+      </Routes>
+    </MemoryRouter>
+  );
+  const target = screen.getByTestId('brain').textContent ?? '';
+  const params = new URLSearchParams(target.split('?')[1] ?? '');
+  return `${target.split('?')[0]}?${params.toString()}`;
+};
+
+describe('OrchestrationRedirect', () => {
+  it('bare /orchestration → the orchestration tab (no view override)', () => {
+    const params = new URLSearchParams(resolve('/orchestration').split('?')[1]);
+    expect(params.get('tab')).toBe('orchestration');
+    expect(params.get('ov')).toBeNull();
+  });
+
+  it.each(['agent', 'overview', 'tasks', 'network', 'medulla'])('legacy ?tab=%s → ?ov=%s', view => {
+    const params = new URLSearchParams(resolve(`/orchestration?tab=${view}`).split('?')[1]);
+    expect(params.get('tab')).toBe('orchestration');
+    expect(params.get('ov')).toBe(view);
+  });
+
+  it.each(['connections', 'discover', 'usage'])('legacy ?tab=%s → ?ov=network&sub=%s', sub => {
+    const params = new URLSearchParams(resolve(`/orchestration?tab=${sub}`).split('?')[1]);
+    expect(params.get('ov')).toBe('network');
+    expect(params.get('sub')).toBe(sub);
+  });
+
+  it('preserves a network ?sub= when landing on ?tab=network', () => {
+    const params = new URLSearchParams(
+      resolve('/orchestration?tab=network&sub=usage').split('?')[1]
+    );
+    expect(params.get('ov')).toBe('network');
+    expect(params.get('sub')).toBe('usage');
+  });
+
+  it('preserves ?session= for the agent chat', () => {
+    const params = new URLSearchParams(
+      resolve('/orchestration?tab=agent&session=sess-1').split('?')[1]
+    );
+    expect(params.get('ov')).toBe('agent');
+    expect(params.get('session')).toBe('sess-1');
+  });
+
+  it('ignores an unknown ?tab= (falls back to the orchestration tab)', () => {
+    const params = new URLSearchParams(resolve('/orchestration?tab=bogus').split('?')[1]);
+    expect(params.get('tab')).toBe('orchestration');
+    expect(params.get('ov')).toBeNull();
+  });
+});

--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -353,10 +353,11 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
 
     // Feed the folded health payload to the daemon-health store (replaces the
     // former standalone health_snapshot poll). Done AFTER the commit and only
-    // when this refresh is still current, so `daemonHealthService` resolves the
-    // freshly-committed identity — not a stale/pre-commit or superseded token,
-    // which during a login/identity flip would write health under the prior or
-    // `__pending__` user.
+    // when this refresh is still current. The resolved `sessionToken` for THIS
+    // refresh is passed explicitly: `commitState` writes the non-React snapshot
+    // store inside a (deferred) React `setState` updater, so reading identity
+    // from that store here would still see the pre-commit token and, during a
+    // login/identity flip, write health under the prior or `__pending__` user.
     if (requestId === snapshotRequestIdRef.current) {
       // Privacy-safe: log presence/shape only, never the payload/tokens.
       log(
@@ -366,7 +367,7 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
         rawSnapshot.health != null,
         rawSnapshot.health ? Object.keys(rawSnapshot.health.components ?? {}).length : 0
       );
-      daemonHealthService.ingestHealthSnapshot(rawSnapshot.health);
+      daemonHealthService.ingestHealthSnapshot(rawSnapshot.health, nextSnapshot.sessionToken);
     } else {
       log(
         'health ingest skipped: superseded refresh requestId=%d current=%d',

--- a/app/src/services/daemonHealthService.ts
+++ b/app/src/services/daemonHealthService.ts
@@ -40,7 +40,10 @@ export class DaemonHealthService {
    */
   ensureWatchdogArmed(): void {
     if (this.healthTimeoutId === null) {
+      console.debug('[DaemonHealth] watchdog: initial arm (no existing timer)');
       this.startHealthTimeout();
+    } else {
+      console.debug('[DaemonHealth] watchdog: already armed, no-op');
     }
   }
 
@@ -53,13 +56,29 @@ export class DaemonHealthService {
    * otherwise a live-but-health-less core would eventually be marked
    * `disconnected`. The daemon store is only updated when a valid health
    * snapshot is present; otherwise it keeps its last-known state.
+   *
+   * `sessionToken` is the token resolved by the *current* snapshot refresh.
+   * Passing it explicitly is load-bearing: `CoreStateProvider` commits the new
+   * identity via React `setState`, whose updater (and the non-React
+   * `setCoreStateSnapshot` it calls) runs *deferred*, so at ingest time the
+   * store still holds the previous token. Deriving the user from the store here
+   * would file this health payload under the prior / `__pending__` user during a
+   * login/identity flip. When omitted (e.g. the hook's baseline arm), we fall
+   * back to the store token.
    */
-  ingestHealthSnapshot(payload: unknown): void {
+  ingestHealthSnapshot(payload: unknown, sessionToken?: string | null): void {
     // Called by CoreStateProvider only after a successful snapshot → liveness.
-    this.startHealthTimeout();
+    this.startHealthTimeout(sessionToken);
     const healthSnapshot = this.parseHealthSnapshot(payload);
+    console.debug(
+      '[DaemonHealth] ingest: hasPayload=%s parsed=%s components=%d storeUpdate=%s',
+      payload != null,
+      healthSnapshot != null,
+      healthSnapshot ? Object.keys(healthSnapshot.components).length : 0,
+      healthSnapshot != null
+    );
     if (healthSnapshot) {
-      this.updateDaemonStoreFromHealth(healthSnapshot);
+      this.updateDaemonStoreFromHealth(healthSnapshot, sessionToken);
     }
   }
 
@@ -129,20 +148,23 @@ export class DaemonHealthService {
     }
   }
 
-  private updateDaemonStoreFromHealth(snapshot: HealthSnapshot): void {
+  private updateDaemonStoreFromHealth(
+    snapshot: HealthSnapshot,
+    sessionToken?: string | null
+  ): void {
     try {
-      updateHealthSnapshot(this.getUserId(), snapshot);
+      updateHealthSnapshot(this.getUserId(sessionToken), snapshot);
     } catch (error) {
       console.error('[DaemonHealth] Error updating daemon store from health:', error);
     }
   }
 
-  private startHealthTimeout(): void {
+  private startHealthTimeout(sessionToken?: string | null): void {
     if (this.healthTimeoutId) {
       clearTimeout(this.healthTimeoutId);
     }
 
-    const userId = this.getUserId();
+    const userId = this.getUserId(sessionToken);
     this.healthTimeoutId = setTimeout(() => {
       console.warn('[DaemonHealth] Health timeout reached - setting status to disconnected');
       setDaemonStatus(userId, 'disconnected');
@@ -150,8 +172,16 @@ export class DaemonHealthService {
     }, this.HEALTH_TIMEOUT_MS);
   }
 
-  private getUserId(): string {
-    const token = getCoreStateSnapshot().snapshot.sessionToken;
+  /**
+   * Resolve the destination user for health writes. When the caller supplies the
+   * refresh's own `sessionToken` (even `null`, meaning signed-out), it wins over
+   * the store — see {@link ingestHealthSnapshot} for why the store token is
+   * stale during an identity flip. `undefined` means "no override", so fall back
+   * to the store.
+   */
+  private getUserId(tokenOverride?: string | null): string {
+    const token =
+      tokenOverride !== undefined ? tokenOverride : getCoreStateSnapshot().snapshot.sessionToken;
     if (!token) {
       return '__pending__';
     }

--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -6085,6 +6085,10 @@ async fn json_rpc_app_state_snapshot_returns_runtime_shape() {
         "expected health.pid: {health}"
     );
     assert!(
+        health.get("updated_at").and_then(Value::as_str).is_some(),
+        "expected health.updated_at (snake_case): {health}"
+    );
+    assert!(
         health
             .get("uptime_seconds")
             .and_then(Value::as_u64)


### PR DESCRIPTION
## Summary

Follow-up review fixes on top of #5075 (the Orchestration-under-Brain fold +
daemon-health/local-AI cleanup, already merged to `main`). These were surfaced
by CodeRabbit/Codex review of the superseded #5080 and are **not** on `main`:

- **daemon-health identity-flip race**: resolve the health-store user from the
  refresh's own `sessionToken` (passed by `CoreStateProvider`) instead of the
  deferred non-React snapshot store — `commitState` writes that store inside a
  React `setState` updater, so reading it at ingest time filed health under the
  prior / `__pending__` user during a login/identity flip. Add privacy-safe
  watchdog + ingest diagnostics.
- **LocalAI download snackbar**: treat an empty-but-successful RPC response as
  transient, not "download complete", so a soft failure no longer freezes the
  fast poll for the rest of the download.
- **Brain sub-tab hygiene**: skip the `memoryTreeGraphExport` fetch and gate
  `useSubconscious` polling (new `enabled` param) off the Orchestration sub-tab,
  so opening `/brain?tab=orchestration` (and the redirected `/orchestration`)
  no longer starts unrelated graph / heartbeat RPCs the standalone page never
  issued.
- **Redirect diagnostics**: privacy-safe entry/exit logging in
  `OrchestrationRedirect` + a new `OrchestrationRedirect.test.tsx` covering every
  mapping branch.
- **RPC contract test**: assert `health.updated_at` in `json_rpc_e2e` (the
  frontend rejects the payload without it).

## Problem

#5075 shipped the fold + poll consolidation, but review flagged a real
identity-flip data-integrity race, a poll-freeze soft-failure, two unrelated
RPC loops newly triggered on the Orchestration sub-tab, and a couple of missing
diagnostics / assertions. None landed on `main`.

## Solution

Small, targeted fixes with regression tests for each; no behaviour change to the
orchestration surfaces themselves.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — new lines are covered by `OrchestrationRedirect.test.tsx`, the Brain orchestration-tab tests, the `useSubconscious` disabled-path test, and the daemon-health ingest tests; the full gate is enforced by CI.
- [x] N/A: Coverage matrix — behaviour-preserving follow-up fixes; no `docs/TEST-COVERAGE-MATRIX.md` feature rows change.
- [x] N/A: No matrix feature IDs affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: No release-cut smoke surfaces changed.
- [x] N/A: No linked issue to close.

## Impact

- **Desktop UI/runtime**: health is filed under the correct user across identity
  flips; download progress no longer freezes on a soft RPC failure; the
  Orchestration sub-tab stops two unrelated background RPC loops. No migration,
  security, or API-surface changes.

## Related

- Builds on: #5075 (merged)
- Supersedes: #5080 (closed as a duplicate of #5075)
- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/daemon-health-and-orch-followups`
- Commit SHA: `a7a2520ab`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: Vitest `OrchestrationRedirect`, `Brain`, `useSubconscious`, `daemonHealthService`, `CoreStateProvider`, `LocalAIDownloadSnackbar` (68 passing)
- [x] Rust fmt/check (if changed): `cargo fmt --all --check` (json_rpc_e2e assertion only)
- [x] N/A: Tauri shell unchanged

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: correct health-store identity on flips; no fast-poll freeze; no unrelated RPCs on the Orchestration sub-tab.
- User-visible effect: reliable download progress + daemon-health status; slightly less background work on Orchestration.

### Parity Contract

- Legacy behavior preserved: orchestration surfaces unchanged; `useSubconscious` defaults to `enabled` for all existing callers.
- Guard/fallback/dispatch parity checks: `getUserId(tokenOverride)` falls back to the store when no token is passed; `useSubconscious(enabled=true)` default keeps Activity + other callers unchanged.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): #5080
- Canonical PR: this PR (fixes) + #5075 (base, merged)
- Resolution: #5080 closed as superseded by #5075; its net-new review fixes salvaged here.
