### PR TITLE
fix(appimage): unblock release smoke by relaxing the userns sysctl

### DIFF
--- a/scripts/release/test-strip-appimage-rpaths.sh
+++ b/scripts/release/test-strip-appimage-rpaths.sh
@@ -571,8 +571,23 @@ printf '%s\n' \
   '  cp "$4" "$APPARMOR_PROFILE_SNAPSHOT"' \
   'fi' \
   >"$APPARMOR_BIN/sudo"
-chmod +x "$APPARMOR_BIN/apparmor_parser" "$APPARMOR_BIN/sudo"
+# Stand in for a restricted Ubuntu 24.04 host so the sysctl branch is exercised
+# deterministically on any development machine, including ones with no sysctl
+# key of that name at all.
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'if [ "${1:-}" = "-n" ]; then' \
+  '  printf "%s\n" "1"' \
+  '  exit 0' \
+  'fi' \
+  'exit 0' \
+  >"$APPARMOR_BIN/sysctl"
+chmod +x \
+  "$APPARMOR_BIN/apparmor_parser" \
+  "$APPARMOR_BIN/sudo" \
+  "$APPARMOR_BIN/sysctl"
 export APPARMOR_RECORD APPARMOR_PROFILE_SNAPSHOT
+USERNS_SYSCTL="kernel.apparmor_restrict_unprivileged_userns"
 PATH="$APPARMOR_BIN:$PATH" install_smoke_userns_profile \
   "$RUNTIME_COMPLETE" "$APPARMOR_PROFILE" \
   || fail "install_smoke_userns_profile rejected the fixture AppDir"
@@ -610,12 +625,16 @@ set -e
 [ "$apparmor_smoke_status" -eq 37 ] \
   || fail "AppArmor wrapper did not preserve smoke failure status 37"
 printf '%s\n' \
+  "--non-interactive sysctl -q -w $USERNS_SYSCTL=0" \
   "--non-interactive apparmor_parser --replace $APPARMOR_PROFILE" \
   "smoke" \
   "--non-interactive apparmor_parser --remove $APPARMOR_PROFILE" \
+  "--non-interactive sysctl -q -w $USERNS_SYSCTL=1" \
   >"$WORK/apparmor-expected-order"
 cmp -s "$WORK/apparmor-expected-order" "$APPARMOR_RECORD" \
   || fail "AppArmor profile was not loaded before and removed after a failing smoke"
+[ ! -e "$APPARMOR_PROFILE.sysctl" ] \
+  || fail "userns sysctl state file survived a failing smoke"
 
 APPARMOR_TERM_RECORD="$WORK/apparmor-term-command-record"
 APPARMOR_TERM_MARKER="$WORK/apparmor-term-smoke-started"
@@ -665,13 +684,60 @@ set -e
 [ "$apparmor_term_status" -eq 143 ] \
   || fail "AppArmor TERM fixture exited $apparmor_term_status instead of 143"
 printf '%s\n' \
+  "--non-interactive sysctl -q -w $USERNS_SYSCTL=0" \
   "--non-interactive apparmor_parser --replace $APPARMOR_PROFILE" \
   "smoke-start" \
   "--non-interactive apparmor_parser --remove $APPARMOR_PROFILE" \
+  "--non-interactive sysctl -q -w $USERNS_SYSCTL=1" \
   >"$WORK/apparmor-term-expected-order"
 cmp -s "$WORK/apparmor-term-expected-order" "$APPARMOR_TERM_RECORD" \
   || fail "AppArmor profile was not removed exactly once after TERM"
+[ ! -e "$APPARMOR_PROFILE.sysctl" ] \
+  || fail "userns sysctl state file survived a TERM-interrupted smoke"
 echo "[test-rpaths] ok: CI smoke grants userns only to the extracted executable"
+
+# The sysctl toggle must be a no-op on hosts that are already permissive or
+# that have no AppArmor userns restriction at all, so the release smoke never
+# needs sudo outside the restricted-Ubuntu case it exists for.
+USERNS_NOOP_BIN="$WORK/userns-noop-bin"
+USERNS_NOOP_RECORD="$WORK/userns-noop-command-record"
+USERNS_NOOP_STATE="$WORK/userns-noop.sysctl"
+mkdir -p "$USERNS_NOOP_BIN"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "%s\n" "$*" >>"$USERNS_NOOP_RECORD"' \
+  >"$USERNS_NOOP_BIN/sudo"
+chmod +x "$USERNS_NOOP_BIN/sudo"
+export USERNS_NOOP_RECORD
+for permissive_value in 0 ""; do
+  : >"$USERNS_NOOP_RECORD"
+  rm -f "$USERNS_NOOP_STATE"
+  if [ -n "$permissive_value" ]; then
+    printf '%s\n' \
+      '#!/usr/bin/env bash' \
+      '[ "${1:-}" = "-n" ] && printf "%s\n" "0"' \
+      'exit 0' \
+      >"$USERNS_NOOP_BIN/sysctl"
+  else
+    # No such key on this host: sysctl exits non-zero and prints nothing.
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 1' \
+      >"$USERNS_NOOP_BIN/sysctl"
+  fi
+  chmod +x "$USERNS_NOOP_BIN/sysctl"
+  PATH="$USERNS_NOOP_BIN:$PATH" \
+    relax_smoke_userns_restriction "$USERNS_NOOP_STATE" >/dev/null \
+    || fail "relax_smoke_userns_restriction failed on a permissive host"
+  [ ! -s "$USERNS_NOOP_RECORD" ] \
+    || fail "relax_smoke_userns_restriction used sudo on a permissive host"
+  [ ! -e "$USERNS_NOOP_STATE" ] \
+    || fail "relax_smoke_userns_restriction recorded state it never changed"
+  PATH="$USERNS_NOOP_BIN:$PATH" \
+    restore_smoke_userns_restriction "$USERNS_NOOP_STATE" >/dev/null \
+    || fail "restore_smoke_userns_restriction failed without recorded state"
+  [ ! -s "$USERNS_NOOP_RECORD" ] \
+    || fail "restore_smoke_userns_restriction used sudo without recorded state"
+done
+echo "[test-rpaths] ok: userns sysctl toggle is a no-op on permissive hosts"
 
 assert_runtime_layout_rejected missing-anylinux \
   "missing anylinux.so" remove_anylinux

--- a/scripts/release/validate-appimage-runtime.sh
+++ b/scripts/release/validate-appimage-runtime.sh
@@ -10,9 +10,12 @@
 # Env:
 #   APPIMAGE_RUNTIME_SMOKE — set to 1 to require the bounded Xvfb startup smoke;
 #                            otherwise only static final-artifact checks run
-#   APPIMAGE_RUNTIME_APPARMOR_USERNS — set to 1 on Ubuntu 24.04 CI to load a
-#                            temporary, per-executable AppArmor profile granting
-#                            Chromium's sandbox access to user namespaces
+#   APPIMAGE_RUNTIME_APPARMOR_USERNS — set to 1 on Ubuntu 24.04 CI to give
+#                            Chromium's sandbox access to user namespaces for
+#                            the smoke window: relaxes
+#                            kernel.apparmor_restrict_unprivileged_userns (and
+#                            restores it afterwards) and loads a temporary,
+#                            per-executable AppArmor profile
 
 set -euo pipefail
 
@@ -208,6 +211,67 @@ smoke_extracted_apprun() {
   echo "[appimage-runtime] Application remained alive for the 15-second startup window"
 }
 
+# Ubuntu 23.10+ (the hosted ubuntu-24.04 runner included) sets
+# `kernel.apparmor_restrict_unprivileged_userns=1`, which denies unprivileged
+# user-namespace creation to every *unconfined* process on the box. Chromium's
+# zygote needs one, so CEF aborts during startup with
+# `FATAL:zygote_host_impl_linux.cc] No usable sandbox!` and the smoke sees exit
+# 133 (SIGTRAP) instead of the expected 124 (still alive at the timeout).
+#
+# `install_smoke_userns_profile` below is Chromium's second documented remedy —
+# a per-executable AppArmor profile carrying `userns,`. It loads successfully
+# but never takes effect here, because the profile attaches by execve path and
+# the sharun launcher runs the app through the AppDir's bundled dynamic loader
+# rather than exec'ing `shared/bin/OpenHuman` directly (Chromium then re-execs
+# `/proc/self/exe` for the zygote). Toggling the sysctl is Chromium's first
+# documented remedy and is path-independent, so it cannot miss the way the
+# profile attachment does. The AppArmor profile is retained alongside it: it is
+# harmless, and it keeps the narrower per-executable grant in place for hosts
+# where the sysctl is unavailable.
+#
+# The original value is restored after the smoke window so the runner is left
+# exactly as it was found.
+SMOKE_USERNS_SYSCTL="kernel.apparmor_restrict_unprivileged_userns"
+
+smoke_userns_sysctl_value() {
+  sysctl -n "$SMOKE_USERNS_SYSCTL" 2>/dev/null || true
+}
+
+relax_smoke_userns_restriction() {
+  local previous_file="$1"
+  local current
+  current="$(smoke_userns_sysctl_value)"
+
+  if [ -z "$current" ]; then
+    echo "[appimage-runtime] $SMOKE_USERNS_SYSCTL is absent; unprivileged user namespaces are already unrestricted"
+    return 0
+  fi
+  if [ "$current" = "0" ]; then
+    echo "[appimage-runtime] $SMOKE_USERNS_SYSCTL is already 0; leaving it unchanged"
+    return 0
+  fi
+
+  command -v sudo >/dev/null 2>&1 \
+    || { runtime_validation_error "sudo is required to relax $SMOKE_USERNS_SYSCTL for the AppImage smoke"; return 1; }
+  sudo --non-interactive sysctl -q -w "$SMOKE_USERNS_SYSCTL=0" \
+    || { runtime_validation_error "could not relax $SMOKE_USERNS_SYSCTL for the AppImage smoke"; return 1; }
+
+  printf '%s\n' "$current" >"$previous_file"
+  echo "[appimage-runtime] Relaxed $SMOKE_USERNS_SYSCTL: $current -> 0 for the smoke window"
+}
+
+restore_smoke_userns_restriction() {
+  local previous_file="$1"
+  [ -s "$previous_file" ] || return 0
+
+  local previous
+  previous="$(cat "$previous_file")"
+  rm -f "$previous_file"
+  sudo --non-interactive sysctl -q -w "$SMOKE_USERNS_SYSCTL=$previous" \
+    || { runtime_validation_error "could not restore $SMOKE_USERNS_SYSCTL to $previous"; return 1; }
+  echo "[appimage-runtime] Restored $SMOKE_USERNS_SYSCTL to $previous"
+}
+
 install_smoke_userns_profile() {
   local appdir="$1"
   local profile_file="$2"
@@ -248,6 +312,8 @@ smoke_extracted_apprun_with_userns() {
   local log_file="$3"
   local profile_file="$4"
   local profile_loaded=0
+  # Derived rather than passed so the four-argument contract is unchanged.
+  local userns_sysctl_file="$profile_file.sysctl"
   local previous_hup_trap previous_int_trap previous_term_trap
   previous_hup_trap="$(trap -p HUP)"
   previous_int_trap="$(trap -p INT)"
@@ -266,6 +332,8 @@ smoke_extracted_apprun_with_userns() {
       remove_smoke_userns_profile "$profile_file" \
         || echo "[appimage-runtime] ERROR: AppArmor cleanup failed after smoke interruption" >&2
     fi
+    restore_smoke_userns_restriction "$userns_sysctl_file" \
+      || echo "[appimage-runtime] ERROR: $SMOKE_USERNS_SYSCTL restore failed after smoke interruption" >&2
   }
 
   interrupt_smoke_with_userns() {
@@ -278,7 +346,15 @@ smoke_extracted_apprun_with_userns() {
   trap 'interrupt_smoke_with_userns 130' INT
   trap 'interrupt_smoke_with_userns 143' TERM
 
+  rm -f "$userns_sysctl_file"
+  if ! relax_smoke_userns_restriction "$userns_sysctl_file"; then
+    restore_smoke_signal_traps
+    return 1
+  fi
+
   if ! install_smoke_userns_profile "$appdir" "$profile_file"; then
+    restore_smoke_userns_restriction "$userns_sysctl_file" \
+      || echo "[appimage-runtime] ERROR: $SMOKE_USERNS_SYSCTL restore failed after AppArmor setup failure" >&2
     restore_smoke_signal_traps
     return 1
   fi
@@ -299,10 +375,18 @@ smoke_extracted_apprun_with_userns() {
     remove_status=$?
   fi
 
+  local restore_status
+  if restore_smoke_userns_restriction "$userns_sysctl_file"; then
+    restore_status=0
+  else
+    restore_status=$?
+  fi
+
   restore_smoke_signal_traps
-  # Preserve the original smoke failure even if profile cleanup also fails.
+  # Preserve the original smoke failure even if cleanup also fails.
   [ "$smoke_status" -eq 0 ] || return "$smoke_status"
-  return "$remove_status"
+  [ "$remove_status" -eq 0 ] || return "$remove_status"
+  return "$restore_status"
 }
 
 validate_final_appimage() (


### PR DESCRIPTION
> **Release-blocking.** Base is **`release`**, not `main`. Every Release Production run has failed on the Linux desktop job since #5189 reached `release`.
> **This must also be cherry-picked to `main`** so `main` does not regress the moment it is promoted again.
> Failed run: https://github.com/tinyhumansai/openhuman/actions/runs/30361949794 (job `Build desktop matrix / Desktop: ubuntu`, `release` @ `9c1e2e65`)

## Summary

- Unblocks Release Production: the Linux `x86_64` AppImage startup smoke added by #5189 has **never** passed and fails deterministically with exit 133 instead of the expected 124.
- Root cause is Ubuntu 23.10+'s `kernel.apparmor_restrict_unprivileged_userns=1`, which denies unprivileged user namespaces to unconfined processes, so CEF's zygote aborts with `No usable sandbox!`.
- #5189's mitigation — a per-executable AppArmor profile — loads successfully but never takes effect, because AppArmor attaches profiles by execve path and the sharun launcher does not exec `shared/bin/OpenHuman` directly.
- Applies Chromium's other documented remedy instead: relax the sysctl for the smoke window and restore it afterwards. Path-independent, so it cannot miss the way profile attachment does.
- No workflow change and no change to the validator's public contract; the fix is entirely inside `validate-appimage-runtime.sh` and its fixture tests.

## Problem

The `Strip host graphics libs and validate final AppImage` step fails on `ubuntu` (`x86_64`). The AppImage itself is fine — it builds, signs, bundles `libcef.so`, and boots far enough to log `[cef-startup]`. What fails is the new bounded startup smoke:

```
[appimage-runtime] AppImage startup smoke failed (status 133):
[appimage-runtime]   unshare: write failed /proc/self/uid_map: Operation not permitted
[appimage-runtime]   ...
[appimage-runtime]   [59873:59873:...:FATAL:content/browser/zygote_host/zygote_host_impl_linux.cc:128]
                     No usable sandbox! If you are running on Ubuntu 23.10+ or another Linux distro
                     that has disabled unprivileged user namespaces with AppArmor ...
[appimage-runtime]   Trace/breakpoint trap (core dumped)
```

`smoke_extracted_apprun` treats `timeout`'s status `124` as success. CEF dies on `SIGTRAP` about one second in, so the smoke sees `133` and fails the release.

### This is a regression from #5189, and the smoke has never passed

| Run | Head SHA | Result |
| --- | --- | --- |
| [30240103654](https://github.com/tinyhumansai/openhuman/actions/runs/30240103654) | `e3a7f5217` | ✅ last green — pre-#5189 script |
| [30242402885](https://github.com/tinyhumansai/openhuman/actions/runs/30242402885) | `2e5b5e7b2` — *Promote main → release (#5203)*, which carried #5189 | ❌ |
| [30351759443](https://github.com/tinyhumansai/openhuman/actions/runs/30351759443) | `a40fbb79d` | ❌ |
| [30361949794](https://github.com/tinyhumansai/openhuman/actions/runs/30361949794) | `9c1e2e657` | ❌ |

The failure is byte-identical across all three. #5189 merged into `main`, where the production AppImage build does not run, so this was never exercised before promotion. `ubuntu-arm64` is unaffected only because `build-desktop.yml` enables the smoke for `x86_64` alone.

### Why #5189's AppArmor profile does not work

`install_smoke_userns_profile` implements Chromium's per-executable-profile remedy against `$appdir/shared/bin/OpenHuman`. The profile loads — the log confirms `Loaded temporary AppArmor userns profile for: .../shared/bin/OpenHuman` — yet `unshare` is still denied. AppArmor attaches profiles by the **execve'd path**, and the sharun launcher runs the app through the AppDir's bundled dynamic loader rather than exec'ing `shared/bin/OpenHuman`; Chromium then re-execs `/proc/self/exe` for the zygote. The confinement target never matches, so the `userns,` grant is never in force.

## Solution

In `scripts/release/validate-appimage-runtime.sh`:

- Add `relax_smoke_userns_restriction` / `restore_smoke_userns_restriction`, which set `kernel.apparmor_restrict_unprivileged_userns=0` for the smoke window and restore the host's original value afterwards — including on the existing `HUP`/`INT`/`TERM` interrupt path and when AppArmor setup itself fails. The runner is left exactly as it was found.
- The toggle is a **no-op** when the key is already `0` or absent on the host, so it never reaches for `sudo` outside the restricted-Ubuntu case it exists for.
- The AppArmor profile is **retained** alongside the sysctl: it is harmless, and it keeps the narrower per-executable grant in place for hosts where the sysctl is unavailable.
- The four-argument contract of `smoke_extracted_apprun_with_userns` is unchanged; the saved-state file is derived as `$profile_file.sysctl`. **No change to `build-desktop.yml` is required.**

Resulting privileged-command sequence, pinned by fixtures:

```
sudo sysctl -q -w …userns=0 → apparmor_parser --replace → smoke → apparmor_parser --remove → sudo sysctl -q -w …userns=<original>
```

### Rejected alternative: `OPENHUMAN_CEF_NO_SANDBOX` / `--no-sandbox`

The smoke currently *unsets* `OPENHUMAN_CEF_NO_SANDBOX`, so setting it looks like the obvious fix. It is not:

- The variable is `#[cfg(debug_assertions)]`-gated in `app/src-tauri/src/lib.rs` (`forced` is hard-coded `false` in release builds, deliberately, per the security review on #2875). It is **inert in the release AppImage**.
- A `--no-sandbox` argv flag would not reach CEF either: the CEF command line is built explicitly via `command_line_args()` rather than forwarded from process argv.

Keeping the sandbox enabled is also the better outcome — the smoke goes on exercising the real production configuration rather than a weakened one.

## Impact

- **CI/release only.** No shipped code changes: no Rust, no frontend, no bundling behaviour, no change to the AppImage bytes.
- Security posture is unchanged in the product. The sysctl is relaxed only on the ephemeral hosted runner, only for the ~15-second smoke window, and is restored afterwards; Chromium's sandbox stays **enabled** in the smoked app.
- If a maintainer needs a second escape hatch, `APPIMAGE_RUNTIME_SMOKE: '0'` for `x86_64` in `.github/workflows/build-desktop.yml` disables the gate in one line.

### Verification

`scripts/release/test-strip-appimage-rpaths.sh` is Linux-only and skips on macOS (`SKIP: patchelf not installed`), so the new logic was additionally driven directly against the same command fakes:

- restricted host → relax, save `1`, restore `1`, state file removed;
- permissive host (`0`) → no `sudo`, no state file;
- absent sysctl key → no `sudo`, no state file;
- full wrapper ordering, preservation of a failing smoke's status `37`, and no leaked state.

The observed sequence matches the fixture expectations exactly. **This cannot be validated end-to-end by normal PR CI** — see the note below.

## Related

- Regressed by: #5189 (reached `release` via promote #5203)
- Follow-up PR(s)/TODOs:
  - **Cherry-pick this commit to `main`** so the next promotion does not reintroduce the failure.
  - Consider whether `install_smoke_userns_profile` should be dropped entirely once a green run confirms the sysctl is the effective remedy; if kept, retarget it at the sharun execve path so the grant actually attaches.
  - Consider running the production AppImage build on PRs that touch `scripts/release/**`, so a smoke gate cannot merge unexercised again.
- Closes:

## Verification by a maintainer is required

Regular PR CI does **not** run the production Linux AppImage build, so this PR's checks cannot prove the fix. **A maintainer must re-dispatch the `Release Production` workflow** (against `release`) to confirm the `Desktop: ubuntu` job now reaches `status 124` and passes.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — `test-strip-appimage-rpaths.sh`: updated both expected privileged-command-order fixtures (failing-smoke and `TERM`-interrupt paths), added no-op coverage for permissive-host and absent-key, and assertions that the saved-state file never leaks.
- [x] **Diff coverage ≥ 80%** — changed lines are Bash in `scripts/release/**`, covered by the `test-strip-appimage-rpaths.sh` fixture suite. `diff-cover` over Vitest + cargo-llvm-cov does not instrument shell; no TS/Rust lines changed.
- [x] Coverage matrix updated — `N/A: CI/release tooling change, no product feature row affected.`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no feature IDs affected.`
- [x] No new external network dependencies introduced — no new downloads or endpoints; `sysctl`/`sudo` are already required by this script.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: restores the intended behaviour of an existing automated release gate; the manual checklist is unchanged.`
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue; this PR is driven by the failed release run linked above.`

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/appimage-smoke-userns-DAPPIMG-39513`
- Commit SHA: `0be92171b`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no files under app/ changed.`
- [x] `pnpm typecheck` — `N/A: no TypeScript changed.`
- [x] Focused tests: `bash -n` on both scripts; new `relax`/`restore` functions and `smoke_extracted_apprun_with_userns` driven against the fixture command fakes (restricted / permissive / absent-key / wrapper ordering / failure-status preservation). `scripts/release/test-strip-appimage-rpaths.sh` skips on macOS (`patchelf` is Linux-only) and runs in CI.
- [x] Rust fmt/check (if changed): `N/A: no Rust changed.`
- [x] Tauri fmt/check (if changed): `N/A: no Tauri code changed.`

### Validation Blocked

- `command:` `Release Production` → `Build desktop matrix / Desktop: ubuntu`
- `error:` not runnable locally — Linux-only AppImage bundling plus an Xvfb/AppArmor runtime smoke; this work was done on macOS, and the job is not triggered by regular PR CI.
- `impact:` the end-to-end fix can only be confirmed by a maintainer re-dispatching `Release Production`. Diagnosis was derived from the full failing log and the scripts; the new shell logic is verified locally against command fakes.

### Behavior Changes

- Intended behavior change: during the release AppImage smoke only, unprivileged user namespaces are permitted on the runner so CEF's zygote sandbox can initialise; the host value is restored immediately afterwards.
- User-visible effect: none. No shipped artifact changes.

### Parity Contract

- Legacy behavior preserved: the AppArmor profile install/remove path, the four-argument signature of `smoke_extracted_apprun_with_userns`, the `124`-means-alive success rule, the forbidden-loader-diagnostic greps, secret scrubbing, and signal-trap restore are all unchanged.
- Guard/fallback/dispatch parity checks: the sysctl toggle is skipped entirely when the key reads `0` or is absent, so non-Ubuntu and already-permissive hosts follow exactly the previous code path; restore is idempotent and runs on the success, failure, AppArmor-setup-failure, and interrupt paths.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A
