### PR TITLE
fix(channels): stop a missing edit route from looking like a deleted message (#5230)

### DIFF
--- a/docs/TEST-COVERAGE-MATRIX.md
+++ b/docs/TEST-COVERAGE-MATRIX.md
@@ -442,6 +442,7 @@ End-to-end coverage of the agent harness via the web-chat RPC surface against an
 | 10.4.2 | Reply to Thread       | WD    | `gmail-flow.spec.ts`                          | ✅     |                                       |
 | 10.4.3 | Initiate Conversation | WD    | `gmail-flow.spec.ts`                          | 🟡     | Telegram/WhatsApp/Slack not exercised |
 | 10.4.4 | Attachment Handling   | WD    | `gmail-flow.spec.ts`                          | 🟡     | Attachment branch shallow             |
+| 10.4.5 | Outbound Message Edit | RU    | `src/api/rest_tests.rs`, `src/openhuman/channels/bus_tests.rs` | 🟡     | #5230 — drives the progressive draft + ephemeral "💭 Thinking:" bubble. RU covers 404 classification (route absence vs deleted message), the message-id retention invariant each recovery depends on, and the per-provider capability latch. The backend implements no `PATCH /channels/:channel/messages/:messageId`, so edits degrade (post-once + replace) instead of updating in place; live-edit coverage needs that route first — separate `tinyhumansai/backend` PR. |
 
 ### 10.5 Cross-Channel Behavior
 

--- a/src/api/rest.rs
+++ b/src/api/rest.rs
@@ -110,6 +110,33 @@ pub fn flatten_authed_error(err: anyhow::Error) -> String {
     }
 }
 
+/// Whether a 404 body came from *no route matching* rather than from a handler
+/// reporting a missing resource.
+///
+/// The backend registers no catch-all 404, so an unmatched route falls through
+/// to Express's built-in `finalhandler`, which answers with an HTML page whose
+/// body reads `Cannot PATCH /channels/…`. Every handler-level 404 answers with a
+/// JSON envelope instead — `DELETE /channels/:channel/messages/:messageId`
+/// already returns `{"success": false, "error": …}`, and a future `PATCH`
+/// handler would mirror it.
+///
+/// So: parses as JSON ⇒ a handler answered ⇒ the message is missing, not the
+/// route. Anything else (HTML, plain text, empty) ⇒ treat as route absence.
+///
+/// The asymmetry is deliberate. Misreading route absence as message absence only
+/// costs one wasted edit attempt per message; misreading a message-missing 404 as
+/// route absence disables progressive edits for the entire provider for the rest
+/// of the process (#5230 review). Defaulting the ambiguous shapes to route
+/// absence also preserves today's behaviour, where no backend implements the
+/// route at all.
+fn is_unmatched_route_404(body: &str) -> bool {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+    serde_json::from_str::<Value>(trimmed).is_err()
+}
+
 /// Extract `(provider, message_id)` from a backend channel path of the
 /// shape `…/channels/<provider>/messages/<id>`. Returns `None` for paths
 /// that do not contain this four-segment subsequence.
@@ -653,16 +680,25 @@ impl BackendOAuthClient {
             // `report_error`. Targets `OPENHUMAN-TAURI-2Y` (~454 events).
             if status_code == 404 {
                 let channel_message = parse_message_path(url.path());
-                // A 404 on the *edit* route is route absence, never message
-                // absence — the backend implements no `PATCH
+                // A 404 on the *edit* route is normally route absence, not
+                // message absence — today the backend implements no `PATCH
                 // /channels/:channel/messages/:messageId` at all (#5230). Answer
                 // with a distinct typed error so `bus.rs` keeps the message id
                 // (it still owns that message and must be able to delete it)
                 // and only disables the edit capability. Checked before the
                 // `MessageNotFound` arm below, which would otherwise swallow it.
+                //
+                // `is_unmatched_route_404` is what keeps this honest once the
+                // route *does* exist (staging, a custom backend, or after the
+                // backend PR lands): a handler-level "that message is gone" 404
+                // must stay a per-message `MessageNotFound`, because
+                // `ChannelEditUnsupported` makes `bus.rs` call
+                // `mark_channel_edits_unsupported` and disable progressive edits
+                // for the whole provider for the rest of the process.
                 if method == Method::PATCH
                     && (channel_message.is_some()
                         || (url.path().contains("/channels/") && url.path().contains("/messages/")))
+                    && is_unmatched_route_404(&text)
                 {
                     let (provider, message_id) = channel_message
                         .map(|(provider, id)| (provider.to_string(), id.to_string()))

--- a/src/api/rest.rs
+++ b/src/api/rest.rs
@@ -39,6 +39,37 @@ pub enum BackendApiError {
         /// Request path the 401 came back from (no query string).
         path: String,
     },
+    /// `PATCH /channels/<provider>/messages/<id>` returned 404 because the
+    /// backend **implements no such route** — not because the message is gone.
+    ///
+    /// The backend's channel router serves `POST /:channel/messages` and
+    /// `DELETE /:channel/messages/:messageId` only; the `PATCH` edit route was
+    /// never added (the deployed OpenAPI contract has no entry for it, and it
+    /// is absent from the SDK's generated public-route registry). Every edit
+    /// therefore hits the unmatched-route 404, and always has (#5230).
+    ///
+    /// This must stay distinct from [`Self::MessageNotFound`]: that variant
+    /// means "this specific message no longer exists", so its handlers
+    /// correctly forget the message id. A missing *route* says nothing about
+    /// the message — it is still there and we still own it, so callers must
+    /// keep the id (to delete or finally edit it) and only disable the edit
+    /// capability. Collapsing the two made the live "💭 Thinking:" bubble and
+    /// the streaming draft leak into the chat un-updated and un-deleted.
+    ///
+    /// Note the backend's `DELETE` handler answers only 400/403/502 and never
+    /// 404, so on the deployed contract a 404 on this path can *only* mean
+    /// route absence today. `MessageNotFound` is retained for `DELETE` because
+    /// the provider-side-deletion semantics are what its callers want and a
+    /// future backend revision may start returning it.
+    #[error(
+        "channel message edit route not implemented by backend ({provider}, message {message_id})"
+    )]
+    ChannelEditUnsupported {
+        /// Channel provider segment (e.g. `"telegram"`, `"discord"`).
+        provider: String,
+        /// Provider-specific message id from the URL.
+        message_id: String,
+    },
     /// `GET /announcements/latest` returned 404. The announcements feature is
     /// a best-effort, cosmetic fetch (`app/src/services/announcementService.ts`:
     /// "a missing announcement is never worth surfacing an error for") — a 404
@@ -621,7 +652,41 @@ impl BackendOAuthClient {
             // ids and skip retry, without funneling the 404 into
             // `report_error`. Targets `OPENHUMAN-TAURI-2Y` (~454 events).
             if status_code == 404 {
-                if let Some((provider, message_id)) = parse_message_path(url.path()) {
+                let channel_message = parse_message_path(url.path());
+                // A 404 on the *edit* route is route absence, never message
+                // absence — the backend implements no `PATCH
+                // /channels/:channel/messages/:messageId` at all (#5230). Answer
+                // with a distinct typed error so `bus.rs` keeps the message id
+                // (it still owns that message and must be able to delete it)
+                // and only disables the edit capability. Checked before the
+                // `MessageNotFound` arm below, which would otherwise swallow it.
+                if method == Method::PATCH
+                    && (channel_message.is_some()
+                        || (url.path().contains("/channels/") && url.path().contains("/messages/")))
+                {
+                    let (provider, message_id) = channel_message
+                        .map(|(provider, id)| (provider.to_string(), id.to_string()))
+                        .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string()));
+                    tracing::warn!(
+                        domain = "backend_api",
+                        operation = "authed_json",
+                        provider = provider,
+                        message_id = message_id,
+                        "[backend_api] channel-message edit 404 on {} {} — backend implements no \
+                         edit route; surfacing ChannelEditUnsupported so callers degrade instead \
+                         of forgetting the message id (#5230)",
+                        method.as_str(),
+                        url.path(),
+                    );
+                    return Err(anyhow::Error::new(
+                        BackendApiError::ChannelEditUnsupported {
+                            provider,
+                            message_id,
+                        },
+                    ));
+                }
+
+                if let Some((provider, message_id)) = channel_message {
                     tracing::info!(
                         domain = "backend_api",
                         operation = "authed_json",
@@ -636,11 +701,13 @@ impl BackendOAuthClient {
                         message_id: message_id.to_string(),
                     }));
                 }
-                // Defense-in-depth: PATCH/DELETE 404s on any channel-message path that
+                // Defense-in-depth: DELETE 404s on any channel-message path that
                 // parse_message_path could not parse (e.g. exotic URL variant with extra
                 // segments). Still an expected backend state — suppress the Sentry event
                 // without propagating a typed error. Targets OPENHUMAN-TAURI-R7.
-                if (method == Method::PATCH || method == Method::DELETE)
+                // PATCH is handled above and returns the typed
+                // `ChannelEditUnsupported` for both the parsed and unparsed shapes.
+                if method == Method::DELETE
                     && url.path().contains("/channels/")
                     && url.path().contains("/messages/")
                 {
@@ -871,6 +938,14 @@ impl BackendOAuthClient {
     /// updated message record, or an `Err` if the backend does not
     /// support editing for this channel (caller should fall back to
     /// atomic-final delivery).
+    ///
+    /// **The deployed backend does not implement this route yet** (#5230): its
+    /// channel router has `POST /:channel/messages` and `DELETE
+    /// /:channel/messages/:messageId` only, so every call currently returns the
+    /// unmatched-route 404, which [`authed_json`](Self::authed_json) surfaces as
+    /// [`BackendApiError::ChannelEditUnsupported`]. Callers must degrade rather
+    /// than treat that as the message having been deleted. Keep this method: it
+    /// starts working unchanged the moment the backend adds the route.
     pub async fn send_channel_edit(
         &self,
         channel: &str,

--- a/src/api/rest_tests.rs
+++ b/src/api/rest_tests.rs
@@ -1,7 +1,7 @@
 use super::{
     backend_api_body_shape, flatten_authed_error, is_announcements_latest_path,
-    key_bytes_from_string, parse_message_path, sanitize_client_version, BackendApiError,
-    BackendOAuthClient, BACKEND_API_BODY_SHAPE_MAX_BYTES,
+    is_unmatched_route_404, key_bytes_from_string, parse_message_path, sanitize_client_version,
+    BackendApiError, BackendOAuthClient, BACKEND_API_BODY_SHAPE_MAX_BYTES,
 };
 use axum::extract::State;
 use axum::http::HeaderMap;
@@ -985,6 +985,50 @@ async fn send_channel_edit_404_is_route_absence_not_a_missing_message() {
 }
 
 #[tokio::test]
+async fn channel_edit_404_from_a_real_handler_stays_a_missing_message() {
+    // #5230 review: the twin of the test above, for the world where the edit
+    // route DOES exist (staging, a custom backend, or after the backend PR
+    // lands). A handler answering "that message is gone" returns a JSON
+    // envelope, exactly as `DELETE /channels/:channel/messages/:messageId`
+    // already does. Classifying that as `ChannelEditUnsupported` would make
+    // `bus.rs` call `mark_channel_edits_unsupported` and switch progressive
+    // edits off for the whole provider for the rest of the process — because
+    // one message expired.
+    let app = Router::new().route(
+        "/channels/telegram/messages/1103",
+        axum::routing::patch(|| async {
+            (
+                axum::http::StatusCode::NOT_FOUND,
+                "{\"success\":false,\"error\":\"message not found\"}",
+            )
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let client = BackendOAuthClient::new(&format!("http://{addr}")).unwrap();
+    let err = client
+        .send_channel_edit("telegram", "1103", "mock-jwt", serde_json::json!({}))
+        .await
+        .unwrap_err();
+
+    let typed = err
+        .downcast_ref::<BackendApiError>()
+        .expect("edit 404 must carry a typed BackendApiError");
+    assert!(
+        matches!(typed, BackendApiError::MessageNotFound { .. }),
+        "a handler-level edit 404 must stay per-message, got {typed:?}"
+    );
+    assert!(
+        !matches!(typed, BackendApiError::ChannelEditUnsupported { .. }),
+        "one missing message must not disable edits for the whole provider"
+    );
+}
+
+#[tokio::test]
 async fn channel_edit_404_on_unparseable_path_is_still_route_absence() {
     // Defense-in-depth twin of the test above: a channel-message path
     // `parse_message_path` cannot decompose (extra segments) must still be
@@ -1148,4 +1192,39 @@ async fn sdk_backed_calls_send_the_core_version_header() {
         seen.lock().unwrap().as_deref(),
         Some(env!("CARGO_PKG_VERSION"))
     );
+}
+
+// ── is_unmatched_route_404 (#5230 review) ──────────────────────────────────
+//
+// A PATCH 404 becomes `ChannelEditUnsupported`, which disables progressive edits
+// for the whole provider for the rest of the process. That is only correct when
+// the *route* is absent. Once the backend implements the route, a handler-level
+// "that message is gone" 404 has to stay a per-message `MessageNotFound`, or one
+// deleted message would switch edits off for everyone.
+
+#[test]
+fn unmatched_route_404_is_expresss_html_page() {
+    // Express's built-in finalhandler — what the backend returns today, since it
+    // registers no catch-all 404 and implements no PATCH route.
+    assert!(is_unmatched_route_404(
+        "<!DOCTYPE html>\n<html lang=\"en\">\n<head>\n<title>Error</title>\n</head>\n<body>\n         <pre>Cannot PATCH /channels/telegram/messages/1103</pre>\n</body>\n</html>"
+    ));
+}
+
+#[test]
+fn unmatched_route_404_covers_empty_and_plain_text_bodies() {
+    // Ambiguous shapes default to route absence, preserving today's behaviour.
+    assert!(is_unmatched_route_404(""));
+    assert!(is_unmatched_route_404("   "));
+    assert!(is_unmatched_route_404("Not Found"));
+}
+
+#[test]
+fn handler_level_404_json_envelope_is_not_route_absence() {
+    // The shape `DELETE /channels/:channel/messages/:messageId` already returns,
+    // and the one a future PATCH handler would mirror.
+    assert!(!is_unmatched_route_404(
+        r#"{"success": false, "error": "message not found"}"#
+    ));
+    assert!(!is_unmatched_route_404(r#"{"error":"gone"}"#));
 }

--- a/src/api/rest_tests.rs
+++ b/src/api/rest_tests.rs
@@ -894,15 +894,18 @@ fn is_announcements_latest_path_rejects_other_paths() {
 #[tokio::test]
 async fn authed_json_patch_404_with_base_path_prefix_does_not_report() {
     // Regression for TAURI-R7: if the resolved URL has a base-path prefix,
-    // authed_json must still suppress the 404 (either via parse_message_path
-    // sliding-window match → MessageNotFound, or via the defense-in-depth
-    // inline check) — NOT call report_error.
+    // authed_json must still suppress the 404 — NOT call report_error.
     //
     // Since BackendOAuthClient strips the base path in `new()`, the path
     // passed to authed_json is always joined against the stripped base. We
-    // verify that a PATCH 404 returns an error without panicking and that
-    // it is NOT classified as a code bug (no BackendApiError::MessageNotFound
-    // wrapping for the generic bail! path, but no Sentry event either).
+    // verify that a PATCH 404 returns an error without panicking and that it
+    // is not classified as a code bug (no Sentry event).
+    //
+    // #5230: the classification is `ChannelEditUnsupported`, NOT
+    // `MessageNotFound`. The backend implements no `PATCH
+    // /channels/:channel/messages/:messageId`, so this 404 is route absence.
+    // Reporting it as a missing *message* made `bus.rs` forget a message id it
+    // still owned, orphaning the streaming draft and the "💭 Thinking:" bubble.
     let app = axum::Router::new().route(
         "/channels/telegram/messages/9999",
         axum::routing::any(|| async { (axum::http::StatusCode::NOT_FOUND, "Not Found") }),
@@ -916,7 +919,6 @@ async fn authed_json_patch_404_with_base_path_prefix_does_not_report() {
     let base_url = format!("http://{addr}");
     let client = BackendOAuthClient::new(&base_url).unwrap();
 
-    // Standard path — must be classified as MessageNotFound (sliding-window parse).
     let err = client
         .authed_json(
             "mock-jwt",
@@ -927,15 +929,123 @@ async fn authed_json_patch_404_with_base_path_prefix_does_not_report() {
         .await
         .unwrap_err();
     let typed = err.downcast_ref::<BackendApiError>().unwrap();
-    let BackendApiError::MessageNotFound {
+    let BackendApiError::ChannelEditUnsupported {
         provider,
         message_id,
     } = typed
     else {
-        panic!("expected MessageNotFound, got {typed:?}");
+        panic!("expected ChannelEditUnsupported, got {typed:?}");
     };
     assert_eq!(provider, "telegram");
     assert_eq!(message_id, "9999");
+}
+
+#[tokio::test]
+async fn send_channel_edit_404_is_route_absence_not_a_missing_message() {
+    // #5230 root-cause pin, driven through the real client method rather than
+    // `authed_json` directly: the deployed backend serves only
+    // `POST /channels/:channel/messages` and
+    // `DELETE /channels/:channel/messages/:messageId`, so every edit hits the
+    // unmatched-route 404. It must NOT surface as `MessageNotFound` — that
+    // variant means "this message is gone", and acting on it discards a
+    // message id that is still live.
+    // POST + DELETE only — deliberately mirrors the real backend router. The
+    // explicit `fallback` reproduces Express's behaviour for an unmatched
+    // method+path pair: it falls through to the app's 404 handler rather than
+    // answering 405 (which is what axum would do on its own).
+    let app = Router::new().route(
+        "/channels/telegram/messages/1103",
+        post(|| async { (axum::http::StatusCode::OK, "{\"success\":true}") })
+            .delete(|| async { (axum::http::StatusCode::OK, "{\"success\":true}") })
+            .fallback(|| async { (axum::http::StatusCode::NOT_FOUND, "Not Found") }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let client = BackendOAuthClient::new(&format!("http://{addr}")).unwrap();
+    let err = client
+        .send_channel_edit("telegram", "1103", "mock-jwt", serde_json::json!({}))
+        .await
+        .unwrap_err();
+
+    let typed = err
+        .downcast_ref::<BackendApiError>()
+        .expect("edit 404 must carry a typed BackendApiError");
+    assert!(
+        matches!(typed, BackendApiError::ChannelEditUnsupported { .. }),
+        "edit 404 must be ChannelEditUnsupported, got {typed:?}"
+    );
+    assert!(
+        !matches!(typed, BackendApiError::MessageNotFound { .. }),
+        "a missing edit route must never masquerade as a deleted message"
+    );
+}
+
+#[tokio::test]
+async fn channel_edit_404_on_unparseable_path_is_still_route_absence() {
+    // Defense-in-depth twin of the test above: a channel-message path
+    // `parse_message_path` cannot decompose (extra segments) must still be
+    // classified as route absence for PATCH, not fall through to the generic
+    // untyped bail! that the DELETE branch uses.
+    let app = axum::Router::new().route(
+        "/api/v1/channels/telegram/messages/9999/extra",
+        axum::routing::any(|| async { (axum::http::StatusCode::NOT_FOUND, "Not Found") }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let client = BackendOAuthClient::new(&format!("http://{addr}")).unwrap();
+    let err = client
+        .authed_json(
+            "mock-jwt",
+            Method::PATCH,
+            "/api/v1/channels/telegram/messages/9999/extra",
+            None,
+        )
+        .await
+        .unwrap_err();
+
+    let typed = err
+        .downcast_ref::<BackendApiError>()
+        .expect("unparseable edit path must still carry a typed error");
+    assert!(
+        matches!(typed, BackendApiError::ChannelEditUnsupported { .. }),
+        "expected ChannelEditUnsupported, got {typed:?}"
+    );
+}
+
+#[tokio::test]
+async fn channel_delete_404_still_means_the_message_is_gone() {
+    // The fix must not widen: `DELETE` keeps `MessageNotFound`, whose
+    // provider-side-deletion semantics are exactly what its caller
+    // (`delete_channel_message`) wants — "already gone, nothing to clean up".
+    let app = Router::new().route(
+        "/channels/telegram/messages/1103",
+        axum::routing::delete(|| async { (axum::http::StatusCode::NOT_FOUND, "Not Found") }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let client = BackendOAuthClient::new(&format!("http://{addr}")).unwrap();
+    let err = client
+        .send_channel_delete("telegram", "1103", "mock-jwt")
+        .await
+        .unwrap_err();
+
+    let typed = err.downcast_ref::<BackendApiError>().unwrap();
+    assert!(
+        matches!(typed, BackendApiError::MessageNotFound { .. }),
+        "DELETE 404 must stay MessageNotFound, got {typed:?}"
+    );
 }
 
 // The channel methods below now reach the backend through the vendored

--- a/src/api/rest_tests.rs
+++ b/src/api/rest_tests.rs
@@ -1029,11 +1029,12 @@ async fn channel_edit_404_from_a_real_handler_stays_a_missing_message() {
 }
 
 #[tokio::test]
-async fn channel_edit_404_on_unparseable_path_is_still_route_absence() {
-    // Defense-in-depth twin of the test above: a channel-message path
-    // `parse_message_path` cannot decompose (extra segments) must still be
-    // classified as route absence for PATCH, not fall through to the generic
-    // untyped bail! that the DELETE branch uses.
+async fn channel_edit_404_on_a_prefixed_path_keeps_the_parsed_ids() {
+    // A `BACKEND_URL` with a base-path prefix plus a trailing segment. The
+    // sliding window in `parse_message_path` still finds
+    // `[channels, telegram, messages, 9999]`, so this must be classified as
+    // route absence for PATCH *and* carry the parsed ids — not fall through to
+    // the generic untyped bail! that the DELETE branch uses.
     let app = axum::Router::new().route(
         "/api/v1/channels/telegram/messages/9999/extra",
         axum::routing::any(|| async { (axum::http::StatusCode::NOT_FOUND, "Not Found") }),
@@ -1057,11 +1058,61 @@ async fn channel_edit_404_on_unparseable_path_is_still_route_absence() {
 
     let typed = err
         .downcast_ref::<BackendApiError>()
-        .expect("unparseable edit path must still carry a typed error");
-    assert!(
-        matches!(typed, BackendApiError::ChannelEditUnsupported { .. }),
-        "expected ChannelEditUnsupported, got {typed:?}"
+        .expect("prefixed edit path must still carry a typed error");
+    match typed {
+        BackendApiError::ChannelEditUnsupported {
+            provider,
+            message_id,
+        } => {
+            assert_eq!(provider, "telegram");
+            assert_eq!(message_id, "9999");
+        }
+        other => panic!("expected ChannelEditUnsupported, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn channel_edit_404_on_an_undecomposable_path_falls_back_to_unknown_ids() {
+    // The case that actually exercises `authed_json`'s
+    // `unwrap_or_else(("unknown", "unknown"))`: an empty message-id segment.
+    // `parse_message_path` drops empty segments, so this yields only
+    // `[channels, telegram, messages]` — no 4-window, hence `None` — while the
+    // path still satisfies the `/channels/` + `/messages/` substring guard, so
+    // the PATCH branch is entered with nothing parsed.
+    let app = axum::Router::new().route(
+        "/channels/telegram/messages/",
+        axum::routing::any(|| async { (axum::http::StatusCode::NOT_FOUND, "Not Found") }),
     );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let client = BackendOAuthClient::new(&format!("http://{addr}")).unwrap();
+    let err = client
+        .authed_json(
+            "mock-jwt",
+            Method::PATCH,
+            "/channels/telegram/messages/",
+            None,
+        )
+        .await
+        .unwrap_err();
+
+    let typed = err
+        .downcast_ref::<BackendApiError>()
+        .expect("undecomposable edit path must still carry a typed error");
+    match typed {
+        BackendApiError::ChannelEditUnsupported {
+            provider,
+            message_id,
+        } => {
+            assert_eq!(provider, "unknown");
+            assert_eq!(message_id, "unknown");
+        }
+        other => panic!("expected ChannelEditUnsupported, got {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/src/openhuman/channels/bus.rs
+++ b/src/openhuman/channels/bus.rs
@@ -335,6 +335,83 @@ fn channel_supports_progressive_ui(channel: &str) -> bool {
     matches!(provider, "telegram" | "tg")
 }
 
+/// Why an edit of an already-posted channel message failed.
+///
+/// These three causes need three different recoveries, and conflating the
+/// first two is what broke the live "💭 Thinking:" bubble (#5230).
+#[derive(Debug, PartialEq, Eq)]
+enum EditFailure {
+    /// The backend serves no message-edit route at all, so the edit could
+    /// never have succeeded. The message itself is untouched and we still own
+    /// it: keep its id so it can still be deleted (or finally edited once the
+    /// backend ships the route) and just stop attempting edits.
+    RouteUnsupported,
+    /// The message really is gone on the provider side (user deleted it, or
+    /// the backend GC'd the relay row). The id is worthless — drop it.
+    MessageGone,
+    /// Anything else (transient 5xx, transport error, rate limit). Counts
+    /// against the per-turn failure budget and may be retried.
+    Transient,
+}
+
+/// Classify an edit failure by typed error rather than by message text, so the
+/// recovery a call site picks cannot drift with `#[error(...)]` wording.
+fn classify_edit_failure(err: &anyhow::Error) -> EditFailure {
+    match err.downcast_ref::<crate::api::rest::BackendApiError>() {
+        Some(crate::api::rest::BackendApiError::ChannelEditUnsupported { .. }) => {
+            EditFailure::RouteUnsupported
+        }
+        Some(crate::api::rest::BackendApiError::MessageNotFound { .. }) => EditFailure::MessageGone,
+        _ => EditFailure::Transient,
+    }
+}
+
+/// Providers whose backend answered "no edit route" at least once this
+/// process. Whether the route exists is a property of the deployed backend,
+/// not of a turn, so re-probing it on every turn only buys a guaranteed-404
+/// round-trip per turn forever. Latching it here keeps that to one attempt per
+/// provider per process — and it self-heals on the next core start once the
+/// backend ships the route (#5230).
+static EDIT_UNSUPPORTED_PROVIDERS: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashSet<String>>,
+> = std::sync::OnceLock::new();
+
+/// Provider key for the edit-capability latch. Inbound channels arrive
+/// provider-prefixed (`telegram:<chat>`), and the route's existence is a
+/// per-provider fact, so latch on the prefix — same reasoning as
+/// [`channel_supports_progressive_ui`].
+fn edit_capability_key(channel: &str) -> String {
+    channel.split(':').next().unwrap_or(channel).to_string()
+}
+
+/// `true` once this process has learned the backend serves no edit route for
+/// `channel`'s provider. Callers should skip the request entirely.
+fn channel_edits_unsupported(channel: &str) -> bool {
+    EDIT_UNSUPPORTED_PROVIDERS
+        .get_or_init(Default::default)
+        .lock()
+        .map(|set| set.contains(&edit_capability_key(channel)))
+        .unwrap_or(false)
+}
+
+/// Latch `channel`'s provider as having no message-edit route.
+fn mark_channel_edits_unsupported(channel: &str) {
+    let key = edit_capability_key(channel);
+    if let Ok(mut set) = EDIT_UNSUPPORTED_PROVIDERS
+        .get_or_init(Default::default)
+        .lock()
+    {
+        if set.insert(key.clone()) {
+            tracing::warn!(
+                "[channel-inbound][edit] backend serves no message-edit route for provider='{}' — \
+                 progressive edits disabled for this process; placeholders will be posted once and \
+                 cleaned up by delete instead (#5230)",
+                key,
+            );
+        }
+    }
+}
+
 /// Maximum consecutive filler-send failures before we stop trying.
 /// Same rationale as the thinking/typing latches.
 const MAX_FILLER_FAILURES: u32 = 2;
@@ -465,6 +542,35 @@ async fn send_typing_indicator(channel: &str, state: &mut TypingState) {
 }
 
 impl StreamingState {
+    /// The backend has no edit route: stop attempting edits but **keep**
+    /// `message_id`. The draft is still on the user's screen and we still own
+    /// it, so finalization needs the id to delete it before posting the
+    /// canonical reply. Dropping the id here is what orphaned the draft and
+    /// left a stale "_working…_" bubble (#5230).
+    fn latch_draft_edits_unsupported(&mut self) {
+        self.edit_disabled = true;
+    }
+
+    /// The draft really is gone provider-side: the id is worthless, so forget
+    /// it as well as disabling edits.
+    fn forget_draft(&mut self) {
+        self.message_id = None;
+        self.edit_disabled = true;
+    }
+
+    /// Thinking-bubble counterpart of [`Self::latch_draft_edits_unsupported`].
+    /// Keeping `thinking_message_id` is what lets finalization delete the
+    /// ephemeral "💭 Thinking:" bubble instead of leaving it in the chat (#5230).
+    fn latch_thinking_edits_unsupported(&mut self) {
+        self.thinking_edit_disabled = true;
+    }
+
+    /// Thinking-bubble counterpart of [`Self::forget_draft`].
+    fn forget_thinking(&mut self) {
+        self.thinking_message_id = None;
+        self.thinking_edit_disabled = true;
+    }
+
     fn compose_draft(&self) -> String {
         let trimmed = self.content.trim_end();
         if trimmed.is_empty() {
@@ -496,6 +602,17 @@ async fn flush_streaming_edit(channel: &str, state: &mut StreamingState) {
     };
 
     if let Some(ref message_id) = state.message_id {
+        // Known-missing edit route: skip the guaranteed 404 and let
+        // finalization replace the draft (delete + fresh atomic reply).
+        if channel_edits_unsupported(channel) {
+            tracing::debug!(
+                "[channel-inbound][stream] skipping edit channel='{}' msg_id={} — no edit route on this backend, draft stays as-is until finalize",
+                channel,
+                message_id,
+            );
+            state.latch_draft_edits_unsupported();
+            return;
+        }
         let body = json!({ "text": draft });
         match client
             .send_channel_edit(channel, message_id, &jwt, body)
@@ -511,19 +628,34 @@ async fn flush_streaming_edit(channel: &str, state: &mut StreamingState) {
                 state.edit_failures = 0;
             }
             Err(err) => {
-                state.edit_failures += 1;
-                if let Some(crate::api::rest::BackendApiError::MessageNotFound { .. }) =
-                    err.downcast_ref::<crate::api::rest::BackendApiError>()
-                {
-                    tracing::info!(
-                        "[channel-inbound][stream] edit channel='{}' msg_id={} — message gone provider-side (404), clearing stale id and disabling further edits",
-                        channel,
-                        message_id,
-                    );
-                    state.message_id = None;
-                    state.edit_disabled = true;
-                    return;
+                match classify_edit_failure(&err) {
+                    EditFailure::RouteUnsupported => {
+                        // Keep `message_id`: the draft is still on screen and
+                        // finalization must be able to delete it before posting
+                        // the canonical reply. Clearing it here (as the old
+                        // `MessageNotFound` branch did) orphaned the draft and
+                        // produced a stale "_working…_" bubble (#5230).
+                        tracing::info!(
+                            "[channel-inbound][stream] edit channel='{}' msg_id={} — backend has no edit route, keeping id for finalize cleanup and disabling progressive edits",
+                            channel,
+                            message_id,
+                        );
+                        mark_channel_edits_unsupported(channel);
+                        state.latch_draft_edits_unsupported();
+                        return;
+                    }
+                    EditFailure::MessageGone => {
+                        tracing::info!(
+                            "[channel-inbound][stream] edit channel='{}' msg_id={} — message gone provider-side (404), clearing stale id and disabling further edits",
+                            channel,
+                            message_id,
+                        );
+                        state.forget_draft();
+                        return;
+                    }
+                    EditFailure::Transient => {}
                 }
+                state.edit_failures += 1;
                 tracing::warn!(
                     "[channel-inbound][stream] edit failed channel='{}' msg_id={} err={} (failures={}/{})",
                     channel,
@@ -632,26 +764,50 @@ async fn flush_thinking_message(channel: &str, state: &mut StreamingState) {
     };
 
     if let Some(msg_id) = state.thinking_message_id.clone() {
+        // Known-missing edit route: the bubble stays as first posted and is
+        // deleted at finalization. Skip the guaranteed 404.
+        if channel_edits_unsupported(channel) {
+            tracing::debug!(
+                "[channel-inbound][thinking] skipping edit channel='{}' msg_id={} — no edit route on this backend, bubble stays until finalize deletes it",
+                channel,
+                msg_id,
+            );
+            state.latch_thinking_edits_unsupported();
+            return;
+        }
         // Edit existing thinking message with updated content.
         let body = json!({ "text": text });
         if let Err(err) = client.send_channel_edit(channel, &msg_id, &jwt, body).await {
-            if let Some(crate::api::rest::BackendApiError::MessageNotFound { .. }) =
-                err.downcast_ref::<crate::api::rest::BackendApiError>()
-            {
-                tracing::info!(
-                    "[channel-inbound][thinking] edit channel='{}' msg_id={} — thinking msg gone provider-side (404), clearing id and disabling further thinking edits",
-                    channel,
-                    msg_id,
-                );
-                state.thinking_message_id = None;
-                state.thinking_edit_disabled = true;
-            } else {
-                tracing::debug!(
-                    "[channel-inbound][thinking] edit failed channel='{}' msg_id={} err={}",
-                    channel,
-                    msg_id,
-                    err,
-                );
+            match classify_edit_failure(&err) {
+                EditFailure::RouteUnsupported => {
+                    // Keep `thinking_message_id`. Clearing it (as the old
+                    // `MessageNotFound` branch did) meant finalization had
+                    // nothing to delete, so the ephemeral "💭 Thinking:"
+                    // bubble stayed in the chat forever (#5230).
+                    tracing::info!(
+                        "[channel-inbound][thinking] edit channel='{}' msg_id={} — backend has no edit route, keeping id so finalize still deletes the bubble",
+                        channel,
+                        msg_id,
+                    );
+                    mark_channel_edits_unsupported(channel);
+                    state.latch_thinking_edits_unsupported();
+                }
+                EditFailure::MessageGone => {
+                    tracing::info!(
+                        "[channel-inbound][thinking] edit channel='{}' msg_id={} — thinking msg gone provider-side (404), clearing id and disabling further thinking edits",
+                        channel,
+                        msg_id,
+                    );
+                    state.forget_thinking();
+                }
+                EditFailure::Transient => {
+                    tracing::debug!(
+                        "[channel-inbound][thinking] edit failed channel='{}' msg_id={} err={}",
+                        channel,
+                        msg_id,
+                        err,
+                    );
+                }
             }
         }
     } else {
@@ -828,6 +984,22 @@ async fn finalize_channel_reply(channel: &str, state: &mut StreamingState, final
     // times (#600).
     'send: {
         if let Some(ref message_id) = state.message_id {
+            // Once this process knows the backend serves no edit route, the
+            // "one last edit" below is a guaranteed 404 — go straight to
+            // replacing the draft. Deleting it first matters: it is still on
+            // screen showing partial text, so leaving it would strand a stale
+            // "_working…_" bubble next to the real answer (#5230).
+            if channel_edits_unsupported(channel) {
+                tracing::info!(
+                    "[channel-inbound] final edit skipped channel='{}' msg_id={} — no edit route on this backend, replacing the draft with a fresh atomic reply",
+                    channel,
+                    message_id,
+                );
+                let orphan = message_id.clone();
+                delete_channel_message(channel, &orphan).await;
+                send_channel_reply(channel, final_text).await;
+                break 'send;
+            }
             // We committed to a draft earlier in the turn. Always attempt
             // to edit it with the canonical reply, even when we'd
             // previously latched `edit_disabled` during the streaming
@@ -849,17 +1021,32 @@ async fn finalize_channel_reply(channel: &str, state: &mut StreamingState, final
                             final_text.len(),
                         );
                     }
-                    Err(err) => {
-                        if let Some(crate::api::rest::BackendApiError::MessageNotFound { .. }) =
-                            err.downcast_ref::<crate::api::rest::BackendApiError>()
-                        {
+                    Err(err) => match classify_edit_failure(&err) {
+                        EditFailure::MessageGone => {
                             tracing::info!(
                                 "[channel-inbound] final edit channel='{}' msg_id={} — draft already gone provider-side (404), sending fresh atomic reply",
                                 channel,
                                 message_id,
                             );
                             send_channel_reply(channel, final_text).await;
-                        } else {
+                        }
+                        // Route absent (or any other failure): the draft is
+                        // still on screen showing partial text, so it has to be
+                        // deleted before the canonical reply lands — otherwise
+                        // the user keeps a stale "_working…_" bubble alongside
+                        // the real answer (#5230).
+                        EditFailure::RouteUnsupported => {
+                            tracing::warn!(
+                                "[channel-inbound] final edit channel='{}' msg_id={} — backend has no edit route, deleting the draft and sending a fresh atomic reply",
+                                channel,
+                                message_id,
+                            );
+                            mark_channel_edits_unsupported(channel);
+                            let orphan = message_id.clone();
+                            delete_channel_message(channel, &orphan).await;
+                            send_channel_reply(channel, final_text).await;
+                        }
+                        EditFailure::Transient => {
                             tracing::warn!(
                                 "[channel-inbound] final edit failed channel='{}' msg_id={} err={} — deleting orphan draft and sending fresh atomic reply so user still sees the canonical response",
                                 channel,
@@ -870,7 +1057,7 @@ async fn finalize_channel_reply(channel: &str, state: &mut StreamingState, final
                             delete_channel_message(channel, &orphan).await;
                             send_channel_reply(channel, final_text).await;
                         }
-                    }
+                    },
                 }
             } else {
                 tracing::warn!(

--- a/src/openhuman/channels/bus_tests.rs
+++ b/src/openhuman/channels/bus_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::api::rest::BackendApiError;
 use crate::core::event_bus::DomainEvent;
 
 #[test]
@@ -15,4 +16,156 @@ async fn unrelated_events_are_ignored() {
             component: "test".into(),
         })
         .await;
+}
+
+// ── Channel-message edit failures (#5230) ──────────────────────────────────
+//
+// The backend implements no `PATCH /channels/:channel/messages/:messageId`, so
+// every edit 404s. That 404 used to be classified as `MessageNotFound` ("the
+// user deleted this message"), and the recovery for *that* condition is to
+// forget the message id — which orphaned the streaming draft and left the
+// ephemeral "💭 Thinking:" bubble in the chat permanently, because finalization
+// then had no id left to delete.
+
+#[test]
+fn edit_failure_classification_separates_route_absence_from_message_absence() {
+    let route_absent = anyhow::Error::new(BackendApiError::ChannelEditUnsupported {
+        provider: "telegram".into(),
+        message_id: "1103".into(),
+    });
+    assert_eq!(
+        classify_edit_failure(&route_absent),
+        EditFailure::RouteUnsupported
+    );
+
+    let message_absent = anyhow::Error::new(BackendApiError::MessageNotFound {
+        provider: "telegram".into(),
+        message_id: "1103".into(),
+    });
+    assert_eq!(
+        classify_edit_failure(&message_absent),
+        EditFailure::MessageGone
+    );
+
+    // Anything untyped (5xx, transport, rate limit) keeps the retry budget.
+    let transient = anyhow::anyhow!("502 Bad Gateway");
+    assert_eq!(classify_edit_failure(&transient), EditFailure::Transient);
+
+    // A different typed variant must not be mistaken for either edit case.
+    let unauthorized = anyhow::Error::new(BackendApiError::Unauthorized {
+        method: "PATCH".into(),
+        path: "/channels/telegram/messages/1103".into(),
+    });
+    assert_eq!(classify_edit_failure(&unauthorized), EditFailure::Transient);
+}
+
+#[test]
+fn route_absence_keeps_the_draft_id_so_finalize_can_clean_it_up() {
+    let mut state = StreamingState {
+        message_id: Some("1103".into()),
+        draft_sent: true,
+        ..Default::default()
+    };
+
+    state.latch_draft_edits_unsupported();
+
+    assert!(state.edit_disabled, "edits must stop being attempted");
+    assert_eq!(
+        state.message_id.as_deref(),
+        Some("1103"),
+        "the draft is still on screen and still ours — finalize needs its id to \
+         delete it before posting the canonical reply (#5230)"
+    );
+}
+
+#[test]
+fn message_absence_forgets_the_draft_id() {
+    let mut state = StreamingState {
+        message_id: Some("1103".into()),
+        draft_sent: true,
+        ..Default::default()
+    };
+
+    state.forget_draft();
+
+    assert!(state.edit_disabled);
+    assert_eq!(
+        state.message_id, None,
+        "a message that is genuinely gone leaves nothing to edit or delete"
+    );
+}
+
+#[test]
+fn route_absence_keeps_the_thinking_bubble_id_so_it_still_gets_deleted() {
+    let mut state = StreamingState {
+        thinking_message_id: Some("2201".into()),
+        thinking_sent: true,
+        ..Default::default()
+    };
+
+    state.latch_thinking_edits_unsupported();
+
+    assert!(state.thinking_edit_disabled);
+    assert_eq!(
+        state.thinking_message_id.as_deref(),
+        Some("2201"),
+        "finalization deletes the ephemeral bubble by id — dropping it here is \
+         why '💭 Thinking:' stayed in the chat forever (#5230)"
+    );
+}
+
+#[test]
+fn message_absence_forgets_the_thinking_bubble_id() {
+    let mut state = StreamingState {
+        thinking_message_id: Some("2201".into()),
+        thinking_sent: true,
+        ..Default::default()
+    };
+
+    state.forget_thinking();
+
+    assert!(state.thinking_edit_disabled);
+    assert_eq!(state.thinking_message_id, None);
+}
+
+#[test]
+fn edit_capability_latches_per_provider_not_per_chat() {
+    // Provider names unique to this test: the latch is process-wide by design,
+    // so sharing `telegram` with another test would couple them.
+    assert!(!channel_edits_unsupported("noedit-a:chat-1"));
+
+    mark_channel_edits_unsupported("noedit-a:chat-1");
+
+    assert!(
+        channel_edits_unsupported("noedit-a:chat-1"),
+        "the channel that taught us must be latched"
+    );
+    assert!(
+        channel_edits_unsupported("noedit-a:chat-2"),
+        "route existence is a per-provider backend fact, so a different chat on \
+         the same provider must not re-probe it"
+    );
+    assert!(
+        channel_edits_unsupported("noedit-a"),
+        "un-prefixed channel ids resolve to the same provider key"
+    );
+    assert!(
+        !channel_edits_unsupported("noedit-b:chat-1"),
+        "an unrelated provider must be unaffected"
+    );
+}
+
+#[test]
+fn marking_edit_capability_twice_is_idempotent() {
+    mark_channel_edits_unsupported("noedit-c:chat-1");
+    mark_channel_edits_unsupported("noedit-c:chat-1");
+    assert!(channel_edits_unsupported("noedit-c:chat-1"));
+}
+
+#[test]
+fn edit_capability_key_strips_the_chat_suffix() {
+    assert_eq!(edit_capability_key("telegram:12345"), "telegram");
+    assert_eq!(edit_capability_key("discord:guild:chan"), "discord");
+    assert_eq!(edit_capability_key("telegram"), "telegram");
+    assert_eq!(edit_capability_key(""), "");
 }


### PR DESCRIPTION
## Summary

- A 404 on `PATCH /channels/:channel/messages/:messageId` is now classified as **route absence** (`BackendApiError::ChannelEditUnsupported`) instead of **message absence** (`MessageNotFound`). `DELETE` keeps `MessageNotFound`; nothing else moves.
- `channels/bus.rs` splits the three real edit-failure causes via `classify_edit_failure` → `RouteUnsupported` / `MessageGone` / `Transient`, off the typed error rather than error text.
- Route absence now **keeps** the message id and only disables editing, so the ephemeral "💭 Thinking:" bubble gets deleted at finalization again and the streaming draft gets deleted before the canonical reply lands.
- A per-provider, process-wide latch records "this backend has no edit route" on the first 404, so later turns skip a guaranteed-404 round-trip instead of re-probing forever.
- **Client half only.** Progressive editing itself needs a backend route that does not exist — see `## Related`.

## Problem

`BackendOAuthClient::send_channel_edit` calls `PATCH /channels/:channel/messages/:messageId`. **The backend implements no such route, and never has.** Verified three ways rather than taken on faith:

- `backend@origin/main` `src/routes/channels.ts` registers `POST /:channel/messages` and `DELETE /:channel/messages/:messageId`. The only `PATCH` in the file is on `threads/:threadId`.
- The vendored SDK's `PUBLIC_ROUTES` (generated from the deployed OpenAPI document) lists POST + DELETE for messages only.
- The SDK's transport gate is a *denylist* (`UNEXPOSED_ROUTES`, 44 admin/webhook entries) containing no `channels` paths — so the request is not rejected locally, it goes over the wire and collects Express's unmatched-route 404.

The 404 itself was survivable. The classification was not. `authed_json` mapped any 404 on that path to `MessageNotFound`, documented as "the user deleted the message provider-side, or the backend GC'd the relay row". The correct recovery for *that* condition is to **forget the message id** — precisely wrong when the message is alive and only the route is missing. All three edit call sites in `channels/bus.rs` then did the wrong thing:

| Call site | Symptom |
| --- | --- |
| `flush_thinking_message` | id cleared → finalization had nothing to delete → the ephemeral **"💭 Thinking:" bubble stayed in the chat permanently** |
| `flush_streaming_edit` | id cleared → orphaned `_working…_` draft that finalization no longer deleted |
| `finalize_channel_reply` | posted a fresh reply and left the stale partial draft beside it |

One finding worth adding to the issue: **the backend's `DELETE` handler answers 400/403/502 and never 404.** So on the deployed contract a 404 on `…/channels/<p>/messages/<id>` can *only* mean route absence — `MessageNotFound` was unreachable for its own documented cause. That reframes the `OPENHUMAN-TAURI-2Y` attribution (~454 events): it was very likely all edit traffic, not provider-side deletion.

Also narrower than the issue states: `channel_supports_progressive_ui` is already an allowlist limited to `telegram`/`tg`, so Discord never reached these paths. The user-visible impact is Telegram-only.

## Solution

The issue offers two options — add the backend route, or delete the client edit path. This PR takes neither verbatim, because option 2 discards code that becomes correct the moment the route ships, and option 1 alone leaves the client mishandling today's 404. So: **keep the capability, fix the misclassification, degrade correctly.** Every user-visible symptom is fixed now, and no client change is needed later.

- **`src/api/rest.rs`** — new `BackendApiError::ChannelEditUnsupported { provider, message_id }`, returned for a 404 on a PATCH of a channel-message path in both the parsed and the base-path-prefixed/unparseable shapes. Checked before the `MessageNotFound` arm, which would otherwise swallow it. The `DELETE` defense-in-depth branch (TAURI-R7) is unchanged.
- **`channels/bus.rs`** — `classify_edit_failure` resolves the typed error into `EditFailure::{RouteUnsupported, MessageGone, Transient}`, so which recovery a call site picks cannot drift if the `#[error(...)]` wording changes.
- The state transitions are now named for their invariant: `latch_draft_edits_unsupported` / `latch_thinking_edits_unsupported` (route absent — **keep the id**) versus `forget_draft` / `forget_thinking` (message genuinely gone — drop it). Keeping the id is the whole fix; the tests assert it directly.
- The capability latch keys on the provider prefix, not the chat id, because route existence is a property of the deployed backend. It self-heals on the next core start once the route ships.

Degradation with the route absent: the thinking bubble posts once and is deleted at finalization; the streaming draft posts once and is deleted immediately before the canonical reply. No orphans, no duplicate bubbles, one wasted request per provider per process instead of one per flush.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — 4 in `rest_tests.rs` (incl. the `DELETE`-keeps-`MessageNotFound` non-regression) and 8 in `bus_tests.rs`
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/ci-lite.yml`](../.github/workflows/ci-lite.yml). Every changed branch in `rest.rs` and every new function/transition in `bus.rs` is driven by a test; no frontend lines changed
- [x] Coverage matrix updated — new row `10.4.5 Outbound Message Edit` in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md), 🟡 with the missing backend route recorded as the reason
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — the new tests stand up local `axum` servers on ephemeral ports, same as the surrounding `rest_tests.rs` cases
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A: no release-cut surface changed; inbound Telegram replies are unaffected apart from the placeholder cleanup this fixes`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Platform:** Rust core, all platforms. No frontend, no Tauri shell, no UI.
- **Behaviour:** inbound Telegram turns stop leaving a permanent "💭 Thinking:" bubble and a stale `_working…_` draft in the chat. The canonical reply was always delivered; what changes is that the placeholders around it are now cleaned up.
- **Performance:** one fewer guaranteed-404 request per edit flush, and after the first 404 the whole edit path is skipped for that provider for the life of the process.
- **Sentry:** `ChannelEditUnsupported` is a typed expected-state error, so it does not `report_error` — consistent with `MessageNotFound` / `Unauthorized` / `AnnouncementNotFound`. It logs at `warn` under `[backend_api]` / `[channel-inbound][edit]` so the contract gap stays visible in logs without 454 events of noise.
- **Compatibility:** forward-compatible. When the backend adds the route the 404 stops, the latch never sets, and edits work with no further client change.
- **Feature gates:** `bus.rs` is inside the `channels` gate; `rest.rs` is not. Verified in both directions (see below).
- **Security / migration:** none.

## Related

- Closes: #5230
- Coverage matrix feature IDs: **10.4.5** (new — Outbound Message Edit)
- Follow-up PR(s)/TODOs: **a separate `tinyhumansai/backend` PR is required for the actual feature.** This PR makes the failure clean, not functional — the "💭 Thinking:" indicator still posts once without live-updating, and the streaming draft is replaced rather than edited in place. Restoring the intended progressive-edit UX needs:
  1. `router.patch('/:channel/messages/:messageId', authenticateJWT, …)` in `backend/src/routes/channels.ts`, mirroring the `DELETE` handler's shape (`editMessageOnChannel`, 400/403/502) — and it should return 404 for a genuinely missing message, which finally makes `MessageNotFound` reachable for its documented cause.
  2. Its `@swagger` block, so the route lands in the deployed OpenAPI document.
  3. In `tinyhumansai/sdk`: add it to `SUPPLEMENTAL_PUBLIC_OPERATIONS` in `scripts/sync-openapi.mjs` until it appears in the deployed spec, then regenerate. (#5230's author deliberately did not add it — correctly, since the server does not serve it.)

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5230-channel-edit-route`
- Commit SHA: `09dce909e23104dc36b5a08354297730698a2104` (fix), `c579b7e2b` (coverage matrix row)

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no files in app/ changed`. `docs/TEST-COVERAGE-MATRIX.md` sits outside that script's `prettier --write .` root, so the row follows the file's existing hand-maintained style rather than reflowing 20 unrelated rows
- [x] `pnpm typecheck` — `N/A: no TypeScript changed`
- [x] Focused tests: `cargo test --lib api::rest` → 58 passed; `--lib openhuman::channels::bus` → 23 passed; wider `--lib api::` → 110 passed and `--lib openhuman::channels` → 233 passed
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo check --lib` clean; `cargo clippy --all-targets` reports nothing in any touched file (its warnings are pre-existing in `api/config.rs`, `flows/ops_tests.rs`, `tests/live_routing_e2e.rs`)
- [x] Tauri fmt/check (if changed): `N/A: app/src-tauri untouched`

Feature-gate verification, since `bus.rs` is inside the `channels` gate and CI's smoke lane only runs `cargo check`: `--no-default-features --features tokenjuice-treesitter` gives 0 errors and the same 8 warnings with and without this diff, and the test-compile in that configuration is also clean.

### Validation Blocked

- `command:` none
- `error:` n/a
- `impact:` n/a

### Behavior Changes

- Intended behavior change: a 404 from a missing edit route no longer causes the core to discard a live message id.
- User-visible effect: inbound Telegram turns no longer strand a permanent "💭 Thinking:" bubble or a stale `_working…_` draft in the chat.

### Parity Contract

- Legacy behavior preserved: `DELETE` 404 → `MessageNotFound` unchanged (pinned by a new test); the TAURI-R7 unparseable-path Sentry suppression unchanged for `DELETE`; the `MessageGone` recovery at all three call sites byte-for-byte identical to before, including log wording; `Transient` still counts against `MAX_EDIT_FAILURES`.
- Guard/fallback/dispatch parity checks: `finalize_channel_reply`'s "never post two bubbles" invariant (#600) holds on every new path — the route-absent branches delete the draft before `send_channel_reply`, and the `draft_sent`-without-id branch is untouched. The `channel_supports_progressive_ui` allowlist still gates which providers reach any of this.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when channel message editing is unavailable.
  * Automatically falls back to sending the completed response without progressive edits.
  * Removes temporary draft and “Thinking” messages when editing is unsupported, preventing stale placeholders.
  * Distinguishes unavailable edit functionality from messages that were deleted, preserving correct recovery behavior.
  * Edit support is tracked independently for each channel provider.

* **Documentation**
  * Updated test coverage documentation for outbound message editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->