### PR TITLE
fix(deps): gate native input crates behind voice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,9 +253,9 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg"]
 tempfile = "3"
 cpal = { version = "0.15", optional = true }
 hound = { version = "3.5", optional = true }
-enigo = "0.3"
-arboard = "3"
-rdev = "0.5"
+enigo = { version = "0.3", optional = true }
+arboard = { version = "3", optional = true }
+rdev = { version = "0.5", optional = true }
 fs2 = "0.4"
 # Cross-platform battery probe for the scheduler gate. Maintained fork of
 # the abandoned `battery` crate; same `use battery::*;` API surface. Used
@@ -434,12 +434,20 @@ documents = ["dep:pdf-extract", "dep:ppt-rs", "dep:docx-rs"]
 # server, always-on listening, and podcast audio generation/email delivery.
 # Default-ON — the desktop app always ships with voice. Slim / headless builds
 # opt out via `--no-default-features --features "<explicit list without voice>"`,
-# which also drops the exclusive `hound` (WAV I/O) + `lettre` (podcast email)
+# which also drops the exclusive `hound` (WAV I/O), `lettre` (podcast email),
+# `arboard`/`enigo` (clipboard-paste insertion), and `rdev` (global hotkeys)
 # dependencies. Composes with the runtime `DomainSet::voice` flag (#4796): the
 # feature narrows the compile-time surface, `DomainSet` gates it at runtime.
 # Requires `inference` (the whisper engine + the cpal capture stack), so
 # enabling `voice` turns `inference` on transitively.
-voice = ["inference", "dep:hound", "dep:lettre"]
+voice = [
+    "inference",
+    "dep:arboard",
+    "dep:enigo",
+    "dep:hound",
+    "dep:lettre",
+    "dep:rdev",
+]
 # Web3 domains: openhuman::wallet + openhuman::web3 + openhuman::x402 — the
 # crypto wallet (multi-chain sign/broadcast), the high-level swap/bridge/dapp
 # surface, and the x402 machine-payment protocol. Default-ON — the desktop app


### PR DESCRIPTION
## Summary

- Make `arboard`, `enigo`, and `rdev` optional root dependencies.
- Enable all three explicitly through the existing default-on `voice` feature.
- Let slim/headless builds omit the native clipboard, input-simulation, and global-hotkey stack without changing the shipped desktop feature set.

## Problem

The only production imports of these crates live in modules compiled behind `feature = "voice"`, but the dependencies were unconditional. As a result, `--no-default-features` builds still retained native text-input dependencies even though the voice domain was absent.

## Solution

The root manifest now marks each dependency optional and adds the corresponding `dep:` edge to `voice`. The feature documentation names the newly gated dependencies. No source or lockfile change is required: enabled voice builds resolve the same crate versions and compile the same modules as before.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) - N/A: manifest-only dependency wiring; the existing 200-test voice suite passed under the minimal `voice` feature set, and dependency-tree checks covered both disabled and enabled configurations.
- [x] **Diff coverage >= 80%** - N/A: only `Cargo.toml` dependency metadata and comments changed; there are no executable changed lines.
- [x] Coverage matrix updated - N/A: no feature row was added, removed, or renamed; this narrows dependencies behind the existing `voice` gate.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` - N/A: no coverage-matrix feature ID applies.
- [x] No new external network dependencies introduced - the same three existing dependencies are now optional.
- [x] Manual smoke checklist updated if this touches release-cut surfaces - N/A: no release flow or user-facing surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- Slim/headless builds without `voice` no longer resolve `arboard`, `enigo`, or `rdev`.
- Default root builds and the desktop shell still enable `voice`, so shipped clipboard insertion and global-hotkey behavior are unchanged.
- No persisted data, RPC, frontend, or runtime behavior changes.

## Related

- Closes #5197
- Follow-up PR(s)/TODOs: #5198 and #5199 cover the broader TinyChannels and supported-build-profile work.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A - tracked as GitHub issue #5197.
- URL: N/A - https://github.com/tinyhumansai/openhuman/issues/5197

### Commit & Branch

- Branch: `codex/5197-gate-voice-input-deps`
- Commit SHA: `28e853cd50d0a80b0f31a03966cd0d7cd5b725f0`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` - N/A: no frontend files changed; `cargo fmt --all -- --check` passed.
- [x] `pnpm typecheck` - N/A: no TypeScript changed.
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --locked --lib --no-default-features --features voice 'openhuman::voice::'` - 200 passed, 0 failed.
- [x] Rust fmt/check (if changed): `cargo fmt --all -- --check`; `GGML_NATIVE=OFF cargo check --locked --no-default-features --lib`; `GGML_NATIVE=OFF cargo check --locked --no-default-features --features voice --lib`; `GGML_NATIVE=OFF cargo check --locked --lib`; `node scripts/ci/check-feature-forwarding.mjs`.
- [x] Tauri fmt/check (if changed) - N/A: no Tauri files changed; the shell check is blocked locally as documented below and is left to CI.

Dependency-graph proof:

- `cargo tree --locked --no-default-features -i arboard|enigo|rdev` reports that each package ID is absent.
- The same three commands with `--features voice` resolve each crate directly from `openhuman`.

### Validation Blocked

- `command:` `pnpm rust:check`
- `error:` the clean worktree does not initialize `app/src-tauri/vendor/tauri-cef`, so Cargo cannot read `vendor/tauri-cef/crates/tauri/Cargo.toml` (OS error 2). The command also reports the local Node 22 version below the app's Node 24 requirement.
- `impact:` Tauri-shell compilation is left to CI. The diff contains no Tauri source changes; the root crate passes the exact minimal `voice` build, the default build, and the feature-forwarding guard that verifies the shell still forwards `voice`.

- `command:` `GGML_NATIVE=OFF cargo test --locked --lib 'openhuman::mcp_server::resources::tests::'` on untouched `origin/main` at `dcc5b9b251f18e74b9b1ea9a3175cf1221dcacfb`
- `error:` 7 tests pass and 2 fail because `RESOURCE_CATALOG` is missing the `flow_memory_agent` added by #5205; the same two tests fail in this PR's Rust Core Coverage job.
- `impact:` this current-main resource-catalog regression is unrelated to the one-file `Cargo.toml` diff. The PR remains draft until an upstream catalog fix lands and CI can be rerun green.

### Behavior Changes

- Intended behavior change: builds without `voice` exclude the native clipboard/input/hotkey dependencies.
- User-visible effect: none; default desktop builds still enable `voice` and retain existing behavior.

### Parity Contract

- Legacy behavior preserved: the default root feature set and desktop shell both continue to enable `voice`, which restores all three dependencies and their existing modules.
- Guard/fallback/dispatch parity checks: disabled and enabled dependency trees were checked separately; the minimal voice build and 200 voice tests passed; the desktop feature-forwarding guard passed.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none. Draft #5202 references #5197 as a separate follow-up but does not make these dependencies optional.
- Canonical PR: this PR.
- Resolution (closed/superseded/updated): N/A.
