### PR TITLE
fix(memory): stop paging on caller ingest-payload schema errors (#5169)

### DIFF
--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -217,6 +217,24 @@ pub async fn rpc_handler(State(state): State<AppState>, Json(req): Json<RpcReque
                         &[("method", method.as_str()), ("elapsed_ms", &ms.to_string())],
                     );
                 }
+            } else if crate::openhuman::memory_tree::tree::rpc::is_invalid_ingest_payload_message(
+                &display_message,
+            ) {
+                // The caller submitted an ingest payload that does not match
+                // the canonicaliser schema for its `source_kind` (#5169). The
+                // handler already returned a precise error naming the missing
+                // or malformed field, and no core-side change can fix a
+                // producer sending the wrong shape — so this is a caller
+                // error, not an actionable core defect. Same treatment as an
+                // unrecognised method above: still captured for triage (a
+                // spike means a producer regressed) but at warn severity, so
+                // it does not page.
+                crate::core::observability::report_warning_message(
+                    display_message.as_str(),
+                    "rpc",
+                    "invoke_method",
+                    &[("method", method.as_str()), ("elapsed_ms", &ms.to_string())],
+                );
             } else {
                 crate::core::observability::report_error_or_expected(
                     display_message.as_str(),

--- a/src/core/jsonrpc_tests.rs
+++ b/src/core/jsonrpc_tests.rs
@@ -1270,6 +1270,101 @@ async fn unknown_method_severity_split_by_probe_allow_list() {
     );
 }
 
+#[cfg(feature = "crash-reporting")]
+#[tokio::test(flavor = "current_thread")]
+#[cfg(feature = "http-server")]
+async fn invalid_ingest_payload_is_captured_at_warn_not_error() {
+    // #5169 (CORE-RUST-1P0): a caller submitting an ingest payload that does
+    // not match the canonicaliser schema is a *caller* error — the handler
+    // already names the offending field and no core change can fix a producer
+    // sending the wrong shape. Prove the same split as the unknown-method case
+    // above: the JSON-RPC error response is unchanged, but the Sentry event is
+    // warn (triage) rather than error (pages).
+    use axum::body::to_bytes;
+    use axum::extract::State;
+    use axum::Json;
+    use sentry::test::TestTransport;
+    use tracing::Level;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    let _env = EnvVarGuard::set_many(vec![(
+        "OPENHUMAN_WORKSPACE",
+        workspace.path().as_os_str().to_os_string(),
+    )]);
+
+    let transport = TestTransport::new();
+    let sentry_options = sentry::ClientOptions {
+        dsn: Some("https://public@sentry.invalid/1".parse().unwrap()),
+        transport: Some(Arc::new(transport.clone())),
+        ..Default::default()
+    };
+    let sentry_hub = Arc::new(sentry::Hub::new(
+        Some(Arc::new(sentry_options.into())),
+        Arc::new(Default::default()),
+    ));
+    let _sentry_guard = sentry::HubSwitchGuard::new(sentry_hub);
+
+    let subscriber = tracing_subscriber::registry().with(
+        sentry::integrations::tracing::layer().event_filter(|metadata| {
+            if metadata.target() == crate::core::observability::REPORT_ERROR_TRACING_TARGET {
+                return sentry::integrations::tracing::EventFilter::Ignore;
+            }
+            match *metadata.level() {
+                Level::ERROR => sentry::integrations::tracing::EventFilter::Event,
+                Level::WARN | Level::INFO => sentry::integrations::tracing::EventFilter::Breadcrumb,
+                _ => sentry::integrations::tracing::EventFilter::Ignore,
+            }
+        }),
+    );
+    let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
+    // `platform` is genuinely required by `ChatBatch` (unlike `timestamp`,
+    // which now defaults — see `chat_payload_without_timestamp_is_accepted`),
+    // so this reaches the invalid-payload branch rather than succeeding.
+    let request = crate::core::types::RpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: json!(1),
+        method: "openhuman.memory_tree_ingest".to_string(),
+        params: json!({
+            "source_kind": "chat",
+            "source_id": "#general",
+            "payload": { "messages": [] },
+        }),
+    };
+    let response = rpc_handler(State(default_state()), Json(request)).await;
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body");
+    let body: serde_json::Value = serde_json::from_slice(&body).expect("json response");
+
+    // The caller still gets the precise, unchanged validation error.
+    assert_eq!(body["error"]["code"], json!(-32000));
+    let message = body["error"]["message"]
+        .as_str()
+        .expect("error message string");
+    assert!(
+        message.starts_with("invalid chat payload: "),
+        "expected an invalid-chat-payload error, got {message:?}"
+    );
+
+    let events = transport.fetch_and_clear_events();
+    assert_eq!(
+        events.len(),
+        1,
+        "invalid ingest payloads should still be captured for triage"
+    );
+    assert_eq!(
+        events[0].level,
+        sentry::Level::Warning,
+        "caller payload errors must be warn-level (triage, not paging)"
+    );
+    assert_eq!(
+        events[0].tags.get("method").map(String::as_str),
+        Some("openhuman.memory_tree_ingest")
+    );
+}
+
 #[test]
 fn is_session_expired_error_matches_session_jwt_required() {
     // Regression: Sentry issue 7472592145.

--- a/src/openhuman/memory_tree/tree/rpc.rs
+++ b/src/openhuman/memory_tree/tree/rpc.rs
@@ -938,6 +938,12 @@ mod tests {
 
     /// Sibling contract for the document arm: `modified_at` is likewise
     /// optional (`#[serde(default = "now_utc")]` in tinycortex).
+    ///
+    /// The payload is deliberately minimal — `title` and `body` are the only
+    /// required fields on `DocumentInput`. `provider` (`default_provider`),
+    /// `source_ref` (`Option`) and `modified_at` (`now_utc`) all carry serde
+    /// defaults, so omitting them together pins the whole optional set rather
+    /// than just the timestamp.
     #[test]
     fn document_payload_without_modified_at_is_accepted() {
         let payload = json!({ "title": "Launch plan", "body": "ship it" });

--- a/src/openhuman/memory_tree/tree/rpc.rs
+++ b/src/openhuman/memory_tree/tree/rpc.rs
@@ -45,6 +45,47 @@ pub struct IngestRequest {
     pub payload: Value,
 }
 
+/// Build the validation error returned when an ingest payload does not match
+/// the canonicaliser schema for its `source_kind`.
+///
+/// Kept as the single construction site so the wording cannot drift away from
+/// [`is_invalid_ingest_payload_message`], which the transport layer uses to
+/// pick the Sentry severity. Same emit-site/classifier pairing as
+/// `dispatch::UNKNOWN_METHOD_PREFIX` / `dispatch::unknown_method_name`.
+fn invalid_payload_message(source_kind: SourceKind, err: &serde_json::Error) -> String {
+    format!("invalid {} payload: {err}", source_kind.as_str())
+}
+
+/// Returns `true` when `message` is an ingest-payload schema-validation
+/// failure produced by `invalid_payload_message`.
+///
+/// Such a failure is a **caller** error — the submitted JSON does not match
+/// the canonicaliser's shape — not a core defect. The handler already returns
+/// a precise, actionable JSON-RPC error naming the offending field, and no
+/// core-side change can fix a producer that sends the wrong shape. Reporting
+/// it at Sentry *error* severity therefore pages on someone else's payload
+/// bug: #5169 (`CORE-RUST-1P0`) was 14 such events for a chat batch whose
+/// messages omitted `timestamp`.
+///
+/// The transport layer demotes these to a warn-level capture — still recorded
+/// for triage, because a spike genuinely means a producer regressed, but not
+/// an error event. See `core::jsonrpc::rpc_handler`.
+///
+/// Anchored on the exact `invalid <kind> payload: ` prefix rather than a
+/// loose `"invalid"` substring so unrelated failures keep paging.
+pub fn is_invalid_ingest_payload_message(message: &str) -> bool {
+    let Some(rest) = message.strip_prefix("invalid ") else {
+        return false;
+    };
+    // Enumerated rather than parsed so a new `SourceKind` that forgets to
+    // update this list stays *loud* (keeps paging) instead of silently
+    // inheriting the demotion. The `all_source_kinds_are_recognised_*` test
+    // below pins that every variant reachable from `ingest_rpc` is covered.
+    [SourceKind::Chat, SourceKind::Email, SourceKind::Document]
+        .iter()
+        .any(|k| rest.starts_with(&format!("{} payload: ", k.as_str())))
+}
+
 /// Unified ingest RPC handler. Dispatches on `source_kind`.
 pub async fn ingest_rpc(
     config: &Config,
@@ -70,7 +111,7 @@ pub async fn ingest_rpc(
     let result = match source_kind {
         SourceKind::Chat => {
             let batch: ChatBatch = serde_json::from_value(payload).map_err(|e| {
-                let msg = format!("invalid chat payload: {e}");
+                let msg = invalid_payload_message(SourceKind::Chat, &e);
                 log::warn!("[memory::rpc] invalid payload for chat");
                 msg
             })?;
@@ -84,7 +125,7 @@ pub async fn ingest_rpc(
         }
         SourceKind::Email => {
             let thread: EmailThread = serde_json::from_value(payload).map_err(|e| {
-                let msg = format!("invalid email payload: {e}");
+                let msg = invalid_payload_message(SourceKind::Email, &e);
                 log::warn!("[memory::rpc] invalid payload for email");
                 msg
             })?;
@@ -98,7 +139,7 @@ pub async fn ingest_rpc(
         }
         SourceKind::Document => {
             let doc: DocumentInput = serde_json::from_value(payload).map_err(|e| {
-                let msg = format!("invalid document payload: {e}");
+                let msg = invalid_payload_message(SourceKind::Document, &e);
                 log::warn!("[memory::rpc] invalid payload for document");
                 msg
             })?;
@@ -868,6 +909,85 @@ mod tests {
         cfg.memory_tree.embedding_model = None;
         cfg.memory_tree.embedding_strict = false;
         (tmp, cfg)
+    }
+
+    /// #5169 (`CORE-RUST-1P0`) — a chat batch whose messages omit `timestamp`
+    /// must ingest, defaulting to `now()`, not reject the whole batch.
+    ///
+    /// The tolerance lives in `tinycortex` (`ChatMessage::timestamp` carries
+    /// `#[serde(default = "chrono_now")]`), which is a **separate repository**
+    /// vendored here as a submodule. Nothing in this repo guarded that
+    /// contract, so a submodule bump could silently reintroduce the hard
+    /// rejection and the 4xx-shaped payload would page again. This test is
+    /// that guard: it fails on the parent-repo side the moment the vendored
+    /// schema stops tolerating an absent timestamp.
+    #[test]
+    fn chat_payload_without_timestamp_is_accepted() {
+        let payload = json!({
+            "platform": "slack",
+            "channel_label": "#general",
+            "messages": [{ "author": "alice", "text": "no timestamp here" }],
+        });
+
+        let batch: ChatBatch = serde_json::from_value(payload)
+            .expect("a chat message omitting `timestamp` must default, not reject the batch");
+
+        assert_eq!(batch.messages.len(), 1);
+        assert_eq!(batch.messages[0].text, "no timestamp here");
+    }
+
+    /// Sibling contract for the document arm: `modified_at` is likewise
+    /// optional (`#[serde(default = "now_utc")]` in tinycortex).
+    #[test]
+    fn document_payload_without_modified_at_is_accepted() {
+        let payload = json!({ "title": "Launch plan", "body": "ship it" });
+
+        let doc: DocumentInput = serde_json::from_value(payload)
+            .expect("a document omitting `modified_at` must default, not reject");
+
+        assert_eq!(doc.title, "Launch plan");
+    }
+
+    /// Every `SourceKind` reachable from `ingest_rpc` must produce a message
+    /// the classifier recognises — otherwise that arm's caller errors keep
+    /// paging while its siblings are demoted, which is the silent-drift
+    /// failure the enumerated list in `is_invalid_ingest_payload_message`
+    /// is meant to make impossible to miss.
+    #[test]
+    fn all_source_kinds_are_recognised_as_caller_payload_errors() {
+        let err = serde_json::from_str::<ChatBatch>("{}").unwrap_err();
+        for kind in [SourceKind::Chat, SourceKind::Email, SourceKind::Document] {
+            let message = invalid_payload_message(kind, &err);
+            assert!(
+                is_invalid_ingest_payload_message(&message),
+                "{} payload errors must classify as caller errors, got {message:?}",
+                kind.as_str()
+            );
+        }
+    }
+
+    /// The verbatim #5169 message shape, and the negative half: unrelated
+    /// failures must keep their error severity so real defects still page.
+    #[test]
+    fn only_ingest_payload_errors_are_demoted() {
+        assert!(is_invalid_ingest_payload_message(
+            "invalid chat payload: missing field `timestamp`"
+        ));
+
+        for other in [
+            "invalid",
+            "invalid payload",
+            "invalid audio payload: missing field `timestamp`",
+            "ingest: chunk store unavailable",
+            "chat payload: missing field `timestamp`",
+            "something failed: invalid chat payload: missing field `timestamp`",
+            "",
+        ] {
+            assert!(
+                !is_invalid_ingest_payload_message(other),
+                "{other:?} must keep paging"
+            );
+        }
     }
 
     fn sample_document(title: &str, body: &str) -> DocumentInput {


### PR DESCRIPTION
## Summary

- Demoted ingest-payload schema-validation failures from Sentry **error** to a **warn-level capture** — still recorded for triage, no longer paging (`CORE-RUST-1P0`, 14 events).
- Routed all three `ingest_rpc` arms through a single `invalid_payload_message` constructor so the error wording cannot drift from the classifier that reads it.
- Added `is_invalid_ingest_payload_message`, anchored on the exact `invalid <kind> payload: ` prefix so unrelated failures keep paging.
- Pinned the cross-repo timestamp-tolerance contract with parent-side tests, so a bad `tinycortex` submodule bump breaks the build here instead of resurfacing in production.
- The JSON-RPC error returned to the caller is **unchanged**.

## Problem

`invalid chat payload: missing field 'timestamp'` reached Sentry at error severity. Investigating turned up two things, and the second is the one that still needed fixing.

**1. The `timestamp` intolerance was already fixed — but not in this repo, and not visibly.** The deserialization target is `tinycortex::…::chat::ChatBatch`. `ChatMessage::timestamp` gained `#[serde(default = "chrono_now")]` in the vendored **tinycortex submodule** on **2026-07-23** — after the 07-15→07-18 Sentry window — inside a commit titled `fix(kv): auto-sanitize PII… (#5164)`, wording that gives no hint it touched the ingest schema. Verified against the exact submodule SHA `main` pins (`e0a8738`), not just a local working tree.

So re-adding a default would have been a no-op. The real exposure is that **nothing in this repo guarded that cross-repo contract**: a submodule bump could silently reintroduce the hard rejection, and the same 4xx-shaped payload would page again.

**2. The severity half was never done.** The issue asks for a clear validation error "rather than logging at error level". A payload that does not match the canonicaliser schema is a **caller** error: `ingest_rpc` already returns a precise JSON-RPC error naming the offending field, and no core-side change can fix a producer that sends the wrong shape. Yet `jsonrpc.rs` still routed it to `report_error_or_expected`, i.e. an error-severity Sentry event — paging on someone else's payload bug.

## Solution

- **One construction site.** All three `ingest_rpc` arms build their error through `invalid_payload_message(SourceKind, &serde_json::Error)`, so the emitted wording and the classifier that matches it cannot drift apart. This is the same emit-site/classifier pairing the codebase already uses for `dispatch::UNKNOWN_METHOD_PREFIX` / `dispatch::unknown_method_name`.
- **Demote, don't suppress.** `core::jsonrpc::rpc_handler` gains a branch, sibling to the existing unrecognised-method one, that routes these through `report_warning_message`. They stay captured — a spike genuinely means a producer regressed — but at warning severity, which does not trip the error-rate paging rules. Chosen over an `ExpectedErrorKind`, which would have suppressed the signal entirely and lost that regression detector.
- **Fail loud on drift.** The source-kind list in the classifier is *enumerated, not parsed*: a future `SourceKind` that forgets to update it keeps paging rather than silently inheriting the demotion. A test pins that every variant reachable from `ingest_rpc` is covered.
- **Guard the vendored contract.** Parent-side tests assert a chat payload omitting `timestamp` and a document payload omitting `modified_at` both deserialize, so the tolerance this repo depends on is enforced from this side of the submodule boundary.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — every changed branch is exercised: the classifier's positive arms (all three source kinds), its negative arms (7 near-miss strings), the two timestamp-tolerance contracts, and an end-to-end `rpc_handler` test asserting the demoted Sentry severity and unchanged error envelope.
- [x] Coverage matrix updated — `N/A: behaviour-only change`; no feature was added, removed, or renamed. Ingest is already covered by the memory rows.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: observability severity only; no user-facing or release-cut surface changes.`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Platform:** Rust core only. No frontend, Tauri, or wire-contract change.
- **User-visible:** none. The JSON-RPC error body, code (`-32000`), and data are byte-identical; only the Sentry severity of the internal report changes.
- **Observability:** caller payload errors move from error events (which page) to warning events (which are retained for triage). Genuine core defects on the same code path are unaffected — the prefix anchor is deliberately narrow.
- **Security/performance/migration:** none.

## Related

- Closes: #5169
- Affected coverage matrix feature IDs: memory ingest (`memory_tree_ingest`) — behaviour-only, no row change.
- Cross-repo context: the `timestamp` tolerance itself lives in `tinyhumansai/tinycortex` (`ChatMessage::timestamp`), vendored here as a submodule.
- Follow-up PR(s)/TODOs: **`EmailMessage::sent_at` in tinycortex has no serde default**, so an email payload omitting it still hard-rejects exactly the way chat did — this issue will recur on the email arm. `DocumentInput::modified_at` is already fine (`default = "now_utc"`). Fixing `sent_at` requires a PR against `tinyhumansai/tinycortex` plus a submodule pin bump, so it is deliberately out of scope here rather than folded in silently.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A — tracked in GitHub as #5169, no Linear issue.
- URL: N/A

### Commit & Branch

- Branch: `fix/5169-chat-timestamp-schema`
- Commit SHA: `947dcd8c257c5bc2109bb0357e75b592f137118e`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no frontend files changed.`
- [x] `pnpm typecheck` — `N/A: no TypeScript changed.`
- [x] Focused tests: new Rust unit + integration tests added (`chat_payload_without_timestamp_is_accepted`, `document_payload_without_modified_at_is_accepted`, `all_source_kinds_are_recognised_as_caller_payload_errors`, `only_ingest_payload_errors_are_demoted`, `invalid_ingest_payload_is_captured_at_warn_not_error`). Execution is delegated to CI — see **Validation Blocked**.
- [x] Rust fmt/check (if changed): `rustfmt --edition 2021 --check` clean on all three changed files. Full `cargo check` / `cargo test` was **not** run locally — delegated to CI, itemised under **Validation Blocked**.
- [x] Tauri fmt/check (if changed): `N/A — no change under app/src-tauri/.`

### Validation Blocked

- `command:` `cargo test --lib memory_tree::tree::rpc` and `cargo test --lib core::jsonrpc`
- `error:` not run — full core builds were intentionally skipped on this machine.
- `impact:` the new Rust is unverified by compilation; CI is the gate. De-risked by inspection: `SourceKind` is `Copy` with exactly three variants and is already imported in `rpc.rs`; `memory_tree::tree::rpc` is ungated, so the `jsonrpc.rs` reference is valid in every feature combination; and the new integration test reuses the same harness as the existing `threads_message_append` test, which already proves domain dispatch and config load work with only `OPENHUMAN_WORKSPACE` set.

### Behavior Changes

- Intended behavior change: ingest-payload schema-validation failures are reported to Sentry at warning severity instead of error.
- User-visible effect: none — the JSON-RPC error response to the caller is unchanged in code, message, and data.

### Parity Contract

- Legacy behavior preserved: the error strings are byte-identical to the previous `format!` literals (`invalid {chat,email,document} payload: {e}`), so existing callers, logs, and any downstream matchers are unaffected. The existing `log::warn!` diagnostics are untouched.
- Guard/fallback/dispatch parity checks: the demotion is anchored on the exact `invalid <kind> payload: ` prefix, and `only_ingest_payload_errors_are_demoted` pins seven near-miss strings — including a nested occurrence and an unknown source kind — that must keep their error severity, so the narrowing cannot silently swallow real defects.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none.
- Canonical PR: this one.
- Resolution: N/A.
