### PR TITLE
fix(chat): wrap long URLs in message bubbles so they don't overflow

### DIFF
--- a/app/src/features/conversations/components/AgentMessageBubble.test.tsx
+++ b/app/src/features/conversations/components/AgentMessageBubble.test.tsx
@@ -41,6 +41,18 @@ describe('AgentMessageBubble markdown links', () => {
     expect(mocks.openWorkspacePath).not.toHaveBeenCalled();
   });
 
+  test('wraps a long auto-linked URL so it cannot overflow the bubble', () => {
+    // A bare URL is auto-linked by GFM; without an overflow-wrap rule the long
+    // unbreakable token expands past the bubble edge and gets clipped.
+    render(
+      <BubbleMarkdown content="https://github.com/tinyhumansai/openhuman/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc" />
+    );
+
+    const link = screen.getByRole('link');
+    expect(link.className).toContain('[overflow-wrap:anywhere]');
+    expect(link.className).toContain('break-words');
+  });
+
   test('opens workspace links through the Tauri workspace path command', async () => {
     render(<BubbleMarkdown content="[summary](workspace:memory_tree/content/summary.md)" />);
 

--- a/app/src/features/conversations/components/AgentMessageBubble.tsx
+++ b/app/src/features/conversations/components/AgentMessageBubble.tsx
@@ -76,7 +76,7 @@ function MarkdownAnchor({ href, children }: { href?: string; children?: ReactNod
           // Ignore launcher errors from OS URL handler failures.
         });
       }}
-      className="cursor-pointer underline">
+      className="cursor-pointer underline break-words [overflow-wrap:anywhere]">
       {children}
     </a>
   );

--- a/app/src/features/conversations/components/ChatThreadView.tsx
+++ b/app/src/features/conversations/components/ChatThreadView.tsx
@@ -877,7 +877,7 @@ export const ChatThreadView = forwardRef<ChatThreadViewHandle, ChatThreadViewPro
                                       </div>
                                     )}
                                     {(displayText || showTime) && (
-                                      <div className="rounded-2xl px-4 py-2.5 bg-primary-500 text-content-inverted rounded-br-md break-words overflow-hidden">
+                                      <div className="rounded-2xl px-4 py-2.5 bg-primary-500 text-content-inverted rounded-br-md break-words [overflow-wrap:anywhere] overflow-hidden">
                                         {displayText && (
                                           <BubbleMarkdown content={displayText} tone="user" />
                                         )}


### PR DESCRIPTION
## Summary

- Long URLs pasted into a chat message (e.g. a GitHub issues link in the Workflow Copilot) no longer overflow / get clipped by the message bubble.
- Add `overflow-wrap: anywhere` to the auto-linked anchor (`MarkdownAnchor`) and to the user message bubble so long unbreakable tokens wrap inside the bubble.
- Applies to both the main chat and the Workflow Copilot (they share `ChatThreadView` + `BubbleMarkdown`).

## Problem

A bare URL in a message is auto-linked by GFM into an `<a>`, and the message bubble is sized with `w-fit` / `max-w-[75%]`. The bubble used `break-words` (`overflow-wrap: break-word`), which does **not** reduce the intrinsic min-content width of a single unbreakable token. Under `w-fit` sizing the box therefore never shrinks, the link expands past the bubble edge, and `overflow-hidden` clips it — the URL visibly runs off the bubble (cut off mid-string). Reproduced in the Workflow Copilot with a pasted `https://github.com/tinyhumansai/openhuman/issues...` link.

## Solution

`overflow-wrap: anywhere` (unlike `break-word`) **does** affect intrinsic sizing, so the box can shrink and wrap the long token. Added it in two places on the shared chat components:

- `AgentMessageBubble.tsx` — `MarkdownAnchor` `<a>` now `... break-words [overflow-wrap:anywhere]` (fixes the auto-linked URL, the exact repro).
- `ChatThreadView.tsx` — the user message bubble now carries `[overflow-wrap:anywhere]` alongside `break-words` (covers plain long tokens too).

CSS-only; no behavior/logic change beyond wrapping.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — added `wraps a long auto-linked URL so it cannot overflow the bubble` in `AgentMessageBubble.test.tsx` (asserts the auto-linked anchor carries the wrap classes). Existing link tests still pass (16/16).
- [x] **Diff coverage ≥ 80%** — the changed `className` lines are exercised by the new test plus existing render tests; focused Vitest run green. CI coverage gate is authoritative.
- [x] N/A: behaviour-only CSS fix — no feature row added/removed/renamed in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] N/A: no matrix feature IDs affected (styling-only change).
- [x] No new external network dependencies introduced.
- [x] N/A: CSS wrap fix, does not change a release-cut flow surface.
- [x] N/A: no separate tracked GitHub issue — reported via internal bug tracker; described inline above.

## Impact

- Desktop/web chat + Workflow Copilot only. No runtime, security, migration, or performance impact (two Tailwind utility classes). No API or Rust changes.

## Related

- Closes: N/A (no separate issue filed; internal tracker item)
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/chat-bubble-long-url-overflow`
- Commit SHA: `4142338b2c66c7075d0f1db526b721d81b7f2f06`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — prettier clean on changed files
- [x] `pnpm typecheck` — exit 0, no TS errors
- [x] Focused tests: `AgentMessageBubble.test.tsx` — 16 passed (incl. the new wrap test)
- [x] Rust fmt/check (if changed): N/A — no Rust changes
- [x] Tauri fmt/check (if changed): N/A — no Tauri/Rust changes

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: long URLs / unbreakable tokens wrap inside chat message bubbles instead of overflowing.
- User-visible effect: URLs are fully readable and contained; no more clipped text running off the bubble edge.

### Parity Contract

- Legacy behavior preserved: yes — only added wrapping utility classes; link click behavior, styling, and layout otherwise unchanged.
- Guard/fallback/dispatch parity checks: N/A

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wrapping for long URLs in agent messages to prevent content from overflowing message bubbles.
  * Improved wrapping for long words and images in user messages for better readability on narrow screens.
* **Tests**
  * Added coverage verifying that long links wrap correctly within conversation bubbles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->