### PR TITLE
fix(memory): match write-path PII-redact/sanitize order in recall and list

### DIFF
--- a/app/src/components/intelligence/WhatsAppMemorySection.test.tsx
+++ b/app/src/components/intelligence/WhatsAppMemorySection.test.tsx
@@ -67,6 +67,7 @@ describe('<WhatsAppMemorySection />', () => {
     );
     render(<WhatsAppMemorySection pollIntervalMs={0} />);
     await waitFor(() => screen.getByTestId('whatsapp-memory-section'));
+    expect(mockWhatsappListChats).toHaveBeenCalledWith({ limit: 200 });
     expect(screen.getByText(/^200\+ chats synced/)).toBeTruthy();
   });
 
@@ -76,6 +77,7 @@ describe('<WhatsAppMemorySection />', () => {
     );
     render(<WhatsAppMemorySection pollIntervalMs={0} />);
     await waitFor(() => screen.getByTestId('whatsapp-memory-section'));
+    expect(mockWhatsappListChats).toHaveBeenCalledWith({ limit: 200 });
     expect(screen.getByText(/^199 chats synced/)).toBeTruthy();
     expect(screen.queryByText(/200\+/)).toBeNull();
   });

--- a/app/src/components/intelligence/WhatsAppMemorySection.test.tsx
+++ b/app/src/components/intelligence/WhatsAppMemorySection.test.tsx
@@ -61,6 +61,25 @@ describe('<WhatsAppMemorySection />', () => {
     expect(screen.getByText(/2 chats synced/)).toBeTruthy();
   });
 
+  it('shows "200+" instead of an exact count when the chat list hits the request limit', async () => {
+    mockWhatsappListChats.mockResolvedValueOnce(
+      Array.from({ length: 200 }, (_, i) => makeChat({ chat_id: `c${i}` }))
+    );
+    render(<WhatsAppMemorySection pollIntervalMs={0} />);
+    await waitFor(() => screen.getByTestId('whatsapp-memory-section'));
+    expect(screen.getByText(/^200\+ chats synced/)).toBeTruthy();
+  });
+
+  it('shows an exact count when the chat list is under the request limit', async () => {
+    mockWhatsappListChats.mockResolvedValueOnce(
+      Array.from({ length: 199 }, (_, i) => makeChat({ chat_id: `c${i}` }))
+    );
+    render(<WhatsAppMemorySection pollIntervalMs={0} />);
+    await waitFor(() => screen.getByTestId('whatsapp-memory-section'));
+    expect(screen.getByText(/^199 chats synced/)).toBeTruthy();
+    expect(screen.queryByText(/200\+/)).toBeNull();
+  });
+
   it('renders singular "chat" for exactly 1 chat', async () => {
     mockWhatsappListChats.mockResolvedValueOnce([makeChat()]);
     render(<WhatsAppMemorySection pollIntervalMs={0} />);

--- a/app/src/components/intelligence/WhatsAppMemorySection.tsx
+++ b/app/src/components/intelligence/WhatsAppMemorySection.tsx
@@ -8,16 +8,25 @@ interface WhatsAppMemorySectionProps {
   pollIntervalMs?: number;
 }
 
+// `whatsappListChats` is capped at this page size (no offset/count endpoint
+// exists). When a fetch returns exactly this many rows the true total may be
+// larger, so the count must be presented as a floor ("200+"), never as an
+// exact total — otherwise a user with more chats than this sees the badge
+// silently frozen at this number forever.
+const CHAT_LIST_LIMIT = 200;
+
 export function WhatsAppMemorySection({ pollIntervalMs = 30000 }: WhatsAppMemorySectionProps) {
   const { t } = useT();
   const [chatCount, setChatCount] = useState<number | null>(null);
+  const [chatCountTruncated, setChatCountTruncated] = useState(false);
   const [lastSyncTs, setLastSyncTs] = useState<number | null>(null);
   const [syncing, setSyncing] = useState(false);
 
   const load = useCallback(async () => {
     try {
-      const chats = await whatsappListChats({ limit: 200 });
+      const chats = await whatsappListChats({ limit: CHAT_LIST_LIMIT });
       setChatCount(chats.length);
+      setChatCountTruncated(chats.length >= CHAT_LIST_LIMIT);
       const latest = chats.reduce((max, c) => Math.max(max, c.updated_at), 0);
       setLastSyncTs(latest > 0 ? latest : null);
     } catch {
@@ -55,7 +64,7 @@ export function WhatsAppMemorySection({ pollIntervalMs = 30000 }: WhatsAppMemory
           <WhatsAppIcon />
           <span className="text-sm font-semibold text-content">{t('whatsapp.title')}</span>
           <span className="text-xs text-content-muted">
-            {chatCount.toLocaleString()}{' '}
+            {chatCountTruncated ? `${CHAT_LIST_LIMIT}+` : chatCount.toLocaleString()}{' '}
             {chatCount !== 1 ? t('whatsapp.chatsSynced') : t('whatsapp.chatSynced')}
             {lastSyncTs !== null && <> · {relativeTime(lastSyncTs, t)}</>}
           </span>

--- a/src/openhuman/memory_store/memory_trait.rs
+++ b/src/openhuman/memory_store/memory_trait.rs
@@ -383,7 +383,17 @@ impl Memory for UnifiedMemory {
         category: Option<&MemoryCategory>,
         session_id: Option<&str>,
     ) -> anyhow::Result<Vec<MemoryEntry>> {
-        let ns = UnifiedMemory::sanitize_namespace(normalize_namespace(namespace));
+        // Must match the write path's order (`upsert_document` in
+        // documents.rs): redact PII first, sanitize second. Sanitizing first
+        // mangles the punctuation a PII pattern relies on before redaction
+        // ever runs, so the computed namespace silently diverges from the
+        // stored one and documents under it never show up in `list()`.
+        let ns = UnifiedMemory::sanitize_namespace(
+            &crate::openhuman::memory_store::safety::pii::redact_pii(normalize_namespace(
+                namespace,
+            ))
+            .value,
+        );
         let conn = self.conn.lock();
         let mut stmt = conn.prepare(
             "SELECT document_id, key, content, category, session_id, updated_at, taint
@@ -562,6 +572,36 @@ mod tests {
         assert_eq!(entries[0].category, MemoryCategory::Daily);
         assert_eq!(entries[0].session_id.as_deref(), Some("session-b"));
         assert!(!entries[0].timestamp.starts_with("idx-"));
+    }
+
+    /// Regression test: `store`/`upsert_document` redact PII from the
+    /// namespace before sanitizing it (e.g. a CPF-shaped namespace like
+    /// `"user/111.444.777-35"` gets its dots replaced only after the CPF
+    /// pattern is redacted). `list()` must derive the same final namespace
+    /// from the same raw input, or documents stored under a PII-shaped
+    /// namespace silently never show up in `list()`.
+    #[tokio::test]
+    async fn list_finds_entries_stored_under_pii_like_namespace() {
+        let (_tmp, mem) = fresh_mem();
+        let raw_namespace = "user/111.444.777-35";
+        mem.store(
+            raw_namespace,
+            "profile",
+            "profile body",
+            MemoryCategory::Core,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let entries = mem.list(Some(raw_namespace), None, None).await.unwrap();
+        assert_eq!(
+            entries.len(),
+            1,
+            "entry stored under a PII-like namespace must be listable via the same raw \
+             namespace, got: {entries:?}"
+        );
+        assert_eq!(entries[0].key, "profile");
     }
 
     #[tokio::test]

--- a/src/openhuman/memory_store/namespace_store/graph.rs
+++ b/src/openhuman/memory_store/namespace_store/graph.rs
@@ -203,7 +203,7 @@ impl UnifiedMemory {
         predicate: Option<&str>,
     ) -> Result<Vec<GraphRelationRecord>, String> {
         let conn = self.conn.lock();
-        let ns = Self::sanitize_namespace(namespace);
+        let ns = Self::normalize_lookup_namespace(namespace);
         let subject = subject.map(Self::normalize_graph_entity);
         let predicate = predicate.map(Self::normalize_graph_predicate);
         let mut stmt = conn
@@ -227,7 +227,7 @@ impl UnifiedMemory {
         {
             let attrs_raw: String = row.get(3).map_err(|e| e.to_string())?;
             out.push(Self::graph_relation_from_parts(
-                Some(Self::sanitize_namespace(namespace)),
+                Some(ns.clone()),
                 row.get(0).map_err(|e| e.to_string())?,
                 row.get(1).map_err(|e| e.to_string())?,
                 row.get(2).map_err(|e| e.to_string())?,
@@ -339,7 +339,12 @@ impl UnifiedMemory {
                     "SELECT attrs_json
                      FROM graph_namespace
                      WHERE namespace = ?1 AND subject = ?2 AND predicate = ?3 AND object = ?4",
-                    params![Self::sanitize_namespace(ns), subject, predicate, object],
+                    params![
+                        Self::normalize_lookup_namespace(ns),
+                        subject,
+                        predicate,
+                        object
+                    ],
                     |row| row.get(0),
                 )
                 .optional()
@@ -367,7 +372,7 @@ impl UnifiedMemory {
                      ON CONFLICT(namespace, subject, predicate, object)
                      DO UPDATE SET attrs_json = excluded.attrs_json, updated_at = excluded.updated_at",
                     params![
-                        Self::sanitize_namespace(ns),
+                        Self::normalize_lookup_namespace(ns),
                         subject,
                         predicate,
                         object,

--- a/src/openhuman/memory_store/namespace_store/query.rs
+++ b/src/openhuman/memory_store/namespace_store/query.rs
@@ -587,8 +587,15 @@ impl UnifiedMemory {
         })
     }
 
-    fn normalize_lookup_namespace(namespace: &str) -> String {
-        Self::sanitize_namespace(&safety::pii::redact_pii(namespace).value)
+    pub(crate) fn normalize_lookup_namespace(namespace: &str) -> String {
+        let redacted = safety::pii::redact_pii(namespace).value;
+        let normalized = Self::sanitize_namespace(&redacted);
+        tracing::debug!(
+            namespace_was_redacted = redacted.as_str() != namespace,
+            normalized_namespace_len = normalized.len(),
+            "[memory_namespace_lookup] normalized lookup scope"
+        );
+        normalized
     }
 
     async fn load_chunks_for_scope(&self, namespace: &str) -> Result<Vec<StoredChunk>, String> {

--- a/src/openhuman/memory_store/namespace_store/query.rs
+++ b/src/openhuman/memory_store/namespace_store/query.rs
@@ -159,7 +159,7 @@ impl UnifiedMemory {
         // redaction ever runs, so the computed lookup namespace silently
         // diverges from the stored one and every document under it becomes
         // unreachable via recall/search (#5164 follow-up).
-        let ns = Self::sanitize_namespace(&safety::pii::redact_pii(namespace).value);
+        let ns = Self::normalize_lookup_namespace(namespace);
         let exclude_session_id = exclude_session_id
             .map(str::trim)
             .filter(|id| !id.is_empty());
@@ -433,8 +433,8 @@ impl UnifiedMemory {
         query: &str,
         limit: u32,
     ) -> Result<NamespaceRetrievalContext, String> {
-        let ns = Self::sanitize_namespace(namespace);
-        let hits = self.query_namespace_hits(&ns, query, limit).await?;
+        let ns = Self::normalize_lookup_namespace(namespace);
+        let hits = self.query_namespace_hits(namespace, query, limit).await?;
         Ok(NamespaceRetrievalContext {
             namespace: ns,
             query: Some(query.to_string()),
@@ -450,7 +450,7 @@ impl UnifiedMemory {
         namespace: &str,
         limit: u32,
     ) -> Result<Vec<NamespaceMemoryHit>, String> {
-        let ns = Self::sanitize_namespace(namespace);
+        let ns = Self::normalize_lookup_namespace(namespace);
         let docs = self.load_documents_for_scope(&ns).await?;
         let kvs = self.kv_records_for_scope(&ns).await?;
         let graph_relations = self
@@ -577,14 +577,18 @@ impl UnifiedMemory {
         namespace: &str,
         limit: u32,
     ) -> Result<NamespaceRetrievalContext, String> {
-        let ns = Self::sanitize_namespace(namespace);
-        let hits = self.recall_namespace_memories(&ns, limit).await?;
+        let ns = Self::normalize_lookup_namespace(namespace);
+        let hits = self.recall_namespace_memories(namespace, limit).await?;
         Ok(NamespaceRetrievalContext {
             namespace: ns,
             query: None,
             context_text: Self::format_context_text(&hits, None),
             hits,
         })
+    }
+
+    fn normalize_lookup_namespace(namespace: &str) -> String {
+        Self::sanitize_namespace(&safety::pii::redact_pii(namespace).value)
     }
 
     async fn load_chunks_for_scope(&self, namespace: &str) -> Result<Vec<StoredChunk>, String> {

--- a/src/openhuman/memory_store/namespace_store/query.rs
+++ b/src/openhuman/memory_store/namespace_store/query.rs
@@ -9,6 +9,7 @@
 use rusqlite::params;
 use std::collections::{HashMap, HashSet};
 
+use crate::openhuman::memory_store::safety;
 use crate::openhuman::memory_store::types::{
     GraphRelationRecord, MemoryItemKind, NamespaceMemoryHit, NamespaceQueryResult,
     NamespaceRetrievalContext, RetrievalScoreBreakdown,
@@ -151,7 +152,14 @@ impl UnifiedMemory {
         limit: u32,
         exclude_session_id: Option<&str>,
     ) -> Result<Vec<NamespaceMemoryHit>, String> {
-        let ns = Self::sanitize_namespace(namespace);
+        // Must match the write path's exact order (`upsert_document` /
+        // `upsert_document_metadata_only` in documents.rs): redact PII first,
+        // sanitize second. Sanitizing first (the previous bug) replaces the
+        // punctuation a PII pattern relies on (e.g. the dots in a CPF) before
+        // redaction ever runs, so the computed lookup namespace silently
+        // diverges from the stored one and every document under it becomes
+        // unreachable via recall/search (#5164 follow-up).
+        let ns = Self::sanitize_namespace(&safety::pii::redact_pii(namespace).value);
         let exclude_session_id = exclude_session_id
             .map(str::trim)
             .filter(|id| !id.is_empty());

--- a/src/openhuman/memory_store/namespace_store/query_tests.rs
+++ b/src/openhuman/memory_store/namespace_store/query_tests.rs
@@ -101,7 +101,7 @@ async fn query_namespace_hits_finds_document_stored_under_pii_like_namespace() {
     let memory = UnifiedMemory::new(tmp.path(), Arc::new(NoopEmbedding), None).unwrap();
 
     let raw_namespace = "user/111.444.777-35";
-    memory
+    let document_id = memory
         .upsert_document(NamespaceDocumentInput {
             namespace: raw_namespace.to_string(),
             key: "profile".to_string(),
@@ -118,6 +118,16 @@ async fn query_namespace_hits_finds_document_stored_under_pii_like_namespace() {
         })
         .await
         .unwrap();
+    memory
+        .graph_upsert_namespace(
+            raw_namespace,
+            "Customer",
+            "has_status",
+            "Onboarded",
+            &json!({"document_id": document_id}),
+        )
+        .await
+        .unwrap();
 
     let hits = memory
         .query_namespace_hits(raw_namespace, "onboarding status", 5)
@@ -130,6 +140,10 @@ async fn query_namespace_hits_finds_document_stored_under_pii_like_namespace() {
          using the same raw namespace, got hits: {hits:?}"
     );
     assert_eq!(hits[0].key, "profile");
+    assert!(
+        !hits[0].supporting_relations.is_empty(),
+        "graph relations must use the same PII-safe namespace normalization"
+    );
 
     let context = memory
         .query_namespace_context_data(raw_namespace, "onboarding status", 5)

--- a/src/openhuman/memory_store/namespace_store/query_tests.rs
+++ b/src/openhuman/memory_store/namespace_store/query_tests.rs
@@ -130,6 +130,39 @@ async fn query_namespace_hits_finds_document_stored_under_pii_like_namespace() {
          using the same raw namespace, got hits: {hits:?}"
     );
     assert_eq!(hits[0].key, "profile");
+
+    let context = memory
+        .query_namespace_context_data(raw_namespace, "onboarding status", 5)
+        .await
+        .unwrap();
+    assert_eq!(
+        context.hits.len(),
+        1,
+        "query context must preserve the raw namespace until PII redaction"
+    );
+    assert_eq!(context.hits[0].key, "profile");
+
+    let recall_hits = memory
+        .recall_namespace_memories(raw_namespace, 5)
+        .await
+        .unwrap();
+    assert_eq!(
+        recall_hits.len(),
+        1,
+        "query-less recall must normalize PII-like namespaces like the write path"
+    );
+    assert_eq!(recall_hits[0].key, "profile");
+
+    let recall_context = memory
+        .recall_namespace_context_data(raw_namespace, 5)
+        .await
+        .unwrap();
+    assert_eq!(
+        recall_context.hits.len(),
+        1,
+        "query-less recall context must pass the raw namespace to lookup"
+    );
+    assert_eq!(recall_context.hits[0].key, "profile");
 }
 
 #[tokio::test]

--- a/src/openhuman/memory_store/namespace_store/query_tests.rs
+++ b/src/openhuman/memory_store/namespace_store/query_tests.rs
@@ -87,6 +87,51 @@ async fn query_namespace_uses_graph_signal_for_document_ranking() {
     assert!(results[0].score > 0.5);
 }
 
+/// Regression test: `upsert_document`/`upsert_document_metadata_only` (in
+/// `documents.rs`) redact PII from the namespace *before* sanitizing it —
+/// e.g. `"user/111.444.777-35"` (a CPF-shaped namespace) is redacted to
+/// something like `"user/[REDACTED_PII_CPF]"` and only then punctuation-
+/// sanitized. The recall/query path must derive the exact same stored
+/// namespace from the same raw input, or documents written under a
+/// PII-shaped namespace become permanently unreachable via search despite
+/// having been written successfully.
+#[tokio::test]
+async fn query_namespace_hits_finds_document_stored_under_pii_like_namespace() {
+    let tmp = TempDir::new().unwrap();
+    let memory = UnifiedMemory::new(tmp.path(), Arc::new(NoopEmbedding), None).unwrap();
+
+    let raw_namespace = "user/111.444.777-35";
+    memory
+        .upsert_document(NamespaceDocumentInput {
+            namespace: raw_namespace.to_string(),
+            key: "profile".to_string(),
+            title: "Profile".to_string(),
+            content: "Customer profile notes about onboarding status.".to_string(),
+            source_type: "doc".to_string(),
+            priority: "medium".to_string(),
+            tags: vec![],
+            metadata: json!({}),
+            category: "core".to_string(),
+            session_id: None,
+            document_id: None,
+            taint: crate::openhuman::memory::MemoryTaint::Internal,
+        })
+        .await
+        .unwrap();
+
+    let hits = memory
+        .query_namespace_hits(raw_namespace, "onboarding status", 5)
+        .await
+        .unwrap();
+    assert_eq!(
+        hits.len(),
+        1,
+        "document written under a PII-like namespace must be reachable via query_namespace_hits \
+         using the same raw namespace, got hits: {hits:?}"
+    );
+    assert_eq!(hits[0].key, "profile");
+}
+
 #[tokio::test]
 async fn query_scores_relation_entities_found_in_document_content() {
     let tmp = TempDir::new().unwrap();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - WhatsApp synced chat counts now display `200+` at the display limit, while totals below the limit remain exact.
  - Memory search/recall and namespace-scoped retrieval are more consistent for namespaces that resemble privacy-sensitive identifier patterns, improving discoverability of previously stored entries.
  - Namespace handling is now standardized across memory queries and graph namespace lookups/upserts for more reliable matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->