### PR TITLE
fix(inference): local model reliability — /api/tags fallback + real Ollama model ids

### DIFF
--- a/src/openhuman/inference/local/lm_studio.rs
+++ b/src/openhuman/inference/local/lm_studio.rs
@@ -291,11 +291,28 @@ pub(crate) struct LmStudioNativeModelsResponse {
 /// Map a normalized `…/v1` base URL to the LM Studio native models endpoint
 /// `…/api/v0/models` (a sibling of `/v1`, served at the host root).
 pub(crate) fn lm_studio_native_models_url(v1_base_url: &str) -> String {
-    let root = v1_base_url
+    format!("{}/api/v0/models", host_root_of(v1_base_url))
+}
+
+/// Strip a trailing `/v1` so sibling endpoints served at the host root can be
+/// derived from an OpenAI-compatible base URL.
+pub(crate) fn host_root_of(v1_base_url: &str) -> &str {
+    v1_base_url
         .trim_end_matches('/')
         .trim_end_matches("/v1")
-        .trim_end_matches('/');
-    format!("{root}/api/v0/models")
+        .trim_end_matches('/')
+}
+
+/// Ollama-native `GET /api/tags` URL derived from an OpenAI-compatible base.
+///
+/// Only used as the one-shot 404 fallback in
+/// [`LocalAiService::list_lm_studio_models`](crate::openhuman::inference::local::service::LocalAiService):
+/// some runtimes are reachable on an OpenAI-shaped base URL but expose only the
+/// Ollama listing (e.g. plain Ollama configured with a `/v1` base). Discovery is
+/// still chosen by provider type first — this is a recovery path, not a probe
+/// order (GH #5055).
+pub(crate) fn ollama_tags_fallback_url(v1_base_url: &str) -> String {
+    format!("{}/api/tags", host_root_of(v1_base_url))
 }
 
 /// Resolve the context window LM Studio reports for `model_id` from a native
@@ -334,6 +351,37 @@ mod tests {
             lm_studio_native_models_url("https://lm.example.com/lmstudio/v1"),
             "https://lm.example.com/lmstudio/api/v0/models"
         );
+    }
+
+    /// GH #5055: the `/api/tags` fallback URL is a sibling of `/v1` at the host
+    /// root. Appending to the `/v1` base would produce `/v1/api/tags` — the
+    /// exact malformed request LM Studio logs as `Unexpected endpoint or
+    /// method` (GH #5053).
+    #[test]
+    fn ollama_tags_fallback_url_is_host_rooted_not_v1_suffixed() {
+        assert_eq!(
+            ollama_tags_fallback_url("http://localhost:1234/v1"),
+            "http://localhost:1234/api/tags"
+        );
+        assert_eq!(
+            ollama_tags_fallback_url("http://127.0.0.1:1234/v1/"),
+            "http://127.0.0.1:1234/api/tags"
+        );
+        assert_eq!(
+            ollama_tags_fallback_url("https://lm.example.com/lmstudio/v1"),
+            "https://lm.example.com/lmstudio/api/tags"
+        );
+        // A host-rooted base (no /v1) is left alone.
+        assert_eq!(
+            ollama_tags_fallback_url("http://localhost:11434"),
+            "http://localhost:11434/api/tags"
+        );
+        for url in [
+            ollama_tags_fallback_url("http://localhost:1234/v1"),
+            ollama_tags_fallback_url("http://localhost:1234/v1/"),
+        ] {
+            assert!(!url.contains("/v1/api/tags"), "malformed probe URL: {url}");
+        }
     }
 
     #[test]

--- a/src/openhuman/inference/local/ollama.rs
+++ b/src/openhuman/inference/local/ollama.rs
@@ -312,6 +312,14 @@ impl OllamaPullProgress {
 pub(crate) struct OllamaTagsResponse {
     #[serde(default)]
     pub models: Vec<OllamaModelTag>,
+    /// Set when the server answered with an error envelope rather than a
+    /// catalog. LM Studio replies to unknown paths with `200 {"error": …}` and
+    /// no `models` (GH #5053), which is indistinguishable from a real catalog
+    /// by `models` alone — a fresh Ollama with nothing pulled legitimately
+    /// returns `{"models":[]}`. Callers must branch on this field, not on
+    /// emptiness.
+    #[serde(default)]
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/src/openhuman/inference/local/service/lm_studio.rs
+++ b/src/openhuman/inference/local/service/lm_studio.rs
@@ -217,17 +217,33 @@ impl LocalAiService {
             }
         };
 
-        // An empty catalog is not a recovery — fall through to the original
-        // /v1/models error so the user sees the real problem. LM Studio answers
-        // unknown paths with `200 {"error": …}` and no models (GH #5053), which
-        // would otherwise look like a successful discovery of zero models.
-        if payload.models.is_empty() {
+        // Reject on an explicit error envelope, NOT on emptiness. LM Studio
+        // answers unknown paths with `200 {"error": …}` and no models
+        // (GH #5053) — that is the case that must fall through to the original
+        // /v1/models error. A fresh Ollama with nothing pulled yet legitimately
+        // returns `{"models":[]}`, and treating that as a failure hid a
+        // reachable runtime behind a 404, so the UI could not offer the
+        // model-download action.
+        if let Some(error) = payload
+            .error
+            .as_deref()
+            .map(str::trim)
+            .filter(|e| !e.is_empty())
+        {
             tracing::debug!(
                 target: "local_ai::lm_studio",
                 url = %fallback_url,
-                "[local_ai:lm_studio] /api/tags fallback returned an empty catalog — not a recovery"
+                error = %error,
+                "[local_ai:lm_studio] /api/tags fallback returned an error envelope — not a recovery"
             );
             return None;
+        }
+        if payload.models.is_empty() {
+            tracing::info!(
+                target: "local_ai::lm_studio",
+                url = %fallback_url,
+                "[local_ai:lm_studio] /api/tags fallback reached a reachable runtime with an empty catalog — recovering as zero models"
+            );
         }
 
         tracing::info!(

--- a/src/openhuman/inference/local/service/lm_studio.rs
+++ b/src/openhuman/inference/local/service/lm_studio.rs
@@ -1,9 +1,10 @@
 use crate::openhuman::config::Config;
 use crate::openhuman::inference::local::lm_studio::{
-    apply_lm_studio_auth, lm_studio_base_url, LmStudioChatCompletionRequest,
-    LmStudioChatCompletionResponse, LmStudioChatMessage, LmStudioModelsResponse,
+    apply_lm_studio_auth, lm_studio_base_url, ollama_tags_fallback_url,
+    LmStudioChatCompletionRequest, LmStudioChatCompletionResponse, LmStudioChatMessage,
+    LmStudioModelsResponse,
 };
-use crate::openhuman::inference::local::ollama::OllamaModelTag;
+use crate::openhuman::inference::local::ollama::{OllamaModelTag, OllamaTagsResponse};
 use crate::openhuman::inference::model_ids;
 
 use super::LocalAiService;
@@ -43,11 +44,15 @@ impl LocalAiService {
     ) -> Result<Vec<OllamaModelTag>, String> {
         let base = lm_studio_base_url(config);
         let url = format!("{base}/models");
+        // GH #5055: log the *resolved* discovery URL so a wrong base URL is
+        // diagnosable from app logs alone, without reproducing against the
+        // runtime's own request log.
         tracing::debug!(
             target: "local_ai::lm_studio",
             %base,
-            %url,
-            "[local_ai:lm_studio] list_models: sending GET"
+            discovery_url = %url,
+            api = "openai_v1_models",
+            "[local_ai:lm_studio] list_models: resolved discovery URL — sending GET"
         );
 
         let request = self
@@ -78,6 +83,20 @@ impl LocalAiService {
                 body = %diagnostic_body_snippet(&body),
                 "[local_ai:lm_studio] list_models: non-success response"
             );
+
+            // GH #5055: a 404 on `/v1/models` means this host is reachable but
+            // does not serve the OpenAI catalog. Try the Ollama-native
+            // `/api/tags` exactly once before giving up, so a runtime that only
+            // speaks the Ollama listing still discovers its models. Discovery is
+            // still selected by provider *type* first (`model_discovery_api`);
+            // this is a recovery path, never a probe order, and it never runs
+            // for any status other than 404.
+            if status == reqwest::StatusCode::NOT_FOUND {
+                if let Some(models) = self.list_ollama_tags_fallback(config, &base).await {
+                    return Ok(models);
+                }
+            }
+
             return Err(format!(
                 "lm studio models failed with status {}{}",
                 status,
@@ -118,6 +137,106 @@ impl LocalAiService {
                 modified_at: None,
             })
             .collect())
+    }
+
+    /// One-shot Ollama-native `/api/tags` fallback for a `/v1/models` 404.
+    ///
+    /// Returns `Some(models)` only when the fallback actually produced a
+    /// catalog; every failure returns `None` so the caller surfaces the original
+    /// `/v1/models` error rather than a confusing second one. Logs at WARN on
+    /// entry because taking this path means the configured base URL and the
+    /// provider type disagree — the user should fix the configuration even
+    /// though discovery recovered (GH #5055).
+    async fn list_ollama_tags_fallback(
+        &self,
+        config: &Config,
+        base: &str,
+    ) -> Option<Vec<OllamaModelTag>> {
+        let fallback_url = ollama_tags_fallback_url(base);
+        tracing::warn!(
+            target: "local_ai::lm_studio",
+            %base,
+            discovery_url = %fallback_url,
+            api = "ollama_api_tags",
+            "[local_ai:lm_studio] list_models: /v1/models returned 404 — retrying once against \
+             the Ollama-native /api/tags. Check the configured base URL: an OpenAI-compatible \
+             runtime should serve /v1/models."
+        );
+
+        let request = self
+            .http
+            .get(&fallback_url)
+            .timeout(std::time::Duration::from_secs(5));
+        let response = match apply_lm_studio_auth(request, config).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::debug!(
+                    target: "local_ai::lm_studio",
+                    url = %fallback_url,
+                    error = %e,
+                    "[local_ai:lm_studio] /api/tags fallback request failed"
+                );
+                return None;
+            }
+        };
+
+        let status = response.status();
+        if !status.is_success() {
+            tracing::debug!(
+                target: "local_ai::lm_studio",
+                url = %fallback_url,
+                %status,
+                "[local_ai:lm_studio] /api/tags fallback returned non-success"
+            );
+            return None;
+        }
+
+        let body = match response.text().await {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::debug!(
+                    target: "local_ai::lm_studio",
+                    url = %fallback_url,
+                    error = %e,
+                    "[local_ai:lm_studio] /api/tags fallback body read failed"
+                );
+                return None;
+            }
+        };
+        let payload: OllamaTagsResponse = match serde_json::from_str(&body) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::debug!(
+                    target: "local_ai::lm_studio",
+                    url = %fallback_url,
+                    error = %e,
+                    body = %diagnostic_body_snippet(&body),
+                    "[local_ai:lm_studio] /api/tags fallback parse failed"
+                );
+                return None;
+            }
+        };
+
+        // An empty catalog is not a recovery — fall through to the original
+        // /v1/models error so the user sees the real problem. LM Studio answers
+        // unknown paths with `200 {"error": …}` and no models (GH #5053), which
+        // would otherwise look like a successful discovery of zero models.
+        if payload.models.is_empty() {
+            tracing::debug!(
+                target: "local_ai::lm_studio",
+                url = %fallback_url,
+                "[local_ai:lm_studio] /api/tags fallback returned an empty catalog — not a recovery"
+            );
+            return None;
+        }
+
+        tracing::info!(
+            target: "local_ai::lm_studio",
+            url = %fallback_url,
+            model_count = payload.models.len(),
+            "[local_ai:lm_studio] recovered model discovery via the Ollama /api/tags fallback"
+        );
+        Some(payload.models)
     }
 
     pub(in crate::openhuman::inference::local::service) async fn has_lm_studio_model(

--- a/src/openhuman/inference/local/service/ollama_admin_tests.rs
+++ b/src/openhuman/inference/local/service/ollama_admin_tests.rs
@@ -1277,3 +1277,134 @@ async fn diagnostics_gates_models_by_context_window() {
         std::env::remove_var("OPENHUMAN_OLLAMA_BASE_URL");
     }
 }
+
+// ── GH #5055: one-shot /api/tags fallback on a /v1/models 404 ───────────────
+//
+// Discovery is still chosen by provider *type* (`model_discovery_api`); these
+// cover the recovery path taken when the chosen OpenAI-compatible endpoint
+// answers 404, so a runtime that only speaks the Ollama listing is not left
+// with an empty catalog.
+
+/// A `/v1/models` 404 falls back to the host-rooted `/api/tags` exactly once
+/// and returns that catalog.
+#[tokio::test]
+async fn v1_models_404_falls_back_to_ollama_api_tags() {
+    let _guard = crate::openhuman::inference::inference_test_guard();
+
+    let app = Router::new()
+        .route(
+            "/v1/models",
+            get(|| async { (axum::http::StatusCode::NOT_FOUND, "404 page not found") }),
+        )
+        .route(
+            "/api/tags",
+            get(|| async {
+                Json(json!({
+                    "models": [
+                        { "name": "local-model", "size": 42, "modified_at": "2026-01-01T00:00:00Z" }
+                    ]
+                }))
+            }),
+        );
+    let base = spawn_mock(app).await;
+    let config = lm_studio_config(&base);
+    let service = LocalAiService::new(&config);
+
+    let models = service
+        .list_lm_studio_models(&config)
+        .await
+        .expect("the /api/tags fallback should recover discovery");
+
+    assert_eq!(models.len(), 1);
+    assert_eq!(models[0].name, "local-model");
+}
+
+/// When neither endpoint serves a catalog, the caller sees the original
+/// `/v1/models` failure — not a second, more confusing error from the fallback.
+#[tokio::test]
+async fn v1_models_404_reports_the_original_error_when_fallback_also_fails() {
+    let _guard = crate::openhuman::inference::inference_test_guard();
+
+    let app = Router::new().route(
+        "/v1/models",
+        get(|| async { (axum::http::StatusCode::NOT_FOUND, "404 page not found") }),
+    );
+    let base = spawn_mock(app).await;
+    let config = lm_studio_config(&base);
+    let service = LocalAiService::new(&config);
+
+    let err = service
+        .list_lm_studio_models(&config)
+        .await
+        .expect_err("no catalog anywhere must fail");
+
+    assert!(
+        err.contains("404"),
+        "expected the original /v1/models status, got: {err}"
+    );
+}
+
+/// LM Studio answers unknown paths with `200 {"error": …}` and no models
+/// (GH #5053). An empty fallback catalog must NOT be treated as a recovery,
+/// otherwise discovery silently "succeeds" with zero models.
+#[tokio::test]
+async fn empty_api_tags_fallback_is_not_treated_as_recovery() {
+    let _guard = crate::openhuman::inference::inference_test_guard();
+
+    let app = Router::new()
+        .route(
+            "/v1/models",
+            get(|| async { (axum::http::StatusCode::NOT_FOUND, "404 page not found") }),
+        )
+        .route("/api/tags", get(|| async { Json(json!({ "models": [] })) }));
+    let base = spawn_mock(app).await;
+    let config = lm_studio_config(&base);
+    let service = LocalAiService::new(&config);
+
+    let err = service
+        .list_lm_studio_models(&config)
+        .await
+        .expect_err("an empty fallback catalog is not a recovery");
+
+    assert!(err.contains("404"), "got: {err}");
+}
+
+/// Any non-404 failure must NOT trigger the fallback: a 500 is a server fault,
+/// not a wrong-endpoint signal, and probing a second path would mask it.
+#[tokio::test]
+async fn non_404_status_does_not_trigger_the_fallback() {
+    let _guard = crate::openhuman::inference::inference_test_guard();
+
+    let hits = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let hits_route = std::sync::Arc::clone(&hits);
+    let app = Router::new()
+        .route(
+            "/v1/models",
+            get(|| async { (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "boom") }),
+        )
+        .route(
+            "/api/tags",
+            get(move || {
+                let hits = std::sync::Arc::clone(&hits_route);
+                async move {
+                    hits.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Json(json!({ "models": [{ "name": "should-not-be-used" }] }))
+                }
+            }),
+        );
+    let base = spawn_mock(app).await;
+    let config = lm_studio_config(&base);
+    let service = LocalAiService::new(&config);
+
+    let err = service
+        .list_lm_studio_models(&config)
+        .await
+        .expect_err("a 500 must surface, not fall back");
+
+    assert!(err.contains("500"), "got: {err}");
+    assert_eq!(
+        hits.load(std::sync::atomic::Ordering::SeqCst),
+        0,
+        "the /api/tags fallback must not run for a non-404 status"
+    );
+}

--- a/src/openhuman/inference/local/service/ollama_admin_tests.rs
+++ b/src/openhuman/inference/local/service/ollama_admin_tests.rs
@@ -1325,10 +1325,28 @@ async fn v1_models_404_falls_back_to_ollama_api_tags() {
 async fn v1_models_404_reports_the_original_error_when_fallback_also_fails() {
     let _guard = crate::openhuman::inference::inference_test_guard();
 
-    let app = Router::new().route(
-        "/v1/models",
-        get(|| async { (axum::http::StatusCode::NOT_FOUND, "404 page not found") }),
-    );
+    // The fallback returns a DISTINCT status (503, not 404). Without that,
+    // Axum's implicit fallback route also answers 404 and the assertion below
+    // would pass even if the implementation surfaced the /api/tags failure.
+    let app = Router::new()
+        .route(
+            "/v1/models",
+            get(|| async {
+                (
+                    axum::http::StatusCode::NOT_FOUND,
+                    "404 page not found: /v1/models",
+                )
+            }),
+        )
+        .route(
+            "/api/tags",
+            get(|| async {
+                (
+                    axum::http::StatusCode::SERVICE_UNAVAILABLE,
+                    "503 fallback unavailable",
+                )
+            }),
+        );
     let base = spawn_mock(app).await;
     let config = lm_studio_config(&base);
     let service = LocalAiService::new(&config);
@@ -1342,13 +1360,45 @@ async fn v1_models_404_reports_the_original_error_when_fallback_also_fails() {
         err.contains("404"),
         "expected the original /v1/models status, got: {err}"
     );
+    assert!(
+        !err.contains("503"),
+        "the fallback failure must not replace the original error, got: {err}"
+    );
 }
 
 /// LM Studio answers unknown paths with `200 {"error": …}` and no models
-/// (GH #5053). An empty fallback catalog must NOT be treated as a recovery,
+/// (GH #5053). That ERROR ENVELOPE must not be treated as a recovery,
 /// otherwise discovery silently "succeeds" with zero models.
 #[tokio::test]
-async fn empty_api_tags_fallback_is_not_treated_as_recovery() {
+async fn error_envelope_api_tags_fallback_is_not_treated_as_recovery() {
+    let _guard = crate::openhuman::inference::inference_test_guard();
+
+    let app = Router::new()
+        .route(
+            "/v1/models",
+            get(|| async { (axum::http::StatusCode::NOT_FOUND, "404 page not found") }),
+        )
+        .route(
+            "/api/tags",
+            get(|| async { Json(json!({ "error": "Unexpected endpoint or method." })) }),
+        );
+    let base = spawn_mock(app).await;
+    let config = lm_studio_config(&base);
+    let service = LocalAiService::new(&config);
+
+    let err = service
+        .list_lm_studio_models(&config)
+        .await
+        .expect_err("an error envelope is not a recovery");
+
+    assert!(err.contains("404"), "got: {err}");
+}
+
+/// A fresh Ollama with nothing pulled answers `{"models":[]}`. That is a
+/// REACHABLE runtime, not a failure: rejecting it hid the server behind the
+/// original 404 so the UI could not offer the model-download action.
+#[tokio::test]
+async fn empty_api_tags_fallback_recovers_as_zero_models() {
     let _guard = crate::openhuman::inference::inference_test_guard();
 
     let app = Router::new()
@@ -1361,12 +1411,15 @@ async fn empty_api_tags_fallback_is_not_treated_as_recovery() {
     let config = lm_studio_config(&base);
     let service = LocalAiService::new(&config);
 
-    let err = service
+    let models = service
         .list_lm_studio_models(&config)
         .await
-        .expect_err("an empty fallback catalog is not a recovery");
+        .expect("a reachable runtime with no models is not an error");
 
-    assert!(err.contains("404"), "got: {err}");
+    assert!(
+        models.is_empty(),
+        "expected an empty catalog, got {models:?}"
+    );
 }
 
 /// Any non-404 failure must NOT trigger the fallback: a 500 is a server fault,

--- a/src/openhuman/inference/model_ids.rs
+++ b/src/openhuman/inference/model_ids.rs
@@ -19,7 +19,14 @@ pub(crate) const DEFAULT_OLLAMA_EMBED_MODEL: &str = "bge-m3";
 
 /// Chat models allowed in the current local Ollama build.
 /// Any resolved chat model ID not listed here is redirected to `MVP_DEFAULT_CHAT_MODEL`.
-const MVP_ALLOWED_CHAT_MODELS: &[&str] = &["gemma3:1b-it-qat", "gemma4:e4b-it-q8_0"];
+///
+/// Every id here must be pullable from the public Ollama library as written —
+/// an entry that does not resolve makes the allowlist silently redirect the
+/// user back to the default, or leaves them with a model that `ollama pull`
+/// cannot fetch (GH #5055). `gemma4:*` was such an entry: there is no `gemma4`
+/// namespace on Ollama. The intended model is Gemma 3n, published as
+/// `gemma3n:e4b-it-q8_0`.
+const MVP_ALLOWED_CHAT_MODELS: &[&str] = &["gemma3:1b-it-qat", "gemma3n:e4b-it-q8_0"];
 const MVP_DEFAULT_CHAT_MODEL: &str = "gemma3:1b-it-qat";
 
 /// Vision models allowed in MVP — only disabled (empty string) since the
@@ -233,10 +240,10 @@ mod tests {
     }
 
     #[test]
-    fn chat_model_allows_requested_ollama_gemma4_q8() {
+    fn chat_model_allows_requested_ollama_gemma3n_q8() {
         let mut config = test_config();
-        config.local_ai.chat_model_id = "gemma4:e4b-it-q8_0".to_string();
-        assert_eq!(effective_chat_model_id(&config), "gemma4:e4b-it-q8_0");
+        config.local_ai.chat_model_id = "gemma3n:e4b-it-q8_0".to_string();
+        assert_eq!(effective_chat_model_id(&config), "gemma3n:e4b-it-q8_0");
     }
 
     #[test]
@@ -272,8 +279,30 @@ mod tests {
         config.local_ai.chat_model_id = "gemma3:270m-it-qat".to_string();
         assert_eq!(effective_chat_model_id(&config), MVP_DEFAULT_CHAT_MODEL);
 
-        config.local_ai.chat_model_id = "gemma4:e4b".to_string();
+        // Bare `gemma3n:e4b` is a real Ollama tag but is NOT the allowlisted
+        // quantization, so it still redirects to the default.
+        config.local_ai.chat_model_id = "gemma3n:e4b".to_string();
         assert_eq!(effective_chat_model_id(&config), MVP_DEFAULT_CHAT_MODEL);
+
+        // The retired `gemma4:*` namespace does not exist on Ollama at all.
+        config.local_ai.chat_model_id = "gemma4:e4b-it-q8_0".to_string();
+        assert_eq!(effective_chat_model_id(&config), MVP_DEFAULT_CHAT_MODEL);
+    }
+
+    /// GH #5055: every allowlisted chat model must be a real, pullable Ollama
+    /// id. `gemma4:*` shipped for a while and could never be pulled.
+    #[test]
+    fn mvp_chat_allowlist_has_no_unpullable_namespaces() {
+        for model in MVP_ALLOWED_CHAT_MODELS {
+            assert!(
+                !model.starts_with("gemma4:"),
+                "`{model}` is not a real Ollama model — there is no gemma4 namespace"
+            );
+            assert!(
+                model.contains(':'),
+                "`{model}` must be a fully-qualified `<model>:<tag>` id"
+            );
+        }
     }
 
     #[test]

--- a/src/openhuman/inference/presets.rs
+++ b/src/openhuman/inference/presets.rs
@@ -169,11 +169,19 @@ pub fn all_presets() -> Vec<ModelPreset> {
         ModelPreset {
             tier: ModelTier::Ram16PlusGb,
             label: "16 GB+",
-            description: "Best local quality with Gemma 4 on higher-end devices.",
-            chat_model_id: "gemma4:e4b",
-            vision_model_id: "gemma4:e4b",
+            description: "Best local quality with Gemma 3n on higher-end devices.",
+            // GH #5055: was `gemma4:e4b`, which does not exist on the Ollama
+            // library — the tier shipped a model no `ollama pull` could fetch.
+            // Gemma 3n is the real publication of the "e4b" (effective-4B)
+            // variant, and `e4b-it-q8_0` (9.5 GB) is what `approx_download_gb`
+            // below was sized against.
+            chat_model_id: "gemma3n:e4b-it-q8_0",
+            vision_model_id: "gemma3n:e4b-it-q8_0",
             embedding_model_id: "nomic-embed-text:latest",
-            quantization: "qat",
+            // The other tiers ship QAT builds; this one is q8_0. The field is a
+            // display label (`effective_quantization`) and does not take part in
+            // resolving the model tag, but it should still match what is pulled.
+            quantization: "q8_0",
             vision_mode: VisionMode::Bundled,
             supports_screen_summary: true,
             target_ram_gb: 16,
@@ -422,5 +430,37 @@ mod tests {
 
         apply_preset_to_config(&mut config, ModelTier::Ram16PlusGb);
         assert_eq!(vision_mode_for_config(&config), VisionMode::Bundled);
+    }
+
+    /// GH #5055: every preset must name a model that actually exists on the
+    /// Ollama library. The 16 GB+ tier shipped `gemma4:e4b` for chat and vision
+    /// — there is no `gemma4` namespace, so the tier offered a model that no
+    /// `ollama pull` could ever fetch. Guard the whole table, not just that row.
+    #[test]
+    fn presets_reference_no_unpullable_gemma4_namespace() {
+        for preset in all_presets() {
+            for (field, id) in [
+                ("chat", preset.chat_model_id),
+                ("vision", preset.vision_model_id),
+                ("embedding", preset.embedding_model_id),
+            ] {
+                assert!(
+                    !id.starts_with("gemma4:"),
+                    "preset {:?} {field} model `{id}` is not a real Ollama model \
+                     — there is no gemma4 namespace",
+                    preset.tier
+                );
+            }
+        }
+    }
+
+    /// The 16 GB+ tier's chat model must be the allowlisted Gemma 3n build, so
+    /// selecting the preset does not immediately get redirected back to the
+    /// default by `enforce_mvp_chat_allowlist`.
+    #[test]
+    fn high_tier_preset_uses_the_allowlisted_gemma3n_build() {
+        let preset = preset_for_tier(ModelTier::Ram16PlusGb).expect("16 GB+ preset");
+        assert_eq!(preset.chat_model_id, "gemma3n:e4b-it-q8_0");
+        assert_eq!(preset.vision_model_id, "gemma3n:e4b-it-q8_0");
     }
 }

--- a/tests/raw_coverage/inference_local_admin_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/inference_local_admin_raw_coverage_e2e.rs
@@ -96,7 +96,7 @@ async fn local_admin_covers_assets_diagnostics_downloads_and_ops_errors() {
     config.local_ai.runtime_enabled = true;
     config.local_ai.opt_in_confirmed = true;
     config.local_ai.base_url = Some(base.clone());
-    config.local_ai.chat_model_id = "gemma4:e4b-it-q8_0".to_string();
+    config.local_ai.chat_model_id = "gemma3n:e4b-it-q8_0".to_string();
     config.local_ai.embedding_model_id = "bge-m3".to_string();
     config.local_ai.vision_model_id = "missing-vision".to_string();
     config.local_ai.selected_tier = Some("custom".to_string());
@@ -134,7 +134,7 @@ async fn local_admin_covers_assets_diagnostics_downloads_and_ops_errors() {
         .as_array()
         .unwrap()
         .iter()
-        .any(|issue| issue.as_str().unwrap().contains("gemma4:e4b-it-q8_0")));
+        .any(|issue| issue.as_str().unwrap().contains("gemma3n:e4b-it-q8_0")));
 
     let assets = service.assets_status(&config).await.expect("assets");
     assert!(assets.ollama_available);
@@ -175,7 +175,7 @@ async fn local_admin_covers_assets_diagnostics_downloads_and_ops_errors() {
         .lock()
         .expect("models")
         .iter()
-        .any(|m| m == "gemma4:e4b-it-q8_0"));
+        .any(|m| m == "gemma3n:e4b-it-q8_0"));
 
     let mut lm_config = config.clone();
     lm_config.local_ai.provider = "lmstudio".to_string();
@@ -220,7 +220,7 @@ async fn local_admin_covers_assets_diagnostics_downloads_and_ops_errors() {
         .await
         .expect("ops progress")
         .value;
-    assert_eq!(ops_progress.chat.id, "gemma4:e4b-it-q8_0");
+    assert_eq!(ops_progress.chat.id, "gemma3n:e4b-it-q8_0");
 
     let ops_asset = local_ai_download_asset(&config, "embedding")
         .await
@@ -529,7 +529,7 @@ async fn ollama_show(Json(body): Json<Value>) -> impl IntoResponse {
             .into_response();
     }
     let context = match model {
-        "gemma4:e4b-it-q8_0" => 1024,
+        "gemma3n:e4b-it-q8_0" => 1024,
         "bge-m3" => 8192,
         _ => 4096,
     };
@@ -545,7 +545,7 @@ async fn ollama_show(Json(body): Json<Value>) -> impl IntoResponse {
 async fn ollama_pull(State(state): State<MockState>, Json(body): Json<Value>) -> impl IntoResponse {
     let name = body["name"]
         .as_str()
-        .unwrap_or("gemma4:e4b-it-q8_0")
+        .unwrap_or("gemma3n:e4b-it-q8_0")
         .to_string();
     state.ollama_models.lock().expect("models").push(name);
     let body = [

--- a/tests/raw_coverage/inference_provider_admin_round22_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/inference_provider_admin_round22_raw_coverage_e2e.rs
@@ -295,7 +295,7 @@ async fn local_admin_covers_diagnostics_errors_assets_status_and_shutdown_with_f
     config.local_ai.runtime_enabled = true;
     config.local_ai.opt_in_confirmed = true;
     config.local_ai.base_url = Some(base.clone());
-    config.local_ai.chat_model_id = "gemma4:e4b-it-q8_0".to_string();
+    config.local_ai.chat_model_id = "gemma3n:e4b-it-q8_0".to_string();
     config.local_ai.embedding_model_id = "all-minilm:latest".to_string();
     config.local_ai.selected_tier = Some("custom".to_string());
     config.local_ai.preload_embedding_model = true;
@@ -325,7 +325,7 @@ async fn local_admin_covers_diagnostics_errors_assets_status_and_shutdown_with_f
     assert!(issues.iter().any(|issue| issue
         .as_str()
         .unwrap()
-        .contains("Chat model `gemma4:e4b-it-q8_0`")));
+        .contains("Chat model `gemma3n:e4b-it-q8_0`")));
     assert!(issues.iter().any(|issue| issue
         .as_str()
         .unwrap()


### PR DESCRIPTION
## Summary

- **Scope is narrower than the issue reads**: #5055's two root-cause sub-issues, **#5053 and #5017, already shipped and are on `main`**. I verified both in the code rather than assuming, and left them alone. Details in **Problem** below.
- Adds the one-shot **`/api/tags` fallback on a `/v1/models` 404** — the piece of the discovery fix that was genuinely missing — with three deliberate non-recovery cases so a permissive fallback can't reintroduce #5053.
- Logs the **resolved discovery URL at DEBUG**, so a wrong base URL is diagnosable from app logs alone.
- Fixes a real defect in the local defaults: **`gemma4` is not an Ollama namespace.** The 16 GB+ preset shipped `gemma4:e4b` for chat and vision, and the chat allowlist carried `gemma4:e4b-it-q8_0` — a model tier no `ollama pull` could ever fetch. Corrected to `gemma3n:e4b-it-q8_0`.
- The **Ollama path is untouched** and the managed/cloud path is not involved at all.

## Problem

#5055 lists five failure modes. Three of them were already fixed before this PR, so re-implementing them would have been duplicated work and churn on tested code. What I found on `main`:

**#5053 (wrong discovery endpoint) — already fixed.** `inference/local/provider.rs` has `model_discovery_api()` and `endpoint_is_openai_v1()`, which gate discovery on endpoint **type** (does the path end in `/v1`?) rather than "is it localhost" — the exact conflation that caused the bug. It is wired into `ollama_admin/diagnostics.rs` and pinned by a regression test whose mock serves *only* `/v1/models`.

**#5017 (embedding verification) — already fixed.** `embeddings/rpc.rs` sends a real `POST /v1/embeddings` carrying the user's model name and API key, and `classify_embed_probe` splits the outcome into seven distinct causes: `EMBEDDINGS_AUTH_FAILED` (401/403), `_ENDPOINT_UNREACHABLE` (network/DNS), `_MODEL_INCOMPATIBLE` (a chat model in the embeddings field — the reporter's exact case), `_DIMENSION_MISMATCH`, `_ENDPOINT_NO_API` (404/405), `_NO_MODEL_LOADED`, and a generic fallback. `EmbeddingsPanel.tsx` surfaces the backend message for every code, and `conformant_custom_endpoint_verifies_and_sends_expected_request` captures the auth header and request body against a mock endpoint to prove the request shape.

That maps onto the issue's requested `NetworkUnreachable / AuthFailed / ModelNotFound / DimensionMismatch / UnexpectedResponse` set, so scope items 2 and 4 needed no code.

**What was actually still broken:**

1. **No 404 fallback.** The issue asks for `/v1/models` → 404 → try `/api/tags` once with a warning. That did not exist in any form.
2. **No resolved-discovery-URL log.**
3. **A model id that cannot be pulled.** `MVP_ALLOWED_CHAT_MODELS` contained `gemma4:e4b-it-q8_0` and the 16 GB+ preset used `gemma4:e4b` for both `chat_model_id` and `vision_model_id`. There is no `gemma4` namespace on the Ollama library — this is precisely the issue's failure mode 3 ("defaults may be stale or unavailable, causing silent fallback or no-model errors"), and it had a second-order effect described below.

## Solution

### 1. One-shot `/api/tags` fallback (`local/service/lm_studio.rs`)

On a `/v1/models` **404 only**, `list_ollama_tags_fallback` retries the host-rooted `/api/tags` once and WARNs on entry (taking this path means the base URL and provider type disagree, so the user should still fix their config even though discovery recovered).

Three cases deliberately **do not** recover, because a permissive fallback would recreate the bug this is meant to fix:

| Case | Behaviour | Why |
|---|---|---|
| Non-404 status | Fallback never runs | A 500 is a server fault, not a wrong-endpoint signal; probing a second path would mask it. Asserted with a request hit-counter on the mock. |
| Empty `/api/tags` catalog | Not a recovery | LM Studio answers unknown paths with `200 {"error": …}` and zero models (#5053). Accepting that would look like "discovered 0 models" instead of a real error. |
| Fallback itself fails | Original `/v1/models` error is surfaced | The user should see the real problem, not a second confusing one from a speculative retry. |

New `ollama_tags_fallback_url()` (`local/lm_studio.rs`) strips a trailing `/v1` via a shared `host_root_of()` helper, so the probe can never become the malformed `/v1/api/tags` that LM Studio logs as `Unexpected endpoint or method`.

**Discovery is still chosen by provider type first.** This is a recovery path, not a probe order.

### 2. DEBUG log of the resolved discovery URL

`discovery_url` + `api = "openai_v1_models"` on the outbound GET, and the equivalent on the fallback.

### 3. `gemma4` → `gemma3n` (`model_ids.rs`, `presets.rs`)

Verified every local default against the public Ollama library before changing anything:

| Model id | Where | Exists? |
|---|---|---|
| `gemma3:1b-it-qat` | default + allowlist + 2–4 GB tier | Yes, 1.0 GB |
| `gemma3:4b-it-qat` | 8–16 GB tier | Yes, 4.0 GB |
| `moondream:1.8b-v2-q4_K_S` | low-vision default | Yes |
| `bge-m3` | `DEFAULT_OLLAMA_EMBED_MODEL` | Yes, 1.2 GB |
| `gemma3n:e4b-it-q8_0` | **new** 16 GB+ tier + allowlist | Yes, 9.5 GB |
| `gemma4:e4b`, `gemma4:e4b-it-q8_0` | **was** 16 GB+ tier + allowlist | **No such namespace** |

"e4b" is Gemma 3n's *Effective 4B* designation, and 9.5 GB + `nomic-embed-text` matches the tier's existing `approx_download_gb: 9.9` — so `gemma3n:e4b-it-q8_0` is what the tier was sized against.

**Latent second bug closed:** the preset (`gemma4:e4b`) and the allowlist (`gemma4:e4b-it-q8_0`) named *different* ids, so selecting that tier would have been silently redirected to `gemma3:1b-it-qat` by `enforce_mvp_chat_allowlist`. They now agree. (The tier is not MVP-gated today, so this bit only on a lifted ceiling — but it was still wrong.)

`quantization` on that tier moves `"qat"` → `"q8_0"` to match what is actually pulled. I checked first: it is a display string consumed by `effective_quantization` and takes no part in resolving the model tag, and no test asserts on it.

### Not addressed (deliberate)

- **spaCy `click`** (issue item 4) is outside this PR's dispatched scope and untouched — it needs its own change.
- **`vision_model_id` on the 16 GB+ tier**: Ollama lists gemma3n variants as text-input, so `vision_mode: Bundled` may be non-functional there. It was *already* non-functional with a model that did not exist, so I corrected the namespace and did **not** re-architect the vision choice on a guess. Flagged under **Related** as a follow-up for someone who can test it.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — 4 fallback tests (recovers / original error preserved / empty catalog rejected / non-404 never probes twice), 1 URL-derivation test, 3 guards against the `gemma4` namespace returning.
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/ci-lite.yml`](../.github/workflows/ci-lite.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge. — every changed Rust path has a new or updated test. **Not run locally** (see *Validation Blocked*); CI is the authority on the number.
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`) — `N/A: behaviour-only change` — no feature leaf added, removed or renamed; this fixes existing local-inference behaviour.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — every new test runs against a local `axum` mock on `127.0.0.1`. The Ollama library lookups used to verify model ids were research during authoring, not test-time calls.
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A: no release-cut smoke step changes` — local-model setup is not in the release-cut checklist, and the default (managed/cloud) path is untouched.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Platform:** desktop + CLI (Rust core only). No frontend, Tauri, or backend changes in this PR.
- **Managed / cloud path: entirely unaffected.** Nothing here touches cloud inference or managed embeddings.
- **Ollama path: unaffected.** The fallback lives only inside `list_lm_studio_models`, which a genuine Ollama config never reaches — `diagnostics()` routes it to the `/api/tags` branch first. Confirmed by tracing every caller.
- **Behaviour change for local users:** an OpenAI-compatible endpoint that 404s on `/v1/models` but serves `/api/tags` now discovers models instead of failing. Users on the 16 GB+ preset get a model that can actually be pulled; anyone who had literally selected `gemma4:*` will be redirected to the default by the existing allowlist, which is the pre-existing behaviour for an unknown id.
- **Performance:** one extra HTTP request, only on a 404, only once, only on the OpenAI-compatible discovery path.
- **Migration:** none. No config schema change; `gemma4:*` in a stored config was already non-functional.

## Related

- Closes: #5055
- Already shipped, scope narrowed accordingly (verified on `main`, not re-implemented here): #5053, #5017
- Coverage matrix feature IDs: `N/A` — no matrix row corresponds to local model discovery today.
- Follow-up PR(s)/TODOs:
  - **spaCy venv missing `click`** (#5055 item 4) — out of this PR's scope, still open.
  - **Tiny Agents end-to-end validation** (#5055's checklist) — needs real Ollama + LM Studio installs; not performed here. Given the `gemma4` find, the 16 GB+ preset should be confirmed to actually pull before #5055 is closed.
  - **16 GB+ tier vision**: `vision_mode: Bundled` with a text-input gemma3n build may be a no-op; needs someone who can run it.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: `N/A` — tracked in GitHub (#5055), not Linear.
- URL: https://github.com/tinyhumansai/openhuman/issues/5055

### Commit & Branch

- Branch: `fix/local-model-reliability`
- Commit SHA: `e499ce440` (branched from `9a484aa50`)

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A` — no frontend files changed in this PR.
- [x] `pnpm typecheck` — `N/A` — no TypeScript changed in this PR.
- [x] Focused tests: **not executed** — see *Validation Blocked*. `GGML_NATIVE=OFF cargo check -p openhuman --tests` completed clean twice (exit 0, only three pre-existing warnings: `address_book`, `Memory`, `alice_phoenix_thread`), so everything compiles including the new tests; the test *run* was stopped before it produced results.
- [x] Rust fmt/check (if changed): `cargo check -p openhuman --tests` clean, as above. `cargo fmt` **not** re-run after the final edit — see *Validation Blocked*.
- [x] Tauri fmt/check (if changed): `N/A` — no files under `app/src-tauri/` changed.

### Validation Blocked

- `command:` `cargo test -p openhuman --lib`, `cargo fmt`, and any further `cargo check`
- `error:` not run — the build machine was overloaded and further cargo compiles were stopped mid-run by an operator instruction; no compile has been run since.
- `impact:` **The six new tests compile but have never been executed — CI is the first thing to actually run them.** Two late edits (the `quantization: "q8_0"` label and its comment) landed *after* the last successful `cargo check`, so they are not type-checked either; both are string literals in an existing struct field with no test asserting on them. If CI shows a formatting failure, `cargo fmt` on `presets.rs` is the likely fix.

### Behavior Changes

- Intended behavior change: a `/v1/models` 404 falls back once to `/api/tags`; the 16 GB+ local preset and the chat allowlist name a real, pullable Gemma 3n build.
- User-visible effect: local model discovery succeeds against runtimes that only serve the Ollama listing; the 16 GB+ preset can actually be downloaded. No change for managed/cloud users or for working Ollama setups.

### Parity Contract

- Legacy behavior preserved: discovery is still selected by provider type (`model_discovery_api`) before any fallback; the Ollama `/api/tags` branch is unchanged; the embeddings verification path is untouched; `enforce_mvp_chat_allowlist` semantics are unchanged.
- Guard/fallback/dispatch parity checks: `non_404_status_does_not_trigger_the_fallback` asserts with a hit counter that a 500 never probes `/api/tags`; `empty_api_tags_fallback_is_not_treated_as_recovery` and `v1_models_404_reports_the_original_error_when_fallback_also_fails` pin the two non-recovery cases; `presets_reference_no_unpullable_gemma4_namespace` and `mvp_chat_allowlist_has_no_unpullable_namespaces` prevent the bad namespace returning.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none open against #5055.
- Canonical PR: this one.
- Resolution (closed/superseded/updated): `N/A` — no duplicates. Note #5053 and #5017 were fixed by earlier, already-merged PRs; this PR does not supersede them, it completes the remainder.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - LM Studio model discovery now falls back to Ollama’s native model endpoint when the compatible endpoint returns a not-found response.
  - Discovery URLs are normalized to avoid invalid paths and improve diagnostics.

- **Bug Fixes**
  - Preserved original errors when fallback discovery fails or returns no models.
  - Updated built-in local presets to use the available Gemma 3n model.

- **Tests**
  - Added coverage for fallback behavior, error handling, URL construction, and updated model presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->