### PR TITLE
fix(composio): gate write actions through approval + reshape agent-path results

### DIFF
--- a/src/openhuman/integrations/composio/action_tool.rs
+++ b/src/openhuman/integrations/composio/action_tool.rs
@@ -316,15 +316,6 @@ impl Tool for ComposioActionTool {
 
         match res {
             Ok(mut resp) => {
-                crate::core::event_bus::publish_global(
-                    crate::core::event_bus::DomainEvent::ComposioActionExecuted {
-                        tool: self.action_name.clone(),
-                        success: resp.successful,
-                        error: resp.error.clone(),
-                        cost_usd: resp.cost_usd,
-                        elapsed_ms,
-                    },
-                );
                 // Slim the provider envelope before it can become the tool body
                 // (#2585) — the same reshape `ComposioExecuteTool` runs, so a
                 // per-action Gmail fetch doesn't drop a full MIME tree into the
@@ -339,6 +330,20 @@ impl Tool for ComposioActionTool {
                         &mut resp.data,
                     );
                 }
+                // Published after the reshape, matching `ComposioExecuteTool`.
+                // The payload names no reshaped field today, so the order is not
+                // observable — but the two surfaces describing the same action
+                // must not disagree about which snapshot the event saw, or the
+                // first field added here diverges silently between them.
+                crate::core::event_bus::publish_global(
+                    crate::core::event_bus::DomainEvent::ComposioActionExecuted {
+                        tool: self.action_name.clone(),
+                        success: resp.successful,
+                        error: resp.error.clone(),
+                        cost_usd: resp.cost_usd,
+                        elapsed_ms,
+                    },
+                );
                 // Mirror `ComposioExecuteTool::execute` (composio/tools.rs):
                 // prefer the backend-rendered `markdownFormatted` for LLM
                 // consumption when present, fall back to the raw JSON

--- a/src/openhuman/integrations/composio/action_tool.rs
+++ b/src/openhuman/integrations/composio/action_tool.rs
@@ -149,6 +149,15 @@ impl Tool for ComposioActionTool {
         PermissionLevel::Write
     }
 
+    fn external_effect_with_args(&self, _args: &Value) -> bool {
+        // The per-action surface must gate on the approval card exactly like the
+        // `composio_execute` dispatcher: a write/admin action (this tool's own
+        // slug) routes through the `ApprovalGate` before it runs; a pure read
+        // flows through unprompted. Without this the model could send mail /
+        // create records via a per-action tool with no approval prompt at all.
+        super::tools::action_mutates_external_state(&self.action_name)
+    }
+
     fn category(&self) -> ToolCategory {
         ToolCategory::Workflow
     }
@@ -292,6 +301,9 @@ impl Tool for ComposioActionTool {
         let effective_connection_id = runtime_connection_id
             .as_deref()
             .or(self.connection_id.as_deref());
+        // Kept for the post-dispatch envelope reshape (#2585): the dispatch
+        // consumes `args`, but the reshape reads it for the `raw_html` opt-out.
+        let reshape_args = args.clone();
         let res = super::execute_dispatch::execute_composio_action_kind_with_connection(
             kind,
             &self.action_name,
@@ -303,7 +315,7 @@ impl Tool for ComposioActionTool {
         let elapsed_ms = started.elapsed().as_millis() as u64;
 
         match res {
-            Ok(resp) => {
+            Ok(mut resp) => {
                 crate::core::event_bus::publish_global(
                     crate::core::event_bus::DomainEvent::ComposioActionExecuted {
                         tool: self.action_name.clone(),
@@ -313,6 +325,20 @@ impl Tool for ComposioActionTool {
                         elapsed_ms,
                     },
                 );
+                // Slim the provider envelope before it can become the tool body
+                // (#2585) — the same reshape `ComposioExecuteTool` runs, so a
+                // per-action Gmail fetch doesn't drop a full MIME tree into the
+                // agent's context. Only the raw-JSON fallback body serializes
+                // `resp.data`; a backend-rendered markdown body is unaffected.
+                if let Some(provider) = super::providers::toolkit_from_slug(&self.action_name)
+                    .and_then(|tk| super::providers::get_provider(&tk))
+                {
+                    provider.post_process_action_result(
+                        &self.action_name,
+                        reshape_args.as_ref(),
+                        &mut resp.data,
+                    );
+                }
                 // Mirror `ComposioExecuteTool::execute` (composio/tools.rs):
                 // prefer the backend-rendered `markdownFormatted` for LLM
                 // consumption when present, fall back to the raw JSON
@@ -744,5 +770,26 @@ mod tests {
             !direct_msg.contains("no backend session"),
             "direct-mode tool must not surface backend-session artifacts: {direct_msg}"
         );
+    }
+
+    #[test]
+    fn per_action_tool_gates_writes_but_not_reads() {
+        // The per-action surface must gate on the approval card exactly like the
+        // dispatcher: a write action routes through the gate, a read does not.
+        let send = ComposioActionTool::new(
+            fake_config(),
+            "GMAIL_SEND_EMAIL".to_string(),
+            "send".to_string(),
+            None,
+        );
+        assert!(send.external_effect_with_args(&serde_json::json!({})));
+
+        let read = ComposioActionTool::new(
+            fake_config(),
+            "GMAIL_FETCH_EMAILS".to_string(),
+            "fetch".to_string(),
+            None,
+        );
+        assert!(!read.external_effect_with_args(&serde_json::json!({})));
     }
 }

--- a/src/openhuman/integrations/composio/tools.rs
+++ b/src/openhuman/integrations/composio/tools.rs
@@ -74,6 +74,15 @@ enum ToolDecision {
 /// blocking rather than letting a potentially-mutating action slip
 /// through uncategorised.
 pub(super) async fn resolve_action_scope(slug: &str) -> ToolScope {
+    resolve_action_scope_sync(slug)
+}
+
+/// Synchronous core of [`resolve_action_scope`]. Every lookup it makes —
+/// `toolkit_from_slug`, the provider/curated-catalog resolution, and the
+/// `classify_unknown` heuristic — is over static data with no `await`, so a
+/// caller that cannot be `async` (the `Tool::external_effect_with_args`
+/// gate-decision hook) can classify a slug directly.
+pub(super) fn resolve_action_scope_sync(slug: &str) -> ToolScope {
     let Some(toolkit) = toolkit_from_slug(slug) else {
         return ToolScope::Write;
     };
@@ -86,6 +95,18 @@ pub(super) async fn resolve_action_scope(slug: &str) -> ToolScope {
         }
     }
     classify_unknown(slug)
+}
+
+/// Whether a Composio action slug mutates external state, i.e. is
+/// `Write`/`Admin`-scoped. This is the predicate the approval gate keys off —
+/// a write/admin Composio action must route through the human-in-the-loop
+/// `ApprovalGate` before it runs, while a pure `Read` flows through unprompted
+/// (matching the `external_effect` contract on the `Tool` trait).
+pub(super) fn action_mutates_external_state(slug: &str) -> bool {
+    matches!(
+        resolve_action_scope_sync(slug),
+        ToolScope::Write | ToolScope::Admin
+    )
 }
 
 /// Decide whether a Composio action slug should be visible / executable
@@ -1313,6 +1334,18 @@ impl Tool for ComposioExecuteTool {
         // as write-level to respect channel permission caps.
         PermissionLevel::Write
     }
+    fn external_effect_with_args(&self, args: &Value) -> bool {
+        // Route a write/admin Composio action (send mail, create issue, delete,
+        // …) through the approval gate; a pure read flows through unprompted.
+        // The action slug is the `tool` argument. An empty/absent slug errs on
+        // the side of gating rather than letting a possibly-mutating call slip
+        // past the prompt.
+        args.get("tool")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|slug| !slug.is_empty())
+            .is_none_or(action_mutates_external_state)
+    }
     fn category(&self) -> ToolCategory {
         ToolCategory::Workflow
     }
@@ -1441,6 +1474,10 @@ impl Tool for ComposioExecuteTool {
             Some(since) => super::task_window::apply_window_args(&tool, arguments, since),
             None => arguments,
         };
+        // Kept for the post-dispatch envelope reshape (#2585): the dispatch
+        // below consumes `arguments`, but the reshape reads it for the
+        // `raw_html` opt-out.
+        let reshape_args = arguments.clone();
 
         // Resolve the client through the mode-aware factory on every
         // call so a direct-mode toggle takes effect immediately
@@ -1490,10 +1527,26 @@ impl Tool for ComposioExecuteTool {
                 // than the window. No-op unless a window is installed AND the
                 // slug is a curated task-fetch action. Runs before the
                 // markdown/JSON body decision so the agent reads filtered data.
-                let resp = match task_window_since {
+                let mut resp = match task_window_since {
                     Some(since) => super::task_window::filter_response(&tool, resp, since),
                     None => resp,
                 };
+                // Slim the provider envelope before it can become the tool body
+                // (#2585). A verbose Composio payload — Gmail's full MIME tree
+                // under `payload.parts[]`, dozens of `Received:` headers — is
+                // reshaped into one clean record per message. Only the fallback
+                // body path serializes `resp.data`, so this shrinks exactly the
+                // raw-JSON case; a backend-rendered `markdown_formatted` body is
+                // already clean and unaffected. The sync path applies the same
+                // reshape via `ReshapingExecutor`; here we run it inline on the
+                // agent's direct call.
+                if let Some(provider) = toolkit_from_slug(&tool).and_then(|tk| get_provider(&tk)) {
+                    provider.post_process_action_result(
+                        &tool,
+                        reshape_args.as_ref(),
+                        &mut resp.data,
+                    );
+                }
                 tracing::info!(
                     tool = %tool,
                     successful = resp.successful,

--- a/src/openhuman/integrations/composio/tools_tests.rs
+++ b/src/openhuman/integrations/composio/tools_tests.rs
@@ -1123,3 +1123,28 @@ fn parse_composio_connect_timeout_honors_override_and_zero_opt_out() {
     // `0` → opt out of the composio-side bound (fall back to the gate TTL).
     assert_eq!(parse_composio_connect_timeout(Some("0")), None);
 }
+
+#[test]
+fn execute_tool_gates_writes_but_not_reads_via_external_effect() {
+    // The approval gate keys off `external_effect_with_args`. A write/admin
+    // Composio action (send/create/delete) must route through the gate; a pure
+    // read (fetch/list) must flow through unprompted. Regression: neither
+    // surface declared external_effect, so mail sends fired with no approval.
+    let t = ComposioExecuteTool::new(fake_config_arc());
+    assert!(
+        t.external_effect_with_args(&serde_json::json!({ "tool": "GMAIL_SEND_EMAIL" })),
+        "a send action must be gated"
+    );
+    assert!(
+        t.external_effect_with_args(&serde_json::json!({ "tool": "GMAIL_DELETE_MESSAGE" })),
+        "a delete action must be gated"
+    );
+    assert!(
+        !t.external_effect_with_args(&serde_json::json!({ "tool": "GMAIL_FETCH_EMAILS" })),
+        "a read action must not prompt"
+    );
+    assert!(
+        t.external_effect_with_args(&serde_json::json!({})),
+        "an absent slug errs on the side of gating"
+    );
+}

--- a/src/openhuman/integrations/composio/tools_tests.rs
+++ b/src/openhuman/integrations/composio/tools_tests.rs
@@ -1147,4 +1147,20 @@ fn execute_tool_gates_writes_but_not_reads_via_external_effect() {
         t.external_effect_with_args(&serde_json::json!({})),
         "an absent slug errs on the side of gating"
     );
+    // A whitespace-only slug is a different path from an absent one: it survives
+    // the key lookup and is only rejected by the `trim` + emptiness filter. A
+    // model that emits `"tool": " "` must still be gated, not waved through on a
+    // slug that classifies as neither read nor write.
+    for blank in [" ", "", "\t\n"] {
+        assert!(
+            t.external_effect_with_args(&serde_json::json!({ "tool": blank })),
+            "a blank slug ({blank:?}) must fail closed"
+        );
+    }
+    // And the same for a slug of the wrong JSON type, which also reaches the
+    // filter with nothing usable.
+    assert!(
+        t.external_effect_with_args(&serde_json::json!({ "tool": 42 })),
+        "a non-string slug must fail closed"
+    );
 }


### PR DESCRIPTION
## Summary

Two gaps on the agent's Composio execution surface, both diagnosed against a live instance.

### Approval gate (the reported bug)

The human-in-the-loop approval card is raised only for a tool whose `external_effect_with_args` is `true`, but neither `composio_execute` nor the per-action `ComposioActionTool` declared it — so a Composio mail send (`GMAIL_SEND_EMAIL`) via the `integrations_agent` fired **with no approval prompt at all**, even when the user had configured "ask before sending". Neither the contract gate (which only ensures the action schema is in context) nor `permission_level = Write` (channel caps: allow/block, not a prompt) raises that card.

Both surfaces now report external-effect for a **write/admin**-scoped action and stay `false` for a pure **read**, so a write routes through the `ApprovalGate` (parking for the card under a WebChat turn, which the inline sub-agent inherits) while a fetch/list flows through unprompted — matching the `external_effect` contract. Scope is classified synchronously: `resolve_action_scope`'s body has no `await`, so it is reused via a `resolve_action_scope_sync` core.

### Agent-path envelope reshape (#2585)

When the agent calls a Composio action directly, a verbose provider envelope — Gmail's full MIME tree under `payload.parts[]`, dozens of `Received:` headers — landed in context on the raw-JSON fallback body. The response reshape that slims it into one clean record per message was wired only into the sync path; it now runs inline on the agent `composio_execute` and per-action paths, so `resp.data` is slimmed before it can become the tool body. A backend-rendered `markdown_formatted` body is already clean and unaffected.

## Tests

`cargo test --lib composio` — new coverage: `execute_tool_gates_writes_but_not_reads_via_external_effect` and `per_action_tool_gates_writes_but_not_reads` assert the gate/no-gate split for send/delete vs fetch. (The `composio::ops` delete-connection tests are flaky only under the parallel chunk-DB cold-open race, fixed separately in tinycortex; they pass `--test-threads=1`.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added approval prompts for actions that modify external data.
  * Read-only actions can now run without approval.
  * Unknown, missing, or invalid action identifiers require approval by default.

* **Bug Fixes**
  * Improved consistency of action results after provider-specific processing.
  * Preserved processed arguments and response data throughout execution.
  * Ensured approval decisions reflect the action’s actual external effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #5299
