### PR TITLE
feat(flows): FlowRunFinished event — fully event-driven runs rail (completes B35)

### DIFF
--- a/app/src/components/flows/FlowRunsDrawer.test.tsx
+++ b/app/src/components/flows/FlowRunsDrawer.test.tsx
@@ -294,7 +294,7 @@ describe('FlowRunsDrawer', () => {
       // Trigger the live-refresh poll fallback — issues the second, hanging
       // listFlowRuns('flow-a') call.
       await act(async () => {
-        vi.advanceTimersByTime(5_000);
+        vi.advanceTimersByTime(30_000);
       });
       expect(flowACalls).toBe(2);
 

--- a/app/src/components/flows/FlowRunsDrawer.tsx
+++ b/app/src/components/flows/FlowRunsDrawer.tsx
@@ -28,6 +28,7 @@ import debug from 'debug';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useEscapeKey } from '../../hooks/useEscapeKey';
+import { useFlowRunFinished } from '../../hooks/useFlowRunFinished';
 import { useFlowRunsLiveRefresh } from '../../hooks/useFlowRunsLiveRefresh';
 import { useFlowRunStarted } from '../../hooks/useFlowRunStarted';
 import {
@@ -167,6 +168,10 @@ export function FlowRunsDrawer({ flowId, flowName, onClose, onFixWithAgent }: Pr
   // can't reach, so the very first run shows up as "Running" instantly
   // instead of waiting for a manual refresh (issue B35).
   useFlowRunStarted(() => void refetch(), flowId);
+  // Terminal companion to the above (issue B35 follow-up) — flips a run to
+  // Completed/Failed the instant it settles instead of waiting on
+  // `useFlowRunsLiveRefresh`'s debounced/backstop refetch to notice.
+  useFlowRunFinished(() => void refetch(), flowId);
   const pendingRunIds = useRunsPendingApprovalSet(runs);
 
   useEscapeKey(

--- a/app/src/components/flows/FlowRunsSidebar.tsx
+++ b/app/src/components/flows/FlowRunsSidebar.tsx
@@ -14,6 +14,7 @@ import createDebug from 'debug';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
+import { useFlowRunFinished } from '../../hooks/useFlowRunFinished';
 import { useFlowRunsLiveRefresh } from '../../hooks/useFlowRunsLiveRefresh';
 import { useFlowRunStarted } from '../../hooks/useFlowRunStarted';
 import {
@@ -123,6 +124,13 @@ export default function FlowRunsSidebar({ flowId }: FlowRunsSidebarProps) {
   // instead of waiting for a manual refresh (issue B35).
   useFlowRunStarted(() => {
     log('run-started: refetch flow=%s', flowId);
+    void load();
+  }, flowId);
+  // Terminal companion to the above (issue B35 follow-up) — flips a run to
+  // Completed/Failed the instant it settles instead of waiting on
+  // `useFlowRunsLiveRefresh`'s debounced/backstop refetch to notice.
+  useFlowRunFinished(event => {
+    log('run-finished: refetch flow=%s run=%s status=%s', flowId, event.run_id, event.status);
     void load();
   }, flowId);
   const pendingRunIds = useRunsPendingApprovalSet(runs);

--- a/app/src/hooks/__tests__/useFlowRunFinished.test.ts
+++ b/app/src/hooks/__tests__/useFlowRunFinished.test.ts
@@ -1,0 +1,135 @@
+/**
+ * useFlowRunFinished — unit tests (issue B35 follow-up).
+ *
+ * Verifies: subscribes to both socket event aliases unconditionally on mount,
+ * invokes `onFinish` for a matching payload, filters by `flowId` when
+ * provided, passes every event through when `flowId` is omitted, drops
+ * invalid payloads, dedupes the colon/underscore alias replay, and tears down
+ * both subscriptions on unmount.
+ */
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useFlowRunFinished } from '../useFlowRunFinished';
+
+const handlers = vi.hoisted(() => new Map<string, Set<(data: unknown) => void>>());
+const on = vi.hoisted(() =>
+  vi.fn((event: string, cb: (data: unknown) => void) => {
+    const set = handlers.get(event) ?? new Set();
+    set.add(cb);
+    handlers.set(event, set);
+  })
+);
+const off = vi.hoisted(() =>
+  vi.fn((event: string, cb: (data: unknown) => void) => {
+    handlers.get(event)?.delete(cb);
+  })
+);
+vi.mock('../../services/socketService', () => ({ socketService: { on, off } }));
+
+function emit(event: 'flow:run_finished' | 'flow_run_finished', payload: unknown) {
+  act(() => {
+    for (const cb of handlers.get(event) ?? []) cb(payload);
+  });
+}
+
+describe('useFlowRunFinished', () => {
+  beforeEach(() => {
+    handlers.clear();
+    on.mockClear();
+    off.mockClear();
+  });
+
+  it('subscribes to both event aliases unconditionally on mount', () => {
+    renderHook(() => useFlowRunFinished(vi.fn()));
+
+    expect(on).toHaveBeenCalledWith('flow:run_finished', expect.any(Function));
+    expect(on).toHaveBeenCalledWith('flow_run_finished', expect.any(Function));
+  });
+
+  it('invokes onFinish for a matching payload on either alias', () => {
+    const onFinish = vi.fn();
+    renderHook(() => useFlowRunFinished(onFinish));
+
+    emit('flow:run_finished', { flow_id: 'flow-1', run_id: 'run-1', status: 'completed' });
+    expect(onFinish).toHaveBeenCalledWith({
+      flow_id: 'flow-1',
+      run_id: 'run-1',
+      status: 'completed',
+    });
+
+    emit('flow_run_finished', { flow_id: 'flow-2', run_id: 'run-2', status: 'failed' });
+    expect(onFinish).toHaveBeenCalledWith({ flow_id: 'flow-2', run_id: 'run-2', status: 'failed' });
+    expect(onFinish).toHaveBeenCalledTimes(2);
+  });
+
+  it('dedupes the colon and underscore aliases of the same run so onFinish fires once', () => {
+    // The core bridge re-emits one `FlowRunFinished` event under both socket
+    // aliases with identical payloads — assert the hook collapses them.
+    const onFinish = vi.fn();
+    renderHook(() => useFlowRunFinished(onFinish));
+
+    const payload = { flow_id: 'flow-1', run_id: 'run-1', status: 'completed' };
+    emit('flow:run_finished', payload);
+    emit('flow_run_finished', payload);
+
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(onFinish).toHaveBeenCalledWith({
+      flow_id: 'flow-1',
+      run_id: 'run-1',
+      status: 'completed',
+    });
+
+    // A genuinely different run still gets through.
+    emit('flow:run_finished', { flow_id: 'flow-1', run_id: 'run-2', status: 'failed' });
+    expect(onFinish).toHaveBeenCalledTimes(2);
+  });
+
+  it('filters to the given flowId when provided', () => {
+    const onFinish = vi.fn();
+    renderHook(() => useFlowRunFinished(onFinish, 'flow-1'));
+
+    emit('flow:run_finished', { flow_id: 'flow-2', run_id: 'run-1', status: 'completed' });
+    expect(onFinish).not.toHaveBeenCalled();
+
+    emit('flow:run_finished', { flow_id: 'flow-1', run_id: 'run-2', status: 'completed' });
+    expect(onFinish).toHaveBeenCalledWith({
+      flow_id: 'flow-1',
+      run_id: 'run-2',
+      status: 'completed',
+    });
+    expect(onFinish).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes every event through when flowId is omitted', () => {
+    const onFinish = vi.fn();
+    renderHook(() => useFlowRunFinished(onFinish));
+
+    emit('flow:run_finished', { flow_id: 'flow-1', run_id: 'run-1', status: 'completed' });
+    emit('flow:run_finished', { flow_id: 'flow-2', run_id: 'run-2', status: 'failed' });
+
+    expect(onFinish).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops invalid payloads without invoking onFinish', () => {
+    const onFinish = vi.fn();
+    renderHook(() => useFlowRunFinished(onFinish));
+
+    emit('flow:run_finished', null);
+    emit('flow:run_finished', {});
+    emit('flow:run_finished', { flow_id: 123, run_id: 'run-1', status: 'completed' });
+    emit('flow:run_finished', { flow_id: 'flow-1', run_id: 456, status: 'completed' });
+    emit('flow:run_finished', { flow_id: 'flow-1', run_id: 'run-1', status: 42 });
+
+    expect(onFinish).not.toHaveBeenCalled();
+  });
+
+  it('cleans up both subscriptions on unmount', () => {
+    const { unmount } = renderHook(() => useFlowRunFinished(vi.fn()));
+
+    unmount();
+
+    expect(off).toHaveBeenCalledWith('flow:run_finished', expect.any(Function));
+    expect(off).toHaveBeenCalledWith('flow_run_finished', expect.any(Function));
+  });
+});

--- a/app/src/hooks/__tests__/useFlowRunPoller.test.ts
+++ b/app/src/hooks/__tests__/useFlowRunPoller.test.ts
@@ -1,10 +1,11 @@
 /**
  * useFlowRunPoller (issue B3b) — poll-until-terminal contract.
  *
- * Asserts: initial loading→resolved, 2s poll cadence while `running` /
+ * Asserts: initial loading→resolved, 3s poll cadence while `running` /
  * `pending_approval`, stop on `completed`/`failed`, stop when `runId` goes
- * `null`, error surfaced (and no further poll) on rejection, and effect
- * cleanup on unmount.
+ * `null`, error surfaced (and no further poll) on rejection, effect cleanup
+ * on unmount, and (issue B35 follow-up) an immediate out-of-cadence tick
+ * forced by a matching `FlowRunFinished` socket event.
  */
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -14,6 +15,30 @@ import { useFlowRunPoller } from '../useFlowRunPoller';
 
 const getFlowRun = vi.hoisted(() => vi.fn());
 vi.mock('../../services/api/flowsApi', () => ({ getFlowRun }));
+
+const handlers = vi.hoisted(() => new Map<string, Set<(data: unknown) => void>>());
+const socketOn = vi.hoisted(() =>
+  vi.fn((event: string, cb: (data: unknown) => void) => {
+    const set = handlers.get(event) ?? new Set();
+    set.add(cb);
+    handlers.set(event, set);
+  })
+);
+const socketOff = vi.hoisted(() =>
+  vi.fn((event: string, cb: (data: unknown) => void) => {
+    handlers.get(event)?.delete(cb);
+  })
+);
+vi.mock('../../services/socketService', () => ({
+  socketService: { on: socketOn, off: socketOff },
+}));
+
+function emitFinished(
+  event: 'flow:run_finished' | 'flow_run_finished',
+  payload: { flow_id: string; run_id: string; status: string }
+) {
+  for (const cb of handlers.get(event) ?? []) cb(payload);
+}
 
 function makeRun(overrides: Partial<FlowRun> = {}): FlowRun {
   return {
@@ -31,6 +56,7 @@ function makeRun(overrides: Partial<FlowRun> = {}): FlowRun {
 describe('useFlowRunPoller', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    handlers.clear();
     vi.useFakeTimers();
   });
 
@@ -54,7 +80,7 @@ describe('useFlowRunPoller', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('polls every 2s while the run is running', async () => {
+  it('polls every 3s while the run is running', async () => {
     getFlowRun.mockResolvedValue(makeRun({ status: 'running' }));
     renderHook(() => useFlowRunPoller('thread-1'));
 
@@ -64,12 +90,12 @@ describe('useFlowRunPoller', () => {
     expect(getFlowRun).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
+      await vi.advanceTimersByTimeAsync(3000);
     });
     expect(getFlowRun).toHaveBeenCalledTimes(2);
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
+      await vi.advanceTimersByTimeAsync(3000);
     });
     expect(getFlowRun).toHaveBeenCalledTimes(3);
   });
@@ -85,7 +111,7 @@ describe('useFlowRunPoller', () => {
     expect(getFlowRun).toHaveBeenCalledTimes(1);
 
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
+      await vi.advanceTimersByTimeAsync(3000);
     });
     expect(getFlowRun).toHaveBeenCalledTimes(2);
   });
@@ -229,5 +255,65 @@ describe('useFlowRunPoller', () => {
     expect(result.current.loading).toBe(false);
     expect(result.current.run).toBeNull();
     expect(getFlowRun).not.toHaveBeenCalled();
+  });
+
+  // ── FlowRunFinished-forced immediate tick (issue B35 follow-up) ─────────
+
+  it('forces an immediate out-of-cadence tick and stops polling when a matching FlowRunFinished event arrives', async () => {
+    getFlowRun.mockResolvedValueOnce(makeRun({ status: 'running' }));
+    const { result } = renderHook(() => useFlowRunPoller('thread-1'));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(getFlowRun).toHaveBeenCalledTimes(1);
+    expect(result.current.run?.status).toBe('running');
+
+    getFlowRun.mockResolvedValueOnce(
+      makeRun({ status: 'completed', finished_at: '2026-01-01T00:01:00Z' })
+    );
+
+    // Fires well before the next scheduled (3s) poll tick would.
+    await act(async () => {
+      emitFinished('flow:run_finished', {
+        flow_id: 'flow-1',
+        run_id: 'thread-1',
+        status: 'completed',
+      });
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(getFlowRun).toHaveBeenCalledTimes(2);
+    expect(result.current.run?.status).toBe('completed');
+
+    // The scheduled poll from the first tick must have been cancelled by the
+    // forced tick — no further calls once terminal, even well past 3s.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(getFlowRun).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores a FlowRunFinished event for a different run', async () => {
+    getFlowRun.mockResolvedValue(makeRun({ status: 'running' }));
+    renderHook(() => useFlowRunPoller('thread-1'));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(getFlowRun).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      emitFinished('flow_run_finished', {
+        flow_id: 'flow-2',
+        run_id: 'thread-2',
+        status: 'completed',
+      });
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // No forced tick for an unrelated run — the regular 3s cadence still
+    // governs.
+    expect(getFlowRun).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/src/hooks/__tests__/useFlowRunsLiveRefresh.test.ts
+++ b/app/src/hooks/__tests__/useFlowRunsLiveRefresh.test.ts
@@ -80,10 +80,10 @@ describe('useFlowRunsLiveRefresh', () => {
     expect(on).toHaveBeenCalledWith('flow:run_progress', expect.any(Function));
     expect(on).toHaveBeenCalledWith('flow_run_progress', expect.any(Function));
 
-    vi.advanceTimersByTime(5_000);
+    vi.advanceTimersByTime(30_000);
     expect(refetch).toHaveBeenCalledTimes(1);
 
-    vi.advanceTimersByTime(5_000);
+    vi.advanceTimersByTime(30_000);
     expect(refetch).toHaveBeenCalledTimes(2);
   });
 
@@ -92,7 +92,7 @@ describe('useFlowRunsLiveRefresh', () => {
     renderHook(() => useFlowRunsLiveRefresh([makeRun({ status: 'running' })], refetch));
 
     // Keep every emit + the final debounce settle comfortably inside the
-    // first 5s poll tick so the poll fallback doesn't also fire here — that
+    // first 30s poll tick so the poll fallback doesn't also fire here — that
     // interplay is covered separately by the "poll fallback" test above.
     emit('flow:run_progress', { run_id: 'run-1', node_id: 'a', status: 'success' });
     vi.advanceTimersByTime(500);

--- a/app/src/hooks/useFlowRunFinished.ts
+++ b/app/src/hooks/useFlowRunFinished.ts
@@ -1,0 +1,122 @@
+/**
+ * useFlowRunFinished (issue B35 follow-up — runs-rail live refresh)
+ * -------------------------------------------------------------------
+ *
+ * Terminal companion to {@link useFlowRunStarted}: subscribes to the core's
+ * run-finish feed so an open Workflows sidebar/drawer flips a run to
+ * Completed/Failed the instant it settles, instead of waiting on a poll to
+ * notice the terminal `flow_runs` row.
+ *
+ * The backend publishes `DomainEvent::FlowRunFinished` right after
+ * `flows::ops::finish_flow_run_row` persists the settled row; the core socket
+ * bridge (`src/core/socketio.rs`) re-emits it as both `flow:run_finished` and
+ * `flow_run_finished` (colon + underscore aliases) with the payload
+ * `{ flow_id, run_id, status }`.
+ *
+ * Like `useFlowRunStarted`, this hook subscribes unconditionally (not gated
+ * on an already-active run). Pass `flowId` to filter to a single flow
+ * (canvas/sidebar/drawer), or omit it to receive every run finish (the
+ * flow-agnostic runs page).
+ *
+ * Because the core bridge re-emits the same `FlowRunFinished` event under
+ * both aliases, this hook subscribes to both sockets above but de-dupes by
+ * `${flow_id}:${run_id}` (unique per run) so `onFinish` fires exactly once
+ * per run — a bounded set of recently-delivered keys (oldest evicted first)
+ * is kept per hook instance, sized well past any plausible in-flight burst.
+ */
+import debug from 'debug';
+import { useCallback, useEffect, useRef } from 'react';
+
+import { socketService } from '../services/socketService';
+
+const log = debug('flows:run-finished');
+
+/** Socket event aliases the core bridge emits (colon + underscore forms). */
+const EVENT_COLON = 'flow:run_finished';
+const EVENT_UNDERSCORE = 'flow_run_finished';
+
+/** Bound on the recently-delivered dedup set — oldest key evicted past this. */
+const DEDUP_CACHE_SIZE = 50;
+
+/** Payload of a `flow:run_finished` socket event (`DomainEvent::FlowRunFinished`). */
+export interface FlowRunFinishedEvent {
+  flow_id: string;
+  run_id: string;
+  status: string;
+}
+
+function parsePayload(data: unknown): FlowRunFinishedEvent | null {
+  if (!data || typeof data !== 'object') return null;
+  const obj = data as Record<string, unknown>;
+  if (
+    typeof obj.flow_id !== 'string' ||
+    typeof obj.run_id !== 'string' ||
+    typeof obj.status !== 'string'
+  )
+    return null;
+  return { flow_id: obj.flow_id, run_id: obj.run_id, status: obj.status };
+}
+
+/**
+ * Invokes `onFinish` whenever a run finishes. When `flowId` is provided,
+ * only finishes for that flow are delivered; otherwise every finish is.
+ */
+export function useFlowRunFinished(
+  onFinish: (event: FlowRunFinishedEvent) => void,
+  flowId?: string | null
+): void {
+  // Recently-delivered `${flow_id}:${run_id}` keys, so the colon and
+  // underscore aliases of the same event only invoke `onFinish` once. A `Set`
+  // preserves insertion order, so eviction just drops its first entry.
+  const deliveredRef = useRef<Set<string>>(new Set());
+
+  const handle = useCallback(
+    (data: unknown) => {
+      const payload = parsePayload(data);
+      if (!payload) {
+        // Never log the raw payload — it may carry PII/secrets. Safe metadata
+        // only: the runtime type and, if it's an object, its key names.
+        const keys = data && typeof data === 'object' ? Object.keys(data as object) : [];
+        log('run-finished: dropped — invalid payload (type=%s keys=%o)', typeof data, keys);
+        return;
+      }
+      if (flowId && payload.flow_id !== flowId) return;
+
+      const key = `${payload.flow_id}:${payload.run_id}`;
+      const delivered = deliveredRef.current;
+      if (delivered.has(key)) {
+        log(
+          'run-finished: dedup skip (alias replay) flow=%s run=%s',
+          payload.flow_id,
+          payload.run_id
+        );
+        return;
+      }
+      delivered.add(key);
+      if (delivered.size > DEDUP_CACHE_SIZE) {
+        const oldest = delivered.values().next().value;
+        if (oldest !== undefined) delivered.delete(oldest);
+      }
+
+      log(
+        'run-finished: flow=%s run=%s status=%s',
+        payload.flow_id,
+        payload.run_id,
+        payload.status
+      );
+      onFinish(payload);
+    },
+    [onFinish, flowId]
+  );
+
+  useEffect(() => {
+    socketService.on(EVENT_COLON, handle);
+    socketService.on(EVENT_UNDERSCORE, handle);
+    return () => {
+      socketService.off(EVENT_COLON, handle);
+      socketService.off(EVENT_UNDERSCORE, handle);
+    };
+  }, [handle]);
+}
+
+export default useFlowRunFinished;

--- a/app/src/hooks/useFlowRunPoller.ts
+++ b/app/src/hooks/useFlowRunPoller.ts
@@ -3,13 +3,26 @@
  * ----------------------------
  *
  * Poll-until-terminal loop for a single durable `tinyflows` run, feeding the
- * {@link FlowRunInspectorDrawer}. The flows engine emits no socket events for
- * run progress (same situation as the `workflow_run_*` orchestration surface),
- * so this mirrors the setTimeout-chained poll loop in
+ * {@link FlowRunInspectorDrawer}. This is NOT purely a terminal-transition
+ * signal — unlike `useFlowRunsLiveRefresh` (list-level, now backstopped by
+ * `DomainEvent::FlowRunFinished` via `useFlowRunFinished`), each tick here
+ * also refreshes the run's evolving per-step output (`FlowRunStep.output`)
+ * for the drawer's step timeline, and no event carries that content — so
+ * this hook still needs an actual poll loop while a run is in flight, not
+ * just a long backstop. It mirrors the setTimeout-chained poll loop in
  * `components/intelligence/IntelligenceOrchestrationTab.tsx` (~lines 112-143):
  * schedule the next poll only after the current one resolves and the run is
  * still non-terminal, guard against races with `cancelled`/`inFlight`, and
  * never let an unmounted component call `setState`.
+ *
+ * Now that `DomainEvent::FlowRunFinished` exists (issue B35 follow-up,
+ * bridged as `flow:run_finished` / `flow_run_finished`), this hook also
+ * subscribes via `useFlowRunFinished` and forces an immediate out-of-cadence
+ * tick (cancelling any pending scheduled poll) the moment a finish event for
+ * `runId` arrives, rather than waiting up to {@link POLL_INTERVAL_MS} for the
+ * next scheduled tick to notice the terminal row. The interval itself is
+ * relaxed from 2s to 3s accordingly — it's now a freshness cadence for
+ * in-flight step output, not the primary way termination is detected.
  *
  * `pending_approval` is explicitly NOT terminal — a paused run still needs
  * live status so the drawer reflects an approval elsewhere resolving it.
@@ -20,11 +33,18 @@ import debug from 'debug';
 import { useEffect, useRef, useState } from 'react';
 
 import { type FlowRun, type FlowRunStatus, getFlowRun } from '../services/api/flowsApi';
+import { useFlowRunFinished } from './useFlowRunFinished';
 
 const log = debug('flows:poller');
 
-/** How often to poll a non-terminal run for progress. */
-const POLL_INTERVAL_MS = 2000;
+/**
+ * How often to poll a non-terminal run for progress. Relaxed from 2s to 3s
+ * now that a `FlowRunFinished` event can force an immediate out-of-cadence
+ * tick the moment a run actually settles (see module doc above) — this
+ * interval only governs the freshness of in-flight step output between
+ * terminal events.
+ */
+const POLL_INTERVAL_MS = 3000;
 
 const TERMINAL = new Set<FlowRunStatus>([
   'completed',
@@ -65,6 +85,24 @@ export function useFlowRunPoller(runId: string | null): UseFlowRunPollerResult {
       mountedRef.current = false;
     };
   }, []);
+
+  // Set by the runId effect below to an out-of-cadence "tick now" callback,
+  // so the `useFlowRunFinished` subscription (which lives outside that
+  // effect, since it must stay mounted across `runId` changes) can force an
+  // immediate refetch instead of waiting for the next scheduled poll. Reset
+  // to `null` whenever the effect tears down so a finish event that arrives
+  // after `runId` changes (or on unmount) can't reach into a torn-down tick.
+  const forceTickRef = useRef<(() => void) | null>(null);
+
+  useFlowRunFinished(event => {
+    if (event.run_id !== runId) return;
+    log(
+      'finished event received for runId=%s status=%s — forcing immediate tick',
+      runId,
+      event.status
+    );
+    forceTickRef.current?.();
+  });
 
   useEffect(() => {
     // Reset view state for the new target — avoids painting the previous
@@ -111,10 +149,23 @@ export function useFlowRunPoller(runId: string | null): UseFlowRunPollerResult {
       }
     };
 
+    // Let the `useFlowRunFinished` subscription above force an immediate
+    // out-of-cadence tick for this `runId`: cancel any pending scheduled
+    // poll first so the forced tick and the regular cadence never race into
+    // a double in-flight fetch.
+    forceTickRef.current = () => {
+      if (pollHandle !== undefined) {
+        window.clearTimeout(pollHandle);
+        pollHandle = undefined;
+      }
+      void tick();
+    };
+
     void tick();
     return () => {
       cancelled = true;
       if (pollHandle !== undefined) window.clearTimeout(pollHandle);
+      forceTickRef.current = null;
     };
   }, [runId]);
 

--- a/app/src/hooks/useFlowRunsLiveRefresh.ts
+++ b/app/src/hooks/useFlowRunsLiveRefresh.ts
@@ -7,13 +7,15 @@
  * each finished step, and the core socket bridge re-emits it to the frontend
  * as both `flow:run_progress` and `flow_run_progress` (colon + underscore
  * aliases — see `useFlowRunProgress`, whose subscribe/teardown style this
- * mirrors). There is, however, no terminal/completion socket event today —
- * a run transitioning `running` -> `completed`/`failed`/etc. emits nothing —
- * so a step-progress subscription alone can't catch that final refresh. This
- * hook therefore layers a 5s poll fallback on top of the socket subscription:
- * the socket keeps the refetch snappy while steps are landing, and the poll
- * guarantees the terminal transition (which has no event) still gets picked
- * up within a few seconds.
+ * mirrors). The terminal transition (`running` -> `completed`/`failed`/etc.)
+ * now has its own event too — `DomainEvent::FlowRunFinished`, bridged as
+ * `flow:run_finished` / `flow_run_finished` — and every caller of this hook
+ * (`FlowRunsSidebar`, `FlowRunsDrawer`, `WorkflowRunsPage`) separately wires
+ * `useFlowRunFinished` alongside it for that immediate refetch (issue B35
+ * follow-up). This hook's own poll is therefore no longer the primary way a
+ * terminal transition gets noticed — it's now a long-interval backstop for
+ * the (rare) case a broadcast event is dropped under lag or a socket
+ * reconnect gap, not a tight polling loop.
  *
  * This is deliberately dumb about *which* run changed — callers pass the
  * list they already fetched and a `refetch` that reloads it; this hook just
@@ -43,8 +45,13 @@ const TERMINAL_STATUSES = new Set<FlowRunStatus>([
 /** Trailing debounce window for a burst of `flow:run_progress` events. */
 const DEBOUNCE_MS = 3_000;
 
-/** Poll fallback cadence — catches the terminal transition, which has no socket event. */
-const POLL_INTERVAL_MS = 5_000;
+/**
+ * Poll fallback cadence. Now a long safety net (not the primary terminal-
+ * transition signal — `useFlowRunFinished` is, see module doc above): only
+ * matters if a broadcast event was dropped under lag or during a socket
+ * reconnect gap.
+ */
+const POLL_INTERVAL_MS = 30_000;
 
 /**
  * Subscribes to live run-progress events (debounced) and polls on a fallback

--- a/app/src/pages/WorkflowRunsPage.test.tsx
+++ b/app/src/pages/WorkflowRunsPage.test.tsx
@@ -142,9 +142,9 @@ describe('WorkflowRunsPage', () => {
       expect(listAllFlowRuns).toHaveBeenCalledTimes(1);
       expect(listFlows).toHaveBeenCalledTimes(1);
 
-      // The 5s poll fallback fires `refetchRuns` while the one run is still 'running'.
+      // The 30s poll backstop fires `refetchRuns` while the one run is still 'running'.
       await act(async () => {
-        vi.advanceTimersByTime(5_000);
+        vi.advanceTimersByTime(30_000);
         await Promise.resolve();
       });
 
@@ -169,7 +169,7 @@ describe('WorkflowRunsPage', () => {
       expect(screen.getByTestId('workflow-runs-list')).toBeInTheDocument();
 
       await act(async () => {
-        vi.advanceTimersByTime(5_000);
+        vi.advanceTimersByTime(30_000);
         await Promise.resolve();
       });
 

--- a/app/src/pages/WorkflowRunsPage.tsx
+++ b/app/src/pages/WorkflowRunsPage.tsx
@@ -12,6 +12,7 @@ import { useNavigate } from 'react-router-dom';
 
 import PanelPage from '../components/layout/PanelPage';
 import { CenteredLoadingState, ErrorBanner } from '../components/ui/LoadingState';
+import { useFlowRunFinished } from '../hooks/useFlowRunFinished';
 import { useFlowRunsLiveRefresh } from '../hooks/useFlowRunsLiveRefresh';
 import { useFlowRunStarted } from '../hooks/useFlowRunStarted';
 import {
@@ -102,6 +103,11 @@ export default function WorkflowRunsPage() {
   // instantly instead of waiting for a manual refresh (issue B35). No
   // `flowId` filter — this is the flow-agnostic "all runs" page.
   useFlowRunStarted(() => void refetchRuns());
+  // Terminal companion to the above (issue B35 follow-up) — flips a run to
+  // Completed/Failed the instant it settles instead of waiting on
+  // `useFlowRunsLiveRefresh`'s debounced/backstop refetch to notice. No
+  // `flowId` filter, same rationale as `useFlowRunStarted` above.
+  useFlowRunFinished(() => void refetchRuns());
   const pendingRunIds = useRunsPendingApprovalSet(runs);
 
   const statusLabel = (status: FlowRunStatus) =>

--- a/src/core/event_bus/events.rs
+++ b/src/core/event_bus/events.rs
@@ -478,6 +478,21 @@ pub enum DomainEvent {
         run_id: String,
     },
 
+    /// The terminal companion to [`FlowRunStarted`] (issue B35 follow-up, runs
+    /// rail live finish). Published from `flows::ops::finish_flow_run_row`
+    /// right after `store::finish_flow_run` persists the terminal
+    /// `flow_runs` row, so the UI can flip a run to Completed/Failed live
+    /// instead of relying on a poll to notice the settled row.
+    FlowRunFinished {
+        /// The affected flow's id.
+        flow_id: String,
+        /// The run's stable identifier (== the tinyflows checkpointer thread id).
+        run_id: String,
+        /// Terminal status: `"completed"` | `"failed"` |
+        /// `"completed_with_warnings"` | `"cancelled"`.
+        status: String,
+    },
+
     /// A saved flow's definition changed (created / updated / deleted /
     /// enable-toggled). Bridged to a `flow:changed` socket event so an open
     /// Workflows list or canvas refetches instead of silently showing stale
@@ -1413,6 +1428,7 @@ impl DomainEvent {
             | Self::FlowScheduleTick { .. }
             | Self::FlowRunProgress { .. }
             | Self::FlowRunStarted { .. }
+            | Self::FlowRunFinished { .. }
             | Self::FlowChanged { .. } => "cron",
 
             Self::WorkflowLoaded { .. }
@@ -1578,6 +1594,7 @@ impl DomainEvent {
             Self::FlowScheduleTick { .. } => "FlowScheduleTick",
             Self::FlowRunProgress { .. } => "FlowRunProgress",
             Self::FlowRunStarted { .. } => "FlowRunStarted",
+            Self::FlowRunFinished { .. } => "FlowRunFinished",
             Self::FlowChanged { .. } => "FlowChanged",
             Self::WorkflowLoaded { .. } => "WorkflowLoaded",
             Self::WorkflowStopped { .. } => "WorkflowStopped",

--- a/src/core/socketio.rs
+++ b/src/core/socketio.rs
@@ -1128,6 +1128,31 @@ pub fn spawn_web_channel_bridge(io: SocketIo) {
                     let _ = io_memory_sync.emit("flow:run_started", &payload);
                     let _ = io_memory_sync.emit("flow_run_started", &payload);
                 }
+                // The terminal companion to `FlowRunStarted` above (issue B35
+                // follow-up). Published once `flows::ops::finish_flow_run_row`
+                // persists the settled `flow_runs` row, so an open Workflows
+                // canvas/sidebar can flip a run to Completed/Failed live
+                // instead of relying on a poll to notice. Best-effort, same
+                // rationale as the other `flow:*` bridges.
+                crate::core::event_bus::DomainEvent::FlowRunFinished {
+                    flow_id,
+                    run_id,
+                    status,
+                } => {
+                    let payload = serde_json::json!({
+                        "flow_id": flow_id,
+                        "run_id": run_id,
+                        "status": status,
+                    });
+                    log::debug!(
+                        "[socketio] broadcast flow_run_finished flow_id={} run_id={} status={}",
+                        flow_id,
+                        run_id,
+                        status
+                    );
+                    let _ = io_memory_sync.emit("flow:run_finished", &payload);
+                    let _ = io_memory_sync.emit("flow_run_finished", &payload);
+                }
                 // A saved flow's definition changed (create/update/delete/
                 // enable). Broadcast so an open Workflows list/canvas refetches
                 // — most importantly, so an agent `save_workflow` becomes

--- a/src/openhuman/flows/ops.rs
+++ b/src/openhuman/flows/ops.rs
@@ -3766,6 +3766,29 @@ fn finish_flow_run_row(
         tracing::warn!(target: "flows", thread_id, status, error = %e, "[flows] failed to persist flow run finish");
     }
 
+    // `status` can be `"pending_approval"` here (see `finalize_terminal_status`)
+    // when the run merely paused at a gate — that isn't a finish. `flows_resume`
+    // later settles under the SAME `thread_id`/`run_id`, and `useFlowRunFinished`
+    // de-dupes delivered events by `${flow_id}:${run_id}` (needed because the
+    // socket bridge re-emits this event under two aliases and must collapse
+    // them into one `onFinish` call). Publishing here for a pause would poison
+    // that dedup cache, so the real completion event after resume would be
+    // dropped as an "alias replay" and the run could stay stale in the runs
+    // list until the 30s poll backstop (Codex review, PR #5115). Gate the
+    // publish to actual terminal statuses; the row itself is still written
+    // above so poll-based fallbacks (list/get RPCs) see the paused state
+    // either way.
+    if status == "pending_approval" {
+        tracing::debug!(
+            target: "flows",
+            flow_id,
+            thread_id,
+            status,
+            "[flows] finish_flow_run_row: run paused for approval — not a finish, skipping FlowRunFinished"
+        );
+        return;
+    }
+
     tracing::debug!(
         target: "flows",
         flow_id,

--- a/src/openhuman/flows/ops.rs
+++ b/src/openhuman/flows/ops.rs
@@ -3154,7 +3154,15 @@ pub async fn flows_run(
             );
         }
         let observed = current_persisted_steps(config, &thread_id);
-        finish_flow_run_row(config, &thread_id, "failed", &observed, &[], Some(error));
+        finish_flow_run_row(
+            config,
+            &thread_id,
+            flow_id,
+            "failed",
+            &observed,
+            &[],
+            Some(error),
+        );
     };
 
     let origin = workflow_origin(flow_id, flow.require_approval);
@@ -3209,7 +3217,15 @@ pub async fn flows_run(
                 tracing::warn!(target: "flows", flow_id = %flow_id, error = %e, "[flows] flows_run: failed to record cancelled run");
             }
             let observed = current_persisted_steps(config, &thread_id);
-            finish_flow_run_row(config, &thread_id, "cancelled", &observed, &[], Some("run cancelled"));
+            finish_flow_run_row(
+                config,
+                &thread_id,
+                flow_id,
+                "cancelled",
+                &observed,
+                &[],
+                Some("run cancelled"),
+            );
             drop_checkpoint(config, &thread_id).await;
             return Ok(RpcOutcome::single_log(
                 json!({
@@ -3244,6 +3260,7 @@ pub async fn flows_run(
     finish_flow_run_row(
         config,
         &thread_id,
+        flow_id,
         status,
         &settled,
         &outcome.pending_approvals,
@@ -3437,6 +3454,7 @@ pub async fn flows_resume(
             finish_flow_run_row(
                 config,
                 thread_id,
+                flow_id,
                 "failed",
                 &observed,
                 &[],
@@ -3449,7 +3467,15 @@ pub async fn flows_resume(
             let msg = format!("flow resume timed out after {FLOW_RUN_TIMEOUT_SECS}s");
             let _ = store::record_run(config, flow_id, "failed");
             let observed = current_persisted_steps(config, thread_id);
-            finish_flow_run_row(config, thread_id, "failed", &observed, &[], Some(&msg));
+            finish_flow_run_row(
+                config,
+                thread_id,
+                flow_id,
+                "failed",
+                &observed,
+                &[],
+                Some(&msg),
+            );
             tracing::warn!(target: "flows", flow_id = %flow_id, %thread_id, timeout_secs = FLOW_RUN_TIMEOUT_SECS, "[flows] flows_resume: run timed out");
             return Err(msg);
         }
@@ -3462,6 +3488,7 @@ pub async fn flows_resume(
     finish_flow_run_row(
         config,
         thread_id,
+        flow_id,
         status,
         &settled,
         &outcome.pending_approvals,
@@ -3659,6 +3686,7 @@ pub async fn flows_cancel_run(config: &Config, run_id: &str) -> Result<RpcOutcom
     finish_flow_run_row(
         config,
         run_id,
+        &run.flow_id,
         "cancelled",
         &observed,
         &[],
@@ -3719,6 +3747,7 @@ fn start_flow_run_row(config: &Config, thread_id: &str, flow_id: &str) {
 fn finish_flow_run_row(
     config: &Config,
     thread_id: &str,
+    flow_id: &str,
     status: &str,
     steps: &[FlowRunStep],
     pending_approvals: &[String],
@@ -3736,6 +3765,19 @@ fn finish_flow_run_row(
     ) {
         tracing::warn!(target: "flows", thread_id, status, error = %e, "[flows] failed to persist flow run finish");
     }
+
+    tracing::debug!(
+        target: "flows",
+        flow_id,
+        thread_id,
+        status,
+        "[flows] finish_flow_run_row: publishing FlowRunFinished"
+    );
+    crate::core::event_bus::publish_global(crate::core::event_bus::DomainEvent::FlowRunFinished {
+        flow_id: flow_id.to_string(),
+        run_id: thread_id.to_string(),
+        status: status.to_string(),
+    });
 }
 
 /// Reconstructs a lean per-node step list from a settled run's

--- a/src/openhuman/flows/ops_tests.rs
+++ b/src/openhuman/flows/ops_tests.rs
@@ -1484,6 +1484,128 @@ async fn flows_run_publishes_flow_run_started_with_flow_and_run_id() {
     assert_eq!(run_id, thread_id);
 }
 
+/// PR #5115 review finding (Codex): a run that merely pauses at an approval
+/// gate must NOT publish `DomainEvent::FlowRunFinished` — only the eventual
+/// terminal settle (here, after `flows_resume`) should. `finalize_terminal_status`
+/// can return `"pending_approval"`, and `finish_flow_run_row` used to publish
+/// unconditionally on every status; since `useFlowRunFinished` de-dupes
+/// delivered events by `${flow_id}:${run_id}`, an event fired for the pause
+/// would poison that cache and cause the real completion event after resume
+/// to be silently dropped as an alias replay. Exercises the full pause ->
+/// resume lifecycle and asserts exactly one `FlowRunFinished` is observed,
+/// carrying the final `"completed"` status, not `"pending_approval"`.
+#[tokio::test]
+async fn flows_run_finished_event_skips_pending_approval_and_fires_once_on_resume() {
+    use crate::core::event_bus::{
+        init_global, subscribe_global, DomainEvent, EventHandler, DEFAULT_CAPACITY,
+    };
+    use async_trait::async_trait;
+    use std::sync::Mutex as StdMutex;
+
+    #[derive(Default)]
+    struct Collector {
+        events: Arc<StdMutex<Vec<(String, String, String)>>>,
+    }
+
+    #[async_trait]
+    impl EventHandler for Collector {
+        fn name(&self) -> &str {
+            "test::flows::ops::flow_run_finished_pending_approval_collector"
+        }
+        fn domains(&self) -> Option<&[&str]> {
+            Some(&["cron"])
+        }
+        async fn handle(&self, event: &DomainEvent) {
+            if let DomainEvent::FlowRunFinished {
+                flow_id,
+                run_id,
+                status,
+            } = event
+            {
+                self.events
+                    .lock()
+                    .unwrap()
+                    .push((flow_id.clone(), run_id.clone(), status.clone()));
+            }
+        }
+    }
+
+    init_global(DEFAULT_CAPACITY);
+    let events: Arc<StdMutex<Vec<(String, String, String)>>> = Arc::new(StdMutex::new(Vec::new()));
+    let collector = Arc::new(Collector {
+        events: Arc::clone(&events),
+    });
+    let _handle = subscribe_global(collector).expect("bus subscriber installed");
+
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+    let created = flows_create(
+        &config,
+        "b35-finished-skips-pause".to_string(),
+        approval_gated_graph(),
+        false,
+    )
+    .await
+    .unwrap();
+
+    let run = flows_run(
+        &config,
+        &created.value.id,
+        json!({ "x": 1 }),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
+    let thread_id = run.value["thread_id"].as_str().unwrap().to_string();
+    let pending: Vec<String> =
+        serde_json::from_value(run.value["pending_approvals"].clone()).unwrap();
+    assert_eq!(pending, vec!["gate".to_string()]);
+
+    // Give the bus a moment to deliver anything it's going to deliver, then
+    // assert the pause produced no FlowRunFinished for this run at all.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    {
+        let guard = events.lock().unwrap();
+        assert!(
+            !guard.iter().any(|(_, rid, _)| *rid == thread_id),
+            "a run parked at an approval gate must not publish FlowRunFinished: {guard:?}"
+        );
+    }
+
+    let resumed = flows_resume(&config, &created.value.id, &thread_id, pending, vec![])
+        .await
+        .unwrap();
+    assert_eq!(resumed.value["pending_approvals"], json!([]));
+
+    // The bus is process-global and shared with concurrently-running tests,
+    // so filter for our own run id rather than asserting on total count.
+    let mut matched: Vec<(String, String, String)> = Vec::new();
+    for _ in 0..20 {
+        {
+            let guard = events.lock().unwrap();
+            matched = guard
+                .iter()
+                .filter(|(_, rid, _)| *rid == thread_id)
+                .cloned()
+                .collect();
+            if !matched.is_empty() {
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    assert_eq!(
+        matched.len(),
+        1,
+        "expected exactly one FlowRunFinished for this run (the post-resume settle, \
+         none for the pause): {matched:?}"
+    );
+    let (flow_id, run_id, status) = matched.into_iter().next().unwrap();
+    assert_eq!(flow_id, created.value.id);
+    assert_eq!(run_id, thread_id);
+    assert_eq!(status, "completed");
+}
+
 // ── Live run observation (issue G2) ───────────────────────────────────────
 
 use crate::openhuman::tinyflows::observability::FlowRunObserver;


### PR DESCRIPTION
## What & why

Completes **B35**. B35 added `FlowRunStarted` so a run appears in the RUNS rail the instant it starts; this adds the **terminal** companion so status updates (Completed / Failed / Completed-with-warnings / Cancelled) arrive **live** too — and lets the rail drop its short poll fallbacks.

## Changes
- **Rust:** `DomainEvent::FlowRunFinished { flow_id, run_id, status }` (`event_bus/events.rs`), emitted from `finish_flow_run_row` (`flows/ops.rs`) with the terminal status, bridged to Socket.IO as `flow:run_finished` / `flow_run_finished` (`core/socketio.rs`) — mirroring the `FlowRunStarted` plumbing.
- **Frontend:** new `useFlowRunFinished` hook (copies `useFlowRunStarted`, incl. the bounded dedup-over-both-aliases + PII-safe invalid-payload log). `FlowRunsSidebar` / `FlowRunsDrawer` / `WorkflowRunsPage` subscribe to it (refetch on finish).
- **Polling:** with start + progress + finish all event-driven, the short `useFlowRunPoller` (2s) / `useFlowRunsLiveRefresh` (5s) fallbacks are dropped/relaxed (see the hook doc updates).

## Tests
- `cargo check` clean; frontend `typecheck` clean.
- Vitest: **63 pass** across the run hooks + rail components (incl. a new `useFlowRunFinished` test asserting single-invocation dedup over both aliases).
