### PR TITLE
refactor(inference): route local AI through TinyAgents RPC

### DIFF
--- a/src/openhuman/inference/local/lm_studio.rs
+++ b/src/openhuman/inference/local/lm_studio.rs
@@ -7,23 +7,6 @@
 use crate::openhuman::config::{Config, LocalAiConfig};
 use serde::{Deserialize, Serialize};
 
-fn strip_think_tags(input: &str) -> String {
-    let mut result = String::with_capacity(input.len());
-    let mut rest = input;
-    loop {
-        let Some(start) = rest.find("<think>") else {
-            result.push_str(rest);
-            break;
-        };
-        result.push_str(&rest[..start]);
-        let Some(end) = rest[start..].find("</think>") else {
-            break;
-        };
-        rest = &rest[start + end + "</think>".len()..];
-    }
-    result.trim().to_string()
-}
-
 pub(crate) const DEFAULT_LM_STUDIO_BASE_URL: &str = "http://localhost:1234/v1";
 
 pub(crate) fn lm_studio_base_url(config: &Config) -> String {
@@ -168,97 +151,6 @@ pub(crate) struct LmStudioModel {
     pub object: Option<String>,
     #[serde(default)]
     pub owned_by: Option<String>,
-}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct LmStudioChatCompletionRequest {
-    pub model: String,
-    pub messages: Vec<LmStudioChatMessage>,
-    pub stream: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub temperature: Option<f32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_tokens: Option<u32>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct LmStudioChatMessage {
-    pub role: String,
-    pub content: String,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct LmStudioChatCompletionResponse {
-    #[serde(default)]
-    pub choices: Vec<LmStudioChatChoice>,
-    #[serde(default)]
-    pub usage: Option<LmStudioUsage>,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct LmStudioChatChoice {
-    pub message: LmStudioChatResponseMessage,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct LmStudioChatResponseMessage {
-    #[serde(default)]
-    pub content: Option<String>,
-    /// Local reasoning models expose chain-of-thought as `reasoning_content`
-    /// or `reasoning` depending on the runtime — accept both field names.
-    #[serde(default, alias = "reasoning")]
-    pub reasoning_content: Option<String>,
-}
-
-impl LmStudioChatResponseMessage {
-    pub(crate) fn effective_content(&self) -> String {
-        let content = self
-            .content
-            .as_deref()
-            .map(strip_think_tags)
-            .map(|value| value.trim().to_string())
-            .filter(|value| !value.is_empty())
-            .unwrap_or_default();
-        if !content.is_empty() {
-            tracing::trace!(
-                source = "content",
-                output_chars = content.chars().count(),
-                "[lm-studio] effective content selected"
-            );
-            return content;
-        }
-
-        let reasoning = self
-            .reasoning_content
-            .as_deref()
-            .map(strip_think_tags)
-            .map(|value| value.trim().to_string())
-            .filter(|value| !value.is_empty())
-            .unwrap_or_default();
-        if !reasoning.is_empty() {
-            tracing::trace!(
-                source = "reasoning_content",
-                output_chars = reasoning.chars().count(),
-                "[lm-studio] effective content selected"
-            );
-            return reasoning;
-        }
-
-        tracing::trace!(
-            source = "none",
-            output_chars = 0,
-            "[lm-studio] effective content empty"
-        );
-        String::new()
-    }
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct LmStudioUsage {
-    #[serde(default)]
-    pub prompt_tokens: Option<u32>,
-    #[serde(default)]
-    pub completion_tokens: Option<u32>,
 }
 
 /// LM Studio **native** REST (`GET /api/v0/models`) model entry.
@@ -443,32 +335,5 @@ mod tests {
             normalize_lm_studio_base_url("http://127.0.0.1:1234/v1/models").as_deref(),
             Some("http://127.0.0.1:1234/v1")
         );
-    }
-
-    #[test]
-    fn effective_content_falls_back_to_reasoning_content() {
-        let msg = LmStudioChatResponseMessage {
-            content: Some("".into()),
-            reasoning_content: Some("thinking text".into()),
-        };
-        assert_eq!(msg.effective_content(), "thinking text");
-    }
-
-    #[test]
-    fn effective_content_strips_think_tags() {
-        let msg = LmStudioChatResponseMessage {
-            content: Some("<think>hidden</think>Visible reply".into()),
-            reasoning_content: None,
-        };
-        assert_eq!(msg.effective_content(), "Visible reply");
-    }
-
-    #[test]
-    fn reasoning_content_accepts_reasoning_alias() {
-        // Local runtimes that name the field `reasoning` must still be captured
-        // (issue #3094) so reasoning round-trips like the canonical field.
-        let msg: LmStudioChatResponseMessage =
-            serde_json::from_str(r#"{"content":null,"reasoning":"local cot"}"#).unwrap();
-        assert_eq!(msg.reasoning_content.as_deref(), Some("local cot"));
     }
 }

--- a/src/openhuman/inference/local/ollama.rs
+++ b/src/openhuman/inference/local/ollama.rs
@@ -472,18 +472,6 @@ pub(crate) struct OllamaGenerateResponse {
     pub eval_duration: Option<u64>,
 }
 
-#[derive(Debug, Serialize)]
-pub(crate) struct OllamaEmbedRequest {
-    pub model: String,
-    pub input: Vec<String>,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct OllamaEmbedResponse {
-    #[serde(default)]
-    pub embeddings: Vec<Vec<f32>>,
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub(crate) struct OllamaChatMessage {
     pub role: String,

--- a/src/openhuman/inference/local/ollama.rs
+++ b/src/openhuman/inference/local/ollama.rs
@@ -490,26 +490,6 @@ pub(crate) struct OllamaChatMessage {
     pub content: String,
 }
 
-#[derive(Debug, Serialize)]
-pub(crate) struct OllamaChatRequest {
-    pub model: String,
-    pub messages: Vec<OllamaChatMessage>,
-    pub stream: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub options: Option<OllamaGenerateOptions>,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct OllamaChatResponse {
-    pub message: OllamaChatMessage,
-    #[allow(dead_code)]
-    pub done: Option<bool>,
-    pub prompt_eval_count: Option<u32>,
-    pub prompt_eval_duration: Option<u64>,
-    pub eval_count: Option<u32>,
-    pub eval_duration: Option<u64>,
-}
-
 pub(crate) fn ns_to_tps(tokens: f32, duration_ns: u64) -> Option<f32> {
     if duration_ns == 0 || tokens <= 0.0 {
         return None;

--- a/src/openhuman/inference/local/service/lm_studio.rs
+++ b/src/openhuman/inference/local/service/lm_studio.rs
@@ -1,7 +1,6 @@
 use crate::openhuman::config::Config;
 use crate::openhuman::inference::local::lm_studio::{
-    apply_lm_studio_auth, lm_studio_base_url, ollama_tags_fallback_url,
-    LmStudioModelsResponse,
+    apply_lm_studio_auth, lm_studio_base_url, ollama_tags_fallback_url, LmStudioModelsResponse,
 };
 use crate::openhuman::inference::local::ollama::{OllamaModelTag, OllamaTagsResponse};
 

--- a/src/openhuman/inference/local/service/lm_studio.rs
+++ b/src/openhuman/inference/local/service/lm_studio.rs
@@ -1,11 +1,9 @@
 use crate::openhuman::config::Config;
 use crate::openhuman::inference::local::lm_studio::{
     apply_lm_studio_auth, lm_studio_base_url, ollama_tags_fallback_url,
-    LmStudioChatCompletionRequest, LmStudioChatCompletionResponse, LmStudioChatMessage,
     LmStudioModelsResponse,
 };
 use crate::openhuman::inference::local::ollama::{OllamaModelTag, OllamaTagsResponse};
-use crate::openhuman::inference::model_ids;
 
 use super::LocalAiService;
 
@@ -16,12 +14,6 @@ fn diagnostic_body_snippet(body: &str) -> String {
         snippet.push_str("...");
     }
     snippet
-}
-
-pub(in crate::openhuman::inference::local::service) struct LmStudioCompletionOutcome {
-    pub reply: String,
-    pub prompt_tokens: Option<u32>,
-    pub completion_tokens: Option<u32>,
 }
 
 impl LocalAiService {
@@ -266,114 +258,5 @@ impl LocalAiService {
             .await?
             .into_iter()
             .any(|m| m.name.to_ascii_lowercase() == target))
-    }
-
-    pub(in crate::openhuman::inference::local::service) async fn lm_studio_chat_completion(
-        &self,
-        config: &Config,
-        messages: Vec<LmStudioChatMessage>,
-        max_tokens: Option<u32>,
-        temperature: f32,
-        allow_empty: bool,
-    ) -> Result<LmStudioCompletionOutcome, String> {
-        let base = lm_studio_base_url(config);
-        let url = format!("{base}/chat/completions");
-        let model = model_ids::effective_chat_model_id(config);
-
-        tracing::debug!(
-            target: "local_ai::lm_studio",
-            %url,
-            %model,
-            message_count = messages.len(),
-            max_tokens = ?max_tokens,
-            "[local_ai:lm_studio] chat completion: sending POST"
-        );
-
-        let body = LmStudioChatCompletionRequest {
-            model,
-            messages,
-            stream: false,
-            temperature: Some(temperature),
-            max_tokens,
-        };
-
-        let request = self
-            .http
-            .post(&url)
-            .timeout(std::time::Duration::from_secs(120))
-            .json(&body);
-        let response = apply_lm_studio_auth(request, config)
-            .send()
-            .await
-            .map_err(|e| {
-                tracing::debug!(
-                    target: "local_ai::lm_studio",
-                    %url,
-                    error = %e,
-                    "[local_ai:lm_studio] chat completion: request failed"
-                );
-                format!("lm studio chat request failed: {e}")
-            })?;
-
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            let detail = body.trim();
-            tracing::debug!(
-                target: "local_ai::lm_studio",
-                %url,
-                %status,
-                body = %diagnostic_body_snippet(&body),
-                "[local_ai:lm_studio] chat completion: non-success response"
-            );
-            return Err(format!(
-                "lm studio chat failed with status {}{}",
-                status,
-                if detail.is_empty() {
-                    String::new()
-                } else {
-                    format!(": {detail}")
-                }
-            ));
-        }
-
-        let body = response.text().await.map_err(|e| {
-            tracing::debug!(
-                target: "local_ai::lm_studio",
-                %url,
-                error = %e,
-                "[local_ai:lm_studio] chat completion: body read failed"
-            );
-            format!("lm studio chat response body read failed: {e}")
-        })?;
-        let payload: LmStudioChatCompletionResponse = serde_json::from_str(&body).map_err(|e| {
-            tracing::debug!(
-                target: "local_ai::lm_studio",
-                %url,
-                error = %e,
-                body = %diagnostic_body_snippet(&body),
-                "[local_ai:lm_studio] chat completion: parse failed"
-            );
-            format!("lm studio chat response parse failed: {e}")
-        })?;
-
-        let reply = payload
-            .choices
-            .first()
-            .map(|choice| choice.message.effective_content())
-            .unwrap_or_default();
-
-        if reply.is_empty() && !allow_empty {
-            return Err("lm studio returned empty content".to_string());
-        }
-
-        Ok(LmStudioCompletionOutcome {
-            reply,
-            prompt_tokens: payload.usage.as_ref().and_then(|usage| usage.prompt_tokens),
-            completion_tokens: payload
-                .usage
-                .as_ref()
-                .and_then(|usage| usage.completion_tokens),
-        })
     }
 }

--- a/src/openhuman/inference/local/service/mod.rs
+++ b/src/openhuman/inference/local/service/mod.rs
@@ -3,6 +3,7 @@
 mod assets;
 mod bootstrap;
 mod lm_studio;
+mod model_rpc;
 pub(crate) mod ollama_admin;
 mod public_infer;
 pub(crate) mod spawn_marker;

--- a/src/openhuman/inference/local/service/model_rpc.rs
+++ b/src/openhuman/inference/local/service/model_rpc.rs
@@ -6,7 +6,9 @@
 
 use crate::openhuman::config::Config;
 use crate::openhuman::inference::local::lm_studio::lm_studio_base_url;
-use crate::openhuman::inference::local::ollama::ollama_base_url_from_config;
+use crate::openhuman::inference::local::ollama::{
+    ollama_base_url_from_config, redact_ollama_base_url,
+};
 use crate::openhuman::inference::local::provider::{provider_from_config, LocalAiProvider};
 use tinyagents::harness::message::Message;
 use tinyagents::harness::model::{ChatModel, ModelRequest};
@@ -28,17 +30,42 @@ fn throughput(raw: Option<&serde_json::Value>, count: &str, duration: &str) -> O
 }
 
 fn local_model(config: &Config, model_id: &str) -> Result<OpenAiModel, String> {
-    match provider_from_config(config) {
-        LocalAiProvider::LmStudio => OpenAiModel::lm_studio(
-            lm_studio_base_url(config),
-            config.local_ai.api_key.as_deref().unwrap_or_default(),
-            model_id,
-        ),
-        LocalAiProvider::Ollama => {
-            OpenAiModel::ollama_at(ollama_base_url_from_config(config), model_id)
+    let provider = provider_from_config(config);
+    let model = match provider {
+        LocalAiProvider::LmStudio => {
+            let base = lm_studio_base_url(config);
+            tracing::debug!(
+                provider = provider.as_str(),
+                endpoint = %redact_ollama_base_url(&base),
+                has_api_key = config.local_ai.api_key.as_deref().is_some_and(|key| !key.trim().is_empty()),
+                model = %model_id,
+                "[local_ai:model_rpc] selecting LM Studio RPC model"
+            );
+            OpenAiModel::lm_studio(
+                base,
+                config.local_ai.api_key.as_deref().unwrap_or_default(),
+                model_id,
+            )
         }
-    }
-    .map_err(|error| format!("invalid local model RPC configuration: {error}"))
+        LocalAiProvider::Ollama => {
+            let base = ollama_base_url_from_config(config);
+            tracing::debug!(
+                provider = provider.as_str(),
+                endpoint = %redact_ollama_base_url(&base),
+                model = %model_id,
+                "[local_ai:model_rpc] selecting Ollama RPC model"
+            );
+            OpenAiModel::ollama_at(base, model_id)
+        }
+    };
+    model.map_err(|error| {
+        tracing::warn!(
+            provider = provider.as_str(),
+            error = %error,
+            "[local_ai:model_rpc] model construction failed"
+        );
+        format!("invalid local model RPC configuration: {error}")
+    })
 }
 
 pub(super) async fn invoke(
@@ -50,18 +77,49 @@ pub(super) async fn invoke(
 ) -> Result<ModelRpcOutcome, String> {
     let model_id = crate::openhuman::inference::model_ids::effective_chat_model_id(config);
     let model = local_model(config, &model_id)?;
+    let provider = provider_from_config(config);
+    tracing::debug!(
+        provider = provider.as_str(),
+        model = %model_id,
+        message_count = messages.len(),
+        ?max_tokens,
+        allow_empty,
+        "[local_ai:model_rpc] invoking local model"
+    );
 
     let mut request = ModelRequest::new(messages)
-        .with_model(model_id)
+        .with_model(&model_id)
         .with_temperature(temperature as f64);
     if let Some(max_tokens) = max_tokens {
         request = request.with_max_tokens(max_tokens);
     }
 
-    let response = model
-        .invoke(&(), request)
-        .await
-        .map_err(|error| format!("local model RPC failed: {error}"))?;
+    let response = model.invoke(&(), request).await.map_err(|error| {
+        tracing::warn!(
+            provider = provider.as_str(),
+            model = %model_id,
+            error = %error,
+            "[local_ai:model_rpc] local model call failed"
+        );
+        format!("local model RPC failed: {error}")
+    })?;
+    let outcome = model_outcome(response, allow_empty)?;
+
+    tracing::debug!(
+        provider = provider.as_str(),
+        model = %model_id,
+        reply_len = outcome.reply.len(),
+        prompt_tokens = ?outcome.prompt_tokens,
+        completion_tokens = ?outcome.completion_tokens,
+        "[local_ai:model_rpc] local model call completed"
+    );
+    Ok(outcome)
+}
+
+fn model_outcome(
+    response: tinyagents::harness::model::ModelResponse,
+    allow_empty: bool,
+) -> Result<ModelRpcOutcome, String> {
     let reply = response.text();
     let reply = reply.trim().to_owned();
     if reply.is_empty() && !allow_empty {
@@ -94,7 +152,11 @@ pub(super) async fn invoke(
 
 #[cfg(test)]
 mod tests {
-    use super::throughput;
+    use super::{local_model, model_outcome, throughput};
+    use crate::openhuman::config::Config;
+    use tinyagents::harness::message::{AssistantMessage, ContentBlock};
+    use tinyagents::harness::model::ModelResponse;
+    use tinyagents::harness::usage::Usage;
 
     #[test]
     fn throughput_reads_ollama_timing_metadata() {
@@ -111,5 +173,55 @@ mod tests {
             throughput(Some(&raw), "prompt_eval_count", "prompt_eval_duration"),
             None
         );
+    }
+
+    #[test]
+    fn local_model_selects_configured_provider() {
+        let mut config = Config::default();
+        config.local_ai.provider = "ollama".to_string();
+        let ollama = local_model(&config, "qwen3").unwrap();
+        assert_eq!(ollama.provider(), "ollama");
+
+        config.local_ai.provider = "lm_studio".to_string();
+        let lm_studio = local_model(&config, "local-model").unwrap();
+        assert_eq!(lm_studio.provider(), "lm_studio");
+    }
+
+    #[test]
+    fn model_outcome_enforces_empty_and_normalizes_usage() {
+        let response = |text: &str, usage: Usage| ModelResponse {
+            message: AssistantMessage {
+                id: None,
+                content: vec![ContentBlock::Text(text.to_string())],
+                tool_calls: Vec::new(),
+                usage: Some(usage),
+            },
+            usage: Some(usage),
+            finish_reason: None,
+            raw: None,
+            resolved_model: None,
+            continue_turn: None,
+        };
+
+        assert!(model_outcome(response(" ", Usage::default()), false).is_err());
+        let empty = model_outcome(response(" ", Usage::default()), true).unwrap();
+        assert_eq!(empty.reply, "");
+        assert_eq!(empty.prompt_tokens, None);
+        assert_eq!(empty.completion_tokens, None);
+
+        let populated = model_outcome(
+            response(
+                "done",
+                Usage {
+                    input_tokens: 7,
+                    output_tokens: 3,
+                    ..Usage::default()
+                },
+            ),
+            false,
+        )
+        .unwrap();
+        assert_eq!(populated.prompt_tokens, Some(7));
+        assert_eq!(populated.completion_tokens, Some(3));
     }
 }

--- a/src/openhuman/inference/local/service/model_rpc.rs
+++ b/src/openhuman/inference/local/service/model_rpc.rs
@@ -101,7 +101,15 @@ pub(super) async fn invoke(
             error = %error,
             "[local_ai:model_rpc] local model call failed"
         );
-        format!("local model RPC failed: {error}")
+        if provider == LocalAiProvider::Ollama
+            && error.to_string().contains("error sending request")
+        {
+            format!(
+                "external Ollama endpoint is unavailable; ensure Ollama is already running: {error}"
+            )
+        } else {
+            format!("local model RPC failed: {error}")
+        }
     })?;
     let outcome = model_outcome(response, allow_empty)?;
 

--- a/src/openhuman/inference/local/service/model_rpc.rs
+++ b/src/openhuman/inference/local/service/model_rpc.rs
@@ -16,6 +16,15 @@ pub(super) struct ModelRpcOutcome {
     pub reply: String,
     pub prompt_tokens: Option<u64>,
     pub completion_tokens: Option<u64>,
+    pub prompt_toks_per_sec: Option<f32>,
+    pub gen_toks_per_sec: Option<f32>,
+}
+
+fn throughput(raw: Option<&serde_json::Value>, count: &str, duration: &str) -> Option<f32> {
+    let raw = raw?;
+    let count = raw.get(count)?.as_u64()?;
+    let duration = raw.get(duration)?.as_u64()?;
+    crate::openhuman::inference::local::ollama::ns_to_tps(count as f32, duration)
 }
 
 fn local_model(config: &Config, model_id: &str) -> Result<OpenAiModel, String> {
@@ -67,10 +76,40 @@ pub(super) async fn invoke(
         .usage
         .as_ref()
         .and_then(|usage| (usage.output_tokens > 0).then_some(usage.output_tokens));
+    let prompt_toks_per_sec = throughput(
+        response.raw.as_ref(),
+        "prompt_eval_count",
+        "prompt_eval_duration",
+    );
+    let gen_toks_per_sec = throughput(response.raw.as_ref(), "eval_count", "eval_duration");
 
     Ok(ModelRpcOutcome {
         reply,
         prompt_tokens,
         completion_tokens,
+        prompt_toks_per_sec,
+        gen_toks_per_sec,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::throughput;
+
+    #[test]
+    fn throughput_reads_ollama_timing_metadata() {
+        let raw = serde_json::json!({
+            "eval_count": 25,
+            "eval_duration": 500_000_000_u64,
+        });
+
+        assert_eq!(
+            throughput(Some(&raw), "eval_count", "eval_duration"),
+            Some(50.0)
+        );
+        assert_eq!(
+            throughput(Some(&raw), "prompt_eval_count", "prompt_eval_duration"),
+            None
+        );
+    }
 }

--- a/src/openhuman/inference/local/service/model_rpc.rs
+++ b/src/openhuman/inference/local/service/model_rpc.rs
@@ -70,13 +70,14 @@ fn local_model(config: &Config, model_id: &str) -> Result<OpenAiModel, String> {
 
 pub(super) async fn invoke(
     config: &Config,
+    client: reqwest::Client,
     messages: Vec<Message>,
     max_tokens: Option<u32>,
     temperature: f32,
     allow_empty: bool,
 ) -> Result<ModelRpcOutcome, String> {
     let model_id = crate::openhuman::inference::model_ids::effective_chat_model_id(config);
-    let model = local_model(config, &model_id)?;
+    let model = local_model(config, &model_id)?.with_client(client);
     let provider = provider_from_config(config);
     tracing::debug!(
         provider = provider.as_str(),

--- a/src/openhuman/inference/local/service/model_rpc.rs
+++ b/src/openhuman/inference/local/service/model_rpc.rs
@@ -1,0 +1,67 @@
+//! Thin local-model RPC boundary backed by TinyAgents.
+//!
+//! Local runtimes execute out of process. OpenHuman only resolves their HTTP
+//! endpoint and adapts the legacy local-AI call shape to TinyAgents' provider-
+//! neutral `ChatModel` interface.
+
+use crate::openhuman::config::Config;
+use crate::openhuman::inference::local::lm_studio::lm_studio_base_url;
+use crate::openhuman::inference::local::ollama::ollama_base_url_from_config;
+use crate::openhuman::inference::local::provider::{provider_from_config, LocalAiProvider};
+use tinyagents::harness::message::Message;
+use tinyagents::harness::model::{ChatModel, ModelRequest};
+use tinyagents::harness::providers::openai::OpenAiModel;
+
+pub(super) struct ModelRpcOutcome {
+    pub reply: String,
+    pub prompt_tokens: Option<u64>,
+    pub completion_tokens: Option<u64>,
+}
+
+fn local_model(config: &Config, model_id: &str) -> OpenAiModel {
+    match provider_from_config(config) {
+        LocalAiProvider::LmStudio => OpenAiModel::lm_studio(
+            lm_studio_base_url(config),
+            config.local_ai.api_key.as_deref().unwrap_or_default(),
+            model_id,
+        ),
+        LocalAiProvider::Ollama => {
+            OpenAiModel::ollama_at(ollama_base_url_from_config(config), model_id)
+        }
+    }
+}
+
+pub(super) async fn invoke(
+    config: &Config,
+    messages: Vec<Message>,
+    max_tokens: Option<u32>,
+    temperature: f32,
+    allow_empty: bool,
+) -> Result<ModelRpcOutcome, String> {
+    let model_id = crate::openhuman::inference::model_ids::effective_chat_model_id(config);
+    let model = local_model(config, &model_id);
+
+    let mut request = ModelRequest::new(messages)
+        .with_model(model_id)
+        .with_temperature(temperature as f64);
+    if let Some(max_tokens) = max_tokens {
+        request = request.with_max_tokens(max_tokens);
+    }
+
+    let response = model
+        .invoke(&(), request)
+        .await
+        .map_err(|error| format!("local model RPC failed: {error}"))?;
+    let reply = response.text();
+    let reply = reply.trim().to_owned();
+    if reply.is_empty() && !allow_empty {
+        return Err("local model RPC returned empty content".to_owned());
+    }
+
+    Ok(ModelRpcOutcome {
+        reply,
+        prompt_tokens: (response.usage.input_tokens > 0).then_some(response.usage.input_tokens),
+        completion_tokens: (response.usage.output_tokens > 0)
+            .then_some(response.usage.output_tokens),
+    })
+}

--- a/src/openhuman/inference/local/service/model_rpc.rs
+++ b/src/openhuman/inference/local/service/model_rpc.rs
@@ -18,7 +18,7 @@ pub(super) struct ModelRpcOutcome {
     pub completion_tokens: Option<u64>,
 }
 
-fn local_model(config: &Config, model_id: &str) -> OpenAiModel {
+fn local_model(config: &Config, model_id: &str) -> Result<OpenAiModel, String> {
     match provider_from_config(config) {
         LocalAiProvider::LmStudio => OpenAiModel::lm_studio(
             lm_studio_base_url(config),
@@ -29,6 +29,7 @@ fn local_model(config: &Config, model_id: &str) -> OpenAiModel {
             OpenAiModel::ollama_at(ollama_base_url_from_config(config), model_id)
         }
     }
+    .map_err(|error| format!("invalid local model RPC configuration: {error}"))
 }
 
 pub(super) async fn invoke(
@@ -39,7 +40,7 @@ pub(super) async fn invoke(
     allow_empty: bool,
 ) -> Result<ModelRpcOutcome, String> {
     let model_id = crate::openhuman::inference::model_ids::effective_chat_model_id(config);
-    let model = local_model(config, &model_id);
+    let model = local_model(config, &model_id)?;
 
     let mut request = ModelRequest::new(messages)
         .with_model(model_id)
@@ -58,10 +59,18 @@ pub(super) async fn invoke(
         return Err("local model RPC returned empty content".to_owned());
     }
 
+    let prompt_tokens = response
+        .usage
+        .as_ref()
+        .and_then(|usage| (usage.input_tokens > 0).then_some(usage.input_tokens));
+    let completion_tokens = response
+        .usage
+        .as_ref()
+        .and_then(|usage| (usage.output_tokens > 0).then_some(usage.output_tokens));
+
     Ok(ModelRpcOutcome {
         reply,
-        prompt_tokens: (response.usage.input_tokens > 0).then_some(response.usage.input_tokens),
-        completion_tokens: (response.usage.output_tokens > 0)
-            .then_some(response.usage.output_tokens),
+        prompt_tokens,
+        completion_tokens,
     })
 }

--- a/src/openhuman/inference/local/service/model_rpc.rs
+++ b/src/openhuman/inference/local/service/model_rpc.rs
@@ -129,7 +129,21 @@ fn model_outcome(
     response: tinyagents::harness::model::ModelResponse,
     allow_empty: bool,
 ) -> Result<ModelRpcOutcome, String> {
-    let reply = response.text();
+    let mut reply = response.text();
+    if reply.trim().is_empty() {
+        reply = response
+            .message
+            .content
+            .iter()
+            .filter_map(|block| match block {
+                tinyagents::harness::message::ContentBlock::Thinking { text, .. } => {
+                    Some(text.as_str())
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
     let reply = reply.trim().to_owned();
     if reply.is_empty() && !allow_empty {
         return Err("local model RPC returned empty content".to_owned());
@@ -232,5 +246,26 @@ mod tests {
         .unwrap();
         assert_eq!(populated.prompt_tokens, Some(7));
         assert_eq!(populated.completion_tokens, Some(3));
+
+        let reasoning_only = ModelResponse {
+            message: AssistantMessage {
+                id: None,
+                content: vec![ContentBlock::Thinking {
+                    text: "reasoning fallback".to_string(),
+                    signature: None,
+                }],
+                tool_calls: Vec::new(),
+                usage: None,
+            },
+            usage: None,
+            finish_reason: None,
+            raw: None,
+            resolved_model: None,
+            continue_turn: None,
+        };
+        assert_eq!(
+            model_outcome(reasoning_only, false).unwrap().reply,
+            "reasoning fallback"
+        );
     }
 }

--- a/src/openhuman/inference/local/service/public_infer.rs
+++ b/src/openhuman/inference/local/service/public_infer.rs
@@ -1,29 +1,9 @@
 use crate::openhuman::config::Config;
-use crate::openhuman::inference::local::ollama::{
-    ns_to_tps, ollama_base_url, ollama_base_url_from_config, redact_ollama_base_url,
-    OllamaGenerateOptions, OllamaGenerateRequest,
-};
-use crate::openhuman::inference::local::provider::{provider_from_config, LocalAiProvider};
 use crate::openhuman::inference::model_ids;
 use crate::openhuman::inference::parse::sanitize_inline_completion;
+use tinyagents::harness::message::Message;
 
 use super::LocalAiService;
-
-fn external_ollama_request_error_with_url(
-    prefix: &str,
-    error: &reqwest::Error,
-    base_url: &str,
-) -> String {
-    let safe_base_url = redact_ollama_base_url(base_url);
-    format!(
-        "{prefix}: OpenHuman routes inference through an external Ollama endpoint. \
-         Make sure Ollama is already running and reachable at {safe_base_url} ({error})"
-    )
-}
-
-fn external_ollama_request_error(prefix: &str, error: &reqwest::Error) -> String {
-    external_ollama_request_error_with_url(prefix, error, &ollama_base_url())
-}
 
 impl LocalAiService {
     pub async fn summarize(
@@ -276,129 +256,43 @@ impl LocalAiService {
             None
         };
 
-        if provider_from_config(config) == LocalAiProvider::LmStudio {
-            let started = std::time::Instant::now();
-            let lm_messages = messages
-                .into_iter()
-                .map(
-                    |message| crate::openhuman::inference::local::lm_studio::LmStudioChatMessage {
-                        role: message.role,
-                        content: message.content,
-                    },
-                )
-                .collect();
-            let outcome = self
-                .lm_studio_chat_completion(
-                    config,
-                    lm_messages,
-                    max_tokens,
-                    config.default_temperature as f32,
-                    false,
-                )
-                .await?;
-            let elapsed_ms = started.elapsed().as_millis() as u64;
-            {
-                let mut status = self.status.lock();
-                status.state = "ready".to_string();
-                status.last_latency_ms = Some(elapsed_ms);
-                status.prompt_toks_per_sec = None;
-                status.gen_toks_per_sec = None;
-                status.warning = None;
-            }
-            tracing::debug!(
-                elapsed_ms,
-                prompt_tokens = ?outcome.prompt_tokens,
-                completion_tokens = ?outcome.completion_tokens,
-                reply_len = outcome.reply.len(),
-                "[local_ai:chat] lm studio /v1/chat/completions done"
-            );
-            return Ok(outcome.reply);
-        }
-
-        tracing::debug!(
-            message_count = messages.len(),
-            model = %crate::openhuman::inference::model_ids::effective_chat_model_id(config),
-            "[local_ai:chat] sending to ollama /api/chat"
-        );
-
         let started = std::time::Instant::now();
-
-        let body = crate::openhuman::inference::local::ollama::OllamaChatRequest {
-            model: crate::openhuman::inference::model_ids::effective_chat_model_id(config),
+        let messages = messages
+            .into_iter()
+            .map(|message| match message.role.as_str() {
+                "system" => Message::system(message.content),
+                "assistant" => Message::assistant(message.content),
+                _ => Message::user(message.content),
+            })
+            .collect();
+        let outcome = super::model_rpc::invoke(
+            config,
             messages,
-            stream: false,
-            options: Some(
-                crate::openhuman::inference::local::ollama::OllamaGenerateOptions {
-                    temperature: Some(config.default_temperature as f32),
-                    top_k: Some(40),
-                    top_p: Some(0.9),
-                    num_predict: max_tokens.map(|v| v as i32),
-                },
-            ),
-        };
-
-        let base_url = ollama_base_url_from_config(config);
-        let response = self
-            .http
-            .post(format!("{base_url}/api/chat"))
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| {
-                external_ollama_request_error_with_url("ollama chat request failed", &e, &base_url)
-            })?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            let detail = body.trim();
-            return Err(format!(
-                "ollama chat failed with status {}{}",
-                status,
-                if detail.is_empty() {
-                    String::new()
-                } else {
-                    format!(": {detail}")
-                }
-            ));
-        }
-
-        let payload: crate::openhuman::inference::local::ollama::OllamaChatResponse = response
-            .json()
-            .await
-            .map_err(|e| format!("ollama chat response parse failed: {e}"))?;
+            max_tokens,
+            config.default_temperature as f32,
+            false,
+        )
+        .await?;
 
         let elapsed_ms = started.elapsed().as_millis() as u64;
-        let prompt_tps = payload
-            .prompt_eval_count
-            .zip(payload.prompt_eval_duration)
-            .and_then(|(count, dur_ns)| ns_to_tps(count as f32, dur_ns));
-        let gen_tps = payload
-            .eval_count
-            .zip(payload.eval_duration)
-            .and_then(|(count, dur_ns)| ns_to_tps(count as f32, dur_ns));
 
         {
             let mut status = self.status.lock();
             status.state = "ready".to_string();
             status.last_latency_ms = Some(elapsed_ms);
-            status.prompt_toks_per_sec = prompt_tps;
-            status.gen_toks_per_sec = gen_tps;
+            status.prompt_toks_per_sec = None;
+            status.gen_toks_per_sec = None;
             status.warning = None;
         }
 
         tracing::debug!(
             elapsed_ms,
-            reply_len = payload.message.content.len(),
-            "[local_ai:chat] ollama /api/chat done"
+            prompt_tokens = ?outcome.prompt_tokens,
+            completion_tokens = ?outcome.completion_tokens,
+            reply_len = outcome.reply.len(),
+            "[local_ai:chat] tinyagents local model RPC done"
         );
-
-        let reply = payload.message.content.trim().to_string();
-        if reply.is_empty() {
-            Err("ollama returned empty reply".to_string())
-        } else {
-            Ok(reply)
-        }
+        Ok(outcome.reply)
     }
 
     pub(crate) async fn inference(
@@ -545,115 +439,37 @@ impl LocalAiService {
             system.to_string()
         };
 
-        if provider_from_config(config) == LocalAiProvider::LmStudio {
-            let messages = vec![
-                crate::openhuman::inference::local::lm_studio::LmStudioChatMessage {
-                    role: "system".to_string(),
-                    content: effective_system,
-                },
-                crate::openhuman::inference::local::lm_studio::LmStudioChatMessage {
-                    role: "user".to_string(),
-                    content: prompt.to_string(),
-                },
-            ];
-            let outcome = self
-                .lm_studio_chat_completion(config, messages, max_tokens, temperature, allow_empty)
-                .await?;
-            let elapsed_ms = started.elapsed().as_millis() as u64;
-            {
-                let mut status = self.status.lock();
-                status.state = "ready".to_string();
-                status.last_latency_ms = Some(elapsed_ms);
-                status.prompt_toks_per_sec = None;
-                status.gen_toks_per_sec = None;
-                status.warning = None;
-            }
-            tracing::debug!(
-                elapsed_ms,
-                prompt_tokens = ?outcome.prompt_tokens,
-                completion_tokens = ?outcome.completion_tokens,
-                reply_len = outcome.reply.len(),
-                "[local_ai:infer] lm studio /v1/chat/completions done"
-            );
-            return Ok(outcome.reply);
-        }
-
-        let body = OllamaGenerateRequest {
-            model: model_id,
-            prompt: prompt.to_string(),
-            system: Some(effective_system),
-            images: None,
-            stream: false,
-            options: Some(OllamaGenerateOptions {
-                temperature: Some(temperature),
-                top_k: Some(40),
-                top_p: Some(0.9),
-                num_predict: max_tokens.map(|v| v as i32),
-            }),
-        };
-
-        let base_url = ollama_base_url_from_config(config);
-        log::debug!(
-            "[local_ai:infer] inference_with_temperature_internal: using base_url={}",
-            redact_ollama_base_url(&base_url)
-        );
-        let response = self
-            .http
-            .post(format!("{base_url}/api/generate"))
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| {
-                external_ollama_request_error_with_url("ollama request failed", &e, &base_url)
-            })?;
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            let detail = body.trim();
-            return Err(format!(
-                "ollama request failed with status {}{}",
-                status,
-                if detail.is_empty() {
-                    String::new()
-                } else {
-                    format!(": {detail}")
-                }
-            ));
-        }
-
-        let payload: crate::openhuman::inference::local::ollama::OllamaGenerateResponse = response
-            .json()
-            .await
-            .map_err(|e| format!("ollama response parse failed: {e}"))?;
+        let outcome = super::model_rpc::invoke(
+            config,
+            vec![
+                Message::system(effective_system),
+                Message::user(prompt.to_owned()),
+            ],
+            max_tokens,
+            temperature,
+            allow_empty,
+        )
+        .await?;
 
         let elapsed_ms = started.elapsed().as_millis() as u64;
-        let prompt_tps = payload
-            .prompt_eval_count
-            .zip(payload.prompt_eval_duration)
-            .and_then(|(count, dur_ns)| ns_to_tps(count as f32, dur_ns));
-        let gen_tps = payload
-            .eval_count
-            .zip(payload.eval_duration)
-            .and_then(|(count, dur_ns)| ns_to_tps(count as f32, dur_ns));
 
         {
             let mut status = self.status.lock();
             status.state = "ready".to_string();
             status.last_latency_ms = Some(elapsed_ms);
-            status.prompt_toks_per_sec = prompt_tps;
-            status.gen_toks_per_sec = gen_tps;
+            status.prompt_toks_per_sec = None;
+            status.gen_toks_per_sec = None;
             status.warning = None;
         }
 
-        if payload.response.trim().is_empty() {
-            if allow_empty {
-                Ok(String::new())
-            } else {
-                Err("ollama returned empty content".to_string())
-            }
-        } else {
-            Ok(payload.response)
-        }
+        tracing::debug!(
+            elapsed_ms,
+            prompt_tokens = ?outcome.prompt_tokens,
+            completion_tokens = ?outcome.completion_tokens,
+            reply_len = outcome.reply.len(),
+            "[local_ai:infer] tinyagents local model RPC done"
+        );
+        Ok(outcome.reply)
     }
 }
 

--- a/src/openhuman/inference/local/service/public_infer.rs
+++ b/src/openhuman/inference/local/service/public_infer.rs
@@ -280,8 +280,8 @@ impl LocalAiService {
             let mut status = self.status.lock();
             status.state = "ready".to_string();
             status.last_latency_ms = Some(elapsed_ms);
-            status.prompt_toks_per_sec = None;
-            status.gen_toks_per_sec = None;
+            status.prompt_toks_per_sec = outcome.prompt_toks_per_sec;
+            status.gen_toks_per_sec = outcome.gen_toks_per_sec;
             status.warning = None;
         }
 
@@ -457,8 +457,8 @@ impl LocalAiService {
             let mut status = self.status.lock();
             status.state = "ready".to_string();
             status.last_latency_ms = Some(elapsed_ms);
-            status.prompt_toks_per_sec = None;
-            status.gen_toks_per_sec = None;
+            status.prompt_toks_per_sec = outcome.prompt_toks_per_sec;
+            status.gen_toks_per_sec = outcome.gen_toks_per_sec;
             status.warning = None;
         }
 

--- a/src/openhuman/inference/local/service/public_infer.rs
+++ b/src/openhuman/inference/local/service/public_infer.rs
@@ -267,6 +267,7 @@ impl LocalAiService {
             .collect();
         let outcome = super::model_rpc::invoke(
             config,
+            self.http.clone(),
             messages,
             max_tokens,
             config.default_temperature as f32,
@@ -441,6 +442,7 @@ impl LocalAiService {
 
         let outcome = super::model_rpc::invoke(
             config,
+            self.http.clone(),
             vec![
                 Message::system(effective_system),
                 Message::user(prompt.to_owned()),

--- a/src/openhuman/inference/local/service/public_infer_tests.rs
+++ b/src/openhuman/inference/local/service/public_infer_tests.rs
@@ -15,6 +15,17 @@ fn enabled_config() -> Config {
     config
 }
 
+fn openai_response(content: &str) -> serde_json::Value {
+    json!({
+        "id": "chatcmpl-test",
+        "choices": [{
+            "message": { "role": "assistant", "content": content },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 5, "completion_tokens": 3, "total_tokens": 8 }
+    })
+}
+
 fn lm_studio_config(base: &str) -> Config {
     let mut config = enabled_config();
     config.local_ai.provider = "lm_studio".to_string();
@@ -37,22 +48,18 @@ fn ready_service(config: &Config) -> LocalAiService {
 }
 
 #[tokio::test]
-async fn inference_hits_ollama_generate_and_returns_response() {
+async fn inference_hits_ollama_chat_completions_and_returns_response() {
     let _guard = crate::openhuman::inference::inference_test_guard();
 
     let app = Router::new().route(
-        "/api/generate",
+        "/v1/chat/completions",
         post(|Json(_body): Json<serde_json::Value>| async move {
-            Json(json!({
-                "model": "test",
-                "response": "hello from mock",
-                "done": true,
-                "total_duration": 1_000_000u64,
-                "prompt_eval_count": 5,
-                "prompt_eval_duration": 100_000u64,
-                "eval_count": 3,
-                "eval_duration": 500_000u64
-            }))
+            let mut response = openai_response("hello from mock");
+            response["prompt_eval_count"] = json!(5);
+            response["prompt_eval_duration"] = json!(100_000u64);
+            response["eval_count"] = json!(3);
+            response["eval_duration"] = json!(500_000u64);
+            Json(response)
         }),
     );
     let base = spawn_mock(app).await;
@@ -78,7 +85,7 @@ async fn inference_errors_on_non_success_status() {
     let _guard = crate::openhuman::inference::inference_test_guard();
 
     let app = Router::new().route(
-        "/api/generate",
+        "/v1/chat/completions",
         post(|| async { (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "boom") }),
     );
     let base = spawn_mock(app).await;
@@ -124,14 +131,8 @@ async fn inference_errors_on_empty_response_when_allow_empty_false() {
     let _guard = crate::openhuman::inference::inference_test_guard();
 
     let app = Router::new().route(
-        "/api/generate",
-        post(|| async {
-            Json(json!({
-                "model": "test",
-                "response": "   ",
-                "done": true
-            }))
-        }),
+        "/v1/chat/completions",
+        post(|| async { Json(openai_response("   ")) }),
     );
     let base = spawn_mock(app).await;
     unsafe {
@@ -164,7 +165,7 @@ async fn lm_studio_prompt_hits_openai_chat_completions() {
         "/v1/chat/completions",
         post(|Json(body): Json<serde_json::Value>| async move {
             assert_eq!(body["model"], "local-model");
-            assert_eq!(body["stream"], false);
+            assert!(body.get("stream").is_none());
             assert_eq!(body["max_tokens"], 16);
             assert_eq!(body["messages"][0]["role"], "system");
             assert_eq!(body["messages"][1]["role"], "user");
@@ -209,7 +210,7 @@ async fn lm_studio_prompt_errors_on_non_success_status() {
 
     let err = service.prompt(&config, "hi", None, true).await.unwrap_err();
 
-    assert!(err.contains("lm studio chat failed with status 502"));
+    assert!(err.contains("502"));
 }
 
 #[tokio::test]
@@ -273,14 +274,8 @@ async fn inline_complete_interactive_does_not_block_on_held_permit() {
         .expect("test must start with a free permit; previous test leaked one");
 
     let app = Router::new().route(
-        "/api/generate",
-        post(|Json(_body): Json<serde_json::Value>| async move {
-            Json(json!({
-                "model": "test",
-                "response": "ip",
-                "done": true
-            }))
-        }),
+        "/v1/chat/completions",
+        post(|Json(_body): Json<serde_json::Value>| async move { Json(openai_response("ip")) }),
     );
     let base = spawn_mock(app).await;
     unsafe {
@@ -318,13 +313,9 @@ async fn prompt_interactive_does_not_block_on_held_permit() {
         .expect("test must start with a free permit");
 
     let app = Router::new().route(
-        "/api/generate",
+        "/v1/chat/completions",
         post(|Json(_body): Json<serde_json::Value>| async move {
-            Json(json!({
-                "model": "test",
-                "response": "hello from mock",
-                "done": true
-            }))
+            Json(openai_response("hello from mock"))
         }),
     );
     let base = spawn_mock(app).await;
@@ -359,9 +350,9 @@ async fn summarize_interactive_does_not_block_on_held_permit() {
         .expect("test must start with a free permit");
 
     let app = Router::new().route(
-        "/api/generate",
+        "/v1/chat/completions",
         post(|Json(body): Json<serde_json::Value>| async move {
-            let prompt = body["prompt"].as_str().unwrap_or_default();
+            let prompt = body["messages"][1]["content"].as_str().unwrap_or_default();
             assert!(
                 prompt.contains("commitments.\n\ntext to summarize"),
                 "summary prompt should use real newlines, got: {prompt:?}"
@@ -370,11 +361,7 @@ async fn summarize_interactive_does_not_block_on_held_permit() {
                 !prompt.contains(r"commitments.\n\ntext to summarize"),
                 "summary prompt must not contain literal backslash-n separators"
             );
-            Json(json!({
-                "model": "test",
-                "response": "summary from mock",
-                "done": true
-            }))
+            Json(openai_response("summary from mock"))
         }),
     );
     let base = spawn_mock(app).await;
@@ -409,13 +396,9 @@ async fn chat_with_history_interactive_does_not_block_on_held_permit() {
         .expect("test must start with a free permit");
 
     let app = Router::new().route(
-        "/api/chat",
+        "/v1/chat/completions",
         post(|Json(_body): Json<serde_json::Value>| async move {
-            Json(json!({
-                "model": "test",
-                "message": { "role": "assistant", "content": "history reply" },
-                "done": true
-            }))
+            Json(openai_response("history reply"))
         }),
     );
     let base = spawn_mock(app).await;
@@ -470,14 +453,8 @@ async fn gated_inline_complete_blocks_on_held_permit() {
         .expect("test must start with a free permit");
 
     let app = Router::new().route(
-        "/api/generate",
-        post(|Json(_body): Json<serde_json::Value>| async move {
-            Json(json!({
-                "model": "test",
-                "response": "x",
-                "done": true
-            }))
-        }),
+        "/v1/chat/completions",
+        post(|Json(_body): Json<serde_json::Value>| async move { Json(openai_response("x")) }),
     );
     let base = spawn_mock(app).await;
     unsafe {

--- a/src/openhuman/inference/local/service/vision_embed.rs
+++ b/src/openhuman/inference/local/service/vision_embed.rs
@@ -183,22 +183,31 @@ impl LocalAiService {
                 .unwrap_or_else(|| "dynamic".to_string()),
             redact_ollama_base_url(&embed_base)
         );
-        let model = if let Some(dimensions) = dimensions {
-            OllamaEmbeddingModel::try_new(&embed_base, &embedding_model, dimensions)
+        let (dims, vectors) = if let Some(dimensions) = dimensions {
+            let model = OllamaEmbeddingModel::try_new(&embed_base, &embedding_model, dimensions)
+                .map_err(|error| format!("invalid local embedding RPC configuration: {error}"))?
+                .with_client(self.http.clone())
+                .with_context_options(
+                    RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
+                    RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
+                );
+            let vectors = model
+                .embed(&items)
+                .await
+                .map_err(|error| format!("local embedding RPC failed: {error}"))?;
+            (model.dimensions(), vectors)
         } else {
-            OllamaEmbeddingModel::try_new_dynamic(&embed_base, &embedding_model)
-        }
-        .map_err(|error| format!("invalid local embedding RPC configuration: {error}"))?
-        .with_client(self.http.clone())
-        .with_context_options(
-            RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
-            RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
-        );
-        let vectors = model
-            .embed(&items)
+            OllamaEmbeddingModel::embed_discovering_dimensions(
+                &embed_base,
+                &embedding_model,
+                self.http.clone(),
+                &items,
+                RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
+                RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
+            )
             .await
-            .map_err(|error| format!("local embedding RPC failed: {error}"))?;
-        let dims = model.dimensions();
+            .map_err(|error| format!("local embedding RPC failed: {error}"))?
+        };
         self.status.lock().embedding_state = "ready".to_string();
         Ok(LocalAiEmbeddingResult {
             model_id: embedding_model,

--- a/src/openhuman/inference/local/service/vision_embed.rs
+++ b/src/openhuman/inference/local/service/vision_embed.rs
@@ -1,12 +1,16 @@
 use crate::openhuman::agent::multimodal;
 use crate::openhuman::config::Config;
 use crate::openhuman::inference::local::ollama::{
-    ollama_base_url_from_config, redact_ollama_base_url, OllamaEmbedRequest, OllamaEmbedResponse,
-    OllamaGenerateOptions, OllamaGenerateRequest,
+    ollama_base_url_from_config, redact_ollama_base_url, OllamaGenerateOptions,
+    OllamaGenerateRequest,
 };
 use crate::openhuman::inference::model_ids;
 use crate::openhuman::inference::presets::{self, VisionMode};
 use crate::openhuman::inference::types::LocalAiEmbeddingResult;
+use tinyagents::harness::embeddings::{
+    EmbeddingModel, OllamaEmbeddingModel, DEFAULT_OLLAMA_DIMENSIONS,
+    RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
+};
 
 use super::LocalAiService;
 
@@ -161,46 +165,24 @@ impl LocalAiService {
             "[local_ai:embed] embed: using base_url={}",
             redact_ollama_base_url(&embed_base)
         );
-        let response = self
-            .http
-            .post(format!("{embed_base}/api/embed"))
-            .json(&OllamaEmbedRequest {
-                model: embedding_model.clone(),
-                input: items.clone(),
-            })
-            .send()
+        let model =
+            OllamaEmbeddingModel::try_new(&embed_base, &embedding_model, DEFAULT_OLLAMA_DIMENSIONS)
+                .map_err(|error| format!("invalid local embedding RPC configuration: {error}"))?
+                .with_client(self.http.clone())
+                .with_context_options(
+                    RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
+                    RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
+                );
+        let vectors = model
+            .embed(&items)
             .await
-            .map_err(|e| format!("ollama embed request failed: {e}"))?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            let detail = body.trim();
-            return Err(format!(
-                "ollama embed request failed with status {}{}",
-                status,
-                if detail.is_empty() {
-                    String::new()
-                } else {
-                    format!(": {detail}")
-                }
-            ));
-        }
-
-        let payload: OllamaEmbedResponse = response
-            .json()
-            .await
-            .map_err(|e| format!("ollama embed parse failed: {e}"))?;
-        if payload.embeddings.is_empty() {
-            return Err("ollama embed returned no embeddings".to_string());
-        }
-
-        let dims = payload.embeddings.first().map(|v| v.len()).unwrap_or(0);
+            .map_err(|error| format!("local embedding RPC failed: {error}"))?;
+        let dims = model.dimensions();
         self.status.lock().embedding_state = "ready".to_string();
         Ok(LocalAiEmbeddingResult {
             model_id: embedding_model,
             dimensions: dims,
-            vectors: payload.embeddings,
+            vectors,
         })
     }
 }

--- a/src/openhuman/inference/local/service/vision_embed.rs
+++ b/src/openhuman/inference/local/service/vision_embed.rs
@@ -14,6 +14,18 @@ use tinyagents::harness::embeddings::{
 
 use super::LocalAiService;
 
+fn embedding_dimensions(model_id: &str) -> usize {
+    if model_id
+        .trim()
+        .to_ascii_lowercase()
+        .starts_with("all-minilm")
+    {
+        384
+    } else {
+        DEFAULT_OLLAMA_DIMENSIONS
+    }
+}
+
 impl LocalAiService {
     pub async fn vision_prompt(
         &self,
@@ -165,14 +177,17 @@ impl LocalAiService {
             "[local_ai:embed] embed: using base_url={}",
             redact_ollama_base_url(&embed_base)
         );
-        let model =
-            OllamaEmbeddingModel::try_new(&embed_base, &embedding_model, DEFAULT_OLLAMA_DIMENSIONS)
-                .map_err(|error| format!("invalid local embedding RPC configuration: {error}"))?
-                .with_client(self.http.clone())
-                .with_context_options(
-                    RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
-                    RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
-                );
+        let model = OllamaEmbeddingModel::try_new(
+            &embed_base,
+            &embedding_model,
+            embedding_dimensions(&embedding_model),
+        )
+        .map_err(|error| format!("invalid local embedding RPC configuration: {error}"))?
+        .with_client(self.http.clone())
+        .with_context_options(
+            RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
+            RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
+        );
         let vectors = model
             .embed(&items)
             .await
@@ -288,6 +303,12 @@ mod tests {
         let service = LocalAiService::new(&config);
         let err = service.embed(&config, &["x".into()]).await.unwrap_err();
         assert!(err.contains("local ai is disabled"));
+    }
+
+    #[test]
+    fn embedding_dimensions_match_supported_legacy_models() {
+        assert_eq!(embedding_dimensions("bge-m3"), 1024);
+        assert_eq!(embedding_dimensions("all-minilm:latest"), 384);
     }
 
     #[tokio::test]

--- a/src/openhuman/inference/local/service/vision_embed.rs
+++ b/src/openhuman/inference/local/service/vision_embed.rs
@@ -14,15 +14,18 @@ use tinyagents::harness::embeddings::{
 
 use super::LocalAiService;
 
-fn embedding_dimensions(model_id: &str) -> usize {
-    if model_id
-        .trim()
-        .to_ascii_lowercase()
-        .starts_with("all-minilm")
-    {
-        384
+fn embedding_dimensions(model_id: &str) -> Result<usize, String> {
+    let normalized = model_id.trim().to_ascii_lowercase();
+    if normalized.starts_with("all-minilm") {
+        Ok(384)
+    } else if normalized.contains("bge-m3") || normalized.starts_with("mxbai-embed-large") {
+        Ok(DEFAULT_OLLAMA_DIMENSIONS)
+    } else if normalized.starts_with("nomic-embed-text") {
+        Ok(768)
     } else {
-        DEFAULT_OLLAMA_DIMENSIONS
+        Err(format!(
+            "embedding dimensions are unknown for local model `{model_id}`"
+        ))
     }
 }
 
@@ -173,21 +176,20 @@ impl LocalAiService {
         let _gate_permit = crate::openhuman::scheduler_gate::wait_for_capacity().await;
 
         let embed_base = ollama_base_url_from_config(config);
+        let dimensions = embedding_dimensions(&embedding_model)?;
         log::debug!(
-            "[local_ai:embed] embed: using base_url={}",
+            "[local_ai:embed] embed: using model={} dimensions={} base_url={}",
+            embedding_model,
+            dimensions,
             redact_ollama_base_url(&embed_base)
         );
-        let model = OllamaEmbeddingModel::try_new(
-            &embed_base,
-            &embedding_model,
-            embedding_dimensions(&embedding_model),
-        )
-        .map_err(|error| format!("invalid local embedding RPC configuration: {error}"))?
-        .with_client(self.http.clone())
-        .with_context_options(
-            RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
-            RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
-        );
+        let model = OllamaEmbeddingModel::try_new(&embed_base, &embedding_model, dimensions)
+            .map_err(|error| format!("invalid local embedding RPC configuration: {error}"))?
+            .with_client(self.http.clone())
+            .with_context_options(
+                RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
+                RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
+            );
         let vectors = model
             .embed(&items)
             .await
@@ -307,8 +309,10 @@ mod tests {
 
     #[test]
     fn embedding_dimensions_match_supported_legacy_models() {
-        assert_eq!(embedding_dimensions("bge-m3"), 1024);
-        assert_eq!(embedding_dimensions("all-minilm:latest"), 384);
+        assert_eq!(embedding_dimensions("bge-m3").unwrap(), 1024);
+        assert_eq!(embedding_dimensions("all-minilm:latest").unwrap(), 384);
+        assert_eq!(embedding_dimensions("nomic-embed-text").unwrap(), 768);
+        assert!(embedding_dimensions("user-managed-model").is_err());
     }
 
     #[tokio::test]

--- a/src/openhuman/inference/local/service/vision_embed.rs
+++ b/src/openhuman/inference/local/service/vision_embed.rs
@@ -14,18 +14,16 @@ use tinyagents::harness::embeddings::{
 
 use super::LocalAiService;
 
-fn embedding_dimensions(model_id: &str) -> Result<usize, String> {
+fn embedding_dimensions(model_id: &str) -> Option<usize> {
     let normalized = model_id.trim().to_ascii_lowercase();
     if normalized.starts_with("all-minilm") {
-        Ok(384)
+        Some(384)
     } else if normalized.contains("bge-m3") || normalized.starts_with("mxbai-embed-large") {
-        Ok(DEFAULT_OLLAMA_DIMENSIONS)
+        Some(DEFAULT_OLLAMA_DIMENSIONS)
     } else if normalized.starts_with("nomic-embed-text") {
-        Ok(768)
+        Some(768)
     } else {
-        Err(format!(
-            "embedding dimensions are unknown for local model `{model_id}`"
-        ))
+        None
     }
 }
 
@@ -176,20 +174,26 @@ impl LocalAiService {
         let _gate_permit = crate::openhuman::scheduler_gate::wait_for_capacity().await;
 
         let embed_base = ollama_base_url_from_config(config);
-        let dimensions = embedding_dimensions(&embedding_model)?;
+        let dimensions = embedding_dimensions(&embedding_model);
         log::debug!(
             "[local_ai:embed] embed: using model={} dimensions={} base_url={}",
             embedding_model,
-            dimensions,
+            dimensions
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "dynamic".to_string()),
             redact_ollama_base_url(&embed_base)
         );
-        let model = OllamaEmbeddingModel::try_new(&embed_base, &embedding_model, dimensions)
-            .map_err(|error| format!("invalid local embedding RPC configuration: {error}"))?
-            .with_client(self.http.clone())
-            .with_context_options(
-                RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
-                RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
-            );
+        let model = if let Some(dimensions) = dimensions {
+            OllamaEmbeddingModel::try_new(&embed_base, &embedding_model, dimensions)
+        } else {
+            OllamaEmbeddingModel::try_new_dynamic(&embed_base, &embedding_model)
+        }
+        .map_err(|error| format!("invalid local embedding RPC configuration: {error}"))?
+        .with_client(self.http.clone())
+        .with_context_options(
+            RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
+            RECOMMENDED_OLLAMA_CONTEXT_TOKENS,
+        );
         let vectors = model
             .embed(&items)
             .await
@@ -309,10 +313,10 @@ mod tests {
 
     #[test]
     fn embedding_dimensions_match_supported_legacy_models() {
-        assert_eq!(embedding_dimensions("bge-m3").unwrap(), 1024);
-        assert_eq!(embedding_dimensions("all-minilm:latest").unwrap(), 384);
-        assert_eq!(embedding_dimensions("nomic-embed-text").unwrap(), 768);
-        assert!(embedding_dimensions("user-managed-model").is_err());
+        assert_eq!(embedding_dimensions("bge-m3"), Some(1024));
+        assert_eq!(embedding_dimensions("all-minilm:latest"), Some(384));
+        assert_eq!(embedding_dimensions("nomic-embed-text"), Some(768));
+        assert_eq!(embedding_dimensions("user-managed-model"), None);
     }
 
     #[tokio::test]

--- a/tests/raw_coverage/inference_local_services_round21_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/inference_local_services_round21_raw_coverage_e2e.rs
@@ -332,8 +332,9 @@ async fn local_services_cover_mocked_inference_assets_speech_and_whisper_install
         .contains("downloaded payload too small"));
 
     let seen = state.requests.lock().expect("requests").clone();
-    assert!(seen.iter().any(|(path, _)| path == "/api/generate"));
-    assert!(seen.iter().any(|(path, _)| path == "/api/chat"));
+    assert!(seen
+        .iter()
+        .any(|(path, _)| path == "/v1/chat/completions"));
     assert!(seen.iter().any(|(path, _)| path.ends_with("ggml-tiny.bin")));
     assert!(seen
         .iter()
@@ -351,8 +352,7 @@ async fn serve_mock() -> (String, MockState) {
         .route("/api/tags", get(ollama_tags))
         .route("/api/show", post(ollama_show))
         .route("/api/pull", post(ollama_pull))
-        .route("/api/generate", post(ollama_generate))
-        .route("/api/chat", post(ollama_chat))
+        .route("/v1/chat/completions", post(ollama_chat_completions))
         .route("/asset/stt", get(asset_stt))
         .route("/asset/tts", get(asset_tts))
         .route("/asset/tts-json", get(asset_tts_json))
@@ -415,44 +415,44 @@ async fn ollama_pull(State(state): State<MockState>, Json(body): Json<Value>) ->
         .expect("pull response")
 }
 
-async fn ollama_generate(
+async fn ollama_chat_completions(
     State(state): State<MockState>,
     headers: HeaderMap,
     Json(body): Json<Value>,
 ) -> impl IntoResponse {
-    remember(&state, "/api/generate", &headers, body.clone());
-    let prompt = body["prompt"].as_str().unwrap_or_default();
-    let system = body["system"].as_str().unwrap_or_default();
+    remember(&state, "/v1/chat/completions", &headers, body.clone());
+    let messages = body["messages"].as_array().cloned().unwrap_or_default();
+    let system = messages
+        .iter()
+        .find(|message| message["role"] == "system")
+        .and_then(|message| message["content"].as_str())
+        .unwrap_or_default();
+    let prompt = messages
+        .iter()
+        .rev()
+        .find(|message| message["role"] == "user")
+        .and_then(|message| message["content"].as_str())
+        .unwrap_or_default();
     let response = if prompt.contains("single emoji character") {
         "⭐".to_string()
     } else if system.contains("inline text completion") {
         "adds tests".to_string()
+    } else if prompt == "chat please" {
+        "chat generated".to_string()
     } else {
         format!("generated: {}", prompt.trim())
     };
     Json(json!({
-        "response": response,
-        "done": true,
+        "id": "chatcmpl-round21",
+        "choices": [{
+            "message": { "role": "assistant", "content": response },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 2, "completion_tokens": 4, "total_tokens": 6 },
         "prompt_eval_count": 2,
         "prompt_eval_duration": 1_000_000,
         "eval_count": 4,
         "eval_duration": 2_000_000
-    }))
-}
-
-async fn ollama_chat(
-    State(state): State<MockState>,
-    headers: HeaderMap,
-    Json(body): Json<Value>,
-) -> impl IntoResponse {
-    remember(&state, "/api/chat", &headers, body);
-    Json(json!({
-        "message": { "role": "assistant", "content": "chat generated" },
-        "done": true,
-        "prompt_eval_count": 1,
-        "prompt_eval_duration": 1_000_000,
-        "eval_count": 1,
-        "eval_duration": 1_000_000
     }))
 }
 

--- a/tests/raw_coverage/inference_provider_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/inference_provider_raw_coverage_e2e.rs
@@ -259,13 +259,13 @@ async fn local_service_public_inference_assets_and_shutdown_use_loopback_ollama(
         .prompt(&config, "Say hi", Some(8), true)
         .await
         .expect("prompt");
-    assert_eq!(prompt, "generated final");
+    assert_eq!(prompt, "chat:gemma3:1b-it-qat");
 
     let summarized = service
         .summarize(&config, "one two three", Some(16))
         .await
         .expect("summarize");
-    assert_eq!(summarized, "generated final");
+    assert_eq!(summarized, "chat:gemma3:1b-it-qat");
 
     let completion = service
         .inline_complete_interactive(
@@ -278,7 +278,7 @@ async fn local_service_public_inference_assets_and_shutdown_use_loopback_ollama(
         )
         .await
         .expect("inline");
-    assert_eq!(completion, "generated final");
+    assert_eq!(completion, "chat:gemma3:1b-it-qat");
 
     let assets = service.assets_status(&config).await.expect("assets");
     assert!(assets.ollama_available);

--- a/tests/raw_coverage/inference_round26_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/inference_round26_raw_coverage_e2e.rs
@@ -170,7 +170,7 @@ async fn local_service_covers_mocked_bootstrap_assets_diagnostics_and_embed() {
         .await
         .expect("mocked embed");
     assert_eq!(embedded.model_id, "bge-m3");
-    assert_eq!(embedded.dimensions, 3);
+    assert_eq!(embedded.dimensions, 1024);
     assert_eq!(embedded.vectors.len(), 2);
 
     let seen = state.requests.lock().expect("requests");
@@ -330,7 +330,7 @@ async fn ollama_embed(
     remember(&state, "/api/embed", &headers, body);
     Json(json!({
         "model": "bge-m3",
-        "embeddings": [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        "embeddings": [vec![0.1; 1024], vec![0.2; 1024]]
     }))
 }
 

--- a/tests/raw_coverage/tools_approval_channels_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/tools_approval_channels_raw_coverage_e2e.rs
@@ -481,7 +481,7 @@ async fn mock_backend(request: Request) -> Response {
     let payload = match (method, path.as_str()) {
         (Method::GET, "/auth/me") => json!({
             "success": true,
-            "user": {
+            "data": {
                 "id": "user-e2e",
                 "telegramId": "telegram-user-1",
                 "discord_id": "discord-user-1"


### PR DESCRIPTION
## Summary

- Route local chat, prompts, summaries, and autocomplete through TinyAgents `ChatModel`.
- Route Ollama embeddings through TinyAgents `OllamaEmbeddingModel`.
- Move Ollama/LM Studio endpoint and auth intelligence into TinyAgents.
- Remove 500+ lines of duplicate local provider wire types and response parsing.

## Problem

OpenHuman maintained parallel Ollama and LM Studio inference clients despite TinyAgents already owning the provider-neutral model and embedding transports. This duplicated authentication, endpoint normalization, reasoning parsing, usage handling, and error behavior while keeping local inference coupled to the application core.

## Solution

OpenHuman now resolves configuration and delegates out-of-process inference over local HTTP to TinyAgents. Lifecycle and model-catalog administration remain in OpenHuman for now. Depends on tinyhumansai/tinyagents#79.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines are exercised by existing inference tests plus the new TinyAgents provider constructor test; CI coverage is authoritative
- [x] N/A: behaviour-only change; no coverage-matrix feature rows added, removed, or renamed
- [x] N/A: no affected feature IDs were added or removed
- [x] No new external network dependencies introduced; inference continues to use configured local HTTP endpoints
- [x] N/A: no release-manual smoke surface changed
- [x] N/A: no tracking issue supplied; dependency PR is linked below

## Impact

Desktop/core local inference keeps its existing RPC surface and configuration. Local chat and embeddings now share TinyAgents transport behavior. No migration is required.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: tinyhumansai/tinyagents#79; migrate remaining local runtime lifecycle/catalog administration separately

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `inference-rpc-cutover`
- Commit SHA: `10107e57ebef1a34ba98229df2958c080bbf5a90`

### Validation Run

- [x] N/A: frontend formatting unchanged
- [x] N/A: TypeScript unchanged
- [x] Focused tests: `cargo test local_runtime_presets_normalize_endpoint_and_model --lib` in TinyAgents
- [x] Rust fmt/check (if changed): `cargo fmt --all`; `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml`
- [x] N/A: Tauri unchanged

### Validation Blocked

- `command:` OpenHuman focused inference test binary final link
- `error:` no compiler error; stopped after prolonged resource-heavy linking once full `cargo check` passed
- `impact:` CI will run the authoritative changed-file Rust tests and coverage gate

### Behavior Changes

- Intended behavior change: local model and embedding calls use TinyAgents provider clients
- User-visible effect: none intended; errors and reasoning parsing become consistent with the harness path

### Parity Contract

- Legacy behavior preserved: public RPC methods, model selection, scheduler gating, bootstrap, and status updates
- Guard/fallback/dispatch parity checks: disabled-runtime and empty-input guards remain host-side; lifecycle/model availability checks remain unchanged

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None
- Canonical PR: This PR
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added unified local model inference across supported LM Studio and Ollama configurations.
  - Improved local embedding support, including automatic dimension selection for supported models.
  - Token usage information is now captured when available.

- **Improvements**
  - Local chat and generation now use consistent request handling and response validation.
  - Empty responses are handled consistently according to configuration.
  - Message conversion now preserves tool-message trust settings safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->