### PR TITLE
Trim Rust dependency graph and duplicate TLS stacks

### DIFF
--- a/.github/workflows/ci-lite.yml
+++ b/.github/workflows/ci-lite.yml
@@ -148,8 +148,10 @@ jobs:
               - 'src/**'
               - 'tests/**'
               - 'scripts/ci-cancel-aware.sh'
+              - 'scripts/check-linux-tls-dependencies.sh'
               - 'scripts/test-rust-e2e.sh'
               - 'scripts/test-rust-with-mock.sh'
+              - 'vendor/motosan-ai-oauth/**'
             # Changes here invalidate per-module test scoping → full suite.
             rust-core-full:
               - '.github/workflows/ci-lite.yml'
@@ -160,6 +162,8 @@ jobs:
               - '.cargo/config.toml'
               - 'rust-toolchain.toml'
               - 'scripts/ci-cancel-aware.sh'
+              - 'scripts/check-linux-tls-dependencies.sh'
+              - 'vendor/motosan-ai-oauth/**'
             rust-core-src:
               - 'src/**'
               - 'tests/**'
@@ -348,6 +352,10 @@ jobs:
 
       - name: Check Rust formatting
         run: cargo fmt --all -- --check
+
+      - name: Enforce Linux TLS dependency policy
+        if: needs.changes.outputs['rust-core'] == 'true'
+        run: bash scripts/check-linux-tls-dependencies.sh
 
       - name: Run clippy (core crate)
         if: needs.changes.outputs['rust-core'] == 'true'

--- a/.github/workflows/ci-lite.yml
+++ b/.github/workflows/ci-lite.yml
@@ -152,6 +152,7 @@ jobs:
               - 'scripts/test-rust-e2e.sh'
               - 'scripts/test-rust-with-mock.sh'
               - 'vendor/motosan-ai-oauth/**'
+              - 'vendor/tinychannels'
             # Changes here invalidate per-module test scoping → full suite.
             rust-core-full:
               - '.github/workflows/ci-lite.yml'
@@ -164,6 +165,7 @@ jobs:
               - 'scripts/ci-cancel-aware.sh'
               - 'scripts/check-linux-tls-dependencies.sh'
               - 'vendor/motosan-ai-oauth/**'
+              - 'vendor/tinychannels'
             rust-core-src:
               - 'src/**'
               - 'tests/**'

--- a/.github/workflows/ci-lite.yml
+++ b/.github/workflows/ci-lite.yml
@@ -356,7 +356,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Enforce Linux TLS dependency policy
-        if: needs.changes.outputs['rust-core'] == 'true'
+        if: needs.changes.outputs['rust-core'] == 'true' || needs.changes.outputs['rust-tauri'] == 'true'
         run: bash scripts/check-linux-tls-dependencies.sh
 
       - name: Run clippy (core crate)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4024,7 +4024,7 @@ dependencies = [
  "base64 0.22.1",
  "percent-encoding",
  "rand 0.9.4",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "sha2 0.10.9",
  "thiserror 2.0.18",
@@ -4701,7 +4701,7 @@ dependencies = [
  "ratatui",
  "rdev",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "ring",
  "rppal",
  "rusqlite",
@@ -5507,7 +5507,6 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -5912,46 +5911,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http 1.4.0",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6152,33 +6111,6 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys 0.8.7",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework 3.7.0",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -6399,17 +6331,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb25f439f97d26fea01d717fa626167ceffcd981addaa670001e70505b72acbb"
 dependencies = [
  "cfg_aliases",
- "httpdate",
- "reqwest 0.13.1",
- "rustls",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
  "sentry-debug-images",
  "sentry-panic",
  "sentry-tracing",
- "tokio",
- "ureq",
 ]
 
 [[package]]
@@ -7281,7 +7208,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "reqwest 0.12.28",
+ "reqwest",
  "rhai",
  "rusqlite",
  "serde",
@@ -7312,7 +7239,7 @@ dependencies = [
  "parking_lot",
  "prost",
  "rand 0.10.1",
- "reqwest 0.12.28",
+ "reqwest",
  "rusqlite",
  "rustls",
  "rustls-pki-types",
@@ -7350,7 +7277,7 @@ dependencies = [
  "parking_lot",
  "rand 0.10.1",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "rusqlite",
  "schemars",
  "serde",
@@ -7420,7 +7347,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "rand 0.8.6",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -8554,15 +8481,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8765,7 +8683,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3042,11 +3042,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -4021,9 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "motosan-ai-oauth"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16994a67367076b08479af83ca05503c4d423fc6631f849fb92fa787956ad557"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "percent-encoding",
@@ -5876,7 +5872,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -5890,7 +5885,6 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "mime_guess",
  "native-tls",
  "percent-encoding",
@@ -7054,27 +7048,6 @@ dependencies = [
  "memchr",
  "ntapi",
  "windows 0.57.0",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.13.1",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys 0.8.7",
- "libc",
 ]
 
 [[package]]
@@ -8862,7 +8835,7 @@ dependencies = [
  "windows-implement 0.58.0",
  "windows-interface 0.58.0",
  "windows-result 0.2.0",
- "windows-strings 0.1.0",
+ "windows-strings",
  "windows-targets 0.52.6",
 ]
 
@@ -8917,17 +8890,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8946,15 +8908,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8962,15 +8915,6 @@ checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result 0.2.0",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1129,18 +1129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
-dependencies = [
- "encode_unicode",
- "libc",
- "unicode-width",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "const-hex"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,12 +1967,6 @@ name = "email_address"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -4676,7 +4658,6 @@ dependencies = [
  "chrono-tz",
  "clap",
  "coins-bip39",
- "console",
  "cpal",
  "cron",
  "crossterm",
@@ -4705,7 +4686,6 @@ dependencies = [
  "hostname",
  "hound",
  "iana-time-zone",
- "image",
  "keyring",
  "landlock",
  "lettre",
@@ -4730,16 +4710,13 @@ dependencies = [
  "rppal",
  "rusqlite",
  "rustls",
- "rustls-pki-types",
  "schemars",
  "sentry",
  "serde",
  "serde_json",
  "serde_repr",
  "serde_yaml",
- "sha1",
  "sha2 0.10.9",
- "similar",
  "socketioxide",
  "starship-battery",
  "sysinfo",
@@ -4753,7 +4730,6 @@ dependencies = [
  "tinyjuice",
  "tinyplace",
  "tokio",
- "tokio-rustls",
  "tokio-stream",
  "tokio-tungstenite 0.24.0",
  "tokio-util",
@@ -4769,7 +4745,6 @@ dependencies = [
  "uuid 1.23.1",
  "wait-timeout",
  "walkdir",
- "webpki-roots 1.0.7",
  "whisper-rs",
  "windows-sys 0.61.2",
  "wiremock",
@@ -6770,12 +6745,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1813,7 +1813,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2079,7 +2079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3465,7 +3465,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4182,7 +4182,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6071,7 +6071,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6331,6 +6331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb25f439f97d26fea01d717fa626167ceffcd981addaa670001e70505b72acbb"
 dependencies = [
  "cfg_aliases",
+ "httpdate",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
@@ -6703,7 +6704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7004,7 +7005,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7017,7 +7018,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8683,7 +8684,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "blo
 # Already in-tree via reqwest/hyper; named directly so `IntegrationClient::get_bytes`
 # can return `bytes::Bytes` without a copy.
 bytes = "1"
-tokio = { version = "1", features = ["full", "sync"] }
+tokio = { version = "1", features = ["full"] }
 once_cell = "1.19"
 parking_lot = "0.12"
 log = "0.4"
@@ -160,15 +160,10 @@ argon2 = "0.5"
 rand = "0.10"
 dirs = "5"
 sha2 = "0.10"
-# Line-level text diffs for the memory_diff module (modified-item unified diffs).
-similar = "2"
 # Git-backed change ledger for the memory_diff module: snapshots are commits,
 # checkpoints are tags, read markers are refs, diffs are git tree diffs.
 # Vendored libgit2 (no system git dependency on end-user machines).
 git2 = { version = "0.21", default-features = false, features = ["vendored-libgit2"] }
-# Legacy SHA-1 only used for Tencent COS HMAC-SHA1 signing (yuanbao
-# channel media upload). Not used for any new security-sensitive work.
-sha1 = "0.10"
 hmac = "0.12"
 # Archive extraction for the Node.js runtime bootstrap. Unix Node
 # distributions ship as .tar.xz, Windows as .zip. `xz2` with `static`
@@ -217,7 +212,6 @@ thiserror = "2.0"
 ring = "0.17"
 chrono-tz = "0.10"
 dotenvy = "0.15"
-console = "0.16"
 regex = "1.10"
 # Multi-pattern fixed-string DFA matcher used by `routing::quality` for
 # refusal/empty-noise detection on local-model responses. Already in the
@@ -229,9 +223,6 @@ walkdir = "2"
 glob = "0.3"
 hostname = "0.4.2"
 rustls = { version = "0.23", features = ["ring"] }
-rustls-pki-types = "1.14.0"
-tokio-rustls = "0.26.4"
-webpki-roots = "1.0.6"
 sysinfo = { version = "0.33", default-features = false, features = ["system"] }
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
 clap = { version = "4.5", features = ["derive"] }
@@ -245,11 +236,10 @@ lettre = { version = "0.11.22", default-features = false, features = ["builder",
 # `http-server` feature note below and `src/core/http_server_status.rs`.
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio", "query", "ws", "macros"], optional = true }
 sentry = { version = "0.47.0", default-features = false, optional = true, features = ["backtrace", "contexts", "panic", "tracing", "debug-images", "reqwest", "rustls"] }
-tokio-stream = { version = "0.1.18", features = ["full"] }
+tokio-stream = { version = "0.1.18", default-features = false, features = ["sync"] }
 url = "2"
 socketioxide = { version = "0.15", features = ["extensions"], optional = true }
 whisper-rs = { version = "0.16", optional = true }
-image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }
 tempfile = "3"
 cpal = { version = "0.15", optional = true }
 hound = { version = "3.5", optional = true }
@@ -459,10 +449,9 @@ web3 = ["dep:bitcoin", "dep:curve25519-dalek"]
 # contracts scaffold. Default-ON. Slim builds opt out via
 # `--no-default-features --features "<explicit list without media>"`.
 # Composes with the runtime `DomainSet::media` flag (#4796).
-# NOTE: this gate sheds NO exclusive dependencies — media generation is
-# backend-proxied (reqwest, shared) and the `image` crate is shared with
-# channel media upload. It is a surface-only gate (drops the tool code +
-# module from the compile), not a dependency-shedding one. There are no
+# NOTE: this gate sheds no exclusive dependencies — media generation is
+# backend-proxied (reqwest, shared). It is a surface-only gate (drops the tool
+# code + module from the compile), not a dependency-shedding one. There are no
 # controllers / stores / subscribers tagged `Media` (agent tools only), and
 # `openhuman::image` is currently unwired scaffold (added #2997).
 media = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -652,6 +652,12 @@ while_let_loop = "allow"
 # See: https://github.com/tinyhumansai/openhuman/issues/273
 [patch.crates-io]
 whisper-rs-sys = { git = "https://github.com/tinyhumansai/whisper-rs-sys.git", branch = "main" }
+# Upstream 0.2.1 enables reqwest's default native-tls backend even though it
+# also requests rustls. Patch the official release locally so Linux/macOS do
+# not inherit OpenSSL; the only source delta disables reqwest defaults.
+# Windows still enables native-tls through the target-specific dependency
+# above. Remove this patch after upstream publishes the same manifest fix.
+motosan-ai-oauth = { path = "vendor/motosan-ai-oauth" }
 # TinyAgents is vendored as a git submodule (pinned at the released tag) so
 # migration work can change the SDK source in-tree, test it against OpenHuman
 # immediately, and PR the diff upstream from the submodule. Keep the submodule

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,7 +235,7 @@ lettre = { version = "0.11.22", default-features = false, features = ["builder",
 # services and answers over the CLI/native dispatch surface. See the
 # `http-server` feature note below and `src/core/http_server_status.rs`.
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio", "query", "ws", "macros"], optional = true }
-sentry = { version = "0.47.0", default-features = false, optional = true, features = ["backtrace", "contexts", "panic", "tracing", "debug-images"] }
+sentry = { version = "0.47.0", default-features = false, optional = true, features = ["backtrace", "contexts", "panic", "tracing", "debug-images", "httpdate"] }
 tokio-stream = { version = "0.1.18", default-features = false, features = ["sync"] }
 url = "2"
 socketioxide = { version = "0.15", features = ["extensions"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,7 +222,7 @@ aho-corasick = "1.1"
 walkdir = "2"
 glob = "0.3"
 hostname = "0.4.2"
-rustls = { version = "0.23", features = ["ring"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 sysinfo = { version = "0.33", default-features = false, features = ["system"] }
 keyring = { version = "3", features = ["apple-native", "windows-native", "linux-native"] }
 clap = { version = "4.5", features = ["derive"] }
@@ -235,7 +235,7 @@ lettre = { version = "0.11.22", default-features = false, features = ["builder",
 # services and answers over the CLI/native dispatch surface. See the
 # `http-server` feature note below and `src/core/http_server_status.rs`.
 axum = { version = "0.8", default-features = false, features = ["http1", "json", "tokio", "query", "ws", "macros"], optional = true }
-sentry = { version = "0.47.0", default-features = false, optional = true, features = ["backtrace", "contexts", "panic", "tracing", "debug-images", "reqwest", "rustls"] }
+sentry = { version = "0.47.0", default-features = false, optional = true, features = ["backtrace", "contexts", "panic", "tracing", "debug-images"] }
 tokio-stream = { version = "0.1.18", default-features = false, features = ["sync"] }
 url = "2"
 socketioxide = { version = "0.15", features = ["extensions"], optional = true }

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -208,7 +208,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -253,7 +253,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -2064,7 +2064,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2482,7 +2482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3690,11 +3690,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -4110,7 +4108,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4764,9 +4762,7 @@ dependencies = [
 
 [[package]]
 name = "motosan-ai-oauth"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16994a67367076b08479af83ca05503c4d423fc6631f849fb92fa787956ad557"
+version = "0.2.1"
 dependencies = [
  "base64 0.22.1",
  "percent-encoding",
@@ -4994,7 +4990,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6541,7 +6537,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6835,7 +6831,6 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -6849,7 +6844,6 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "mime_guess",
  "native-tls",
  "percent-encoding",
@@ -7124,7 +7118,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7183,7 +7177,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7930,7 +7924,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8301,27 +8295,6 @@ dependencies = [
  "memchr",
  "ntapi",
  "windows 0.57.0",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys 0.8.7",
- "libc",
 ]
 
 [[package]]
@@ -8790,7 +8763,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9634,7 +9607,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -208,7 +208,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -253,7 +253,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "x11rb",
 ]
 
@@ -2064,7 +2064,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2482,7 +2482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4110,7 +4110,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4994,7 +4994,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6541,7 +6541,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7124,7 +7124,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7183,7 +7183,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7478,6 +7478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb25f439f97d26fea01d717fa626167ceffcd981addaa670001e70505b72acbb"
 dependencies = [
  "cfg_aliases",
+ "httpdate",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
@@ -7929,7 +7930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8789,7 +8790,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9633,7 +9634,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10406,7 +10407,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -208,7 +208,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -253,7 +253,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -2064,7 +2064,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2482,7 +2482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4110,7 +4110,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4994,7 +4994,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5544,7 +5544,6 @@ dependencies = [
  "chrono-tz",
  "clap",
  "coins-bip39",
- "console",
  "cpal",
  "cron",
  "curve25519-dalek",
@@ -5569,7 +5568,6 @@ dependencies = [
  "hostname",
  "hound",
  "iana-time-zone",
- "image",
  "keyring",
  "lettre",
  "libc",
@@ -5590,16 +5588,13 @@ dependencies = [
  "ring",
  "rusqlite",
  "rustls",
- "rustls-pki-types",
  "schemars 1.2.1",
  "sentry",
  "serde",
  "serde_json",
  "serde_repr",
  "serde_yaml",
- "sha1",
  "sha2 0.10.9",
- "similar",
  "socketioxide",
  "starship-battery",
  "sysinfo",
@@ -5613,7 +5608,6 @@ dependencies = [
  "tinyjuice",
  "tinyplace",
  "tokio",
- "tokio-rustls",
  "tokio-stream",
  "tokio-tungstenite 0.24.0",
  "tokio-util",
@@ -5627,7 +5621,6 @@ dependencies = [
  "uuid 1.23.1",
  "wait-timeout",
  "walkdir",
- "webpki-roots 1.0.7",
  "whisper-rs",
  "windows-sys 0.61.2",
  "x25519-dalek",
@@ -6522,7 +6515,6 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -6549,7 +6541,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6892,10 +6884,8 @@ checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -6906,7 +6896,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -7135,7 +7124,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7194,7 +7183,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7489,17 +7478,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb25f439f97d26fea01d717fa626167ceffcd981addaa670001e70505b72acbb"
 dependencies = [
  "cfg_aliases",
- "httpdate",
- "reqwest 0.13.1",
- "rustls",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
  "sentry-debug-images",
  "sentry-panic",
  "sentry-tracing",
- "tokio",
- "ureq",
 ]
 
 [[package]]
@@ -7886,12 +7870,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "similar"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-
-[[package]]
 name = "simplecss"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7951,7 +7929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8811,7 +8789,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9655,7 +9633,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10428,7 +10406,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -103,7 +103,7 @@ env_logger = "0.11"
 # can be overridden at runtime via the same env var. Feature set mirrors the
 # core sidecar (`Cargo.toml` at repo root) minus `tracing` since the shell
 # uses `log` + `env_logger`.
-sentry = { version = "0.47.0", default-features = false, features = ["backtrace", "contexts", "panic", "debug-images", "reqwest", "rustls"] }
+sentry = { version = "0.47.0", default-features = false, features = ["backtrace", "contexts", "panic", "debug-images"] }
 
 # Used by the imessage_scanner module.
 anyhow = "1.0"

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -263,6 +263,9 @@ e2e-test-support = ["openhuman_core/e2e-test-support"]
 # whisper.cpp to use MSVC's static runtime (/MT), matching CEF and avoiding
 # LNK2038/LNK1169 CRT conflicts on Windows.
 whisper-rs-sys = { git = "https://github.com/tinyhumansai/whisper-rs-sys.git", branch = "main" }
+# Keep reqwest defaults disabled in this independent Cargo world too. Without
+# this patch, the registry release reintroduces native-tls/OpenSSL on Linux.
+motosan-ai-oauth = { path = "../../vendor/motosan-ai-oauth" }
 # TinyAgents vendored submodule (repo-root vendor/tinyagents, pinned at the
 # released tag) — same patch as the root Cargo world so both resolve the
 # in-tree SDK source. `git submodule update --init vendor/tinyagents` first.

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -103,7 +103,7 @@ env_logger = "0.11"
 # can be overridden at runtime via the same env var. Feature set mirrors the
 # core sidecar (`Cargo.toml` at repo root) minus `tracing` since the shell
 # uses `log` + `env_logger`.
-sentry = { version = "0.47.0", default-features = false, features = ["backtrace", "contexts", "panic", "debug-images"] }
+sentry = { version = "0.47.0", default-features = false, features = ["backtrace", "contexts", "panic", "debug-images", "httpdate"] }
 
 # Used by the imessage_scanner module.
 anyhow = "1.0"

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -2609,6 +2609,9 @@ pub fn run() {
             Some(event)
         })),
         sample_rate: 1.0,
+        transport: Some(std::sync::Arc::new(
+            openhuman_core::core::sentry_transport::factory,
+        )),
         ..sentry::ClientOptions::default()
     });
     // Tag every Sentry event with CPU architecture and OS so Intel-specific

--- a/scripts/check-linux-tls-dependencies.sh
+++ b/scripts/check-linux-tls-dependencies.sh
@@ -2,12 +2,23 @@
 set -euo pipefail
 
 target="${1:-x86_64-unknown-linux-gnu}"
-forbidden='^(native-tls|openssl|openssl-sys) v'
+forbidden='^(native-tls|openssl|openssl-sys|aws-lc-rs|aws-lc-sys) v'
 
 tree="$(cargo tree --locked --target "$target" --prefix none)"
 if matches="$(printf '%s\n' "$tree" | grep -E "$forbidden")"; then
   printf 'error: native TLS/OpenSSL dependencies found for %s:\n%s\n' \
     "$target" "$matches" >&2
+  exit 1
+fi
+
+reqwest_versions="$(
+  printf '%s\n' "$tree" |
+    sed -nE 's/^reqwest v([^ ]+).*/\1/p' |
+    sort -u
+)"
+if [[ "$(printf '%s\n' "$reqwest_versions" | sed '/^$/d' | wc -l)" -ne 1 ]]; then
+  printf 'error: expected exactly one reqwest version for %s, found:\n%s\n' \
+    "$target" "$reqwest_versions" >&2
   exit 1
 fi
 

--- a/scripts/check-linux-tls-dependencies.sh
+++ b/scripts/check-linux-tls-dependencies.sh
@@ -45,6 +45,12 @@ check_world() {
         "$package" "$label" "$owners" >&2
       exit 1
     fi
+    if [[ "$label" == tauri ]] &&
+      printf '%s\n' "$owners" | grep -Eq '^motosan-ai-oauth v'; then
+      printf 'error: motosan-ai-oauth owns %s in %s\n%s\n' \
+        "$package" "$label" "$owners" >&2
+      exit 1
+    fi
   done
 }
 

--- a/scripts/check-linux-tls-dependencies.sh
+++ b/scripts/check-linux-tls-dependencies.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target="${1:-x86_64-unknown-linux-gnu}"
+forbidden='^(native-tls|openssl|openssl-sys) v'
+
+tree="$(cargo tree --locked --target "$target" --prefix none)"
+if matches="$(printf '%s\n' "$tree" | grep -E "$forbidden")"; then
+  printf 'error: native TLS/OpenSSL dependencies found for %s:\n%s\n' \
+    "$target" "$matches" >&2
+  exit 1
+fi
+
+printf 'Linux TLS dependency policy passed for %s\n' "$target"

--- a/scripts/check-linux-tls-dependencies.sh
+++ b/scripts/check-linux-tls-dependencies.sh
@@ -2,24 +2,48 @@
 set -euo pipefail
 
 target="${1:-x86_64-unknown-linux-gnu}"
-forbidden='^(native-tls|openssl|openssl-sys|aws-lc-rs|aws-lc-sys) v'
+forbidden='^(native-tls|openssl|openssl-sys) v'
 
-tree="$(cargo tree --locked --target "$target" --prefix none)"
-if matches="$(printf '%s\n' "$tree" | grep -E "$forbidden")"; then
-  printf 'error: native TLS/OpenSSL dependencies found for %s:\n%s\n' \
-    "$target" "$matches" >&2
-  exit 1
-fi
+check_world() {
+  local label="$1"
+  local manifest="$2"
+  local tree
+  tree="$(cargo tree --locked --manifest-path "$manifest" --target "$target" --prefix none)"
+  if [[ "$label" == core ]] &&
+    matches="$(printf '%s\n' "$tree" | grep -E "$forbidden")"; then
+    printf 'error: native TLS/OpenSSL dependencies found in %s for %s:\n%s\n' \
+      "$label" "$target" "$matches" >&2
+    exit 1
+  fi
 
-reqwest_versions="$(
-  printf '%s\n' "$tree" |
-    sed -nE 's/^reqwest v([^ ]+).*/\1/p' |
-    sort -u
-)"
-if [[ "$(printf '%s\n' "$reqwest_versions" | sed '/^$/d' | wc -l)" -ne 1 ]]; then
-  printf 'error: expected exactly one reqwest version for %s, found:\n%s\n' \
-    "$target" "$reqwest_versions" >&2
-  exit 1
-fi
+  # Tauri legitimately owns reqwest 0.13 for its dev proxy/updater. Sentry
+  # must never own that tree: OpenHuman supplies its reqwest 0.12 transport.
+  for version in 0.13.1 0.13.2; do
+    owners="$(
+      cargo tree --locked --manifest-path "$manifest" --target "$target" \
+        --invert "reqwest@$version" 2>/dev/null || true
+    )"
+    if printf '%s\n' "$owners" | grep -Eq '^sentry v'; then
+      printf 'error: Sentry owns reqwest %s in %s\n%s\n' \
+        "$version" "$label" "$owners" >&2
+      exit 1
+    fi
+  done
 
-printf 'Linux TLS dependency policy passed for %s\n' "$target"
+  for package in native-tls openssl openssl-sys; do
+    owners="$(
+      cargo tree --locked --manifest-path "$manifest" --target "$target" \
+        --invert "$package" 2>/dev/null || true
+    )"
+    if printf '%s\n' "$owners" | grep -Eq '^sentry v'; then
+      printf 'error: Sentry owns %s in %s\n%s\n' \
+        "$package" "$label" "$owners" >&2
+      exit 1
+    fi
+  done
+}
+
+check_world core Cargo.toml
+check_world tauri app/src-tauri/Cargo.toml
+
+printf 'Linux TLS/Sentry dependency policy passed for both Cargo worlds (%s)\n' "$target"

--- a/scripts/check-linux-tls-dependencies.sh
+++ b/scripts/check-linux-tls-dependencies.sh
@@ -18,7 +18,12 @@ check_world() {
 
   # Tauri legitimately owns reqwest 0.13 for its dev proxy/updater. Sentry
   # must never own that tree: OpenHuman supplies its reqwest 0.12 transport.
-  for version in 0.13.1 0.13.2; do
+  mapfile -t reqwest_013_versions < <(
+    printf '%s\n' "$tree" |
+      sed -nE 's/^reqwest v(0\.13\.[^ ]+).*/\1/p' |
+      sort -u
+  )
+  for version in "${reqwest_013_versions[@]}"; do
     owners="$(
       cargo tree --locked --manifest-path "$manifest" --target "$target" \
         --invert "reqwest@$version" 2>/dev/null || true

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -25,6 +25,8 @@ pub mod memory_cli;
 pub mod observability;
 pub mod rpc_log;
 pub mod runtime;
+#[cfg(feature = "crash-reporting")]
+pub mod sentry_transport;
 pub mod shutdown;
 pub mod socketio;
 pub mod subconscious_cli;

--- a/src/core/sentry_transport.rs
+++ b/src/core/sentry_transport.rs
@@ -1,37 +1,43 @@
 //! Sentry envelope transport backed by the core's shared reqwest 0.12 stack.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc};
+use std::thread::JoinHandle;
 use std::time::Duration;
 
-use sentry::{ClientOptions, Envelope, Transport};
+use sentry::transports::{RateLimiter, RateLimitingCategory};
+use sentry::{sentry_debug, ClientOptions, Envelope, Transport};
 
-enum Command {
+enum Task {
     Send(Envelope),
     Flush(mpsc::SyncSender<()>),
-    Shutdown(mpsc::SyncSender<()>),
+    Shutdown,
 }
 
-/// A background Sentry transport that avoids Sentry's reqwest 0.13 dependency.
+/// A bounded, nonblocking Sentry transport using reqwest 0.12.
 pub struct SharedReqwestTransport {
-    sender: mpsc::Sender<Command>,
+    sender: mpsc::SyncSender<Task>,
+    shutdown: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
 }
 
 impl SharedReqwestTransport {
-    /// Build a transport from the same client options consumed by Sentry's
-    /// built-in HTTP transport.
+    /// Build a transport from the options consumed by Sentry's HTTP transport.
     pub fn new(options: &ClientOptions) -> Self {
         let mut builder = reqwest::blocking::Client::builder();
         if options.accept_invalid_certs {
             builder = builder.danger_accept_invalid_certs(true);
         }
-        if let Some(proxy) = options.http_proxy.as_ref() {
-            if let Ok(proxy) = reqwest::Proxy::http(proxy.as_ref()) {
-                builder = builder.proxy(proxy);
+        if let Some(url) = options.http_proxy.as_ref() {
+            match reqwest::Proxy::http(url.as_ref()) {
+                Ok(proxy) => builder = builder.proxy(proxy),
+                Err(error) => sentry_debug!("invalid HTTP proxy: {error:?}"),
             }
         }
-        if let Some(proxy) = options.https_proxy.as_ref() {
-            if let Ok(proxy) = reqwest::Proxy::https(proxy.as_ref()) {
-                builder = builder.proxy(proxy);
+        if let Some(url) = options.https_proxy.as_ref() {
+            match reqwest::Proxy::https(url.as_ref()) {
+                Ok(proxy) => builder = builder.proxy(proxy),
+                Err(error) => sentry_debug!("invalid HTTPS proxy: {error:?}"),
             }
         }
         let client = builder
@@ -43,64 +49,185 @@ impl SharedReqwestTransport {
             .expect("Sentry transport requires a DSN");
         let auth = dsn.to_auth(Some(&options.user_agent)).to_string();
         let url = dsn.envelope_api_url().to_string();
-        let (sender, receiver) = mpsc::channel();
+        let (sender, receiver) = mpsc::sync_channel(30);
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let worker_shutdown = shutdown.clone();
 
-        std::thread::Builder::new()
+        let handle = std::thread::Builder::new()
             .name("sentry-transport".into())
             .spawn(move || {
-                while let Ok(command) = receiver.recv() {
-                    match command {
-                        Command::Send(envelope) => {
-                            let mut body = Vec::new();
-                            if envelope.to_writer(&mut body).is_ok() {
-                                let _ = client
-                                    .post(&url)
-                                    .header("X-Sentry-Auth", &auth)
-                                    .body(body)
-                                    .send();
+                let mut rate_limiter = RateLimiter::new();
+                for task in receiver {
+                    if worker_shutdown.load(Ordering::SeqCst) {
+                        return;
+                    }
+                    let envelope = match task {
+                        Task::Send(envelope) => envelope,
+                        Task::Flush(done) => {
+                            let _ = done.send(());
+                            continue;
+                        }
+                        Task::Shutdown => return,
+                    };
+                    if rate_limiter
+                        .is_disabled(RateLimitingCategory::Any)
+                        .is_some()
+                    {
+                        sentry_debug!("Sentry envelope discarded due to global rate limit");
+                        continue;
+                    }
+                    let Some(envelope) = rate_limiter.filter_envelope(envelope) else {
+                        sentry_debug!("Sentry envelope discarded due to category rate limit");
+                        continue;
+                    };
+                    let mut body = Vec::new();
+                    if let Err(error) = envelope.to_writer(&mut body) {
+                        sentry_debug!("failed to serialize Sentry envelope: {error}");
+                        continue;
+                    }
+                    match client
+                        .post(&url)
+                        .header("X-Sentry-Auth", &auth)
+                        .body(body)
+                        .send()
+                    {
+                        Ok(response) => {
+                            if let Some(value) = response
+                                .headers()
+                                .get("x-sentry-rate-limits")
+                                .and_then(|value| value.to_str().ok())
+                            {
+                                rate_limiter.update_from_sentry_header(value);
+                            } else if let Some(value) = response
+                                .headers()
+                                .get(reqwest::header::RETRY_AFTER)
+                                .and_then(|value| value.to_str().ok())
+                            {
+                                rate_limiter.update_from_retry_after(value);
+                            } else if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                                rate_limiter.update_from_429();
+                            }
+                            if response.status() == reqwest::StatusCode::PAYLOAD_TOO_LARGE {
+                                sentry_debug!("Sentry envelope rejected as too large");
                             }
                         }
-                        Command::Flush(done) => {
-                            let _ = done.send(());
-                        }
-                        Command::Shutdown(done) => {
-                            let _ = done.send(());
-                            break;
-                        }
+                        Err(error) => sentry_debug!("failed to send Sentry envelope: {error}"),
                     }
                 }
             })
-            .expect("spawn Sentry transport worker");
-
-        Self { sender }
-    }
-
-    fn drain(&self, timeout: Duration, shutdown: bool) -> bool {
-        let (done_tx, done_rx) = mpsc::sync_channel(0);
-        let command = if shutdown {
-            Command::Shutdown(done_tx)
-        } else {
-            Command::Flush(done_tx)
-        };
-        self.sender.send(command).is_ok() && done_rx.recv_timeout(timeout).is_ok()
+            .ok();
+        Self {
+            sender,
+            shutdown,
+            handle,
+        }
     }
 }
 
 impl Transport for SharedReqwestTransport {
     fn send_envelope(&self, envelope: Envelope) {
-        let _ = self.sender.send(Command::Send(envelope));
+        if let Err(error) = self.sender.try_send(Task::Send(envelope)) {
+            sentry_debug!("Sentry envelope dropped: {error}");
+        }
     }
 
     fn flush(&self, timeout: Duration) -> bool {
-        self.drain(timeout, false)
+        let (done_tx, done_rx) = mpsc::sync_channel(1);
+        self.sender.send(Task::Flush(done_tx)).is_ok() && done_rx.recv_timeout(timeout).is_ok()
     }
 
     fn shutdown(&self, timeout: Duration) -> bool {
-        self.drain(timeout, true)
+        let flushed = self.flush(timeout);
+        self.shutdown.store(true, Ordering::SeqCst);
+        let _ = self.sender.send(Task::Shutdown);
+        flushed
+    }
+}
+
+impl Drop for SharedReqwestTransport {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        let _ = self.sender.send(Task::Shutdown);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
     }
 }
 
 /// Factory suitable for [`ClientOptions::transport`].
 pub fn factory(options: &ClientOptions) -> Arc<dyn Transport> {
     Arc::new(SharedReqwestTransport::new(options))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    fn event_envelope(message: &str) -> Envelope {
+        let mut envelope = Envelope::new();
+        envelope.add_item(sentry::protocol::Event {
+            message: Some(message.to_owned()),
+            ..Default::default()
+        });
+        envelope
+    }
+
+    #[test]
+    fn sends_authenticated_envelope_and_applies_category_rate_limit() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let request = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .unwrap();
+            let mut bytes = Vec::new();
+            let mut buffer = [0; 4096];
+            loop {
+                let read = stream.read(&mut buffer).unwrap();
+                bytes.extend_from_slice(&buffer[..read]);
+                if read < buffer.len() {
+                    break;
+                }
+            }
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nX-Sentry-Rate-Limits: 60:error:project\r\nContent-Length: 0\r\n\r\n",
+                )
+                .unwrap();
+            String::from_utf8(bytes).unwrap()
+        });
+        let options = ClientOptions {
+            dsn: Some(format!("http://public@{address}/1").parse().unwrap()),
+            ..Default::default()
+        };
+        let transport = SharedReqwestTransport::new(&options);
+        transport.send_envelope(event_envelope("first"));
+        assert!(transport.flush(Duration::from_secs(3)));
+        transport.send_envelope(event_envelope("rate-limited"));
+        assert!(transport.flush(Duration::from_secs(3)));
+
+        let request = request.join().unwrap();
+        assert!(request.contains("POST /api/1/envelope/ HTTP/1.1"));
+        assert!(request.contains("x-sentry-auth: Sentry"));
+        assert!(request.contains("\"message\":\"first\""));
+        assert!(!request.contains("rate-limited"));
+    }
+
+    #[test]
+    fn send_failure_does_not_prevent_flush() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let options = ClientOptions {
+            dsn: Some(format!("http://public@{address}/1").parse().unwrap()),
+            ..Default::default()
+        };
+        let transport = SharedReqwestTransport::new(&options);
+        transport.send_envelope(event_envelope("unreachable"));
+        assert!(transport.flush(Duration::from_secs(3)));
+        assert!(transport.shutdown(Duration::from_secs(3)));
+    }
 }

--- a/src/core/sentry_transport.rs
+++ b/src/core/sentry_transport.rs
@@ -1,0 +1,106 @@
+//! Sentry envelope transport backed by the core's shared reqwest 0.12 stack.
+
+use std::sync::{mpsc, Arc};
+use std::time::Duration;
+
+use sentry::{ClientOptions, Envelope, Transport};
+
+enum Command {
+    Send(Envelope),
+    Flush(mpsc::SyncSender<()>),
+    Shutdown(mpsc::SyncSender<()>),
+}
+
+/// A background Sentry transport that avoids Sentry's reqwest 0.13 dependency.
+pub struct SharedReqwestTransport {
+    sender: mpsc::Sender<Command>,
+}
+
+impl SharedReqwestTransport {
+    /// Build a transport from the same client options consumed by Sentry's
+    /// built-in HTTP transport.
+    pub fn new(options: &ClientOptions) -> Self {
+        let mut builder = reqwest::blocking::Client::builder();
+        if options.accept_invalid_certs {
+            builder = builder.danger_accept_invalid_certs(true);
+        }
+        if let Some(proxy) = options.http_proxy.as_ref() {
+            if let Ok(proxy) = reqwest::Proxy::http(proxy.as_ref()) {
+                builder = builder.proxy(proxy);
+            }
+        }
+        if let Some(proxy) = options.https_proxy.as_ref() {
+            if let Ok(proxy) = reqwest::Proxy::https(proxy.as_ref()) {
+                builder = builder.proxy(proxy);
+            }
+        }
+        let client = builder
+            .build()
+            .expect("reqwest 0.12 TLS client must be available");
+        let dsn = options
+            .dsn
+            .as_ref()
+            .expect("Sentry transport requires a DSN");
+        let auth = dsn.to_auth(Some(&options.user_agent)).to_string();
+        let url = dsn.envelope_api_url().to_string();
+        let (sender, receiver) = mpsc::channel();
+
+        std::thread::Builder::new()
+            .name("sentry-transport".into())
+            .spawn(move || {
+                while let Ok(command) = receiver.recv() {
+                    match command {
+                        Command::Send(envelope) => {
+                            let mut body = Vec::new();
+                            if envelope.to_writer(&mut body).is_ok() {
+                                let _ = client
+                                    .post(&url)
+                                    .header("X-Sentry-Auth", &auth)
+                                    .body(body)
+                                    .send();
+                            }
+                        }
+                        Command::Flush(done) => {
+                            let _ = done.send(());
+                        }
+                        Command::Shutdown(done) => {
+                            let _ = done.send(());
+                            break;
+                        }
+                    }
+                }
+            })
+            .expect("spawn Sentry transport worker");
+
+        Self { sender }
+    }
+
+    fn drain(&self, timeout: Duration, shutdown: bool) -> bool {
+        let (done_tx, done_rx) = mpsc::sync_channel(0);
+        let command = if shutdown {
+            Command::Shutdown(done_tx)
+        } else {
+            Command::Flush(done_tx)
+        };
+        self.sender.send(command).is_ok() && done_rx.recv_timeout(timeout).is_ok()
+    }
+}
+
+impl Transport for SharedReqwestTransport {
+    fn send_envelope(&self, envelope: Envelope) {
+        let _ = self.sender.send(Command::Send(envelope));
+    }
+
+    fn flush(&self, timeout: Duration) -> bool {
+        self.drain(timeout, false)
+    }
+
+    fn shutdown(&self, timeout: Duration) -> bool {
+        self.drain(timeout, true)
+    }
+}
+
+/// Factory suitable for [`ClientOptions::transport`].
+pub fn factory(options: &ClientOptions) -> Arc<dyn Transport> {
+    Arc::new(SharedReqwestTransport::new(options))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -277,6 +277,9 @@ fn main() {
             Some(event)
         })),
         sample_rate: 1.0,
+        transport: Some(std::sync::Arc::new(
+            openhuman_core::core::sentry_transport::factory,
+        )),
         ..sentry::ClientOptions::default()
     });
 

--- a/vendor/motosan-ai-oauth/Cargo.toml
+++ b/vendor/motosan-ai-oauth/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "motosan-ai-oauth"
+version = "0.2.1"
+edition = "2021"
+rust-version = "1.82"
+license = "MIT"
+description = "Provider-agnostic PKCE OAuth login and token refresh"
+repository = "https://github.com/motosan-dev/motosan-ai"
+homepage = "https://github.com/motosan-dev/motosan-ai"
+documentation = "https://docs.rs/motosan-ai-oauth"
+keywords = ["oauth", "pkce", "authentication", "openai"]
+categories = ["authentication", "api-bindings"]
+
+[features]
+default = []
+codex = []
+
+[dependencies]
+thiserror = "2"
+serde = { version = "1", features = ["derive"] }
+base64 = "0.22"
+sha2 = "0.10"
+rand = "0.9"
+# Keep this crate transport-neutral beyond its rustls requirement. OpenHuman
+# deliberately enables reqwest/native-tls only on Windows; reqwest's defaults
+# would otherwise pull OpenSSL into Linux builds as a second TLS stack.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+percent-encoding = "2"
+tokio = { version = "1", features = [
+  "net",
+  "io-util",
+  "rt-multi-thread",
+  "macros",
+  "time",
+] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
+mockito = "1"

--- a/vendor/motosan-ai-oauth/README.openhuman.md
+++ b/vendor/motosan-ai-oauth/README.openhuman.md
@@ -1,0 +1,21 @@
+# OpenHuman patch
+
+This directory contains the source of the official `motosan-ai-oauth` 0.2.1
+crate from crates.io:
+
+- Download: <https://static.crates.io/crates/motosan-ai-oauth/motosan-ai-oauth-0.2.1.crate>
+- SHA-256: `244943168db97b6874d3a88f5fff7029ab002d84c9c572e3bfe6e8cd92af0bae`
+
+To reproduce the source verification, download that archive and verify it with
+`sha256sum`. This vendored copy deliberately retains only the provider enabled
+by OpenHuman (`codex`); the unused Gemini and Anthropic provider modules are
+omitted. In particular, the Gemini module distributed public installed-app
+OAuth credentials which OpenHuman neither compiles nor uses.
+
+The other source delta is in `Cargo.toml`: unused provider features are removed
+and the crate's `reqwest` dependency sets `default-features = false`. The
+released manifest enables both reqwest's default native-TLS backend and
+`rustls-tls`, which brings OpenSSL into Linux builds. OpenHuman already chooses
+its TLS backend by target: rustls on Linux/macOS and native TLS on Windows.
+
+Remove this patch after an upstream release includes the same manifest change.

--- a/vendor/motosan-ai-oauth/src/error.rs
+++ b/vendor/motosan-ai-oauth/src/error.rs
@@ -1,0 +1,19 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("HTTP error: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("Callback error: {0}")]
+    Callback(String),
+
+    #[error("State mismatch (possible CSRF): received unexpected state value")]
+    StateMismatch,
+
+    #[error("Token exchange failed: {0}")]
+    TokenExchange(String),
+}

--- a/vendor/motosan-ai-oauth/src/exchange.rs
+++ b/vendor/motosan-ai-oauth/src/exchange.rs
@@ -1,0 +1,232 @@
+use serde::Deserialize;
+
+use crate::{error::Error, unix_now, OAuthConfig, StateStrategy, Token};
+
+#[derive(Deserialize)]
+struct RawTokenResponse {
+    access_token: String,
+    /// Servers may omit `refresh_token` on a refresh grant (RFC 6749 §6).
+    /// Callers must pass their existing refresh token as fallback.
+    #[serde(default)]
+    refresh_token: Option<String>,
+    #[serde(default)]
+    id_token: Option<String>,
+    expires_in: u64,
+}
+
+impl RawTokenResponse {
+    fn into_token(self, fallback_refresh: Option<&str>) -> Token {
+        Token {
+            access_token: self.access_token,
+            refresh_token: self
+                .refresh_token
+                .or_else(|| fallback_refresh.map(str::to_owned))
+                .unwrap_or_default(),
+            id_token: self.id_token,
+            expires_in: self.expires_in,
+            issued_at: unix_now(),
+        }
+    }
+}
+
+async fn post_token(
+    token_url: &str,
+    body_format: crate::TokenBodyFormat,
+    params: Vec<(&str, &str)>,
+    fallback_refresh: Option<&str>,
+) -> Result<Token, Error> {
+    let client = reqwest::Client::new();
+    // No custom User-Agent override — reqwest's default is safer than a
+    // "Mozilla/5.0..." string (which can look like a bot to anti-abuse
+    // systems). Accept: application/json matches pi-ai's reference impl.
+    let req = client.post(token_url).header("Accept", "application/json");
+
+    let req = match body_format {
+        crate::TokenBodyFormat::Form => req.form(&params),
+        crate::TokenBodyFormat::Json => {
+            let map: std::collections::HashMap<&str, &str> = params.iter().copied().collect();
+            req.json(&map)
+        }
+    };
+
+    let resp = req.send().await?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(Error::TokenExchange(format!("HTTP {status}: {body}")));
+    }
+
+    Ok(resp
+        .json::<RawTokenResponse>()
+        .await?
+        .into_token(fallback_refresh))
+}
+
+pub async fn exchange_code(
+    config: &OAuthConfig,
+    code: &str,
+    state: &str,
+    verifier: &str,
+    redirect_uri: &str,
+) -> Result<Token, Error> {
+    // Standard OAuth (RFC 6749 §4.1.3) does not require `state` on the
+    // token endpoint, and some servers reject extra fields. Anthropic's
+    // endpoint empirically validates it, so only echo `state` for the
+    // Anthropic-style strategy where state equals the PKCE verifier.
+    let mut params = vec![
+        ("grant_type", "authorization_code"),
+        ("code", code),
+        ("redirect_uri", redirect_uri),
+        ("code_verifier", verifier),
+        ("client_id", config.client_id),
+    ];
+    if matches!(config.state_strategy, StateStrategy::EqualsVerifier) {
+        params.push(("state", state));
+    }
+    if let Some(secret) = config.client_secret {
+        params.push(("client_secret", secret));
+    }
+    post_token(config.token_url, config.token_body, params, None).await
+}
+
+pub async fn refresh_token(config: &OAuthConfig, refresh_token: &str) -> Result<Token, Error> {
+    let mut params = vec![
+        ("grant_type", "refresh_token"),
+        ("refresh_token", refresh_token),
+        ("client_id", config.client_id),
+    ];
+    if let Some(secret) = config.client_secret {
+        params.push(("client_secret", secret));
+    }
+    post_token(
+        config.token_url,
+        config.token_body,
+        params,
+        Some(refresh_token),
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::TokenBodyFormat;
+    use mockito::Matcher;
+
+    #[tokio::test]
+    async fn exchange_code_omits_state_for_random_strategy_form_body() {
+        let mut server = mockito::Server::new_async().await;
+        let token_url: &'static str = Box::leak(format!("{}/token", server.url()).into_boxed_str());
+
+        let mock = server
+            .mock("POST", "/token")
+            .match_header(
+                "content-type",
+                Matcher::Regex("application/x-www-form-urlencoded".into()),
+            )
+            .match_body(Matcher::Exact(
+                "grant_type=authorization_code&code=AUTHCODE&redirect_uri=http%3A%2F%2F127.0.0.1%2Fcb&code_verifier=VERIFIER&client_id=test-client"
+                    .into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"access_token":"AT","refresh_token":"RT","expires_in":3600}"#)
+            .create_async()
+            .await;
+
+        let cfg = crate::OAuthConfig {
+            client_id: "test-client",
+            client_secret: None,
+            auth_url: "https://unused/",
+            token_url,
+            scopes: &[],
+            redirect_port: None,
+            callback_path: "/auth/callback",
+            redirect_uri_host: "127.0.0.1",
+            token_body: TokenBodyFormat::Form,
+            extra_auth_params: &[],
+            state_strategy: crate::StateStrategy::Random,
+        };
+        let token = exchange_code(&cfg, "AUTHCODE", "STATE", "VERIFIER", "http://127.0.0.1/cb")
+            .await
+            .expect("ok");
+        assert_eq!(token.access_token, "AT");
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn exchange_code_omits_state_for_random_strategy_json_body() {
+        let mut server = mockito::Server::new_async().await;
+        let token_url: &'static str = Box::leak(format!("{}/token", server.url()).into_boxed_str());
+
+        let mock = server
+            .mock("POST", "/token")
+            .match_header("content-type", Matcher::Regex("application/json".into()))
+            // Matcher::JsonString compares parsed JSON, so key order in the
+            // serialized HashMap does not matter.
+            .match_body(Matcher::JsonString(
+                r#"{"grant_type":"authorization_code","code":"AUTHCODE","redirect_uri":"http://127.0.0.1/cb","code_verifier":"VERIFIER","client_id":"test-client"}"#
+                .into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"access_token":"AT","refresh_token":"RT","expires_in":3600}"#)
+            .create_async()
+            .await;
+
+        let cfg = crate::OAuthConfig {
+            client_id: "test-client",
+            client_secret: None,
+            auth_url: "https://unused/",
+            token_url,
+            scopes: &[],
+            redirect_port: None,
+            callback_path: "/auth/callback",
+            redirect_uri_host: "127.0.0.1",
+            token_body: TokenBodyFormat::Json,
+            extra_auth_params: &[],
+            state_strategy: crate::StateStrategy::Random,
+        };
+        let token = exchange_code(&cfg, "AUTHCODE", "STATE", "VERIFIER", "http://127.0.0.1/cb")
+            .await
+            .expect("ok");
+        assert_eq!(token.access_token, "AT");
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn exchange_code_sends_state_for_equals_verifier_strategy_json_body() {
+        let mut server = mockito::Server::new_async().await;
+        let token_url: &'static str = Box::leak(format!("{}/token", server.url()).into_boxed_str());
+
+        let mock = server
+            .mock("POST", "/token")
+            .match_header("content-type", Matcher::Regex("application/json".into()))
+            .match_body(Matcher::JsonString(
+                r#"{"grant_type":"authorization_code","code":"AUTHCODE","state":"STATE","redirect_uri":"http://127.0.0.1/cb","code_verifier":"VERIFIER","client_id":"test-client"}"#
+                .into(),
+            ))
+            .with_status(200)
+            .with_body(r#"{"access_token":"AT","refresh_token":"RT","expires_in":3600}"#)
+            .create_async()
+            .await;
+
+        let cfg = crate::OAuthConfig {
+            client_id: "test-client",
+            client_secret: None,
+            auth_url: "https://unused/",
+            token_url,
+            scopes: &[],
+            redirect_port: None,
+            callback_path: "/auth/callback",
+            redirect_uri_host: "127.0.0.1",
+            token_body: TokenBodyFormat::Json,
+            extra_auth_params: &[],
+            state_strategy: crate::StateStrategy::EqualsVerifier,
+        };
+        let token = exchange_code(&cfg, "AUTHCODE", "STATE", "VERIFIER", "http://127.0.0.1/cb")
+            .await
+            .expect("ok");
+        assert_eq!(token.access_token, "AT");
+        mock.assert_async().await;
+    }
+}

--- a/vendor/motosan-ai-oauth/src/lib.rs
+++ b/vendor/motosan-ai-oauth/src/lib.rs
@@ -1,0 +1,274 @@
+mod error;
+mod exchange;
+mod pkce;
+pub mod providers;
+mod server;
+
+pub use error::Error;
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use rand::RngCore as _;
+
+const LOGIN_TIMEOUT_SECS: u64 = 120;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenBodyFormat {
+    Form,
+    Json,
+}
+
+/// How to derive the OAuth `state` CSRF nonce.
+///
+/// Most servers treat `state` as opaque and echo it back unchanged. Anthropic's
+/// `claude.ai/oauth/authorize` endpoint empirically rejects random `state`
+/// values with "Invalid request format"; setting `state` equal to the PKCE
+/// verifier (as the Claude Code CLI and `@earendil-works/pi-ai` both do) is
+/// accepted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StateStrategy {
+    /// Generate a fresh random 16-byte base64url value. Standard OAuth.
+    Random,
+    /// Reuse the PKCE verifier as the state nonce. Required for Anthropic.
+    EqualsVerifier,
+}
+
+#[derive(Debug, Clone)]
+pub struct OAuthConfig {
+    pub client_id: &'static str,
+    pub client_secret: Option<&'static str>,
+    pub auth_url: &'static str,
+    pub token_url: &'static str,
+    pub scopes: &'static [&'static str],
+    pub redirect_port: Option<u16>,
+    pub callback_path: &'static str,
+    pub redirect_uri_host: &'static str,
+    pub token_body: TokenBodyFormat,
+    pub extra_auth_params: &'static [(&'static str, &'static str)],
+    pub state_strategy: StateStrategy,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Token {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub id_token: Option<String>,
+    pub expires_in: u64,
+    pub issued_at: u64,
+}
+
+impl Token {
+    pub fn is_expired(&self) -> bool {
+        unix_now() + 60 >= self.issued_at + self.expires_in
+    }
+}
+
+pub async fn login(config: &OAuthConfig) -> Result<Token, Error> {
+    let pkce = pkce::Pkce::generate();
+
+    let state = match config.state_strategy {
+        StateStrategy::Random => {
+            let mut state_bytes = [0u8; 16];
+            rand::rng().fill_bytes(&mut state_bytes);
+            URL_SAFE_NO_PAD.encode(state_bytes)
+        }
+        StateStrategy::EqualsVerifier => pkce.verifier.clone(),
+    };
+
+    let server = server::bind(config.redirect_port).await?;
+    let redirect_uri =
+        build_redirect_uri(config.redirect_uri_host, server.port, config.callback_path);
+
+    let auth_url = build_auth_url(config, &pkce.challenge, &state, &redirect_uri);
+
+    println!("Open this URL to log in:\n\n  {auth_url}\n");
+    let _ = open_browser(&auth_url);
+
+    let (code, returned_state) = tokio::time::timeout(
+        std::time::Duration::from_secs(LOGIN_TIMEOUT_SECS),
+        server::wait_for_callback(server, config.callback_path),
+    )
+    .await
+    .map_err(|_| {
+        Error::Callback(format!(
+            "timed out waiting for browser callback ({LOGIN_TIMEOUT_SECS}s)"
+        ))
+    })??;
+
+    if returned_state != state {
+        return Err(Error::StateMismatch);
+    }
+
+    exchange::exchange_code(config, &code, &state, &pkce.verifier, &redirect_uri).await
+}
+
+pub async fn refresh(config: &OAuthConfig, refresh_token: &str) -> Result<Token, Error> {
+    exchange::refresh_token(config, refresh_token).await
+}
+
+pub(crate) fn build_redirect_uri(host: &str, port: u16, path: &str) -> String {
+    format!("http://{host}:{port}{path}")
+}
+
+pub(crate) fn build_auth_url(
+    config: &OAuthConfig,
+    challenge: &str,
+    state: &str,
+    redirect_uri: &str,
+) -> String {
+    let mut url = reqwest::Url::parse(config.auth_url).expect("auth_url must be valid");
+    {
+        let mut q = url.query_pairs_mut();
+        q.append_pair("client_id", config.client_id)
+            .append_pair("response_type", "code")
+            .append_pair("redirect_uri", redirect_uri)
+            .append_pair("scope", &config.scopes.join(" "))
+            .append_pair("state", state)
+            .append_pair("code_challenge", challenge)
+            .append_pair("code_challenge_method", "S256");
+        for (k, v) in config.extra_auth_params {
+            q.append_pair(k, v);
+        }
+    }
+    url.to_string()
+}
+
+pub(crate) fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn open_browser(url: &str) -> std::io::Result<()> {
+    #[cfg(target_os = "macos")]
+    std::process::Command::new("open").arg(url).spawn()?;
+    #[cfg(target_os = "linux")]
+    std::process::Command::new("xdg-open").arg(url).spawn()?;
+    #[cfg(target_os = "windows")]
+    std::process::Command::new("cmd")
+        .args(["/c", "start", "", url])
+        .spawn()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_config() -> OAuthConfig {
+        OAuthConfig {
+            client_id: "test-client",
+            client_secret: None,
+            auth_url: "https://auth.example.com/oauth/authorize",
+            token_url: "https://auth.example.com/oauth/token",
+            scopes: &["openid", "profile"],
+            redirect_port: None,
+            callback_path: "/auth/callback",
+            redirect_uri_host: "127.0.0.1",
+            token_body: TokenBodyFormat::Form,
+            extra_auth_params: &[],
+            state_strategy: StateStrategy::Random,
+        }
+    }
+
+    #[test]
+    fn build_auth_url_contains_required_params() {
+        let config = dummy_config();
+        let url = build_auth_url(
+            &config,
+            "challenge123",
+            "state456",
+            "http://127.0.0.1:9999/auth/callback",
+        );
+        assert!(url.contains("client_id=test-client"));
+        assert!(url.contains("response_type=code"));
+        assert!(url.contains("code_challenge=challenge123"));
+        assert!(url.contains("code_challenge_method=S256"));
+        assert!(url.contains("state=state456"));
+        assert!(url.contains("redirect_uri="));
+        assert!(url.contains("scope="));
+    }
+
+    #[test]
+    fn build_auth_url_includes_scopes_joined() {
+        let config = dummy_config();
+        let url = build_auth_url(&config, "c", "s", "http://127.0.0.1:1234/auth/callback");
+        assert!(url.contains("scope=openid+profile") || url.contains("scope=openid%20profile"));
+    }
+
+    #[test]
+    fn build_auth_url_parses_as_valid_url() {
+        let config = dummy_config();
+        let url = build_auth_url(&config, "c", "s", "http://127.0.0.1:1234/auth/callback");
+        reqwest::Url::parse(&url).expect("auth URL must be valid");
+    }
+
+    #[test]
+    fn build_auth_url_appends_extra_auth_params() {
+        let config = OAuthConfig {
+            extra_auth_params: &[("foo", "bar"), ("baz", "qux")],
+            ..dummy_config()
+        };
+        let url = build_auth_url(&config, "c", "s", "http://127.0.0.1:1234/auth/callback");
+        assert!(url.contains("foo=bar"));
+        assert!(url.contains("baz=qux"));
+    }
+
+    #[test]
+    fn build_auth_url_no_longer_hardcodes_access_type() {
+        // Empty extra_auth_params should produce no access_type query pair.
+        let config = OAuthConfig {
+            extra_auth_params: &[],
+            ..dummy_config()
+        };
+        let url = build_auth_url(&config, "c", "s", "http://127.0.0.1:1234/auth/callback");
+        assert!(!url.contains("access_type="));
+    }
+
+    #[test]
+    fn build_auth_url_uses_redirect_uri_host_in_uri() {
+        // The redirect_uri is built by login(); we test the helper that constructs it.
+        // The host substring comes from config.redirect_uri_host, not from the bind addr.
+        let uri = build_redirect_uri("localhost", 53692, "/callback");
+        assert_eq!(uri, "http://localhost:53692/callback");
+
+        let uri = build_redirect_uri("127.0.0.1", 1455, "/auth/callback");
+        assert_eq!(uri, "http://127.0.0.1:1455/auth/callback");
+    }
+
+    #[test]
+    fn token_is_expired_when_issued_at_zero() {
+        let token = Token {
+            access_token: "a".into(),
+            refresh_token: "r".into(),
+            id_token: None,
+            expires_in: 3600,
+            issued_at: 0,
+        };
+        assert!(token.is_expired());
+    }
+
+    #[test]
+    fn token_not_expired_when_just_issued() {
+        let token = Token {
+            access_token: "a".into(),
+            refresh_token: "r".into(),
+            id_token: None,
+            expires_in: 3600,
+            issued_at: unix_now(),
+        };
+        assert!(!token.is_expired());
+    }
+
+    #[test]
+    fn token_within_buffer_is_considered_expired() {
+        let token = Token {
+            access_token: "a".into(),
+            refresh_token: "r".into(),
+            id_token: None,
+            expires_in: 30, // expires in 30s, within the 60s buffer
+            issued_at: unix_now(),
+        };
+        assert!(token.is_expired());
+    }
+}

--- a/vendor/motosan-ai-oauth/src/pkce.rs
+++ b/vendor/motosan-ai-oauth/src/pkce.rs
@@ -1,0 +1,71 @@
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use rand::RngCore as _;
+use sha2::{Digest, Sha256};
+
+pub struct Pkce {
+    pub verifier: String,
+    pub challenge: String,
+}
+
+impl Pkce {
+    pub fn generate() -> Self {
+        let mut bytes = [0u8; 64];
+        rand::rng().fill_bytes(&mut bytes);
+        let verifier = URL_SAFE_NO_PAD.encode(bytes);
+
+        let hash = Sha256::digest(verifier.as_bytes());
+        let challenge = URL_SAFE_NO_PAD.encode(hash);
+
+        Pkce {
+            verifier,
+            challenge,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verifier_is_base64url_no_pad() {
+        let pkce = Pkce::generate();
+        assert!(
+            pkce.verifier
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+            "verifier contains non-base64url chars: {}",
+            pkce.verifier
+        );
+        assert!(
+            !pkce.verifier.contains('='),
+            "verifier must not have padding"
+        );
+        assert_eq!(pkce.verifier.len(), 86);
+    }
+
+    #[test]
+    fn challenge_matches_s256_of_verifier() {
+        let pkce = Pkce::generate();
+        let hash = Sha256::digest(pkce.verifier.as_bytes());
+        let expected = URL_SAFE_NO_PAD.encode(hash);
+        assert_eq!(pkce.challenge, expected);
+    }
+
+    #[test]
+    fn challenge_is_base64url_no_pad() {
+        let pkce = Pkce::generate();
+        assert!(pkce
+            .challenge
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+        assert!(!pkce.challenge.contains('='));
+    }
+
+    #[test]
+    fn each_generate_is_unique() {
+        let a = Pkce::generate();
+        let b = Pkce::generate();
+        assert_ne!(a.verifier, b.verifier);
+    }
+}

--- a/vendor/motosan-ai-oauth/src/providers/codex.rs
+++ b/vendor/motosan-ai-oauth/src/providers/codex.rs
@@ -1,0 +1,46 @@
+use crate::{OAuthConfig, StateStrategy, TokenBodyFormat};
+
+pub fn codex() -> OAuthConfig {
+    OAuthConfig {
+        client_id: "app_EMoamEEZ73f0CkXaXp7hrann",
+        client_secret: None,
+        auth_url: "https://auth.openai.com/oauth/authorize",
+        token_url: "https://auth.openai.com/oauth/token",
+        scopes: &["openid", "profile", "email", "offline_access"],
+        redirect_port: Some(1455),
+        callback_path: "/auth/callback",
+        redirect_uri_host: "127.0.0.1",
+        token_body: TokenBodyFormat::Form,
+        extra_auth_params: &[("access_type", "offline")],
+        state_strategy: StateStrategy::Random,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_config_has_correct_client_id() {
+        let c = codex();
+        assert_eq!(c.client_id, "app_EMoamEEZ73f0CkXaXp7hrann");
+    }
+
+    #[test]
+    fn codex_config_has_no_client_secret() {
+        let c = codex();
+        assert!(c.client_secret.is_none());
+    }
+
+    #[test]
+    fn codex_config_redirect_port_is_1455() {
+        let c = codex();
+        assert_eq!(c.redirect_port, Some(1455));
+    }
+
+    #[test]
+    fn codex_config_auth_url_is_openai() {
+        let c = codex();
+        assert!(c.auth_url.contains("auth.openai.com"));
+    }
+}

--- a/vendor/motosan-ai-oauth/src/providers/mod.rs
+++ b/vendor/motosan-ai-oauth/src/providers/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "codex")]
+pub mod codex;

--- a/vendor/motosan-ai-oauth/src/server.rs
+++ b/vendor/motosan-ai-oauth/src/server.rs
@@ -1,0 +1,215 @@
+use percent_encoding::percent_decode_str;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+
+use crate::error::Error;
+
+pub struct BoundServer {
+    pub port: u16,
+    listener: TcpListener,
+}
+
+/// Bind to 127.0.0.1:{port} (or OS-assigned if port is None).
+/// Returns BoundServer with the actual bound port.
+pub async fn bind(port: Option<u16>) -> Result<BoundServer, Error> {
+    let addr = format!("127.0.0.1:{}", port.unwrap_or(0));
+    let listener = TcpListener::bind(&addr).await.map_err(|e| {
+        if e.kind() == std::io::ErrorKind::AddrInUse {
+            Error::Callback(format!(
+                "port {} is already in use; close other instances and retry",
+                port.unwrap_or(0)
+            ))
+        } else {
+            Error::Io(e)
+        }
+    })?;
+    let actual_port = listener.local_addr().map_err(Error::Io)?.port();
+    Ok(BoundServer {
+        port: actual_port,
+        listener,
+    })
+}
+
+/// Wait for one /auth/callback?code=...&state=... request.
+/// Returns (code, state). Ignores other requests (e.g. favicon).
+pub async fn wait_for_callback(
+    server: BoundServer,
+    callback_path: &str,
+) -> Result<(String, String), Error> {
+    let BoundServer { listener, .. } = server;
+    loop {
+        let (mut stream, _) = listener.accept().await?;
+        let buf = read_headers(&mut stream).await?;
+        let request = String::from_utf8_lossy(&buf);
+
+        if !is_callback_request(&request, callback_path) {
+            let _ = stream
+                .write_all(b"HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n")
+                .await;
+            continue;
+        }
+
+        let html = "<html><body>Login successful. You can close this tab.</body></html>";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            html.len(),
+            html
+        );
+        let _ = stream.write_all(response.as_bytes()).await;
+        return parse_callback(&request);
+    }
+}
+
+async fn read_headers(stream: &mut tokio::net::TcpStream) -> Result<Vec<u8>, Error> {
+    let mut buf = Vec::with_capacity(4096);
+    let mut chunk = [0u8; 512];
+    loop {
+        let n = stream.read(&mut chunk).await?;
+        if n == 0 {
+            break;
+        }
+        if buf.len() + n >= 16384 {
+            return Err(Error::Callback("request too large".into()));
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if buf.windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+    }
+    Ok(buf)
+}
+
+fn is_callback_request(request: &str, callback_path: &str) -> bool {
+    let path = request
+        .lines()
+        .next()
+        .unwrap_or("")
+        .split_whitespace()
+        .nth(1)
+        .unwrap_or("");
+    path.starts_with(callback_path) && path.contains("code=")
+}
+
+fn parse_callback(request: &str) -> Result<(String, String), Error> {
+    let first_line = request.lines().next().unwrap_or("");
+    let path = first_line
+        .split_whitespace()
+        .nth(1)
+        .ok_or_else(|| Error::Callback("malformed HTTP request".into()))?;
+
+    let query = path.split_once('?').map(|(_, q)| q).unwrap_or("");
+
+    let mut code = None;
+    let mut state = None;
+
+    for pair in query.split('&') {
+        if let Some((k, v)) = pair.split_once('=') {
+            let decoded = percent_decode_str(v)
+                .decode_utf8()
+                .map_err(|_| Error::Callback(format!("param '{k}' is not valid UTF-8")))?
+                .into_owned();
+            match k {
+                "code" => code = Some(decoded),
+                "state" => state = Some(decoded),
+                _ => {}
+            }
+        }
+    }
+
+    let code = code.ok_or_else(|| Error::Callback("missing code param".into()))?;
+    let state = state.ok_or_else(|| Error::Callback("missing state param".into()))?;
+    Ok((code, state))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn get(path: &str) -> String {
+        format!("GET {path} HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    }
+
+    #[test]
+    fn parses_normal_callback() {
+        let (code, state) = parse_callback(&get("/auth/callback?code=abc123&state=xyz")).unwrap();
+        assert_eq!(code, "abc123");
+        assert_eq!(state, "xyz");
+    }
+
+    #[test]
+    fn decodes_percent_encoded_params() {
+        let (code, state) =
+            parse_callback(&get("/auth/callback?code=ab%2Bcd&state=x%3Dy")).unwrap();
+        assert_eq!(code, "ab+cd");
+        assert_eq!(state, "x=y");
+    }
+
+    #[test]
+    fn extra_params_are_ignored() {
+        let (code, state) =
+            parse_callback(&get("/auth/callback?code=c&state=s&session_state=ignored")).unwrap();
+        assert_eq!(code, "c");
+        assert_eq!(state, "s");
+    }
+
+    #[test]
+    fn missing_code_returns_error() {
+        let err = parse_callback(&get("/auth/callback?state=s")).unwrap_err();
+        assert!(err.to_string().contains("missing code"));
+    }
+
+    #[test]
+    fn missing_state_returns_error() {
+        let err = parse_callback(&get("/auth/callback?code=c")).unwrap_err();
+        assert!(err.to_string().contains("missing state"));
+    }
+
+    #[test]
+    fn non_callback_path_is_not_callback() {
+        assert!(!is_callback_request(&get("/favicon.ico"), "/auth/callback"));
+        assert!(!is_callback_request(&get("/"), "/auth/callback"));
+    }
+
+    #[test]
+    fn callback_path_with_code_is_callback() {
+        assert!(is_callback_request(
+            &get("/auth/callback?code=abc&state=xyz"),
+            "/auth/callback"
+        ));
+    }
+
+    #[test]
+    fn anthropic_callback_path_is_callback() {
+        assert!(is_callback_request(
+            &get("/callback?code=abc&state=xyz"),
+            "/callback"
+        ));
+    }
+
+    #[test]
+    fn auth_callback_path_does_not_match_anthropic_request() {
+        // A request to /callback must not be accepted when callback_path is /auth/callback.
+        assert!(!is_callback_request(
+            &get("/callback?code=abc&state=xyz"),
+            "/auth/callback"
+        ));
+    }
+
+    #[tokio::test]
+    async fn bind_dynamic_port_returns_nonzero_port() {
+        let server = bind(None).await.expect("bind should succeed");
+        assert!(server.port > 0, "dynamic port should be nonzero");
+    }
+
+    #[tokio::test]
+    async fn bind_specific_port_returns_that_port() {
+        let probe = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let free_port = probe.local_addr().unwrap().port();
+        drop(probe);
+
+        let server = bind(Some(free_port)).await.expect("bind should succeed");
+        assert_eq!(server.port, free_port);
+    }
+}


### PR DESCRIPTION
## Summary

- remove unused direct Rust dependencies and narrow over-broad Tokio feature activation
- vendor the Codex-only OAuth crate with reqwest defaults disabled, eliminating its accidental native-tls/OpenSSL stack on Linux and macOS
- replace Sentry's separate reqwest 0.13 transport with a bounded, rate-limited transport built on the existing reqwest 0.12 client
- enforce dependency-policy invariants across both the root core and independent Tauri Cargo worlds

## Why

The release graph carried unused crates, duplicate HTTP clients, and unintended TLS providers. In particular, the OAuth dependency enabled reqwest's default native-TLS backend even though non-Windows builds are intended to use rustls.

The vendored OAuth source is minimized to the Codex provider used by OpenHuman; unused Gemini/Anthropic provider sources are excluded.

## Validation

- Linux dependency policy passes for both Cargo worlds
- focused Sentry transport tests pass (authenticated envelopes, category rate limiting, failure/flush/shutdown)
- locked metadata resolves for root and Tauri manifests
- Linux/macOS exclude the OAuth-owned native-TLS/OpenSSL path
- Windows retains intended target-specific native TLS
- independent whole-branch review approved with no findings

Related follow-ups: #5197, #5198, #5199.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth sign-in and token refresh support for the Codex provider, including PKCE and local callback handling.
  * Improved crash-report delivery with a background, nonblocking transport that supports rate limiting and graceful shutdown.

* **Bug Fixes**
  * Reduced Linux TLS dependency conflicts by standardizing secure transport configuration.

* **Quality Improvements**
  * Added automated checks to enforce Linux TLS policies during relevant builds and tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->