### PR TITLE
chore(fmt): rustfmt caps.rs + provider.rs to unblock the CI pipeline

### DIFF
--- a/src/openhuman/agent/harness/subagent_runner/ops/provider.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops/provider.rs
@@ -252,8 +252,9 @@ pub(crate) struct LazyToolkitResolver {
     /// for a slug, subsequent `resolve()` calls for the same slug reuse the
     /// cached instance — sharing its [`ContractGate`] state (#5119).
     #[allow(dead_code)] // used via pub(super) from tests
-    pub(super) resolved:
-        std::sync::Mutex<std::collections::HashMap<String, std::sync::Arc<dyn crate::openhuman::tools::Tool>>>,
+    pub(super) resolved: std::sync::Mutex<
+        std::collections::HashMap<String, std::sync::Arc<dyn crate::openhuman::tools::Tool>>,
+    >,
 }
 
 /// Minimum normalized-slug length before the prefix/superstring tier in
@@ -302,14 +303,13 @@ impl LazyToolkitResolver {
         }
 
         let action = self.find_action(name)?;
-        let tool: std::sync::Arc<dyn crate::openhuman::tools::Tool> = std::sync::Arc::new(
-            crate::openhuman::composio::ComposioActionTool::new(
+        let tool: std::sync::Arc<dyn crate::openhuman::tools::Tool> =
+            std::sync::Arc::new(crate::openhuman::composio::ComposioActionTool::new(
                 self.config.clone(),
                 action.name.clone(),
                 action.description.clone(),
                 action.parameters.clone(),
-            ),
-        );
+            ));
 
         // Store in cache for future lookups.
         {

--- a/src/openhuman/tinyflows/caps.rs
+++ b/src/openhuman/tinyflows/caps.rs
@@ -442,7 +442,10 @@ fn extract_fenced_json_block(text: &str) -> Option<Value> {
     let fence_start = text.find("```")?;
     let after_fence = text[fence_start + 3..].trim();
     // Skip optional "json" after the opening fence
-    let content = after_fence.strip_prefix("json").unwrap_or(after_fence).trim();
+    let content = after_fence
+        .strip_prefix("json")
+        .unwrap_or(after_fence)
+        .trim();
     // Find the *last* closing ``` (preferring the outermost fence, which
     // matches how Markdown renderers treat nested fences — the last ``` is
     // the one that closes the block the LLM opened).
@@ -5660,11 +5663,7 @@ mod tests {
                 "schema": { "type": "array" }
             }
         });
-        let result = build_agent_result(
-            "agent-1",
-            "Here is the list: [1, 2, 3]",
-            &request,
-        );
+        let result = build_agent_result("agent-1", "Here is the list: [1, 2, 3]", &request);
         assert_eq!(result, json!([1, 2, 3]));
     }
 
@@ -5699,7 +5698,8 @@ mod tests {
                 "schema": { "type": "object" }
             }
         });
-        let text = "Some text\n```json\n{\"from_fence\": true}\n```\nmore text { \"from_brace\": true }";
+        let text =
+            "Some text\n```json\n{\"from_fence\": true}\n```\nmore text { \"from_brace\": true }";
         let result = build_agent_result("agent-1", text, &request);
         assert_eq!(result, json!({ "from_fence": true }));
     }


### PR DESCRIPTION
## Summary

`upstream/main` head (`e780277e7`) currently **fails `Rust Quality (fmt, clippy)`** on pre-existing rustfmt violations that landed with recent merges:
- `src/openhuman/tinyflows/caps.rs` — from #5151 (the JSON-fence extraction helper).
- `src/openhuman/agent/harness/subagent_runner/ops/provider.rs` — from the lazy-toolkit resolver (#5119-era).

## Why this matters (it's not cosmetic)

In `.github/workflows/ci-lite.yml`:
- `rust-core-coverage` is gated `if: … && needs['rust-quality'].result == 'success'` — so when rust-quality fails, **coverage + the Rust unit tests SKIP**.
- `PR CI Gate` fails any needed job whose result is neither `success` nor `skipped` — rust-quality = `failure` makes **the gate fail**.

Net effect: **every branch cut from current main is blocked from merging and its tests never run.** This fixes the root cause once.

## Change

`rustfmt --edition 2021` on the two offending files. **Formatting only** — line-wrapping of long generic types / constructor calls. Zero logic change (verify: the diff is pure whitespace/line-breaks).

## Submission Checklist

- [x] Tests added or updated — N/A: formatting-only, no behavior change
- [x] Diff coverage ≥ 80% — N/A: no executable lines changed
- [x] Coverage matrix updated — N/A: no feature change
- [x] All affected feature IDs listed — N/A
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated — N/A: no runtime surface touched
- [x] Linked issue closed via `Closes #NNN` — N/A: pipeline hygiene, no issue

## Impact

Unblocks the CI-lite pipeline (coverage lane + PR CI Gate) for all in-flight PRs. No runtime, API, or behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Applied internal formatting and type-clarity improvements without changing functionality.
  * Preserved existing tool resolution, caching, and JSON extraction behavior.
* **Tests**
  * Reformatted test assertions and fixtures without changing test coverage or expected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->