### PR TITLE
feat(flows): enable agent file output → attachment via the storage-URL path (B39 phase 1-2)

### DIFF
--- a/src/openhuman/agent_registry/agents/code_executor/prompt.md
+++ b/src/openhuman/agent_registry/agents/code_executor/prompt.md
@@ -39,6 +39,18 @@ When a task involves a GitHub repository, you act through **two distinct surface
 
 If you genuinely need a GitHub action Composio doesn't expose yet, say so explicitly in your response and ask the user to either grant the missing scope or run the action themselves; do **not** silently fall back to `gh`.
 
+## Producing a file a downstream workflow step needs
+
+When you're running as a node inside an automation (a tinyflows workflow) and
+your output is a **file** a later step in that same workflow needs (e.g. an
+email attachment, a document to post elsewhere) — don't just leave it on disk
+in the action sandbox. Downstream nodes can't read your local filesystem;
+they can only bind to fields in your own structured response. Call
+`storage_upload_file { path }` on the file you produced and include its
+returned `file_id` and (for public files) `public_url` in your response, so
+a downstream `tool_call` node can bind them (e.g.
+`=nodes.<this_agent_id>.item.json.public_url`) into an attachment argument.
+
 ## Execution environment
 
 Shell commands run through an approval gate under the user's access policy. Keep this in mind so you don't waste turns being blocked:

--- a/src/openhuman/agent_registry/agents/code_executor/prompt.md
+++ b/src/openhuman/agent_registry/agents/code_executor/prompt.md
@@ -46,10 +46,14 @@ your output is a **file** a later step in that same workflow needs (e.g. an
 email attachment, a document to post elsewhere) — don't just leave it on disk
 in the action sandbox. Downstream nodes can't read your local filesystem;
 they can only bind to fields in your own structured response. Call
-`storage_upload_file { path }` on the file you produced and include its
-returned `file_id` and (for public files) `public_url` in your response, so
+`storage_upload_file { path, visibility: "public" }` on the file you produced
+and include its returned `file_id` and `public_url` in your response, so
 a downstream `tool_call` node can bind them (e.g.
 `=nodes.<this_agent_id>.item.json.public_url`) into an attachment argument.
+Uploading is private by default, and the returned `public_url` is null unless
+you upload with `visibility: "public"`; a null `public_url` silently breaks
+the downstream attachment binding, so set it explicitly when a later node
+needs the URL.
 
 ## Execution environment
 

--- a/src/openhuman/flows/agents/workflow_builder/prompt.md
+++ b/src/openhuman/flows/agents/workflow_builder/prompt.md
@@ -325,6 +325,22 @@ A `WorkflowGraph` is `{ name?, nodes: [...], edges: [...] }`.
    (recall a preference) or should remember a result/state across runs, wire
    an `agent` node that uses memory instead of hardcoding context memory
    already holds. Use sparingly — only when the workflow truly needs it.
+
+   **File-producing agent nodes.** An `agent` node's own output is text/JSON
+   only — it cannot hand a downstream node a real file (e.g. something a
+   `code_executor`-style step generated on disk). To get a produced file to a
+   downstream node (a Gmail attachment, a document upload elsewhere), set
+   `config.agent_ref` to a file-capable agent (one with `storage_upload_file`
+   on its belt, e.g. `code_executor`) and instruct it, in the prompt, to
+   `storage_upload_file` the file it produced and include the resulting
+   `file_id` and `public_url` as fields in its structured response —
+   `config.output_parser.schema` must declare both so they're addressable.
+   The downstream `tool_call` then binds
+   `=nodes.<agent_id>.item.json.public_url` (or `.file_id`, depending on
+   what the attachment action needs) into its arg — e.g. into
+   `GMAIL_SEND_EMAIL_WITH_ATTACHMENT`'s attachment field. Ground the
+   attachment action's real arg name with `get_tool_contract` first, same as
+   any other `tool_call`.
 3. **`tool_call`** — an action. Two flavours by `config.slug`:
    - **Composio app action** — `config.slug` = a real action slug (from
      `search_tool_catalog`, e.g. `GMAIL_SEND_EMAIL`) + `config.connection_ref`

--- a/src/openhuman/flows/agents/workflow_builder/prompt.md
+++ b/src/openhuman/flows/agents/workflow_builder/prompt.md
@@ -355,7 +355,9 @@ A `WorkflowGraph` is `{ name?, nodes: [...], edges: [...] }`.
    downstream node (a Gmail attachment, a document upload elsewhere), set
    `config.agent_ref` to a file-capable agent (one with `storage_upload_file`
    on its belt, e.g. `code_executor`) and instruct it, in the prompt, to
-   `storage_upload_file` the file it produced and include the resulting
+   `storage_upload_file` the file it produced with `visibility: "public"` (the
+   default is private, which leaves `public_url` null and silently breaks the
+   binding below) and include the resulting
    `file_id` and `public_url` as fields in its structured response —
    `config.output_parser.schema` must declare both so they're addressable.
    The downstream `tool_call` then binds

--- a/src/openhuman/memory_sync/composio/providers/gmail/tests.rs
+++ b/src/openhuman/memory_sync/composio/providers/gmail/tests.rs
@@ -85,6 +85,41 @@ fn default_impl_matches_new() {
     // Both are unit structs — constructing via Default is the cover target.
 }
 
+/// The curated catalog must expose both the plain send action and its
+/// attachment variant, and both must be `Write` scope. The attachment
+/// variant (`GMAIL_SEND_EMAIL_WITH_ATTACHMENT`) is the downstream half of
+/// the B39 storage-URL file-attachment path: without a curated entry the
+/// flow curation gate (`flow_tool_allowed`) rejects it outright, and the
+/// scope must match `GMAIL_SEND_EMAIL` so the autonomy tier gate classifies
+/// it as a side-effecting Network call that still requires approval (never
+/// a scope-free Read that auto-fires).
+#[test]
+fn curated_catalog_includes_send_and_attachment_variant_as_write() {
+    use crate::openhuman::memory_sync::composio::providers::{
+        curated_scope_for, find_curated, ToolScope,
+    };
+
+    let p = GmailProvider::new();
+    let curated = p.curated_tools().expect("GMAIL_CURATED is registered");
+
+    for slug in ["GMAIL_SEND_EMAIL", "GMAIL_SEND_EMAIL_WITH_ATTACHMENT"] {
+        let entry = find_curated(curated, slug)
+            .unwrap_or_else(|| panic!("curated catalog must contain {slug}"));
+        assert_eq!(
+            entry.scope,
+            ToolScope::Write,
+            "{slug} must be Write scope (side-effecting send, approval-gated)"
+        );
+        // The tier gate resolves scope through `curated_scope_for`; pin that
+        // it agrees, so the send never degrades to an auto-firing Read.
+        assert_eq!(
+            curated_scope_for(slug),
+            Some(ToolScope::Write),
+            "{slug} tier-gate scope lookup must resolve to Write"
+        );
+    }
+}
+
 #[test]
 fn epoch_filter_is_preferred_over_day_filter_for_typical_internal_date() {
     // The provider tries `cursor_to_gmail_after_epoch_filter` first

--- a/src/openhuman/memory_sync/composio/providers/gmail/tools.rs
+++ b/src/openhuman/memory_sync/composio/providers/gmail/tools.rs
@@ -75,6 +75,17 @@ pub const GMAIL_CURATED: &[CuratedTool] = &[
         slug: "GMAIL_SEND_EMAIL",
         scope: ToolScope::Write,
     },
+    // Attachment variant of GMAIL_SEND_EMAIL — the downstream half of the
+    // storage-URL file-attachment path (B39/Gap 3, Option A): a flow's
+    // file-producing agent node uploads via `storage_upload_file` and binds
+    // the resulting `public_url`/`file_id` into this action's attachment arg.
+    // See `flows/agents/workflow_builder/prompt.md` and
+    // `agent_registry/agents/code_executor/prompt.md` for the producer-side
+    // guidance.
+    CuratedTool {
+        slug: "GMAIL_SEND_EMAIL_WITH_ATTACHMENT",
+        scope: ToolScope::Write,
+    },
     CuratedTool {
         slug: "GMAIL_REPLY_TO_THREAD",
         scope: ToolScope::Write,


### PR DESCRIPTION
## Summary

B39 (Gap 3, Option A) — Phases 1-2 only, per architect verdict.

**Problem:** an `agent` node in a tinyflows workflow returns text/JSON only, so a file that a `code_executor`-style step writes to disk has no way to become a downstream email attachment.

**Fix (the safe, deterministic half — no base64/binary-item model needed):**

- **Phase 1 — curate the attachment action.** Added `GMAIL_SEND_EMAIL_WITH_ATTACHMENT` (Write scope) to `GMAIL_CURATED` in `src/openhuman/memory_sync/composio/providers/gmail/tools.rs`, alongside `GMAIL_SEND_EMAIL`. This is the hard allowlist `is_curated_flow_tool`/`flow_tool_allowed` (`src/openhuman/tinyflows/caps.rs`) checks before any flow `tool_call` is permitted — without this entry the action is rejected outright regardless of connection/scope.
- **Phase 2 — document the file-producer pattern:**
  - `src/openhuman/flows/agents/workflow_builder/prompt.md`: new "File-producing agent nodes" note under the `agent` node kind — when a step produces a file a downstream node needs, set `config.agent_ref` to a file-capable agent (e.g. `code_executor`, which already has `storage_upload_file` on its tool belt per its `agent.toml`), have it `storage_upload_file` the file and include `file_id`/`public_url` in its `output_parser.schema`, and bind `=nodes.<agent>.item.json.public_url` into the attachment `tool_call`'s arg.
  - `src/openhuman/agent_registry/agents/code_executor/prompt.md`: new "Producing a file a downstream workflow step needs" section with the matching producer-side instruction.

**Deferred (conditional follow-up, not implemented here):** Phase 3 (a `storage_get_base64` helper) and Phase 4 (`caps.rs` arg pre-processing) are only needed **if** the live Composio `GMAIL_SEND_EMAIL_WITH_ATTACHMENT` schema requires base64 content rather than accepting a URL — a runtime `get_tool_contract` discovery question that can't be resolved from static code alone. Left as follow-up.

## Files changed
- `src/openhuman/memory_sync/composio/providers/gmail/tools.rs`
- `src/openhuman/flows/agents/workflow_builder/prompt.md`
- `src/openhuman/agent_registry/agents/code_executor/prompt.md`

## Test plan
- [x] Ran `GGML_NATIVE=OFF cargo test -p openhuman --lib memory_sync::composio::providers::gmail::tests` locally — 23 passed, 0 failed, including the new `curated_catalog_includes_send_and_attachment_variant_as_write` guard (the full core crate compiles here in ~37 min under worktree contention).
- [x] `cargo fmt` run on all changed files (clean, no diff).
- [x] Manual read-through confirming the `CuratedTool { slug, scope }` struct literal matches neighboring entries exactly, and that the curation gate (`flow_tool_allowed`, Path A) + tier gate (`curated_scope_for` → Write → Network) admit it as an approval-gated send.

## Review addendum (automated CodeRabbit-style pass, 2026-07-22)
A fresh review pass applied two fixes on top of the original PR:
- **Correctness:** the file-producer guidance in both `code_executor` and `workflow_builder` prompts now instructs `storage_upload_file { path, visibility: "public" }`. `storage_upload_file` defaults to **private** and only populates `public_url` for public uploads, so the original `storage_upload_file { path }` guidance would have bound a **null** `public_url` and silently broken the attachment path.
- **Test coverage:** added a Gmail curated-catalog guard test pinning `GMAIL_SEND_EMAIL_WITH_ATTACHMENT` as `Write` scope (mirrors the guards other providers already have).

Two subjective/deferred items were posted as inline review comments rather than applied: a least-exposure `ttl_days` suggestion for the public upload, and a note that the storage-URL path silently fails if the live Composio schema wants base64 content instead of a URL (the PR's own deferred Phase 3/4 question).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow automations can now pass generated files between steps by uploading the file and exposing file references for downstream use.
  * Added an attachment-capable Gmail action for sending emails with files.
* **Documentation**
  * Expanded workflow builder guidance on using file-producing agent nodes and wiring uploaded file references into downstream attachments.
* **Tests**
  * Added coverage to ensure the Gmail curated tools catalog includes both send variants with the correct write scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

> [!WARNING]
> ## ⛔ Addendum (2026-07-23) — RECOMMEND REWORK / HOLD before merge
>
> A second review pass grounded against **live runtime evidence** (see [review](https://github.com/tinyhumansai/openhuman/pull/5122#pullrequestreview-4757936902)) found a blocking issue the first pass missed:
>
> **`GMAIL_SEND_EMAIL_WITH_ATTACHMENT` is a phantom slug.** Running `get_tool_contract` on it in a live app returns *"not a real action in the 'gmail' toolkit's live catalog — use `search_tool_catalog` to find a real slug."* Curating a slug in `GMAIL_CURATED` only adds it to the flows allow-list (`flow_tool_allowed` Path A, `tinyflows/caps.rs`), which — unlike Path B for uncurated toolkits — performs **no liveness/existence check** against Composio's live catalog. So this PR curates and prescribes an action that cannot be called. Composio's real gmail send is `GMAIL_SEND_EMAIL` (attachments via its own `attachment` param); there is no `_WITH_ATTACHMENT` variant.
>
> The **storage-URL design itself is sound** — `storage_upload_file { visibility: "public" }` returns a genuinely backend-fetchable `public_url`, and the prompts correctly bind that (not a local `file_path`), matching the runtime finding that backend-executed Composio actions can't read local paths (`ENOENT`). The problem is confined to the terminal slug.
>
> **Action:** hold this PR (or rework) until (1) the real attachment-capable gmail send action + arg is grounded against `search_tool_catalog`/`get_tool_contract`, and (2) the URL-vs-arg binding is confirmed against that real action's contract. Kept as **DRAFT**; do not merge.
