### PR TITLE
fix(tests): serialize backend-env tests behind one lock (fixes flaky Rust Core Coverage)

### DIFF
--- a/src/openhuman/composio/ops_tests.rs
+++ b/src/openhuman/composio/ops_tests.rs
@@ -975,6 +975,11 @@ async fn composio_get_user_profile_via_mock_returns_provider_profile() {
     use crate::openhuman::config::TEST_ENV_LOCK;
     let _cache_guard = cache_guard();
     let _env_guard = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // This test mutates BACKEND_URL below via EnvVarGuard, which races with
+    // api::config / core::cli_tests / medulla::ops / medulla::resolve tests
+    // that mutate the same process-global var under the crate-wide lock —
+    // TEST_ENV_LOCK alone does not serialize against those. Hold both.
+    let _backend_env_guard = crate::api::config::backend_env_test_lock();
 
     crate::openhuman::composio::providers::init_default_providers();
 
@@ -1118,6 +1123,11 @@ async fn composio_sync_gmail_via_mock_stores_skill_document_and_updates_outcome(
     use crate::openhuman::config::TEST_ENV_LOCK;
     let _cache_guard = cache_guard();
     let _env_guard = TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // See composio_get_user_profile_via_mock_returns_provider_profile: this
+    // test also mutates BACKEND_URL via EnvVarGuard below, which needs the
+    // crate-wide lock to serialize against api::config / core::cli_tests /
+    // medulla's tests on the same process-global var.
+    let _backend_env_guard = crate::api::config::backend_env_test_lock();
 
     crate::openhuman::composio::providers::init_default_providers();
 


### PR DESCRIPTION
## Summary

Root cause: `BACKEND_URL` / `VITE_BACKEND_URL` / `OPENHUMAN_MEDULLA_BASE_URL` are process-global env vars mutated by tests across several modules under uncoordinated locks. Under the full-suite coverage lane (parallel test threads across modules) those mutations race and flip `medulla::ops`'s "unconfigured" assertions — pre-existing since #5260, deterministic under `Rust Core Coverage`, blocking every Rust PR's coverage lane.

Investigation found this was **already mostly fixed on `main`**: `d125b857f` introduced `api::config::backend_env_test_lock()` as the crate-wide lock and routed `api::config`, `core::cli_tests`, `medulla::ops`, and `medulla::resolve` through it. `integrations::client_tests` and `socket::ws_loop_tests` only reference these vars in comments/log assertions — they never mutate them, so no change was needed.

The one remaining gap: `composio::ops_tests` mutates `BACKEND_URL` via `EnvVarGuard::set` in two mock-backend tests, serialized only by its own module-local `TEST_ENV_LOCK` — which doesn't coordinate with the crate-wide lock the other modules use, leaving the race open.

- Route `composio_get_user_profile_via_mock_returns_provider_profile` and `composio_sync_gmail_via_mock_stores_skill_document_and_updates_outcome` through `api::config::backend_env_test_lock()` (in addition to their existing `TEST_ENV_LOCK`, kept for the other config vars those tests touch).

Unblocks the `Rust Core Coverage` lane for #5265 and every Rust PR.

## Test plan

- [x] `cargo fmt --all`
- [x] `GGML_NATIVE=OFF cargo test --manifest-path Cargo.toml -- medulla::ops api::config composio::ops_tests core::cli integrations::client socket::ws_loop` — the 5 `medulla::ops` tests (incl. the 2 previously-racing `not_configured...`/`status_reports_unconfigured...`) pass, 0 failed
- [x] `cargo clippy -p openhuman -- -D warnings` — clean