### PR TITLE
fix(chat): stop the composer-footer render loop (#5162)

### DIFF
--- a/app/src/components/orchestration/AgentChatPanel.tsx
+++ b/app/src/components/orchestration/AgentChatPanel.tsx
@@ -77,23 +77,42 @@ function ChatPageScaffold({
   const footerRef = useRef<HTMLDivElement | null>(null);
   const [footerHeight, setFooterHeight] = useState(0);
 
+  // Subscribe on footer *presence*, never on the `footer` node itself. Every
+  // call site passes inline JSX, so `footer` has a fresh object identity on
+  // every render — depending on it re-ran this effect each render, tearing down
+  // and rebuilding the ResizeObserver and re-measuring. Because
+  // `ResizeObserver.observe` delivers an immediate initial observation, each
+  // render therefore scheduled another `setFooterHeight`; any measurement that
+  // disagreed with the committed height re-rendered, re-ran the effect, and
+  // cascaded until React's nested-update limit tripped with "Maximum update
+  // depth exceeded" (#5162 / TAURI-REACT-2G). Typing was the easiest trigger:
+  // the composer's auto-growing textarea lives inside this footer, so each
+  // keystroke changed the measured height. The observer already reports every
+  // size change, so it never needs re-subscribing when the footer's children
+  // re-render — only when the footer element mounts or unmounts.
+  const hasFooter = Boolean(footer);
+
   useEffect(() => {
+    // Drop measurements that match the committed height so a settled layout can
+    // never schedule a re-render, and therefore can never feed a cascade.
+    const applyHeight = (next: number) => setFooterHeight(prev => (prev === next ? prev : next));
+
     const el = footerRef.current;
-    if (!el) {
-      setFooterHeight(0);
+    if (!hasFooter || !el) {
+      applyHeight(0);
       return;
     }
     // ResizeObserver may be absent in some test environments; fall back to a
     // one-shot measure so the layout still resolves.
     if (typeof ResizeObserver === 'undefined') {
-      setFooterHeight(el.offsetHeight);
+      applyHeight(el.offsetHeight);
       return;
     }
-    const ro = new ResizeObserver(() => setFooterHeight(el.offsetHeight));
+    const ro = new ResizeObserver(() => applyHeight(el.offsetHeight));
     ro.observe(el);
-    setFooterHeight(el.offsetHeight);
+    applyHeight(el.offsetHeight);
     return () => ro.disconnect();
-  }, [footer]);
+  }, [hasFooter]);
 
   return (
     <div className="relative flex h-full flex-col overflow-hidden bg-surface/70 dark:bg-black/40">
@@ -118,6 +137,7 @@ function ChatPageScaffold({
       {footer ? (
         <div
           ref={footerRef}
+          data-testid="orch-chat-footer"
           className="absolute inset-x-0 bottom-0 z-20 mx-auto w-full max-w-[48.75rem] px-4 pb-4 pt-6">
           {footer}
         </div>

--- a/app/src/components/orchestration/__tests__/AgentChatPanel.test.tsx
+++ b/app/src/components/orchestration/__tests__/AgentChatPanel.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { SessionSummary } from '../../../lib/orchestration/orchestrationClient';
 import AgentChatPanel from '../AgentChatPanel';
@@ -264,5 +264,113 @@ describe('AgentChatPanel', () => {
     render(<AgentChatPanel />);
     // Exercises `selected?.messages ?? EMPTY_MESSAGES`; the panel still renders.
     expect(screen.getByTestId('orch-agent-tab-master')).toBeInTheDocument();
+  });
+
+  // ── Composer-footer measurement (regression: #5162 / TAURI-REACT-2G) ───────
+  //
+  // `ChatPageScaffold` measures its floating footer with a ResizeObserver and
+  // feeds the height into the scroll region's bottom padding. The effect used to
+  // depend on the `footer` *node*, which is inline JSX at every call site and so
+  // takes a fresh identity on every render — the observer was torn down and
+  // rebuilt each pass, and because `observe()` delivers an immediate
+  // observation, every render scheduled another height update. Any measurement
+  // that disagreed with the committed value re-rendered and re-ran the effect,
+  // cascading until React aborted with "Maximum update depth exceeded". Typing
+  // was the easiest trigger: the composer's auto-growing textarea lives inside
+  // this footer.
+  describe('composer footer measurement', () => {
+    /** Model of the real ResizeObserver: `observe()` reports an initial size. */
+    class MockResizeObserver {
+      static instances: MockResizeObserver[] = [];
+      observed: Element[] = [];
+      disconnected = false;
+      constructor(private readonly cb: () => void) {
+        MockResizeObserver.instances.push(this);
+      }
+      observe(el: Element) {
+        this.observed.push(el);
+        this.cb();
+      }
+      unobserve() {}
+      disconnect() {
+        this.disconnected = true;
+      }
+      /** Drive a size change the way a real layout change would. */
+      fire() {
+        this.cb();
+      }
+    }
+
+    /**
+     * Observers watching the composer footer. `useStickToBottom` also builds a
+     * ResizeObserver (on the scroll container), so the global mock catches both —
+     * select ours by the element it observes.
+     */
+    const footerObservers = () =>
+      MockResizeObserver.instances.filter(o =>
+        o.observed.some(el => (el as HTMLElement).dataset?.testid === 'orch-chat-footer')
+      );
+
+    const footerHeight = { current: 96 };
+    let originalResizeObserver: typeof globalThis.ResizeObserver | undefined;
+    let originalOffsetHeight: PropertyDescriptor | undefined;
+
+    beforeEach(() => {
+      MockResizeObserver.instances = [];
+      footerHeight.current = 96;
+      originalResizeObserver = globalThis.ResizeObserver;
+      globalThis.ResizeObserver = MockResizeObserver as unknown as typeof globalThis.ResizeObserver;
+      // jsdom does no layout, so every `offsetHeight` is 0. Report a real height
+      // for the footer wrapper only, so the measurement path is observable.
+      originalOffsetHeight = Object.getOwnPropertyDescriptor(
+        HTMLElement.prototype,
+        'offsetHeight'
+      ) as PropertyDescriptor | undefined;
+      Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+        configurable: true,
+        get(this: HTMLElement) {
+          return this.dataset.testid === 'orch-chat-footer' ? footerHeight.current : 0;
+        },
+      });
+    });
+
+    afterEach(() => {
+      if (originalResizeObserver) globalThis.ResizeObserver = originalResizeObserver;
+      else delete (globalThis as { ResizeObserver?: unknown }).ResizeObserver;
+      if (originalOffsetHeight) {
+        Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeight);
+      } else {
+        delete (HTMLElement.prototype as unknown as Record<string, unknown>).offsetHeight;
+      }
+    });
+
+    it('does not rebuild the footer ResizeObserver on every render while typing', () => {
+      render(<AgentChatPanel />);
+      expect(footerObservers()).toHaveLength(1);
+
+      // Each keystroke re-renders the panel, which produces a fresh `footer`
+      // element. That must NOT re-subscribe the observer.
+      const textbox = screen.getByRole('textbox');
+      fireEvent.change(textbox, { target: { value: 'h' } });
+      fireEvent.change(textbox, { target: { value: 'he' } });
+      fireEvent.change(textbox, { target: { value: 'hey' } });
+
+      expect(footerObservers()).toHaveLength(1);
+      expect(footerObservers()[0].disconnected).toBe(false);
+    });
+
+    it('still reserves the measured footer height on the scroll region', () => {
+      render(<AgentChatPanel />);
+      const scroll = screen.getByTestId('orch-chat-scroll');
+      expect(scroll.style.paddingBottom).toBe('96px');
+
+      // A real layout change (the composer growing a line) must still be picked
+      // up now that the effect subscribes on footer presence rather than identity.
+      footerHeight.current = 132;
+      act(() => footerObservers()[0].fire());
+
+      expect(scroll.style.paddingBottom).toBe('132px');
+      expect(footerObservers()).toHaveLength(1);
+    });
   });
 });

--- a/app/src/features/conversations/Conversations.tsx
+++ b/app/src/features/conversations/Conversations.tsx
@@ -86,10 +86,12 @@ import {
   fetchAndHydrateTurnState,
   hydrateThreadUsage,
   markThreadSendPending,
+  type ProcessingTranscriptItem,
   type QueuedFollowup,
   registerParallelRequest,
   setTaskBoardForThread,
   setToolTimelineForThread,
+  type ToolTimelineEntry,
 } from '../../store/chatRuntimeSlice';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import { selectSocketStatus } from '../../store/socketSelectors';
@@ -160,6 +162,13 @@ const EMPTY_ACTIVE_THREADS: Record<string, true> = {};
 // Stable empty reference for the queued-follow-ups map, so the selector keeps
 // the same identity when the slice field is absent (narrow test stores).
 const EMPTY_QUEUED_FOLLOWUPS: Record<string, QueuedFollowup[]> = {};
+
+// Stable empty live tool-timeline / processing-transcript for the selected
+// thread. A fresh `[]` here took a new identity every render, invalidating the
+// `backgroundProcesses` memo below on each pass and adding avoidable re-render
+// churn to the chat's hot path (#5162).
+const EMPTY_TOOL_TIMELINE: ToolTimelineEntry[] = [];
+const EMPTY_PROCESSING: ProcessingTranscriptItem[] = [];
 
 export function isComposerInteractionBlocked(args: {
   /** Whether the *currently selected* thread has an in-flight inference turn. */
@@ -1594,11 +1603,11 @@ const Conversations = ({
   // the global `selectedThreadId`. What remains here is what the header badge
   // and the composer footer still need directly.
   const selectedThreadToolTimeline = selectedThreadId
-    ? (toolTimelineByThread[selectedThreadId] ?? [])
-    : [];
+    ? (toolTimelineByThread[selectedThreadId] ?? EMPTY_TOOL_TIMELINE)
+    : EMPTY_TOOL_TIMELINE;
   const selectedThreadProcessing = selectedThreadId
-    ? (processingByThread[selectedThreadId] ?? [])
-    : [];
+    ? (processingByThread[selectedThreadId] ?? EMPTY_PROCESSING)
+    : EMPTY_PROCESSING;
   // Detached background sub-agents (mode === 'async') spawned in this thread.
   // Kept here (in addition to ChatThreadView's own copy) because the header's
   // background-processes badge needs the count/status without reaching into
@@ -1745,7 +1754,13 @@ const Conversations = ({
     if (!el) return;
     const measure = () => {
       const next = Math.round(el.getBoundingClientRect().height);
-      if (next > 0) setComposerFooterHeight(next);
+      if (next <= 0) return;
+      // Skip no-op updates. This observer watches the footer that *contains* the
+      // composer, while `composerFooterHeight` feeds the message list's bottom
+      // padding — so re-rendering on an unchanged measurement lets a sub-pixel
+      // rounding oscillation cascade into React's nested-update limit
+      // ("Maximum update depth exceeded", #5162 / TAURI-REACT-2G).
+      setComposerFooterHeight(prev => (prev === next ? prev : next));
     };
     measure();
     const observer = new ResizeObserver(measure);

--- a/app/src/features/conversations/components/ChatThreadView.memoIdentity.test.tsx
+++ b/app/src/features/conversations/components/ChatThreadView.memoIdentity.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Identity-stability regression tests for the transcript's live tool-timeline
+ * and processing-transcript fallbacks (#5162).
+ *
+ * `selectedThreadToolTimeline` / `selectedThreadProcessing` used to fall back to
+ * a freshly-allocated `[]` on every render. That gave the value a new identity
+ * each pass, so the `backgroundProcesses` `useMemo` keyed on it was invalidated
+ * every render and `selectBackgroundProcesses` re-ran for no reason — avoidable
+ * churn on the chat's hot path, and the same identity mistake that fed the
+ * render loop this change set fixes. Both now fall back to module-level
+ * `EMPTY_*` constants, matching the convention the surrounding code already
+ * used for the past-turn maps.
+ *
+ * The contract is "the memo is not invalidated by a re-render", so these tests
+ * count `selectBackgroundProcesses` invocations across re-renders. The mock
+ * delegates to the real selector, so behaviour is unchanged.
+ */
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import chatRuntimeReducer from '../../../store/chatRuntimeSlice';
+import themeReducer from '../../../store/themeSlice';
+import threadReducer from '../../../store/threadSlice';
+import { ChatThreadView } from './ChatThreadView';
+
+const selectSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('./BackgroundProcessesPanel', async orig => {
+  const actual = await orig<typeof import('./BackgroundProcessesPanel')>();
+  return {
+    ...actual,
+    // Delegate to the real selector; we only need the call count.
+    selectBackgroundProcesses: (...args: Parameters<typeof actual.selectBackgroundProcesses>) => {
+      selectSpy();
+      return actual.selectBackgroundProcesses(...args);
+    },
+  };
+});
+
+// Layout effects are meaningless in jsdom — same stub the sibling suites use.
+vi.mock('../../../hooks/useStickToBottom', () => ({
+  useStickToBottom: vi.fn(() => ({ containerRef: { current: null }, endRef: { current: null } })),
+}));
+
+const emptyThreadState = {
+  threads: [],
+  selectedThreadId: null,
+  activeThreadIds: {},
+  welcomeThreadId: null,
+  messagesByThreadId: {},
+  messages: [],
+  isLoadingThreads: false,
+  isLoadingMessages: false,
+  messagesError: null,
+};
+
+function buildStore() {
+  return configureStore({
+    reducer: combineReducers({
+      thread: threadReducer,
+      chatRuntime: chatRuntimeReducer,
+      theme: themeReducer,
+    }),
+    preloadedState: { thread: emptyThreadState } as never,
+  });
+}
+
+describe('ChatThreadView empty-fallback identity (#5162)', () => {
+  beforeEach(() => {
+    selectSpy.mockClear();
+  });
+
+  it('does not re-derive background processes across re-renders with no thread', () => {
+    const store = buildStore();
+    const { rerender } = render(
+      <Provider store={store}>
+        <ChatThreadView threadId={null} />
+      </Provider>
+    );
+
+    expect(selectSpy).toHaveBeenCalledTimes(1);
+
+    // Nothing about the timeline changed, so the memo must hold. Pre-fix the
+    // `?? []` fallback handed it a new array identity on each pass and this
+    // climbed with every render.
+    rerender(
+      <Provider store={store}>
+        <ChatThreadView threadId={null} />
+      </Provider>
+    );
+    rerender(
+      <Provider store={store}>
+        <ChatThreadView threadId={null} />
+      </Provider>
+    );
+
+    expect(selectSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-derive background processes for a thread with no timeline yet', () => {
+    const store = buildStore();
+    const props = { threadId: 't-1' };
+    const { rerender } = render(
+      <Provider store={store}>
+        <ChatThreadView {...props} />
+      </Provider>
+    );
+
+    expect(selectSpy).toHaveBeenCalledTimes(1);
+
+    // The `toolTimelineByThread[threadId] ?? EMPTY_TOOL_TIMELINE` miss is the
+    // common case for a fresh thread — it must be identity-stable too.
+    rerender(
+      <Provider store={store}>
+        <ChatThreadView {...props} />
+      </Provider>
+    );
+
+    expect(selectSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/features/conversations/components/ChatThreadView.tsx
+++ b/app/src/features/conversations/components/ChatThreadView.tsx
@@ -103,6 +103,12 @@ const EMPTY_TRANSCRIPT: ProcessingTranscriptItem[] = [];
 // Stable empty tool-row list for a transcript-only past turn (agent thought /
 // narrated but ran no tools).
 const EMPTY_TRANSCRIPT_ENTRIES: ToolTimelineEntry[] = [];
+// Stable empty live tool-timeline / processing-transcript for the selected
+// thread. Allocating a fresh `[]` here gave the value a new identity on every
+// render, which invalidated the `backgroundProcesses` memo below every time and
+// added avoidable re-render churn to the chat's hot path (#5162).
+const EMPTY_TOOL_TIMELINE: ToolTimelineEntry[] = [];
+const EMPTY_PROCESSING: ProcessingTranscriptItem[] = [];
 
 export interface ChatThreadViewHandle {
   /** Opens the detached background sub-agents panel — called from the host
@@ -253,8 +259,12 @@ export const ChatThreadView = forwardRef<ChatThreadViewHandle, ChatThreadViewPro
       }
     };
 
-    const selectedThreadToolTimeline = threadId ? (toolTimelineByThread[threadId] ?? []) : [];
-    const selectedThreadProcessing = threadId ? (processingByThread[threadId] ?? []) : [];
+    const selectedThreadToolTimeline = threadId
+      ? (toolTimelineByThread[threadId] ?? EMPTY_TOOL_TIMELINE)
+      : EMPTY_TOOL_TIMELINE;
+    const selectedThreadProcessing = threadId
+      ? (processingByThread[threadId] ?? EMPTY_PROCESSING)
+      : EMPTY_PROCESSING;
     // Detached background sub-agents (mode === 'async') spawned in this thread.
     const backgroundProcesses = useMemo(
       () => selectBackgroundProcesses(selectedThreadToolTimeline),

--- a/app/src/pages/__tests__/Conversations.render.test.tsx
+++ b/app/src/pages/__tests__/Conversations.render.test.tsx
@@ -2988,6 +2988,78 @@ describe('Conversations — message list reserves room for the floating composer
       globalThis.ResizeObserver = original;
     }
   });
+
+  // #5162: this observer watches the footer that *contains* the composer while
+  // its measurement drives the message list's bottom padding — a cycle that is
+  // one oscillating measurement away from "Maximum update depth exceeded". This
+  // pins the observer's idempotence: a settled layout re-reporting the same
+  // height converges instead of re-rendering on every notification.
+  //
+  // Note on scope: this does NOT discriminate the `prev === next ? prev : next`
+  // guard in `measure()`. React's own Object.is bail-out already absorbs an
+  // identical `setState`, so render counts are byte-identical with and without
+  // that guard (measured: 8 → 9, 9, 9 either way). The guard is defensive and
+  // self-documenting, not load-bearing; what is worth pinning — and what this
+  // test pins — is that repeat notifications converge and never walk the
+  // padding.
+  it('converges when the observer re-reports an unchanged footer height', async () => {
+    const original = globalThis.ResizeObserver;
+    const handle: { cb: ResizeObserverCallback | null } = { cb: null };
+    class MockResizeObserver {
+      constructor(cb: ResizeObserverCallback) {
+        handle.cb = cb;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+    try {
+      await renderActiveConversationWithMessages();
+      const footer = document.querySelector('[data-walkthrough="home-cta"]') as HTMLElement | null;
+      expect(footer).not.toBeNull();
+      (footer as HTMLElement).getBoundingClientRect = () => ({ height: 240 }) as DOMRect;
+
+      // First measurement settles the height.
+      await act(async () => {
+        handle.cb?.([], {} as ResizeObserver);
+      });
+      expect(paddingBottomPx()).toBe(256);
+
+      // `useUsageState` is called exactly once per `Conversations` render, so
+      // its call count is a render counter for the component under test.
+      const settled = mockUseUsageState.mock.calls.length;
+
+      // A settled layout re-reporting itself, as a ResizeObserver does on any
+      // sibling layout change. Each notification must stop costing renders.
+      await act(async () => {
+        handle.cb?.([], {} as ResizeObserver);
+      });
+      const afterFirstRepeat = mockUseUsageState.mock.calls.length;
+
+      await act(async () => {
+        handle.cb?.([], {} as ResizeObserver);
+      });
+      await act(async () => {
+        handle.cb?.([], {} as ResizeObserver);
+      });
+
+      // Converged: further identical notifications cost nothing at all, so a
+      // stuck-oscillating observer cannot escalate into a nested-update loop.
+      expect(mockUseUsageState.mock.calls.length).toBe(afterFirstRepeat);
+      expect(afterFirstRepeat - settled).toBeLessThanOrEqual(1);
+      expect(paddingBottomPx()).toBe(256);
+
+      // A genuine resize must still get through — convergence is not deafness.
+      (footer as HTMLElement).getBoundingClientRect = () => ({ height: 300 }) as DOMRect;
+      await act(async () => {
+        handle.cb?.([], {} as ResizeObserver);
+      });
+      expect(paddingBottomPx()).toBe(316);
+    } finally {
+      globalThis.ResizeObserver = original;
+    }
+  });
 });
 
 // The in-chat "Leaving your device" external-transfer disclosure card was


### PR DESCRIPTION
## Summary

- Fix the infinite render loop behind `Maximum update depth exceeded` (Sentry `TAURI-REACT-2G`, ~12 events / ~5 users across 3 shortIds).
- Root cause: `ChatPageScaffold`'s composer-footer `ResizeObserver` effect depended on the `footer` React node, which is inline JSX at every call site and therefore has a new object identity on every render.
- Subscribe on footer *presence* instead of identity, and drop measurements that match the committed height.
- Harden the same shape in the main chat (`Conversations`) so a sub-pixel rounding oscillation cannot feed the same cascade.
- Replace two per-render `[]` allocations in the chat hot path with the stable `EMPTY_*` constants the surrounding code already established (also clears both `react-hooks/exhaustive-deps` warnings there).

## Problem

`ChatPageScaffold` (`app/src/components/orchestration/AgentChatPanel.tsx`) measures its floating composer footer with a `ResizeObserver` and feeds the height into the scroll region's bottom padding. The effect's dependency was the `footer` node itself:

```js
}, [footer]);   // footer is inline JSX at every call site
```

Because both call sites pass inline JSX, `footer` takes a **fresh object identity on every render**. Three effects compounded:

1. The effect re-ran on *every* render, tearing down and rebuilding the observer each pass.
2. `ResizeObserver.observe()` delivers an **immediate initial observation**, so every render scheduled another `setFooterHeight`.
3. `setFooterHeight` was unconditional, so any measurement disagreeing with committed state re-rendered → new `footer` identity → back to step 1.

That cascade runs until React trips its nested-update limit and throws `Maximum update depth exceeded`.

**Why Sentry blamed `ChatComposer.onChange`:** the composer's auto-growing textarea lives *inside* that footer, so each keystroke changed the measured height and pumped the cycle. The composer was the trigger, not the defect — which is why the previous mitigations tagged `TAURI-REACT-2G` in `ChatComposer` / `Conversations` / `ThreadGoalChip` never closed the issue.

## Solution

**`AgentChatPanel.tsx` (root cause).** Key the subscription on footer *presence* (`hasFooter = Boolean(footer)`) rather than the node. The observer already reports every size change, so it only needs re-subscribing when the footer element mounts or unmounts — not when its children re-render. A local `applyHeight` helper drops measurements equal to the committed height, so a settled layout can never schedule a re-render and therefore can never feed a cascade.

**`Conversations.tsx` (same shape, hardening).** The main chat's composer-footer observer now skips no-op updates. Its deps were already stable, so this was not looping, but it watches the footer that *contains* the composer while feeding the message list's padding — the exact coupling that lets sub-pixel rounding oscillate.

**`Conversations.tsx` + `ChatThreadView.tsx` (render churn).** `selectedThreadToolTimeline` / `selectedThreadProcessing` allocated a fresh `[]` per render, giving them a new identity every pass and invalidating the `backgroundProcesses` `useMemo` every time. Both files already define `EMPTY_*` constants for precisely this reason; these two sites were missed.

Behavior is preserved throughout — the observer still reports every real size change.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/ci-lite.yml`](../.github/workflows/ci-lite.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] `N/A: behaviour-only change` — Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (no feature rows added/removed/renamed)
- [x] `N/A` — All affected feature IDs from the matrix are listed in the PR description under `## Related` (no matrix rows change)
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] `N/A: no release-cut surface touched` — Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

### Regression test

`app/src/components/orchestration/__tests__/AgentChatPanel.test.tsx` adds a `composer footer measurement` block that stubs `ResizeObserver` (modelling the real initial observation on `observe()`) and reports a real `offsetHeight` for the footer wrapper only.

- **`does not rebuild the footer ResizeObserver on every render while typing`** — the failure-path test. Verified failing before / passing after: with *only* the dependency array reverted to `[footer]` (test hook kept in place), it reports **4 footer observers instead of 1** — one per keystroke render.
- **`still reserves the measured footer height on the scroll region`** — the happy path, guarding that the changed subscription key didn't break the layout feature: a size change through the observer still updates `paddingBottom`.

`useStickToBottom` also builds a `ResizeObserver`, so the assertions select ours by the element it observes.

## Impact

- **Platform:** desktop (Tauri/CEF) React renderer only. No Rust, no core, no RPC, no schema change.
- **Performance:** strictly positive — removes a per-render observer teardown/rebuild on the orchestration chat and two per-render array allocations plus a wasted memo recompute on the main chat's hot path.
- **Security / migration / compatibility:** none.
- **User-visible:** the crash stops; layout behaviour is unchanged.

## Related

- Closes: #5162
- Follow-up PR(s)/TODOs: the render-loop diagnostic guard in `app/src/components/chat/ChatComposer.tsx` (lines ~112-129) is a leftover mitigation for this issue — it mutates a ref and calls `setTimeout` during render (an impure render side effect) and `console.warn`s in production. Left in place to keep this diff focused; worth removing now that the root cause is fixed.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: N/A
- Commit SHA: N/A

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — Prettier clean on all four changed files
- [x] `pnpm typecheck` — clean
- [x] Focused tests: `vitest related` over the three changed source files — **18 files / 287 tests passed**; full frontend suite **768 files / 8971 tests passed, 0 failed**
- [x] `N/A: no Rust changed` — Rust fmt/check (if changed)
- [x] `N/A: no Tauri shell changed` — Tauri fmt/check (if changed)

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none beyond removing the crash — the footer observer still reports every real size change and the reserved padding is identical.
- User-visible effect: the chat surfaces no longer die with `Maximum update depth exceeded` while typing.

### Parity Contract

- Legacy behavior preserved: yes. The footer height still drives the scroll region's `paddingBottom`; only the subscription key (presence vs node identity) and the no-op-update guard changed.
- Guard/fallback/dispatch parity checks: the `typeof ResizeObserver === 'undefined'` one-shot fallback is retained; the `!el` early return now also covers `!hasFooter`, and both still reset the height to `0`.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented chat composer layout updates from entering a repeated update loop.
  * Improved footer height tracking so scrolling reserves the correct space and updates reliably when the footer resizes.
  * Reduced unnecessary updates when no conversation thread is selected or when measured dimensions remain unchanged.

* **Tests**
  * Added regression coverage for footer resizing, scrolling space, and stable observer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->