### PR TITLE
fix(appimage): give the release startup smoke a D-Bus session bus

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -183,7 +183,7 @@ jobs:
             libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
             libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
             libgbm1 libpango-1.0-0 libcairo2 libatspi2.0-0 libxshmfence1 libu2f-udev \
-            xvfb
+            xvfb dbus dbus-x11
           if [ "$MATRIX_TARGET" = "x86_64-unknown-linux-gnu" ] \
             && ! command -v apparmor_parser >/dev/null 2>&1; then
             sudo apt-get install -y apparmor

--- a/scripts/release/validate-appimage-runtime.sh
+++ b/scripts/release/validate-appimage-runtime.sh
@@ -158,6 +158,52 @@ smoke_extracted_apprun() {
     [ -n "$secret_name" ] && unset_args+=(-u "$secret_name")
   done < <(compgen -v OPENAI_ || true)
 
+  # ── D-Bus session bus for the smoke window ─────────────────────────────────
+  #
+  # A real desktop user always launches the AppImage inside a session that has a
+  # D-Bus session bus; a CI runner does not. `tauri-plugin-single-instance` calls
+  # `zbus::blocking::connection::Builder::session().unwrap()` in its `setup()`,
+  # so with no usable bus it panics before any window exists:
+  #
+  #   thread 'main' panicked at plugins/single-instance/src/platform_impl/linux.rs:57
+  #   called `Result::unwrap()` on an `Err` value:
+  #     Address("unsupported transport 'disabled'")
+  #
+  # ...which is exactly how the Release Production ubuntu smoke failed (exit 101,
+  # actions/runs/30393949588). Chromium logs the same underlying condition as
+  # "Failed to connect to the bus: Could not parse server address".
+  #
+  # `app/scripts/e2e-run-session.sh` already solves this for the desktop e2e
+  # runner by starting a bus with `dbus-launch`; the AppImage smoke never got the
+  # same treatment. Wrapping in `dbus-run-session` is the modern equivalent and
+  # needs no explicit teardown — the bus dies with the wrapped command, so the
+  # 15s `timeout` still bounds everything.
+  #
+  # Echo the inherited value first: whether it arrives as `disabled`, `disabled:`
+  # or unset changes which code path the app takes, and the failing log gave us
+  # no way to tell.
+  echo "[appimage-runtime] Inherited DBUS_SESSION_BUS_ADDRESS=${DBUS_SESSION_BUS_ADDRESS:-<unset>}"
+
+  # Always drop the inherited value: the wrapper below supplies a real one, and
+  # if no wrapper is available a poisoned `disabled` must not reach the app —
+  # with the variable absent the app's own `can_register_single_instance_plugin()`
+  # probe falls back to inspecting `$XDG_RUNTIME_DIR/bus`, whereas the literal
+  # string `disabled` is precisely what zbus refuses to parse.
+  unset_args+=(-u DBUS_SESSION_BUS_ADDRESS)
+
+  local -a dbus_wrapper=()
+  if command -v dbus-run-session >/dev/null 2>&1; then
+    dbus_wrapper=(dbus-run-session --)
+    echo "[appimage-runtime] Providing a session bus via dbus-run-session"
+  elif command -v dbus-launch >/dev/null 2>&1; then
+    # Older images ship dbus-launch (from dbus-x11) but not dbus-run-session.
+    dbus_wrapper=(dbus-launch --exit-with-session)
+    echo "[appimage-runtime] Providing a session bus via dbus-launch"
+  else
+    echo "[appimage-runtime] WARNING: neither dbus-run-session nor dbus-launch found;" \
+      "smoking without a session bus (single-instance will be skipped)"
+  fi
+
   local status
   if (
     cd "$foreign_cwd"
@@ -170,6 +216,7 @@ smoke_extracted_apprun() {
         XDG_CACHE_HOME="$smoke_cache" \
         OPENHUMAN_CEF_PREWARM=0 \
         OPENHUMAN_DISABLE_GPU=1 \
+        ${dbus_wrapper[@]+"${dbus_wrapper[@]}"} \
         "$appdir/AppRun"
   ) >"$log_file" 2>&1; then
     status=0
@@ -195,6 +242,17 @@ smoke_extracted_apprun() {
   fi
   if grep -Eiq 'error while loading shared libraries' "$log_file"; then
     forbidden=1
+  fi
+
+  # Name this failure explicitly. It exits 101 like any other Rust panic, and the
+  # generic "status 101" message sent the last investigation looking at the
+  # non-fatal `libcef.so => not found` ldd lines instead of the actual cause.
+  if grep -Eq "unsupported transport 'disabled'|single-instance/src/platform_impl/linux\.rs" \
+    "$log_file"; then
+    forbidden=1
+    echo "[appimage-runtime] Detected the single-instance D-Bus panic — the smoke" \
+      "environment has no usable session bus. Check the dbus-run-session wrapper" \
+      "above and that 'dbus'/'dbus-x11' are installed on the runner." >&2
   fi
 
   # The desktop process is expected to remain alive until timeout ends the


### PR DESCRIPTION
## Summary

- Wrap the AppImage startup smoke in `dbus-run-session` (falling back to `dbus-launch`) so `tauri-plugin-single-instance` can initialise in the headless CI environment instead of panicking.
- Always drop the inherited `DBUS_SESSION_BUS_ADDRESS` before the smoke, so a poisoned `disabled` value can never reach the app.
- Install `dbus` / `dbus-x11` on the ubuntu builders so the wrapper is guaranteed present rather than silently degrading.
- Detect this specific panic explicitly, and echo the inherited bus address, so a recurrence is self-diagnosing.
- No Rust change — the existing single-instance guard stays as the runtime safety net.

## Problem

Release Production fails in **Build desktop matrix / Desktop: ubuntu**: https://github.com/tinyhumansai/openhuman/actions/runs/30393949588 (branch `release` @ `42cdf77e`).

The userns fix from #5251 / #5252 **is working** — the log shows `Relaxed kernel.apparmor_restrict_unprivileged_userns: 1 -> 0` and the temporary AppArmor profile loading. The smoke now dies for a different reason, exit 101:

```
[appimage-runtime]   [ERROR:dbus/bus.cc:405] Failed to connect to the bus:
                     Could not parse server address: Unknown address type
[appimage-runtime]   thread 'main' (60614) panicked at
                     plugins/single-instance/src/platform_impl/linux.rs:57:18:
[appimage-runtime]   called `Result::unwrap()` on an `Err` value:
                     Address("unsupported transport 'disabled'")
```

`tauri-plugin-single-instance` calls `zbus::blocking::connection::Builder::session().unwrap()` in its `setup()`, so with no usable session bus it takes the process down before any window exists.

**The `libcef.so => not found` ldd lines in that job are not the failure.** The app reached `main()` and printed its own `[startup] platform`, `[cef-profile]`, `[deep-link-ipc]` and `[cef-startup]` logs, so CEF loaded fine. Calling this out because it cost the previous investigation time.

## Solution

A real desktop user always launches the AppImage inside a session that has a D-Bus session bus; a CI runner does not. This repo already solves the identical problem for the desktop e2e runner — [`app/scripts/e2e-run-session.sh`](../app/scripts/e2e-run-session.sh) starts a bus with `dbus-launch` when the address is empty or matches `^disabled`, and its comment cites this exact panic. The AppImage smoke simply never got the same treatment.

So `smoke_extracted_apprun()` now:

1. **Echoes the inherited `DBUS_SESSION_BUS_ADDRESS`** before running (see the open question below).
2. **Always unsets it**, so even on the no-wrapper path a literal `disabled` cannot reach the app. With the variable absent, the app's own `can_register_single_instance_plugin()` probe falls back to inspecting `$XDG_RUNTIME_DIR/bus`; the string `disabled` is precisely what zbus refuses to parse.
3. **Wraps `AppRun` in `dbus-run-session --`**, falling back to `dbus-launch --exit-with-session`, warning if neither exists. The bus dies with the wrapped command, so no teardown is needed, the 15s `timeout` still bounds the run, and the required exit-124 contract is unchanged.
4. **Names this failure** in the forbidden-pattern check, since it exits 101 like any other Rust panic.

`dbus` / `dbus-x11` are added to the ubuntu apt install so step 3 takes the real path.

### An open question I could not close, flagged deliberately

The app **already guards this case**: `can_register_single_instance_plugin()` (`app/src-tauri/src/lib.rs:2042`) skips plugin registration when the bus address is unsupported, and `dbus_address_is_supported("disabled")` correctly returns `false`. I confirmed the guard is present at the failing commit `42cdf77e`, not only on `main`.

Yet its warn line `[single-instance] D-Bus session bus unreachable` appears **nowhere** in the 33,503-line run log — so the guard evidently returned `true`. The only way that happens is `DBUS_SESSION_BUS_ADDRESS` being *unset* while `$XDG_RUNTIME_DIR/bus` exists, but then zbus could never produce the string `disabled`. I could not reconcile those two facts from the logs, and this is a Linux CI AppImage failure that cannot be reproduced on a Mac.

This fix therefore does not depend on knowing which it is — it makes the smoke environment correct either way. The new echo line is there so the next run answers the question. If it turns out the variable *is* unset with a stale `$XDG_RUNTIME_DIR/bus` socket present, then the guard's `None => xdg_runtime_bus_socket_exists` branch is too optimistic (a socket file can exist without a live bus) and should be tightened in a follow-up — but I did not want to speculatively change Rust I cannot compile-check here during a release incident.

## Submission Checklist

- [x] Tests added or updated — `N/A: CI-only shell/workflow change.` The script's fixture test `scripts/release/test-strip-appimage-rpaths.sh` covers the static-validation path and `SKIP`s without `patchelf`; the smoke path itself requires a real Linux AppImage and is exercised by the release job.
- [x] **Diff coverage ≥ 80%** — `N/A: no Vitest/Rust source changed (shell script + workflow YAML only).`
- [x] Coverage matrix updated — `N/A: behaviour-only change to a CI validation script.`
- [x] All affected feature IDs listed — `N/A: no feature surface touched.`
- [x] No new external network dependencies introduced — no network use added; `dbus`/`dbus-x11` are distro packages installed alongside the existing ubuntu build deps.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: this changes how the automated smoke runs, not what a human verifies post-release.`
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue; this is a direct fix for the failed run linked above.`

## Impact

- **Platform:** Linux release builds only. Nothing in the shipped artifact changes — the AppImage bytes are identical; only how CI exercises them changes.
- **Verification:** validated locally as far as a Mac allows — `bash -n` clean, and the `${arr[@]+"${arr[@]}"}` idiom proven safe under `set -euo pipefail` on bash 3.2 both empty and filled (a bare `"${arr[@]}"` breaks on bash < 4.4, which this script's `set -u` would trip). The Linux AppImage path itself cannot be run here.
- **A maintainer must re-dispatch Release Production to confirm the fix.** This PR targets `main` only; the release branch will need the usual promotion or a cherry-pick once verified.

## Related

- Failed run: https://github.com/tinyhumansai/openhuman/actions/runs/30393949588
- #5251 / #5252 — userns sysctl relaxation (working; this is the next failure behind it)
- #5189 — sharun paths
- Prior art for this exact panic: `app/scripts/e2e-run-session.sh` (dbus-launch for the desktop e2e runner)
