### PR TITLE
refactor(core): make spaCy opt-in + demand-gate the Python runtime (#5056)

### DIFF
--- a/src/openhuman/config/schema/storage_memory.rs
+++ b/src/openhuman/config/schema/storage_memory.rs
@@ -366,7 +366,13 @@ pub struct MemoryTreeConfig {
 }
 
 fn default_memory_tree_spacy_enabled() -> bool {
-    true
+    // Opt-in (#5056). Default OFF so a fresh install never provisions the spaCy
+    // venv + `en_core_web_sm` model on first launch, and the runtime Python
+    // server is not spawned on every boot when no local NLP is configured.
+    // Query-entity extraction degrades to the in-Rust regex+LLM extractor
+    // (`score::extract`); operators opt in via config or
+    // `OPENHUMAN_MEMORY_TREE_SPACY_ENABLED=1`.
+    false
 }
 
 /// Returns `None` so that existing installs that never opted into Phase 4
@@ -511,6 +517,15 @@ mod tests {
             Some(DEFAULT_CLOUD_LLM_MODEL)
         );
         assert_eq!(DEFAULT_CLOUD_LLM_MODEL, "summarization-v1");
+    }
+
+    /// #5056: spaCy is opt-in — a fresh install must never provision the
+    /// spaCy venv / `en_core_web_sm` model, nor spawn the runtime Python
+    /// server, without an explicit config or env-var opt-in.
+    #[test]
+    fn spacy_enabled_defaults_to_false() {
+        assert!(!MemoryTreeConfig::default().spacy_enabled);
+        assert!(!default_memory_tree_spacy_enabled());
     }
 
     #[test]

--- a/src/openhuman/harness_init/registry.rs
+++ b/src/openhuman/harness_init/registry.rs
@@ -5,9 +5,15 @@
 //! orchestrates and reports; it does not reimplement any download logic.
 //!
 //! Current steps (all non-required — failure degrades to a fallback):
-//!   1. `python_runtime` — managed CPython (prerequisite for spaCy).
-//!   2. `spacy`          — spaCy venv + `en_core_web_sm` model.
-//!   3. `runtime_python_server` — long-running Python backend host.
+//!   1. `python_runtime` — managed CPython. Only provisions eagerly when a
+//!      Python backend is actually enabled (`enabled_backends` non-empty);
+//!      otherwise it is a no-op and lazy consumers (Python tools / skills)
+//!      resolve the interpreter on first use (#5056).
+//!   2. `spacy`          — spaCy venv + `en_core_web_sm` model. Opt-in
+//!      (`memory_tree.spacy_enabled`, default OFF) so a fresh install does not
+//!      provision it — nor spawn the runtime Python server — on launch.
+//!   3. `runtime_python_server` — long-running Python backend host. Derived:
+//!      launches only when `enabled_backends` is non-empty.
 //!   4. `node_runtime`   — managed Node.js (skills / MCP).
 //!
 //! Voice models (Whisper, Piper) and Ollama stay lazy/opt-in and are
@@ -73,9 +79,20 @@ fn python_runtime_step() -> HarnessInitStep {
     }
 }
 
+/// Whether the managed interpreter must be provisioned **eagerly at boot**.
+/// True only when Python is enabled AND a Python backend (spaCy / Kompress)
+/// actually needs it. When no backend is enabled we skip the speculative
+/// managed-CPython download entirely (#5056) — lazy consumers (Python tools /
+/// skills, Python MCP servers) still resolve the interpreter on first use.
+fn python_needed_eagerly(config: &Config) -> bool {
+    config.runtime_python.enabled
+        && !crate::openhuman::runtime_python_server::enabled_backends(config).is_empty()
+}
+
 async fn python_is_done(config: &Config) -> bool {
-    if !config.runtime_python.enabled {
-        // Disabled → nothing to provision; treat as satisfied.
+    if !python_needed_eagerly(config) {
+        // Nothing at boot needs the interpreter → treat as satisfied. Never
+        // downloads CPython speculatively.
         return true;
     }
     // Durable on-disk probe: survives restarts (unlike the process-local
@@ -89,7 +106,7 @@ async fn python_is_done(config: &Config) -> bool {
 }
 
 async fn python_run(config: &Config) -> Result<(), String> {
-    if !config.runtime_python.enabled {
+    if !python_needed_eagerly(config) {
         return Ok(());
     }
     use crate::openhuman::runtime_python::PythonBootstrap;
@@ -299,6 +316,46 @@ mod tests {
                 step.id
             );
         }
+    }
+
+    /// #5056: on a fresh install (`Config::default()`) `runtime_python.enabled`
+    /// is `true` but no Python backend (spaCy/Kompress) is on, so the
+    /// `python_runtime` step must report itself already `Done` and `run` must
+    /// be a no-op — proving the eager managed-CPython download is skipped
+    /// when nothing at boot needs it. This is a pure gating check
+    /// (`python_needed_eagerly` returns `false`): it never touches disk or
+    /// resolves a real interpreter, so it stays hermetic.
+    #[tokio::test]
+    async fn python_runtime_step_is_done_by_default_with_no_backend_enabled() {
+        let config = Config::default();
+        assert!(
+            !python_needed_eagerly(&config),
+            "default config should not need Python eagerly (no backend enabled)"
+        );
+        assert!(
+            python_is_done(&config).await,
+            "python_runtime step should be Done without provisioning when no backend is enabled"
+        );
+        assert!(
+            python_run(&config).await.is_ok(),
+            "python_runtime run should no-op when no backend is enabled"
+        );
+    }
+
+    /// Inverse of the above: once a backend (spaCy) is enabled, the step must
+    /// no longer be trivially `Done` via the eager-skip branch — proving the
+    /// gate still allows provisioning when a backend genuinely needs Python.
+    /// We only assert the gating predicate here (not `is_done`/`run`), so the
+    /// test never attempts a real interpreter probe/download.
+    #[test]
+    fn python_needed_eagerly_true_when_spacy_backend_enabled() {
+        let mut config = Config::default();
+        config.runtime_python.enabled = true;
+        config.memory_tree.spacy_enabled = true;
+        assert!(
+            python_needed_eagerly(&config),
+            "python should be needed eagerly once a Python backend is enabled"
+        );
     }
 
     #[tokio::test]

--- a/src/openhuman/runtime_python_server/registry.rs
+++ b/src/openhuman/runtime_python_server/registry.rs
@@ -35,6 +35,19 @@ pub fn enabled_backends(config: &Config) -> Vec<RuntimePythonBackend> {
 mod tests {
     use super::*;
 
+    /// #5056: a fresh install (`Config::default()`) must not enable any
+    /// Python backend, so the runtime Python server never launches — and the
+    /// managed CPython interpreter is never speculatively downloaded — on a
+    /// default boot.
+    #[test]
+    fn enabled_backends_is_empty_by_default() {
+        let config = Config::default();
+        assert!(
+            enabled_backends(&config).is_empty(),
+            "default config must not enable any runtime Python backend"
+        );
+    }
+
     #[test]
     fn registry_respects_runtime_and_spacy_flags() {
         let mut config = Config::default();


### PR DESCRIPTION
## Summary

- Default `memory_tree.spacy_enabled` to `false` (was `true`) — spaCy becomes opt-in.
- Demand-gate the `python_runtime` harness-init step so managed CPython is not downloaded speculatively at boot.
- Result: a fresh install no longer spawns the runtime Python server on every launch, nor provisions a spaCy venv + `en_core_web_sm` model on first run, when no local NLP is configured.

## Problem

On a fresh install, `spacy_enabled` defaulted `true`, so `enabled_backends()` returned `[Spacy]` and the runtime Python server launched on **every** boot, with the first run building a spaCy venv + downloading `en_core_web_sm`. Separately, the `python_runtime` step resolved/downloaded managed CPython whenever `runtime_python.enabled` (default true), even when nothing needed Python. This is the core of #5056's "unnecessary runtimes" item (and relates to #4814). spaCy only improves person/org recall in the E2GraphRAG query-entity extractor, which already has a full in-Rust regex+LLM fallback.

## Solution

- `default_memory_tree_spacy_enabled()` → `false`. With spaCy off (Kompress already off by default), `enabled_backends()` is empty → the runtime Python server never launches at boot and the spaCy venv/model is never provisioned. Query-entity extraction degrades to `score::extract`. Opt in via config or `OPENHUMAN_MEMORY_TREE_SPACY_ENABLED=1`.
- New `python_needed_eagerly(config)` = `runtime_python.enabled && !enabled_backends(config).is_empty()`. The `python_runtime` step's `is_done`/`run` gate on it, so managed CPython is provisioned eagerly only when a Python backend actually needs it. Lazy consumers (Python tools / skills / MCP) still resolve the interpreter on first use.
- Node, Kompress, and the server-launch steps are unchanged — they already derive correctly.
- `CREATE_NO_WINDOW` coverage is untouched (already complete); this PR changes *whether* work happens at boot, not *how* processes spawn.

Coordinates with #5055 (spaCy provider reliability): this makes spaCy opt-in, it does not remove it.

## Submission Checklist

- [x] Tests added or updated — added: `spacy_enabled` defaults false; `enabled_backends(&Config::default())` is empty; `python_runtime` step is auto-done / no-op by default and provisions when a backend is enabled. Updated existing harness_init / runtime_python_server / config-default tests for the new default.
- [x] **Diff coverage ≥ 80%** — changed lines are covered by the added/updated unit tests.
- [x] Coverage matrix updated — `N/A: behaviour-default change` (no feature row add/remove; spaCy path unchanged, only its default).
- [x] All affected feature IDs listed under `## Related`
- [x] No new external network dependencies introduced (this removes speculative downloads)
- [x] Manual smoke checklist — `N/A`: retrieval works identically via the regex fallback; opt-in spaCy path unchanged.
- [x] Linked issue — partial; see `## Related` (does not close #5056).

## Impact

- Runtime: fresh installs no longer spawn the Python server every launch or download spaCy/CPython on first run. Retrieval quality: query-entity extraction uses the regex+LLM fallback until a user opts into spaCy (person/org recall slightly lower, no correctness regression).
- Migration: existing installs that persisted `spacy_enabled: true` keep spaCy on (serde default applies only to absent fields) — no behaviour change for current users; only fresh installs get the new default.
- Build: `cargo check` passes (media ON + disabled gate); harness_init 12/12, runtime_python_server 17/17, memory_tree 210/210, config:: 472/472.

## Related

- Part of #5056 (does not close — one slice of a multi-part cleanup)
- Relates to #4814 (CMD windows / unnecessary boot spawns) and #5055 (spaCy provider reliability — coordinate)
- Follow-up PR(s): remaining #5056 slices

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: `fixes/spacy-off-lazy-runtimes`
- Commit SHA: 832c0a21c

### Validation Run
- [ ] `pnpm --filter openhuman-app format:check` — N/A (no app changes)
- [ ] `pnpm typecheck` — N/A (no TS changes)
- [x] Focused tests: harness_init 12/12, runtime_python_server 17/17, memory_tree 210/210, config:: 472/472
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo check` media ON + disabled gate pass
- [ ] Tauri fmt/check (if changed): N/A

### Behavior Changes
- Intended behavior change: spaCy is opt-in; the Python runtime + server are not provisioned/launched at boot unless a backend needs them
- User-visible effect: fewer background processes / no first-run spaCy download on fresh installs; retrieval uses the regex fallback until spaCy is enabled

### Parity Contract
- Legacy behavior preserved: existing installs with spacy_enabled persisted keep current behavior; enabling spaCy restores the full path
- Guard/fallback/dispatch parity checks: `enabled_backends` derivation unchanged; server/kompress/node steps unchanged

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Python runtime components are now provisioned only when an enabled feature requires them.
  * spaCy support is now opt-in and disabled by default on fresh installations.

* **Bug Fixes**
  * Prevented unnecessary Python downloads and setup when no Python-backed features are enabled.
  * Improved initialization behavior while preserving automatic setup when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->