### PR TITLE
fix(memory): connector-aware recall — re-embed sweep, signature/provider, gmail body, scout memory-first

### DIFF
--- a/src/core/runtime/services.rs
+++ b/src/core/runtime/services.rs
@@ -277,6 +277,10 @@ pub fn start_bootstrap_jobs(services: ServiceSet, config: &Config) {
     if plan.memory_queue {
         log::debug!("[runtime.bootstrap] starting memory queue workers");
         crate::openhuman::memory::queue::start(config.clone());
+        // Resume re-embedding whatever the previous run left without a usable
+        // vector. Those rows are the durable work-list, so a restart — however
+        // the last run ended — is just another trigger.
+        crate::openhuman::memory::store::vector_reembed::ensure_vector_reembed();
     } else {
         log::debug!("[runtime.bootstrap] memory queue workers disabled by ServiceSet");
     }

--- a/src/openhuman/agent/harness/memory_context.rs
+++ b/src/openhuman/agent/harness/memory_context.rs
@@ -42,18 +42,14 @@ pub(crate) async fn build_context(
     let mut context = String::new();
     let mut seen_keys = HashSet::new();
 
-    // Pull relevant memories for this message — routed through the tinyagents
-    // retrieval facade (issue #4249, 09.2) so recall is swappable and emits
-    // `MemoryLoaded`. The facade wraps `Memory::recall` verbatim, so the
-    // rendered `[Memory context]` block stays byte-identical.
-    if let Ok(entries) = crate::openhuman::agent::tinyagents::retriever::recall_through_facade(
-        mem,
-        user_msg,
-        5,
-        crate::openhuman::memory::RecallOpts::default(),
-    )
-    .await
+    // Pull relevant memories for this message. The global namespace goes
+    // through the tinyagents retrieval facade (issue #4249, 09.2) so recall
+    // stays swappable and emits `MemoryLoaded`; connector namespaces
+    // (`skill-*`) are merged in alongside it, because a synced email the user
+    // is asking about is otherwise in the store and unreachable from this turn.
     {
+        let entries =
+            crate::openhuman::memory::auto_recall::recall_with_connectors(mem, user_msg, 5).await;
         let relevant: Vec<_> = entries
             .iter()
             .filter(|e| match e.score {

--- a/src/openhuman/agent/registry/agents/context_scout/prompt.md
+++ b/src/openhuman/agent/registry/agents/context_scout/prompt.md
@@ -30,7 +30,15 @@ read at a glance — and tell it which of the caller's visible tools to call nex
      registry. If a skill clearly fits the request, surface it under
      `recommended_skills` (below) so the orchestrator can run or install it.
    - **Connected integrations** — the Connected Integrations section below tells
-     you which platforms (gmail, notion, slack, …) are actually wired up.
+     you which platforms (gmail, notion, slack, …) are wired up. Their history
+     is **synced into memory** under `skill-<toolkit>` namespaces (e.g.
+     `skill-gmail`, `skill-slack`), so for a question about a connector's past
+     data, **recall memory first**: `memory_recall` with the namespace omitted
+     searches those connector namespaces alongside `global`, and it is faster,
+     cheaper, and works offline. Only recommend a *live* integration fetch (a
+     delegation tool) when memory comes back empty or the request truly needs
+     the very latest, not-yet-synced items — never as the reflexive first move
+     just because the platform is connected.
    - **The web** — `web_search_tool` / `web_fetch` for fresh external facts the
      request genuinely depends on. Skip the web when memory/goals already cover
      it; you are meant to be cheap.

--- a/src/openhuman/agent/registry/agents/context_scout/prompt.rs
+++ b/src/openhuman/agent/registry/agents/context_scout/prompt.rs
@@ -40,9 +40,11 @@ fn render_connected_integrations(integrations: &[ConnectedIntegration]) -> Strin
         return String::new();
     }
     let mut out = String::from(
-        "## Connected Integrations\n\nThese platforms are connected and reachable via the \
-         orchestrator's delegation tools — factor them into the plan when a request needs \
-         live data from one:\n",
+        "## Connected Integrations\n\nThese platforms are connected. Their synced history \
+         already lives in memory under `skill-<toolkit>` (e.g. `skill-gmail`) — recall it \
+         first with `memory_recall` (cheaper, offline, no live round-trip). Reach for the \
+         orchestrator's live delegation tools only when the request needs the very latest, \
+         not-yet-synced data, not just because the platform is connected:\n",
     );
     for ci in connected {
         let _ = writeln!(out, "- {}", ci.toolkit);
@@ -204,5 +206,26 @@ mod tests {
     fn render_connected_integrations_empty_when_none_connected() {
         assert!(render_connected_integrations(&[integration("gmail", false)]).is_empty());
         assert!(render_connected_integrations(&[]).is_empty());
+    }
+
+    #[test]
+    fn connected_integrations_block_points_the_scout_at_memory_first() {
+        // The scout was skipping `memory_recall` and recommending a live Gmail
+        // delegation for data already synced into `skill-gmail`. The block must
+        // steer it to memory first so a connected platform is not a reflexive
+        // reason to re-fetch live.
+        let out = render_connected_integrations(&[integration("gmail", true)]);
+        assert!(
+            out.contains("skill-"),
+            "must mention the connector memory namespace: {out}"
+        );
+        assert!(
+            out.contains("memory_recall"),
+            "must name the recall tool: {out}"
+        );
+        assert!(
+            out.to_lowercase().contains("recall it first"),
+            "must instruct memory-first: {out}"
+        );
     }
 }

--- a/src/openhuman/channels/context.rs
+++ b/src/openhuman/channels/context.rs
@@ -115,10 +115,11 @@ pub(crate) async fn build_memory_context(
 ) -> String {
     let mut context = String::new();
 
-    if let Ok(entries) = mem
-        .recall(user_msg, 5, crate::openhuman::memory::RecallOpts::default())
-        .await
+    // Global plus connector namespaces — the channel-side turn context has the
+    // same blind spot as the harness one when it only reads `global`.
     {
+        let entries =
+            crate::openhuman::memory::auto_recall::recall_with_connectors(mem, user_msg, 5).await;
         let mut included = 0usize;
         let mut used_chars = 0usize;
 

--- a/src/openhuman/inference/embeddings/rpc.rs
+++ b/src/openhuman/inference/embeddings/rpc.rs
@@ -365,6 +365,10 @@ pub async fn update_settings(
 
     if sig_changed {
         crate::openhuman::memory::queue::ensure_reembed_backfill(&config);
+        // A new embedder changes the active dimension, which is what the base
+        // sweep keys off: every chunk stored at the old dimension is pending
+        // work the moment the switch lands.
+        crate::openhuman::memory::store::vector_reembed::ensure_vector_reembed();
     }
 
     tracing::info!(

--- a/src/openhuman/inference/embeddings/rpc.rs
+++ b/src/openhuman/inference/embeddings/rpc.rs
@@ -364,6 +364,19 @@ pub async fn update_settings(
     config.save().await.map_err(|e| e.to_string())?;
 
     if sig_changed {
+        // Rebuild the live memory client first. Its `UnifiedMemory` resolved an
+        // embedder at construction and never re-reads the config, so a sweep
+        // started before this would scan and write under the signature the save
+        // above just superseded — repairing nothing and marking the new
+        // signature's rows done. A rebuild failure is logged and the sweep still
+        // runs: it is then no worse off than it was without this call.
+        if let Err(error) = crate::openhuman::memory::global::rebind_current_workspace() {
+            tracing::warn!(
+                error = %error,
+                "{LOG_PREFIX} could not rebuild the memory client for the new embedder; \
+                 the re-embed sweep will run against the previous one"
+            );
+        }
         crate::openhuman::memory::queue::ensure_reembed_backfill(&config);
         // A new embedder changes the active dimension, which is what the base
         // sweep keys off: every chunk stored at the old dimension is pending

--- a/src/openhuman/memory/auto_recall.rs
+++ b/src/openhuman/memory/auto_recall.rs
@@ -1,0 +1,136 @@
+//! Namespace scope for per-turn automatic recall.
+//!
+//! `RecallOpts::default()` resolves to the `global` namespace, so the automatic
+//! turn context has never searched connector memories: a synced email can sit
+//! in `skill-gmail` and still be unreachable from the very turn that asks about
+//! it. That scoping is not a decision — it is what an unfinished namespace
+//! migration left behind, and connector sync landed on top of it.
+//!
+//! Recall is namespace-scoped in the store, so widening the scope means fanning
+//! out: one recall per namespace, run concurrently, merged by score. The fan-out
+//! is deliberately bounded — each namespace recall embeds the query and scans
+//! that namespace's chunks, so unbounded connector growth would otherwise turn
+//! every single turn into a full-store scan.
+
+use futures::future::join_all;
+
+use crate::openhuman::memory::{Memory, MemoryEntry, RecallOpts};
+
+/// Namespace prefix connector-synced documents are stored under
+/// (`skill-gmail`, `skill-slack`, …).
+const SKILL_NAMESPACE_PREFIX: &str = "skill-";
+
+/// Connector namespaces searched per turn, largest first.
+///
+/// Every extra namespace costs one query embedding plus a scan of that
+/// namespace's chunks. Four keeps the added turn latency to roughly one
+/// concurrent recall while still covering the connectors a user actually syncs;
+/// the rest stay reachable through the explicit `memory_recall` tool, which
+/// takes a namespace.
+pub(crate) const MAX_CONNECTOR_NAMESPACES: usize = 4;
+
+/// Recall for the automatic turn context: the global namespace plus the
+/// busiest connector namespaces, merged and ranked as one result set.
+///
+/// Never fails the turn — a namespace whose recall errors is skipped, and a
+/// store that cannot enumerate namespaces degrades to global-only, which is
+/// exactly the previous behaviour.
+pub(crate) async fn recall_with_connectors(
+    mem: &dyn Memory,
+    query: &str,
+    limit: usize,
+) -> Vec<MemoryEntry> {
+    let mut entries = match crate::openhuman::tinyagents::retriever::recall_through_facade(
+        mem,
+        query,
+        limit,
+        RecallOpts::default(),
+    )
+    .await
+    {
+        Ok(entries) => entries,
+        Err(error) => {
+            tracing::debug!("[memory::auto-recall] global recall failed: {error}");
+            Vec::new()
+        }
+    };
+
+    let namespaces = connector_namespaces(mem).await;
+    if !namespaces.is_empty() {
+        tracing::debug!(
+            "[memory::auto-recall] fanning out to connector namespaces: {}",
+            namespaces.join(", ")
+        );
+    }
+    let recalls = namespaces.iter().map(|namespace| async move {
+        mem.recall(
+            query,
+            limit,
+            RecallOpts {
+                namespace: Some(namespace),
+                ..Default::default()
+            },
+        )
+        .await
+    });
+    for (namespace, result) in namespaces.iter().zip(join_all(recalls).await) {
+        match result {
+            Ok(hits) => entries.extend(hits),
+            Err(error) => {
+                tracing::debug!("[memory::auto-recall] recall failed for {namespace}: {error}")
+            }
+        }
+    }
+
+    rank_and_truncate(entries, limit)
+}
+
+/// The connector namespaces worth searching this turn: non-empty, busiest
+/// first, capped at [`MAX_CONNECTOR_NAMESPACES`].
+async fn connector_namespaces(mem: &dyn Memory) -> Vec<String> {
+    let mut summaries = match mem.namespace_summaries().await {
+        Ok(summaries) => summaries,
+        Err(error) => {
+            tracing::debug!("[memory::auto-recall] namespace listing failed: {error}");
+            return Vec::new();
+        }
+    };
+    summaries.retain(|summary| {
+        summary.count > 0 && summary.namespace.starts_with(SKILL_NAMESPACE_PREFIX)
+    });
+    // Busiest first, name as the tie-break so the selected set is stable across
+    // turns rather than reshuffling with map iteration order.
+    summaries.sort_by(|a, b| {
+        b.count
+            .cmp(&a.count)
+            .then_with(|| a.namespace.cmp(&b.namespace))
+    });
+    summaries.truncate(MAX_CONNECTOR_NAMESPACES);
+    summaries
+        .into_iter()
+        .map(|summary| summary.namespace)
+        .collect()
+}
+
+/// Merge hits from several namespaces into one ranked list.
+///
+/// Scores are comparable across namespaces (the same hybrid scorer produced
+/// them), so a connector hit outranks a weak global one on merit rather than on
+/// which namespace it came from. Unscored entries sort last instead of being
+/// dropped: non-vector backends return them and they were previously kept.
+fn rank_and_truncate(mut entries: Vec<MemoryEntry>, limit: usize) -> Vec<MemoryEntry> {
+    entries.sort_by(|a, b| {
+        b.score
+            .unwrap_or(f64::NEG_INFINITY)
+            .total_cmp(&a.score.unwrap_or(f64::NEG_INFINITY))
+    });
+    // One document reachable from two namespaces must not occupy two slots.
+    let mut seen = std::collections::HashSet::new();
+    entries.retain(|entry| seen.insert((entry.namespace.clone(), entry.key.clone())));
+    entries.truncate(limit);
+    entries
+}
+
+#[cfg(test)]
+#[path = "auto_recall_tests.rs"]
+mod tests;

--- a/src/openhuman/memory/auto_recall.rs
+++ b/src/openhuman/memory/auto_recall.rs
@@ -40,7 +40,33 @@ pub(crate) async fn recall_with_connectors(
     query: &str,
     limit: usize,
 ) -> Vec<MemoryEntry> {
-    let mut entries = match crate::openhuman::tinyagents::retriever::recall_through_facade(
+    recall_across(mem, query, limit, Some(MAX_CONNECTOR_NAMESPACES)).await
+}
+
+/// Recall for the **explicit** `memory_recall` tool called without a namespace.
+///
+/// Searches every non-empty connector namespace, not the busiest few. The tool's
+/// schema tells the model that omitting the namespace searches everywhere, and
+/// the model is instructed to omit it; borrowing the per-turn cap here would
+/// make that instruction quietly false for anyone with more connectors than the
+/// cap, and the memory it was told to look for would simply not be looked at.
+/// The turn-context path keeps the cap — there the cost is paid on every turn,
+/// not on a call the model chose to make.
+pub(crate) async fn recall_every_namespace(
+    mem: &dyn Memory,
+    query: &str,
+    limit: usize,
+) -> Vec<MemoryEntry> {
+    recall_across(mem, query, limit, None).await
+}
+
+async fn recall_across(
+    mem: &dyn Memory,
+    query: &str,
+    limit: usize,
+    max_namespaces: Option<usize>,
+) -> Vec<MemoryEntry> {
+    let mut entries = match crate::openhuman::agent::tinyagents::retriever::recall_through_facade(
         mem,
         query,
         limit,
@@ -55,7 +81,7 @@ pub(crate) async fn recall_with_connectors(
         }
     };
 
-    let namespaces = connector_namespaces(mem).await;
+    let namespaces = connector_namespaces(mem, max_namespaces).await;
     if !namespaces.is_empty() {
         tracing::debug!(
             "[memory::auto-recall] fanning out to connector namespaces: {}",
@@ -85,9 +111,9 @@ pub(crate) async fn recall_with_connectors(
     rank_and_truncate(entries, limit)
 }
 
-/// The connector namespaces worth searching this turn: non-empty, busiest
-/// first, capped at [`MAX_CONNECTOR_NAMESPACES`].
-async fn connector_namespaces(mem: &dyn Memory) -> Vec<String> {
+/// The connector namespaces worth searching: non-empty, busiest first, capped at
+/// `max_namespaces` when the caller sets one. `None` searches all of them.
+async fn connector_namespaces(mem: &dyn Memory, max_namespaces: Option<usize>) -> Vec<String> {
     let mut summaries = match mem.namespace_summaries().await {
         Ok(summaries) => summaries,
         Err(error) => {
@@ -105,7 +131,9 @@ async fn connector_namespaces(mem: &dyn Memory) -> Vec<String> {
             .cmp(&a.count)
             .then_with(|| a.namespace.cmp(&b.namespace))
     });
-    summaries.truncate(MAX_CONNECTOR_NAMESPACES);
+    if let Some(cap) = max_namespaces {
+        summaries.truncate(cap);
+    }
     summaries
         .into_iter()
         .map(|summary| summary.namespace)

--- a/src/openhuman/memory/auto_recall_tests.rs
+++ b/src/openhuman/memory/auto_recall_tests.rs
@@ -1,0 +1,227 @@
+//! Tests for connector-aware automatic recall.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use super::*;
+use crate::openhuman::memory::{MemoryCategory, NamespaceSummary};
+
+/// Memory whose recall is a per-namespace lookup table, so a test states
+/// exactly what each namespace holds. Records the namespaces it was asked for.
+struct NamespacedMemory {
+    hits: HashMap<Option<String>, Vec<MemoryEntry>>,
+    summaries: Vec<NamespaceSummary>,
+    asked: Mutex<Vec<Option<String>>>,
+    fail_summaries: bool,
+}
+
+impl NamespacedMemory {
+    fn new(hits: Vec<(Option<&str>, Vec<MemoryEntry>)>, counts: Vec<(&str, usize)>) -> Self {
+        Self {
+            hits: hits
+                .into_iter()
+                .map(|(namespace, entries)| (namespace.map(str::to_string), entries))
+                .collect(),
+            summaries: counts
+                .into_iter()
+                .map(|(namespace, count)| NamespaceSummary {
+                    namespace: namespace.to_string(),
+                    count,
+                    last_updated: None,
+                })
+                .collect(),
+            asked: Mutex::new(Vec::new()),
+            fail_summaries: false,
+        }
+    }
+
+    fn asked_namespaces(&self) -> Vec<Option<String>> {
+        self.asked.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl Memory for NamespacedMemory {
+    fn name(&self) -> &str {
+        "namespaced-mock"
+    }
+
+    async fn store(
+        &self,
+        _namespace: &str,
+        _key: &str,
+        _content: &str,
+        _category: MemoryCategory,
+        _session_id: Option<&str>,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn recall(
+        &self,
+        _query: &str,
+        _limit: usize,
+        opts: RecallOpts<'_>,
+    ) -> anyhow::Result<Vec<MemoryEntry>> {
+        let namespace = opts.namespace.map(str::to_string);
+        self.asked.lock().unwrap().push(namespace.clone());
+        Ok(self.hits.get(&namespace).cloned().unwrap_or_default())
+    }
+
+    async fn get(&self, _namespace: &str, _key: &str) -> anyhow::Result<Option<MemoryEntry>> {
+        Ok(None)
+    }
+
+    async fn list(
+        &self,
+        _namespace: Option<&str>,
+        _category: Option<&MemoryCategory>,
+        _session_id: Option<&str>,
+    ) -> anyhow::Result<Vec<MemoryEntry>> {
+        Ok(Vec::new())
+    }
+
+    async fn forget(&self, _namespace: &str, _key: &str) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+
+    async fn namespace_summaries(&self) -> anyhow::Result<Vec<NamespaceSummary>> {
+        if self.fail_summaries {
+            anyhow::bail!("namespace listing unavailable");
+        }
+        Ok(self.summaries.clone())
+    }
+
+    async fn count(&self) -> anyhow::Result<usize> {
+        Ok(0)
+    }
+
+    async fn health_check(&self) -> bool {
+        true
+    }
+}
+
+fn entry(namespace: Option<&str>, key: &str, score: f64) -> MemoryEntry {
+    MemoryEntry {
+        id: key.into(),
+        key: key.into(),
+        content: format!("content of {key}"),
+        namespace: namespace.map(str::to_string),
+        category: MemoryCategory::Conversation,
+        timestamp: "now".into(),
+        session_id: None,
+        score: Some(score),
+        taint: Default::default(),
+    }
+}
+
+#[tokio::test]
+async fn a_connector_hit_reaches_the_turn_context() {
+    // The bug in one test: the email lives in `skill-gmail`, the turn asks
+    // about it, and global-only recall never sees it.
+    let mem = NamespacedMemory::new(
+        vec![
+            (None, vec![entry(None, "chat-note", 0.20)]),
+            (
+                Some("skill-gmail"),
+                vec![entry(Some("skill-gmail"), "gmail:colorado", 0.80)],
+            ),
+        ],
+        vec![("skill-gmail", 12), ("global", 40)],
+    );
+
+    let entries = recall_with_connectors(&mem, "colorado", 5).await;
+    let keys: Vec<&str> = entries.iter().map(|e| e.key.as_str()).collect();
+
+    assert!(
+        keys.contains(&"gmail:colorado"),
+        "connector hit must surface"
+    );
+    // Ranked on score, not on which namespace it came from.
+    assert_eq!(keys.first(), Some(&"gmail:colorado"));
+    assert!(keys.contains(&"chat-note"), "global hits are not displaced");
+
+    // Only connector namespaces are fanned out to; `global` is the default
+    // recall, not a second explicit one.
+    let asked = mem.asked_namespaces();
+    assert_eq!(asked.iter().filter(|ns| ns.is_none()).count(), 1);
+    assert!(asked.contains(&Some("skill-gmail".to_string())));
+    assert!(
+        !asked.contains(&Some("global".to_string())),
+        "global must not be searched twice: {asked:?}"
+    );
+}
+
+#[tokio::test]
+async fn the_fan_out_is_bounded_to_the_busiest_namespaces() {
+    let counts = vec![
+        ("skill-a", 1),
+        ("skill-b", 900),
+        ("skill-c", 50),
+        ("skill-d", 700),
+        ("skill-e", 300),
+        ("skill-empty", 0),
+    ];
+    let mem = NamespacedMemory::new(vec![(None, Vec::new())], counts);
+
+    let _ = recall_with_connectors(&mem, "anything", 5).await;
+    let asked: Vec<String> = mem
+        .asked_namespaces()
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        asked.len(),
+        MAX_CONNECTOR_NAMESPACES,
+        "an unbounded fan-out would scan the whole store every turn: {asked:?}"
+    );
+    // Busiest first, and an empty namespace is never worth a scan.
+    assert_eq!(asked, vec!["skill-b", "skill-d", "skill-e", "skill-c"]);
+    assert!(!asked.contains(&"skill-empty".to_string()));
+}
+
+#[tokio::test]
+async fn results_are_deduplicated_and_capped_at_the_limit() {
+    let mem = NamespacedMemory::new(
+        vec![
+            (
+                None,
+                vec![entry(None, "dupe", 0.5), entry(None, "global-2", 0.4)],
+            ),
+            (
+                Some("skill-gmail"),
+                vec![
+                    // Same (namespace, key) twice — one slot, not two.
+                    entry(None, "dupe", 0.5),
+                    entry(Some("skill-gmail"), "gmail-1", 0.9),
+                ],
+            ),
+        ],
+        vec![("skill-gmail", 5)],
+    );
+
+    let entries = recall_with_connectors(&mem, "q", 2).await;
+    assert_eq!(entries.len(), 2, "the caller's limit is respected");
+    let keys: Vec<&str> = entries.iter().map(|e| e.key.as_str()).collect();
+    assert_eq!(keys, vec!["gmail-1", "dupe"]);
+}
+
+#[tokio::test]
+async fn a_store_that_cannot_list_namespaces_degrades_to_global_only() {
+    let mut mem = NamespacedMemory::new(
+        vec![(None, vec![entry(None, "chat-note", 0.3)])],
+        vec![("skill-gmail", 12)],
+    );
+    mem.fail_summaries = true;
+
+    let entries = recall_with_connectors(&mem, "q", 5).await;
+    assert_eq!(entries.len(), 1, "global recall still returns its hits");
+    assert_eq!(
+        mem.asked_namespaces(),
+        vec![None],
+        "no connector recall is attempted when the listing fails"
+    );
+}

--- a/src/openhuman/memory/global.rs
+++ b/src/openhuman/memory/global.rs
@@ -126,6 +126,7 @@ pub fn rebind_current_workspace() -> Result<Option<MemoryClientRef>, String> {
 }
 
 fn rebind_in_slot(slot: &GlobalClientSlot) -> Result<Option<MemoryClientRef>, String> {
+    log::debug!("[memory:global] rebind entry");
     let workspace_dir = {
         let guard = slot
             .read()
@@ -133,7 +134,7 @@ fn rebind_in_slot(slot: &GlobalClientSlot) -> Result<Option<MemoryClientRef>, St
         match guard.as_ref() {
             Some(existing) => existing.workspace_dir.clone(),
             None => {
-                log::debug!("[memory:global] rebind skipped — no client bound yet");
+                log::debug!("[memory:global] rebind exit branch=nothing-bound");
                 return Ok(None);
             }
         }
@@ -153,7 +154,16 @@ fn rebind_in_slot_for(
         "[memory:global] rebuilding MemoryClient in place workspace={}",
         workspace_dir.display()
     );
-    let client = Arc::new(MemoryClient::from_workspace_dir(workspace_dir.clone())?);
+    let client = match MemoryClient::from_workspace_dir(workspace_dir.clone()) {
+        Ok(client) => Arc::new(client),
+        Err(error) => {
+            log::debug!(
+                "[memory:global] rebind exit branch=build-failed workspace={} error={error}",
+                workspace_dir.display()
+            );
+            return Err(error);
+        }
+    };
 
     let mut guard = slot
         .write()
@@ -175,6 +185,10 @@ fn rebind_in_slot_for(
             return Ok(None);
         }
     }
+    log::debug!(
+        "[memory:global] rebind exit branch=installed workspace={}",
+        workspace_dir.display()
+    );
     *guard = Some(GlobalMemoryClient {
         workspace_dir,
         client: Arc::clone(&client),

--- a/src/openhuman/memory/global.rs
+++ b/src/openhuman/memory/global.rs
@@ -107,6 +107,54 @@ fn init_in_slot(
     Ok(client)
 }
 
+/// Rebuild the global client for the workspace it is already bound to.
+///
+/// [`init`] deliberately no-ops when the workspace is unchanged, which is right
+/// for its callers — but wrong for a change in *how* memory embeds rather than
+/// *where* it lives. `UnifiedMemory` resolves its embedder once, at
+/// construction, so after an embedding provider / model / dimension switch the
+/// live client still holds the old one: the base re-embed sweep would then scan
+/// and write under the superseded signature, leaving every row that the switch
+/// just made pending stuck that way until the next boot.
+///
+/// Returns `Ok(None)` when nothing is bound yet — there is no client to
+/// replace, and the next [`init`] picks up the saved config anyway. A rebuild
+/// failure leaves the existing client in place: a stale embedder still answers
+/// queries, where an empty slot answers nothing.
+pub fn rebind_current_workspace() -> Result<Option<MemoryClientRef>, String> {
+    rebind_in_slot(global_slot())
+}
+
+fn rebind_in_slot(slot: &GlobalClientSlot) -> Result<Option<MemoryClientRef>, String> {
+    let workspace_dir = {
+        let guard = slot
+            .read()
+            .map_err(|e| format!("[memory:global] read lock poisoned: {e}"))?;
+        match guard.as_ref() {
+            Some(existing) => existing.workspace_dir.clone(),
+            None => {
+                log::debug!("[memory:global] rebind skipped — no client bound yet");
+                return Ok(None);
+            }
+        }
+    };
+
+    log::info!(
+        "[memory:global] rebuilding MemoryClient in place workspace={}",
+        workspace_dir.display()
+    );
+    let client = Arc::new(MemoryClient::from_workspace_dir(workspace_dir.clone())?);
+
+    let mut guard = slot
+        .write()
+        .map_err(|e| format!("[memory:global] write lock poisoned: {e}"))?;
+    *guard = Some(GlobalMemoryClient {
+        workspace_dir,
+        client: Arc::clone(&client),
+    });
+    Ok(Some(client))
+}
+
 /// Initialise using the default `~/.openhuman/workspace` directory.
 ///
 /// **TEST-ONLY.** Production code must call [`init`] with the real workspace
@@ -202,6 +250,40 @@ mod tests {
 
         assert!(!Arc::ptr_eq(&first, &second));
         assert!(Arc::ptr_eq(&second, &current));
+    }
+
+    /// `init` returning the same handle for an unchanged workspace is what makes
+    /// a dedicated rebind necessary: an embedder swap changes how memory embeds,
+    /// not where it lives, so the workspace-keyed short-circuit would keep the
+    /// old embedder alive and the base sweep would run under a dead signature.
+    #[tokio::test]
+    async fn rebind_replaces_the_client_for_the_same_workspace() {
+        let slot = GlobalClientSlot::default();
+        let tmp = TempDir::new().unwrap();
+        let workspace = tmp.path().join("ws");
+
+        let first = init_in_slot(&slot, workspace.clone()).unwrap();
+        // The path `init` takes for an unchanged workspace, spelled out.
+        assert!(Arc::ptr_eq(
+            &first,
+            &init_in_slot(&slot, workspace.clone()).unwrap()
+        ));
+
+        let rebound = rebind_in_slot(&slot).unwrap().expect("a client was bound");
+        let current = client_from(&slot).unwrap();
+
+        assert!(
+            !Arc::ptr_eq(&first, &rebound),
+            "rebind must build a new client, not hand back the bound one"
+        );
+        assert!(Arc::ptr_eq(&rebound, &current), "and must install it");
+    }
+
+    #[tokio::test]
+    async fn rebind_is_a_no_op_when_nothing_is_bound() {
+        let slot = GlobalClientSlot::default();
+        assert!(rebind_in_slot(&slot).unwrap().is_none());
+        assert!(client_from(&slot).is_err());
     }
 
     #[tokio::test]

--- a/src/openhuman/memory/global.rs
+++ b/src/openhuman/memory/global.rs
@@ -138,7 +138,17 @@ fn rebind_in_slot(slot: &GlobalClientSlot) -> Result<Option<MemoryClientRef>, St
             }
         }
     };
+    rebind_in_slot_for(slot, workspace_dir)
+}
 
+/// The build-and-install half of [`rebind_in_slot`], split out so the
+/// install-time recheck can be exercised directly: a test can hand it a
+/// workspace the slot has since moved off, which is what the released lock
+/// makes possible in production.
+fn rebind_in_slot_for(
+    slot: &GlobalClientSlot,
+    workspace_dir: PathBuf,
+) -> Result<Option<MemoryClientRef>, String> {
     log::info!(
         "[memory:global] rebuilding MemoryClient in place workspace={}",
         workspace_dir.display()
@@ -148,6 +158,23 @@ fn rebind_in_slot(slot: &GlobalClientSlot) -> Result<Option<MemoryClientRef>, St
     let mut guard = slot
         .write()
         .map_err(|e| format!("[memory:global] write lock poisoned: {e}"))?;
+    // The lock is released while the client is built, so an `init` for a
+    // different workspace (a post-login active-user switch) can land in the
+    // gap. Installing unconditionally would then overwrite that newer binding
+    // with a client for the workspace this rebind started from, and every write
+    // after it would go to the previous user's store. A rebind is only ever
+    // valid for the binding it read.
+    match guard.as_ref() {
+        Some(current) if current.workspace_dir == workspace_dir => {}
+        _ => {
+            log::info!(
+                "[memory:global] discarding rebuilt MemoryClient for {} — the global rebound \
+                 while it was being built",
+                workspace_dir.display()
+            );
+            return Ok(None);
+        }
+    }
     *guard = Some(GlobalMemoryClient {
         workspace_dir,
         client: Arc::clone(&client),
@@ -277,6 +304,31 @@ mod tests {
             "rebind must build a new client, not hand back the bound one"
         );
         assert!(Arc::ptr_eq(&rebound, &current), "and must install it");
+    }
+
+    /// The window the rebind opens: it releases the read lock to build, so an
+    /// `init` for a different workspace can land before it installs. Installing
+    /// anyway would point the global at the workspace the rebind *started*
+    /// from — the pre-login store, after a post-login user switch. Simulated by
+    /// rebinding the slot out from under a client built for the old workspace.
+    #[tokio::test]
+    async fn rebind_does_not_overwrite_a_workspace_bound_while_it_was_building() {
+        let slot = GlobalClientSlot::default();
+        let tmp = TempDir::new().unwrap();
+        let workspace_a = tmp.path().join("ws-a");
+
+        let _a = init_in_slot(&slot, workspace_a.clone()).unwrap();
+        // Stand in for the build window: the switch happens before the install.
+        let b = init_in_slot(&slot, tmp.path().join("ws-b")).unwrap();
+
+        // A rebind that read `ws-a` must find the slot changed and stand down.
+        let stale = rebind_in_slot_for(&slot, workspace_a).unwrap();
+
+        assert!(stale.is_none(), "a stale rebind must not install");
+        assert!(
+            Arc::ptr_eq(&client_from(&slot).unwrap(), &b),
+            "the newer binding must survive"
+        );
     }
 
     #[tokio::test]

--- a/src/openhuman/memory/mod.rs
+++ b/src/openhuman/memory/mod.rs
@@ -21,6 +21,7 @@ pub mod ops;
 pub mod people;
 pub mod preferences;
 pub mod queue;
+pub mod recall_shaping;
 pub mod rpc_models;
 pub mod schemas;
 pub mod search;

--- a/src/openhuman/memory/mod.rs
+++ b/src/openhuman/memory/mod.rs
@@ -11,6 +11,7 @@
 
 // Legacy memory modules
 pub mod agent;
+pub mod auto_recall;
 pub mod conversations;
 pub mod diff;
 pub mod global;

--- a/src/openhuman/memory/recall_shaping.rs
+++ b/src/openhuman/memory/recall_shaping.rs
@@ -12,7 +12,7 @@
 //! sees the matching passages, not a wall of unrelated text); the char cap is
 //! the backstop that also bounds documents stored before any of this existed.
 
-use crate::openhuman::memory_store::UnifiedMemory;
+use crate::openhuman::memory::store::UnifiedMemory;
 use crate::openhuman::util::truncate_with_ellipsis;
 
 /// Most chunks surfaced from one source document. Enough to carry the matching
@@ -103,11 +103,17 @@ fn condense_with(
 /// Truncate so the result is at most `max_chars` characters *including* the
 /// ellipsis — `truncate_with_ellipsis` alone can exceed its budget by the
 /// suffix length, which would defeat a hard cap.
+/// Characters `truncate_with_ellipsis` appends when it truncates.
+const ELLIPSIS_CHARS: usize = 3;
+
 fn hard_cap(text: &str, max_chars: usize) -> String {
     if text.chars().count() <= max_chars {
         return text.to_string();
     }
-    truncate_with_ellipsis(text, max_chars.saturating_sub(1))
+    // `truncate_with_ellipsis` appends "..." ON TOP of the budget it is given,
+    // so the suffix has to come out of the budget or the result is three chars
+    // over the cap this function exists to enforce.
+    truncate_with_ellipsis(text, max_chars.saturating_sub(ELLIPSIS_CHARS))
 }
 
 /// Lowercased query tokens, split on whitespace. Substring matching keeps this

--- a/src/openhuman/memory/recall_shaping.rs
+++ b/src/openhuman/memory/recall_shaping.rs
@@ -1,0 +1,136 @@
+//! Bound the size of one recalled memory before it reaches the model.
+//!
+//! Recall returns whole documents, and a document can be large — a synced email
+//! thread, or (from an older build) a subagent's entire system-prompt envelope
+//! saved as a "conversation". One such document filled the recall tool's whole
+//! result budget, hid every other hit, and pushed the agent to re-search the
+//! live source it had just been handed the answer from.
+//!
+//! So a recalled entry is condensed to the handful of *chunks* most relevant to
+//! the query — the same chunk unit the store already splits documents into —
+//! and then hard-capped. The chunk selection is the useful part (the reader
+//! sees the matching passages, not a wall of unrelated text); the char cap is
+//! the backstop that also bounds documents stored before any of this existed.
+
+use crate::openhuman::memory_store::UnifiedMemory;
+use crate::openhuman::util::truncate_with_ellipsis;
+
+/// Most chunks surfaced from one source document. Enough to carry the matching
+/// passage plus a little surrounding context; few enough that one document
+/// cannot dominate the result.
+pub(crate) const MAX_CHUNKS_PER_SOURCE: usize = 3;
+
+/// Per-chunk display budget. Each surfaced chunk is trimmed to this so three of
+/// them fit inside the entry cap and the reader sees the head of each relevant
+/// passage rather than one long chunk crowding out the others.
+const MAX_CHARS_PER_CHUNK: usize = 400;
+
+/// Hard ceiling on one entry's rendered characters, whatever its chunking —
+/// the backstop that bounds even a single un-splittable blob (an old subagent
+/// envelope saved as one document). Sized to hold the three per-chunk budgets
+/// plus the elision markers between them.
+pub(crate) const MAX_CHARS_PER_ENTRY: usize = 1400;
+
+/// Token budget per chunk, matching the store's own `upsert_document` chunking
+/// so "chunk" means the same thing on the way out as on the way in.
+const CHUNK_MAX_TOKENS: usize = 225;
+
+/// Condense `content` to at most [`MAX_CHUNKS_PER_SOURCE`] query-relevant chunks
+/// and [`MAX_CHARS_PER_ENTRY`] characters.
+pub(crate) fn condense_recall_content(query: &str, content: &str) -> String {
+    condense_with(
+        query,
+        content,
+        MAX_CHUNKS_PER_SOURCE,
+        MAX_CHARS_PER_CHUNK,
+        MAX_CHARS_PER_ENTRY,
+    )
+}
+
+fn condense_with(
+    query: &str,
+    content: &str,
+    max_chunks: usize,
+    max_chars_per_chunk: usize,
+    max_chars: usize,
+) -> String {
+    let trimmed = content.trim();
+    let chunks = UnifiedMemory::chunk_document_content(trimmed, CHUNK_MAX_TOKENS);
+
+    // Short, few-chunk content is the common case for a real fact — pass it
+    // through untouched so nothing is lost to condensation it didn't need.
+    if chunks.len() <= max_chunks && trimmed.chars().count() <= max_chars {
+        return trimmed.to_string();
+    }
+    if chunks.is_empty() {
+        return hard_cap(trimmed, max_chars);
+    }
+
+    let query_terms = query_terms(query);
+    // Rank by relevance to pick *which* chunks, but keep the survivors in their
+    // original order so the passage still reads top-to-bottom.
+    let mut ranked: Vec<(usize, usize)> = chunks
+        .iter()
+        .enumerate()
+        .map(|(idx, chunk)| (idx, chunk_relevance(chunk, &query_terms)))
+        .collect();
+    ranked.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+
+    let mut keep: Vec<usize> = ranked
+        .into_iter()
+        .take(max_chunks)
+        .map(|(idx, _)| idx)
+        .collect();
+    keep.sort_unstable();
+
+    let dropped = chunks.len() - keep.len();
+    let mut rendered = String::new();
+    for (position, &idx) in keep.iter().enumerate() {
+        if position > 0 {
+            rendered.push_str(" … ");
+        }
+        // Trim each kept chunk so three of them share the entry budget rather
+        // than the first one consuming it all.
+        rendered.push_str(&truncate_with_ellipsis(&chunks[idx], max_chars_per_chunk));
+    }
+    if dropped > 0 {
+        rendered.push_str(&format!(" … (+{dropped} more section(s))"));
+    }
+
+    hard_cap(&rendered, max_chars)
+}
+
+/// Truncate so the result is at most `max_chars` characters *including* the
+/// ellipsis — `truncate_with_ellipsis` alone can exceed its budget by the
+/// suffix length, which would defeat a hard cap.
+fn hard_cap(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    truncate_with_ellipsis(text, max_chars.saturating_sub(1))
+}
+
+/// Lowercased query tokens, split on whitespace. Substring matching keeps this
+/// correct for Korean (no word segmenter needed): a query token like `콜로라도`
+/// matches any chunk containing it.
+fn query_terms(query: &str) -> Vec<String> {
+    query
+        .split_whitespace()
+        .map(|term| term.trim().to_lowercase())
+        .filter(|term| !term.is_empty())
+        .collect()
+}
+
+/// How many distinct query terms appear in this chunk. Cheap and
+/// language-agnostic — enough to pick the matching passages out of a document.
+fn chunk_relevance(chunk: &str, query_terms: &[String]) -> usize {
+    let lower = chunk.to_lowercase();
+    query_terms
+        .iter()
+        .filter(|term| lower.contains(term.as_str()))
+        .count()
+}
+
+#[cfg(test)]
+#[path = "recall_shaping_tests.rs"]
+mod tests;

--- a/src/openhuman/memory/recall_shaping.rs
+++ b/src/openhuman/memory/recall_shaping.rs
@@ -56,14 +56,32 @@ fn condense_with(
 ) -> String {
     let trimmed = content.trim();
     let chunks = UnifiedMemory::chunk_document_content(trimmed, CHUNK_MAX_TOKENS);
+    // Counts and lengths only — this function's input is recalled memory, so
+    // its content must not reach the log.
+    log::debug!(
+        "[memory::recall_shaping] condense entry chars={} chunks={} max_chunks={max_chunks} \
+         max_chars={max_chars} query_chars={}",
+        trimmed.chars().count(),
+        chunks.len(),
+        query.chars().count()
+    );
 
     // Short, few-chunk content is the common case for a real fact — pass it
     // through untouched so nothing is lost to condensation it didn't need.
     if chunks.len() <= max_chunks && trimmed.chars().count() <= max_chars {
+        log::debug!(
+            "[memory::recall_shaping] condense exit branch=passthrough chars={}",
+            trimmed.chars().count()
+        );
         return trimmed.to_string();
     }
     if chunks.is_empty() {
-        return hard_cap(trimmed, max_chars);
+        let out = hard_cap(trimmed, max_chars);
+        log::debug!(
+            "[memory::recall_shaping] condense exit branch=unsplittable chars={}",
+            out.chars().count()
+        );
+        return out;
     }
 
     let query_terms = query_terms(query);
@@ -76,8 +94,16 @@ fn condense_with(
         .collect();
     ranked.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
 
+    // Once anything matches, an unmatched chunk is not a runner-up — it is
+    // unrelated text, and padding the remaining slots with it hands the model
+    // content the query never asked for next to content it did. Only when
+    // nothing matches does the head of the document become the best available
+    // answer, which is the fallback the all-zero case keeps (the sort's
+    // index tie-break leaves the chunks in document order).
+    let has_match = ranked.iter().any(|(_, score)| *score > 0);
     let mut keep: Vec<usize> = ranked
         .into_iter()
+        .filter(|(_, score)| !has_match || *score > 0)
         .take(max_chunks)
         .map(|(idx, _)| idx)
         .collect();
@@ -97,7 +123,14 @@ fn condense_with(
         rendered.push_str(&format!(" … (+{dropped} more section(s))"));
     }
 
-    hard_cap(&rendered, max_chars)
+    let out = hard_cap(&rendered, max_chars);
+    log::debug!(
+        "[memory::recall_shaping] condense exit branch=selected kept={} dropped={dropped} \
+         had_match={has_match} chars={}",
+        keep.len(),
+        out.chars().count()
+    );
+    out
 }
 
 /// Truncate so the result is at most `max_chars` characters *including* the

--- a/src/openhuman/memory/recall_shaping_tests.rs
+++ b/src/openhuman/memory/recall_shaping_tests.rs
@@ -92,3 +92,22 @@ fn the_system_prompt_envelope_no_longer_floods_the_result() {
         "envelope exceeded the cap"
     );
 }
+
+/// The cap is a cap. `truncate_with_ellipsis` adds its "..." on top of the
+/// budget it is handed, so a hard cap that forgets to reserve those characters
+/// returns text longer than the limit it was asked to enforce — silently, and on
+/// every truncated recall entry.
+#[test]
+fn hard_cap_counts_the_ellipsis_against_the_budget() {
+    let long = "x".repeat(500);
+    for max in [10usize, 33, 120] {
+        let capped = super::hard_cap(&long, max);
+        assert!(
+            capped.chars().count() <= max,
+            "hard_cap({max}) returned {} chars: {capped}",
+            capped.chars().count()
+        );
+    }
+    // Text that already fits is returned whole, ellipsis or not.
+    assert_eq!(super::hard_cap("short", 32), "short");
+}

--- a/src/openhuman/memory/recall_shaping_tests.rs
+++ b/src/openhuman/memory/recall_shaping_tests.rs
@@ -44,6 +44,53 @@ fn only_the_query_relevant_chunks_survive() {
     );
 }
 
+/// With fewer matches than slots, the leftover slots used to be filled by
+/// whatever sorted next — which, once anything matches, is unrelated text. The
+/// model then read a passage the query never asked for beside one it did.
+#[test]
+fn unmatched_sections_do_not_pad_out_the_remaining_slots() {
+    let content = [
+        para("alpha unrelated"),
+        para("beta 콜로라도 대학 연구"),
+        para("gamma unrelated"),
+        para("delta unrelated"),
+        para("epsilon unrelated"),
+    ]
+    .join("\n\n");
+
+    let out = condense_recall_content("콜로라도", &content);
+
+    assert!(
+        out.contains("beta"),
+        "the only match must be kept: {out:.120}"
+    );
+    for unrelated in ["alpha", "gamma", "delta", "epsilon"] {
+        assert!(
+            !out.contains(unrelated),
+            "`{unrelated}` does not match the query and must not fill a slot: {out:.200}"
+        );
+    }
+}
+
+/// The fallback the change above must not break: with nothing matching there is
+/// no better answer than the head of the document, so the slots are still used.
+#[test]
+fn nothing_matching_still_returns_the_head_of_the_document() {
+    let content = (0..5)
+        .map(|i| para(&format!("sec{i} unrelated")))
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    let out = condense_recall_content("콜로라도", &content);
+    let kept = (0..5).filter(|i| out.contains(&format!("sec{i}"))).count();
+
+    assert_eq!(
+        kept, MAX_CHUNKS_PER_SOURCE,
+        "with no match the cap still fills from the top: {out:.200}"
+    );
+    assert!(out.contains("sec0"), "and starts at the head: {out:.120}");
+}
+
 #[test]
 fn at_most_three_chunks_from_one_source() {
     // Six sections all match — the cap, not relevance, must bound the output.

--- a/src/openhuman/memory/recall_shaping_tests.rs
+++ b/src/openhuman/memory/recall_shaping_tests.rs
@@ -1,0 +1,94 @@
+//! Tests for recall content condensation.
+
+use super::*;
+
+/// One store chunk is ~225 tokens ≈ 900 chars. Size a paragraph just under
+/// that so each `para` is exactly one chunk and "section" counts are intuitive.
+fn para(tag: &str) -> String {
+    format!("{tag} {}", "filler ".repeat(90))
+}
+
+#[test]
+fn short_content_passes_through_untouched() {
+    let fact = "User is the PI on the Colorado collaboration.";
+    assert_eq!(condense_recall_content("colorado", fact), fact);
+}
+
+#[test]
+fn only_the_query_relevant_chunks_survive() {
+    // Five distinct large sections; only two mention the needle.
+    let content = [
+        para("alpha unrelated"),
+        para("beta 콜로라도 대학 연구"),
+        para("gamma unrelated"),
+        para("delta unrelated"),
+        para("epsilon 콜로라도 공동연구"),
+    ]
+    .join("\n\n");
+
+    let out = condense_recall_content("콜로라도 연구", &content);
+
+    assert!(
+        out.contains("beta"),
+        "a matching section must be kept: {out:.120}"
+    );
+    assert!(out.contains("epsilon"), "the other match must be kept too");
+    // An unrelated section is dropped, and the drop is disclosed.
+    assert!(
+        !out.contains("gamma"),
+        "an unrelated section must be dropped"
+    );
+    assert!(
+        out.contains("more section(s)"),
+        "the elision is disclosed: {out:.80}"
+    );
+}
+
+#[test]
+fn at_most_three_chunks_from_one_source() {
+    // Six sections all match — the cap, not relevance, must bound the output.
+    let content = (0..6)
+        .map(|i| para(&format!("sec{i} 콜로라도")))
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    let out = condense_recall_content("콜로라도", &content);
+    let kept = (0..6).filter(|i| out.contains(&format!("sec{i}"))).count();
+    assert!(
+        kept <= MAX_CHUNKS_PER_SOURCE,
+        "kept {kept} sections, cap is {MAX_CHUNKS_PER_SOURCE}"
+    );
+    assert!(kept > 0, "at least the matching sections are shown");
+    assert!(
+        out.contains("more section(s)"),
+        "the dropped sections are disclosed: {out:.80}"
+    );
+}
+
+#[test]
+fn an_unsplittable_blob_is_hard_capped() {
+    // No paragraph breaks: chunk selection can't help, so the char cap is the
+    // only thing standing between a 20 KB blob and the result budget.
+    let blob = "x".repeat(20_000);
+    let out = condense_recall_content("anything", &blob);
+    assert!(
+        out.chars().count() <= MAX_CHARS_PER_ENTRY,
+        "a blob must be truncated to the char cap, got {} chars",
+        out.chars().count()
+    );
+}
+
+#[test]
+fn the_system_prompt_envelope_no_longer_floods_the_result() {
+    // The real regression: a subagent's system-prompt envelope saved as a
+    // conversation. Whatever its size, one entry must not exceed the cap.
+    let envelope = format!(
+        "{{\"_meta\":{{\"agent\":\"integrations_agent\"}}}}\n{}",
+        para("You are the Integrations Agent").repeat(30)
+    );
+    let out = condense_recall_content("콜로라도 대학 연구", &envelope);
+    assert!(
+        out.chars().count() <= MAX_CHARS_PER_ENTRY,
+        "envelope exceeded the cap"
+    );
+}

--- a/src/openhuman/memory/store/client.rs
+++ b/src/openhuman/memory/store/client.rs
@@ -17,6 +17,7 @@ use crate::openhuman::memory::ingestion::{
     IngestionJob, IngestionQueue, IngestionState, MemoryIngestionConfig, MemoryIngestionRequest,
     MemoryIngestionResult,
 };
+use crate::openhuman::memory::store::namespace_store::reembed::ReembedSweepReport;
 use crate::openhuman::memory::store::namespace_store::UnifiedMemory;
 use crate::openhuman::memory::store::types::{
     NamespaceDocumentInput, NamespaceMemoryHit, NamespaceRetrievalContext,
@@ -495,6 +496,16 @@ impl MemoryClient {
             }
             None => self.inner.graph_query_all(subject, predicate).await,
         }
+    }
+
+    /// Re-embed up to `budget` chunks whose vector is missing or unusable under
+    /// the active embedder, returning what the pass managed to repair.
+    ///
+    /// Deficient rows stay in `vector_chunks` until they are repaired, so the
+    /// pending set is re-derived from the table on every call: a pass that dies
+    /// — or a process that restarts — loses no work and needs no queue.
+    pub(crate) async fn sweep_pending_embeddings(&self, budget: usize) -> ReembedSweepReport {
+        self.inner.reembed_pending(budget).await
     }
 }
 

--- a/src/openhuman/memory/store/mod.rs
+++ b/src/openhuman/memory/store/mod.rs
@@ -34,6 +34,7 @@ pub mod vectors;
 mod client;
 pub mod factories;
 mod memory_trait;
+pub mod vector_reembed;
 
 pub use kinds::MemoryKind;
 pub use traits::{ObsidianFile, ObsidianRepresentable, VectorEmbeddable};

--- a/src/openhuman/memory/store/namespace_store/mod.rs
+++ b/src/openhuman/memory/store/namespace_store/mod.rs
@@ -33,4 +33,5 @@ mod helpers;
 mod init;
 pub mod profile;
 mod query;
+pub(crate) mod reembed;
 pub mod segments;

--- a/src/openhuman/memory/store/namespace_store/reembed.rs
+++ b/src/openhuman/memory/store/namespace_store/reembed.rs
@@ -1,0 +1,264 @@
+//! Durable re-embedding sweep for `vector_chunks`.
+//!
+//! A chunk whose vector never landed — the batch embed failed and the row was
+//! persisted text-only (`documents.rs`) — or whose stored vector is unusable
+//! under the active embedder (a dimension the live query can never match, e.g.
+//! the degenerate `dims=1` rows a partial cloud-embedding failure leaves
+//! behind) is invisible to recall: the vector path skips any chunk whose
+//! dimension differs from the live query embedding (`query.rs`).
+//!
+//! Those deficient rows persist in the table, so they are their own durable
+//! work-list: the sweep re-derives the pending set from `vector_chunks` on
+//! every boot. That is exactly what makes recovery survive a service restart
+//! without a separate queue — the missing/degenerate vector *is* the pending
+//! marker.
+
+use rusqlite::params;
+
+use super::UnifiedMemory;
+use crate::openhuman::embeddings::retry_after::{backoff_ms_for_attempt, MAX_429_RETRIES};
+use crate::openhuman::memory_tree::health::classify_embed_error;
+
+/// A `vector_chunks` row whose embedding must be recomputed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReembedCandidate {
+    pub namespace: String,
+    pub document_id: String,
+    pub chunk_id: String,
+    pub text: String,
+}
+
+/// Tally of one [`UnifiedMemory::reembed_pending`] pass.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct ReembedSweepReport {
+    /// Deficient rows the scan returned this pass (bounded by `budget`).
+    pub scanned: usize,
+    /// Rows given a fresh, usable vector.
+    pub reembedded: usize,
+    /// Rows still without a usable vector after this pass (they stay pending).
+    pub failed: usize,
+}
+
+impl UnifiedMemory {
+    /// Scan `vector_chunks` for rows whose vector is missing or unusable under
+    /// the active embedder, newest-first, capped at `limit`.
+    ///
+    /// A row is pending when either holds:
+    ///   * `embedding IS NULL` — the batch embed failed and the chunk was
+    ///     persisted text-only.
+    ///   * `dim IS NULL` or `dim <> active` — a dimension the live query can
+    ///     never match, so recall drops the row. This is the signal that
+    ///     catches the degenerate `dims=1` vectors a partial cloud failure
+    ///     writes: they satisfy a naive "has an embedding" check yet score
+    ///     against nothing.
+    ///
+    /// Dimension — not the signature string — is the predicate on purpose: it
+    /// is the format-agnostic, numeric truth, so this stays correct regardless
+    /// of the separate signature-convention unification. Blank-text rows are
+    /// excluded: they are permanently un-embeddable, not pending work, and
+    /// re-queuing them would spin forever.
+    pub(crate) fn scan_chunks_needing_reembed(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<ReembedCandidate>, String> {
+        let active_dim = self.embedder.dimensions() as i64;
+        let conn = self.conn.lock();
+        let mut stmt = conn
+            .prepare(
+                "SELECT namespace, document_id, chunk_id, text
+                   FROM vector_chunks
+                  WHERE (embedding IS NULL OR dim IS NULL OR dim <> ?1)
+                    AND text IS NOT NULL
+                    AND trim(text) <> ''
+                  ORDER BY updated_at DESC, chunk_id ASC
+                  LIMIT ?2",
+            )
+            .map_err(|e| format!("prepare scan_chunks_needing_reembed: {e}"))?;
+        let rows = stmt
+            .query_map(params![active_dim, limit as i64], |row| {
+                Ok(ReembedCandidate {
+                    namespace: row.get(0)?,
+                    document_id: row.get(1)?,
+                    chunk_id: row.get(2)?,
+                    text: row.get(3)?,
+                })
+            })
+            .map_err(|e| format!("query scan_chunks_needing_reembed: {e}"))?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(|e| format!("collect scan_chunks_needing_reembed: {e}"))
+    }
+
+    /// Re-embed up to `budget` deficient chunks (see
+    /// [`scan_chunks_needing_reembed`]) in a single pass, newest-first.
+    ///
+    /// `budget` doubles as the batch size: the pending texts are embedded in
+    /// one provider call, so a scheduler bounds provider load by calling this
+    /// repeatedly with a modest budget rather than passing a huge one. A
+    /// transient provider failure retries the batch with jittered exponential
+    /// backoff; an unrecoverable one (auth missing, refused input) ends the
+    /// pass without a tight loop — the rows stay pending in the table and the
+    /// next scheduled pass retries them, so recovery survives a restart and a
+    /// signed-out interval alike.
+    pub(crate) async fn reembed_pending(&self, budget: usize) -> ReembedSweepReport {
+        let mut report = ReembedSweepReport::default();
+        if budget == 0 {
+            return report;
+        }
+        let candidates = match self.scan_chunks_needing_reembed(budget) {
+            Ok(candidates) => candidates,
+            Err(error) => {
+                log::warn!("[memory::reembed] scan failed: {error}");
+                return report;
+            }
+        };
+        report.scanned = candidates.len();
+        if candidates.is_empty() {
+            return report;
+        }
+
+        let texts: Vec<&str> = candidates.iter().map(|c| c.text.as_str()).collect();
+        let vectors = match self.embed_with_backoff(&texts).await {
+            Ok(vectors) => vectors,
+            Err(error) => {
+                let failure = classify_embed_error(&error);
+                log::warn!(
+                    "[memory::reembed] batch embed failed for {} chunk(s) (code={:?}, unrecoverable={}): {error:#}",
+                    candidates.len(),
+                    failure.code,
+                    failure.is_unrecoverable(),
+                );
+                report.failed = candidates.len();
+                return report;
+            }
+        };
+
+        let signature = self.embedder.signature();
+        let active_dim = self.embedder.dimensions();
+        let now = Self::now_ts();
+        for (candidate, vector) in candidates.iter().zip(vectors.iter()) {
+            // Only a vector the live query can actually score against counts as
+            // a repair. A provider that degrades mid-failure returns short
+            // vectors (flo's `dims=1` rows came from exactly that); writing one
+            // back would satisfy "has an embedding" while still matching
+            // nothing, and — because the row stays pending — would make the
+            // sweep rewrite the same row forever.
+            if vector.len() != active_dim {
+                log::debug!(
+                    "[memory::reembed] provider returned {} dims for {}/{} (active {active_dim}) — leaving pending",
+                    vector.len(),
+                    candidate.namespace,
+                    candidate.chunk_id
+                );
+                report.failed += 1;
+                continue;
+            }
+            match self.write_chunk_embedding(candidate, vector, &signature, now) {
+                Ok(()) => report.reembedded += 1,
+                Err(error) => {
+                    log::warn!(
+                        "[memory::reembed] write-back failed for {}/{}: {error}",
+                        candidate.namespace,
+                        candidate.chunk_id
+                    );
+                    report.failed += 1;
+                }
+            }
+        }
+        // A provider that returned fewer vectors than inputs leaves the tail
+        // pending; count them so the report reflects real progress.
+        if vectors.len() < candidates.len() {
+            report.failed += candidates.len() - vectors.len();
+        }
+        if report.reembedded > 0 {
+            log::info!(
+                "[memory::reembed] re-embedded {}/{} pending chunk(s)",
+                report.reembedded,
+                report.scanned
+            );
+        }
+        report
+    }
+
+    /// Embed `texts`, retrying a transient provider failure with jittered
+    /// exponential backoff (reusing `retry_after::backoff_ms_for_attempt`). An
+    /// unrecoverable failure (per `classify_embed_error`) returns immediately —
+    /// retrying it only burns the backoff budget against a condition a retry
+    /// can never change.
+    async fn embed_with_backoff(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        let mut attempt = 0u32;
+        loop {
+            match self.embedder.embed(texts).await {
+                Ok(vectors) => return Ok(vectors),
+                Err(error) => {
+                    if classify_embed_error(&error).is_unrecoverable() || attempt >= MAX_429_RETRIES
+                    {
+                        return Err(error);
+                    }
+                    let delay = jitter_ms(backoff_ms_for_attempt(attempt, None));
+                    log::debug!(
+                        "[memory::reembed] embed attempt {} failed, retrying in {delay}ms: {error:#}",
+                        attempt + 1
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(delay)).await;
+                    attempt += 1;
+                }
+            }
+        }
+    }
+
+    /// Stamp a freshly-computed vector onto its `vector_chunks` row, replacing a
+    /// missing or wrong-dimension one. `dim` and `model_signature` are written
+    /// together with the blob so a later scan and the recall dimension guard
+    /// both read a consistent row.
+    fn write_chunk_embedding(
+        &self,
+        candidate: &ReembedCandidate,
+        vector: &[f32],
+        signature: &str,
+        now: f64,
+    ) -> Result<(), String> {
+        let bytes = Self::vec_to_bytes(vector);
+        let dim = vector.len() as i64;
+        let conn = self.conn.lock();
+        conn.execute(
+            "UPDATE vector_chunks
+                SET embedding = ?1, dim = ?2, model_signature = ?3, updated_at = ?4
+              WHERE namespace = ?5 AND chunk_id = ?6",
+            params![
+                bytes,
+                dim,
+                signature,
+                now,
+                candidate.namespace,
+                candidate.chunk_id
+            ],
+        )
+        .map_err(|error| {
+            format!(
+                "write_chunk_embedding {}/{}: {error}",
+                candidate.namespace, candidate.chunk_id
+            )
+        })?;
+        Ok(())
+    }
+}
+
+/// Spread a backoff delay across `[base/2, base]` so many instances retrying a
+/// recovering backend do not resynchronise into a thundering herd. Uses the
+/// clock's sub-millisecond noise as a dependency-free entropy source — retry
+/// jitter needs spread, not cryptographic randomness.
+fn jitter_ms(base_ms: u64) -> u64 {
+    if base_ms == 0 {
+        return 0;
+    }
+    let half = base_ms / 2;
+    let noise = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| u64::from(elapsed.subsec_nanos()))
+        .unwrap_or(0);
+    half + noise % (half + 1)
+}
+
+#[cfg(test)]
+#[path = "reembed_tests.rs"]
+mod tests;

--- a/src/openhuman/memory/store/namespace_store/reembed.rs
+++ b/src/openhuman/memory/store/namespace_store/reembed.rs
@@ -16,8 +16,10 @@
 use rusqlite::params;
 
 use super::UnifiedMemory;
-use crate::openhuman::embeddings::retry_after::{backoff_ms_for_attempt, MAX_429_RETRIES};
-use crate::openhuman::memory_tree::health::classify_embed_error;
+use crate::openhuman::inference::embeddings::retry_after::{
+    backoff_ms_for_attempt, MAX_429_RETRIES,
+};
+use crate::openhuman::memory::tree::health::classify_embed_error;
 
 /// A `vector_chunks` row whose embedding must be recomputed.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -52,30 +54,42 @@ impl UnifiedMemory {
     ///     writes: they satisfy a naive "has an embedding" check yet score
     ///     against nothing.
     ///
-    /// Dimension — not the signature string — is the predicate on purpose: it
-    /// is the format-agnostic, numeric truth, so this stays correct regardless
-    /// of the separate signature-convention unification. Blank-text rows are
-    /// excluded: they are permanently un-embeddable, not pending work, and
-    /// re-queuing them would spin forever.
+    ///   * `model_signature` is set and differs from the active embedder's —
+    ///     recall skips those rows outright, because cosine across two
+    ///     embedding spaces is meaningless. A provider or model swap that keeps
+    ///     the dimension is invisible to the two checks above, so without this
+    ///     the `sig_changed` trigger would schedule a sweep that repairs
+    ///     nothing and the rows would stay unreachable until their document was
+    ///     rewritten.
+    ///
+    /// A NULL signature is deliberately NOT pending. Recall accepts those rows
+    /// (written before model tagging) as long as the dimension matches, so
+    /// selecting them would re-embed the entire legacy corpus to change nothing.
+    /// Blank-text rows are excluded too: they are permanently un-embeddable, not
+    /// pending work, and re-queuing them would spin forever.
     pub(crate) fn scan_chunks_needing_reembed(
         &self,
         limit: usize,
     ) -> Result<Vec<ReembedCandidate>, String> {
         let active_dim = self.embedder.dimensions() as i64;
+        let active_signature = self.embedder.signature();
         let conn = self.conn.lock();
         let mut stmt = conn
             .prepare(
                 "SELECT namespace, document_id, chunk_id, text
                    FROM vector_chunks
-                  WHERE (embedding IS NULL OR dim IS NULL OR dim <> ?1)
+                  WHERE (embedding IS NULL
+                         OR dim IS NULL
+                         OR dim <> ?1
+                         OR (model_signature IS NOT NULL AND model_signature <> ?2))
                     AND text IS NOT NULL
                     AND trim(text) <> ''
                   ORDER BY updated_at DESC, chunk_id ASC
-                  LIMIT ?2",
+                  LIMIT ?3",
             )
             .map_err(|e| format!("prepare scan_chunks_needing_reembed: {e}"))?;
         let rows = stmt
-            .query_map(params![active_dim, limit as i64], |row| {
+            .query_map(params![active_dim, active_signature, limit as i64], |row| {
                 Ok(ReembedCandidate {
                     namespace: row.get(0)?,
                     document_id: row.get(1)?,
@@ -220,25 +234,43 @@ impl UnifiedMemory {
         let bytes = Self::vec_to_bytes(vector);
         let dim = vector.len() as i64;
         let conn = self.conn.lock();
-        conn.execute(
-            "UPDATE vector_chunks
+        // Keyed on the scanned `text` as well as the row identity: the embed
+        // call between the scan and this write is a network round trip with
+        // retries, and a document re-ingested in that window leaves a row whose
+        // text this vector no longer describes. Overwriting it would stamp the
+        // stale vector with the ACTIVE dim and signature, so no later scan could
+        // ever tell it apart from a healthy row.
+        let updated = conn
+            .execute(
+                "UPDATE vector_chunks
                 SET embedding = ?1, dim = ?2, model_signature = ?3, updated_at = ?4
-              WHERE namespace = ?5 AND chunk_id = ?6",
-            params![
-                bytes,
-                dim,
-                signature,
-                now,
-                candidate.namespace,
-                candidate.chunk_id
-            ],
-        )
-        .map_err(|error| {
-            format!(
-                "write_chunk_embedding {}/{}: {error}",
-                candidate.namespace, candidate.chunk_id
+              WHERE namespace = ?5 AND chunk_id = ?6 AND text = ?7",
+                params![
+                    bytes,
+                    dim,
+                    signature,
+                    now,
+                    candidate.namespace,
+                    candidate.chunk_id,
+                    candidate.text
+                ],
             )
-        })?;
+            .map_err(|error| {
+                format!(
+                    "write_chunk_embedding {}/{}: {error}",
+                    candidate.namespace, candidate.chunk_id
+                )
+            })?;
+        if updated == 0 {
+            // The row moved on (re-ingested, or deleted). Nothing to repair from
+            // this pass; if it still needs an embedding the next scan picks up
+            // its current text.
+            tracing::debug!(
+                namespace = %candidate.namespace,
+                chunk_id = %candidate.chunk_id,
+                "[memory][reembed] row changed under the sweep; vector discarded"
+            );
+        }
         Ok(())
     }
 }

--- a/src/openhuman/memory/store/namespace_store/reembed_tests.rs
+++ b/src/openhuman/memory/store/namespace_store/reembed_tests.rs
@@ -1,0 +1,204 @@
+//! Tests for the `reembed` sweep — which `vector_chunks` rows are pending.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tempfile::TempDir;
+
+use crate::openhuman::inference::embeddings::EmbeddingProvider;
+use crate::openhuman::memory::store::UnifiedMemory;
+
+/// Embedder whose only interesting property is a fixed dimensionality: the
+/// sweep predicate keys entirely off `dimensions()`. `returns` is the width of
+/// the vectors it actually hands back, which a degraded provider lets drift
+/// away from the declared `dims`.
+struct DimStub {
+    dims: usize,
+    returns: usize,
+}
+
+impl DimStub {
+    /// A healthy provider: returns vectors at its declared dimensionality.
+    fn healthy(dims: usize) -> Self {
+        Self {
+            dims,
+            returns: dims,
+        }
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for DimStub {
+    fn name(&self) -> &str {
+        "stub"
+    }
+    fn model_id(&self) -> &str {
+        "stub-model"
+    }
+    fn dimensions(&self) -> usize {
+        self.dims
+    }
+    async fn embed(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+        Ok(texts
+            .iter()
+            .map(|_| vec![0.1_f32; self.returns.max(1)])
+            .collect())
+    }
+}
+
+/// Insert one `vector_chunks` row directly. `dim = Some(n)` writes a matching
+/// non-null embedding blob (mirroring `documents.rs`, which sets `embedding`
+/// and `dim` together); `dim = None` writes the text-only, vector-less row a
+/// failed batch embed leaves behind.
+fn insert_chunk(
+    memory: &UnifiedMemory,
+    namespace: &str,
+    document_id: &str,
+    idx: usize,
+    text: &str,
+    dim: Option<i64>,
+) {
+    let embedding: Option<Vec<u8>> = dim.map(|d| vec![0_u8; (d.max(0) as usize) * 4]);
+    let model_signature: Option<String> =
+        dim.map(|d| format!("provider=stub;model=stub-model;dims={d}"));
+    let conn = memory.conn.lock();
+    conn.execute(
+        "INSERT OR REPLACE INTO vector_chunks
+           (namespace, document_id, chunk_id, text, embedding, metadata_json, created_at, updated_at, model_signature, dim)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+        rusqlite::params![
+            namespace,
+            document_id,
+            format!("{document_id}:{idx}"),
+            text,
+            embedding,
+            "{}",
+            1000.0_f64,
+            1000.0_f64,
+            model_signature,
+            dim,
+        ],
+    )
+    .unwrap();
+}
+
+#[tokio::test]
+async fn scan_flags_null_and_wrong_dimension_but_not_healthy_or_empty() {
+    let tmp = TempDir::new().unwrap();
+    let memory = UnifiedMemory::new(tmp.path(), Arc::new(DimStub::healthy(1024)), None).unwrap();
+
+    // Healthy: dimension matches the active embedder (1024) — NOT pending.
+    insert_chunk(
+        &memory,
+        "skill-gmail",
+        "healthy",
+        0,
+        "colorado boulder",
+        Some(1024),
+    );
+    // Degenerate dims=1 (a partial cloud failure) — pending.
+    insert_chunk(
+        &memory,
+        "skill-gmail",
+        "degenerate",
+        0,
+        "colorado springs",
+        Some(1),
+    );
+    // Never embedded (NULL vector) — pending.
+    insert_chunk(&memory, "skill-gmail", "failed", 0, "denver colorado", None);
+    // Blank text — permanently un-embeddable, must never be pending.
+    insert_chunk(&memory, "skill-gmail", "blank", 0, "   ", None);
+
+    let pending = memory.scan_chunks_needing_reembed(100).unwrap();
+    let ids: HashSet<&str> = pending.iter().map(|c| c.document_id.as_str()).collect();
+
+    assert!(
+        ids.contains("degenerate"),
+        "dims=1 degenerate row must be pending"
+    );
+    assert!(ids.contains("failed"), "NULL-embedding row must be pending");
+    assert!(
+        !ids.contains("healthy"),
+        "matching-dim row must not be pending"
+    );
+    assert!(
+        !ids.contains("blank"),
+        "blank-text row must never be pending"
+    );
+    assert_eq!(
+        pending.len(),
+        2,
+        "exactly the two deficient rows are pending"
+    );
+}
+
+#[tokio::test]
+async fn scan_respects_limit() {
+    let tmp = TempDir::new().unwrap();
+    let memory = UnifiedMemory::new(tmp.path(), Arc::new(DimStub::healthy(1024)), None).unwrap();
+    for i in 0..5 {
+        insert_chunk(&memory, "skill-gmail", "doc", i, "needs embedding", None);
+    }
+    let pending = memory.scan_chunks_needing_reembed(3).unwrap();
+    assert_eq!(pending.len(), 3, "limit caps the returned candidate count");
+}
+
+#[tokio::test]
+async fn sweep_reembeds_pending_rows_and_clears_the_pending_set() {
+    let tmp = TempDir::new().unwrap();
+    // 8-dim active embedder: rows at dim=8 are healthy, dim=1 / NULL are not.
+    let memory = UnifiedMemory::new(tmp.path(), Arc::new(DimStub::healthy(8)), None).unwrap();
+    insert_chunk(&memory, "skill-gmail", "failed", 0, "denver colorado", None);
+    insert_chunk(
+        &memory,
+        "skill-gmail",
+        "degenerate",
+        0,
+        "colorado springs",
+        Some(1),
+    );
+    insert_chunk(&memory, "skill-gmail", "healthy", 0, "boulder", Some(8));
+
+    let report = memory.reembed_pending(100).await;
+    assert_eq!(
+        report.reembedded, 2,
+        "the NULL and dims=1 rows get fresh vectors"
+    );
+    assert_eq!(
+        report.failed, 0,
+        "no row is left pending after a clean sweep"
+    );
+
+    // Nothing is pending once the sweep has stamped every deficient row.
+    let pending = memory.scan_chunks_needing_reembed(100).unwrap();
+    assert!(pending.is_empty(), "sweep cleared the pending set");
+}
+
+#[tokio::test]
+async fn a_degraded_provider_leaves_rows_pending_instead_of_stamping_short_vectors() {
+    let tmp = TempDir::new().unwrap();
+    // Declares 8 dims but hands back 1 — the partial cloud failure that put
+    // `dims=1` vectors into flo's store in the first place.
+    let memory = UnifiedMemory::new(
+        tmp.path(),
+        Arc::new(DimStub {
+            dims: 8,
+            returns: 1,
+        }),
+        None,
+    )
+    .unwrap();
+    insert_chunk(&memory, "skill-gmail", "failed", 0, "denver colorado", None);
+
+    let report = memory.reembed_pending(100).await;
+    assert_eq!(report.reembedded, 0, "a short vector is not a repair");
+    assert_eq!(report.failed, 1, "the row is reported as still pending");
+
+    // Still pending — so a later sweep, under a working provider, fixes it.
+    // Stamping the short vector instead would both hide the row from recall and
+    // keep it pending forever, re-embedding it on every single pass.
+    let pending = memory.scan_chunks_needing_reembed(100).unwrap();
+    assert_eq!(pending.len(), 1, "the row must stay in the pending set");
+}

--- a/src/openhuman/memory/store/vector_reembed.rs
+++ b/src/openhuman/memory/store/vector_reembed.rs
@@ -1,0 +1,78 @@
+//! Background driver for the base-store re-embedding sweep.
+//!
+//! [`namespace_store::reembed`](super::namespace_store::reembed) knows *which*
+//! `vector_chunks` rows need a vector and how to compute one; this module
+//! decides *when* to run it. The pending set lives in the table itself, so a
+//! trigger is only ever a nudge: whatever a run leaves unfinished — because the
+//! provider was down, the session was signed out, or the process exited — is
+//! rediscovered by the next one. That is what makes recovery survive a service
+//! restart without a queue to keep in sync.
+//!
+//! Idempotent and non-fatal, like the tree-side
+//! [`ensure_reembed_backfill`](crate::openhuman::memory::queue::ensure_reembed_backfill)
+//! it runs beside: at most one sweep is in flight, and a failure is logged
+//! rather than propagated into whatever user action triggered it.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Chunks per pass — also the provider batch size. Small enough that a failing
+/// provider wastes one modest call rather than a huge one, and that a sweep
+/// competes gently with live embedding traffic.
+const SWEEP_BATCH: usize = 64;
+
+/// Upper bound on passes per trigger. A backlog larger than this (flo carried
+/// thousands of vector-less gmail chunks) is drained across triggers instead of
+/// in one unbounded run, so a sweep can never monopolise the embedder.
+const MAX_BATCHES_PER_RUN: usize = 64;
+
+static SWEEP_RUNNING: AtomicBool = AtomicBool::new(false);
+
+/// Clears the in-flight flag however the sweep ends, including a panic — a
+/// stuck flag would silently disable re-embedding for the rest of the process.
+struct SweepGuard;
+
+impl Drop for SweepGuard {
+    fn drop(&mut self) {
+        SWEEP_RUNNING.store(false, Ordering::SeqCst);
+    }
+}
+
+/// Nudge the sweep: drain pending chunks in the background if a sweep is not
+/// already running and the memory store is up.
+///
+/// Returns immediately — callers are user-facing paths (sync completion,
+/// startup, a credential or model change) that must not wait on the embedder.
+pub fn ensure_vector_reembed() {
+    if tokio::runtime::Handle::try_current().is_err() {
+        // No runtime to spawn onto (unit tests, sync CLI paths). The rows stay
+        // pending, so the next trigger inside the service picks them up.
+        return;
+    }
+    let Some(client) = crate::openhuman::memory::global::client_if_ready() else {
+        return;
+    };
+    if SWEEP_RUNNING.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    tokio::spawn(async move {
+        let _guard = SweepGuard;
+        let mut repaired = 0usize;
+        for _ in 0..MAX_BATCHES_PER_RUN {
+            let report = client.sweep_pending_embeddings(SWEEP_BATCH).await;
+            repaired += report.reembedded;
+            // Nothing pending, or a pass that repaired nothing: the provider is
+            // failing or the remaining rows are un-embeddable. Either way the
+            // next trigger retries — spinning here would only burn quota.
+            if report.scanned == 0 || report.reembedded == 0 {
+                break;
+            }
+        }
+        if repaired > 0 {
+            log::info!("[memory::reembed] sweep repaired {repaired} chunk(s)");
+        }
+    });
+}
+
+#[cfg(test)]
+#[path = "vector_reembed_tests.rs"]
+mod tests;

--- a/src/openhuman/memory/store/vector_reembed_tests.rs
+++ b/src/openhuman/memory/store/vector_reembed_tests.rs
@@ -1,0 +1,35 @@
+//! Tests for the sweep trigger's in-flight guard.
+//!
+//! One test function on purpose: both assertions read `SWEEP_RUNNING`, and
+//! separate `#[test]`s would race each other inside the shared test process.
+
+use super::*;
+
+#[test]
+fn the_in_flight_flag_is_never_left_set() {
+    // Outside a runtime there is nothing to spawn onto, so the trigger returns
+    // before claiming the flag — otherwise the first such call would disable
+    // re-embedding for the rest of the process.
+    ensure_vector_reembed();
+    assert!(
+        !SWEEP_RUNNING.load(Ordering::SeqCst),
+        "a trigger that spawns nothing must not claim the flag"
+    );
+
+    // A sweep that unwinds must still release the flag. The panicking scope
+    // runs on its own thread rather than behind a swapped panic hook: the hook
+    // is process-global, and replacing it disturbs every test running in
+    // parallel.
+    SWEEP_RUNNING.store(true, Ordering::SeqCst);
+    let outcome = std::thread::spawn(|| {
+        let _guard = SweepGuard;
+        panic!("sweep died mid-batch");
+    })
+    .join();
+
+    assert!(outcome.is_err(), "the test's own panic must have unwound");
+    assert!(
+        !SWEEP_RUNNING.load(Ordering::SeqCst),
+        "a panicking sweep must not disable re-embedding for the process"
+    );
+}

--- a/src/openhuman/memory/sync/composio/providers/gmail/post_process.rs
+++ b/src/openhuman/memory/sync/composio/providers/gmail/post_process.rs
@@ -260,7 +260,12 @@ fn validate_segments_against_hints(segments: &[String], hints: &[Value]) -> bool
 
 /// Returns true when the caller explicitly set `raw_html: true` (or the
 /// camelCase `rawHtml: true`) in the `arguments` object.
-fn is_raw_html_flag_set(arguments: Option<&Value>) -> bool {
+/// Whether the caller asked for the raw Composio shape.
+///
+/// `pub(super)` so the sync executor can gate its own reshape step on the same
+/// answer: two reshapes that disagree about the flag would let one of them run
+/// on a payload the caller asked to keep untouched.
+pub(super) fn is_raw_html_flag_set(arguments: Option<&Value>) -> bool {
     let Some(obj) = arguments.and_then(|v| v.as_object()) else {
         return false;
     };

--- a/src/openhuman/memory/sync_events.rs
+++ b/src/openhuman/memory/sync_events.rs
@@ -180,6 +180,11 @@ impl EventHandler for SyncCompleteEmbedTrigger {
             if stage == "completed" {
                 log::debug!("[memory-sync] sync completed — triggering batch embedding backfill");
                 crate::openhuman::memory::queue::ensure_reembed_backfill(&self.config);
+                // The tree backfill above covers `mem_tree_chunk_embeddings`
+                // only. Base `vector_chunks` rows whose batch embed failed
+                // during the sync are repaired by their own sweep — a sync is
+                // exactly when a crop of them appears.
+                crate::openhuman::memory::store::vector_reembed::ensure_vector_reembed();
             }
         }
     }

--- a/src/openhuman/memory/tools/recall.rs
+++ b/src/openhuman/memory/tools/recall.rs
@@ -88,7 +88,10 @@ impl Tool for MemoryRecallTool {
                 }
             }
             None => {
-                crate::openhuman::memory::auto_recall::recall_with_connectors(
+                // The schema says omitting the namespace searches everywhere,
+                // so it has to search everywhere — the per-turn cap belongs to
+                // the automatic context path, not to a call the model made.
+                crate::openhuman::memory::auto_recall::recall_every_namespace(
                     self.memory.as_ref(),
                     query,
                     limit,
@@ -116,7 +119,7 @@ impl Tool for MemoryRecallTool {
                 .namespace
                 .as_deref()
                 .filter(|namespace| {
-                    *namespace != crate::openhuman::memory_store::types::GLOBAL_NAMESPACE
+                    *namespace != crate::openhuman::memory::store::types::GLOBAL_NAMESPACE
                 })
                 .map_or_else(String::new, |namespace| format!(" ({namespace})"));
             // Condense to the query-relevant chunks, capped: recall returns

--- a/src/openhuman/memory/tools/recall.rs
+++ b/src/openhuman/memory/tools/recall.rs
@@ -115,12 +115,22 @@ impl Tool for MemoryRecallTool {
             let origin = entry
                 .namespace
                 .as_deref()
-                .filter(|namespace| *namespace != crate::openhuman::memory_store::types::GLOBAL_NAMESPACE)
+                .filter(|namespace| {
+                    *namespace != crate::openhuman::memory_store::types::GLOBAL_NAMESPACE
+                })
                 .map_or_else(String::new, |namespace| format!(" ({namespace})"));
+            // Condense to the query-relevant chunks, capped: recall returns
+            // whole documents, and one large document (a synced thread, or an
+            // old subagent envelope) would otherwise fill the entire result and
+            // bury every other hit.
+            let content = crate::openhuman::memory::recall_shaping::condense_recall_content(
+                query,
+                &entry.content,
+            );
             let _ = writeln!(
                 output,
-                "- [{}]{origin} {}: {}{score}",
-                entry.category, entry.key, entry.content
+                "- [{}]{origin} {}: {content}{score}",
+                entry.category, entry.key
             );
         }
         Ok(ToolResult::success(output))

--- a/src/openhuman/memory/tools/recall.rs
+++ b/src/openhuman/memory/tools/recall.rs
@@ -36,26 +36,27 @@ impl Tool for MemoryRecallTool {
                 },
                 "namespace": {
                     "type": "string",
-                    "description": "Namespace to search (e.g. 'global', 'background', 'autocomplete', or 'skill-{id}')"
+                    "description": "Namespace to search (e.g. 'global', 'background', 'autocomplete', or 'skill-{id}'). OMIT THIS to search everywhere — 'global' plus connected-app memories like 'skill-gmail'. Only name one when you specifically want to exclude the others."
                 },
                 "limit": {
                     "type": "integer",
                     "description": "Max results to return (default: 5)"
                 }
             },
-            "required": ["namespace", "query"]
+            "required": ["query"]
         })
     }
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        // An omitted namespace means "search everywhere". Requiring one made
+        // every recall a guess the model usually got wrong: it reads `global`
+        // first in the schema, picks it, and connector memories — where synced
+        // mail actually lives — are structurally unreachable.
         let namespace = args
             .get("namespace")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| anyhow::anyhow!("Missing 'namespace' parameter"))?
-            .trim();
-        if namespace.is_empty() {
-            return Err(anyhow::anyhow!("namespace cannot be empty"));
-        }
+            .map(str::trim)
+            .filter(|namespace| !namespace.is_empty());
         let query = args
             .get("query")
             .and_then(|v| v.as_str())
@@ -75,30 +76,54 @@ impl Tool for MemoryRecallTool {
         // string would add a redundant token matching almost every row. Instead,
         // namespace scoping belongs in RecallOpts so the backend restricts the
         // search to the correct namespace column.
-        let recall_opts = crate::openhuman::memory::RecallOpts {
-            namespace: Some(namespace),
-            ..crate::openhuman::memory::RecallOpts::default()
-        };
-        match self.memory.recall(query, limit, recall_opts).await {
-            Ok(entries) if entries.is_empty() => Ok(ToolResult::success(
-                "No memories found matching that query.",
-            )),
-            Ok(entries) => {
-                let mut output = format!("Found {} memories:\n", entries.len());
-                for entry in &entries {
-                    let score = entry
-                        .score
-                        .map_or_else(String::new, |s| format!(" [{s:.0}%]"));
-                    let _ = writeln!(
-                        output,
-                        "- [{}] {}: {}{score}",
-                        entry.category, entry.key, entry.content
-                    );
+        let entries = match namespace {
+            Some(namespace) => {
+                let recall_opts = crate::openhuman::memory::RecallOpts {
+                    namespace: Some(namespace),
+                    ..crate::openhuman::memory::RecallOpts::default()
+                };
+                match self.memory.recall(query, limit, recall_opts).await {
+                    Ok(entries) => entries,
+                    Err(e) => return Ok(ToolResult::error(format!("Memory recall failed: {e}"))),
                 }
-                Ok(ToolResult::success(output))
             }
-            Err(e) => Ok(ToolResult::error(format!("Memory recall failed: {e}"))),
+            None => {
+                crate::openhuman::memory::auto_recall::recall_with_connectors(
+                    self.memory.as_ref(),
+                    query,
+                    limit,
+                )
+                .await
+            }
+        };
+
+        if entries.is_empty() {
+            return Ok(ToolResult::success(
+                "No memories found matching that query.",
+            ));
         }
+        let mut output = format!("Found {} memories:\n", entries.len());
+        for entry in &entries {
+            // Percent, not the raw 0–1 score: rendering 0.68 as "[1%]" told the
+            // model every hit was worthless and pushed it to re-search live
+            // sources it had just been handed the answer from.
+            let score = entry
+                .score
+                .map_or_else(String::new, |s| format!(" [{:.0}%]", s * 100.0));
+            // Name the namespace when it isn't the default one, so a
+            // search-everywhere result says which connector it came from.
+            let origin = entry
+                .namespace
+                .as_deref()
+                .filter(|namespace| *namespace != crate::openhuman::memory_store::types::GLOBAL_NAMESPACE)
+                .map_or_else(String::new, |namespace| format!(" ({namespace})"));
+            let _ = writeln!(
+                output,
+                "- [{}]{origin} {}: {}{score}",
+                entry.category, entry.key, entry.content
+            );
+        }
+        Ok(ToolResult::success(output))
     }
 }
 
@@ -198,5 +223,75 @@ mod tests {
         let tool = MemoryRecallTool::new(mem);
         assert_eq!(tool.name(), "memory_recall");
         assert!(tool.parameters_schema()["properties"]["query"].is_object());
+    }
+
+    #[test]
+    fn namespace_is_optional_so_the_model_is_not_forced_to_guess_one() {
+        // Requiring a namespace made every recall a guess: the model reads
+        // `global` first, picks it, and connector memories are unreachable.
+        let (_tmp, mem) = seeded_mem();
+        let tool = MemoryRecallTool::new(mem);
+        let required = tool.parameters_schema()["required"].clone();
+        assert_eq!(required, json!(["query"]));
+    }
+
+    #[tokio::test]
+    async fn omitting_the_namespace_searches_connector_memories_too() {
+        let (_tmp, mem) = seeded_mem();
+        mem.store(
+            "skill-gmail",
+            "gmail:1",
+            "Boulder visit confirmed with the University of Colorado",
+            MemoryCategory::Core,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let tool = MemoryRecallTool::new(mem);
+        let result = tool
+            .execute(json!({"query": "University of Colorado"}))
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        let output = result.output();
+        assert!(
+            output.contains("Boulder visit"),
+            "a connector memory must be reachable without naming its namespace: {output}"
+        );
+        // …and the result says where it came from, so the model can tell a
+        // connector hit from a chat one.
+        assert!(output.contains("(skill-gmail)"), "{output}");
+    }
+
+    #[tokio::test]
+    async fn scores_render_as_real_percentages() {
+        let (_tmp, mem) = seeded_mem();
+        mem.store(
+            "global",
+            "lang",
+            "User prefers Rust",
+            MemoryCategory::Core,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let tool = MemoryRecallTool::new(mem);
+        let output = tool
+            .execute(json!({"namespace": "global", "query": "Rust"}))
+            .await
+            .unwrap()
+            .output();
+
+        // A 0–1 score printed with a `%` sign made every hit read as "[0%]" or
+        // "[1%]" — the model saw worthless results and went back to the live
+        // source it had just been given the answer from.
+        assert!(
+            !output.contains("[0%]") && !output.contains("[1%]"),
+            "a matching hit must not render as 0–1%: {output}"
+        );
+        assert!(output.contains('%'), "the score is still shown: {output}");
     }
 }

--- a/src/openhuman/security/credentials/ops.rs
+++ b/src/openhuman/security/credentials/ops.rs
@@ -615,6 +615,10 @@ async fn store_session_inner(
         "[credentials][auth-store] scheduler gate cleared; ensuring re-embed backfill after login"
     );
     crate::openhuman::memory::queue::ensure_reembed_backfill(&effective_config);
+    // Base `vector_chunks` rows left vector-less while the session was signed
+    // out are unrecoverable-classified, so nothing retries them until the
+    // condition that caused them clears. Logging in is that moment.
+    crate::openhuman::memory::store::vector_reembed::ensure_vector_reembed();
     logs.push("memory re-embed backfill checked after login".to_string());
 
     // Bind the Sentry scope to this user so background events that fire


### PR DESCRIPTION
> **Status (2026-09-02): the tinycortex dependency has cleared, and a different blocker replaced it.**
> tinyhumansai/tinycortex#132 merged on 2026-08-10 and `main` pins `vendor/tinycortex` at `8dab3d2e`, 37 commits past it — `EmbeddingConfig.provider` and `GmailSyncPipeline::with_executor` are both available and no submodule bump is needed.
> What blocks this now is that `ba088ec20` deleted the legacy memory subsystem: 14 of this PR's 23 files no longer exist and the work they carried lives in the `tinymemory` vendor crate. See the discussion below.

## Summary

Layered fixes to why connector-synced memories (a Gmail thread) were unretrievable, each confirmed against a live instance.

- **`feat(memory)` durable re-embed sweep** — a chunk whose batch embed failed is stored text-only, and a partial cloud failure writes degenerate short vectors; both are invisible to recall (which drops any chunk whose dimension differs from the live query). Deficient `vector_chunks` rows are their own durable work-list: the sweep re-derives the pending set every pass, so recovery survives a restart without a queue. Transient failures retry with jittered exponential backoff; unrecoverable ones (auth missing) end the pass and are retried by the next trigger — which is why logging in is one. A returned vector is only written when its width matches the active embedder, so a degraded provider can't stamp a short vector that stays pending forever. Triggers: startup, sync completion, login, embedder switch.
- **`fix(memory-sync)` restore the Gmail response reshape** — the reshape that slims a verbose payload into one record per message lost its caller in the TinyCortex engine migration, so the sync had been storing raw provider JSON. Restored via a `ReshapingExecutor` that wraps the executor the pipeline fetches through.
- **`fix(tinycortex)` carry the embedding provider into the tree config** — so the tree's active signature names the same provider the namespace store's embedder does.
- **`feat(memory)` auto-recall searches connector namespaces** — `RecallOpts::default()` resolved to `global` only, so the per-turn context never searched connector memories. It now fans out to `global` plus the busiest `skill-*` namespaces, merged by score, bounded so an unbounded connector store doesn't turn every turn into a full scan.
- **`fix(memory)` `memory_recall`: search everywhere + real scores** — `namespace` was required, so the model guessed `global` and connector memories were unreachable; it is now optional (omitted → search everywhere). Scores render as real percentages (a 0.68 hit was printing as `[1%]`), and hits name their namespace.
- **`fix(memory)` condense recalled documents** — recall returns whole documents, and one large document (a synced thread, or an old subagent envelope) filled the entire tool result and buried every other hit. An entry is condensed to the few chunks most relevant to the query, each trimmed, with a hard per-entry char cap.
- **`fix(context-scout)` recall connector memory before a live fetch** — the scout emitted its bundle with no tool calls and recommended a live Gmail delegation even though the emails are in `skill-gmail`. Its prompt now states connector history lives in memory under `skill-<toolkit>` and to recall it first; a live delegation is for the very latest, not-yet-synced items.

## Tests

`openhuman::memory` (serial) 1276, plus memory_store / memory_sync / channels / credentials / embeddings / tinycortex suites — green. New coverage across the re-embed sweep (incl. degraded-provider guard), connector fan-out, recall search-all + scores, recall condensation, the reshaping executor, and the scout memory-first prompt.

## Validation (live)

Re-embed sweep repaired ~2819 pending chunks (pending → 0); a Colorado-email query now retrieves the real `skill-gmail` threads with canonicalised Korean bodies, condensed to relevant chunks with real percentages; and the context scout calls `memory_recall` first instead of a live fetch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Memory recall now searches relevant connector namespaces alongside global memories.
  - Recall results are ranked, deduplicated, labeled by origin, and condensed for clearer responses.
  - Connector-related questions can use synced memory before live integration retrieval.
- **Bug Fixes**
  - Added durable recovery for missing, outdated, or incompatible memory embeddings.
  - Embedding repairs now resume automatically after restarts, synchronization, login, or embedding configuration changes.
  - Improved resilience when memory or embedding services encounter partial failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #5300

