### PR TITLE
fix(flows): stop the builder authoring memory steps that fabricate

### DIFF
--- a/src/openhuman/flows/agents/workflow_builder/builder_prompt.rs
+++ b/src/openhuman/flows/agents/workflow_builder/builder_prompt.rs
@@ -753,6 +753,93 @@ mod tests {
         );
     }
 
+    /// Regression guard for the shipped prompt bug this test was added with:
+    /// the standing prompt used to claim an `agent` node "can also **read and
+    /// write the user's memory at run time**". Both halves were false. A plain
+    /// `agent` node is a single completion through `OpenHumanLlm::complete`
+    /// (`tinyflows/caps.rs`) — no tool loop, so it can neither read nor write
+    /// memory. Told otherwise, the builder authored a plain agent node
+    /// prompted to "recall the user's preference", and the model FABRICATED
+    /// one: the step silently invented context instead of failing, which is
+    /// strictly worse than not working. The banned strings below are the exact
+    /// wording that produced that, so it can never be reintroduced verbatim.
+    #[test]
+    fn standing_prompt_does_not_claim_plain_agent_nodes_reach_memory() {
+        const STANDING_PROMPT: &str = include_str!("prompt.md");
+
+        for banned in [
+            "read and write the user's\n   memory at run time",
+            "wire\n   an `agent` node that uses memory",
+        ] {
+            assert!(
+                !STANDING_PROMPT.contains(banned),
+                "standing prompt must not tell the builder a plain `agent` node can \
+                 reach memory ({banned:?}) — it has no tool loop, so the model \
+                 fabricates the recalled value instead of looking it up"
+            );
+        }
+
+        assert!(
+            STANDING_PROMPT.contains("A plain `agent` node has NO\n   memory access"),
+            "standing prompt must state outright that a plain agent node has no \
+             memory access, so the builder never authors a no-op recall step"
+        );
+    }
+
+    /// The two mechanisms that DO reach memory from inside a running flow must
+    /// both be taught, with the correct binding path for the deterministic one.
+    /// A native `oh:` tool result is a `ToolResult` — `{ content: [{ type,
+    /// text }], is_error }` — so a downstream binding dereferences
+    /// `.item.json.content[0].text`, not the bare `.item.json.<field>` an
+    /// agent/`http_request` output would use. Getting that path wrong is the
+    /// same class of silent-null failure the `=`-binding rules exist to stop.
+    #[test]
+    fn standing_prompt_teaches_the_two_working_memory_read_paths() {
+        const STANDING_PROMPT: &str = include_str!("prompt.md");
+
+        for rule in [
+            "oh:memory_recall",
+            "oh:memory_hybrid_search",
+            "context_scout",
+            "=nodes.<id>.item.json.content[0].text",
+        ] {
+            assert!(
+                STANDING_PROMPT.contains(rule),
+                "standing prompt must teach `{rule}` — it is one of the only two \
+                 mechanisms that actually read memory at flow run time, or the \
+                 binding path needed to consume one"
+            );
+        }
+    }
+
+    /// Flows run on trigger data a third party can influence (an inbound
+    /// email, a webhook payload), so writing that into the user's personal
+    /// memory is deliberately not offered. `agent_memory` is NOT an escape
+    /// hatch here despite being a registered, `read_only` builtin: its
+    /// `memory_tree` tool inherits the trait-default `PermissionLevel::ReadOnly`
+    /// while dispatching an `ingest_document` WRITE mode, so it survives the
+    /// read-only tool filter in `session/builder/factory.rs` (which consults
+    /// the argless `permission_level()`). Steering the builder there would
+    /// hand prompt-injected trigger content a memory-write foothold — exactly
+    /// the hole `context_scout`'s own agent.toml documents refusing.
+    #[test]
+    fn standing_prompt_states_flows_cannot_write_memory_and_avoids_agent_memory() {
+        const STANDING_PROMPT: &str = include_str!("prompt.md");
+
+        assert!(
+            STANDING_PROMPT.contains("can never WRITE the user's memory"),
+            "standing prompt must state plainly that a workflow cannot write the \
+             user's memory, so the builder stops authoring remember/store steps"
+        );
+        assert!(
+            !STANDING_PROMPT.contains("agent_memory"),
+            "standing prompt must not steer the builder to `agent_memory` as a \
+             flow agent_ref: its `memory_tree` tool declares ReadOnly but exposes \
+             an ingest_document write mode, so it would give prompt-injectable \
+             trigger data a memory-write path"
+        );
+    }
+
     #[test]
     fn repair_includes_run_id_error_and_failing_nodes() {
         let mut r = req(BuildMode::Repair);

--- a/src/openhuman/flows/agents/workflow_builder/prompt.md
+++ b/src/openhuman/flows/agents/workflow_builder/prompt.md
@@ -325,11 +325,32 @@ A `WorkflowGraph` is `{ name?, nodes: [...], edges: [...] }`.
    what makes the output-parser coerce/validate it into a real boolean rather
    than a string that merely looks like one.
 
-   An `agent` node inside a workflow can also **read and write the user's
-   memory at run time**. If a workflow genuinely needs the user's context
-   (recall a preference) or should remember a result/state across runs, wire
-   an `agent` node that uses memory instead of hardcoding context memory
-   already holds. Use sparingly — only when the workflow truly needs it.
+   **Reading the user's memory at run time.** A plain `agent` node has NO
+   memory access: it is a single completion, so it cannot look anything up
+   and it cannot decide to. Prompting one to "recall the user's preference"
+   does not read memory — the model simply INVENTS an answer, and the graph
+   still looks correct. Never author that. Two mechanisms actually work:
+   - **A `tool_call` node** with `config.slug` = `oh:memory_recall` (semantic
+     recall) or `oh:memory_hybrid_search` (keyword/lexical lookup). One
+     deterministic read at a fixed point in the graph. Its output is a native
+     tool result, so bind downstream off
+     `=nodes.<id>.item.json.content[0].text` — NOT `.item.json.<field>`.
+   - **`config.agent_ref` = `context_scout`** when the step needs to DECIDE
+     what to look up, or to look up several things across multiple steps.
+     That runs a real read-only agent turn with memory recall, transcript
+     search, and thread reads, and returns a context bundle you feed into a
+     following `agent` node via `input_context`.
+
+   **A workflow can never WRITE the user's memory.** There is no
+   remember/store step, and no `agent_ref` that grants one — a flow runs on
+   trigger data that a third party can influence (an inbound email, a webhook
+   payload), so writing that into the user's memory is deliberately not
+   possible. If the user asks for a workflow that "remembers" something
+   across runs, say plainly that memory writes are not available to workflows
+   yet and build the rest of the flow without that step.
+
+   Use memory reads sparingly — only when the workflow genuinely needs the
+   user's context, rather than hardcoding what memory already holds.
 
    **Picking a specialist via `agent_ref`.** A plain `agent` node (no
    `agent_ref`) only has the default LLM plus whatever it's given in
@@ -347,7 +368,8 @@ A `WorkflowGraph` is `{ name?, nodes: [...], edges: [...] }`.
    `config.agent_ref` — never hallucinate an id, exactly like grounding a
    `tool_call` slug via `search_tool_catalog`. Examples: "generate an HTML
    report from this data" → `code_executor`; "research our competitors" →
-   `researcher`.
+   `researcher`; "work out what this customer has asked us before" →
+   `context_scout` (see "Reading the user's memory at run time" above).
 3. **`tool_call`** — an action. Two flavours by `config.slug`:
    - **Composio app action** — `config.slug` = a real action slug (from
      `search_tool_catalog`, e.g. `GMAIL_SEND_EMAIL`) + `config.connection_ref`


### PR DESCRIPTION
## Summary

- The `workflow_builder` standing prompt told the builder an `agent` node "can also **read and write the user's memory at run time**". Both halves are false, and the failure mode is fabrication rather than an error.
- Replaced it with the two mechanisms that actually reach memory from a running flow, including the correct downstream binding path for a native tool result.
- States plainly that a workflow can never WRITE the user's memory, so the builder stops authoring remember/store steps and tells the user instead.
- Deliberately does **not** steer to `agent_memory` — see Impact for the injection reason.
- 3 regression tests.

## Problem

A plain `agent` node (no `agent_ref`) is a single completion through `OpenHumanLlm::complete` — no tool loop. It cannot read memory and it cannot write memory.

The prompt said otherwise, so when a user asked for a memory-aware workflow the builder authored a plain agent node prompted to "recall the user's preference". The model has no retrieval path, so it **invents** the value. The node succeeds, the graph validates, the run completes — and the workflow acts on fabricated context.

That is worse than a broken step: a failure is visible, a fabrication is not. It has also been self-contradictory since #5120, whose own text four lines below states a plain agent node "cannot run code, browse the web, or reach any domain-specific tool".

## Solution

Two mechanisms genuinely reach memory at flow run time, and the prompt now teaches both:

1. **`tool_call` node** with `config.slug` = `oh:memory_recall` / `oh:memory_hybrid_search` — one deterministic read at a fixed point. A native tool result is a `ToolResult` (`{ content: [{ type, text }], is_error }`), so the downstream binding is `=nodes.<id>.item.json.content[0].text`, **not** the bare `.item.json.<field>` an agent/`http_request` output uses. Getting that path wrong reproduces the same silent-null class the `=`-binding rules exist to prevent, so it is spelled out.
2. **`config.agent_ref = "context_scout"`** when the step must *decide* what to look up, or look up several things — that routes through `run_via_harness` (#5120/#5121) to a real read-only tool loop with memory recall, transcript search, and thread reads.

`context_scout` was also added to the `agent_ref` worked examples, which previously listed only `code_executor` and `researcher`.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — 3 tests: banned-wording regression guard, both working read paths + binding path, and the no-write/no-`agent_memory` contract
- [x] **Diff coverage ≥ 80%** — changed lines are `prompt.md` (data, `include_str!`-asserted by all 3 tests) and the tests themselves
- [x] Coverage matrix updated — `N/A: behaviour-only change to agent prompt guidance`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature row covers builder prompt copy`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface touched`
- [x] Linked issue closed via `Closes #NNN` — N/A: no issue filed; bug found while auditing the flows/memory integration

## Impact

Behaviour-only change to builder guidance. No runtime, schema, or API change. Existing saved flows are untouched; newly authored ones stop containing no-op memory steps.

**Security — why `agent_memory` is deliberately not recommended.** It looks like the obvious pick: a registered builtin, `sandbox_mode = "read_only"`, memory tools in its belt. But its `memory_tree` tool does not override `permission_level()`, so it inherits the trait default `PermissionLevel::ReadOnly` while dispatching an `ingest_document` mode that **writes** to the tree. The read-only tool filter in `session/builder/factory.rs` consults the argless `permission_level()`, so `memory_tree` survives that filter.

Flows run on trigger data a third party can influence (an inbound email, a webhook payload). Pointing the builder at `agent_memory` would therefore hand prompt-injected content a memory-write foothold — precisely the hole `context_scout`'s own `agent.toml` documents refusing for the same reason. This PR routes around it; the underlying tool-permission gap is pre-existing, out of scope here, and worth its own issue.

## Related

Follows #5120 (specialist selection via `agent_ref`) and #5121 (custom registry agents run with real tools), which together made the harness path the real mechanism this prompt now points at.

