### PR TITLE
fix(inference): keep Claude CLI prompts out of Windows argv

### DIFF
--- a/src/openhuman/inference/provider/claude_agent_sdk/subprocess.rs
+++ b/src/openhuman/inference/provider/claude_agent_sdk/subprocess.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Context;
 use async_trait::async_trait;
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 use tokio::time::{timeout, Duration};
 
@@ -13,6 +13,45 @@ use super::protocol::SdkMessage;
 
 pub struct ClaudeAgentSdkProvider {
     pub(super) config: ClaudeAgentSdkConfig,
+}
+
+struct ClaudeInvocation {
+    args: Vec<String>,
+    stdin: String,
+}
+
+fn build_invocation(
+    system_prompt: Option<&str>,
+    message: &str,
+    model: &str,
+    max_budget_usd: Option<f64>,
+) -> ClaudeInvocation {
+    let stdin = match system_prompt {
+        Some(system) if !system.trim().is_empty() => {
+            format!("[SYSTEM]\n{system}\n[/SYSTEM]\n\n{message}")
+        }
+        _ => message.to_string(),
+    };
+    let mut args = vec![
+        "-p".to_string(),
+        "--model".to_string(),
+        model.to_string(),
+        "--output-format".to_string(),
+        "stream-json".to_string(),
+        "--no-color".to_string(),
+    ];
+    if let Some(budget) = max_budget_usd {
+        args.push("--max-turns".to_string());
+        args.push("10".to_string());
+        args.push("--budget".to_string());
+        args.push(format!("{budget:.4}"));
+    }
+    ClaudeInvocation { args, stdin }
+}
+
+fn spawn_error(binary: &str, source: std::io::Error) -> anyhow::Error {
+    let message = format!("failed to spawn claude binary '{binary}': {source}");
+    anyhow::Error::new(source).context(message)
 }
 
 impl ClaudeAgentSdkProvider {
@@ -36,42 +75,47 @@ impl Provider for ClaudeAgentSdkProvider {
             model
         };
 
-        // Prepend system prompt inline — claude -p has no separate system flag.
-        let full_message = match system_prompt {
-            Some(s) if !s.trim().is_empty() => {
-                format!("[SYSTEM]\n{s}\n[/SYSTEM]\n\n{message}")
-            }
-            _ => message.to_string(),
-        };
+        // `claude -p` reads stdin in non-interactive mode. Keep the full
+        // request out of argv so large harness prompts can spawn on Windows.
+        let invocation =
+            build_invocation(system_prompt, message, model, self.config.max_budget_usd);
 
         let mut cmd = Command::new(&self.config.binary);
-        cmd.arg("-p")
-            .arg(&full_message)
-            .arg("--model")
-            .arg(model)
-            .arg("--output-format")
-            .arg("stream-json")
-            .arg("--no-color")
+        cmd.args(&invocation.args)
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
-            .stdin(std::process::Stdio::null());
-
-        if let Some(budget) = self.config.max_budget_usd {
-            cmd.arg("--max-turns").arg("10");
-            // Note: --budget flag controls the spend cap in the Claude CLI
-            cmd.arg("--budget").arg(format!("{budget:.4}"));
-        }
+            .stdin(std::process::Stdio::piped())
+            .kill_on_drop(true);
 
         tracing::debug!(
             "[claude_agent_sdk] spawning claude binary={} model={} message_len={}",
             self.config.binary,
             model,
-            full_message.len()
+            invocation.stdin.len()
         );
 
-        let mut child = cmd
-            .spawn()
-            .with_context(|| format!("failed to spawn claude binary '{}'", self.config.binary))?;
+        let mut child = cmd.spawn().map_err(|source| {
+            tracing::error!(
+                error = %source,
+                binary = %self.config.binary,
+                "[claude_agent_sdk] failed to spawn claude binary"
+            );
+            spawn_error(&self.config.binary, source)
+        })?;
+
+        let mut stdin = child
+            .stdin
+            .take()
+            .context("claude subprocess has no stdin")?;
+        stdin
+            .write_all(invocation.stdin.as_bytes())
+            .await
+            .context("failed to write claude request to stdin")?;
+        stdin
+            .shutdown()
+            .await
+            .context("failed to close claude subprocess stdin")?;
+        drop(stdin);
 
         let stdout = child
             .stdout
@@ -212,5 +256,113 @@ mod tests {
         let config = ClaudeAgentSdkConfig::default();
         assert!(!config.enabled);
         assert!(config.max_budget_usd.is_none());
+    }
+
+    #[test]
+    fn large_request_is_delivered_over_stdin_instead_of_argv() {
+        let system_prompt = "system instruction\n".repeat(2_500);
+        assert!(system_prompt.len() > 32_767);
+
+        let invocation = build_invocation(Some(&system_prompt), "hello", "claude-sonnet-4-6", None);
+
+        assert_eq!(
+            invocation.args,
+            [
+                "-p",
+                "--model",
+                "claude-sonnet-4-6",
+                "--output-format",
+                "stream-json",
+                "--no-color"
+            ]
+        );
+        assert!(!invocation
+            .args
+            .iter()
+            .any(|arg| arg.contains(&system_prompt)));
+        assert_eq!(
+            invocation.stdin,
+            format!("[SYSTEM]\n{system_prompt}\n[/SYSTEM]\n\nhello")
+        );
+    }
+
+    #[test]
+    fn invocation_preserves_plain_message_and_budget_flags() {
+        let invocation = build_invocation(None, "hello", "claude-opus-4-6", Some(1.25));
+
+        assert_eq!(invocation.stdin, "hello");
+        assert_eq!(
+            &invocation.args[6..],
+            ["--max-turns", "10", "--budget", "1.2500"]
+        );
+    }
+
+    #[test]
+    fn spawn_error_message_includes_the_os_source() {
+        let source = std::io::Error::from_raw_os_error(206);
+        let error = spawn_error(r"C:\Users\test\.local\bin\claude.exe", source);
+
+        assert!(error.to_string().contains("os error 206"));
+        assert_eq!(
+            error.chain().count(),
+            2,
+            "io::Error source must be preserved"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn provider_pipes_large_request_to_cli_stdin() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let script = dir.path().join("claude");
+        std::fs::write(
+            &script,
+            r#"#!/bin/sh
+cat > "$0.stdin"
+printf '%s\n' '{"type":"result","result":"captured","is_error":false}'
+"#,
+        )
+        .expect("write fake claude");
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o700))
+            .expect("make fake claude executable");
+
+        let mut config = ClaudeAgentSdkConfig::default();
+        config.binary = script.display().to_string();
+        let provider = ClaudeAgentSdkProvider::new(config);
+        let system_prompt = "system instruction\n".repeat(2_500);
+
+        let output = provider
+            .chat_with_system(Some(&system_prompt), "hello", "claude-sonnet-4-6", 0.0)
+            .await
+            .expect("fake claude response");
+
+        assert_eq!(output, "captured");
+        assert_eq!(
+            std::fs::read_to_string(format!("{}.stdin", script.display())).expect("captured stdin"),
+            format!("[SYSTEM]\n{system_prompt}\n[/SYSTEM]\n\nhello")
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_spawn_error_includes_the_os_source() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut config = ClaudeAgentSdkConfig::default();
+        config.binary = dir.path().join("missing-claude").display().to_string();
+        let provider = ClaudeAgentSdkProvider::new(config);
+
+        let error = provider
+            .chat_with_system(None, "hello", "claude-sonnet-4-6", 0.0)
+            .await
+            .expect_err("missing binary must fail");
+
+        assert!(error.to_string().contains("failed to spawn claude binary"));
+        assert!(error.to_string().contains("os error"));
+        assert_eq!(
+            error.chain().count(),
+            2,
+            "io::Error source must be preserved"
+        );
     }
 }

--- a/src/openhuman/inference/provider/claude_code/driver.rs
+++ b/src/openhuman/inference/provider/claude_code/driver.rs
@@ -198,7 +198,24 @@ fn append_system_prompt_args(
     };
 
     let path = dir.join("append-system-prompt.txt");
-    std::fs::write(&path, prompt)?;
+    log::debug!(
+        "[claude-code][driver] append-system-prompt file write start path={} bytes={}",
+        path.display(),
+        prompt.len()
+    );
+    if let Err(error) = std::fs::write(&path, prompt) {
+        log::warn!(
+            "[claude-code][driver] append-system-prompt file write failed path={} error={}",
+            path.display(),
+            error
+        );
+        return Err(error);
+    }
+    log::debug!(
+        "[claude-code][driver] append-system-prompt file write complete path={} bytes={}",
+        path.display(),
+        prompt.len()
+    );
     Ok(vec![
         "--append-system-prompt-file".to_string(),
         path.display().to_string(),
@@ -525,6 +542,18 @@ mod tests {
 
         assert!(args.is_empty());
         assert!(!dir.path().join("append-system-prompt.txt").exists());
+    }
+
+    #[test]
+    fn system_prompt_write_error_is_propagated() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let not_a_directory = dir.path().join("file");
+        std::fs::write(&not_a_directory, "occupied").expect("write blocking file");
+
+        let error = append_system_prompt_args(&not_a_directory, Some("system prompt"))
+            .expect_err("non-directory parent must fail");
+
+        assert!(!error.to_string().is_empty());
     }
 
     #[cfg(target_os = "macos")]

--- a/src/openhuman/inference/provider/claude_code/driver.rs
+++ b/src/openhuman/inference/provider/claude_code/driver.rs
@@ -186,6 +186,25 @@ fn write_mcp_http_config(
     Ok(path)
 }
 
+/// Keep the potentially large harness prompt out of argv. Windows flattens
+/// argv into a command line capped at 32,767 UTF-16 code units, while Claude's
+/// file flag has no such limit. The per-turn scratch directory owns cleanup.
+fn append_system_prompt_args(
+    dir: &std::path::Path,
+    prompt: Option<&str>,
+) -> std::io::Result<Vec<String>> {
+    let Some(prompt) = prompt.filter(|value| !value.trim().is_empty()) else {
+        return Ok(Vec::new());
+    };
+
+    let path = dir.join("append-system-prompt.txt");
+    std::fs::write(&path, prompt)?;
+    Ok(vec![
+        "--append-system-prompt-file".to_string(),
+        path.display().to_string(),
+    ])
+}
+
 /// Run one turn against the `claude` CLI. Awaits process exit. Forwards
 /// `ProviderDelta`s through `ctx.stream` as they arrive and returns the
 /// aggregated `ChatResponse` when done.
@@ -281,14 +300,10 @@ pub async fn run_turn(ctx: TurnContext<'_>) -> anyhow::Result<ChatResponse> {
         "--model".into(),
         ctx.model.clone(),
     ];
-    if let Some(sp) = ctx
-        .append_system_prompt
-        .as_ref()
-        .filter(|s| !s.trim().is_empty())
-    {
-        args.push("--append-system-prompt".into());
-        args.push(sp.clone());
-    }
+    args.extend(
+        append_system_prompt_args(scratch.path(), ctx.append_system_prompt.as_deref())
+            .map_err(|e| anyhow::anyhow!("write Claude Code system prompt file: {e}"))?,
+    );
     if let Some(p) = mcp_config_path.as_ref() {
         args.push("--mcp-config".into());
         args.push(p.display().to_string());
@@ -484,6 +499,32 @@ mod tests {
         assert_eq!(server["headers"]["Authorization"], "Bearer tok-abc123");
         // It must NOT spawn a stdio child (the old jailed path).
         assert!(server.get("command").is_none());
+    }
+
+    #[test]
+    fn large_system_prompt_is_written_to_file_instead_of_argv() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let prompt = "system instruction\n".repeat(2_500);
+        assert!(prompt.len() > 32_767);
+
+        let args = append_system_prompt_args(dir.path(), Some(&prompt)).expect("prompt args");
+
+        assert_eq!(args[0], "--append-system-prompt-file");
+        assert_eq!(args.len(), 2);
+        assert!(!args.iter().any(|arg| arg.contains(&prompt)));
+        assert_eq!(
+            std::fs::read_to_string(&args[1]).expect("read prompt file"),
+            prompt
+        );
+    }
+
+    #[test]
+    fn empty_system_prompt_does_not_add_an_argument() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let args = append_system_prompt_args(dir.path(), Some("  \n ")).expect("prompt args");
+
+        assert!(args.is_empty());
+        assert!(!dir.path().join("append-system-prompt.txt").exists());
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
## Summary

- Keep Claude Code harness prompts out of Windows argv by using `--append-system-prompt-file` in the existing per-turn scratch directory.
- Pipe Claude Agent SDK requests through stdin in non-interactive mode instead of passing the full request as a positional argument.
- Preserve and log the underlying OS spawn error, with regression coverage for >32 KB prompts, stdin EOF delivery, and missing executables.

## Problem

Both Claude CLI providers place the harness prompt in argv. Windows flattens argv into a command line capped at 32,767 UTF-16 code units, so sufficiently large harness prompts fail in `CreateProcess` before Claude starts. The Agent SDK path also returned only the outer anyhow context, hiding the useful OS error from the journal log.

## Solution

The Claude Code driver writes a non-empty appended system prompt into its private per-turn temp directory and passes the path through Claude's supported `--append-system-prompt-file` flag. The temp directory remains alive for the turn and is cleaned up automatically.

The Agent SDK provider keeps its existing composed `[SYSTEM]` request format but sends those bytes through piped stdin. It explicitly closes and drops stdin so Claude receives EOF before output is read. Spawn failures are logged with the source `io::Error`, and the returned message includes that source while retaining the anyhow chain.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage >= 80%** - verified by the passing `Rust Core Coverage (cargo-llvm-cov)` and `PR CI Gate` checks on commit `863ecda5dd78d15fea40499b1745f7eb0e755951`.
- [x] Coverage matrix updated - N/A: behavior-only provider transport fix; no feature row added, removed, or renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` - N/A: no coverage-matrix feature ID applies.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces - N/A: no release-cut surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

Windows desktop users can spawn both Claude CLI providers with harness prompts larger than the platform command-line limit. macOS and Linux use the same bounded-argv transports. Prompt contents remain transient and are not logged; Claude Code's file lives only in the existing per-turn private temp directory.

## Related

- Closes #5044
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A - GitHub issue #5044
- URL: https://github.com/tinyhumansai/openhuman/issues/5044

### Commit & Branch

- Branch: `codex/5044-windows-claude-argv`
- Commit SHA: `863ecda5dd78d15fea40499b1745f7eb0e755951`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` (pre-push hook)
- [x] `pnpm typecheck` (pre-push hook)
- [x] Focused tests: Agent SDK subprocess tests, 7 passed; Claude Code driver tests, 9 passed
- [x] Rust fmt/check (if changed): `cargo fmt --all -- --check`; `cargo check --lib`; `cargo clippy -p openhuman -- -D warnings`
- [x] Tauri fmt/check (if changed): N/A - no Tauri Rust files changed

Focused Cargo commands were run with temporary patch overrides pointing to the exact gitlink revisions `tinycortex@9a0603a` and `tinyflows@e5327de`, because this local working tree retained newer submodule checkouts from earlier work.

### Validation Blocked

- N/A: local `cargo-llvm-cov` is unavailable, but the authoritative `Rust Core Coverage (cargo-llvm-cov)` and aggregate `PR CI Gate` checks passed on the current commit.

### Behavior Changes

- Intended behavior change: deliver large Claude prompts outside argv and include the OS source in Agent SDK spawn failures
- User-visible effect: Claude CLI turns no longer fail at Windows' 32,767-character process creation limit

### Parity Contract

- Legacy behavior preserved: system and user message composition, model/output/budget flags, NDJSON parsing, and Claude Code scratch-directory cleanup
- Guard/fallback/dispatch parity checks: empty system prompts add no file flag; plain messages and budget flags are preserved; missing binaries retain the source error

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None found in the final live search
- Canonical PR: This PR
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Claude integration by sending full requests (including optional system prompts) via standard input rather than command-line arguments, avoiding argument-length limits.
  * Updated Claude Code turn handling to store non-empty system prompts in a per-turn file and pass a reference, not the raw prompt in argv.
  * Improved error reporting when the Claude process fails to start.
  * Whitespace-only system prompts are now ignored.
* **Tests**
  * Added coverage for stdin-based delivery, prompt-file behavior, argument/budget propagation, and spawn/piping error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
