### PR TITLE
fix(agent): stop the compact→retrieve→re-run infinite loop

### DIFF
--- a/src/openhuman/inference/tokenjuice/tools.rs
+++ b/src/openhuman/inference/tokenjuice/tools.rs
@@ -125,9 +125,19 @@ impl Tool for TokenjuiceRetrieveTool {
 }
 
 fn miss_message(token: &str) -> String {
+    // Deliberately does NOT say "re-run the tool". Re-running regenerates the
+    // same oversized result, which is compacted and offloaded again under a new
+    // token that can be evicted just as fast — so a blind re-run turns one cache
+    // miss into an unbounded compact→retrieve→re-run loop (observed live: a
+    // parent agent re-delegated forever on an evicted subagent result). Tell the
+    // model to proceed with the compacted summary it already has instead.
     format!(
-        "tokenjuice_retrieve: no cached original for token '{token}' \
-         (it may have been evicted; re-run the tool to regenerate it)"
+        "tokenjuice_retrieve: the full original for token '{token}' is no longer cached \
+         (evicted, or from an earlier session). Do NOT re-run the same tool call to \
+         regenerate it — that will produce the same oversized result and be compacted \
+         again. Proceed using the compacted summary already shown above; only if a \
+         specific missing detail is essential, retry with narrower arguments (a tighter \
+         query, filter, or smaller limit) so the result is small enough to keep in full."
     )
 }
 

--- a/src/openhuman/inference/tokenjuice/tools_tests.rs
+++ b/src/openhuman/inference/tokenjuice/tools_tests.rs
@@ -35,3 +35,19 @@ async fn missing_token_is_error() {
     let res2 = tool.execute(json!({})).await.unwrap();
     assert!(res2.is_error);
 }
+
+#[test]
+fn miss_message_does_not_instruct_a_blind_re_run() {
+    // See `miss_message` — "re-run the tool" here is what turned a single
+    // eviction into an unbounded compact→retrieve→re-run loop.
+    let msg = miss_message("deadbeefcafe").to_lowercase();
+    assert!(!msg.contains("re-run the same tool") || msg.contains("do not re-run"));
+    assert!(
+        msg.contains("do not re-run"),
+        "must discourage re-running: {msg}"
+    );
+    assert!(
+        msg.contains("compacted summary"),
+        "must point at the summary: {msg}"
+    );
+}

--- a/src/openhuman/inference/tokenjuice/tools_tests.rs
+++ b/src/openhuman/inference/tokenjuice/tools_tests.rs
@@ -41,11 +41,23 @@ fn miss_message_does_not_instruct_a_blind_re_run() {
     // See `miss_message` — "re-run the tool" here is what turned a single
     // eviction into an unbounded compact→retrieve→re-run loop.
     let msg = miss_message("deadbeefcafe").to_lowercase();
-    assert!(!msg.contains("re-run the same tool") || msg.contains("do not re-run"));
     assert!(
         msg.contains("do not re-run"),
         "must discourage re-running: {msg}"
     );
+    // And must not also say the opposite. The loop this fixes came from an
+    // affirmative instruction, so a message carrying both would read as
+    // permission to re-run while the assertion above still passed. Every
+    // mention of re-running has to be the negated one.
+    let mut cursor = 0;
+    while let Some(found) = msg[cursor..].find("re-run") {
+        let at = cursor + found;
+        assert!(
+            msg[..at].trim_end().ends_with("do not"),
+            "every mention of re-running must be negated, found a bare one at {at}: {msg}"
+        );
+        cursor = at + "re-run".len();
+    }
     assert!(
         msg.contains("compacted summary"),
         "must point at the summary: {msg}"

--- a/src/openhuman/tools/impl/system/retrieve_tool_output.rs
+++ b/src/openhuman/tools/impl/system/retrieve_tool_output.rs
@@ -77,9 +77,21 @@ impl Tool for RetrieveToolOutputTool {
                 );
                 Ok(ToolResult::success(original))
             }
+            // Deliberately does NOT say "re-run the tool". Re-running
+            // regenerates the same oversized result, which is compacted and
+            // offloaded again under a new hash that can be evicted just as fast
+            // — so a blind re-run turns one cache miss into an unbounded
+            // compact→retrieve→re-run loop (observed live: a parent agent
+            // re-delegated forever on an evicted subagent result). Tell the
+            // model to proceed with the compacted summary it already has.
             Ok(None) => Ok(ToolResult::error(format!(
-                "retrieve_tool_output: no cached original for hash '{hash}' \
-                 (it may have been evicted; re-run the tool to regenerate it)"
+                "retrieve_tool_output: the full original for hash '{hash}' is no longer \
+                 cached (evicted, or from an earlier session). Do NOT re-run the same tool \
+                 call to regenerate it — that produces the same oversized result and is \
+                 compacted again. Proceed using the compacted summary already shown above; \
+                 only if a specific missing detail is essential, retry with narrower \
+                 arguments (a tighter query, filter, or smaller limit) so the result is \
+                 small enough to keep in full."
             ))),
             Err(error) => Ok(ToolResult::error(error)),
         }

--- a/src/openhuman/tools/impl/system/retrieve_tool_output_tests.rs
+++ b/src/openhuman/tools/impl/system/retrieve_tool_output_tests.rs
@@ -33,14 +33,26 @@ async fn a_cache_miss_does_not_tell_the_model_to_re_run() {
         .await
         .unwrap()
         .output();
+    let lowered = msg.to_lowercase();
     assert!(
-        !msg.to_lowercase().contains("re-run the tool"),
-        "a miss must not instruct a blind re-run: {msg}"
-    );
-    assert!(
-        msg.to_lowercase().contains("do not re-run"),
+        lowered.contains("do not re-run"),
         "a miss must explicitly discourage re-running: {msg}"
     );
+    // Scan rather than match one phrase. `!contains("re-run the tool")` both
+    // accepts a bare "re-run the same call" elsewhere in the string — which
+    // reads to the model as permission, and is the loop this fixes — and
+    // rejects the perfectly good "Do not re-run the tool". Every mention of
+    // re-running has to be the negated one. Mirrors the assertion in
+    // `inference/tokenjuice/tools_tests.rs`.
+    let mut cursor = 0;
+    while let Some(found) = lowered[cursor..].find("re-run") {
+        let at = cursor + found;
+        assert!(
+            lowered[..at].trim_end().ends_with("do not"),
+            "every mention of re-running must be negated, found a bare one at {at}: {msg}"
+        );
+        cursor = at + "re-run".len();
+    }
     assert!(
         msg.contains("compacted summary"),
         "a miss must point the model at the summary it already has: {msg}"

--- a/src/openhuman/tools/impl/system/retrieve_tool_output_tests.rs
+++ b/src/openhuman/tools/impl/system/retrieve_tool_output_tests.rs
@@ -21,3 +21,28 @@ async fn missing_hash_is_error() {
     let res2 = tool.execute(json!({})).await.unwrap();
     assert!(res2.is_error);
 }
+
+#[tokio::test]
+async fn a_cache_miss_does_not_tell_the_model_to_re_run() {
+    // The loop this guards against: a miss that says "re-run the tool" makes
+    // the agent regenerate the same oversized result, which is compacted and
+    // evicted again — an unbounded compact→retrieve→re-run loop.
+    let tool = RetrieveToolOutputTool::new();
+    let msg = tool
+        .execute(json!({ "hash": "deadbeefcafe" }))
+        .await
+        .unwrap()
+        .output();
+    assert!(
+        !msg.to_lowercase().contains("re-run the tool"),
+        "a miss must not instruct a blind re-run: {msg}"
+    );
+    assert!(
+        msg.to_lowercase().contains("do not re-run"),
+        "a miss must explicitly discourage re-running: {msg}"
+    );
+    assert!(
+        msg.contains("compacted summary"),
+        "a miss must point the model at the summary it already has: {msg}"
+    );
+}


### PR DESCRIPTION
## Summary

Chat could hang forever and never answer. A large tool result is compacted to a summary plus a `retrieve_tool_output(hash)` / `⟦tj:hash⟧` marker, with the original offloaded to the CCR store. When the model later retrieved that hash and the store missed, the error told it to **"re-run the tool to regenerate it"** — so it re-ran, produced the same oversized result, which was compacted and offloaded again under a new hash that missed just as fast. Observed live: a parent agent re-delegated to a subagent forever on an evicted result, burning turns and cost with no reply.

Two changes remove the loop:

- **The retrieve-miss message no longer instructs a blind re-run.** It tells the model the original is gone, to NOT re-run the same call, and to proceed with the compacted summary it already has (retrying only with narrower arguments if a specific detail is essential). The worst case is now a slightly less detailed answer, not an unbounded loop. Applies to both `retrieve_tool_output` and `tokenjuice_retrieve`.
- **`ccr_disk_enabled` now defaults ON.** The in-memory CCR store is FIFO-bounded (256 entries) and lost on restart, so a retrieve footer the model was handed can go stale within a single busy turn. The disk tier (TTL + size-cap gc'd) keeps those originals recoverable, so a compaction footer becomes a promise the store can actually keep. Existing configs that explicitly set `false` are unchanged.

The subagent side (a specialist re-calling a succeeding tool with varied args) is already bounded by the iteration cap; the unbounded behaviour was the parent's re-delegation, which these changes stop.

## Tests

- `retrieve_tool_output`: added `a_cache_miss_does_not_tell_the_model_to_re_run` (asserts the miss discourages re-running and points at the summary). 3 pass.
- `tokenjuice_retrieve`: added `miss_message_does_not_instruct_a_blind_re_run`. 4 pass.
- `openhuman::config` (427), `openhuman::tinyagents::middleware` (51), `tools::implementations::system` (187) — green.

## Validation

Reproduced and confirmed fixed on a live instance: before, the parent run never reached a terminal event and its `delegate_to_integrations_agent` count kept growing; after, delegation is bounded (2), the run reaches `run_completed`, and the user gets a full itemised answer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated missing-result messages to clearly discourage repeating the same retrieval.
  * Guidance now recommends using the available compacted summary or retrying with narrower arguments when necessary.

* **Tests**
  * Added coverage to ensure cache-miss messages do not suggest blindly re-running retrievals and reference the compacted summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #5301
