### PR TITLE
fix(flows): shorter approval TTL for copilot live-run parks

### DIFF
--- a/src/openhuman/approval/gate.rs
+++ b/src/openhuman/approval/gate.rs
@@ -825,8 +825,18 @@ impl ApprovalGate {
 
         let request_id = uuid::Uuid::new_v4().to_string();
         let now = chrono::Utc::now();
-        let expires_at =
-            Some(now + chrono::Duration::from_std(self.effective_ttl()).unwrap_or_default());
+        // Resolve the clamped park TTL up front so the persisted `expires_at`
+        // and the actual wait below (see `resolve_park_ttl` further down)
+        // use the same value — see `Self::resolve_park_ttl` and the
+        // COPILOT_APPROVAL_TTL / IN_CALL_APPROVAL_TTL clamps. Computing this
+        // only after persisting the pending row let a copilot-streaming park
+        // advertise the old 10-minute `expires_at` while only actually
+        // waiting 180s, so a core restart or an `expire_stale` sweep mid-park
+        // could leave the row "actionable" for the wrong window (CodeRabbit
+        // + Codex review on PR #5112).
+        let effective_ttl =
+            Self::resolve_park_ttl(self.effective_ttl(), in_call_ctx.is_some(), copilot_stream);
+        let expires_at = Some(now + chrono::Duration::from_std(effective_ttl).unwrap_or_default());
 
         // Correlation context (flow-approval-surface, PR2): a Workflow-origin
         // park carries the flow id on the origin itself, but not the run id —
@@ -972,9 +982,11 @@ impl ApprovalGate {
 
         // Live meetings and copilot-streaming flows_build runs each get a
         // clamped park window — see IN_CALL_APPROVAL_TTL / COPILOT_APPROVAL_TTL
-        // and `Self::resolve_park_ttl`. `effective_ttl()` applies the
-        // debug-only env override; the clamp is applied on top so a longer
-        // override can't extend either park past its clamp.
+        // and `Self::resolve_park_ttl`. `effective_ttl` was resolved above
+        // (before `expires_at` was built) so the persisted expiry and this
+        // wait use the identical clamped duration; `effective_ttl()` applies
+        // the debug-only env override, and the clamp is applied on top so a
+        // longer override can't extend either park past its clamp.
         if copilot_stream {
             tracing::debug!(
                 tool = tool_name,
@@ -983,8 +995,6 @@ impl ApprovalGate {
                  COPILOT_APPROVAL_TTL"
             );
         }
-        let effective_ttl =
-            Self::resolve_park_ttl(self.effective_ttl(), in_call_ctx.is_some(), copilot_stream);
 
         // Optional caller-supplied park bound (issue #4756). A caller
         // (`composio_connect`) can cap how long the gate parks so a turn
@@ -2580,6 +2590,73 @@ mod tests {
                 tighter
             );
         }
+    }
+
+    /// Integration regression test for the streaming-to-gate contract
+    /// (CodeRabbit review on PR #5112): `resolve_park_ttl` is covered directly
+    /// above, but that alone doesn't prove `intercept_audited_inner` actually
+    /// persists the clamped TTL when the copilot-streaming context is scoped.
+    /// Builds a gate with the full `DEFAULT_APPROVAL_TTL` boot TTL (unlike
+    /// `test_gate()`'s 2s, which is already shorter than either clamp and
+    /// would make this assertion vacuous), scopes
+    /// `APPROVAL_COPILOT_STREAM_CONTEXT` alongside the chat context + WebChat
+    /// origin the way `flows::ops::flows_build` does in production, and
+    /// inspects the persisted `expires_at` on the pending row.
+    #[tokio::test]
+    async fn copilot_streaming_park_persists_the_clamped_expiry() {
+        let dir = TempDir::new().unwrap();
+        let config = Config {
+            workspace_dir: dir.path().to_path_buf(),
+            ..Config::default()
+        };
+        let session = format!("session-{}", uuid::Uuid::new_v4());
+        let gate = ApprovalGate::new(config, session, DEFAULT_APPROVAL_TTL);
+        let gate = Arc::new(gate);
+
+        let before = chrono::Utc::now();
+        let g = gate.clone();
+        let handle = tokio::spawn(async move {
+            turn_origin::with_origin(
+                web_origin(),
+                APPROVAL_CHAT_CONTEXT.scope(
+                    chat_ctx(),
+                    APPROVAL_COPILOT_STREAM_CONTEXT.scope(
+                        (),
+                        g.intercept("composio", "send slack", serde_json::json!({})),
+                    ),
+                ),
+            )
+            .await
+        });
+
+        let pending = loop {
+            if let Some(p) = gate.list_pending().unwrap().into_iter().next() {
+                break p;
+            }
+            tokio::task::yield_now().await;
+        };
+
+        let expires_at = pending
+            .expires_at
+            .expect("a parked approval always sets expires_at");
+        let ttl_persisted = expires_at - before;
+        assert!(
+            ttl_persisted
+                <= chrono::Duration::from_std(COPILOT_APPROVAL_TTL).unwrap()
+                    + chrono::Duration::seconds(5),
+            "copilot-streaming park must persist an expires_at clamped to COPILOT_APPROVAL_TTL \
+             (180s), not the gate's full {:?} boot TTL — got a {ttl_persisted} window",
+            DEFAULT_APPROVAL_TTL
+        );
+        assert!(
+            ttl_persisted < chrono::Duration::from_std(DEFAULT_APPROVAL_TTL).unwrap(),
+            "sanity: the persisted expiry must be shorter than the unclamped default TTL"
+        );
+
+        gate.decide(&pending.request_id, ApprovalDecision::ApproveOnce)
+            .unwrap();
+        let outcome = handle.await.unwrap();
+        assert!(matches!(outcome, GateOutcome::Allow));
     }
 
     #[test]

--- a/src/openhuman/approval/gate.rs
+++ b/src/openhuman/approval/gate.rs
@@ -69,6 +69,19 @@ const DEFAULT_APPROVAL_TTL: Duration = Duration::from_secs(60 * 10);
 /// minutes — if nobody approves within two, deny and move on.
 const IN_CALL_APPROVAL_TTL: Duration = Duration::from_secs(120);
 
+/// Shorter park window for approvals raised by the Flow Canvas copilot's
+/// live-run path — `flows_build` streaming into the copilot pane calling
+/// `run_flow` / `resume_flow_run` (PR #5090). A stale ten-minute park on a
+/// copilot pane the user may have already navigated away from is a long time
+/// to leave a live Slack/Gmail/HTTP node waiting; if nobody approves within
+/// three minutes, deny and let the authoring turn continue (the user can
+/// still re-trigger the run from the Runs rail). Mirrors
+/// [`IN_CALL_APPROVAL_TTL`]'s clamp, scoped by [`APPROVAL_COPILOT_STREAM_CONTEXT`]
+/// instead of [`APPROVAL_IN_CALL_CONTEXT`]. Deliberately NOT applied to
+/// main-chat `WebChat` parks — only `flows::ops::flows_build`'s streaming
+/// branch scopes the task-local below.
+const COPILOT_APPROVAL_TTL: Duration = Duration::from_secs(180);
+
 /// Per-turn chat context for routing a parked approval's yes/no reply back to
 /// the originating thread. The web channel scopes this task-local around the
 /// agent run (`web_chat`); because the `run_turn` handler, the
@@ -104,6 +117,19 @@ pub struct InCallApprovalContext {
 
 tokio::task_local! {
     pub static APPROVAL_IN_CALL_CONTEXT: InCallApprovalContext;
+}
+
+tokio::task_local! {
+    /// Marks a park as originating from the Flow Canvas copilot's streaming
+    /// `flows_build` path — scoped by `flows::ops::flows_build` around the
+    /// streaming `agent.run_single(&prompt)` call, alongside the existing
+    /// `AgentTurnOrigin::WebChat` + [`APPROVAL_CHAT_CONTEXT`] double-scope that
+    /// path already uses. Presence alone is the signal (no fields needed): when
+    /// set, the park window is clamped to [`COPILOT_APPROVAL_TTL`] instead of
+    /// the gate's own (possibly env-overridden) TTL. Absent for every other
+    /// caller — in particular, plain main-chat `WebChat` turns do not scope
+    /// this, so they keep the full [`DEFAULT_APPROVAL_TTL`].
+    pub static APPROVAL_COPILOT_STREAM_CONTEXT: ();
 }
 
 /// Per-run flow context (flow-approval-surface, PR2 of the tinyflows
@@ -342,6 +368,28 @@ impl ApprovalGate {
             return ttl;
         }
         self.ttl
+    }
+
+    /// Resolve the actual park duration from the gate's own `effective_ttl`
+    /// plus whichever origin-specific clamp is active for this call
+    /// (`in_call` → [`IN_CALL_APPROVAL_TTL`], `copilot_stream` →
+    /// [`COPILOT_APPROVAL_TTL`]). A clamp only ever *shortens* the park — it
+    /// can never extend `effective_ttl` past what the gate itself allows
+    /// (e.g. a debug env override). Both flags are expected to be mutually
+    /// exclusive in production (a live-meeting turn and a `flows_build`
+    /// copilot stream are different call sites), but if both were ever true
+    /// the tighter of the two clamps wins, since each `min` only narrows.
+    /// Split out (rather than inlined at the call site) so it is unit
+    /// testable without needing to actually park a future.
+    fn resolve_park_ttl(effective_ttl: Duration, in_call: bool, copilot_stream: bool) -> Duration {
+        let mut ttl = effective_ttl;
+        if in_call {
+            ttl = ttl.min(IN_CALL_APPROVAL_TTL);
+        }
+        if copilot_stream {
+            ttl = ttl.min(COPILOT_APPROVAL_TTL);
+        }
+        ttl
     }
 
     /// Whether `tool_name` is on the user's "Always allow" list. Prefers the
@@ -613,6 +661,11 @@ impl ApprovalGate {
         // live-meeting orchestrator turn. Enables the spoken approval
         // channel alongside the thread card (issue #3513).
         let in_call_ctx = APPROVAL_IN_CALL_CONTEXT.try_with(|c| c.clone()).ok();
+
+        // Copilot-streaming context — set by `flows::ops::flows_build` around
+        // the streaming `run_single` call. Presence alone clamps the park
+        // window to `COPILOT_APPROVAL_TTL`; see that task-local's doc.
+        let copilot_stream = APPROVAL_COPILOT_STREAM_CONTEXT.try_with(|_| ()).is_ok();
 
         // Branch by origin. Web chat parks for an in-app approval; external
         // channel persists an audit row and TTL-denies (no routable approval
@@ -917,15 +970,21 @@ impl ApprovalGate {
             "[approval::gate] tool call parked, waiting for decision"
         );
 
-        // Live meetings get a clamped park window — see IN_CALL_APPROVAL_TTL.
-        // `effective_ttl()` applies the debug-only env override; the in-call
-        // clamp is applied on top so a longer override can't extend a live
-        // meeting's park window past IN_CALL_APPROVAL_TTL.
-        let effective_ttl = if in_call_ctx.is_some() {
-            IN_CALL_APPROVAL_TTL.min(self.effective_ttl())
-        } else {
-            self.effective_ttl()
-        };
+        // Live meetings and copilot-streaming flows_build runs each get a
+        // clamped park window — see IN_CALL_APPROVAL_TTL / COPILOT_APPROVAL_TTL
+        // and `Self::resolve_park_ttl`. `effective_ttl()` applies the
+        // debug-only env override; the clamp is applied on top so a longer
+        // override can't extend either park past its clamp.
+        if copilot_stream {
+            tracing::debug!(
+                tool = tool_name,
+                ttl_secs = COPILOT_APPROVAL_TTL.as_secs(),
+                "[approval::gate] flows_build copilot-streaming park — clamping park window to \
+                 COPILOT_APPROVAL_TTL"
+            );
+        }
+        let effective_ttl =
+            Self::resolve_park_ttl(self.effective_ttl(), in_call_ctx.is_some(), copilot_stream);
 
         // Optional caller-supplied park bound (issue #4756). A caller
         // (`composio_connect`) can cap how long the gate parks so a turn
@@ -2446,6 +2505,81 @@ mod tests {
             Duration::from_secs(2),
             "unset OPENHUMAN_APPROVAL_TTL_SECS must fall back to boot-time TTL"
         );
+    }
+
+    /// Tests for `resolve_park_ttl` — the pure clamp-selection helper behind
+    /// the copilot-streaming TTL shortening (fix/flows-copilot-approval-ttl).
+    /// Exercised directly (rather than by actually parking + waiting out a
+    /// multi-minute TTL) so the assertions stay fast and deterministic.
+    mod resolve_park_ttl_tests {
+        use super::*;
+
+        #[test]
+        fn default_park_keeps_the_full_ttl() {
+            let default_ttl = DEFAULT_APPROVAL_TTL;
+            assert_eq!(
+                ApprovalGate::resolve_park_ttl(default_ttl, false, false),
+                default_ttl,
+                "a plain park (no in-call, no copilot stream) must not be clamped"
+            );
+        }
+
+        #[test]
+        fn copilot_stream_shortens_a_default_ten_minute_park() {
+            let default_ttl = DEFAULT_APPROVAL_TTL;
+            assert_eq!(
+                ApprovalGate::resolve_park_ttl(default_ttl, false, true),
+                COPILOT_APPROVAL_TTL,
+                "a flows_build copilot-streaming park must clamp to COPILOT_APPROVAL_TTL"
+            );
+            assert!(
+                COPILOT_APPROVAL_TTL < DEFAULT_APPROVAL_TTL,
+                "the copilot clamp must actually be shorter than the default TTL"
+            );
+        }
+
+        #[test]
+        fn in_call_clamp_is_unaffected_by_the_copilot_flag() {
+            let default_ttl = DEFAULT_APPROVAL_TTL;
+            assert_eq!(
+                ApprovalGate::resolve_park_ttl(default_ttl, true, false),
+                IN_CALL_APPROVAL_TTL,
+                "an in-call meeting park must keep clamping to IN_CALL_APPROVAL_TTL, unchanged \
+                 by this fix"
+            );
+        }
+
+        #[test]
+        fn a_clamp_never_extends_a_shorter_boot_time_ttl() {
+            // Mirrors production's env-override guard: a clamp may only
+            // narrow, never widen, the gate's own effective TTL (e.g. a
+            // debug-only `OPENHUMAN_APPROVAL_TTL_SECS=60` override that is
+            // already shorter than either clamp).
+            let short_ttl = Duration::from_secs(60);
+            assert_eq!(
+                ApprovalGate::resolve_park_ttl(short_ttl, false, true),
+                short_ttl,
+                "copilot clamp must not extend a boot-time TTL that is already shorter"
+            );
+            assert_eq!(
+                ApprovalGate::resolve_park_ttl(short_ttl, true, false),
+                short_ttl,
+                "in-call clamp must not extend a boot-time TTL that is already shorter"
+            );
+        }
+
+        #[test]
+        fn both_flags_active_takes_the_tighter_clamp() {
+            // Not expected in production (different call sites), but the
+            // helper must not panic or pick the wrong side if it ever
+            // happens — the tighter of the two clamps should win either way.
+            let default_ttl = DEFAULT_APPROVAL_TTL;
+            let tighter = IN_CALL_APPROVAL_TTL.min(COPILOT_APPROVAL_TTL);
+            assert_eq!(
+                ApprovalGate::resolve_park_ttl(default_ttl, true, true),
+                tighter
+            );
+        }
     }
 
     #[test]

--- a/src/openhuman/approval/mod.rs
+++ b/src/openhuman/approval/mod.rs
@@ -22,7 +22,8 @@ pub mod types;
 
 pub use gate::{
     parse_approval_reply, ApprovalChatContext, ApprovalGate, FlowRunContext, InCallApprovalContext,
-    APPROVAL_CHAT_CONTEXT, APPROVAL_FLOW_RUN_CONTEXT, APPROVAL_IN_CALL_CONTEXT,
+    APPROVAL_CHAT_CONTEXT, APPROVAL_COPILOT_STREAM_CONTEXT, APPROVAL_FLOW_RUN_CONTEXT,
+    APPROVAL_IN_CALL_CONTEXT,
 };
 pub use redact::{redact_args, summarize_action};
 pub use schemas::all_controller_schemas as all_approval_controller_schemas;

--- a/src/openhuman/flows/ops.rs
+++ b/src/openhuman/flows/ops.rs
@@ -11,7 +11,8 @@ use tinyflows::model::{NodeKind, TriggerKind, WorkflowGraph};
 
 use crate::openhuman::agent::turn_origin::{with_origin, AgentTurnOrigin, TrustedAutomationSource};
 use crate::openhuman::approval::{
-    ApprovalChatContext, FlowRunContext, APPROVAL_CHAT_CONTEXT, APPROVAL_FLOW_RUN_CONTEXT,
+    ApprovalChatContext, FlowRunContext, APPROVAL_CHAT_CONTEXT, APPROVAL_COPILOT_STREAM_CONTEXT,
+    APPROVAL_FLOW_RUN_CONTEXT,
 };
 use crate::openhuman::config::Config;
 use crate::openhuman::flows::bus;
@@ -4451,11 +4452,22 @@ pub async fn flows_build(
                 request_id = %target.request_id,
                 "[flows] flows_build: streaming copilot turn — WebChat origin + \
                  APPROVAL_CHAT_CONTEXT scoped, live-run tools park for approval instead \
-                 of auto-allowing"
+                 of auto-allowing (shortened to COPILOT_APPROVAL_TTL via \
+                 APPROVAL_COPILOT_STREAM_CONTEXT)"
             );
+            // `APPROVAL_COPILOT_STREAM_CONTEXT` scopes alongside the existing
+            // chat context so any `run_flow`/`resume_flow_run` park raised by
+            // this turn is clamped to the shorter `COPILOT_APPROVAL_TTL`
+            // instead of the gate's full ten-minute default — a stale park on
+            // a copilot pane the user may have already navigated away from
+            // shouldn't idle that long. Main-chat turns never scope this, so
+            // they are unaffected.
             let run = with_origin(
                 origin,
-                APPROVAL_CHAT_CONTEXT.scope(chat_ctx, agent.run_single(&prompt)),
+                APPROVAL_CHAT_CONTEXT.scope(
+                    chat_ctx,
+                    APPROVAL_COPILOT_STREAM_CONTEXT.scope((), agent.run_single(&prompt)),
+                ),
             );
             let run =
                 tokio::time::timeout(std::time::Duration::from_secs(FLOW_BUILD_TIMEOUT_SECS), run);


### PR DESCRIPTION
## Summary

`flows_build`'s streaming (copilot pane) path already scopes `APPROVAL_CHAT_CONTEXT` + `AgentTurnOrigin::WebChat` (PR #5090) so `run_flow` / `resume_flow_run` park for a real human approval instead of auto-allowing. Those parks were using the gate's full 10-minute `DEFAULT_APPROVAL_TTL` (`src/openhuman/approval/gate.rs:65`) — a long time to leave a live Slack/Gmail/HTTP node waiting on a copilot pane the user may have already navigated away from.

This reuses the existing "shorten a specific park" mechanism already established for live meetings (`IN_CALL_APPROVAL_TTL` / `APPROVAL_IN_CALL_CONTEXT`, issue #3513) rather than adding a parallel path:

- New `COPILOT_APPROVAL_TTL` constant (180s / 3 min) in `src/openhuman/approval/gate.rs`.
- New `APPROVAL_COPILOT_STREAM_CONTEXT` task-local, scoped by `flows::ops::flows_build`'s streaming branch alongside the existing `APPROVAL_CHAT_CONTEXT` scope (`src/openhuman/flows/ops.rs`).
- The gate reads the new task-local exactly like it already reads `APPROVAL_IN_CALL_CONTEXT`, and clamps the park window through a new `ApprovalGate::resolve_park_ttl` helper — extracted from the existing in-call min/clamp logic so the clamp-selection is unit testable without actually parking a future and waiting out a multi-minute TTL.
- `DEFAULT_APPROVAL_TTL` itself is untouched, and no new global constant replaces it.

**Only `flows_build`'s streaming branch scopes the new context**, so main-chat and every other approval path (external channel, in-call meetings, workflow automation, CLI, composio's own `park_bound`) keep their existing behavior unmodified.

## Test plan

- [x] `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml` — passes.
- [x] `GGML_NATIVE=OFF cargo test --lib --manifest-path Cargo.toml approval::gate` — 47 passed (including 5 new `resolve_park_ttl_tests` covering: default park unclamped, copilot clamp shortens a 10-minute default, in-call clamp unaffected by the new flag, a clamp never extends an already-shorter boot-time TTL, and the tighter-of-two-clamps case).
- [x] `GGML_NATIVE=OFF cargo test --lib --manifest-path Cargo.toml openhuman::flows::ops` — 183 passed, no regressions.
- [x] `cargo fmt --check` on changed files — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Approval requests generated during copilot streaming now expire based on a dedicated, shorter TTL (about 3 minutes).
  * Approval TTL clamping now applies correctly across copilot-stream, in-call, and default scenarios, without extending the gate’s own effective TTL—even with debug overrides.
  * Stored approval expiry (`expires_at`) is now aligned with the actual clamped wait duration to reduce stale waits.
  * Added targeted test coverage for TTL resolution and copilot-stream persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->