### PR TITLE
fix(agentbox): normalize GMI_MAAS_BASE_URL with trailing /v1

### DIFF
--- a/app/src/components/settings/panels/__tests__/builtinCloudProviders.test.ts
+++ b/app/src/components/settings/panels/__tests__/builtinCloudProviders.test.ts
@@ -13,6 +13,7 @@ describe('builtinCloudProviders', () => {
   });
 
   it.each([
+    ['gmi', 'https://api.gmi-serving.com/v1', 'bearer'],
     ['groq', 'https://api.groq.com/openai/v1', 'bearer'],
     ['deepseek', 'https://api.deepseek.com/v1', 'bearer'],
     ['minimax', 'https://api.minimax.io/v1', 'bearer'],

--- a/app/src/components/settings/panels/builtinCloudProviders.ts
+++ b/app/src/components/settings/panels/builtinCloudProviders.ts
@@ -64,7 +64,7 @@ export const BUILTIN_CLOUD_PROVIDERS: BuiltinCloudProvider[] = [
     endpoint: 'https://api.gmi-serving.com/v1',
     authStyle: 'bearer',
     tone: TONE.fuchsia,
-    keyPlaceholder: 'gmi-...',
+    keyPlaceholder: 'eyJ....',
   },
   {
     slug: 'fireworks',

--- a/src/openhuman/agentbox/env.rs
+++ b/src/openhuman/agentbox/env.rs
@@ -79,10 +79,21 @@ where
         return Err(format!("missing/blank: {}", missing.join(", ")));
     }
     Ok(GmiConfig {
-        base_url: base_url.unwrap(),
+        base_url: normalize_gmi_maas_base_url(&base_url.unwrap()),
         api_key: api_key.unwrap(),
         model: model.unwrap(),
     })
+}
+
+/// Normalize `GMI_MAAS_BASE_URL` to an OpenAI-compatible `/v1` base URL.
+///
+/// AgentBox injects a host-only URL (no `/v1`). `OpenAiModel` appends
+/// `/chat/completions` but does not add `/v1`, so marketplace inference
+/// 404s without this step. Idempotent for already-correct inputs.
+pub fn normalize_gmi_maas_base_url(url: &str) -> String {
+    let trimmed = url.trim().trim_end_matches('/');
+    let without_v1 = trimmed.strip_suffix("/v1").unwrap_or(trimmed);
+    format!("{}/v1", without_v1.trim_end_matches('/'))
 }
 
 fn nonblank<F: Fn(&str) -> Option<String>>(get: &F, key: &str) -> Option<String> {

--- a/src/openhuman/agentbox/env_tests.rs
+++ b/src/openhuman/agentbox/env_tests.rs
@@ -1,4 +1,7 @@
-use super::env::{agentbox_mode_enabled, collect_gmi_config, GmiConfig, AGENTBOX_MODE_ENV_VAR};
+use super::env::{
+    agentbox_mode_enabled, collect_gmi_config, normalize_gmi_maas_base_url, GmiConfig,
+    AGENTBOX_MODE_ENV_VAR,
+};
 
 #[test]
 fn collect_returns_some_when_all_three_vars_present() {
@@ -11,7 +14,7 @@ fn collect_returns_some_when_all_three_vars_present() {
     assert_eq!(
         cfg,
         Ok(GmiConfig {
-            base_url: "https://api.gmi-serving.com".into(),
+            base_url: "https://api.gmi-serving.com/v1".into(),
             api_key: "sk-test".into(),
             model: "deepseek-ai/DeepSeek-V4-Pro".into(),
         })
@@ -86,9 +89,41 @@ fn collect_trims_leading_and_trailing_whitespace() {
     assert_eq!(
         cfg,
         Ok(GmiConfig {
-            base_url: "https://api.gmi-serving.com".into(),
+            base_url: "https://api.gmi-serving.com/v1".into(),
             api_key: "sk-test".into(),
             model: "deepseek-ai/DeepSeek-V4-Pro".into(),
         })
+    );
+}
+
+#[test]
+fn normalize_gmi_maas_base_url_appends_v1() {
+    assert_eq!(
+        normalize_gmi_maas_base_url("https://api.gmi-serving.com"),
+        "https://api.gmi-serving.com/v1"
+    );
+}
+
+#[test]
+fn normalize_gmi_maas_base_url_strips_trailing_slash() {
+    assert_eq!(
+        normalize_gmi_maas_base_url("https://api.gmi-serving.com/"),
+        "https://api.gmi-serving.com/v1"
+    );
+}
+
+#[test]
+fn normalize_gmi_maas_base_url_keeps_existing_v1() {
+    assert_eq!(
+        normalize_gmi_maas_base_url("https://api.gmi-serving.com/v1"),
+        "https://api.gmi-serving.com/v1"
+    );
+}
+
+#[test]
+fn normalize_gmi_maas_base_url_strips_v1_trailing_slash() {
+    assert_eq!(
+        normalize_gmi_maas_base_url("https://api.gmi-serving.com/v1/"),
+        "https://api.gmi-serving.com/v1"
     );
 }

--- a/src/openhuman/agentbox/status.rs
+++ b/src/openhuman/agentbox/status.rs
@@ -98,7 +98,7 @@ mod tests {
             assert!(status.provider_configured);
             let provider = status.provider.expect("provider populated");
             assert_eq!(provider.slug, GMI_MAAS_SLUG);
-            assert_eq!(provider.base_url, "https://api.gmi-serving.com");
+            assert_eq!(provider.base_url, "https://api.gmi-serving.com/v1");
             assert_eq!(provider.model, "deepseek-ai/DeepSeek-V4-Pro");
 
             // Defense-in-depth: the serialized status must never carry the key.


### PR DESCRIPTION
## Summary

- Normalize `GMI_MAAS_BASE_URL` in AgentBox marketplace registration so the provider endpoint always ends with exactly one `/v1`.
- Fixes marketplace inference 404 (`…/chat/completions` → `…/v1/chat/completions`) without changing AgentBox’s env-injection contract.
- Update GMI settings key placeholder to a JWT-shaped hint (`eyJ....`) and cover GMI in the builtin provider endpoint/auth test.
- Add focused Rust normalize unit tests (trailing slash, existing `/v1`, `/v1/`).

## Problem

- AgentBox injects `GMI_MAAS_BASE_URL` without `/v1` by contract (e.g. `https://api.gmi-serving.com`).
- The OpenAI-compatible client appends only `/chat/completions`, so marketplace requests hit `POST …/chat/completions` and return **404**.
- The valid OpenAI-compatible path is `POST …/v1/chat/completions`. Builtin UI GMI endpoint already includes `/v1`; only the marketplace env registration path was missing normalization.
- Reviewers should confirm we never double-append `/v1` and that existing trimmed/whitespace env values still resolve correctly.

## Solution

- Add `normalize_gmi_maas_base_url`: trim → strip trailing `/` → strip a terminal `/v1` if present → append exactly one `/v1`.
- Apply normalization in `collect_gmi_config` before the value is written to `cloud_providers.endpoint`, so all downstream registration uses the fixed base URL.
- Keep AgentBox env injection unchanged; fix on the OpenHuman consumer side (scoped, reversible, no platform contract change).
- UI/test polish only for GMI placeholder + parameterized provider mapping; pricing/branding remain out of scope.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/ci-lite.yml`](../.github/workflows/ci-lite.yml). Focused tests cover the changed lines (`cargo test --lib agentbox::env`, Vitest `builtinCloudProviders`); full `pnpm test:coverage` / `pnpm test:rust` + diff-cover ≥ 80% enforced by CI.
- [x] N/A: Coverage matrix — behaviour-only URL normalization + existing provider panel tests; no new/removed/renamed feature rows in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] N/A: Affected feature IDs — no matrix feature IDs for this behaviour-only change.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: Manual smoke checklist — does not change release-cut smoke surfaces; optional live MaaS smoke documented under Validation.
- [x] N/A: Linked issue — no public GitHub issue number; tracked internally as GMI Cloud EC-280.

## Impact

- Runtime/platform: marketplace / AgentBox mode inference only; desktop/UI GMI builtin path already used `/v1`.
- Performance: none (one-time string normalize at provider registration).
- Security: no secrets logged; placeholder remains non-credential JWT-shaped text.
- Migration/compat: URLs already ending in `/v1` or `/v1/` stay correct; no config file migration required.

## Related

- Closes: N/A (no GitHub issue). Internal tracker: GMI Cloud **EC-280** (TinyHuman × GMI — marketplace MaaS `/v1` fix).
- Follow-up PR(s)/TODOs: GMI cost catalog / `PRICING_AS_OF`; optional branding “GMI” → “GMI Cloud”; AgentBox sandbox backend after Runtime 2.0 GA.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/gmi-maas-base-url-v1`
- Commit SHA: `f7d38395e6726a59c5f61d9c2f63a2b0aa5fb242`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — passed locally (Prettier + `cargo fmt --check` for main + src-tauri)
- [x] `pnpm typecheck` — passed locally (`tsc --noEmit`)
- [x] Focused tests:
  - `cargo test --lib agentbox::env` → 9 passed
  - Vitest `builtinCloudProviders.test.ts` → 8 passed
- [x] Rust fmt/check (if changed): passed locally (`cargo fmt --all -- --check`; also covered by format:check). `cargo check -p openhuman --lib` passed.
- [x] N/A: Tauri fmt/check — no src-tauri / Tauri shell changes; format:check still ran `cargo fmt` on src-tauri and passed.

### Validation Blocked

- `command:` N/A — format/typecheck/rustfmt/cargo check ran locally; full coverage suite left to CI
- `error:` N/A
- `impact:` CI `ci-lite.yml` must still confirm merged diff-cover ≥ 80%

### Behavior Changes

- Intended behavior change: marketplace-registered GMI MaaS base URL always ends with exactly one `/v1` before chat completions are requested.
- User-visible effect: marketplace AgentBox inference stops 404ing on chat completions when AgentBox injects a non-`/v1` base URL; settings GMI key field shows JWT-shaped placeholder.

### Parity Contract

- Legacy behavior preserved: UI builtin GMI endpoint already `/v1`; desktop non-AgentBox paths unchanged.
- Guard/fallback/dispatch parity checks: idempotent normalize (with or without trailing `/` / existing `/v1`); missing env vars still skip registration as before.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A
