### PR TITLE
fix(harness-init): bound the status poll loop instead of retrying forever (#5157)

### DIFF
--- a/app/src/components/InitProgressScreen/HarnessInitOverlay.test.tsx
+++ b/app/src/components/InitProgressScreen/HarnessInitOverlay.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { CoreRpcError } from '../../services/coreRpcClient';
 import type { HarnessInitSnapshot } from '../../services/harnessInitService';
 import { renderWithProviders } from '../../test/test-utils';
 // Imported after the mock is registered.
@@ -43,6 +44,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 describe('HarnessInitOverlay', () => {
@@ -115,5 +117,66 @@ describe('HarnessInitOverlay', () => {
     fetchHarnessInitStatus.mockResolvedValue(snapshot({ startedAt: 'run-2' }));
     renderWithProviders(<HarnessInitOverlay />);
     expect(await screen.findByText('Run in background')).toBeInTheDocument();
+  });
+
+  // --- #5157: the poll loop must be bounded -------------------------------
+  //
+  // Before the fix, *any* status failure rescheduled the poll unconditionally
+  // every 2s for the life of the window. Against a core that never serves the
+  // method that was a permanent 30-calls-per-minute loop, and since the core
+  // records each miss it produced ~9k Sentry events/day from one client.
+
+  it('stops polling when the core does not expose harness_init_status (#5157)', async () => {
+    vi.useFakeTimers();
+    fetchHarnessInitStatus.mockRejectedValue(
+      new CoreRpcError('unknown method: openhuman.harness_init_status', 'method_not_found')
+    );
+
+    const { container } = renderWithProviders(<HarnessInitOverlay />);
+
+    // Let the immediate poll settle, then run well past many poll intervals.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchHarnessInitStatus).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    // Permanently absent ⇒ exactly one attempt, ever. No retry, no overlay.
+    expect(fetchHarnessInitStatus).toHaveBeenCalledTimes(1);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('gives up after a bounded number of consecutive transient failures (#5157)', async () => {
+    vi.useFakeTimers();
+    // A persistent non-method-not-found fault (core wedged, transport down).
+    fetchHarnessInitStatus.mockRejectedValue(new Error('error sending request for url'));
+
+    renderWithProviders(<HarnessInitOverlay />);
+
+    // 5 attempts, backing off 2s → 4s → 8s → 16s between them (30s total).
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(fetchHarnessInitStatus).toHaveBeenCalledTimes(5);
+
+    // And it stays stopped rather than resuming later.
+    await vi.advanceTimersByTimeAsync(600_000);
+    expect(fetchHarnessInitStatus).toHaveBeenCalledTimes(5);
+  });
+
+  it('keeps polling after a transient failure while the core is still booting', async () => {
+    vi.useFakeTimers();
+    // The legitimate cold-start case the retry exists for: fail once, then the
+    // core comes up. The failure budget must reset on success, not leak.
+    fetchHarnessInitStatus
+      .mockRejectedValueOnce(new Error('error sending request for url'))
+      .mockResolvedValue(snapshot({ startedAt: 'cold-run' }));
+
+    renderWithProviders(<HarnessInitOverlay />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    // Retried once and recovered — the overlay renders the live run.
+    expect(fetchHarnessInitStatus).toHaveBeenCalledTimes(2);
+    expect(screen.getByText('Run in background')).toBeInTheDocument();
   });
 });

--- a/app/src/components/InitProgressScreen/HarnessInitOverlay.test.tsx
+++ b/app/src/components/InitProgressScreen/HarnessInitOverlay.test.tsx
@@ -161,6 +161,51 @@ describe('HarnessInitOverlay', () => {
     expect(fetchHarnessInitStatus).toHaveBeenCalledTimes(5);
   });
 
+  // Review follow-up on #5157: the failure cap must not strand the *blocking*
+  // overlay. If the core has a transient outage that outlasts the budget while
+  // a `running` snapshot is on screen, giving up would pin the app behind stale
+  // progress for the rest of the session — the pre-#5157 loop recovered from
+  // exactly that. The cap still applies when nothing blocking is displayed
+  // (covered by the give-up test above); here the loop drops to a slow cadence
+  // instead of stopping.
+  it('keeps watching a running overlay through an outage longer than the failure budget', async () => {
+    vi.useFakeTimers();
+    fetchHarnessInitStatus
+      // A provisioning run is live — the overlay is now blocking the app.
+      .mockResolvedValueOnce(snapshot({ startedAt: 'stall-run' }))
+      // The core drops out for well past MAX_TRANSIENT_FAILURES attempts.
+      .mockRejectedValueOnce(new Error('error sending request for url'))
+      .mockRejectedValueOnce(new Error('error sending request for url'))
+      .mockRejectedValueOnce(new Error('error sending request for url'))
+      .mockRejectedValueOnce(new Error('error sending request for url'))
+      .mockRejectedValueOnce(new Error('error sending request for url'))
+      .mockRejectedValueOnce(new Error('error sending request for url'))
+      .mockRejectedValueOnce(new Error('error sending request for url'))
+      .mockRejectedValueOnce(new Error('error sending request for url'))
+      // ...and then comes back, having finished the run.
+      .mockResolvedValue(
+        snapshot({ overall: 'done', startedAt: 'stall-run', finishedAt: '2026-07-20T00:05:00Z' })
+      );
+
+    renderWithProviders(<HarnessInitOverlay />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByText('Run in background')).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300_000);
+    });
+
+    // It kept polling past the 5-attempt cap instead of freezing...
+    expect(fetchHarnessInitStatus.mock.calls.length).toBeGreaterThan(6);
+    // ...so the recovered core's terminal snapshot was observed and the
+    // blocking overlay cleared itself. (Asserted directly rather than through
+    // `waitFor`, which would wait on real timers while fake ones are installed.)
+    expect(screen.queryByText('Run in background')).not.toBeInTheDocument();
+  });
+
   it('keeps polling after a transient failure while the core is still booting', async () => {
     vi.useFakeTimers();
     // The legitimate cold-start case the retry exists for: fail once, then the

--- a/app/src/components/InitProgressScreen/HarnessInitOverlay.tsx
+++ b/app/src/components/InitProgressScreen/HarnessInitOverlay.tsx
@@ -28,9 +28,32 @@ const POLL_MS = 2000;
 const MAX_TRANSIENT_FAILURES = 5;
 const MAX_BACKOFF_MS = 30_000;
 
+// Exhausting the retries must not strand a *blocking* overlay on stale
+// progress. While a `running` snapshot is on screen the UI is covering the app
+// and waiting for a terminal snapshot, so a transient outage (brief core
+// overload, network blip) that outlasts the cap has to stay watchable — giving
+// up there would freeze the overlay on a half-finished run until the user hits
+// "Run in background", and the pre-#5157 loop did recover from exactly that.
+//
+// So the cap still applies whenever nothing blocking is displayed (the #5157
+// case: a core that never serves this method, with no UI on screen), and
+// otherwise the loop drops to this much slower cadence instead of stopping.
+// 2 calls/min is 15x below the runaway loop #5157 fixed, and only ever runs
+// while a blocking overlay is actually up.
+const STALLED_POLL_MS = MAX_BACKOFF_MS;
+
 /** Backoff for the Nth consecutive transient failure (1-based), capped. */
 function transientRetryDelayMs(consecutiveFailures: number): number {
   return Math.min(POLL_MS * 2 ** (consecutiveFailures - 1), MAX_BACKOFF_MS);
+}
+
+/**
+ * Whether this snapshot puts the blocking overlay on screen. `running` is also
+ * the only non-terminal blocking state, so it is what the poll loop must keep
+ * watching for a terminal result.
+ */
+function isBlockingSnapshot(snapshot: HarnessInitSnapshot): boolean {
+  return snapshot.overall === 'running' || snapshot.overall === 'failed';
 }
 
 // Persist the "Run in background" dismissal for the *current* provisioning run
@@ -123,6 +146,10 @@ export default function HarnessInitOverlay() {
   const cancelledRef = useRef(false);
   // Mirrors `dismissed` so the poll loop can stop without re-running the effect.
   const dismissedRef = useRef(false);
+  // Mirrors "a blocking overlay is currently on screen, still waiting on a
+  // terminal snapshot", so the failure branch can tell a stranded user from a
+  // silent background loop without re-running the effect.
+  const awaitingTerminalRef = useRef(false);
 
   useEffect(() => {
     cancelledRef.current = false;
@@ -140,6 +167,7 @@ export default function HarnessInitOverlay() {
         consecutiveFailures = 0;
         if (next) {
           setSnapshot(next);
+          awaitingTerminalRef.current = next.overall === 'running';
           // If this run was already dismissed to the background (possibly in a
           // prior mount / before a reload), stay hidden and stop polling —
           // don't let a remount reopen the overlay (GH-5047).
@@ -173,17 +201,36 @@ export default function HarnessInitOverlay() {
         // Status can fail while the core is still coming up — keep polling, but
         // only for a bounded number of attempts, backing off between each.
         if (consecutiveFailures >= MAX_TRANSIENT_FAILURES) {
-          log('status poll failed %d consecutive times — giving up: %O', consecutiveFailures, err);
-          return;
+          // Nothing blocking on screen: this is the #5157 runaway loop, stop.
+          if (!awaitingTerminalRef.current) {
+            log(
+              'status poll failed %d consecutive times — giving up: %O',
+              consecutiveFailures,
+              err
+            );
+            return;
+          }
+          // A `running` overlay is covering the app. Stopping here would pin it
+          // to stale progress for the rest of the session even after the core
+          // recovers, so keep watching at a much slower cadence instead.
+          retryDelayMs = STALLED_POLL_MS;
+          log(
+            'status poll failed %d consecutive times but a running overlay is on screen — ' +
+              'continuing at %dms: %O',
+            consecutiveFailures,
+            retryDelayMs,
+            err
+          );
+        } else {
+          retryDelayMs = transientRetryDelayMs(consecutiveFailures);
+          log(
+            'status poll failed (attempt %d/%d), retrying in %dms: %O',
+            consecutiveFailures,
+            MAX_TRANSIENT_FAILURES,
+            retryDelayMs,
+            err
+          );
         }
-        retryDelayMs = transientRetryDelayMs(consecutiveFailures);
-        log(
-          'status poll failed (attempt %d/%d), retrying in %dms: %O',
-          consecutiveFailures,
-          MAX_TRANSIENT_FAILURES,
-          retryDelayMs,
-          err
-        );
       }
       if (!cancelledRef.current && !dismissedRef.current) {
         timeoutId = window.setTimeout(() => void poll(), retryDelayMs);
@@ -221,6 +268,10 @@ export default function HarnessInitOverlay() {
     log('user dismissed overlay to background for run %s', runKey(snapshot));
     writeDismissedRun(runKey(snapshot));
     dismissedRef.current = true;
+    // Nothing is blocking any more, so a later failure must not keep the slow
+    // watch alive. (`dismissedRef` already stops the loop; this keeps the two
+    // flags from disagreeing.)
+    awaitingTerminalRef.current = false;
     setDismissed(true);
   }, [snapshot]);
 
@@ -236,8 +287,7 @@ export default function HarnessInitOverlay() {
   // Block only while a run is actively in progress, or hold a failed run on
   // screen until the user explicitly continues. `idle` (no run started yet)
   // and `done` never block.
-  const shouldShow = snapshot.overall === 'running' || snapshot.overall === 'failed';
-  if (!shouldShow) {
+  if (!isBlockingSnapshot(snapshot)) {
     return null;
   }
 

--- a/app/src/components/InitProgressScreen/HarnessInitOverlay.tsx
+++ b/app/src/components/InitProgressScreen/HarnessInitOverlay.tsx
@@ -1,6 +1,7 @@
 import debugFactory from 'debug';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { isMethodNotFoundCoreRpcError } from '../../services/coreRpcClient';
 import {
   fetchHarnessInitStatus,
   type HarnessInitSnapshot,
@@ -11,6 +12,26 @@ import InitProgressScreen from './InitProgressScreen';
 const log = debugFactory('harness-init');
 
 const POLL_MS = 2000;
+
+// A status poll can legitimately fail while the core is still coming up, so a
+// failure is retried. But the retry must be *bounded*: before #5157 any failure
+// rescheduled the poll unconditionally every 2s for the life of the window. A
+// core that never serves this method (version skew / domain-gated build) turned
+// that into a permanent 30-calls-per-minute loop, and because each miss is
+// recorded core-side it produced ~9k Sentry events/day from a single client.
+//
+// Two guards now bound it:
+//   - a permanent failure (`method_not_found`) stops the loop immediately —
+//     retrying an absent method can never succeed;
+//   - any other failure gets a capped number of attempts with exponential
+//     backoff, so even an unforeseen persistent fault decays and stops.
+const MAX_TRANSIENT_FAILURES = 5;
+const MAX_BACKOFF_MS = 30_000;
+
+/** Backoff for the Nth consecutive transient failure (1-based), capped. */
+function transientRetryDelayMs(consecutiveFailures: number): number {
+  return Math.min(POLL_MS * 2 ** (consecutiveFailures - 1), MAX_BACKOFF_MS);
+}
 
 // Persist the "Run in background" dismissal for the *current* provisioning run
 // so a remount or reload does not reopen the overlay (GH-5047). A run is keyed
@@ -107,12 +128,16 @@ export default function HarnessInitOverlay() {
     cancelledRef.current = false;
     let timeoutId: number | null = null;
 
+    let consecutiveFailures = 0;
+
     const poll = async () => {
+      let retryDelayMs = POLL_MS;
       try {
         const next = await fetchHarnessInitStatusCoalesced();
         if (cancelledRef.current || dismissedRef.current) {
           return;
         }
+        consecutiveFailures = 0;
         if (next) {
           setSnapshot(next);
           // If this run was already dismissed to the background (possibly in a
@@ -134,11 +159,34 @@ export default function HarnessInitOverlay() {
           }
         }
       } catch (err) {
-        // Status can fail while the core is still coming up — keep polling.
-        log('status poll failed: %O', err);
+        if (cancelledRef.current || dismissedRef.current) {
+          return;
+        }
+        // The running core has no `harness_init_status` at all (version skew,
+        // domain-gated or slim build). Permanent — stop, and render nothing.
+        // There is no init run to report, so there is nothing to show (#5157).
+        if (isMethodNotFoundCoreRpcError(err)) {
+          log('status poll: core does not expose harness_init_status — stopping poll');
+          return;
+        }
+        consecutiveFailures += 1;
+        // Status can fail while the core is still coming up — keep polling, but
+        // only for a bounded number of attempts, backing off between each.
+        if (consecutiveFailures >= MAX_TRANSIENT_FAILURES) {
+          log('status poll failed %d consecutive times — giving up: %O', consecutiveFailures, err);
+          return;
+        }
+        retryDelayMs = transientRetryDelayMs(consecutiveFailures);
+        log(
+          'status poll failed (attempt %d/%d), retrying in %dms: %O',
+          consecutiveFailures,
+          MAX_TRANSIENT_FAILURES,
+          retryDelayMs,
+          err
+        );
       }
       if (!cancelledRef.current && !dismissedRef.current) {
-        timeoutId = window.setTimeout(() => void poll(), POLL_MS);
+        timeoutId = window.setTimeout(() => void poll(), retryDelayMs);
       }
     };
 

--- a/app/src/services/__tests__/coreRpcClient.test.ts
+++ b/app/src/services/__tests__/coreRpcClient.test.ts
@@ -705,6 +705,10 @@ describe('classifyRpcError', () => {
     ['no backend session token; run auth_store_session first', undefined, 'auth_expired'],
     ['NO BACKEND SESSION TOKEN', undefined, 'auth_expired'],
     ['HTTP 429 rate-limit exceeded', undefined, 'rate_limited'],
+    // #5157 verbatim from Sentry (CORE-RUST-1PY) — the running core does not
+    // expose the method. Permanent, so pollers must be able to stop.
+    ['unknown method: openhuman.harness_init_status', undefined, 'method_not_found'],
+    ['unknown method: openhuman.memory_tree_create_namespace', undefined, 'method_not_found'],
     ['Budget exceeded for current period', undefined, 'budget_exceeded'],
     ['Insufficient budget for request', undefined, 'budget_exceeded'],
     ['error sending request for url', undefined, 'transport'],
@@ -750,6 +754,16 @@ describe('classifyRpcError', () => {
 
   test('http status 429 wins over message text', () => {
     expect(classifyRpcError('anything', 429)).toBe('rate_limited');
+  });
+
+  test('unknown-method match is prefix-anchored, mirroring the Rust strip_prefix', () => {
+    // `dispatch::unknown_method_name` classifies with `strip_prefix`, so the
+    // frontend anchors identically — a nested/quoted occurrence is not the
+    // core telling us *this* call's method is absent.
+    expect(classifyRpcError('unknown method: openhuman.harness_init_status')).toBe(
+      'method_not_found'
+    );
+    expect(classifyRpcError('tool failed: unknown method: openhuman.foo_bar')).toBe('unknown');
   });
 
   test('structured ThreadNotFound data wins over message text', () => {

--- a/app/src/services/coreRpcClient.ts
+++ b/app/src/services/coreRpcClient.ts
@@ -116,7 +116,14 @@ type CoreRpcErrorKind =
   | 'rate_limited'
   | 'budget_exceeded'
   | 'thread_not_found'
+  | 'method_not_found' // the running core does not expose this method — permanent
   | 'unknown';
+
+/**
+ * Prefix the core prepends to an unrecognised-method error. Mirrors
+ * `UNKNOWN_METHOD_PREFIX` in `src/core/dispatch.rs` — keep the two in sync.
+ */
+const UNKNOWN_METHOD_PREFIX = 'unknown method: ';
 
 export class CoreRpcError extends Error {
   readonly kind: CoreRpcErrorKind;
@@ -147,6 +154,11 @@ export function classifyRpcError(
   if (isThreadNotFoundRpcData(data)) return 'thread_not_found';
   if (httpStatus === 401) return 'auth_expired';
   if (httpStatus === 429) return 'rate_limited';
+  // The running core has no such method — a transport-boundary version skew
+  // (older core than the UI bundle, a domain-gated `DomainSet`, or a slim
+  // feature build), never a transient fault. Classified before the generic
+  // arms so polling callers can stop instead of retrying forever (#5157).
+  if (message.startsWith(UNKNOWN_METHOD_PREFIX)) return 'method_not_found';
   // Confirmed OpenHuman session expiry — explicit markers from the backend/core.
   if (/Session expired|SESSION_EXPIRED/i.test(message)) return 'auth_expired';
   // Core-side "no backend session token" → the auth profile is gone but the
@@ -236,6 +248,18 @@ function threadIdFromRpcData(data: unknown): string | null {
   if (typeof record.thread_id === 'string') return record.thread_id;
   if (typeof record.threadId === 'string') return record.threadId;
   return null;
+}
+
+/**
+ * Whether `error` is the core reporting that it does not expose the method.
+ *
+ * This is a **permanent** condition for the life of the connection: the method
+ * is absent from the running core's registry, so retrying can never succeed.
+ * Pollers must treat it as terminal and stop — an unbounded retry loop against
+ * an absent method produced ~9k Sentry events/day from a single client (#5157).
+ */
+export function isMethodNotFoundCoreRpcError(error: unknown): error is CoreRpcError {
+  return error instanceof CoreRpcError && error.kind === 'method_not_found';
 }
 
 export function isThreadNotFoundCoreRpcError(

--- a/src/core/dispatch.rs
+++ b/src/core/dispatch.rs
@@ -107,8 +107,19 @@ pub const UNKNOWN_METHOD_PREFIX: &str = "unknown method: ";
 /// and never will be (issue #3567): `rpc.discover` (JSON-RPC service
 /// discovery), `list_methods`, liveness `status`, `auth.status`, `config/get`.
 /// This also covers retired feature calls from older clients when no safe
-/// canonical handler exists (#3565: `openhuman.memory_tree_create_namespace`,
-/// #5157: `openhuman.harness_init_status`).
+/// canonical handler exists (#3565: `openhuman.memory_tree_create_namespace`).
+///
+/// `openhuman.harness_init_status` (#5157) is in the list for a *different*
+/// reason and must not be read as retired — it is a **live, registered**
+/// method (`harness_init::all_harness_init_registered_controllers`, tagged
+/// `DomainGroup::Platform`). It only misses when the caller and the running
+/// core disagree about the surface: an older core behind a newer UI bundle, a
+/// runtime `DomainSet` without `Platform` (e.g. `DomainSet::harness()`), or a
+/// slim feature build. Those are legitimate configurations, not core defects,
+/// so the miss stays debug-only — but do **not** delete the controller on the
+/// strength of this entry. `harness_init_status_is_registered_in_a_full_build`
+/// below pins that the method really is served, so a genuine regression fails
+/// a test instead of being silently swallowed by this allow-list.
 ///
 /// Each miss previously produced recurring Sentry events with zero user
 /// impact. The transport layer keeps these debug-only (never captured). The
@@ -393,6 +404,27 @@ mod tests {
         assert!(!is_known_probe_method("rpc.discover.extra")); // exact match only
         assert!(!is_known_probe_method("memory_tree_create_namespace"));
         assert!(!is_known_probe_method(""));
+    }
+
+    /// `openhuman.harness_init_status` is allow-listed as a debug-only miss so
+    /// client/core surface skew stops paging Sentry (#5157) — but it is a
+    /// **live** method, not a retired one. That allow-list entry means a
+    /// genuine regression (controller dropped from the registry) would go
+    /// completely silent: no error, no warn, no Sentry event. This test is the
+    /// replacement signal — if the method stops being served in a full build,
+    /// this fails instead of the regression shipping unnoticed.
+    #[test]
+    fn harness_init_status_is_registered_in_a_full_build() {
+        let served: Vec<String> = crate::core::all::all_controller_schemas()
+            .iter()
+            .map(crate::core::all::rpc_method_name)
+            .collect();
+        assert!(
+            served.iter().any(|m| m == "openhuman.harness_init_status"),
+            "harness_init_status must remain a registered controller — it is \
+             allow-listed in KNOWN_PROBE_METHODS for client/core skew only, so \
+             losing the real handler would be silently swallowed"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Bound the `HarnessInitOverlay` status poll loop, which retried a failing RPC every 2s forever with no cap and no backoff — the source of 64,715 Sentry events (~9k/day) from a single client (`CORE-RUST-1PY`).
- Added a `method_not_found` `CoreRpcError` kind so pollers can recognise a **permanent** RPC miss and stop, instead of treating it as transient.
- Capped non-permanent failures at 5 attempts with 2s→30s exponential backoff, while preserving the cold-start retry the loop exists for.
- Corrected the `KNOWN_PROBE_METHODS` rationale in `src/core/dispatch.rs`, which described `harness_init_status` as a retired method — it is live and served.
- Pinned the controller registration with a test, so a genuine regression fails loudly rather than being silenced by that allow-list.

## Problem

`HarnessInitOverlay` polls `openhuman.harness_init_status` every 2s. On **any** error it called `setTimeout(poll, POLL_MS)` unconditionally — no attempt cap, no backoff, and no concept of a failure that can never succeed. Against a core that does not serve the method this became a permanent 30-calls-per-minute loop for the life of the window, and because the core records every unknown-method miss it produced 64,715 events.

**The issue's framing is inverted, and it changes the fix.** `harness_init_status` is not a removed RPC. It is a live, registered controller (`harness_init::all_harness_init_registered_controllers`, tagged `DomainGroup::Platform`, covered by `json_rpc_harness_init_status_returns_snapshot_envelope`). It misses only when caller and core disagree about the served surface:

- an older core behind a newer UI bundle (the Sentry release is `0.57.5`; `harness_init` landed in `0.58.0` via #4021),
- a runtime `DomainSet` without `Platform` — e.g. `DomainSet::harness()`,
- a slim feature build.

Those are legitimate configurations, so the *first* miss is expected and correct. The amplification from 1 to 64,715 is entirely client-side.

This also means the existing server-side allow-list entry (added in #5171) cannot have fixed the reported events: the affected cores are `0.57.5`, versions that shipped long before that allow-list existed.

## Solution

**Client — stop the amplification at its source.**

- `classifyRpcError` maps an `unknown method: ` response to a new `method_not_found` kind, prefix-anchored to mirror `dispatch::unknown_method_name`'s `strip_prefix`, so the two classifiers cannot drift. Exposed as `isMethodNotFoundCoreRpcError` so callers branch on `kind` rather than a message regex — which is what that module's own doc-comment already requires.
- The overlay stops polling immediately on `method_not_found` and renders nothing: a core without `harness_init` has no init run to report.
- Any other failure gets at most `MAX_TRANSIENT_FAILURES` (5) attempts with exponential backoff capped at 30s, so even an unforeseen persistent fault decays and stops rather than running forever.
- The failure budget resets on the first success, keeping the legitimate "core is still booting" retry intact.

**Core — correct a misleading note and close the observability hole it opened.**

The `KNOWN_PROBE_METHODS` comment listed `harness_init_status` alongside genuinely retired calls, as a "retired feature call ... when no safe canonical handler exists". It is served, so that note invited deleting a live controller. And because the allow-list makes the miss debug-only, a genuine regression — the controller dropped from the registry — would have gone completely silent: no error, no warn, no Sentry event. The comment now states the real reason (surface skew), and `harness_init_status_is_registered_in_a_full_build` pins that the method really is served.

**Tradeoff considered:** removing the allow-list entry instead. Rejected — the miss is legitimate under domain-gated and slim builds, so it should stay debug-only; the correct guard is a test that fails on regression, not a Sentry event on a supported configuration.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — every changed branch is exercised: permanent-miss stop, bounded transient retry, success-resets-budget, classifier prefix anchoring (positive + negative), and the Rust registration pin.
- [x] Coverage matrix updated — `N/A: behaviour-only change`; feature row 0.2.5 already covers `harness_init_status` and no feature was added, removed, or renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface changed; the overlay's visible states are unchanged.`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Platform:** desktop (Tauri/React renderer) plus a comment/test-only change in the Rust core. No behaviour change to the core's RPC surface or wire contract.
- **User-visible:** none on a healthy install. On a core that does not serve `harness_init_status` the overlay now stays hidden instead of silently retrying forever — the same rendered result, without the traffic.
- **Observability:** removes ~9k Sentry events/day per affected client. The remaining first-miss is still recorded core-side at debug.
- **Performance:** removes a permanent 30 RPC/minute background loop in the skew case.
- **Compatibility:** additive only. `method_not_found` is a new `CoreRpcErrorKind` variant; no existing classification changes, and the JSON-RPC response to callers is untouched.

## Related

- Closes: #5157
- Affected coverage matrix feature IDs: `0.2.5` (First-Run Harness Init)
- Context: #5171 added the allow-list entry whose rationale this PR corrects; #4021 introduced `harness_init`.
- Follow-up PR(s)/TODOs: `harnessInitService`'s doc-comment states it mirrors `daemonHealthService`'s polling contract — worth auditing that poller for the same unbounded-retry shape. Not touched here to keep this change scoped to #5157.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A — tracked in GitHub as #5157, no Linear issue.
- URL: N/A

### Commit & Branch

- Branch: `fix/5157-harness-init-status`
- Commit SHA: `e9700acaced960304c1a238d9381d6957d5a5b37`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — Prettier applied to all four changed frontend files; ESLint clean.
- [x] `pnpm typecheck` — `tsc --noEmit` clean.
- [x] Focused tests: `vitest run HarnessInitOverlay.test.tsx coreRpcClient.test.ts` → **108 passed**.
- [x] Rust fmt/check (if changed): `rustfmt --check src/core/dispatch.rs` clean. Full `cargo check` / `cargo test` was **not** run locally — that verification is delegated to CI and is itemised under **Validation Blocked** below.
- [x] Tauri fmt/check (if changed): `N/A — no change under app/src-tauri/.`

### Validation Blocked

- `command:` `cargo test --lib core::dispatch`
- `error:` not run — full core builds were intentionally skipped locally on this machine.
- `impact:` the new Rust test `harness_init_status_is_registered_in_a_full_build` is unverified by compilation. Its two APIs (`core::all::all_controller_schemas`, `core::all::rpc_method_name`) were confirmed present and type-compatible by inspection, and `DomainSet` scoping is `tokio::task_local!` so the test cannot be contaminated by the domain-gating tests in the same binary. CI is the gate.

### Behavior Changes

- Intended behavior change: a status poll that fails permanently now stops instead of retrying every 2s indefinitely; other failures are capped and backed off.
- User-visible effect: none in the healthy case. In the skew case the overlay renders nothing (as before) but no longer generates continuous background RPC traffic.

### Parity Contract

- Legacy behavior preserved: the cold-start retry path is unchanged for the first 4 consecutive failures, and the consecutive-failure budget resets on any success. The dismissal/remount semantics from GH-5047 and the StrictMode poll coalescing are untouched — their existing tests still pass.
- Guard/fallback/dispatch parity checks: the frontend `UNKNOWN_METHOD_PREFIX` mirrors the Rust constant in `src/core/dispatch.rs`, and the match is prefix-anchored exactly as `unknown_method_name` uses `strip_prefix`. A test pins that a nested/quoted occurrence does **not** classify as `method_not_found`. The JSON-RPC error envelope returned to callers is unchanged.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none.
- Canonical PR: this one.
- Resolution: N/A.

## Regression evidence

The new overlay tests fail against the pre-fix code and pass after — reverting only `HarnessInitOverlay.tsx` and re-running:

```
× stops polling when the core does not expose harness_init_status (#5157)
    AssertionError: expected "vi.fn()" to be called 1 times, but got 61 times
× gives up after a bounded number of consecutive transient failures (#5157)
    AssertionError: expected "vi.fn()" to be called 5 times, but got 61 times
```

61 calls in the same window is the 64,715-event generator, reproduced.

