### PR TITLE
fix(mcp): add the missing flow_memory_agent resource-catalog entry

### DIFF
--- a/src/openhuman/mcp_server/resources.rs
+++ b/src/openhuman/mcp_server/resources.rs
@@ -248,6 +248,12 @@ const RESOURCE_CATALOG: &[PromptResource] = &[
         content: include_str!("../flows/agents/workflow_builder/prompt.md"),
     },
     PromptResource {
+        uri: "openhuman://prompts/agents/flow_memory_agent",
+        name: "flow_memory_agent",
+        description: "Flow Memory Agent — read-only context and memory retrieval specialist a flow's `agent` node routes to for run-time context, style, history, or people lookups.",
+        content: include_str!("../agent_registry/agents/flow_memory_agent/prompt.md"),
+    },
+    PromptResource {
         uri: "openhuman://prompts/agents/agent_memory",
         name: "agent_memory",
         description: "Dedicated memory retrieval subagent using smart-walk strategies.",


### PR DESCRIPTION
`flow_memory_agent` is a registered built-in agent (`src/openhuman/agent_registry/agents/loader.rs`) but had no entry in `RESOURCE_CATALOG` in `src/openhuman/mcp_server/resources.rs`, so the MCP resource catalog listed 37 of the 38 built-ins.

Two tests fail without the entry:

- `openhuman::mcp_server::resources::tests::catalog_mirrors_builtins`
- `openhuman::mcp_server::resources::tests::read_resource_returns_content_for_each_subagent`

The gap is pre-existing on `main`, not introduced by this branch. It went unnoticed because those tests are only reachable with the `mcp` feature enabled, which the common slim test invocation omits.

`flow_memory_agent` was the only gap — with the entry added the catalog mirrors all 38 built-ins and there are no stale entries.

## Verification

```
GGML_NATIVE=OFF RUST_MIN_STACK=16777216 cargo test --lib --no-default-features \
  --features "tokenjuice-treesitter,mcp,flows,skills,medulla" mcp_server::resources
```

9 passed; 0 failed. `cargo fmt -- --check` is clean.