### PR TITLE
feat(flows): link to the saved workflow from the chat proposal card (B36)

### DIFF
--- a/app/src/components/chat/WorkflowProposalCard.test.tsx
+++ b/app/src/components/chat/WorkflowProposalCard.test.tsx
@@ -144,16 +144,38 @@ describe('WorkflowProposalCard', () => {
     expect(screen.getByTestId('workflow-proposal-card')).toBeInTheDocument();
   });
 
-  it('saves via createFlow with the right args and clears optimistically', async () => {
+  it('saves via createFlow with the right args and shows the saved confirmation', async () => {
     const p = proposal();
     render(<WorkflowProposalCard threadId="t1" proposal={p} />);
     fireEvent.click(screen.getByText('chat.flowProposal.save'));
     await waitFor(() =>
       expect(mockCreateFlow).toHaveBeenCalledWith(p.name, p.graph, p.requireApproval)
     );
-    expect(mockDispatch).toHaveBeenCalledTimes(1);
     // createFlow already came back enabled — no need for a follow-up arm.
     expect(mockSetFlowEnabled).not.toHaveBeenCalled();
+    // The card stays mounted (issue B36) showing a saved confirmation with a
+    // link into the persisted flow — it must not silently clear/unmount, so
+    // the proposal is NOT dispatched away until the user follows that link.
+    await waitFor(() => expect(screen.getByTestId('workflow-proposal-saved')).toBeInTheDocument());
+    expect(screen.getByText('chat.flowProposal.savedConfirmation')).toBeInTheDocument();
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates to the persisted flow and clears the proposal when "View workflow" is clicked', async () => {
+    const p = proposal();
+    render(<WorkflowProposalCard threadId="t1" proposal={p} />);
+    fireEvent.click(screen.getByText('chat.flowProposal.save'));
+    await waitFor(() =>
+      expect(screen.getByText('chat.flowProposal.viewWorkflow')).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByText('chat.flowProposal.viewWorkflow'));
+
+    // Navigates straight to the saved flow's own canvas route — the created
+    // flow's real id ('f1'), not the unsaved-draft route.
+    expect(mockNavigate).toHaveBeenCalledWith('/flows/f1');
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
   });
 
   it('shows a loading state while saving', async () => {
@@ -195,7 +217,10 @@ describe('WorkflowProposalCard', () => {
     render(<WorkflowProposalCard threadId="t1" proposal={p} />);
     fireEvent.click(screen.getByText('chat.flowProposal.save'));
     await waitFor(() => expect(mockSetFlowEnabled).toHaveBeenCalledWith('f1', true));
-    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    // The proposal isn't dispatched away immediately — the card shows the
+    // saved confirmation with a view link instead (issue B36).
+    await waitFor(() => expect(screen.getByTestId('workflow-proposal-saved')).toBeInTheDocument());
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
   it('keeps the flow saved and lets the user retry just the enable step if setFlowEnabled fails', async () => {
@@ -216,11 +241,14 @@ describe('WorkflowProposalCard', () => {
 
     mockSetFlowEnabled.mockResolvedValueOnce({ id: 'f1', enabled: true });
     fireEvent.click(screen.getByText('chat.flowProposal.save'));
-    await waitFor(() => expect(mockDispatch).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(screen.getByTestId('workflow-proposal-saved')).toBeInTheDocument());
     // Only ever created once, even though "Save & enable" was clicked twice.
     expect(mockCreateFlow).toHaveBeenCalledTimes(1);
     expect(mockSetFlowEnabled).toHaveBeenCalledTimes(2);
     expect(mockSetFlowEnabled).toHaveBeenLastCalledWith('f1', true);
+    // Still not dispatched away — the retry lands on the same saved
+    // confirmation, not an immediate clear.
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
   it('opens the proposed graph in the canvas as an unsaved draft without persisting', () => {

--- a/app/src/components/chat/WorkflowProposalCard.test.tsx
+++ b/app/src/components/chat/WorkflowProposalCard.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { WorkflowProposal } from '../../store/chatRuntimeSlice';
+import { markWorkflowProposalCompleted, type WorkflowProposal } from '../../store/chatRuntimeSlice';
 import { WorkflowProposalCard } from './WorkflowProposalCard';
 
 // Echo i18n keys so we can assert on the stable key string.
@@ -158,7 +158,15 @@ describe('WorkflowProposalCard', () => {
     // the proposal is NOT dispatched away until the user follows that link.
     await waitFor(() => expect(screen.getByTestId('workflow-proposal-saved')).toBeInTheDocument());
     expect(screen.getByText('chat.flowProposal.savedConfirmation')).toBeInTheDocument();
-    expect(mockDispatch).not.toHaveBeenCalled();
+    // The completion IS mirrored into Redux (not just local state) so the
+    // confirmation survives a remount before "View workflow" is clicked —
+    // see `WorkflowProposal.completedFlowId`. It must not be the
+    // proposal-clearing dispatch, though — that only happens on "View
+    // workflow"/"Dismiss".
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith(
+      markWorkflowProposalCompleted({ threadId: 't1', flowId: 'f1' })
+    );
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
@@ -169,13 +177,54 @@ describe('WorkflowProposalCard', () => {
     await waitFor(() =>
       expect(screen.getByText('chat.flowProposal.viewWorkflow')).toBeInTheDocument()
     );
+    // The successful save already dispatched markWorkflowProposalCompleted;
+    // record how many calls happened before "View workflow" is clicked so
+    // the assertions below are about what that click itself does.
+    const callsBeforeClick = mockDispatch.mock.calls.length;
 
     fireEvent.click(screen.getByText('chat.flowProposal.viewWorkflow'));
 
     // Navigates straight to the saved flow's own canvas route — the created
     // flow's real id ('f1'), not the unsaved-draft route.
     expect(mockNavigate).toHaveBeenCalledWith('/flows/f1');
-    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledTimes(callsBeforeClick + 1);
+    // Assert the RELATIVE order, not just that both happened: the
+    // proposal-clearing dispatch must fire before navigation away, since the
+    // parent only renders this card while the proposal survives in Redux —
+    // navigating first (even a tick early) risks unmounting before the
+    // dispatch lands.
+    const dispatchOrder = mockDispatch.mock.invocationCallOrder[callsBeforeClick];
+    const navigateOrder = mockNavigate.mock.invocationCallOrder[0];
+    expect(dispatchOrder).toBeLessThan(navigateOrder);
+  });
+
+  // Regression test for the remount bug flagged in review (issue B36): the
+  // card intentionally stays mounted showing the saved confirmation instead
+  // of dispatching the proposal away, so a thread switch / route change can
+  // unmount and remount it before the user clicks "View workflow". Before
+  // `completedFlowId` was mirrored into Redux, remounting reset the card's
+  // local state to null, so it fell back to the pre-save editable view — and
+  // a second "Save & enable" click would call `createFlow` again and
+  // duplicate the flow.
+  it('keeps showing the saved confirmation across a remount instead of re-offering "Save & enable"', async () => {
+    const p = proposal();
+    const { unmount } = render(<WorkflowProposalCard threadId="t1" proposal={p} />);
+    fireEvent.click(screen.getByText('chat.flowProposal.save'));
+    await waitFor(() => expect(screen.getByTestId('workflow-proposal-saved')).toBeInTheDocument());
+
+    // Simulate a thread switch / route change: unmount the card, then
+    // remount it with the proposal as it would now read from Redux — still
+    // present (the completion dispatch didn't clear it), but carrying the
+    // `completedFlowId` set by `markWorkflowProposalCompleted`.
+    unmount();
+    mockCreateFlow.mockClear();
+    render(<WorkflowProposalCard threadId="t1" proposal={{ ...p, completedFlowId: 'f1' }} />);
+
+    // Must still show the saved confirmation, not the editable "Save &
+    // enable" view that would let a second click duplicate the flow.
+    expect(screen.getByTestId('workflow-proposal-saved')).toBeInTheDocument();
+    expect(screen.queryByText('chat.flowProposal.save')).not.toBeInTheDocument();
+    expect(mockCreateFlow).not.toHaveBeenCalled();
   });
 
   it('shows a loading state while saving', async () => {
@@ -218,9 +267,14 @@ describe('WorkflowProposalCard', () => {
     fireEvent.click(screen.getByText('chat.flowProposal.save'));
     await waitFor(() => expect(mockSetFlowEnabled).toHaveBeenCalledWith('f1', true));
     // The proposal isn't dispatched away immediately — the card shows the
-    // saved confirmation with a view link instead (issue B36).
+    // saved confirmation with a view link instead (issue B36). The only
+    // dispatch is the Redux-mirrored completion (survives a remount), not a
+    // clear.
     await waitFor(() => expect(screen.getByTestId('workflow-proposal-saved')).toBeInTheDocument());
-    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith(
+      markWorkflowProposalCompleted({ threadId: 't1', flowId: 'f1' })
+    );
   });
 
   it('keeps the flow saved and lets the user retry just the enable step if setFlowEnabled fails', async () => {
@@ -247,8 +301,12 @@ describe('WorkflowProposalCard', () => {
     expect(mockSetFlowEnabled).toHaveBeenCalledTimes(2);
     expect(mockSetFlowEnabled).toHaveBeenLastCalledWith('f1', true);
     // Still not dispatched away — the retry lands on the same saved
-    // confirmation, not an immediate clear.
-    expect(mockDispatch).not.toHaveBeenCalled();
+    // confirmation, not an immediate clear. The only dispatch is the
+    // Redux-mirrored completion once the retry succeeds.
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith(
+      markWorkflowProposalCompleted({ threadId: 't1', flowId: 'f1' })
+    );
   });
 
   it('opens the proposed graph in the canvas as an unsaved draft without persisting', () => {

--- a/app/src/components/chat/WorkflowProposalCard.tsx
+++ b/app/src/components/chat/WorkflowProposalCard.tsx
@@ -93,6 +93,14 @@ interface Props {
  * (disabled) and the card keeps `savedFlowId` around so a retry re-enables
  * instead of re-creating (which would duplicate the flow).
  *
+ * On a fully successful save (issue B36), the card does NOT dispatch
+ * `clearWorkflowProposalForThread` immediately — doing so would unmount it
+ * (the parent only renders this card while a pending proposal exists in
+ * Redux) before the user ever saw confirmation. Instead it swaps to a
+ * terminal "saved" view with a link into the persisted flow's own
+ * `/flows/:id` canvas; the proposal is only cleared once the user follows
+ * that link (see `viewWorkflow`) or hits "Dismiss".
+ *
  * Mirrors {@link PlanReviewCard}'s placement/chrome above the composer, and
  * the tool-timeline `StatusTag`/detail-chip visual language for the
  * node-kind badges + config hints in the step list.
@@ -108,6 +116,13 @@ export const WorkflowProposalCard: React.FC<Props> = ({ threadId, proposal, onSa
   // yet. Non-null means a retry of `save` should skip `createFlow` entirely
   // and only retry the enable step.
   const [savedFlowId, setSavedFlowId] = useState<string | null>(null);
+  // Set once the flow is fully persisted AND enabled — the terminal success
+  // state. Non-null swaps the card's body from the editable proposal (name/
+  // trigger/steps/buttons) to a compact saved confirmation with a link into
+  // the persisted flow's own canvas (issue B36). Kept distinct from
+  // `savedFlowId` above: that one tracks an in-between "saved but not yet
+  // armed" retry state, this one is the fully-done state.
+  const [completedFlowId, setCompletedFlowId] = useState<string | null>(null);
 
   /**
    * When this proposal was rehydrated from a persisted thread message (the
@@ -128,6 +143,17 @@ export const WorkflowProposalCard: React.FC<Props> = ({ threadId, proposal, onSa
   const dismiss = () => {
     markSourceMessageConsumed();
     dispatch(clearWorkflowProposalForThread({ threadId }));
+  };
+
+  /**
+   * From the terminal "saved" confirmation (issue B36), jump into the
+   * persisted flow's own canvas. Clears the proposal from the thread's
+   * pending state at this point — the user is leaving to look at the
+   * authoritative canvas, so there is nothing left for this card to show.
+   */
+  const viewWorkflow = (flowId: string) => {
+    dispatch(clearWorkflowProposalForThread({ threadId }));
+    navigate(`/flows/${flowId}`);
   };
 
   /**
@@ -173,7 +199,8 @@ export const WorkflowProposalCard: React.FC<Props> = ({ threadId, proposal, onSa
         if (flow.enabled) {
           log('save: createFlow returned enabled — nothing further to arm id=%s', flow.id);
           markSourceMessageConsumed();
-          dispatch(clearWorkflowProposalForThread({ threadId }));
+          setSaving(false);
+          setCompletedFlowId(flow.id);
           onSaved?.();
           return;
         }
@@ -185,7 +212,8 @@ export const WorkflowProposalCard: React.FC<Props> = ({ threadId, proposal, onSa
       }
       await setFlowEnabled(flowId, true);
       markSourceMessageConsumed();
-      dispatch(clearWorkflowProposalForThread({ threadId }));
+      setSaving(false);
+      setCompletedFlowId(flowId);
       onSaved?.();
     } catch (e) {
       log('save failed (createFlow/setFlowEnabled): %o', e);
@@ -204,85 +232,115 @@ export const WorkflowProposalCard: React.FC<Props> = ({ threadId, proposal, onSa
       className="mb-2 rounded-xl border border-ocean-300 bg-surface p-3 text-sm shadow-md dark:border-ocean-700">
       <div className="flex items-start gap-2">
         <span aria-hidden className="text-base leading-none text-ocean-700 dark:text-ocean-200">
-          ⚙️
+          {completedFlowId ? '✅' : '⚙️'}
         </span>
         <div className="min-w-0 flex-1">
-          <p className="font-semibold text-ocean-900 dark:text-ocean-100">
-            {proposal.name || t('chat.flowProposal.title')}
-          </p>
-          <p className="mt-1 break-words text-ocean-800/90 dark:text-ocean-200/90">
-            {t('chat.flowProposal.subtitle')}
-          </p>
+          {completedFlowId ? (
+            // Terminal success state (issue B36): the flow is saved and
+            // enabled, so the editable proposal (name/trigger/steps/buttons)
+            // gives way to a compact confirmation with a link into the
+            // persisted flow's own canvas, instead of the card silently
+            // collapsing to nothing.
+            <div
+              data-testid="workflow-proposal-saved"
+              className="flex flex-wrap items-center gap-2">
+              <p className="font-semibold text-ocean-900 dark:text-ocean-100">
+                {proposal.name || t('chat.flowProposal.title')}
+              </p>
+              <span className="text-xs text-sage-700 dark:text-sage-300">
+                <span aria-hidden>✓</span> {t('chat.flowProposal.savedConfirmation')}
+              </span>
+              <Button
+                variant="tertiary"
+                size="sm"
+                data-analytics-id="workflow-proposal-view"
+                onClick={() => viewWorkflow(completedFlowId)}
+                trailingIcon={<span aria-hidden>→</span>}>
+                {t('chat.flowProposal.viewWorkflow')}
+              </Button>
+            </div>
+          ) : (
+            <>
+              <p className="font-semibold text-ocean-900 dark:text-ocean-100">
+                {proposal.name || t('chat.flowProposal.title')}
+              </p>
+              <p className="mt-1 break-words text-ocean-800/90 dark:text-ocean-200/90">
+                {t('chat.flowProposal.subtitle')}
+              </p>
 
-          <p className="mt-2 text-xs break-words text-content-secondary">
-            <span className="font-medium text-content-muted">
-              {t('chat.flowProposal.triggerLabel')}:
-            </span>{' '}
-            {proposal.summary.trigger}
-          </p>
+              <p className="mt-2 text-xs break-words text-content-secondary">
+                <span className="font-medium text-content-muted">
+                  {t('chat.flowProposal.triggerLabel')}:
+                </span>{' '}
+                {proposal.summary.trigger}
+              </p>
 
-          <div className="mt-2">
-            <p className="text-xs font-medium text-content-muted">
-              {t('chat.flowProposal.stepsLabel')}
-            </p>
-            {proposal.summary.steps.length > 0 ? (
-              <ol className="mt-1 max-h-56 list-decimal overflow-y-auto pl-6 text-content-secondary">
-                {proposal.summary.steps.map((step, i) => {
-                  const kindI18nKey = stepKindI18nKey(step.kind);
-                  const kindLabel = kindI18nKey
-                    ? t(kindI18nKey)
-                    : humanizeUnknownStepKind(step.kind);
-                  return (
-                    <li key={i} className="break-words">
-                      <span
-                        data-testid="workflow-proposal-step-kind"
-                        className="mr-1.5 inline-block rounded-full bg-ocean-100 px-1.5 py-0.5 text-[10px] font-medium text-ocean-700 dark:bg-ocean-500/15 dark:text-ocean-300">
-                        {kindLabel}
-                      </span>
-                      <span>{step.name}</span>
-                    </li>
-                  );
-                })}
-              </ol>
-            ) : (
-              <p className="mt-1 text-xs text-content-faint">{t('chat.flowProposal.noSteps')}</p>
-            )}
-          </div>
+              <div className="mt-2">
+                <p className="text-xs font-medium text-content-muted">
+                  {t('chat.flowProposal.stepsLabel')}
+                </p>
+                {proposal.summary.steps.length > 0 ? (
+                  <ol className="mt-1 max-h-56 list-decimal overflow-y-auto pl-6 text-content-secondary">
+                    {proposal.summary.steps.map((step, i) => {
+                      const kindI18nKey = stepKindI18nKey(step.kind);
+                      const kindLabel = kindI18nKey
+                        ? t(kindI18nKey)
+                        : humanizeUnknownStepKind(step.kind);
+                      return (
+                        <li key={i} className="break-words">
+                          <span
+                            data-testid="workflow-proposal-step-kind"
+                            className="mr-1.5 inline-block rounded-full bg-ocean-100 px-1.5 py-0.5 text-[10px] font-medium text-ocean-700 dark:bg-ocean-500/15 dark:text-ocean-300">
+                            {kindLabel}
+                          </span>
+                          <span>{step.name}</span>
+                        </li>
+                      );
+                    })}
+                  </ol>
+                ) : (
+                  <p className="mt-1 text-xs text-content-faint">
+                    {t('chat.flowProposal.noSteps')}
+                  </p>
+                )}
+              </div>
 
-          {proposal.requireApproval && (
-            <p className="mt-2 text-xs text-content-faint">
-              {t('chat.flowProposal.requireApprovalHint')}
-            </p>
+              {proposal.requireApproval && (
+                <p className="mt-2 text-xs text-content-faint">
+                  {t('chat.flowProposal.requireApprovalHint')}
+                </p>
+              )}
+
+              {errorMsg && <p className="mt-2 text-xs text-coral">⚠ {errorMsg}</p>}
+
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <Button
+                  variant="primary"
+                  size="sm"
+                  data-analytics-id="workflow-proposal-save"
+                  onClick={() => void save()}
+                  disabled={saving}>
+                  {saving ? t('chat.flowProposal.saving') : t('chat.flowProposal.save')}
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  data-analytics-id="workflow-proposal-open-canvas"
+                  onClick={openInCanvas}
+                  disabled={saving}>
+                  {t('chat.flowProposal.openInCanvas')}
+                </Button>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  data-analytics-id="workflow-proposal-dismiss"
+                  onClick={dismiss}
+                  disabled={saving}>
+                  {t('chat.flowProposal.dismiss')}
+                </Button>
+              </div>
+            </>
           )}
-
-          {errorMsg && <p className="mt-2 text-xs text-coral">⚠ {errorMsg}</p>}
-
-          <div className="mt-3 flex flex-wrap items-center gap-2">
-            <Button
-              variant="primary"
-              size="sm"
-              data-analytics-id="workflow-proposal-save"
-              onClick={() => void save()}
-              disabled={saving}>
-              {saving ? t('chat.flowProposal.saving') : t('chat.flowProposal.save')}
-            </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              data-analytics-id="workflow-proposal-open-canvas"
-              onClick={openInCanvas}
-              disabled={saving}>
-              {t('chat.flowProposal.openInCanvas')}
-            </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              data-analytics-id="workflow-proposal-dismiss"
-              onClick={dismiss}
-              disabled={saving}>
-              {t('chat.flowProposal.dismiss')}
-            </Button>
-          </div>
         </div>
       </div>
     </div>

--- a/app/src/components/chat/WorkflowProposalCard.tsx
+++ b/app/src/components/chat/WorkflowProposalCard.tsx
@@ -9,6 +9,7 @@ import { createFlow, setFlowEnabled } from '../../services/api/flowsApi';
 import { threadApi } from '../../services/api/threadApi';
 import {
   clearWorkflowProposalForThread,
+  markWorkflowProposalCompleted,
   type WorkflowProposal,
 } from '../../store/chatRuntimeSlice';
 import { useAppDispatch } from '../../store/hooks';
@@ -122,7 +123,19 @@ export const WorkflowProposalCard: React.FC<Props> = ({ threadId, proposal, onSa
   // the persisted flow's own canvas (issue B36). Kept distinct from
   // `savedFlowId` above: that one tracks an in-between "saved but not yet
   // armed" retry state, this one is the fully-done state.
-  const [completedFlowId, setCompletedFlowId] = useState<string | null>(null);
+  //
+  // Initialized from `proposal.completedFlowId` (mirrored into Redux via
+  // `markWorkflowProposalCompleted`) rather than always starting at `null`:
+  // the card intentionally stays mounted after a successful save (its
+  // parent renders it only while the proposal survives in
+  // `pendingWorkflowProposalsByThread`), so a thread/route change can
+  // remount it before the user clicks "View workflow". Seeding from the
+  // Redux-persisted value keeps the confirmation showing across that
+  // remount instead of resetting to the pre-save editable view — which
+  // would let a second "Save & enable" click duplicate the flow.
+  const [completedFlowId, setCompletedFlowId] = useState<string | null>(
+    () => proposal.completedFlowId ?? null
+  );
 
   /**
    * When this proposal was rehydrated from a persisted thread message (the
@@ -181,6 +194,17 @@ export const WorkflowProposalCard: React.FC<Props> = ({ threadId, proposal, onSa
     navigate(FLOW_CANVAS_DRAFT_ROUTE, { state: draft });
   };
 
+  /**
+   * Record the terminal "saved and enabled" state both locally (drives this
+   * render) and in Redux via `markWorkflowProposalCompleted` (survives a
+   * remount before the user clicks "View workflow" — see the
+   * `completedFlowId` state comment above).
+   */
+  const markCompleted = (flowId: string) => {
+    setCompletedFlowId(flowId);
+    dispatch(markWorkflowProposalCompleted({ threadId, flowId }));
+  };
+
   const save = async () => {
     if (saving) return;
     setSaving(true);
@@ -200,7 +224,7 @@ export const WorkflowProposalCard: React.FC<Props> = ({ threadId, proposal, onSa
           log('save: createFlow returned enabled — nothing further to arm id=%s', flow.id);
           markSourceMessageConsumed();
           setSaving(false);
-          setCompletedFlowId(flow.id);
+          markCompleted(flow.id);
           onSaved?.();
           return;
         }
@@ -213,7 +237,7 @@ export const WorkflowProposalCard: React.FC<Props> = ({ threadId, proposal, onSa
       await setFlowEnabled(flowId, true);
       markSourceMessageConsumed();
       setSaving(false);
-      setCompletedFlowId(flowId);
+      markCompleted(flowId);
       onSaved?.();
     } catch (e) {
       log('save failed (createFlow/setFlowEnabled): %o', e);

--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -3433,6 +3433,8 @@ const messages: TranslationMap = {
   'chat.flowProposal.error': 'تعذّر حفظ سير العمل. حاول مرة أخرى.',
   'chat.flowProposal.enableError':
     'تم حفظ سير العمل، لكن تعذّر تفعيله. حاول مرة أخرى، أو فعّله من صفحة سير العمل.',
+  'chat.flowProposal.savedConfirmation': 'تم الحفظ',
+  'chat.flowProposal.viewWorkflow': 'عرض سير العمل',
   'chat.flowProposal.stepKind.agent': 'وكيل',
   'chat.flowProposal.stepKind.toolCall': 'إجراء',
   'chat.flowProposal.stepKind.httpRequest': 'طلب ويب',

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -3512,6 +3512,8 @@ const messages: TranslationMap = {
   'chat.flowProposal.error': 'ওয়ার্কফ্লো সংরক্ষণ করা যায়নি। আবার চেষ্টা করুন।',
   'chat.flowProposal.enableError':
     'ওয়ার্কফ্লো সংরক্ষিত হয়েছে, কিন্তু সক্ষম করা যায়নি। আবার চেষ্টা করুন, বা Workflows পৃষ্ঠা থেকে সক্ষম করুন।',
+  'chat.flowProposal.savedConfirmation': 'সংরক্ষিত হয়েছে',
+  'chat.flowProposal.viewWorkflow': 'ওয়ার্কফ্লো দেখুন',
   'chat.flowProposal.stepKind.agent': 'এজেন্ট',
   'chat.flowProposal.stepKind.toolCall': 'কার্যক্রম',
   'chat.flowProposal.stepKind.httpRequest': 'ওয়েব অনুরোধ',

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -3614,6 +3614,8 @@ const messages: TranslationMap = {
     'Der Workflow konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.',
   'chat.flowProposal.enableError':
     'Workflow gespeichert, konnte aber nicht aktiviert werden. Versuchen Sie es erneut oder aktivieren Sie ihn auf der Workflows-Seite.',
+  'chat.flowProposal.savedConfirmation': 'Gespeichert',
+  'chat.flowProposal.viewWorkflow': 'Workflow ansehen',
   'chat.flowProposal.stepKind.agent': 'Agent',
   'chat.flowProposal.stepKind.toolCall': 'Aktion',
   'chat.flowProposal.stepKind.httpRequest': 'Webanfrage',

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -3917,6 +3917,11 @@ const en: TranslationMap = {
   'chat.flowProposal.error': 'Could not save the workflow. Please try again.',
   'chat.flowProposal.enableError':
     'Workflow saved, but could not enable it. Try again, or enable it from the Workflows page.',
+  // Terminal success state (issue B36): shown once the flow is saved and
+  // enabled, in place of the editable proposal, with a link into the
+  // persisted flow's own canvas.
+  'chat.flowProposal.savedConfirmation': 'Saved',
+  'chat.flowProposal.viewWorkflow': 'View workflow',
   // Plain-language labels for each `tinyflows` node kind, shown as the badge
   // next to each step in the proposal card's step list. Keep names short:
   // they render as small pill badges.

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -3576,6 +3576,8 @@ const messages: TranslationMap = {
   'chat.flowProposal.error': 'No se pudo guardar el flujo de trabajo. Inténtalo de nuevo.',
   'chat.flowProposal.enableError':
     'Flujo de trabajo guardado, pero no se pudo activar. Inténtalo de nuevo o actívalo desde la página de Workflows.',
+  'chat.flowProposal.savedConfirmation': 'Guardado',
+  'chat.flowProposal.viewWorkflow': 'Ver flujo de trabajo',
   'chat.flowProposal.stepKind.agent': 'Agente',
   'chat.flowProposal.stepKind.toolCall': 'Acción',
   'chat.flowProposal.stepKind.httpRequest': 'Solicitud web',

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -3599,6 +3599,8 @@ const messages: TranslationMap = {
   'chat.flowProposal.error': "Impossible d'enregistrer le workflow. Veuillez réessayer.",
   'chat.flowProposal.enableError':
     "Workflow enregistré, mais impossible de l'activer. Réessayez, ou activez-le depuis la page Workflows.",
+  'chat.flowProposal.savedConfirmation': 'Enregistré',
+  'chat.flowProposal.viewWorkflow': 'Voir le workflow',
   'chat.flowProposal.stepKind.agent': 'Agent',
   'chat.flowProposal.stepKind.toolCall': 'Action',
   'chat.flowProposal.stepKind.httpRequest': 'Requête web',

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -3511,6 +3511,8 @@ const messages: TranslationMap = {
   'chat.flowProposal.error': 'वर्कफ़्लो सहेजा नहीं जा सका। कृपया फिर से प्रयास करें।',
   'chat.flowProposal.enableError':
     'वर्कफ़्लो सहेजा गया, लेकिन सक्षम नहीं किया जा सका। फिर से प्रयास करें, या Workflows पेज से इसे सक्षम करें।',
+  'chat.flowProposal.savedConfirmation': 'सहेजा गया',
+  'chat.flowProposal.viewWorkflow': 'वर्कफ़्लो देखें',
   'chat.flowProposal.stepKind.agent': 'एजेंट',
   'chat.flowProposal.stepKind.toolCall': 'कार्रवाई',
   'chat.flowProposal.stepKind.httpRequest': 'वेब अनुरोध',

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -3528,6 +3528,8 @@ const messages: TranslationMap = {
   'chat.flowProposal.error': 'Alur kerja tidak dapat disimpan. Silakan coba lagi.',
   'chat.flowProposal.enableError':
     'Alur kerja disimpan, tetapi tidak dapat diaktifkan. Coba lagi, atau aktifkan dari halaman Workflows.',
+  'chat.flowProposal.savedConfirmation': 'Tersimpan',
+  'chat.flowProposal.viewWorkflow': 'Lihat alur kerja',
   'chat.flowProposal.stepKind.agent': 'Agen',
   'chat.flowProposal.stepKind.toolCall': 'Tindakan',
   'chat.flowProposal.stepKind.httpRequest': 'Permintaan web',

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -3575,6 +3575,8 @@ const messages: TranslationMap = {
   'chat.flowProposal.error': 'Impossibile salvare il workflow. Riprova.',
   'chat.flowProposal.enableError':
     'Workflow salvato, ma non è stato possibile attivarlo. Riprova, oppure attivalo dalla pagina Workflows.',
+  'chat.flowProposal.savedConfirmation': 'Salvato',
+  'chat.flowProposal.viewWorkflow': 'Visualizza workflow',
   'chat.flowProposal.stepKind.agent': 'Agente',
   'chat.flowProposal.stepKind.toolCall': 'Azione',
   'chat.flowProposal.stepKind.httpRequest': 'Richiesta web',

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -3476,6 +3476,8 @@ const messages: TranslationMap = {
   'chat.flowProposal.error': '워크플로를 저장할 수 없습니다. 다시 시도하세요.',
   'chat.flowProposal.enableError':
     '워크플로는 저장되었지만 활성화할 수 없습니다. 다시 시도하거나 Workflows 페이지에서 활성화하세요.',
+  'chat.flowProposal.savedConfirmation': '저장됨',
+  'chat.flowProposal.viewWorkflow': '워크플로 보기',
   'chat.flowProposal.stepKind.agent': '에이전트',
   'chat.flowProposal.stepKind.toolCall': '작업',
   'chat.flowProposal.stepKind.httpRequest': '웹 요청',

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -3556,6 +3556,8 @@ const messages: TranslationMap = {
   'chat.flowProposal.error': 'Nie udało się zapisać przepływu pracy. Spróbuj ponownie.',
   'chat.flowProposal.enableError':
     'Przepływ pracy zapisany, ale nie udało się go włączyć. Spróbuj ponownie lub włącz go na stronie Workflows.',
+  'chat.flowProposal.savedConfirmation': 'Zapisano',
+  'chat.flowProposal.viewWorkflow': 'Zobacz przepływ pracy',
   'chat.flowProposal.stepKind.agent': 'Agent',
   'chat.flowProposal.stepKind.toolCall': 'Akcja',
   'chat.flowProposal.stepKind.httpRequest': 'Żądanie sieciowe',

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -3568,6 +3568,8 @@ const messages: TranslationMap = {
   'chat.flowProposal.error': 'Não foi possível salvar o fluxo de trabalho. Tente novamente.',
   'chat.flowProposal.enableError':
     'Fluxo de trabalho salvo, mas não foi possível ativá-lo. Tente novamente ou ative-o na página Workflows.',
+  'chat.flowProposal.savedConfirmation': 'Salvo',
+  'chat.flowProposal.viewWorkflow': 'Ver fluxo de trabalho',
   'chat.flowProposal.stepKind.agent': 'Agente',
   'chat.flowProposal.stepKind.toolCall': 'Ação',
   'chat.flowProposal.stepKind.httpRequest': 'Pedido web',

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -3540,6 +3540,8 @@ const messages: TranslationMap = {
   'chat.flowProposal.error': 'Не удалось сохранить рабочий процесс. Попробуйте еще раз.',
   'chat.flowProposal.enableError':
     'Рабочий процесс сохранён, но не удалось его включить. Попробуйте ещё раз или включите его на странице Workflows.',
+  'chat.flowProposal.savedConfirmation': 'Сохранено',
+  'chat.flowProposal.viewWorkflow': 'Просмотреть рабочий процесс',
   'chat.flowProposal.stepKind.agent': 'Агент',
   'chat.flowProposal.stepKind.toolCall': 'Действие',
   'chat.flowProposal.stepKind.httpRequest': 'Веб-запрос',

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -3329,6 +3329,8 @@ const messages: TranslationMap = {
   'chat.flowProposal.dismiss': '忽略',
   'chat.flowProposal.error': '无法保存该工作流。请重试。',
   'chat.flowProposal.enableError': '工作流已保存，但无法启用。请重试，或在“工作流”页面手动启用。',
+  'chat.flowProposal.savedConfirmation': '已保存',
+  'chat.flowProposal.viewWorkflow': '查看工作流',
   'chat.flowProposal.stepKind.agent': '智能体',
   'chat.flowProposal.stepKind.toolCall': '操作',
   'chat.flowProposal.stepKind.httpRequest': '网络请求',

--- a/app/src/store/chatRuntimeSlice.ts
+++ b/app/src/store/chatRuntimeSlice.ts
@@ -546,6 +546,18 @@ export interface WorkflowProposal {
    * message `consumed: true` so the card does not resurrect on reload.
    */
   sourceMessageId?: string;
+  /**
+   * Id of the flow once `WorkflowProposalCard`'s "Save & enable" has fully
+   * persisted AND enabled it (issue B36). Mirrored into Redux (rather than
+   * living only in the card's component state) because the card
+   * deliberately stays mounted showing a "saved" confirmation after success
+   * instead of dispatching `clearWorkflowProposalForThread` right away — so
+   * a thread/route change can remount the card before the user clicks
+   * "View workflow". Without this, the remount would reset local state to
+   * `null`, fall back to the pre-save editable view, and a second "Save &
+   * enable" click would call `createFlow` again and duplicate the flow.
+   */
+  completedFlowId?: string;
 }
 
 /**
@@ -1749,6 +1761,23 @@ const chatRuntimeSlice = createSlice({
       delete state.pendingWorkflowProposalsByThread[action.payload.threadId];
     },
     /**
+     * Record that a pending workflow proposal's flow finished saving AND
+     * enabling (issue B36), so `WorkflowProposalCard`'s terminal "saved"
+     * state survives a remount (thread switch, route change) while the
+     * proposal is still sitting in `pendingWorkflowProposalsByThread` — see
+     * `WorkflowProposal.completedFlowId`. No-op if the proposal was already
+     * cleared (e.g. a race with `clearWorkflowProposalForThread`).
+     */
+    markWorkflowProposalCompleted: (
+      state,
+      action: PayloadAction<{ threadId: string; flowId: string }>
+    ) => {
+      const proposal = state.pendingWorkflowProposalsByThread[action.payload.threadId];
+      if (proposal) {
+        proposal.completedFlowId = action.payload.flowId;
+      }
+    },
+    /**
      * Mark a producer-tool call as in-flight so the `ArtifactCard` can
      * render a spinner before any ready/failed event arrives. Caller
      * usually fires this off the corresponding `ChatToolCallEvent`
@@ -2286,6 +2315,7 @@ export const {
   clearPendingPlanReviewForThread,
   setWorkflowProposalForThread,
   clearWorkflowProposalForThread,
+  markWorkflowProposalCompleted,
   upsertArtifactInProgressForThread,
   upsertArtifactReadyForThread,
   upsertArtifactFailedForThread,


### PR DESCRIPTION
## What

When a workflow is saved from the main-chat `WorkflowProposalCard`, the card previously called `createFlow` → `setFlowEnabled` → cleared the proposal from Redux immediately, so it silently collapsed with no way to get to the saved flow. It now:

- Captures the persisted `flowId` from `createFlow`'s response.
- On successful save (both the immediately-enabled path and the B29-Rule-1 disabled-then-armed retry path), swaps the card's body to a compact "Saved" confirmation with a "View workflow" button instead of dispatching the proposal away.
- Clicking "View workflow" navigates to `/flows/${flowId}` (the persisted canvas — matching the route the rest of the app already uses via `useCreateFlow`'s `navigate(\`/flows/${flow.id}\`)`, not the unsaved-draft `/flows/draft` route) and only *then* dispatches `clearWorkflowProposalForThread`, since the parent (`Conversations.tsx`) only renders the card while a pending proposal exists in Redux — clearing it earlier would unmount the card before the user ever saw the confirmation.
- "Dismiss" is unchanged.
- `markSourceMessageConsumed()` / `setFlowEnabled` / `onSaved?.()` behavior is unchanged.

## Why

Previously a successful save gave no feedback beyond the card vanishing — there was no way to jump to the flow you just created without navigating to the Flows page and finding it manually.

## Out of scope

The copilot/delegate `save_workflow` autosave path (a separate agent-message surface, not this human-in-the-loop card) is untouched — noted per the issue.

## Test plan

- [x] `pnpm typecheck` — passes
- [x] `pnpm test WorkflowProposalCard` — 17/17 passing, including two new/updated tests: the saved-confirmation renders after a successful save without dispatching the proposal away, and clicking "View workflow" navigates to `/flows/f1` and dispatches the clear
- [x] `pnpm exec prettier --check` (fixed one formatting issue with `--write`) + `eslint` on changed files — clean
- [x] `pnpm i18n:check` — 0 missing / 0 extra keys across all 13 locales (`ar`, `bn`, `de`, `es`, `fr`, `hi`, `id`, `it`, `ko`, `pl`, `pt`, `ru`, `zh-CN`); new keys `chat.flowProposal.savedConfirmation` / `chat.flowProposal.viewWorkflow` added everywhere, no em dashes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a post-save confirmation state that remains visible after successfully creating and enabling a workflow.
  - Added a **View workflow** action that takes users to the saved workflow.

- **Bug Fixes**
  - Ensures the saved confirmation persists across remounts until the workflow is opened.
  - Prevents duplicate workflow creation during retry attempts and refines enablement retry behavior.

- **Tests**
  - Updated tests to validate saved-confirmation persistence, retry/enablement flows, navigation, and proposal-clearing timing.

- **Documentation**
  - Added i18n labels for the saved confirmation and **View workflow** action (all supported languages).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->