### PR TITLE
chore(core): drop the unused direct sha1 dependency (#5056)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4714,7 +4714,6 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_yaml",
- "sha1",
  "sha2 0.10.9",
  "similar",
  "socketioxide",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,9 +141,6 @@ similar = "2"
 # checkpoints are tags, read markers are refs, diffs are git tree diffs.
 # Vendored libgit2 (no system git dependency on end-user machines).
 git2 = { version = "0.21", default-features = false, features = ["vendored-libgit2"] }
-# Legacy SHA-1 only used for Tencent COS HMAC-SHA1 signing (yuanbao
-# channel media upload). Not used for any new security-sensitive work.
-sha1 = "0.10"
 hmac = "0.12"
 # Archive extraction for the Node.js runtime bootstrap. Unix Node
 # distributions ship as .tar.xz, Windows as .zip. `xz2` with `static`


### PR DESCRIPTION
## Summary

- Remove the unused direct `sha1` dependency from the core `Cargo.toml`.
- No behaviour change: `sha1` has zero use-sites in this crate; it stays in `Cargo.lock` transitively for crates that do need it.

## Problem

`sha1` was declared as a direct dependency only for legacy Tencent COS HMAC-SHA1 signing (yuanbao channel media upload), which now lives in the `tinychannels` crate. It is the last zero-reference dependency from the #5056 cleanup audit — the OpenTelemetry trio, `prost`, `postgres`, `ripemd`, `unicode-normalization`, `prometheus`, `dialoguer`, `clap_complete`, and `shellexpand` were already removed upstream by #5052.

## Solution

- Drop `sha1 = "0.10"` and its stale comment from `[dependencies]`.
- Regenerate `Cargo.lock` (only the direct edge is removed; `sha1` remains transitively).
- `hmac` is kept — still used by x402 / clob_auth / tinyplace (HMAC-SHA256 etc.).
- `webpki-roots` is intentionally **not** removed: it backs the `rustls-tls-webpki-roots` TLS feature (tokio-tungstenite) and is a load-bearing version pin despite having no direct code reference.

Verified zero use-sites: no `sha1::`, `use sha1`, `Sha1`, or `Hmac<Sha1>` anywhere in `src/`, `tests/`, or `examples/`.

## Submission Checklist

- [x] Tests added or updated — `N/A: dependency-manifest change`, no code paths added/removed.
- [x] **Diff coverage ≥ 80%** — `N/A: no executable lines changed`.
- [x] Coverage matrix updated — `N/A: no feature change`.
- [x] All affected feature IDs listed under `## Related`
- [x] No new external network dependencies introduced (this removes one)
- [x] Manual smoke checklist — `N/A: build-only change`.
- [x] Linked issue — partial; see `## Related` (does not close #5056).

## Impact

- Runtime: none.
- Build: one fewer direct dependency edge. `cargo check` passes with `media` ON and the disabled gate.

## Related

- Part of #5056 (does not close — one slice of a multi-part cleanup)
- Complements #5051 / #5052 (the bulk zero-ref dependency removal, already merged)
- Follow-up PR(s): remaining #5056 slices

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fixes/rm-zero-ref-deps`
- Commit SHA: 2b3d84404

### Validation Run
- [ ] `pnpm --filter openhuman-app format:check` — N/A (no app changes)
- [ ] `pnpm typecheck` — N/A (no TS changes)
- [x] Focused tests: `cargo check` media ON + disabled gate both pass
- [x] Rust fmt/check (if changed): no Rust source changed (manifest only)
- [ ] Tauri fmt/check (if changed): N/A

### Behavior Changes
- Intended behavior change: none (removes an unused direct dependency edge)
- User-visible effect: none

### Parity Contract
- Legacy behavior preserved: yes — sha1 had no use-sites; hmac + webpki-roots retained
- Guard/fallback/dispatch parity checks: N/A

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none (complements the already-merged #5052)
- Canonical PR: this
- Resolution: N/A
