### PR TITLE
fix(threads): keep the conversation store off the async workers (#5156)

### DIFF
--- a/app/src/components/layout/shell/useHomeNav.test.tsx
+++ b/app/src/components/layout/shell/useHomeNav.test.tsx
@@ -47,6 +47,10 @@ vi.mock('../../../store/accountsSlice', () => ({
 }));
 vi.mock('../../../store/threadSlice', () => ({
   createNewThread: vi.fn(() => ({ type: 'thread/createNewThread' })),
+  // The hook normalises a rejected `.unwrap()` (a bare string / SerializedError,
+  // never an `Error`) before logging it (#5156).
+  formatThreadCreateError: (error: unknown) =>
+    error instanceof Error ? error.message : String(error),
   loadThreadMessages: vi.fn((id: string) => ({ type: 'thread/loadThreadMessages', payload: id })),
   setSelectedThread: vi.fn((id: string) => ({ type: 'thread/setSelectedThread', payload: id })),
 }));

--- a/app/src/components/layout/shell/useHomeNav.ts
+++ b/app/src/components/layout/shell/useHomeNav.ts
@@ -3,7 +3,12 @@ import { useLocation, useNavigate } from 'react-router-dom';
 
 import { setActiveAccount } from '../../../store/accountsSlice';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
-import { createNewThread, loadThreadMessages, setSelectedThread } from '../../../store/threadSlice';
+import {
+  createNewThread,
+  formatThreadCreateError,
+  loadThreadMessages,
+  setSelectedThread,
+} from '../../../store/threadSlice';
 import { AGENT_ACCOUNT_ID } from '../../../utils/accountsFullscreen';
 import { chatThreadPath } from '../../../utils/chatRoutes';
 
@@ -46,6 +51,14 @@ export function useHomeNav(): () => void {
         void dispatch(loadThreadMessages(thr.id));
         navigate(chatThreadPath(thr.id));
       })
-      .catch(() => {});
+      .catch(err => {
+        // The rejection MUST stay consumed here — unconsumed it becomes
+        // `UnhandledRejection: Core RPC openhuman.threads_create_new timed out
+        // after 30000ms` (#5156). Swallowing it silently was the other half of
+        // that bug: Home did nothing and said nothing. The user-visible surface
+        // is `thread.createThreadError`, which the chat page renders; this log
+        // keeps the cause diagnosable.
+        console.error('[home-nav] createNewThread failed', formatThreadCreateError(err));
+      });
   }, [navigate, location.pathname, dispatch, threads]);
 }

--- a/app/src/components/layout/shell/useNewChat.test.tsx
+++ b/app/src/components/layout/shell/useNewChat.test.tsx
@@ -52,6 +52,10 @@ vi.mock('../../../store/accountsSlice', () => ({
 }));
 vi.mock('../../../store/threadSlice', () => ({
   createNewThread: vi.fn(() => ({ type: 'thread/createNewThread' })),
+  // The hook normalises a rejected `.unwrap()` (a bare string / SerializedError,
+  // never an `Error`) before logging it (#5156).
+  formatThreadCreateError: (error: unknown) =>
+    error instanceof Error ? error.message : String(error),
   loadThreadMessages: vi.fn((id: string) => ({ type: 'thread/loadThreadMessages', payload: id })),
   setSelectedThread: vi.fn((id: string) => ({ type: 'thread/setSelectedThread', payload: id })),
 }));

--- a/app/src/components/layout/shell/useNewChat.ts
+++ b/app/src/components/layout/shell/useNewChat.ts
@@ -7,7 +7,12 @@ import {
 } from '../../../features/conversations/utils/threadFilter';
 import { setActiveAccount } from '../../../store/accountsSlice';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
-import { createNewThread, loadThreadMessages, setSelectedThread } from '../../../store/threadSlice';
+import {
+  createNewThread,
+  formatThreadCreateError,
+  loadThreadMessages,
+  setSelectedThread,
+} from '../../../store/threadSlice';
 import { AGENT_ACCOUNT_ID } from '../../../utils/accountsFullscreen';
 import { chatThreadPath } from '../../../utils/chatRoutes';
 
@@ -83,8 +88,12 @@ export function useNewChat(): () => void {
       })
       .catch(err => {
         // Don't silently drop the primary New Chat path — log so the failure is
-        // diagnosable. The user stays where they are (no broken navigation).
-        console.error('[new-chat] createNewThread failed', err);
+        // diagnosable. The user stays where they are (no broken navigation), and
+        // the chat page renders `thread.createThreadError` so the failure is
+        // visible rather than a dead button (#5156). Normalising the value keeps
+        // the log readable: an `.unwrap()` rejection is a bare string or a
+        // `SerializedError`, never an `Error`.
+        console.error('[new-chat] createNewThread failed', formatThreadCreateError(err));
       });
   }, [navigate, dispatch, threads, messagesByThreadId, streamingByThread, pendingSendThreadIds]);
 }

--- a/app/src/features/conversations/Conversations.tsx
+++ b/app/src/features/conversations/Conversations.tsx
@@ -96,6 +96,7 @@ import { selectSocketStatus } from '../../store/socketSelectors';
 import {
   addInferenceResponse,
   addMessageLocal,
+  clearCreateThreadError,
   clearThreadInferenceActive,
   createNewThread,
   deleteThread,
@@ -205,6 +206,30 @@ export function formatThreadLoadError(err: unknown): string {
   return String(err);
 }
 
+/**
+ * What the error strip above the composer renders: this turn's send failure if
+ * there is one, otherwise a thread-create failure recorded by `threadSlice`.
+ *
+ * A create that blew the 30 s RPC budget used to have no surface at all — the
+ * shell's "New chat" / Home actions caught the rejection and dropped it, so the
+ * button just did nothing, and a call site that forgot to catch turned the same
+ * failure into `UnhandledRejection: … threads_create_new timed out after
+ * 30000ms` (#5156). Routing the slice-recorded failure through the existing
+ * banner gives every create path one visible outcome. Exported so the precedence
+ * rule is unit-testable without mounting the page.
+ */
+export function deriveChatErrorBanner(
+  sendError: ChatSendError | null,
+  createThreadError: string | null,
+  createThreadFailedMessage: string
+): ChatSendError | null {
+  if (sendError) return sendError;
+  if (createThreadError) {
+    return chatSendError('create_thread_failed', createThreadFailedMessage);
+  }
+  return null;
+}
+
 const Conversations = ({
   variant = 'page',
   composer: composerProp = 'text',
@@ -264,6 +289,12 @@ const Conversations = ({
   const selectedLabel = GENERAL_TAB_VALUE;
   const [threadSearch, setThreadSearch] = useState('');
   const [sendError, setSendError] = useState<ChatSendError | null>(null);
+  // Recorded by the slice for *every* create path (#5156) — including the shell's
+  // "New chat" button and the home-nav shortcut, which have no UI of their own —
+  // so a failed create always has somewhere to show up.
+  // Optional-chain + default, same as `activeThreadIds` below: narrow test
+  // stores predate this field.
+  const createThreadError = useAppSelector(state => state.thread.createThreadError ?? null);
   const [attachError, setAttachError] = useState<ChatSendError | null>(null);
   const [sendAdvisory, setSendAdvisory] = useState<string | null>(null);
   // Refs mirroring error/advisory state for effects that read them without
@@ -271,6 +302,13 @@ const Conversations = ({
   // that contributes to "Maximum update depth exceeded" (TAURI-REACT-2G).
   const sendErrorRef = useRef(sendError);
   sendErrorRef.current = sendError;
+  const createThreadErrorRef = useRef(createThreadError);
+  createThreadErrorRef.current = createThreadError;
+  const displayedSendError = deriveChatErrorBanner(
+    sendError,
+    createThreadError,
+    t('chat.createThreadFailed')
+  );
   const sendAdvisoryRef = useRef(sendAdvisory);
   sendAdvisoryRef.current = sendAdvisory;
   const [openRouterStatus, setOpenRouterStatus] = useState<'idle' | 'saving' | 'error'>('idle');
@@ -730,6 +768,11 @@ const Conversations = ({
   useEffect(() => {
     if (sendErrorRef.current && inputValue.length > 0) {
       setSendError(null);
+    }
+    // The store-recorded create failure (#5156) dismisses on the same signal:
+    // the user is composing, so they have seen it.
+    if (createThreadErrorRef.current && inputValue.length > 0) {
+      dispatch(clearCreateThreadError());
     }
     if (sendAdvisoryRef.current && inputValue.length > 0) {
       setSendAdvisory(null);
@@ -2008,16 +2051,18 @@ const Conversations = ({
           </div>
         )}
 
-        {sendError && (
+        {displayedSendError && (
           <div className="flex items-center justify-between mb-2">
-            <p className="text-xs text-coral-500" data-chat-send-error-code={sendError.code}>
-              {sendError.message}
+            <p
+              className="text-xs text-coral-500"
+              data-chat-send-error-code={displayedSendError.code}>
+              {displayedSendError.message}
             </p>
             <div className="flex items-center gap-2 flex-shrink-0 ml-2">
-              {(sendError.code === 'stt_not_ready' ||
-                sendError.code === 'voice_transcription' ||
-                sendError.code === 'tts_not_ready' ||
-                sendError.code === 'voice_synthesis') && (
+              {(displayedSendError.code === 'stt_not_ready' ||
+                displayedSendError.code === 'voice_transcription' ||
+                displayedSendError.code === 'tts_not_ready' ||
+                displayedSendError.code === 'voice_synthesis') && (
                 <button
                   type="button"
                   data-analytics-id="chat-send-error-setup"
@@ -2035,7 +2080,10 @@ const Conversations = ({
               <button
                 type="button"
                 data-analytics-id="chat-send-error-dismiss"
-                onClick={() => setSendError(null)}
+                onClick={() => {
+                  setSendError(null);
+                  dispatch(clearCreateThreadError());
+                }}
                 className="text-xs text-content-muted hover:text-content-secondary dark:text-neutral-200 dark:hover:text-neutral-200 transition-colors">
                 {t('common.dismiss')}
               </button>

--- a/app/src/pages/__tests__/Conversations.test.tsx
+++ b/app/src/pages/__tests__/Conversations.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  deriveChatErrorBanner,
   formatThreadLoadError,
   isComposerInteractionBlocked,
   isImeCompositionKeyEvent,
@@ -76,5 +77,31 @@ describe('formatThreadLoadError', () => {
 
   it('ignores non-string message fields and falls back to String(err)', () => {
     expect(formatThreadLoadError({ message: 42 })).toBe('[object Object]');
+  });
+});
+
+describe('deriveChatErrorBanner (#5156)', () => {
+  const CREATE_FAILED = "Couldn't create a new thread. Please try again.";
+
+  it('surfaces a slice-recorded thread-create failure when there is no send error', () => {
+    const banner = deriveChatErrorBanner(
+      null,
+      'Core RPC openhuman.threads_create_new timed out after 30000ms',
+      CREATE_FAILED
+    );
+
+    // The RPC text stays in the log/Sentry breadcrumb; the strip shows the
+    // localized message, tagged with the existing analytics-stable code.
+    expect(banner).toEqual({ code: 'create_thread_failed', message: CREATE_FAILED });
+  });
+
+  it("prefers this turn's send error over an older create failure", () => {
+    const sendError = { code: 'cloud_send_failed', message: 'send blew up' } as const;
+
+    expect(deriveChatErrorBanner(sendError, 'stale create failure', CREATE_FAILED)).toBe(sendError);
+  });
+
+  it('renders nothing when neither failure is present', () => {
+    expect(deriveChatErrorBanner(null, null, CREATE_FAILED)).toBeNull();
   });
 });

--- a/app/src/store/__tests__/threadSlice.createThread.test.ts
+++ b/app/src/store/__tests__/threadSlice.createThread.test.ts
@@ -157,5 +157,78 @@ describe('createNewThread failure handling (#5156)', () => {
       expect(formatThreadCreateError('   ')).toBe('Failed to create thread');
       expect(formatThreadCreateError({})).toBe('Failed to create thread');
     });
+
+    // A native `new Error()` has `message === ''`. Returning it verbatim stored
+    // a falsy `createThreadError`, which `deriveChatErrorBanner` reads as "no
+    // failure" — so the user got the dead New Chat button with no banner, the
+    // exact outcome #5156 exists to prevent.
+    it('falls back for an Error carrying an empty or blank message', () => {
+      expect(formatThreadCreateError(new Error())).toBe('Failed to create thread');
+      expect(formatThreadCreateError(new Error(''))).toBe('Failed to create thread');
+      expect(formatThreadCreateError(new Error('   '))).toBe('Failed to create thread');
+      expect(formatThreadCreateError({ name: 'Error', message: '   ' })).toBe(
+        'Failed to create thread'
+      );
+    });
+  });
+
+  // Two creates overlap when the user hits New Chat again while the first RPC
+  // is still hung on its 30 s budget. Only the latest attempt may write the
+  // create-error state, or a late failure from the superseded one repaints the
+  // banner over a chat that was actually created.
+  describe('overlapping create attempts', () => {
+    it('ignores a stale rejection that lands after a newer create succeeded', async () => {
+      const store = createStore();
+
+      // Request A hangs; we hold its rejection until after B has succeeded.
+      let failA: (reason: unknown) => void = () => {};
+      mockedThreadApi.createNewThread.mockImplementationOnce(
+        () =>
+          new Promise<Thread>((_resolve, reject) => {
+            failA = reject;
+          })
+      );
+      const a = store.dispatch(createNewThread(undefined));
+
+      // Request B starts and succeeds while A is still in flight.
+      mockedThreadApi.createNewThread.mockResolvedValueOnce(makeThread());
+      mockedThreadApi.getThreads.mockResolvedValueOnce({ threads: [makeThread()], count: 1 });
+      await store.dispatch(createNewThread(undefined));
+      expect(store.getState().thread.createThreadError).toBeNull();
+
+      // Only now does A time out.
+      failA(new CoreRpcError(TIMEOUT_MESSAGE, 'timeout'));
+      await a;
+
+      // The banner must stay clear — B's chat exists.
+      expect(store.getState().thread.createThreadError).toBeNull();
+    });
+
+    it('still records the failure when the latest attempt is the one that fails', async () => {
+      const store = createStore();
+
+      let succeedA: (thread: Thread) => void = () => {};
+      mockedThreadApi.createNewThread.mockImplementationOnce(
+        () =>
+          new Promise<Thread>(resolve => {
+            succeedA = resolve;
+          })
+      );
+      const a = store.dispatch(createNewThread(undefined));
+
+      // B starts after A and fails — B is the live attempt, so its failure counts.
+      mockedThreadApi.createNewThread.mockRejectedValueOnce(
+        new CoreRpcError(TIMEOUT_MESSAGE, 'timeout')
+      );
+      await store.dispatch(createNewThread(undefined));
+      expect(store.getState().thread.createThreadError).toBe(TIMEOUT_MESSAGE);
+
+      // A's late *success* must not clear a banner it no longer owns.
+      mockedThreadApi.getThreads.mockResolvedValueOnce({ threads: [makeThread()], count: 1 });
+      succeedA(makeThread());
+      await a;
+
+      expect(store.getState().thread.createThreadError).toBe(TIMEOUT_MESSAGE);
+    });
   });
 });

--- a/app/src/store/__tests__/threadSlice.createThread.test.ts
+++ b/app/src/store/__tests__/threadSlice.createThread.test.ts
@@ -1,0 +1,161 @@
+/**
+ * #5156 — a `threads_create_new` that blows the 30 s RPC budget must land as a
+ * recorded, displayable failure, never as an unhandled rejection.
+ *
+ * The original Sentry report (TAURI-REACT-10) read `UnhandledRejection:
+ * Non-Error promise rejection captured with value: Core RPC
+ * openhuman.threads_create_new timed out after 30000ms`. Two things made that
+ * possible: `.unwrap()` throws the `rejectWithValue` payload (a bare string with
+ * no stack, hence "Non-Error"), and nothing in the store observed
+ * `createNewThread.rejected` — so handling was per-call-site, and a site that
+ * forgot leaked, while a site that caught-and-ignored showed the user nothing.
+ */
+import { configureStore } from '@reduxjs/toolkit';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { threadApi } from '../../services/api/threadApi';
+import { CoreRpcError } from '../../services/coreRpcClient';
+import type { Thread } from '../../types/thread';
+import threadReducer, {
+  clearCreateThreadError,
+  createNewThread,
+  formatThreadCreateError,
+} from '../threadSlice';
+
+vi.mock('../../services/api/threadApi', () => ({
+  threadApi: {
+    createNewThread: vi.fn(),
+    getThreads: vi.fn(),
+    getThreadMessages: vi.fn(),
+    appendMessage: vi.fn(),
+    deleteThread: vi.fn(),
+    generateTitleIfNeeded: vi.fn(),
+    updateMessage: vi.fn(),
+    updateLabels: vi.fn(),
+    updateTitle: vi.fn(),
+    purge: vi.fn(),
+  },
+}));
+
+const mockedThreadApi = vi.mocked(threadApi);
+
+const TIMEOUT_MESSAGE = 'Core RPC openhuman.threads_create_new timed out after 30000ms';
+
+function createStore() {
+  return configureStore({ reducer: { thread: threadReducer } });
+}
+
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: 't-1',
+    title: 'Chat Jul 30 1:23 AM',
+    chatId: null,
+    isActive: false,
+    messageCount: 0,
+    lastMessageAt: '2026-07-30T00:00:00.000Z',
+    createdAt: '2026-07-30T00:00:00.000Z',
+    labels: [],
+    ...overrides,
+  };
+}
+
+describe('createNewThread failure handling (#5156)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('records the RPC timeout in state instead of leaving it to the call site', async () => {
+    const store = createStore();
+    mockedThreadApi.createNewThread.mockRejectedValueOnce(
+      new CoreRpcError(TIMEOUT_MESSAGE, 'timeout')
+    );
+
+    const result = await store.dispatch(createNewThread(undefined));
+
+    expect(result.type).toBe('thread/createNewThread/rejected');
+    expect(store.getState().thread.createThreadError).toBe(TIMEOUT_MESSAGE);
+  });
+
+  it('surfaces the timeout to `.unwrap()` callers as a catchable rejection', async () => {
+    const store = createStore();
+    mockedThreadApi.createNewThread.mockRejectedValueOnce(
+      new CoreRpcError(TIMEOUT_MESSAGE, 'timeout')
+    );
+
+    const thrown = await store
+      .dispatch(createNewThread(undefined))
+      .unwrap()
+      .then(() => null)
+      .catch((err: unknown) => err);
+
+    expect(thrown).not.toBeNull();
+    // Whatever shape `.unwrap()` throws, the normaliser yields the message a
+    // caller can log or display — that is what keeps both the Sentry breadcrumb
+    // and the UI banner readable.
+    expect(formatThreadCreateError(thrown)).toBe(TIMEOUT_MESSAGE);
+  });
+
+  it('clears the recorded failure when a retry starts and when it succeeds', async () => {
+    const store = createStore();
+    mockedThreadApi.createNewThread.mockRejectedValueOnce(
+      new CoreRpcError(TIMEOUT_MESSAGE, 'timeout')
+    );
+    await store.dispatch(createNewThread(undefined));
+    expect(store.getState().thread.createThreadError).toBe(TIMEOUT_MESSAGE);
+
+    mockedThreadApi.createNewThread.mockResolvedValueOnce(makeThread());
+    mockedThreadApi.getThreads.mockResolvedValueOnce({ threads: [makeThread()], count: 1 });
+    await store.dispatch(createNewThread(undefined));
+
+    expect(store.getState().thread.createThreadError).toBeNull();
+  });
+
+  it('clears the recorded failure on explicit dismissal', async () => {
+    const store = createStore();
+    mockedThreadApi.createNewThread.mockRejectedValueOnce(
+      new CoreRpcError(TIMEOUT_MESSAGE, 'timeout')
+    );
+    await store.dispatch(createNewThread(undefined));
+
+    store.dispatch(clearCreateThreadError());
+
+    expect(store.getState().thread.createThreadError).toBeNull();
+  });
+
+  it('records a failure that comes from the follow-up thread reload', async () => {
+    const store = createStore();
+    mockedThreadApi.createNewThread.mockResolvedValueOnce(makeThread());
+    // `createNewThread` awaits `loadThreads().unwrap()`, which throws a bare
+    // string payload rather than an `Error` — the shape that used to fall through
+    // the `error instanceof Error` check and be reported as a generic message.
+    mockedThreadApi.getThreads.mockRejectedValueOnce(
+      new CoreRpcError('Core RPC openhuman.threads_list timed out after 30000ms', 'timeout')
+    );
+
+    const result = await store.dispatch(createNewThread(undefined));
+
+    expect(result.type).toBe('thread/createNewThread/rejected');
+    expect(store.getState().thread.createThreadError).toBe(
+      'Core RPC openhuman.threads_list timed out after 30000ms'
+    );
+  });
+
+  describe('formatThreadCreateError', () => {
+    it('passes a bare string payload through', () => {
+      expect(formatThreadCreateError(TIMEOUT_MESSAGE)).toBe(TIMEOUT_MESSAGE);
+    });
+
+    it('reads `message` off an Error and off a SerializedError-shaped object', () => {
+      expect(formatThreadCreateError(new Error('boom'))).toBe('boom');
+      expect(formatThreadCreateError({ name: 'Error', message: 'serialized boom' })).toBe(
+        'serialized boom'
+      );
+    });
+
+    it('falls back for shapes that carry no message', () => {
+      expect(formatThreadCreateError(undefined)).toBe('Failed to create thread');
+      expect(formatThreadCreateError('   ')).toBe('Failed to create thread');
+      expect(formatThreadCreateError({})).toBe('Failed to create thread');
+    });
+  });
+});

--- a/app/src/store/threadSlice.ts
+++ b/app/src/store/threadSlice.ts
@@ -43,6 +43,18 @@ interface ThreadState {
    * dead "New chat" button. The chat surface renders this.
    */
   createThreadError: string | null;
+  /**
+   * `requestId` of the most recently *started* `createNewThread`, so a
+   * completion from a superseded attempt can be ignored.
+   *
+   * Two creates can overlap — the user hits New Chat again while the first RPC
+   * is still hung on its 30 s budget. Without this, the newer request could
+   * succeed and clear the banner, and then the older one would time out and set
+   * `createThreadError` again, showing "Couldn't create a new thread" on a chat
+   * that was in fact created. Only the latest attempt is allowed to write this
+   * slice's create-error state.
+   */
+  createThreadRequestId: string | null;
 }
 
 const initialState: ThreadState = {
@@ -56,6 +68,7 @@ const initialState: ThreadState = {
   isLoadingMessages: false,
   messagesError: null,
   createThreadError: null,
+  createThreadRequestId: null,
 };
 
 function appendMessageToCache(
@@ -101,7 +114,11 @@ export const loadThreads = createAsyncThunk(
  */
 export function formatThreadCreateError(error: unknown): string {
   if (typeof error === 'string' && error.trim().length > 0) return error;
-  if (error instanceof Error) return error.message;
+  // `new Error()` carries an empty `message`. Returning it would store a falsy
+  // `createThreadError`, which `deriveChatErrorBanner` treats as "no failure" —
+  // the user would get a dead New Chat button and no banner, the exact outcome
+  // #5156 exists to prevent. Fall through to the generic fallback instead.
+  if (error instanceof Error && error.message.trim().length > 0) return error.message;
   if (error && typeof error === 'object' && 'message' in error) {
     const message = (error as { message?: unknown }).message;
     if (typeof message === 'string' && message.trim().length > 0) return message;
@@ -470,14 +487,21 @@ const threadSlice = createSlice({
         state.isLoadingThreads = false;
       })
       // A create in flight supersedes the previous attempt's failure, so the
-      // banner clears the moment the user retries rather than lingering.
-      .addCase(createNewThread.pending, state => {
+      // banner clears the moment the user retries rather than lingering. The
+      // starting request also becomes the only one allowed to write the error
+      // state — see `createThreadRequestId`.
+      .addCase(createNewThread.pending, (state, action) => {
+        state.createThreadRequestId = action.meta.requestId;
         state.createThreadError = null;
       })
-      .addCase(createNewThread.fulfilled, state => {
+      .addCase(createNewThread.fulfilled, (state, action) => {
+        if (action.meta.requestId !== state.createThreadRequestId) return;
         state.createThreadError = null;
       })
       .addCase(createNewThread.rejected, (state, action) => {
+        // A superseded attempt failing late must not repaint the banner over a
+        // newer create that already succeeded.
+        if (action.meta.requestId !== state.createThreadRequestId) return;
         state.createThreadError = formatThreadCreateError(action.payload ?? action.error?.message);
       })
       .addCase(loadThreadMessages.pending, state => {

--- a/app/src/store/threadSlice.ts
+++ b/app/src/store/threadSlice.ts
@@ -32,6 +32,17 @@ interface ThreadState {
   isLoadingThreads: boolean;
   isLoadingMessages: boolean;
   messagesError: string | null;
+  /**
+   * Why the last `createNewThread` failed, or `null` when the last attempt
+   * succeeded (or none has run). Recorded centrally so a failed create is never
+   * invisible: before #5156 nothing in the store observed
+   * `createNewThread.rejected`, so every call site had to remember its own
+   * `.catch` — one that forgot produced `UnhandledRejection: Core RPC
+   * openhuman.threads_create_new timed out after 30000ms` (Sentry
+   * TAURI-REACT-10) and one that caught-and-ignored left the user staring at a
+   * dead "New chat" button. The chat surface renders this.
+   */
+  createThreadError: string | null;
 }
 
 const initialState: ThreadState = {
@@ -44,6 +55,7 @@ const initialState: ThreadState = {
   isLoadingThreads: false,
   isLoadingMessages: false,
   messagesError: null,
+  createThreadError: null,
 };
 
 function appendMessageToCache(
@@ -77,6 +89,26 @@ export const loadThreads = createAsyncThunk(
   }
 );
 
+/**
+ * Normalise whatever `dispatch(createNewThread()).unwrap()` throws into a
+ * displayable string.
+ *
+ * `createAsyncThunk` throws the `rejectWithValue` payload (a bare string) or, if
+ * the thunk threw, Redux's `SerializedError` — a plain object, not an `Error`.
+ * Neither carries a stack, which is why the original report surfaced as
+ * "Non-Error promise rejection captured with value: …" (#5156). Mirrors
+ * `formatThreadLoadError` in `features/conversations/Conversations.tsx`.
+ */
+export function formatThreadCreateError(error: unknown): string {
+  if (typeof error === 'string' && error.trim().length > 0) return error;
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === 'string' && message.trim().length > 0) return message;
+  }
+  return 'Failed to create thread';
+}
+
 export const createNewThread = createAsyncThunk(
   'thread/createNewThread',
   async (labels: string[] | undefined, { dispatch, rejectWithValue }) => {
@@ -85,7 +117,10 @@ export const createNewThread = createAsyncThunk(
       await dispatch(loadThreads()).unwrap();
       return thread;
     } catch (error) {
-      return rejectWithValue(error instanceof Error ? error.message : 'Failed to create thread');
+      // Keep the payload a plain string (redux-serializable) but normalise every
+      // throw shape, including the `SerializedError` a nested `.unwrap()` raises
+      // when `loadThreads` is what actually failed (#5156).
+      return rejectWithValue(formatThreadCreateError(error));
     }
   }
 );
@@ -330,6 +365,13 @@ const threadSlice = createSlice({
   name: 'thread',
   initialState,
   reducers: {
+    /**
+     * Dismiss the "couldn't start a new chat" surface (#5156) — the user has
+     * seen it and moved on (typed into the composer, navigated away).
+     */
+    clearCreateThreadError: state => {
+      state.createThreadError = null;
+    },
     setSelectedThread: (state, action: { payload: string }) => {
       state.selectedThreadId = action.payload;
       state.messages = state.messagesByThreadId[action.payload] ?? [];
@@ -427,6 +469,17 @@ const threadSlice = createSlice({
       .addCase(loadThreads.rejected, state => {
         state.isLoadingThreads = false;
       })
+      // A create in flight supersedes the previous attempt's failure, so the
+      // banner clears the moment the user retries rather than lingering.
+      .addCase(createNewThread.pending, state => {
+        state.createThreadError = null;
+      })
+      .addCase(createNewThread.fulfilled, state => {
+        state.createThreadError = null;
+      })
+      .addCase(createNewThread.rejected, (state, action) => {
+        state.createThreadError = formatThreadCreateError(action.payload ?? action.error?.message);
+      })
       .addCase(loadThreadMessages.pending, state => {
         state.isLoadingMessages = true;
         state.messagesError = null;
@@ -498,6 +551,7 @@ const threadSlice = createSlice({
 });
 
 export const {
+  clearCreateThreadError,
   setSelectedThread,
   clearSelectedThread,
   setActiveThread,

--- a/src/openhuman/agent_memory/memory_loader.rs
+++ b/src/openhuman/agent_memory/memory_loader.rs
@@ -9,7 +9,7 @@ use crate::openhuman::agent::harness::memory_context::{
     CROSS_CHAT_LIMIT, CROSS_CHAT_SNIPPET_CHARS, WORKING_MEMORY_KEY_PREFIX, WORKING_MEMORY_LIMIT,
 };
 use crate::openhuman::learning::transcript_ingest::CONVERSATION_MEMORY_NAMESPACE;
-use crate::openhuman::memory_conversations::ConversationStore;
+use crate::openhuman::memory_conversations::blocking as conversations_blocking;
 
 /// Maximum number of `[Prior conversations]` lines surfaced into the prompt
 /// at the start of a fresh chat. Tight cap on purpose: this block is meant
@@ -367,12 +367,18 @@ impl MemoryLoader for DefaultMemoryLoader {
                 crate::openhuman::tinyagents::thread_context::current_thread_id();
             let cross_hits: Vec<(String, String)> = if let Some(workspace_dir) = &self.workspace_dir
             {
-                let store = ConversationStore::new(workspace_dir.clone());
-                match store.search_cross_thread_messages(
-                    user_message,
+                // Blocking pool: on a cold inverted index this reads every
+                // thread's transcript, and it takes the store's process-global
+                // mutex to run the search. Inline, it parked an async worker on
+                // every turn — the starvation behind #5156.
+                match conversations_blocking::search_cross_thread_messages(
+                    workspace_dir.clone(),
+                    user_message.to_string(),
                     CROSS_CHAT_LIMIT * 4,
-                    current_thread_id.as_deref(),
-                ) {
+                    current_thread_id.clone(),
+                )
+                .await
+                {
                     Ok(hits) => {
                         tracing::debug!(
                             "[memory_loader] cross-chat JSONL scan returned {} hits (exclude={:?})",

--- a/src/openhuman/memory_conversations/blocking.rs
+++ b/src/openhuman/memory_conversations/blocking.rs
@@ -1,0 +1,188 @@
+//! Async wrappers that run the conversation store's **blocking** operations on
+//! tokio's blocking pool (#5156).
+//!
+//! Every `tinycortex::memory::conversations` entry point is synchronous, and
+//! each one takes the process-global `CONVERSATION_STORE_LOCK` — a
+//! `parking_lot::Mutex` — and then does fsync'd JSONL file IO while holding it.
+//! Calling one directly from an `async fn` therefore parks a tokio **worker**
+//! thread for the whole wait, and the wait is not short:
+//!
+//! * `threads.jsonl` is folded from scratch on nearly every operation
+//!   (`thread_index_unlocked`), and it grows by roughly two lines per appended
+//!   message and is never compacted — so the per-call fold cost grows with the
+//!   user's whole history;
+//! * `append_message` writes two fsync'd appends under the lock, and
+//!   `update_message` reads and rewrites a thread's entire message log under it,
+//!   so a live streaming turn holds the lock repeatedly;
+//! * `search_cross_thread_messages` reads every thread's transcript on a cold
+//!   index.
+//!
+//! Once more concurrent conversation operations than there are worker threads
+//! are parked on that mutex, the runtime stops polling **anything** — including
+//! the HTTP task that owes the client its response. That is how a create that
+//! only needs one append blows the frontend's 30 s RPC budget:
+//! `UnhandledRejection: Core RPC openhuman.threads_create_new timed out after
+//! 30000ms` (Sentry TAURI-REACT-10, #5156).
+//!
+//! Moving each call onto the blocking pool keeps the lock wait off the async
+//! workers. The work is just as serialized as before — the store's lock still
+//! decides who writes when — but the executor stays live, so the RPC server
+//! keeps answering while a slow conversation operation drains, and a queued
+//! create completes as soon as the lock frees instead of after the client has
+//! given up.
+//!
+//! Callers pass owned arguments because the closure must be `'static`.
+
+use std::path::PathBuf;
+
+use tinycortex::memory::conversations as store;
+
+use super::{
+    ConversationMessage, ConversationMessagePatch, ConversationPurgeStats, ConversationStore,
+    ConversationThread, CreateConversationThread, CrossThreadHit,
+};
+
+/// Run one blocking store call on the blocking pool.
+///
+/// A `JoinError` here means the pool task panicked (or the runtime is shutting
+/// down); surface it as a store error rather than propagating the panic into
+/// the RPC dispatcher, which would turn a transient store fault into a 500-shaped
+/// unknown failure.
+async fn run<T, F>(operation: &'static str, f: F) -> Result<T, String>
+where
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::task::spawn_blocking(f).await {
+        Ok(result) => result,
+        Err(error) => {
+            tracing::warn!(
+                operation,
+                error = %error,
+                "[conversations] blocking store task failed to join"
+            );
+            Err(format!(
+                "conversation store {operation} task failed: {error}"
+            ))
+        }
+    }
+}
+
+/// [`store::ensure_thread`] on the blocking pool.
+pub async fn ensure_thread(
+    workspace_dir: PathBuf,
+    request: CreateConversationThread,
+) -> Result<ConversationThread, String> {
+    run("ensure_thread", move || {
+        store::ensure_thread(workspace_dir, request)
+    })
+    .await
+}
+
+/// [`store::list_threads`] on the blocking pool.
+pub async fn list_threads(workspace_dir: PathBuf) -> Result<Vec<ConversationThread>, String> {
+    run("list_threads", move || store::list_threads(workspace_dir)).await
+}
+
+/// [`store::get_messages`] on the blocking pool.
+pub async fn get_messages(
+    workspace_dir: PathBuf,
+    thread_id: String,
+) -> Result<Vec<ConversationMessage>, String> {
+    run("get_messages", move || {
+        store::get_messages(workspace_dir, &thread_id)
+    })
+    .await
+}
+
+/// [`store::append_message`] on the blocking pool.
+pub async fn append_message(
+    workspace_dir: PathBuf,
+    thread_id: String,
+    message: ConversationMessage,
+) -> Result<ConversationMessage, String> {
+    run("append_message", move || {
+        store::append_message(workspace_dir, &thread_id, message)
+    })
+    .await
+}
+
+/// [`store::update_message`] on the blocking pool.
+pub async fn update_message(
+    workspace_dir: PathBuf,
+    thread_id: String,
+    message_id: String,
+    patch: ConversationMessagePatch,
+) -> Result<ConversationMessage, String> {
+    run("update_message", move || {
+        store::update_message(workspace_dir, &thread_id, &message_id, patch)
+    })
+    .await
+}
+
+/// [`store::update_thread_title`] on the blocking pool.
+pub async fn update_thread_title(
+    workspace_dir: PathBuf,
+    thread_id: String,
+    title: String,
+    updated_at: String,
+) -> Result<ConversationThread, String> {
+    run("update_thread_title", move || {
+        store::update_thread_title(workspace_dir, &thread_id, &title, &updated_at)
+    })
+    .await
+}
+
+/// [`store::update_thread_labels`] on the blocking pool.
+pub async fn update_thread_labels(
+    workspace_dir: PathBuf,
+    thread_id: String,
+    labels: Vec<String>,
+    updated_at: String,
+) -> Result<ConversationThread, String> {
+    run("update_thread_labels", move || {
+        store::update_thread_labels(workspace_dir, &thread_id, labels, &updated_at)
+    })
+    .await
+}
+
+/// [`store::delete_thread`] on the blocking pool.
+pub async fn delete_thread(
+    workspace_dir: PathBuf,
+    thread_id: String,
+    deleted_at: String,
+) -> Result<bool, String> {
+    run("delete_thread", move || {
+        store::delete_thread(workspace_dir, &thread_id, &deleted_at)
+    })
+    .await
+}
+
+/// [`store::purge_threads`] on the blocking pool.
+pub async fn purge_threads(workspace_dir: PathBuf) -> Result<ConversationPurgeStats, String> {
+    run("purge_threads", move || store::purge_threads(workspace_dir)).await
+}
+
+/// [`ConversationStore::search_cross_thread_messages`] on the blocking pool.
+///
+/// The heaviest operation in the family: a cold inverted index reads every
+/// thread's transcript before the search runs.
+pub async fn search_cross_thread_messages(
+    workspace_dir: PathBuf,
+    query: String,
+    limit: usize,
+    exclude_thread_id: Option<String>,
+) -> Result<Vec<CrossThreadHit>, String> {
+    run("search_cross_thread_messages", move || {
+        ConversationStore::new(workspace_dir).search_cross_thread_messages(
+            &query,
+            limit,
+            exclude_thread_id.as_deref(),
+        )
+    })
+    .await
+}
+
+#[cfg(test)]
+#[path = "blocking_tests.rs"]
+mod tests;

--- a/src/openhuman/memory_conversations/blocking_tests.rs
+++ b/src/openhuman/memory_conversations/blocking_tests.rs
@@ -82,20 +82,84 @@ async fn store_errors_surface_unchanged() {
 /// is parked in `lock()` and nothing else on the runtime can be polled. Off the
 /// blocking pool they all complete, and a plain cooperative task keeps being
 /// polled while they do.
+///
+/// The cooperative ticker alone would not prove that: its 64 yields can all
+/// retire before any store task even reaches the lock, so it would stay green
+/// against an implementation that ran the store inline. Determinism comes from
+/// `probe` — a store closure *held open* for the whole window — plus a watchdog
+/// that observes progress while it is held.
+///
+/// The watchdog is a plain OS thread on purpose. A `tokio::time::timeout` cannot
+/// bound this: if the store ran inline, the sole worker would be parked inside
+/// the probe closure and the timeout future would never be polled either, so the
+/// test would hang instead of failing. An OS thread cannot be starved by the
+/// runtime, and it releases the probe on its way out so a starved runtime always
+/// recovers far enough to report the failure.
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn concurrent_operations_complete_without_stalling_the_single_async_worker() {
+    use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    const TICK_TARGET: u32 = 64;
+    const WATCHDOG_BUDGET: Duration = Duration::from_secs(10);
+
     let tmp = TempDir::new().unwrap();
     let dir = tmp.path().to_path_buf();
 
+    // A store call pinned open for as long as we hold `release`. `recv()` is a
+    // genuinely blocking wait — the same shape as `parking_lot::Mutex::lock`.
+    let probe_entered = Arc::new(AtomicBool::new(false));
+    let (release, held) = std::sync::mpsc::channel::<()>();
+    let probe = tokio::spawn(run("blocked_probe", {
+        let probe_entered = Arc::clone(&probe_entered);
+        move || {
+            probe_entered.store(true, Ordering::SeqCst);
+            let _ = held.recv();
+            Ok::<(), String>(())
+        }
+    }));
+
     // A cooperative task that only ever yields: it can make progress solely
     // because no store call is holding the worker hostage.
-    let ticker = tokio::spawn(async {
-        let mut ticks = 0_u32;
-        for _ in 0..64 {
-            tokio::task::yield_now().await;
-            ticks += 1;
+    let ticks = Arc::new(AtomicU32::new(0));
+    let ticker = tokio::spawn({
+        let ticks = Arc::clone(&ticks);
+        async move {
+            for _ in 0..TICK_TARGET {
+                tokio::task::yield_now().await;
+                ticks.fetch_add(1, Ordering::SeqCst);
+            }
         }
-        ticks
+    });
+
+    let watchdog = std::thread::spawn({
+        let probe_entered = Arc::clone(&probe_entered);
+        let ticks = Arc::clone(&ticks);
+        move || {
+            let deadline = Instant::now() + WATCHDOG_BUDGET;
+            // 1. The probe must actually be executing, or its "blocking window"
+            //    means nothing.
+            while Instant::now() < deadline && !probe_entered.load(Ordering::SeqCst) {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            let entered = probe_entered.load(Ordering::SeqCst);
+            // 2. The ticker must then run to completion *while* that store call
+            //    is still held. Inline execution parks the sole worker inside
+            //    the closure, so this expires with ticks stuck at 0.
+            let mut observed = 0;
+            while Instant::now() < deadline {
+                observed = ticks.load(Ordering::SeqCst);
+                if observed >= TICK_TARGET {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            // Always release, even on failure: a starved runtime has to recover
+            // far enough for the assertions below to run and report.
+            let _ = release.send(());
+            (entered, observed)
+        }
     });
 
     let mut handles = Vec::new();
@@ -116,6 +180,24 @@ async fn concurrent_operations_complete_without_stalling_the_single_async_worker
         }));
     }
 
+    // The load-bearing assertions, both observed from outside the runtime.
+    let (probe_started, observed_ticks) = watchdog.join().expect("join watchdog");
+    assert!(
+        probe_started,
+        "the blocking store probe never started — the pool is not running store work"
+    );
+    assert_eq!(
+        observed_ticks, TICK_TARGET,
+        "the async worker must keep polling while a store call is blocked; \
+         only {observed_ticks}/{TICK_TARGET} ticks retired within {WATCHDOG_BUDGET:?}"
+    );
+
+    ticker.await.expect("join ticker");
+    probe
+        .await
+        .expect("join probe")
+        .expect("probe closure result");
+
     let mut ids = Vec::new();
     for handle in handles {
         ids.push(handle.await.expect("join create task"));
@@ -127,7 +209,6 @@ async fn concurrent_operations_complete_without_stalling_the_single_async_worker
         8,
         "every concurrent create must land its own thread"
     );
-    assert_eq!(ticker.await.expect("join ticker"), 64);
 
     let threads = list_threads(dir).await.expect("list_threads");
     assert_eq!(threads.len(), 8);

--- a/src/openhuman/memory_conversations/blocking_tests.rs
+++ b/src/openhuman/memory_conversations/blocking_tests.rs
@@ -1,0 +1,219 @@
+//! Tests for the blocking-pool conversation-store wrappers (#5156).
+//!
+//! The property under test is that the wrappers are a faithful, `.await`-able
+//! stand-in for the synchronous store: same results, same errors, and safe to
+//! drive concurrently from several tasks on a runtime with a single async worker
+//! — which is exactly the shape that used to starve (a sync call parks the
+//! worker on the store's `parking_lot` mutex, so with every worker parked the
+//! runtime stops polling the HTTP task that owes the client its response).
+
+use serde_json::json;
+use tempfile::TempDir;
+
+use super::*;
+
+fn message(id: &str, content: &str) -> ConversationMessage {
+    ConversationMessage {
+        id: id.to_string(),
+        content: content.to_string(),
+        message_type: "text".to_string(),
+        extra_metadata: json!({}),
+        sender: "user".to_string(),
+        created_at: "2026-07-30T00:00:00Z".to_string(),
+    }
+}
+
+fn create(id: &str) -> CreateConversationThread {
+    CreateConversationThread {
+        id: id.to_string(),
+        title: format!("Title {id}"),
+        created_at: "2026-07-30T00:00:00Z".to_string(),
+        parent_thread_id: None,
+        labels: None,
+        personality_id: None,
+    }
+}
+
+#[tokio::test]
+async fn create_append_read_round_trips_through_the_blocking_pool() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().to_path_buf();
+
+    let thread = ensure_thread(dir.clone(), create("thread-a"))
+        .await
+        .expect("ensure_thread");
+    assert_eq!(thread.id, "thread-a");
+
+    append_message(dir.clone(), "thread-a".to_string(), message("m1", "hello"))
+        .await
+        .expect("append_message");
+
+    let messages = get_messages(dir.clone(), "thread-a".to_string())
+        .await
+        .expect("get_messages");
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].content, "hello");
+
+    let threads = list_threads(dir.clone()).await.expect("list_threads");
+    assert_eq!(threads.len(), 1);
+    assert_eq!(threads[0].message_count, 1);
+}
+
+#[tokio::test]
+async fn store_errors_surface_unchanged() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().to_path_buf();
+
+    // Appending to a thread that was never created is the store's own error,
+    // not a join failure — the wrapper must pass it through verbatim so the
+    // RPC layer's thread-scoped error mapping still recognises it.
+    let error = append_message(dir, "missing".to_string(), message("m1", "hello"))
+        .await
+        .expect_err("append to a missing thread must fail");
+    assert!(
+        error.contains("not found"),
+        "expected the store's own error, got: {error}"
+    );
+}
+
+/// The starvation shape from #5156: several conversation operations in flight at
+/// once on a runtime with a **single** async worker. Each one contends for the
+/// store's process-global mutex, so with the calls made inline the single worker
+/// is parked in `lock()` and nothing else on the runtime can be polled. Off the
+/// blocking pool they all complete, and a plain cooperative task keeps being
+/// polled while they do.
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn concurrent_operations_complete_without_stalling_the_single_async_worker() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().to_path_buf();
+
+    // A cooperative task that only ever yields: it can make progress solely
+    // because no store call is holding the worker hostage.
+    let ticker = tokio::spawn(async {
+        let mut ticks = 0_u32;
+        for _ in 0..64 {
+            tokio::task::yield_now().await;
+            ticks += 1;
+        }
+        ticks
+    });
+
+    let mut handles = Vec::new();
+    for idx in 0..8 {
+        let dir = dir.clone();
+        handles.push(tokio::spawn(async move {
+            let thread = ensure_thread(dir.clone(), create(&format!("thread-{idx}")))
+                .await
+                .expect("ensure_thread");
+            append_message(
+                dir,
+                thread.id.clone(),
+                message(&format!("m{idx}"), "concurrent"),
+            )
+            .await
+            .expect("append_message");
+            thread.id
+        }));
+    }
+
+    let mut ids = Vec::new();
+    for handle in handles {
+        ids.push(handle.await.expect("join create task"));
+    }
+    ids.sort();
+    ids.dedup();
+    assert_eq!(
+        ids.len(),
+        8,
+        "every concurrent create must land its own thread"
+    );
+    assert_eq!(ticker.await.expect("join ticker"), 64);
+
+    let threads = list_threads(dir).await.expect("list_threads");
+    assert_eq!(threads.len(), 8);
+    assert!(threads.iter().all(|thread| thread.message_count == 1));
+}
+
+#[tokio::test]
+async fn title_labels_delete_and_purge_round_trip() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().to_path_buf();
+    ensure_thread(dir.clone(), create("thread-a"))
+        .await
+        .expect("ensure_thread");
+
+    let retitled = update_thread_title(
+        dir.clone(),
+        "thread-a".to_string(),
+        "Renamed".to_string(),
+        "2026-07-30T00:01:00Z".to_string(),
+    )
+    .await
+    .expect("update_thread_title");
+    assert_eq!(retitled.title, "Renamed");
+
+    let relabelled = update_thread_labels(
+        dir.clone(),
+        "thread-a".to_string(),
+        vec!["general".to_string()],
+        "2026-07-30T00:02:00Z".to_string(),
+    )
+    .await
+    .expect("update_thread_labels");
+    assert_eq!(relabelled.labels, vec!["general".to_string()]);
+    assert_eq!(relabelled.title, "Renamed", "labels update preserves title");
+
+    assert!(
+        delete_thread(
+            dir.clone(),
+            "thread-a".to_string(),
+            "2026-07-30T00:03:00Z".to_string()
+        )
+        .await
+        .expect("delete_thread"),
+        "deleting a live thread reports true"
+    );
+    assert!(list_threads(dir.clone()).await.unwrap().is_empty());
+
+    ensure_thread(dir.clone(), create("thread-b"))
+        .await
+        .expect("ensure_thread");
+    purge_threads(dir.clone()).await.expect("purge_threads");
+    assert!(list_threads(dir).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn update_message_patches_metadata_and_search_finds_content() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().to_path_buf();
+    ensure_thread(dir.clone(), create("thread-a"))
+        .await
+        .expect("ensure_thread");
+    append_message(
+        dir.clone(),
+        "thread-a".to_string(),
+        message("m1", "quarterly roadmap review"),
+    )
+    .await
+    .expect("append_message");
+
+    let patched = update_message(
+        dir.clone(),
+        "thread-a".to_string(),
+        "m1".to_string(),
+        ConversationMessagePatch {
+            extra_metadata: Some(json!({"pinned": true})),
+        },
+    )
+    .await
+    .expect("update_message");
+    assert_eq!(patched.extra_metadata, json!({"pinned": true}));
+
+    let hits = search_cross_thread_messages(dir, "roadmap".to_string(), 10, None)
+        .await
+        .expect("search_cross_thread_messages");
+    assert!(
+        hits.iter().any(|hit| hit.thread_id == "thread-a"),
+        "cross-thread search must find the appended message, got: {hits:?}"
+    );
+}

--- a/src/openhuman/memory_conversations/mod.rs
+++ b/src/openhuman/memory_conversations/mod.rs
@@ -14,6 +14,7 @@
 //! bridges typed channel events onto the crate store (the crate abstracts the
 //! bus behind its own `ConversationEventBus` trait; the host wires the real one).
 
+pub mod blocking;
 mod bus;
 
 pub use bus::register_conversation_persistence_subscriber;

--- a/src/openhuman/threads/README.md
+++ b/src/openhuman/threads/README.md
@@ -62,7 +62,7 @@ Wired into the registry from `src/core/all.rs` (controllers + schemas extended w
 
 ## Persistence
 
-- **Threads + messages**: delegated to `memory::conversations` (JSONL store under the workspace), not owned here.
+- **Threads + messages**: delegated to `memory::conversations` (JSONL store under the workspace), not owned here. Every call goes through `memory_conversations::blocking::*` (`tokio::task::spawn_blocking`) — **never** the sync entry points directly, see the note below.
 - **Turn snapshots** (`turn_state/store.rs`): one JSON file per thread at `<workspace>/memory/conversations/turn_states/<hex(thread_id)>.json`. Whole-file atomic overwrite (tempfile → fsync → persist → best-effort dir fsync), serialized through a process-wide `parking_lot::Mutex`. A non-terminal file surviving cold boot is marked `Interrupted`; a `Completed` snapshot is intentionally retained (for processing replay) and skipped by startup interrupted-marking. The next turn on the thread overwrites it.
 - **Task board**: persisted by `agent::task_board::TaskBoardStore` under the workspace (this module only proxies).
 - **Migration marker**: `state/migrations/welcome_to_orchestrator_v1.done` guards the welcome migration.
@@ -88,6 +88,7 @@ Wired into the registry from `src/core/all.rs` (controllers + schemas extended w
 
 ## Notes / gotchas
 
+- **Never call the sync `memory_conversations` API from these handlers — use `memory_conversations::blocking::*`.** Each store entry point takes a process-global `parking_lot::Mutex` and then does fsync'd JSONL IO while holding it, and the per-call cost grows with the user's history (`threads.jsonl` is folded on nearly every operation and gains ~2 lines per message, uncompacted). Called inline, a handler parks a tokio *worker* thread on that mutex; once more conversation ops are queued than there are workers, the runtime stops polling anything — including the HTTP task that owes the client a response — and a one-append create blows the frontend's 30 s RPC budget (`UnhandledRejection: Core RPC openhuman.threads_create_new timed out after 30000ms`, Sentry TAURI-REACT-10 / #5156). The wrappers keep the lock wait on the blocking pool; the store is just as serialized, but the executor stays live. `welcome_migration.rs` is the deliberate exception: it is a sync, one-shot, marker-guarded boot migration, not a request path.
 - `generate_title` only replaces titles matching the `Chat <Mon> <d> <h>:<mm> <AM|PM>` placeholder shape (`is_auto_generated_thread_title`); user-renamed threads are never overwritten. Provider/init/sanitization failures degrade to a deterministic fallback title derived from the first user message — never an error.
 - `delete` invalidates the web-channel session **before** turn-snapshot cleanup (ordering is load-bearing per the inline comment); snapshot-cleanup failure surfaces as an RPC error so callers see a partial failure rather than silent on-disk drift.
 - `purge` uses `clear_all` (not list+delete) so corrupted/half-written snapshot files — which `list()` warn-skips — are also removed.

--- a/src/openhuman/threads/ops.rs
+++ b/src/openhuman/threads/ops.rs
@@ -11,9 +11,15 @@ use crate::openhuman::memory::{
     UpdateConversationMessageRequest, UpdateConversationThreadLabelsRequest,
     UpdateConversationThreadTitleRequest, UpsertConversationThreadRequest,
 };
+// Every conversation-store call in this module goes through
+// `conversations::blocking::*`, which runs the store's synchronous,
+// globally-locked, fsync'ing operations on tokio's blocking pool. Calling the
+// sync entry points directly from these handlers parked async worker threads on
+// the store's `parking_lot` mutex, which starved the runtime and made
+// `threads_create_new` blow the frontend's 30 s RPC budget (#5156).
 use crate::openhuman::memory_conversations::{
-    self as conversations, ConversationMessage, ConversationMessagePatch, ConversationStore,
-    ConversationThread, CreateConversationThread, CrossThreadHit,
+    self as conversations, ConversationMessage, ConversationMessagePatch, ConversationThread,
+    CreateConversationThread, CrossThreadHit,
 };
 use crate::openhuman::threads::title::{
     build_title_prompt, is_auto_generated_thread_title, sanitize_generated_title,
@@ -127,7 +133,7 @@ fn fallback_title_from_user_message(thread_id: &str, user_message: &str) -> Opti
     title
 }
 
-fn update_thread_with_fallback_title(
+async fn update_thread_with_fallback_title(
     dir: PathBuf,
     thread: ConversationThread,
     user_message: &str,
@@ -138,7 +144,13 @@ fn update_thread_with_fallback_title(
     if title == thread.title {
         return Ok(thread);
     }
-    conversations::update_thread_title(dir, &thread.id, &title, &chrono::Utc::now().to_rfc3339())
+    conversations::blocking::update_thread_title(
+        dir,
+        thread.id.clone(),
+        title,
+        chrono::Utc::now().to_rfc3339(),
+    )
+    .await
 }
 
 /// Lists all conversation threads.
@@ -146,7 +158,8 @@ pub async fn threads_list(
     _request: EmptyRequest,
 ) -> Result<RpcOutcome<ApiEnvelope<ConversationThreadsListResponse>>, String> {
     let dir = workspace_dir().await?;
-    let threads = conversations::list_threads(dir)?
+    let threads = conversations::blocking::list_threads(dir)
+        .await?
         .into_iter()
         .map(thread_to_summary)
         .collect::<Vec<_>>();
@@ -163,7 +176,7 @@ pub async fn thread_upsert(
     request: UpsertConversationThreadRequest,
 ) -> Result<RpcOutcome<ApiEnvelope<ConversationThreadSummary>>, String> {
     let dir = workspace_dir().await?;
-    let thread = conversations::ensure_thread(
+    let thread = conversations::blocking::ensure_thread(
         dir,
         CreateConversationThread {
             id: request.id,
@@ -173,7 +186,8 @@ pub async fn thread_upsert(
             labels: request.labels,
             personality_id: request.personality_id,
         },
-    )?;
+    )
+    .await?;
     Ok(envelope(
         thread_to_summary(thread),
         Some(counts([("num_threads", 1)])),
@@ -190,7 +204,7 @@ pub async fn thread_create_new(
     let now = chrono::Local::now();
     let title = format!("Chat {} {}", now.format("%b %-d"), now.format("%-I:%M %p"));
     let created_at = chrono::Utc::now().to_rfc3339();
-    let thread = conversations::ensure_thread(
+    let thread = conversations::blocking::ensure_thread(
         dir,
         CreateConversationThread {
             id,
@@ -203,7 +217,8 @@ pub async fn thread_create_new(
             labels: request.labels,
             personality_id: request.personality_id,
         },
-    )?;
+    )
+    .await?;
     tracing::debug!(
         thread_id = %thread.id,
         labels = ?thread.labels,
@@ -221,7 +236,8 @@ pub async fn messages_list(
     request: ConversationMessagesRequest,
 ) -> Result<RpcOutcome<ApiEnvelope<ConversationMessagesResponse>>, String> {
     let dir = workspace_dir().await?;
-    let messages = conversations::get_messages(dir, &request.thread_id)?
+    let messages = conversations::blocking::get_messages(dir, request.thread_id.clone())
+        .await?
         .into_iter()
         .map(message_to_record)
         .collect::<Vec<_>>();
@@ -252,11 +268,13 @@ pub async fn transcript_search(
         limit,
         exclude_thread_id
     );
-    let hits = ConversationStore::new(dir).search_cross_thread_messages(
-        query,
+    let hits = conversations::blocking::search_cross_thread_messages(
+        dir,
+        query.to_string(),
         limit,
-        exclude_thread_id,
-    )?;
+        exclude_thread_id.map(str::to_string),
+    )
+    .await?;
     log::debug!("[threads][transcript_search] hits={}", hits.len());
     Ok(hits)
 }
@@ -266,9 +284,13 @@ pub async fn message_append(
     request: AppendConversationMessageRequest,
 ) -> Result<RpcOutcome<ApiEnvelope<ConversationMessageRecord>>, ThreadsError> {
     let dir = workspace_dir().await?;
-    let message =
-        conversations::append_message(dir, &request.thread_id, record_to_message(request.message))
-            .map_err(|err| ThreadsError::from_thread_scoped_store_error(&request.thread_id, err))?;
+    let message = conversations::blocking::append_message(
+        dir,
+        request.thread_id.clone(),
+        record_to_message(request.message),
+    )
+    .await
+    .map_err(|err| ThreadsError::from_thread_scoped_store_error(&request.thread_id, err))?;
     Ok(envelope(
         message_to_record(message),
         Some(counts([("num_messages", 1)])),
@@ -284,7 +306,8 @@ pub async fn thread_generate_title(
         .await
         .map_err(|e| format!("load config: {e}"))?;
     let dir = config.workspace_dir.clone();
-    let Some(thread) = conversations::list_threads(dir.clone())?
+    let Some(thread) = conversations::blocking::list_threads(dir.clone())
+        .await?
         .into_iter()
         .find(|thread| thread.id == request.thread_id)
     else {
@@ -305,7 +328,8 @@ pub async fn thread_generate_title(
         ));
     }
 
-    let messages = conversations::get_messages(dir.clone(), &request.thread_id)?;
+    let messages =
+        conversations::blocking::get_messages(dir.clone(), request.thread_id.clone()).await?;
     let Some(first_user_message) = messages
         .iter()
         .find(|message| message.sender == "user" && !message.content.trim().is_empty())
@@ -340,7 +364,7 @@ pub async fn thread_generate_title(
             thread_id = %request.thread_id,
             "{THREAD_TITLE_LOG_PREFIX} no assistant message yet; applying fallback title"
         );
-        let updated = update_thread_with_fallback_title(dir, thread, &first_user_message)?;
+        let updated = update_thread_with_fallback_title(dir, thread, &first_user_message).await?;
         return Ok(envelope(
             thread_to_summary(updated),
             Some(counts([("num_threads", 1)])),
@@ -356,7 +380,8 @@ pub async fn thread_generate_title(
                 error = %error,
                 "{THREAD_TITLE_LOG_PREFIX} provider init failed; applying fallback title"
             );
-            let updated = update_thread_with_fallback_title(dir, thread, &first_user_message)?;
+            let updated =
+                update_thread_with_fallback_title(dir, thread, &first_user_message).await?;
             return Ok(envelope(
                 thread_to_summary(updated),
                 Some(counts([("num_threads", 1)])),
@@ -392,7 +417,8 @@ pub async fn thread_generate_title(
                 error = %error,
                 "{THREAD_TITLE_LOG_PREFIX} title generation failed; applying fallback title"
             );
-            let updated = update_thread_with_fallback_title(dir, thread, &first_user_message)?;
+            let updated =
+                update_thread_with_fallback_title(dir, thread, &first_user_message).await?;
             return Ok(envelope(
                 thread_to_summary(updated),
                 Some(counts([("num_threads", 1)])),
@@ -408,7 +434,7 @@ pub async fn thread_generate_title(
             raw_title_hash = %title_log_fingerprint(&raw_title),
             "{THREAD_TITLE_LOG_PREFIX} generated empty title after sanitization; applying fallback title"
         );
-        let updated = update_thread_with_fallback_title(dir, thread, &first_user_message)?;
+        let updated = update_thread_with_fallback_title(dir, thread, &first_user_message).await?;
         return Ok(envelope(
             thread_to_summary(updated),
             Some(counts([("num_threads", 1)])),
@@ -424,12 +450,13 @@ pub async fn thread_generate_title(
         ));
     }
 
-    let updated = conversations::update_thread_title(
+    let updated = conversations::blocking::update_thread_title(
         dir,
-        &request.thread_id,
-        &title,
-        &chrono::Utc::now().to_rfc3339(),
+        request.thread_id.clone(),
+        title,
+        chrono::Utc::now().to_rfc3339(),
     )
+    .await
     .map_err(|err| ThreadsError::from_thread_scoped_store_error(&request.thread_id, err))?;
 
     tracing::debug!(
@@ -455,12 +482,13 @@ pub async fn thread_update_labels(
     request: UpdateConversationThreadLabelsRequest,
 ) -> Result<RpcOutcome<ApiEnvelope<ConversationThreadSummary>>, String> {
     let dir = workspace_dir().await?;
-    let thread = conversations::update_thread_labels(
+    let thread = conversations::blocking::update_thread_labels(
         dir,
-        &request.thread_id,
+        request.thread_id.clone(),
         request.labels.clone(),
-        &chrono::Utc::now().to_rfc3339(),
-    )?;
+        chrono::Utc::now().to_rfc3339(),
+    )
+    .await?;
     tracing::debug!(
         thread_id = %request.thread_id,
         labels = ?request.labels,
@@ -482,12 +510,13 @@ pub async fn thread_update_title(
     if title.is_empty() {
         return Err("title must not be empty".to_string());
     }
-    let updated = conversations::update_thread_title(
+    let updated = conversations::blocking::update_thread_title(
         dir,
-        &request.thread_id,
-        &title,
-        &chrono::Utc::now().to_rfc3339(),
+        request.thread_id.clone(),
+        title,
+        chrono::Utc::now().to_rfc3339(),
     )
+    .await
     .map_err(|err| format!("update title: {err}"))?;
     tracing::debug!(
         thread_id = %request.thread_id,
@@ -506,14 +535,15 @@ pub async fn message_update(
     request: UpdateConversationMessageRequest,
 ) -> Result<RpcOutcome<ApiEnvelope<ConversationMessageRecord>>, String> {
     let dir = workspace_dir().await?;
-    let message = conversations::update_message(
+    let message = conversations::blocking::update_message(
         dir,
-        &request.thread_id,
-        &request.message_id,
+        request.thread_id.clone(),
+        request.message_id.clone(),
         ConversationMessagePatch {
             extra_metadata: request.extra_metadata,
         },
-    )?;
+    )
+    .await?;
     Ok(envelope(
         message_to_record(message),
         Some(counts([("num_messages", 1)])),
@@ -526,8 +556,12 @@ pub async fn thread_delete(
     request: DeleteConversationThreadRequest,
 ) -> Result<RpcOutcome<ApiEnvelope<DeleteConversationThreadResponse>>, String> {
     let dir = workspace_dir().await?;
-    let deleted = ConversationStore::new(dir.clone())
-        .delete_thread(&request.thread_id, &request.deleted_at)?;
+    let deleted = conversations::blocking::delete_thread(
+        dir.clone(),
+        request.thread_id.clone(),
+        request.deleted_at.clone(),
+    )
+    .await?;
     // Invalidate the in-process web-channel session BEFORE the
     // turn-state cleanup. The snapshot deletion is fallible and
     // returns early on error; if invalidation ran after, an active
@@ -578,7 +612,7 @@ pub async fn threads_purge(
     _request: EmptyRequest,
 ) -> Result<RpcOutcome<ApiEnvelope<PurgeConversationThreadsResponse>>, String> {
     let dir = workspace_dir().await?;
-    let stats = conversations::purge_threads(dir.clone())?;
+    let stats = conversations::blocking::purge_threads(dir.clone()).await?;
     // No parent thread survives a purge, so cancel every detached sub-agent and
     // wipe every queued result. Same ordering as `thread_delete`: abort the
     // in-flight runs first, then clear the delivery queue. Tombstone each

--- a/src/openhuman/threads/ops.rs
+++ b/src/openhuman/threads/ops.rs
@@ -1,5 +1,6 @@
 //! RPC operations for conversation thread management.
 
+use crate::core::runtime::context::CoreContext;
 use crate::openhuman::config::Config;
 use crate::openhuman::inference::provider;
 use crate::openhuman::memory::{
@@ -76,6 +77,49 @@ async fn workspace_dir() -> Result<PathBuf, String> {
         .await
         .map(|c| c.workspace_dir)
         .map_err(|e| format!("load config: {e}"))
+}
+
+/// Run a destructive sequence to completion even if the caller's future is
+/// dropped (client disconnect, RPC timeout).
+///
+/// Moving the store onto the blocking pool (#5156) introduced a cancellation
+/// point that did not exist before. `spawn_blocking` work is never cancelled
+/// when its `JoinHandle` is dropped, so the store mutation lands regardless —
+/// but the `.await` on that handle *is* a yield point, and previously the
+/// synchronous store call had none. Dropping the handler there leaves the thread
+/// deleted while the cleanup that follows it never runs: the web-channel session
+/// stays live and can append to a thread index row that no longer exists,
+/// detached sub-agents keep running and queueing completions, and the turn
+/// snapshot survives to resurface as `Interrupted` for a thread that is gone.
+/// Those are precisely the invariants `thread_delete`'s ordering comments exist
+/// to hold.
+///
+/// Owning the mutation *and* its cleanup in one spawned task decouples the
+/// sequence from the caller's lifetime. The ambient [`CoreContext`] is carried
+/// across explicitly: a bare `tokio::spawn` drops the `task_local` scope, and
+/// `CoreContext::current` then silently falls back to the process default —
+/// which under multi-tenant scoped dispatch is the wrong workspace.
+async fn run_to_completion<T, F>(operation: &'static str, fut: F) -> Result<T, String>
+where
+    F: std::future::Future<Output = Result<T, String>> + Send + 'static,
+    T: Send + 'static,
+{
+    let ctx = CoreContext::current();
+    tokio::spawn(async move {
+        match ctx {
+            Some(ctx) => CoreContext::scope(ctx, fut).await,
+            None => fut.await,
+        }
+    })
+    .await
+    .unwrap_or_else(|error| {
+        tracing::warn!(
+            operation,
+            error = %error,
+            "[threads] destructive task failed to join"
+        );
+        Err(format!("{operation} task failed: {error}"))
+    })
 }
 
 fn thread_to_summary(thread: ConversationThread) -> ConversationThreadSummary {
@@ -552,10 +596,22 @@ pub async fn message_update(
 }
 
 /// Deletes a conversation thread and its message log.
+///
+/// The store mutation and every cleanup step it implies run inside one
+/// [`run_to_completion`] task, so a caller that disconnects mid-delete cannot
+/// leave the thread gone from the store with its sessions, sub-agents and turn
+/// snapshot still live.
 pub async fn thread_delete(
     request: DeleteConversationThreadRequest,
 ) -> Result<RpcOutcome<ApiEnvelope<DeleteConversationThreadResponse>>, String> {
     let dir = workspace_dir().await?;
+    run_to_completion("thread_delete", thread_delete_inner(dir, request)).await
+}
+
+async fn thread_delete_inner(
+    dir: PathBuf,
+    request: DeleteConversationThreadRequest,
+) -> Result<RpcOutcome<ApiEnvelope<DeleteConversationThreadResponse>>, String> {
     let deleted = conversations::blocking::delete_thread(
         dir.clone(),
         request.thread_id.clone(),
@@ -608,10 +664,20 @@ pub async fn thread_delete(
 }
 
 /// Purges all conversation threads and messages.
+///
+/// Same cancellation contract as [`thread_delete`]: the purge and its sub-agent
+/// / turn-snapshot cleanup are one [`run_to_completion`] unit, so a dropped
+/// caller cannot leave every thread wiped while their sub-agents keep running.
 pub async fn threads_purge(
     _request: EmptyRequest,
 ) -> Result<RpcOutcome<ApiEnvelope<PurgeConversationThreadsResponse>>, String> {
     let dir = workspace_dir().await?;
+    run_to_completion("threads_purge", threads_purge_inner(dir)).await
+}
+
+async fn threads_purge_inner(
+    dir: PathBuf,
+) -> Result<RpcOutcome<ApiEnvelope<PurgeConversationThreadsResponse>>, String> {
     let stats = conversations::blocking::purge_threads(dir.clone()).await?;
     // No parent thread survives a purge, so cancel every detached sub-agent and
     // wipe every queued result. Same ordering as `thread_delete`: abort the

--- a/src/openhuman/threads/ops_tests.rs
+++ b/src/openhuman/threads/ops_tests.rs
@@ -705,3 +705,56 @@ async fn thread_update_title_returns_error_for_missing_thread() {
         "error must describe the update-title failure, got: {err}"
     );
 }
+
+/// Review follow-up on #5282: moving the conversation store onto the blocking
+/// pool put an `.await` between a destructive store mutation and the cleanup
+/// that has to follow it (web-session invalidation, sub-agent cancellation,
+/// turn-snapshot deletion).
+///
+/// `spawn_blocking` work is never cancelled by dropping its `JoinHandle`, so a
+/// caller that goes away in that window — client disconnect, RPC timeout —
+/// used to leave the thread deleted from the store while every one of those
+/// cleanup steps was skipped. `run_to_completion` owns the mutation *and* the
+/// cleanup in one spawned task, so the tail runs regardless of the caller.
+#[tokio::test]
+async fn run_to_completion_runs_the_tail_after_the_caller_is_dropped() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    let tail_ran = Arc::new(AtomicBool::new(false));
+    let flag = Arc::clone(&tail_ran);
+    let (release, parked) = tokio::sync::oneshot::channel::<()>();
+
+    let mut call = Box::pin(run_to_completion("test_destructive_op", async move {
+        // Stands in for the blocking store mutation still in progress.
+        let _ = parked.await;
+        // Stands in for the cleanup that must never be skipped.
+        flag.store(true, Ordering::SeqCst);
+        Ok::<(), String>(())
+    }));
+
+    // Poll once so the inner task is spawned, then abandon the caller — exactly
+    // what dropping the RPC future does.
+    tokio::select! {
+        biased;
+        _ = &mut call => panic!("the inner task should still be parked"),
+        _ = tokio::task::yield_now() => {}
+    }
+    drop(call);
+
+    assert!(
+        !tail_ran.load(Ordering::SeqCst),
+        "the tail must not have run before the mutation completed"
+    );
+
+    // The store mutation finishes after the caller is already gone.
+    release.send(()).expect("release the parked task");
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        while !tail_ran.load(Ordering::SeqCst) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("cleanup must still run after the caller's future was dropped");
+}

--- a/src/openhuman/web_chat/run_task.rs
+++ b/src/openhuman/web_chat/run_task.rs
@@ -182,10 +182,15 @@ pub(crate) async fn run_chat_task(
                  from conversation-log prose",
                 thread_id
             );
-            match crate::openhuman::memory_conversations::get_messages(
+            // Blocking pool: the store takes a process-global mutex and reads
+            // the thread's whole JSONL under it, so doing this inline parked an
+            // async worker on the chat hot path (#5156).
+            match crate::openhuman::memory_conversations::blocking::get_messages(
                 config.workspace_dir.clone(),
-                thread_id,
-            ) {
+                thread_id.to_string(),
+            )
+            .await
+            {
                 Ok(prior_messages) if !prior_messages.is_empty() => {
                     let pairs: Vec<(String, String)> = prior_messages
                         .into_iter()


### PR DESCRIPTION
## Summary

- `threads_create_new` no longer waits behind a starved runtime: every conversation-store call on a request path now runs on tokio's blocking pool (`memory_conversations::blocking::*`) instead of parking an async worker thread on the store's process-global mutex.
- Same treatment for the two other hot paths that hold that mutex — the chat resume read in `web_chat::run_task` and the per-turn cross-thread search in `agent_memory::memory_loader`, whose cold index reads every transcript in the workspace.
- A failed thread create is now recorded once, centrally (`thread.createThreadError`), so it can no longer escape as an unhandled promise rejection **or** vanish silently.
- The chat error strip renders it through the existing `create_thread_failed` code and copy, so the shell's "New chat" / Home actions stop being dead buttons on failure.
- `threads/README.md` documents the rule (and its one deliberate exception) so the sync entry points don't creep back into request paths.

## Problem

Sentry TAURI-REACT-10 (#5156), 18 events / 3 users, `openhuman@0.61.8`:

```
UnhandledRejection: Non-Error promise rejection captured with value:
Core RPC openhuman.threads_create_new timed out after 30000ms
```

Two independent defects meet here.

### 1. The create was not slow — the executor was starved

Every `tinycortex::memory::conversations` entry point is **synchronous**. Each one takes a process-global `parking_lot::Mutex` and then does fsync'd JSONL file IO while holding it:

- `thread_index_unlocked` folds the whole of `threads.jsonl` on nearly every operation, and that file gains **~2 lines per appended message** and is never compacted — so the per-call cost grows with the user's entire history;
- `append_message` performs two fsync'd appends under the lock, and `update_message` reads and rewrites a thread's whole message log under it, so a live streaming turn takes the lock over and over;
- `search_cross_thread_messages` reads every thread's transcript on a cold index.

`threads/ops.rs` called those entry points **inline from its `async fn` handlers**. `parking_lot::Mutex::lock()` is a blocking lock, so each call parks a tokio *worker* thread for the whole wait — and so did `web_chat::run_task` and the per-turn memory loader. Once more conversation operations are queued than there are worker threads, the runtime stops polling **anything**, including the HTTP task that owes the client its response.

So a create that needs one append can blow a 30 s budget while doing nothing: it is waiting for a worker to be free to poll it. That also explains the shape of the report — rare (3 users), and concentrated on users with enough history to make each fold expensive.

### 2. The failure had nowhere to go

Nothing in the store observed `createNewThread.rejected`. Handling was therefore per-call-site, and the two shell entry points diverged in opposite failure modes:

- `useHomeNav` did `.catch(() => {})` — Home did nothing, said nothing;
- any site that forgot a `.catch` leaked the rejection.

And `.unwrap()` throws the `rejectWithValue` payload — a bare **string**, not an `Error` — which is exactly why Sentry recorded a "Non-Error promise rejection" with no app frames. The same class was fixed once before for `threads_list` (`formatThreadLoadError`, OPENHUMAN-REACT-X); this is that fix's missing sibling.

## Solution

### Core: `memory_conversations::blocking`

A thin module of `spawn_blocking` wrappers (`ensure_thread`, `list_threads`, `get_messages`, `append_message`, `update_message`, `update_thread_title`, `update_thread_labels`, `delete_thread`, `purge_threads`, `search_cross_thread_messages`). All 15 store calls in `threads/ops.rs` plus the two other async hot paths go through them.

The store is **exactly as serialized as before** — its lock still decides who writes when. What changes is where the wait happens: on the blocking pool instead of on a scarce async worker. The executor stays live, so the RPC server keeps answering while a slow conversation operation drains, and a queued create completes as soon as the lock frees rather than after the client has given up. A `JoinError` is surfaced as a store error, so a pool panic can't reach the dispatcher as an unknown failure.

`welcome_migration.rs` deliberately stays synchronous: it is a one-shot, marker-guarded boot migration, not a request path.

### Frontend: one recorded outcome per create

`threadSlice` gains `createThreadError`, set on `createNewThread.rejected` and cleared on `pending` / `fulfilled` / explicit dismissal. `formatThreadCreateError` normalises every throw shape (`rejectWithValue` string, `Error`, `SerializedError`) — including the nested `loadThreads().unwrap()` failure inside the thunk, which the old `error instanceof Error` check flattened into a generic message. `Conversations` renders it via the exported `deriveChatErrorBanner` (send error wins; create failure otherwise), and both shell hooks log a normalised message instead of swallowing.

## Impact

- **Desktop / core (Rust) + renderer.** No RPC signature, schema, or storage-format change; no migration.
- **Behaviour:** slow conversation operations no longer stall unrelated RPCs; a failed thread create shows a message above the composer instead of doing nothing or raising an unhandled rejection.
- **Not changed on purpose:** the 30 s client budget stays as-is — raising it would hide latency rather than fix it.
- **Known follow-up:** `threads.jsonl`'s unbounded growth and per-call refold is the underlying latency driver, but it lives in the vendored `tinycortex` submodule; fixing it needs its own PR there plus a submodule bump. This PR removes the starvation, not the fold.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines are covered by the new Rust (`memory_conversations::blocking`) and Vitest suites listed below; `pnpm typecheck` and the targeted Vitest runs are green locally, Rust compiles in CI
- [x] Coverage matrix updated — `N/A: behaviour-only change` (no feature row added, removed, or renamed)
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix feature IDs affected`
- [x] No new external network dependencies introduced (mock policy unaffected — the new tests use `TempDir` workspaces and the existing `threadApi` mock)
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: does not touch release-cut surfaces`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

Tests:

- `memory_conversations::blocking` — create/append/read round-trip; store errors pass through verbatim (a missing thread still yields the store's own `not found`, so the RPC layer's thread-scoped error mapping keeps working); title/labels/delete/purge round-trip; `update_message` + cross-thread search; and **8 concurrent operations on a `worker_threads = 1` runtime** completing while a purely cooperative task keeps being polled — the starvation shape from the report.
- `threadSlice.createThread.test.ts` — the RPC timeout is recorded in state; `.unwrap()` rejects catchably and normalises back to the original message; the failure clears on retry, on success, and on dismissal; a failure originating in the follow-up `loadThreads` is recorded with its own message; `formatThreadCreateError` covers string / `Error` / `SerializedError` / message-less shapes.
- `Conversations.test.tsx` — `deriveChatErrorBanner` precedence: create failure surfaces with the `create_thread_failed` code, a live send error wins over a stale create failure, neither present renders nothing.

## Related

- Closes: #5156
- Context: OPENHUMAN-REACT-X (`formatThreadLoadError`, the same non-Error rejection class fixed earlier for `threads_list`); tinycortex issue #2849 (the cold-index lock work this builds on)
- Follow-up PR(s)/TODOs: compact / incrementally index `threads.jsonl` in `tinycortex` so the per-operation fold stops scaling with total history

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5156-rpc-threads-create-timeout`
- Commit SHA: `8757eeecf`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — Prettier clean on every touched file
- [x] `pnpm typecheck` — clean
- [x] Focused tests: `threadSlice.createThread.test.ts` (8), `pages/__tests__/Conversations.test.tsx` (15), `src/components/layout/shell` + `store/__tests__/threadSlice.test.ts` (92), `src/features/conversations` (301) — all passing
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; compilation + the new `blocking` suite run in CI
- [x] Tauri fmt/check (if changed): N/A — no `app/src-tauri` change

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: conversation-store work no longer blocks the async runtime, and a failed thread create is recorded and displayed instead of being dropped or leaked as an unhandled rejection.
- User-visible effect: "New chat" / Home no longer fail silently — the chat view shows "Couldn't create a new thread. Please try again."; unrelated RPCs stay responsive while a slow conversation operation drains.

### Parity Contract

- Legacy behavior preserved: identical store semantics and serialization (same lock, same order, same errors verbatim); RPC signatures, schemas, and the JSONL format are untouched; `welcome_migration` intentionally keeps its synchronous boot-time path.
- Guard/fallback/dispatch parity checks: `ThreadsError::from_thread_scoped_store_error` still receives the store's own error text (pinned by a test); the create-failure banner reuses the existing `create_thread_failed` code and copy rather than introducing a new surface.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clear, actionable chat error banners when starting a new chat fails, with consistent dismissal/clearing behavior.
* **Bug Fixes**
  * Improved responsiveness for conversation and cross-chat search by preventing storage work from blocking chat processing.
  * Reduced risk of RPC timeouts during thread/message operations and improved resilience to overlapping thread creation attempts.
* **Tests**
  * Expanded coverage for chat error banner precedence and create-failure formatting, concurrent create overlap handling, and destructive-operation lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->