### PR TITLE
fix(channels): read checkbox state before the setState updater runs (#5161)

### DIFF
--- a/app/src/components/channels/DiscordConfig.tsx
+++ b/app/src/components/channels/DiscordConfig.tsx
@@ -383,12 +383,13 @@ const DiscordConfig = ({ definition }: DiscordConfigProps) => {
                   <input
                     type="checkbox"
                     checked={Boolean(clearMemoryOnDisconnect[compositeKey])}
-                    onChange={event =>
-                      setClearMemoryOnDisconnect(prev => ({
-                        ...prev,
-                        [compositeKey]: event.currentTarget.checked,
-                      }))
-                    }
+                    onChange={event => {
+                      // See the sibling checkbox below / #5161: `currentTarget`
+                      // is null by the time a functional updater runs, so the
+                      // value has to be read synchronously in the handler.
+                      const { checked } = event.currentTarget;
+                      setClearMemoryOnDisconnect(prev => ({ ...prev, [compositeKey]: checked }));
+                    }}
                     className="mt-0.5 h-4 w-4 rounded border-line-strong text-primary-600 focus:ring-primary-500"
                   />
                   <span className="min-w-0">
@@ -423,12 +424,13 @@ const DiscordConfig = ({ definition }: DiscordConfigProps) => {
                     <input
                       type="checkbox"
                       checked={Boolean(clearMemoryOnDisconnect[compositeKey])}
-                      onChange={event =>
-                        setClearMemoryOnDisconnect(prev => ({
-                          ...prev,
-                          [compositeKey]: event.currentTarget.checked,
-                        }))
-                      }
+                      onChange={event => {
+                        // React resets `currentTarget` to null once the handler
+                        // returns, and the updater below runs later — read the
+                        // value synchronously (#5161).
+                        const { checked } = event.currentTarget;
+                        setClearMemoryOnDisconnect(prev => ({ ...prev, [compositeKey]: checked }));
+                      }}
                       className="mt-0.5 h-4 w-4 rounded border-line-strong text-primary-600 focus:ring-primary-500"
                     />
                     <span className="min-w-0">

--- a/app/src/components/channels/TelegramConfig.tsx
+++ b/app/src/components/channels/TelegramConfig.tsx
@@ -372,12 +372,16 @@ const TelegramConfig = ({ definition }: TelegramConfigProps) => {
                 <input
                   type="checkbox"
                   checked={Boolean(clearMemoryOnDisconnect[compositeKey])}
-                  onChange={event =>
-                    setClearMemoryOnDisconnect(prev => ({
-                      ...prev,
-                      [compositeKey]: event.currentTarget.checked,
-                    }))
-                  }
+                  onChange={event => {
+                    // Read `checked` here, not inside the updater. React resets
+                    // `currentTarget` to null as soon as the handler returns,
+                    // and a functional updater is invoked later while React
+                    // processes the update queue — so reading it in there threw
+                    // "Cannot read properties of null (reading 'checked')"
+                    // (#5161).
+                    const { checked } = event.currentTarget;
+                    setClearMemoryOnDisconnect(prev => ({ ...prev, [compositeKey]: checked }));
+                  }}
                   className="mt-0.5 h-4 w-4 rounded border-line-strong text-primary-600 focus:ring-primary-500"
                 />
                 <span className="min-w-0">

--- a/app/src/components/channels/__tests__/DiscordConfig.test.tsx
+++ b/app/src/components/channels/__tests__/DiscordConfig.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { FALLBACK_DEFINITIONS } from '../../../lib/channels/definitions';
@@ -171,6 +171,58 @@ describe('DiscordConfig', () => {
       );
     });
   });
+
+  // Regression: #5161 / Sentry TAURI-REACT-39 — "Cannot read properties of null
+  // (reading 'checked')". Both memory checkboxes (the managed_dm branch and the
+  // all-other-modes branch) used to read `event.currentTarget.checked` inside
+  // the functional setState updater. React nulls `currentTarget` once the
+  // handler returns and only evaluates an updater eagerly while the fiber has no
+  // pending work, so a second toggle in the same batch ran its updater later
+  // against a nulled `currentTarget` and threw. One case per render branch.
+  for (const { label, authMode, capabilities } of [
+    { label: 'bot token', authMode: 'bot_token' as const, capabilities: ['read', 'write'] },
+    { label: 'managed DM', authMode: 'managed_dm' as const, capabilities: ['dm'] },
+  ]) {
+    it(`toggles the ${label} memory checkbox when React defers the state updater (#5161)`, async () => {
+      const store = createTestStore();
+      store.dispatch(
+        upsertChannelConnection({
+          channel: 'discord',
+          authMode,
+          patch: { status: 'connected', capabilities },
+        })
+      );
+      vi.mocked(channelConnectionsApi.disconnectChannel).mockResolvedValue(undefined);
+
+      renderWithProviders(<DiscordConfig definition={discordDef} />, { store });
+
+      const checkbox = screen.getByLabelText(/also delete memory/i) as HTMLInputElement;
+
+      // Three toggles in ONE batch: the first takes React's eager-state path,
+      // the rest defer their updater to render time — the window where
+      // `event.currentTarget` is already null.
+      act(() => {
+        fireEvent.click(checkbox);
+        fireEvent.click(checkbox);
+        fireEvent.click(checkbox);
+      });
+
+      // Odd number of toggles ⇒ still checked, proving the deferred updates
+      // applied rather than being swallowed.
+      expect(checkbox.checked).toBe(true);
+
+      const disconnectButton = screen
+        .getAllByRole('button', { name: 'Disconnect' })
+        .find(button => !button.hasAttribute('disabled'));
+      fireEvent.click(disconnectButton!);
+
+      await waitFor(() => {
+        expect(channelConnectionsApi.disconnectChannel).toHaveBeenCalledWith('discord', authMode, {
+          clearMemory: true,
+        });
+      });
+    });
+  }
 
   it('hides managed channel auth modes for local users', () => {
     coreStateMock.mockReturnValue({ snapshot: { sessionToken: 'header.payload.local' } });

--- a/app/src/components/channels/__tests__/TelegramConfig.test.tsx
+++ b/app/src/components/channels/__tests__/TelegramConfig.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { FALLBACK_DEFINITIONS } from '../../../lib/channels/definitions';
@@ -88,6 +88,56 @@ describe('TelegramConfig', () => {
       .getAllByRole('button', { name: 'Disconnect' })
       .find(button => !button.hasAttribute('disabled'));
     expect(disconnectButton).toBeDefined();
+    fireEvent.click(disconnectButton!);
+
+    await waitFor(() => {
+      expect(channelConnectionsApi.disconnectChannel).toHaveBeenCalledWith(
+        'telegram',
+        'bot_token',
+        { clearMemory: true }
+      );
+    });
+  });
+
+  // Regression: #5161 / Sentry TAURI-REACT-39 — "Cannot read properties of null
+  // (reading 'checked')". The memory checkbox used to read
+  // `event.currentTarget.checked` *inside* the functional setState updater.
+  // React resets `currentTarget` to null the moment the handler returns, and it
+  // only evaluates an updater eagerly while the fiber has no pending work — so
+  // as soon as a second toggle landed in the same batch, the updater ran later
+  // (during render) against a nulled `currentTarget` and threw.
+  it('toggles the memory checkbox when React defers the state updater (#5161)', async () => {
+    const store = createTestStore();
+    store.dispatch(
+      upsertChannelConnection({
+        channel: 'telegram',
+        authMode: 'bot_token',
+        patch: { status: 'connected', capabilities: ['read', 'write'] },
+      })
+    );
+    vi.mocked(channelConnectionsApi.disconnectChannel).mockResolvedValue(undefined);
+
+    renderWithProviders(<TelegramConfig definition={telegramDef} />, { store });
+
+    const checkbox = screen.getByLabelText(/also delete memory/i) as HTMLInputElement;
+
+    // Three toggles inside ONE batch. The first takes React's eager-state path
+    // (fiber has no pending lanes); the rest find pending work and therefore
+    // defer their updater to render time — exactly the window where
+    // `event.currentTarget` is already null.
+    act(() => {
+      fireEvent.click(checkbox);
+      fireEvent.click(checkbox);
+      fireEvent.click(checkbox);
+    });
+
+    // An odd number of toggles must leave it checked: proves the deferred
+    // updates actually applied rather than being swallowed.
+    expect(checkbox.checked).toBe(true);
+
+    const disconnectButton = screen
+      .getAllByRole('button', { name: 'Disconnect' })
+      .find(button => !button.hasAttribute('disabled'));
     fireEvent.click(disconnectButton!);
 
     await waitFor(() => {

--- a/app/src/services/analyticsInteractions.ts
+++ b/app/src/services/analyticsInteractions.ts
@@ -115,15 +115,13 @@ function destinationForElement(element: HTMLElement): string {
 function controlState(element: HTMLElement): string {
   if (element instanceof HTMLInputElement) {
     if (element.type === 'checkbox' || element.type === 'radio') {
-      // Defensive guard: React 19's controlled-component state restoration
-      // can briefly leave an input's DOM node in an inconsistent state where
-      // `instanceof HTMLInputElement` passes but the element is disconnected
-      // and its `checked` property access throws (see issue #5161).
-      try {
-        return element.checked ? 'checked' : 'unchecked';
-      } catch {
-        return 'changed';
-      }
+      // `element` is an `HTMLInputElement` reached from a live `change` event, so
+      // reading `checked` is always safe: the getter works on disconnected and
+      // never-mounted nodes alike and cannot throw. (An earlier try/catch here
+      // blamed #5161 on a disconnected DOM node — that was a misdiagnosis; the
+      // real fault was reading `event.currentTarget` inside a deferred setState
+      // updater in the Telegram/Discord config panels.)
+      return element.checked ? 'checked' : 'unchecked';
     }
     if (element.type === 'range') return 'changed';
   }


### PR DESCRIPTION
## Summary

- Fix `TypeError: Cannot read properties of null (reading 'checked')` (Sentry `TAURI-REACT-39`, ~8 events / ~7 users across 4 shortIds).
- Root cause: the "also delete memory" checkbox in the Telegram and Discord config panels read `event.currentTarget.checked` from **inside a functional setState updater**, which React invokes after it has already nulled `currentTarget`.
- Read `checked` synchronously in the handler and let the updater close over the captured value — three sites (Telegram ×1, Discord ×2).
- Drop an unreachable `try/catch` in `analyticsInteractions.ts` that misattributed this issue to a disconnected DOM node.
- Regression tests reproduce the exact production error before the fix, one case per patched render branch.

## Problem

The memory checkbox in both channel config panels was wired like this:

```jsx
onChange={event =>
  setClearMemoryOnDisconnect(prev => ({
    ...prev,
    [compositeKey]: event.currentTarget.checked,
  }))
}
```

React resets `event.currentTarget` to `null` as soon as the handler returns. A **functional** updater is not evaluated inside the handler — React invokes it later, while processing the update queue during render. The read therefore landed on a nulled `currentTarget` and threw.

**Why it only failed sometimes** (~8 events across ~7 users, rather than on every toggle): React evaluates an updater *eagerly* inside `dispatchSetState` while the fiber has no pending work, as a bail-out optimisation. On that path the read still happens inside the handler's synchronous window and succeeds. As soon as any other update was already queued — a second toggle, a concurrent render — the eager path is skipped, the updater runs at render time, and `currentTarget` is gone. This also explains the `useState` frame in the Sentry stack: the throw happens inside React's update-queue processing, not in the event handler.

Note the issue's hint pointed at a null element *ref*. The actual null is the synthetic event's `currentTarget` — there is no `ref.current.checked` anywhere in `app/src`.

## Solution

Capture the value synchronously, then close the updater over it:

```jsx
onChange={event => {
  const { checked } = event.currentTarget;
  setClearMemoryOnDisconnect(prev => ({ ...prev, [compositeKey]: checked }));
}}
```

Applied at all three affected sites: `TelegramConfig`, and both of `DiscordConfig`'s (the `managed_dm` branch and the all-other-modes branch). The functional-updater form is retained — it is correct for this keyed map — only the event read moves out of it.

**Coverage of the bug class.** All 35 `currentTarget` reads in `app/src` were reviewed; the other 32 are synchronous reads inside their handler and are unaffected. `ComposioConnectModal` renders the same checkbox but passes a plain value rather than an updater, so it was never at risk.

**`analyticsInteractions.ts`.** An earlier attempt at this issue wrapped `element.checked` in a `try/catch`, commented as guarding a disconnected DOM node whose `checked` access "throws". Verified against jsdom that `HTMLInputElement`'s `checked` getter returns normally on both disconnected and never-mounted nodes and cannot throw — the catch was unreachable, and its comment misdiagnosed this issue for the next reader. Replaced with a direct return and an accurate note. No behaviour change.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/ci-lite.yml`](../.github/workflows/ci-lite.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] N/A: bug fix only — no feature rows added, removed, or renamed. Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change
- [x] N/A: no matrix rows change, so no feature IDs apply. All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] N/A: no release-cut surface touched — an existing checkbox keeps its existing behaviour. Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

### Regression tests

Three cases, one per patched render branch, in `TelegramConfig.test.tsx` and `DiscordConfig.test.tsx`. Each fires **three toggles inside one `act` batch**: the first takes React's eager-state path, the rest find pending lanes and defer their updater to render time — precisely the window where `currentTarget` is null.

Each then asserts an odd toggle count leaves the box **checked** and that disconnect carries `clearMemory: true`, so the test proves the deferred updates actually applied rather than merely not throwing.

Verified failing before the fix by reverting each site in turn, with the exact production error:

- Telegram reverted → 1 failure, `TypeError: Cannot read properties of null (reading 'checked')`
- Discord reverted → 2 failures, same error (one per branch)

## Impact

- **Platform:** desktop (Tauri/CEF) React renderer only. No Rust, no core, no RPC, no schema change.
- **User-visible:** toggling "also delete memory" on the Telegram/Discord disconnect flow no longer throws; the setting now applies reliably instead of intermittently failing mid-update.
- **Performance / security / migration / compatibility:** none.

## Related

- Closes: #5161
- Follow-up PR(s)/TODOs: `app/src/services/analyticsInteractions.ts:103` has a `console.debug` that fires in production on every click of an unlabelled interactive control. Untouched here (out of scope); worth removing separately.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: N/A
- Commit SHA: N/A

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — Prettier clean on all five changed files
- [x] `pnpm typecheck` — clean
- [x] Focused tests: channels + services suites **114 files / 1494 tests passed**; full frontend suite **768 files / 8972 tests passed, 0 failed**
- [x] N/A: no Rust changed. Rust fmt/check (if changed)
- [x] N/A: no Tauri shell changed. Tauri fmt/check (if changed)

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none beyond removing the crash. The checkbox drives the same `clearMemory` disconnect flag it always did.
- User-visible effect: the toggle stops throwing and applies reliably.

### Parity Contract

- Legacy behavior preserved: yes. The functional-updater form is retained (correct for this keyed map); only the event read moves out of it, and `analyticsInteractions.controlState` returns exactly the same values as before.
- Guard/fallback/dispatch parity checks: `controlState`'s `checkbox`/`radio`, `range`, `select`, and `aria-checked` branches are unchanged; the removed `catch` was unreachable, so no fallback path was lost.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A
