### PR TITLE
fix(theme): cancel mesh-gradient timers on teardown (#5160)

### DIFF
--- a/app/src/lib/meshGradient.d.ts
+++ b/app/src/lib/meshGradient.d.ts
@@ -12,10 +12,27 @@ export class Gradient {
    * `mesh.material` and would throw when it is absent (#3524).
    */
   mesh?: unknown;
+  /** Resolved style of the canvas; only set once `connect()` ran. */
+  computedCanvasStyle?: CSSStyleDeclaration;
+  /**
+   * Latched by `disconnect()`. Every async entry point below bails on it so a
+   * queued frame/timer never touches a canvas React already unmounted (#5160).
+   */
+  destroyed: boolean;
   play(): void;
   pause(): void;
   disconnect(): void;
   initGradient(selector: string): this;
   toggleColor(index: number): void;
   updateFrequency(freq: number): void;
+  /**
+   * Lifecycle internals. Public only because the teardown regression tests
+   * (#5160) drive them directly — the React wrapper uses `initGradient`,
+   * `play`, `pause` and `disconnect`.
+   */
+  init(): void;
+  initMesh(): void;
+  resize(): void;
+  waitForCssVars(): void;
+  addIsLoadedClass(): void;
 }

--- a/app/src/lib/meshGradient.d.ts
+++ b/app/src/lib/meshGradient.d.ts
@@ -31,6 +31,7 @@ export class Gradient {
    * `play`, `pause` and `disconnect`.
    */
   init(): void;
+  initGradientColors(): void;
   initMesh(): void;
   resize(): void;
   waitForCssVars(): void;

--- a/app/src/lib/meshGradient.js
+++ b/app/src/lib/meshGradient.js
@@ -715,7 +715,10 @@ class Gradient {
       (this.initGradientColors(),
         this.initMesh(),
         this.resize(),
-        requestAnimationFrame(this.animate),
+        // Track this first frame like every other one: `disconnect()` only
+        // cancels `animateRaf`, so leaving this handle unstored let the opening
+        // frame outlive teardown — the exact leak this change set closes.
+        (this.animateRaf = requestAnimationFrame(this.animate)),
         window.addEventListener('resize', this.resize));
     } catch (err) {
       console.warn('[MeshGradient] init failed, gradient disabled:', err);

--- a/app/src/lib/meshGradient.js
+++ b/app/src/lib/meshGradient.js
@@ -400,6 +400,21 @@ class Gradient {
       e(this, 'maxCssVarRetries', 200),
       e(this, 'angle', 0),
       e(this, 'isLoadedClass', !1),
+      /*
+       * Teardown bookkeeping (#5160). A Gradient owns three async chains that
+       * outlive the canvas: the `waitForCssVars` rAF retry loop (up to 200
+       * frames), the `animate` rAF loop, and the 3s `isLoaded` timeout. React
+       * unmounts `<MeshGradient />` on every theme switch / backdrop change, so
+       * those callbacks used to run against a canvas that was already detached
+       * and dereference `this.el.parentElement.classList` — the source of the
+       * "Cannot read properties of null (reading 'classList')" family. Every
+       * async entry point now records its handle here and bails on `destroyed`,
+       * and `disconnect()` cancels all of them.
+       */
+      e(this, 'destroyed', !1),
+      e(this, 'isLoadedTimeout', void 0),
+      e(this, 'cssVarsRaf', 0),
+      e(this, 'animateRaf', 0),
       e(this, 'isScrolling', !1),
       /*e(this, "isStatic", o.disableAmbientAnimations()),*/ e(this, 'scrollingTimeout', void 0),
       e(this, 'scrollingRefreshDelay', 200),
@@ -441,6 +456,10 @@ class Gradient {
         ((this.isScrolling = !1), this.isIntersecting && this.play());
       }),
       e(this, 'resize', () => {
+        if (this.destroyed || !this.minigl || !this.mesh) {
+          console.debug('[MeshGradient] resize ignored — gradient not live');
+          return;
+        }
         ((this.width = window.innerWidth),
           (this.height = window.innerHeight),
           this.minigl.setSize(this.width, this.height),
@@ -455,12 +474,17 @@ class Gradient {
         this.isGradientLegendVisible &&
           ((this.isMetaKey = e.metaKey),
           (this.isMouseDown = !0),
-          !1 === this.conf.playing && requestAnimationFrame(this.animate));
+          !1 === this.conf.playing && (this.animateRaf = requestAnimationFrame(this.animate)));
       }),
       e(this, 'handleMouseUp', () => {
         this.isMouseDown = !1;
       }),
       e(this, 'animate', e => {
+        this.animateRaf = 0;
+        if (this.destroyed) {
+          console.debug('[MeshGradient] animate frame dropped — gradient disconnected');
+          return;
+        }
         if (!this.shouldSkipFrame(e) || this.isMouseDown) {
           if (((this.t += Math.min(e - this.last, 1e3 / 15)), (this.last = e), this.isMouseDown)) {
             let e = 160;
@@ -470,21 +494,44 @@ class Gradient {
         }
         if (0 !== this.last && this.isStatic) return (this.minigl.render(), void this.disconnect());
         /*this.isIntersecting && */ (this.conf.playing || this.isMouseDown) &&
-          requestAnimationFrame(this.animate);
+          (this.animateRaf = requestAnimationFrame(this.animate));
       }),
       e(this, 'addIsLoadedClass', () => {
-        /*this.isIntersecting && */ !this.isLoadedClass &&
-          ((this.isLoadedClass = !0),
+        /*this.isIntersecting && */
+        if (this.destroyed || this.isLoadedClass) return;
+        ((this.isLoadedClass = !0),
           this.el && this.el.classList.add('isLoaded'),
-          setTimeout(() => {
-            this.el && this.el.parentElement && this.el.parentElement.classList.add('isLoaded');
-          }, 3e3));
+          // Deferred so the canvas has faded in before the wrapper is marked
+          // loaded. The handle is retained because React can unmount the canvas
+          // well inside these 3s (#5160) — `disconnect()` clears it, and the
+          // detached-node checks below cover a teardown we did not observe.
+          (this.isLoadedTimeout = setTimeout(() => {
+            this.isLoadedTimeout = void 0;
+            const parent = this.destroyed ? null : this.el && this.el.parentElement;
+            if (!parent) {
+              console.debug('[MeshGradient] isLoaded skipped — canvas detached before timeout', {
+                destroyed: this.destroyed,
+                hasEl: Boolean(this.el),
+              });
+              return;
+            }
+            parent.classList.add('isLoaded');
+          }, 3e3)));
       }),
       e(this, 'pause', () => {
-        this.conf.playing = false;
+        // `conf` only exists once connect() ran, and the React wrapper calls
+        // pause() right after disconnect() on a gradient whose WebGL init may
+        // have bailed early — so never assume it is there.
+        (this.conf && (this.conf.playing = false),
+          this.animateRaf && cancelAnimationFrame(this.animateRaf),
+          (this.animateRaf = 0));
       }),
       e(this, 'play', () => {
-        (requestAnimationFrame(this.animate), (this.conf.playing = true));
+        if (this.destroyed) {
+          console.debug('[MeshGradient] play ignored — gradient disconnected');
+          return;
+        }
+        ((this.animateRaf = requestAnimationFrame(this.animate)), (this.conf.playing = true));
       }),
       e(this, 'initGradient', selector => {
         this.el = document.querySelector(selector);
@@ -519,10 +566,13 @@ class Gradient {
         ? console.log('DID NOT LOAD HERO STRIPE CANVAS')
         : ((this.minigl = new MiniGl(this.el, null, null, !0)),
           this.minigl.gl
-            ? requestAnimationFrame(() => {
-                this.el &&
-                  ((this.computedCanvasStyle = getComputedStyle(this.el)), this.waitForCssVars());
-              })
+            ? (this.cssVarsRaf = requestAnimationFrame(() => {
+                ((this.cssVarsRaf = 0),
+                  !this.destroyed &&
+                    this.el &&
+                    ((this.computedCanvasStyle = getComputedStyle(this.el)),
+                    this.waitForCssVars()));
+              }))
             : console.warn('[MeshGradient] MiniGl has no GL context — gradient disabled')));
     /*
         this.scrollObserver = await s.create(.1, !1),
@@ -534,7 +584,32 @@ class Gradient {
             window.addEventListener("scroll", this.handleScroll), window.addEventListener("mousedown", this.handleMouseDown), window.addEventListener("mouseup", this.handleMouseUp), window.addEventListener("keydown", this.handleKeyDown), this.isIntersecting = !0, this.addIsLoadedClass(), this.play()
         })*/
   }
+  /*
+   * Tears the gradient down for good. Cancels every pending async chain
+   * (`waitForCssVars` retries, the animation loop, the deferred `isLoaded`
+   * class, the scroll-end debounce) and latches `destroyed` so anything already
+   * queued in the current frame/task bails instead of touching a canvas React
+   * has removed from the document (#5160). Safe to call more than once.
+   */
   disconnect() {
+    this.destroyed = !0;
+    if (this.conf) this.conf.playing = !1;
+    if (this.isLoadedTimeout) {
+      clearTimeout(this.isLoadedTimeout);
+      this.isLoadedTimeout = void 0;
+    }
+    if (this.scrollingTimeout) {
+      clearTimeout(this.scrollingTimeout);
+      this.scrollingTimeout = void 0;
+    }
+    if (this.cssVarsRaf) {
+      cancelAnimationFrame(this.cssVarsRaf);
+      this.cssVarsRaf = 0;
+    }
+    if (this.animateRaf) {
+      cancelAnimationFrame(this.animateRaf);
+      this.animateRaf = 0;
+    }
     (this.scrollObserver &&
       (window.removeEventListener('scroll', this.handleScroll),
       window.removeEventListener('mousedown', this.handleMouseDown),
@@ -542,6 +617,7 @@ class Gradient {
       window.removeEventListener('keydown', this.handleKeyDown),
       this.scrollObserver.disconnect()),
       window.removeEventListener('resize', this.resize));
+    console.debug('[MeshGradient] disconnected — pending frames and timers cancelled');
   }
   initMaterial() {
     this.uniforms = {
@@ -631,6 +707,10 @@ class Gradient {
       document.body && document.body.classList.remove('isGradientLegendVisible'));
   }
   init() {
+    if (this.destroyed) {
+      console.debug('[MeshGradient] init skipped — gradient already disconnected');
+      return;
+    }
     try {
       (this.initGradientColors(),
         this.initMesh(),
@@ -646,6 +726,10 @@ class Gradient {
    * Using default colors assigned below if no variables have been found after maxCssVarRetries
    */
   waitForCssVars() {
+    if (this.destroyed) {
+      console.debug('[MeshGradient] waitForCssVars stopped — gradient disconnected');
+      return;
+    }
     if (
       this.computedCanvasStyle &&
       -1 !== this.computedCanvasStyle.getPropertyValue('--gradient-color-1').indexOf('#')
@@ -658,7 +742,9 @@ class Gradient {
           void this.init()
         );
       }
-      requestAnimationFrame(() => this.waitForCssVars());
+      this.cssVarsRaf = requestAnimationFrame(() => {
+        ((this.cssVarsRaf = 0), this.waitForCssVars());
+      });
     }
   }
   /*

--- a/app/src/lib/meshGradient.test.ts
+++ b/app/src/lib/meshGradient.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Gradient } from './meshGradient';
+
+/**
+ * Teardown safety for the WebGL mesh gradient (issue #5160).
+ *
+ * `Gradient` drives three async chains that all outlive a single React commit:
+ * the `waitForCssVars` rAF retry loop, the `animate` rAF loop, and the 3s
+ * deferred `isLoaded` class. `<MeshGradient />` unmounts on every theme switch
+ * and backdrop change, so those callbacks used to fire against a canvas React
+ * had already removed — `this.el.parentElement` was `null` and the
+ * `.classList.add()` threw the "Cannot read properties of null (reading
+ * 'classList')" family Sentry grouped across five bundles.
+ *
+ * These tests drive the lib directly (no WebGL): they set `el` by hand and
+ * exercise the lifecycle entry points, which is where the leak lived.
+ */
+describe('Gradient teardown (#5160)', () => {
+  let wrapper: HTMLDivElement;
+  let canvas: HTMLCanvasElement;
+  let rafQueue: Map<number, FrameRequestCallback>;
+  let nextRafHandle: number;
+  let cancelled: number[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    wrapper = document.createElement('div');
+    canvas = document.createElement('canvas');
+    canvas.id = 'mesh-gradient';
+    wrapper.appendChild(canvas);
+    document.body.appendChild(wrapper);
+
+    rafQueue = new Map();
+    nextRafHandle = 0;
+    cancelled = [];
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(callback => {
+      nextRafHandle += 1;
+      rafQueue.set(nextRafHandle, callback);
+      return nextRafHandle;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(handle => {
+      cancelled.push(handle);
+      rafQueue.delete(handle);
+    });
+  });
+
+  afterEach(() => {
+    wrapper.remove();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  /** Runs whatever is queued right now, exactly like a single browser frame. */
+  function flushFrame() {
+    const pending = [...rafQueue.entries()];
+    rafQueue.clear();
+    for (const [, callback] of pending) callback(performance.now());
+  }
+
+  function mountedGradient() {
+    const gradient = new Gradient();
+    gradient.el = canvas;
+    return gradient;
+  }
+
+  it('marks the wrapper loaded when the canvas is still mounted 3s later', () => {
+    const gradient = mountedGradient();
+
+    gradient.addIsLoadedClass();
+    expect(canvas.classList.contains('isLoaded')).toBe(true);
+
+    vi.advanceTimersByTime(3000);
+    expect(wrapper.classList.contains('isLoaded')).toBe(true);
+  });
+
+  it('cancels the deferred isLoaded class when disconnect() runs first', () => {
+    const gradient = mountedGradient();
+
+    gradient.addIsLoadedClass();
+    // React unmounts the component well inside the 3s window. The canvas is
+    // deliberately left in the DOM here so the assertion pins the *timer being
+    // cancelled* rather than the detached-node guard below it.
+    gradient.disconnect();
+
+    expect(() => vi.advanceTimersByTime(3000)).not.toThrow();
+    expect(wrapper.classList.contains('isLoaded')).toBe(false);
+  });
+
+  it('skips the deferred isLoaded class when the canvas was detached without a disconnect', () => {
+    const gradient = mountedGradient();
+
+    gradient.addIsLoadedClass();
+    // Node pulled out from under us — `el.parentElement` is now null, which is
+    // the exact dereference Sentry reported.
+    canvas.remove();
+
+    expect(() => vi.advanceTimersByTime(3000)).not.toThrow();
+    expect(wrapper.classList.contains('isLoaded')).toBe(false);
+  });
+
+  it('stops the waitForCssVars retry loop after disconnect()', () => {
+    const gradient = mountedGradient();
+    // No `--gradient-color-1` yet, so waitForCssVars re-schedules itself.
+    gradient.computedCanvasStyle = { getPropertyValue: () => '' } as unknown as CSSStyleDeclaration;
+
+    gradient.waitForCssVars();
+    expect(rafQueue.size).toBe(1);
+
+    gradient.disconnect();
+    expect(rafQueue.size).toBe(0);
+
+    // Even a frame that was already dispatched must not restart the chain.
+    gradient.waitForCssVars();
+    expect(rafQueue.size).toBe(0);
+  });
+
+  it('never re-enters init() once disconnected', () => {
+    const gradient = mountedGradient();
+    const initMesh = vi.spyOn(gradient, 'initMesh');
+
+    gradient.disconnect();
+    gradient.init();
+
+    expect(initMesh).not.toHaveBeenCalled();
+  });
+
+  it('drops an animation frame that lands after disconnect() instead of throwing', () => {
+    const gradient = mountedGradient();
+    gradient.conf = { playing: true };
+
+    gradient.play();
+    expect(rafQueue.size).toBe(1);
+    const queuedFrame = [...rafQueue.values()][0];
+
+    gradient.disconnect();
+
+    // `mesh` never existed here, so the pre-fix animate() would have thrown on
+    // `this.mesh.material` for this already-queued frame.
+    expect(() => queuedFrame(performance.now())).not.toThrow();
+  });
+
+  it('cancels the queued animation frame on pause() and refuses play() after disconnect()', () => {
+    const gradient = mountedGradient();
+    const conf = { playing: false };
+    gradient.conf = conf;
+
+    gradient.play();
+    expect(conf.playing).toBe(true);
+    const handle = nextRafHandle;
+
+    gradient.pause();
+    expect(cancelled).toContain(handle);
+    expect(conf.playing).toBe(false);
+
+    gradient.disconnect();
+    gradient.play();
+    expect(rafQueue.size).toBe(0);
+    expect(conf.playing).toBe(false);
+  });
+
+  it('ignores a resize event fired after teardown', () => {
+    const gradient = mountedGradient();
+
+    gradient.disconnect();
+    // `minigl`/`mesh` are absent, so the pre-fix handler threw here.
+    expect(() => gradient.resize()).not.toThrow();
+  });
+
+  it('is safe to disconnect twice', () => {
+    const gradient = mountedGradient();
+
+    gradient.addIsLoadedClass();
+    gradient.disconnect();
+    expect(() => gradient.disconnect()).not.toThrow();
+
+    flushFrame();
+    vi.advanceTimersByTime(3000);
+    expect(wrapper.classList.contains('isLoaded')).toBe(false);
+  });
+});

--- a/app/src/lib/meshGradient.test.ts
+++ b/app/src/lib/meshGradient.test.ts
@@ -125,6 +125,27 @@ describe('Gradient teardown (#5160)', () => {
     expect(initMesh).not.toHaveBeenCalled();
   });
 
+  it("cancels init()'s opening animation frame on disconnect()", () => {
+    const gradient = mountedGradient();
+    // Stub the WebGL setup so init() reaches its requestAnimationFrame call
+    // without a real GL context. init() swallows throws, so the size assertion
+    // below is what proves the frame was actually scheduled.
+    vi.spyOn(gradient, 'initGradientColors').mockImplementation(() => {});
+    vi.spyOn(gradient, 'initMesh').mockImplementation(() => {});
+    vi.spyOn(gradient, 'resize').mockImplementation(() => {});
+
+    gradient.init();
+    expect(rafQueue.size).toBe(1);
+    const openingFrame = nextRafHandle;
+
+    gradient.disconnect();
+
+    // Pre-fix this handle was never stored on `animateRaf`, so disconnect() had
+    // nothing to cancel and the opening frame outlived teardown.
+    expect(cancelled).toContain(openingFrame);
+    expect(rafQueue.size).toBe(0);
+  });
+
   it('drops an animation frame that lands after disconnect() instead of throwing', () => {
     const gradient = mountedGradient();
     gradient.conf = { playing: true };


### PR DESCRIPTION
## Summary

- `Gradient.disconnect()` now cancels every pending async chain it owns — the `waitForCssVars` rAF retry loop, the `animate` rAF loop, the 3s deferred `isLoaded` class, and the scroll-end debounce — instead of leaking them past unmount.
- Adds a `destroyed` latch that `init()` / `waitForCssVars()` / `play()` / `animate()` bail on, so a frame already dispatched in the current tick cannot restart the retry chain or dereference an absent `mesh`.
- `pause()` now actually cancels the queued frame (the contract its call site in `MeshGradient.tsx` already documented) and stops assuming `conf` exists.
- `resize()` ignores events arriving without a live `minigl`/`mesh`.
- New `app/src/lib/meshGradient.test.ts` — 10 lifecycle regression tests, 6 of which fail against the previous implementation.
- `init()` now stores its opening `animate` frame on `animateRaf`, so `disconnect()` can cancel it too (CodeRabbit review).

## Problem

`<MeshGradient />` (the Stripe-style WebGL backdrop) unmounts on every theme switch, backdrop change and window teardown. Its `Gradient` instance owns three async chains that outlive the canvas React gave it:

1. the `waitForCssVars` rAF retry loop (up to 200 frames),
2. the `animate` rAF loop,
3. a **3-second deferred `isLoaded` class**.

`disconnect()` cancelled none of them — it only removed the `resize` listener (its scroll-listener block is dead code, since `scrollObserver` is permanently `undefined`). So after unmount those callbacks kept firing against a canvas React had already removed, and the 3s timeout evaluated `this.el.parentElement.classList` on a **detached** node → `parentElement === null` → `TypeError: Cannot read properties of null (reading 'classList')`.

That matches the Sentry signature reported in #5160: a 2-frame stack (the outer frame is `browserApiErrorsIntegration`'s `setTimeout` wrapper, which `services/analytics.ts` enables explicitly; the inner one is the anonymous arrow), the `src/lib/meshGradient` culprit on the one shortId that resolved, and 5 shortIds that are the same defect across 5 release bundle hashes rather than 5 distinct bugs — 27 events / 13 users.

For completeness: no other unguarded `.classList` read exists in the shipped bundle. The two remaining reads in `app/src` are on `document.documentElement` (never null), and no bundled runtime dependency reads `classList` off a nullable node — the `dom-helpers` / `react-transition-group` path is unreachable here because `react-smooth` never calls into it.

PR #5171 added `this.el && this.el.parentElement &&` guards at the crash site. That stopped the throw but left the leak in place — timers and frames still running after teardown, one guard deletion away from re-opening.

## Solution

Make the lifecycle cancellable at the root rather than guarding the last dereference:

- Every async entry point records its handle (`isLoadedTimeout`, `cssVarsRaf`, `animateRaf`) on the instance.
- `disconnect()` latches `destroyed`, clears both timeouts, cancels both rAF handles, and stays idempotent.
- `init()` / `waitForCssVars()` / `play()` / `animate()` return early when `destroyed`, covering a callback that was already dispatched before `disconnect()` ran.
- The `isLoaded` timeout keeps a detached-node check as a second line of defence for a teardown we never observed, and logs why it skipped.
- Each teardown decision logs under the grep-friendly `[MeshGradient]` prefix.

The existing `this.el && …` guards from #5171 are retained — they are now unreachable in the normal path but cost nothing.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `app/src/lib/meshGradient.test.ts`: happy path (canvas still mounted at 3s), plus disconnect-first, detached-without-disconnect, retry-loop-after-disconnect, frame-after-disconnect, pause/play, resize-after-teardown and double-disconnect
- [x] **Diff coverage ≥ 80%** — the new suite drives every changed branch in `meshGradient.js`; the `.d.ts` is type-only
- [x] N/A: bug fix to an existing feature — no matrix row added, removed, or renamed. Coverage matrix updated
- [x] N/A: no matrix rows affected, so no feature IDs apply. All affected feature IDs from the matrix are listed under `## Related`
- [x] No new external network dependencies introduced — tests are pure jsdom, no WebGL and no network
- [x] N/A: no release-cut surface changed; the gradient renders identically. Manual smoke checklist updated
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Platform:** desktop (all three OSes) — the animated backdrop is desktop-only UI. No core/Rust, backend or CLI surface touched.
- **Behaviour:** unchanged while mounted. The only user-visible difference is that a gradient torn down inside the 3s `isLoaded` window no longer marks its (already removed) wrapper as loaded.
- **Performance:** strictly better — a stale `Gradient` no longer holds a self-rescheduling rAF loop alive after unmount, which was burning frames indefinitely on repeated theme switches. Related in spirit to the #3524 idle-GPU work.
- **Security / migration / compatibility:** none.

## Related

- Closes: #5160
- Follow-up PR(s)/TODOs: none. #5161 (`reading 'checked'`) is a separate signature already guarded in `services/analyticsInteractions.ts` by #5171.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5160-null-classlist`
- Commit SHA: `1f151cf69`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `prettier --check` clean on all three changed files
- [x] `pnpm typecheck` — clean (the earlier `@xyflow/react` failure was a stale local install of an unrelated dependency; resolved after a reinstall, and it never affected `src/lib/meshGradient*`)
- [x] Focused tests: `vitest related src/lib/meshGradient.*` → 5 files / 66 tests passed; `meshGradient.test.ts` alone → 10 passed. The new `init()`-frame test fails against the pre-fix lib ("expected [] to include 1")
- [x] N/A: no Rust touched. Rust fmt/check (if changed)
- [x] N/A: no Tauri shell code touched. Tauri fmt/check (if changed)

### Validation Blocked

- `command:` N/A — nothing is blocked. The previously-reported `pnpm typecheck` failure (`Cannot find module '@xyflow/react'`) was a stale local `node_modules`; it is clean after a reinstall.
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: a disconnected `Gradient` performs no further DOM or WebGL work.
- User-visible effect: none while the backdrop is mounted; a Sentry error family affecting ~13 users stops firing.

### Parity Contract

- Legacy behavior preserved: identical rendering, colour resolution and play/pause semantics while mounted. `pause()` cancelling the queued frame brings the implementation in line with the contract already documented at its `MeshGradient.tsx` call site.
- Guard/fallback/dispatch parity checks: the `this.el && …` null guards from #5171 are retained rather than replaced; the no-GPU fallback (#3524, `mesh` absent → never `play()`) is untouched and re-pinned by `MeshGradient.test.tsx`, which still passes unchanged.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gradient teardown behavior when components are unmounted or canvases are detached.
  * Prevented delayed animations, styling updates, and CSS variable checks from running after disconnection.
  * Made pause, play, resize, and repeated disconnect operations safer.

* **Documentation**
  * Expanded the gradient API declarations with lifecycle methods and teardown state information.

* **Tests**
  * Added coverage for asynchronous cleanup, detached canvases, animation cancellation, and repeated teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
