### PR TITLE
fix(flows): live-refresh the runs rail when a run starts (B35)

### DIFF
--- a/app/src/components/flows/FlowRunsDrawer.tsx
+++ b/app/src/components/flows/FlowRunsDrawer.tsx
@@ -84,6 +84,13 @@ export function FlowRunsDrawer({ flowId, flowName, onClose, onFixWithAgent }: Pr
   // it's stale once the drawer flips to a new flowId and bail instead of
   // clobbering the new flow's already-loaded runs.
   const currentFlowIdRef = useRef(flowId);
+  // Per-request generation counter, shared by the initial load effect and
+  // `refetch` below: a request started before a run-started event (or before
+  // a newer refetch) can resolve AFTER it and, without this guard, clobber a
+  // fresh "Running" row with stale data — even for the SAME flowId, where the
+  // `currentFlowIdRef` check alone can't tell requests apart. Only the
+  // most-recently-issued request for the current flow may apply its result.
+  const requestGenRef = useRef(0);
 
   useEffect(() => {
     currentFlowIdRef.current = flowId;
@@ -100,16 +107,17 @@ export function FlowRunsDrawer({ flowId, flowName, onClose, onFixWithAgent }: Pr
     }
 
     let cancelled = false;
+    const requestGen = ++requestGenRef.current;
     setLoading(true);
     log('loading runs: flowId=%s', flowId);
     listFlowRuns(flowId)
       .then(result => {
-        if (cancelled) return;
+        if (cancelled || requestGen !== requestGenRef.current) return;
         setRuns(result);
         log('loaded runs: flowId=%s count=%d', flowId, result.length);
       })
       .catch(err => {
-        if (cancelled) return;
+        if (cancelled || requestGen !== requestGenRef.current) return;
         const msg = err instanceof Error ? err.message : String(err);
         log('load failed: flowId=%s err=%s', flowId, msg);
         setError(msg);
@@ -126,21 +134,28 @@ export function FlowRunsDrawer({ flowId, flowName, onClose, onFixWithAgent }: Pr
   // Background refresh for the live-update hook below — deliberately doesn't
   // touch `loading`/`error` so a poll tick or progress event never flashes
   // the loading state or clobbers a real load error with a transient one.
-  // Guards against a stale response: if the drawer flips from flow A to flow
-  // B while an A refetch is still in flight, the late A response must not
-  // overwrite B's already-loaded runs (mirrors the `cancelled` guard on the
-  // main load effect above).
+  // Guards against a stale response two ways: if the drawer flips from flow A
+  // to flow B while an A refetch is still in flight, the late A response must
+  // not overwrite B's already-loaded runs (`currentFlowIdRef`); and if two
+  // requests for the SAME flow race (e.g. the initial load and an
+  // event-driven refetch, or two refetches back to back), only the response
+  // to the most-recently-issued one may apply (`requestGenRef`).
   const refetch = useCallback(() => {
     if (!flowId) return;
     const requestFlowId = flowId;
+    const requestGen = ++requestGenRef.current;
     listFlowRuns(requestFlowId)
       .then(result => {
-        if (currentFlowIdRef.current !== requestFlowId) return;
+        if (currentFlowIdRef.current !== requestFlowId || requestGen !== requestGenRef.current) {
+          return;
+        }
         setRuns(result);
         log('refetched runs: flowId=%s count=%d', requestFlowId, result.length);
       })
       .catch(err => {
-        if (currentFlowIdRef.current !== requestFlowId) return;
+        if (currentFlowIdRef.current !== requestFlowId || requestGen !== requestGenRef.current) {
+          return;
+        }
         const msg = err instanceof Error ? err.message : String(err);
         log('refetch failed: flowId=%s err=%s', requestFlowId, msg);
       });

--- a/app/src/components/flows/FlowRunsDrawer.tsx
+++ b/app/src/components/flows/FlowRunsDrawer.tsx
@@ -29,6 +29,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useEscapeKey } from '../../hooks/useEscapeKey';
 import { useFlowRunsLiveRefresh } from '../../hooks/useFlowRunsLiveRefresh';
+import { useFlowRunStarted } from '../../hooks/useFlowRunStarted';
 import {
   resolveDisplayStatus,
   useRunsPendingApprovalSet,
@@ -146,6 +147,11 @@ export function FlowRunsDrawer({ flowId, flowName, onClose, onFixWithAgent }: Pr
   }, [flowId]);
 
   useFlowRunsLiveRefresh(runs, refetch);
+  // Unconditional (unlike useFlowRunsLiveRefresh, which is gated on an
+  // already-active run) — fills the empty-list gap ("No runs yet") that hook
+  // can't reach, so the very first run shows up as "Running" instantly
+  // instead of waiting for a manual refresh (issue B35).
+  useFlowRunStarted(() => void refetch(), flowId);
   const pendingRunIds = useRunsPendingApprovalSet(runs);
 
   useEscapeKey(

--- a/app/src/components/flows/FlowRunsSidebar.test.tsx
+++ b/app/src/components/flows/FlowRunsSidebar.test.tsx
@@ -24,6 +24,18 @@ vi.mock('../../services/api/flowsApi', () => ({ listFlowRuns }));
 const fetchPendingApprovals = vi.hoisted(() => vi.fn());
 vi.mock('../../services/api/approvalApi', () => ({ fetchPendingApprovals }));
 
+// Stub the run-started hook (issue B35) so tests can trigger its `onStart`
+// callback directly, without standing up a real socket subscription — its own
+// match/filter/teardown behavior is covered by useFlowRunStarted.test.ts.
+const flowRunStartedCalls = vi.hoisted(
+  () => [] as Array<{ onStart: () => void; flowId?: string | null }>
+);
+vi.mock('../../hooks/useFlowRunStarted', () => ({
+  useFlowRunStarted: (onStart: () => void, flowId?: string | null) => {
+    flowRunStartedCalls.push({ onStart, flowId });
+  },
+}));
+
 // Capture the props handed to the drawer so "Fix with agent" can be invoked
 // directly without standing up the drawer's own run-polling machinery
 // (mirrors `FlowApprovalCard.test.tsx`'s stub pattern).
@@ -100,6 +112,7 @@ describe('FlowRunsSidebar', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     inspectorDrawerProps.current = null;
+    flowRunStartedCalls.length = 0;
     fetchPendingApprovals.mockResolvedValue([]);
   });
 
@@ -211,5 +224,40 @@ describe('FlowRunsSidebar', () => {
 
     const runRow = await screen.findByTestId('flow-runs-sidebar-run-run-1');
     await waitFor(() => expect(runRow).toHaveTextContent('Running'));
+  });
+
+  it('registers useFlowRunStarted scoped to this flow and refetches when it fires (B35)', async () => {
+    listFlowRuns.mockResolvedValue([]);
+    renderSidebar('flow-1');
+
+    await screen.findByTestId('flow-runs-sidebar-empty');
+    // The hook is called (with the same args) on every render — assert the
+    // most recent registration is scoped to this flow.
+    const latestCall = flowRunStartedCalls.at(-1);
+    expect(latestCall?.flowId).toBe('flow-1');
+    expect(listFlowRuns).toHaveBeenCalledTimes(1);
+
+    listFlowRuns.mockResolvedValue([makeRun({ status: 'running' })]);
+    act(() => {
+      latestCall?.onStart();
+    });
+
+    await waitFor(() => expect(listFlowRuns.mock.calls.length).toBeGreaterThanOrEqual(2));
+    expect(await screen.findByTestId('flow-runs-sidebar-run-run-1')).toHaveTextContent('Running');
+    expect(screen.queryByTestId('flow-runs-sidebar-empty')).not.toBeInTheDocument();
+  });
+
+  it('shows runs once a run starts even though the list began empty (B35)', async () => {
+    listFlowRuns.mockResolvedValue([]);
+    renderSidebar();
+
+    expect(await screen.findByTestId('flow-runs-sidebar-empty')).toBeInTheDocument();
+
+    listFlowRuns.mockResolvedValue([makeRun({ status: 'running' })]);
+    act(() => {
+      flowRunStartedCalls.at(-1)?.onStart();
+    });
+
+    expect(await screen.findByTestId('flow-runs-sidebar-run-run-1')).toBeInTheDocument();
   });
 });

--- a/app/src/components/flows/FlowRunsSidebar.tsx
+++ b/app/src/components/flows/FlowRunsSidebar.tsx
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useFlowRunsLiveRefresh } from '../../hooks/useFlowRunsLiveRefresh';
+import { useFlowRunStarted } from '../../hooks/useFlowRunStarted';
 import {
   resolveDisplayStatus,
   useRunsPendingApprovalSet,
@@ -105,6 +106,14 @@ export default function FlowRunsSidebar({ flowId }: FlowRunsSidebarProps) {
   }, [load]);
 
   useFlowRunsLiveRefresh(runs, load);
+  // Unconditional (unlike useFlowRunsLiveRefresh, which is gated on an
+  // already-active run) — fills the empty-list gap ("No runs yet") that
+  // hook can't reach, so the very first run shows up as "Running" instantly
+  // instead of waiting for a manual refresh (issue B35).
+  useFlowRunStarted(() => {
+    log('run-started: refetch flow=%s', flowId);
+    void load();
+  }, flowId);
   const pendingRunIds = useRunsPendingApprovalSet(runs);
 
   return (

--- a/app/src/components/flows/FlowRunsSidebar.tsx
+++ b/app/src/components/flows/FlowRunsSidebar.tsx
@@ -11,7 +11,7 @@
  * appears for a persisted flow (a draft has no runs yet).
  */
 import createDebug from 'debug';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { useFlowRunsLiveRefresh } from '../../hooks/useFlowRunsLiveRefresh';
@@ -85,12 +85,23 @@ export default function FlowRunsSidebar({ flowId }: FlowRunsSidebarProps) {
     [navigate]
   );
 
+  // Per-request generation counter: a `load()` started before a run-started
+  // event (see `useFlowRunStarted` below) can resolve AFTER the event-driven
+  // refetch and, without this guard, clobber the fresh "Running" row with
+  // stale data. Only the most recently-issued request may apply its result.
+  const requestGenRef = useRef(0);
+
   const load = useCallback(async () => {
     log('loading runs for flow=%s', flowId);
+    const requestGen = ++requestGenRef.current;
     setLoading(true);
     setError(null);
     try {
       const result = await listFlowRuns(flowId);
+      if (requestGen !== requestGenRef.current) {
+        log('load: dropped stale response for flow=%s', flowId);
+        return;
+      }
       setRuns(result);
       log('loaded %d runs', result.length);
     } catch (err) {

--- a/app/src/hooks/__tests__/useFlowRunStarted.test.ts
+++ b/app/src/hooks/__tests__/useFlowRunStarted.test.ts
@@ -1,0 +1,103 @@
+/**
+ * useFlowRunStarted — unit tests (issue B35).
+ *
+ * Verifies: subscribes to both socket event aliases unconditionally on mount,
+ * invokes `onStart` for a matching payload, filters by `flowId` when
+ * provided, passes every event through when `flowId` is omitted, drops
+ * invalid payloads, and tears down both subscriptions on unmount.
+ */
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useFlowRunStarted } from '../useFlowRunStarted';
+
+const handlers = vi.hoisted(() => new Map<string, Set<(data: unknown) => void>>());
+const on = vi.hoisted(() =>
+  vi.fn((event: string, cb: (data: unknown) => void) => {
+    const set = handlers.get(event) ?? new Set();
+    set.add(cb);
+    handlers.set(event, set);
+  })
+);
+const off = vi.hoisted(() =>
+  vi.fn((event: string, cb: (data: unknown) => void) => {
+    handlers.get(event)?.delete(cb);
+  })
+);
+vi.mock('../../services/socketService', () => ({ socketService: { on, off } }));
+
+function emit(event: 'flow:run_started' | 'flow_run_started', payload: unknown) {
+  act(() => {
+    for (const cb of handlers.get(event) ?? []) cb(payload);
+  });
+}
+
+describe('useFlowRunStarted', () => {
+  beforeEach(() => {
+    handlers.clear();
+    on.mockClear();
+    off.mockClear();
+  });
+
+  it('subscribes to both event aliases unconditionally on mount', () => {
+    renderHook(() => useFlowRunStarted(vi.fn()));
+
+    expect(on).toHaveBeenCalledWith('flow:run_started', expect.any(Function));
+    expect(on).toHaveBeenCalledWith('flow_run_started', expect.any(Function));
+  });
+
+  it('invokes onStart for a matching payload on either alias', () => {
+    const onStart = vi.fn();
+    renderHook(() => useFlowRunStarted(onStart));
+
+    emit('flow:run_started', { flow_id: 'flow-1', run_id: 'run-1' });
+    expect(onStart).toHaveBeenCalledWith({ flow_id: 'flow-1', run_id: 'run-1' });
+
+    emit('flow_run_started', { flow_id: 'flow-2', run_id: 'run-2' });
+    expect(onStart).toHaveBeenCalledWith({ flow_id: 'flow-2', run_id: 'run-2' });
+    expect(onStart).toHaveBeenCalledTimes(2);
+  });
+
+  it('filters to the given flowId when provided', () => {
+    const onStart = vi.fn();
+    renderHook(() => useFlowRunStarted(onStart, 'flow-1'));
+
+    emit('flow:run_started', { flow_id: 'flow-2', run_id: 'run-1' });
+    expect(onStart).not.toHaveBeenCalled();
+
+    emit('flow:run_started', { flow_id: 'flow-1', run_id: 'run-2' });
+    expect(onStart).toHaveBeenCalledWith({ flow_id: 'flow-1', run_id: 'run-2' });
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes every event through when flowId is omitted', () => {
+    const onStart = vi.fn();
+    renderHook(() => useFlowRunStarted(onStart));
+
+    emit('flow:run_started', { flow_id: 'flow-1', run_id: 'run-1' });
+    emit('flow:run_started', { flow_id: 'flow-2', run_id: 'run-2' });
+
+    expect(onStart).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops invalid payloads without invoking onStart', () => {
+    const onStart = vi.fn();
+    renderHook(() => useFlowRunStarted(onStart));
+
+    emit('flow:run_started', null);
+    emit('flow:run_started', {});
+    emit('flow:run_started', { flow_id: 123, run_id: 'run-1' });
+    emit('flow:run_started', { flow_id: 'flow-1', run_id: 456 });
+
+    expect(onStart).not.toHaveBeenCalled();
+  });
+
+  it('cleans up both subscriptions on unmount', () => {
+    const { unmount } = renderHook(() => useFlowRunStarted(vi.fn()));
+
+    unmount();
+
+    expect(off).toHaveBeenCalledWith('flow:run_started', expect.any(Function));
+    expect(off).toHaveBeenCalledWith('flow_run_started', expect.any(Function));
+  });
+});

--- a/app/src/hooks/__tests__/useFlowRunStarted.test.ts
+++ b/app/src/hooks/__tests__/useFlowRunStarted.test.ts
@@ -58,6 +58,24 @@ describe('useFlowRunStarted', () => {
     expect(onStart).toHaveBeenCalledTimes(2);
   });
 
+  it('dedupes the colon and underscore aliases of the same run so onStart fires once', () => {
+    // The core bridge re-emits one `FlowRunStarted` event under both socket
+    // aliases with identical payloads — assert the hook collapses them.
+    const onStart = vi.fn();
+    renderHook(() => useFlowRunStarted(onStart));
+
+    const payload = { flow_id: 'flow-1', run_id: 'run-1' };
+    emit('flow:run_started', payload);
+    emit('flow_run_started', payload);
+
+    expect(onStart).toHaveBeenCalledTimes(1);
+    expect(onStart).toHaveBeenCalledWith({ flow_id: 'flow-1', run_id: 'run-1' });
+
+    // A genuinely different run still gets through.
+    emit('flow:run_started', { flow_id: 'flow-1', run_id: 'run-2' });
+    expect(onStart).toHaveBeenCalledTimes(2);
+  });
+
   it('filters to the given flowId when provided', () => {
     const onStart = vi.fn();
     renderHook(() => useFlowRunStarted(onStart, 'flow-1'));

--- a/app/src/hooks/useFlowRunStarted.ts
+++ b/app/src/hooks/useFlowRunStarted.ts
@@ -1,0 +1,80 @@
+/**
+ * useFlowRunStarted (issue B35 — runs-rail live refresh)
+ * -------------------------------------------------------
+ *
+ * Subscribes to the core's run-start feed so an open Workflows sidebar/drawer
+ * shows a just-started run as "Running" immediately, instead of waiting on a
+ * manual refresh or a navigate-away-and-back. `flows_run` is a blocking RPC
+ * (up to 610s), so the caller awaiting it can't be the signal — this hook
+ * lets the UI learn a run began the moment the `flow_runs` row is persisted,
+ * well before the RPC resolves or the first `FlowRunProgress` step lands.
+ *
+ * The backend publishes `DomainEvent::FlowRunStarted` right after
+ * `flows::ops::start_flow_run_row` returns; the core socket bridge
+ * (`src/core/socketio.rs`) re-emits it as both `flow:run_started` and
+ * `flow_run_started` (colon + underscore aliases) with the payload
+ * `{ flow_id, run_id }`.
+ *
+ * Unlike {@link useFlowRunsLiveRefresh}, this hook subscribes unconditionally
+ * (not gated on an already-active run) — that's the whole point: it fills the
+ * gap where the runs list is empty ("No runs yet") and so has no active run to
+ * gate on. Pass `flowId` to filter to a single flow (canvas/sidebar/drawer),
+ * or omit it to receive every run start (the flow-agnostic runs page).
+ */
+import debug from 'debug';
+import { useCallback, useEffect } from 'react';
+
+import { socketService } from '../services/socketService';
+
+const log = debug('flows:run-started');
+
+/** Socket event aliases the core bridge emits (colon + underscore forms). */
+const EVENT_COLON = 'flow:run_started';
+const EVENT_UNDERSCORE = 'flow_run_started';
+
+/** Payload of a `flow:run_started` socket event (`DomainEvent::FlowRunStarted`). */
+export interface FlowRunStartedEvent {
+  flow_id: string;
+  run_id: string;
+}
+
+function parsePayload(data: unknown): FlowRunStartedEvent | null {
+  if (!data || typeof data !== 'object') return null;
+  const obj = data as Record<string, unknown>;
+  if (typeof obj.flow_id !== 'string' || typeof obj.run_id !== 'string') return null;
+  return { flow_id: obj.flow_id, run_id: obj.run_id };
+}
+
+/**
+ * Invokes `onStart` whenever a run starts. When `flowId` is provided, only
+ * starts for that flow are delivered; otherwise every start is.
+ */
+export function useFlowRunStarted(
+  onStart: (event: FlowRunStartedEvent) => void,
+  flowId?: string | null
+): void {
+  const handle = useCallback(
+    (data: unknown) => {
+      const payload = parsePayload(data);
+      if (!payload) {
+        log('run-started: dropped — invalid payload %o', data);
+        return;
+      }
+      if (flowId && payload.flow_id !== flowId) return;
+      log('run-started: flow=%s run=%s', payload.flow_id, payload.run_id);
+      onStart(payload);
+    },
+    [onStart, flowId]
+  );
+
+  useEffect(() => {
+    socketService.on(EVENT_COLON, handle);
+    socketService.on(EVENT_UNDERSCORE, handle);
+    return () => {
+      socketService.off(EVENT_COLON, handle);
+      socketService.off(EVENT_UNDERSCORE, handle);
+    };
+  }, [handle]);
+}
+
+export default useFlowRunStarted;

--- a/app/src/hooks/useFlowRunStarted.ts
+++ b/app/src/hooks/useFlowRunStarted.ts
@@ -20,9 +20,15 @@
  * gap where the runs list is empty ("No runs yet") and so has no active run to
  * gate on. Pass `flowId` to filter to a single flow (canvas/sidebar/drawer),
  * or omit it to receive every run start (the flow-agnostic runs page).
+ *
+ * Because the core bridge re-emits the same `FlowRunStarted` event under both
+ * aliases, this hook subscribes to both sockets above but de-dupes by
+ * `${flow_id}:${run_id}` (unique per run) so `onStart` fires exactly once per
+ * run — a bounded set of recently-delivered keys (oldest evicted first) is
+ * kept per hook instance, sized well past any plausible in-flight burst.
  */
 import debug from 'debug';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { socketService } from '../services/socketService';
 
@@ -31,6 +37,9 @@ const log = debug('flows:run-started');
 /** Socket event aliases the core bridge emits (colon + underscore forms). */
 const EVENT_COLON = 'flow:run_started';
 const EVENT_UNDERSCORE = 'flow_run_started';
+
+/** Bound on the recently-delivered dedup set — oldest key evicted past this. */
+const DEDUP_CACHE_SIZE = 50;
 
 /** Payload of a `flow:run_started` socket event (`DomainEvent::FlowRunStarted`). */
 export interface FlowRunStartedEvent {
@@ -53,14 +62,39 @@ export function useFlowRunStarted(
   onStart: (event: FlowRunStartedEvent) => void,
   flowId?: string | null
 ): void {
+  // Recently-delivered `${flow_id}:${run_id}` keys, so the colon and
+  // underscore aliases of the same event only invoke `onStart` once. A `Set`
+  // preserves insertion order, so eviction just drops its first entry.
+  const deliveredRef = useRef<Set<string>>(new Set());
+
   const handle = useCallback(
     (data: unknown) => {
       const payload = parsePayload(data);
       if (!payload) {
-        log('run-started: dropped — invalid payload %o', data);
+        // Never log the raw payload — it may carry PII/secrets. Safe metadata
+        // only: the runtime type and, if it's an object, its key names.
+        const keys = data && typeof data === 'object' ? Object.keys(data as object) : [];
+        log('run-started: dropped — invalid payload (type=%s keys=%o)', typeof data, keys);
         return;
       }
       if (flowId && payload.flow_id !== flowId) return;
+
+      const key = `${payload.flow_id}:${payload.run_id}`;
+      const delivered = deliveredRef.current;
+      if (delivered.has(key)) {
+        log(
+          'run-started: dedup skip (alias replay) flow=%s run=%s',
+          payload.flow_id,
+          payload.run_id
+        );
+        return;
+      }
+      delivered.add(key);
+      if (delivered.size > DEDUP_CACHE_SIZE) {
+        const oldest = delivered.values().next().value;
+        if (oldest !== undefined) delivered.delete(oldest);
+      }
+
       log('run-started: flow=%s run=%s', payload.flow_id, payload.run_id);
       onStart(payload);
     },

--- a/app/src/pages/WorkflowRunsPage.tsx
+++ b/app/src/pages/WorkflowRunsPage.tsx
@@ -7,7 +7,7 @@
  * so a run doesn't sit on "Running" until the user reloads the page.
  */
 import debug from 'debug';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import PanelPage from '../components/layout/PanelPage';
@@ -46,11 +46,20 @@ export default function WorkflowRunsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Per-request generation counter: a `load()` started before a run-started
+  // event (see `useFlowRunStarted` below) can resolve AFTER the event-driven
+  // `refetchRuns` and, without this guard, clobber the fresh "Running" row
+  // with stale data. Only the most-recently-issued request may apply its
+  // result — shared between `load` and `refetchRuns` below.
+  const requestGenRef = useRef(0);
+
   const load = useCallback(async () => {
+    const requestGen = ++requestGenRef.current;
     setLoading(true);
     setError(null);
     try {
       const [allRuns, flows] = await Promise.all([listAllFlowRuns(), listFlows()]);
+      if (requestGen !== requestGenRef.current) return;
       const names: Record<string, string> = {};
       flows.forEach((f: Flow) => {
         names[f.id] = f.name;
@@ -58,6 +67,7 @@ export default function WorkflowRunsPage() {
       setRuns(allRuns);
       setFlowNames(names);
     } catch (err) {
+      if (requestGen !== requestGenRef.current) return;
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setLoading(false);
@@ -72,8 +82,12 @@ export default function WorkflowRunsPage() {
   // too), since flow names rarely change mid-run and re-fetching them on
   // every live-refresh tick would be wasted work.
   const refetchRuns = useCallback(() => {
+    const requestGen = ++requestGenRef.current;
     listAllFlowRuns()
-      .then(setRuns)
+      .then(result => {
+        if (requestGen !== requestGenRef.current) return;
+        setRuns(result);
+      })
       .catch(err => {
         // Best-effort background refresh — a transient failure here shouldn't
         // clobber the page's existing error/loading state from `load`.

--- a/app/src/pages/WorkflowRunsPage.tsx
+++ b/app/src/pages/WorkflowRunsPage.tsx
@@ -13,6 +13,7 @@ import { useNavigate } from 'react-router-dom';
 import PanelPage from '../components/layout/PanelPage';
 import { CenteredLoadingState, ErrorBanner } from '../components/ui/LoadingState';
 import { useFlowRunsLiveRefresh } from '../hooks/useFlowRunsLiveRefresh';
+import { useFlowRunStarted } from '../hooks/useFlowRunStarted';
 import {
   resolveDisplayStatus,
   useRunsPendingApprovalSet,
@@ -81,6 +82,12 @@ export default function WorkflowRunsPage() {
   }, []);
 
   useFlowRunsLiveRefresh(runs, refetchRuns);
+  // Unconditional (unlike useFlowRunsLiveRefresh, which is gated on an
+  // already-active run) — fills the empty-list gap ("No runs yet") that hook
+  // can't reach, so the very first run across any flow shows up as "Running"
+  // instantly instead of waiting for a manual refresh (issue B35). No
+  // `flowId` filter — this is the flow-agnostic "all runs" page.
+  useFlowRunStarted(() => void refetchRuns());
   const pendingRunIds = useRunsPendingApprovalSet(runs);
 
   const statusLabel = (status: FlowRunStatus) =>

--- a/src/core/event_bus/events.rs
+++ b/src/core/event_bus/events.rs
@@ -463,6 +463,21 @@ pub enum DomainEvent {
         status: String,
     },
 
+    /// A `flows_run` (or `flows_resume`) invocation just persisted its
+    /// `flow_runs` row, before execution begins (issue B35, runs-rail live
+    /// refresh). Published from `flows::ops::flows_run` right after
+    /// `start_flow_run_row` returns, so the UI can show "Running" immediately
+    /// instead of waiting for the blocking RPC to resolve or the first
+    /// `FlowRunProgress` step. Covers every run source (Rpc/Schedule/AppEvent/
+    /// Resume, incl. copilot live-run) since they all funnel through
+    /// `start_flow_run_row`.
+    FlowRunStarted {
+        /// The affected flow's id.
+        flow_id: String,
+        /// The run's stable identifier (== the tinyflows checkpointer thread id).
+        run_id: String,
+    },
+
     /// A saved flow's definition changed (created / updated / deleted /
     /// enable-toggled). Bridged to a `flow:changed` socket event so an open
     /// Workflows list or canvas refetches instead of silently showing stale
@@ -1397,6 +1412,7 @@ impl DomainEvent {
             | Self::ProactiveMessageRequested { .. }
             | Self::FlowScheduleTick { .. }
             | Self::FlowRunProgress { .. }
+            | Self::FlowRunStarted { .. }
             | Self::FlowChanged { .. } => "cron",
 
             Self::WorkflowLoaded { .. }
@@ -1561,6 +1577,7 @@ impl DomainEvent {
             Self::ProactiveMessageRequested { .. } => "ProactiveMessageRequested",
             Self::FlowScheduleTick { .. } => "FlowScheduleTick",
             Self::FlowRunProgress { .. } => "FlowRunProgress",
+            Self::FlowRunStarted { .. } => "FlowRunStarted",
             Self::FlowChanged { .. } => "FlowChanged",
             Self::WorkflowLoaded { .. } => "WorkflowLoaded",
             Self::WorkflowStopped { .. } => "WorkflowStopped",

--- a/src/core/socketio.rs
+++ b/src/core/socketio.rs
@@ -1087,6 +1087,25 @@ pub fn spawn_web_channel_bridge(io: SocketIo) {
                     let _ = io_memory_sync.emit("flow:run_progress", &payload);
                     let _ = io_memory_sync.emit("flow_run_progress", &payload);
                 }
+                // A `flow_runs` row was just persisted, before execution begins
+                // (issue B35, runs-rail live refresh). Broadcast so an open
+                // Workflows canvas/sidebar can show "Running" immediately
+                // instead of waiting for the blocking `flows_run` RPC to
+                // resolve or the first `FlowRunProgress` step. Best-effort,
+                // same rationale as `flow:run_progress` above.
+                crate::core::event_bus::DomainEvent::FlowRunStarted { flow_id, run_id } => {
+                    let payload = serde_json::json!({
+                        "flow_id": flow_id,
+                        "run_id": run_id,
+                    });
+                    log::debug!(
+                        "[socketio] broadcast flow_run_started flow_id={} run_id={}",
+                        flow_id,
+                        run_id
+                    );
+                    let _ = io_memory_sync.emit("flow:run_started", &payload);
+                    let _ = io_memory_sync.emit("flow_run_started", &payload);
+                }
                 // A saved flow's definition changed (create/update/delete/
                 // enable). Broadcast so an open Workflows list/canvas refetches
                 // — most importantly, so an agent `save_workflow` becomes

--- a/src/openhuman/flows/ops.rs
+++ b/src/openhuman/flows/ops.rs
@@ -3122,6 +3122,17 @@ pub async fn flows_run(
 
     start_flow_run_row(config, &thread_id, flow_id);
 
+    tracing::debug!(
+        target: "flows",
+        flow_id = %flow_id,
+        run_id = %thread_id,
+        "[flows] flows_run: publishing FlowRunStarted"
+    );
+    crate::core::event_bus::publish_global(crate::core::event_bus::DomainEvent::FlowRunStarted {
+        flow_id: flow_id.to_string(),
+        run_id: thread_id.clone(),
+    });
+
     // Register this run as in-flight (issue G4) so a concurrent
     // `flows_cancel_run` can signal it to abort. The guard deregisters on any
     // exit from this fn (including the early returns below).

--- a/src/openhuman/flows/ops_tests.rs
+++ b/src/openhuman/flows/ops_tests.rs
@@ -1407,6 +1407,83 @@ async fn flows_run_does_not_notify_when_run_completes_without_pending_approvals(
     );
 }
 
+/// Issue B35 (runs-rail live refresh): `flows_run` must publish
+/// `DomainEvent::FlowRunStarted` right after the run row is persisted, with
+/// the flow id and the run's thread id, so the socket bridge can tell an open
+/// Workflows sidebar/drawer to refetch and show "Running" immediately instead
+/// of waiting for the (up to 610s) blocking RPC to resolve.
+#[tokio::test]
+async fn flows_run_publishes_flow_run_started_with_flow_and_run_id() {
+    use crate::core::event_bus::{
+        init_global, subscribe_global, DomainEvent, EventHandler, DEFAULT_CAPACITY,
+    };
+    use async_trait::async_trait;
+    use std::sync::Mutex as StdMutex;
+
+    #[derive(Default)]
+    struct Collector {
+        events: Arc<StdMutex<Vec<(String, String)>>>,
+    }
+
+    #[async_trait]
+    impl EventHandler for Collector {
+        fn name(&self) -> &str {
+            "test::flows::ops::flow_run_started_collector"
+        }
+        fn domains(&self) -> Option<&[&str]> {
+            Some(&["cron"])
+        }
+        async fn handle(&self, event: &DomainEvent) {
+            if let DomainEvent::FlowRunStarted { flow_id, run_id } = event {
+                self.events
+                    .lock()
+                    .unwrap()
+                    .push((flow_id.clone(), run_id.clone()));
+            }
+        }
+    }
+
+    init_global(DEFAULT_CAPACITY);
+    let events: Arc<StdMutex<Vec<(String, String)>>> = Arc::new(StdMutex::new(Vec::new()));
+    let collector = Arc::new(Collector {
+        events: Arc::clone(&events),
+    });
+    let _handle = subscribe_global(collector).expect("bus subscriber installed");
+
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+    let created = flows_create(
+        &config,
+        "b35-run-started".to_string(),
+        trigger_only_graph(),
+        false,
+    )
+    .await
+    .unwrap();
+
+    let run = flows_run(&config, &created.value.id, json!({}), FlowRunTrigger::Rpc)
+        .await
+        .unwrap();
+    let thread_id = run.value["thread_id"].as_str().unwrap().to_string();
+
+    // The bus is process-global and shared with concurrently-running tests,
+    // so filter for our own flow id rather than asserting on total count.
+    let mut found = None;
+    for _ in 0..20 {
+        {
+            let guard = events.lock().unwrap();
+            if let Some(entry) = guard.iter().find(|(fid, _)| *fid == created.value.id) {
+                found = Some(entry.clone());
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    let (flow_id, run_id) = found.expect("expected a FlowRunStarted event for this flow");
+    assert_eq!(flow_id, created.value.id);
+    assert_eq!(run_id, thread_id);
+}
+
 // ── Live run observation (issue G2) ───────────────────────────────────────
 
 use crate::openhuman::tinyflows::observability::FlowRunObserver;


### PR DESCRIPTION
## What & why (bug B35)

On the Flow Canvas, the left **RUNS** rail didn't update when a run started — hitting **Run** (▶), or a run kicked off by a schedule / Composio event / resume / the copilot live-run, did **not** appear in the rail. It stayed on **"No runs yet"** until a manual ⟳ refresh or a navigate-away-and-back.

**Root cause:** `useFlowRunsLiveRefresh` only subscribes/polls when the list *already* has a non-terminal run (`hasActive`) — so from an empty list it's dormant. And `flows_run` is a blocking RPC that emits no "run started" event, so nothing tells the rail a new run began.

## Fix

New **`DomainEvent::FlowRunStarted { flow_id, run_id }`**, published right after the run row is persisted in `flows_run` (`start_flow_run_row`) — so it fires for **every** run source (Run button / schedule / Composio / resume / copilot). Bridged to Socket.IO as `flow:run_started` (+ `flow_run_started` alias), mirroring the existing `FlowChanged`/`FlowRunProgress` pattern.

New **`useFlowRunStarted`** hook (copies `useFlowChanged`); `FlowRunsSidebar` / `FlowRunsDrawer` / `WorkflowRunsPage` subscribe **unconditionally** → the "Running" row appears instantly, then `useFlowRunsLiveRefresh` naturally takes over for step/status updates to completion.

## Changes
- **Rust:** `event_bus/events.rs` (variant + `domain()` + display name), `flows/ops.rs` (emit after persist + `[flows]` debug log), `core/socketio.rs` (socket bridge), `flows/ops_tests.rs` (event-publish test).
- **Frontend:** new `hooks/useFlowRunStarted.ts` (+ test), and the 3 rail consumers subscribe.
- No new i18n (statuses already keyed); no new analytics (`automation_run_started` already fires).

## Status transitions in the rail
`FlowRunStarted` → "Running" → `flow:run_progress` live updates → approval poll shows "Awaiting approval" → terminal Completed / **Completed-with-warnings** (amber, B3/F3) / Failed / Cancelled via the existing status maps.

## Follow-up (out of scope)
A companion `FlowRunFinished { flow_id, run_id, status }` event would let the 5s/2s poll fallbacks go fully event-driven — separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Run lists now update immediately when a workflow run starts, including when the list was previously empty.
  - Workflow run pages, sidebars, and drawers reflect newly started runs as “Running” in real time.

- **Bug Fixes**
  - Prevented stale/out-of-order refresh responses from overwriting newer “Running” run data.

- **Tests**
  - Added and expanded unit/integration coverage for run-start events, payload validation, flowId filtering, deduplication, and automatic refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->