### PR TITLE
fix(flows): close two authorization boundaries in flow-run tools

### DIFF
--- a/src/openhuman/approval/gate.rs
+++ b/src/openhuman/approval/gate.rs
@@ -2251,6 +2251,41 @@ mod tests {
         }
     }
 
+    /// T-M3 (flows `cancel_flow_run`): the gate has no special-casing per tool
+    /// name — any call intercepted under a chat origin/context with no
+    /// matching auto-allowlist entry parks and, absent a human decision,
+    /// times out to `Deny` rather than executing. This pins that
+    /// `cancel_flow_run` — now that `builder_tools::CancelFlowRunTool`
+    /// reports `external_effect() == true` (T-M3) so
+    /// `ApprovalSecurityMiddleware` routes it through exactly this call —
+    /// genuinely parks for a real approval decision instead of running
+    /// unapproved, mirroring `timeout_returns_deny` above.
+    #[tokio::test]
+    async fn cancel_flow_run_parks_for_approval_when_a_gate_is_present() {
+        let (gate, _dir) = test_gate(); // TTL = 500ms
+        let gate = Arc::new(gate);
+        let outcome = turn_origin::with_origin(
+            web_origin(),
+            APPROVAL_CHAT_CONTEXT.scope(
+                chat_ctx(),
+                gate.intercept(
+                    "cancel_flow_run",
+                    "cancel run r-1 of flow f-1",
+                    serde_json::json!({ "flow_id": "f-1", "run_id": "r-1" }),
+                ),
+            ),
+        )
+        .await;
+        // No decision ever arrives — the call must NOT auto-execute. It
+        // parks until the gate's TTL elapses, then denies (never `Allow`).
+        match outcome {
+            GateOutcome::Deny { reason } => assert!(reason.contains("timed out")),
+            other => panic!(
+                "expected the parked cancel_flow_run call to time out to Deny, got {other:?}"
+            ),
+        }
+    }
+
     #[tokio::test]
     async fn decide_unknown_id_is_noop() {
         let (gate, _dir) = test_gate();

--- a/src/openhuman/flows/builder_tools.rs
+++ b/src/openhuman/flows/builder_tools.rs
@@ -1113,6 +1113,21 @@ impl Tool for ResumeFlowRunTool {
 
 /// `cancel_flow_run`: stop an in-flight or parked run. Write-class — it changes
 /// run state but fires no new outbound effect.
+///
+/// **T-M3 fix.** This tool used to cancel an arbitrary `run_id` with no
+/// ownership check at all — combined with `external_effect() == false` (so
+/// the approval gate never parked it) and hiding that only covered the two
+/// `flows_build` copilot/headless paths (`FLOWS_BUILD_COPILOT_HIDDEN_TOOLS`,
+/// not the orchestrator-delegation or main-chat paths that also carry this
+/// tool), a prompt-injected turn could cancel ANY user's in-flight or
+/// approval-parked automation, unapproved. Two independent closes now apply:
+/// 1. **Ownership check** — the caller must name the `flow_id` it believes
+///    owns the run (mirrors [`ResumeFlowRunTool`]'s existing `{ flow_id,
+///    run_id }` shape); the run row's *actual* `flow_id` is resolved and
+///    compared, and a mismatch is refused rather than silently cancelling a
+///    run scoped to a different flow.
+/// 2. **`external_effect() == true`** — parks for approval on any surface
+///    that has a gate, same as `resume_flow_run`.
 pub struct CancelFlowRunTool {
     config: Arc<Config>,
 }
@@ -1131,16 +1146,19 @@ impl Tool for CancelFlowRunTool {
 
     fn description(&self) -> &str {
         "Cancel an in-flight or approval-parked flow run by its run_id (from list_flow_runs). \
-         Stops a runaway or stuck run; fires no new outbound effect. Params: { run_id }."
+         Stops a runaway or stuck run; fires no new outbound effect. The run_id must belong to \
+         the given flow_id — cancelling a run that belongs to a different flow is refused. \
+         Approval-gated. Params: { flow_id, run_id }."
     }
 
     fn parameters_schema(&self) -> Value {
         json!({
             "type": "object",
             "properties": {
+                "flow_id": { "type": "string", "description": "The flow that owns the run being cancelled (from list_flow_runs)." },
                 "run_id": { "type": "string", "description": "The run (thread) id to cancel." }
             },
-            "required": ["run_id"],
+            "required": ["flow_id", "run_id"],
             "additionalProperties": false
         })
     }
@@ -1150,15 +1168,44 @@ impl Tool for CancelFlowRunTool {
     }
 
     fn external_effect(&self) -> bool {
-        false
+        true
     }
 
     async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let flow_id = match args.get("flow_id").and_then(Value::as_str).map(str::trim) {
+            Some(id) if !id.is_empty() => id.to_string(),
+            _ => return Ok(ToolResult::error("Missing 'flow_id' parameter".to_string())),
+        };
         let run_id = match args.get("run_id").and_then(Value::as_str).map(str::trim) {
             Some(id) if !id.is_empty() => id.to_string(),
             _ => return Ok(ToolResult::error("Missing 'run_id' parameter".to_string())),
         };
-        tracing::debug!(target: "flows", %run_id, "[flows] cancel_flow_run: cancelling run");
+
+        // SECURITY (T-M3 fix): verify the run actually belongs to the
+        // caller-named flow before cancelling anything — mirrors
+        // `resume_flow_run` (`ops::flows_resume`)'s existing `run_record.flow_id
+        // != flow_id` guard. Without this, any run_id (guessed, enumerated, or
+        // named by a prompt-injected turn that never called list_flow_runs)
+        // could cancel a run scoped to a completely different flow.
+        let run = match ops::flows_get_run(&self.config, &run_id).await {
+            Ok(outcome) => outcome.value,
+            Err(e) => return Ok(ToolResult::error(format!("Could not cancel run: {e}"))),
+        };
+        if run.flow_id != flow_id {
+            tracing::warn!(
+                target: "flows",
+                %flow_id,
+                %run_id,
+                actual_flow_id = %run.flow_id,
+                "[flows] cancel_flow_run: refused — run belongs to a different flow than the one named"
+            );
+            return Ok(ToolResult::error(format!(
+                "run '{run_id}' belongs to flow '{}', not '{flow_id}' — refusing to cancel",
+                run.flow_id
+            )));
+        }
+
+        tracing::debug!(target: "flows", %flow_id, %run_id, "[flows] cancel_flow_run: cancelling run");
         match ops::flows_cancel_run(&self.config, &run_id).await {
             Ok(outcome) => Ok(ToolResult::success(serde_json::to_string_pretty(
                 &outcome.value,

--- a/src/openhuman/flows/builder_tools_tests.rs
+++ b/src/openhuman/flows/builder_tools_tests.rs
@@ -2643,6 +2643,9 @@ fn phase4_write_tools_have_the_right_permissions() {
         CancelFlowRunTool::new(config.clone()).permission_level(),
         PermissionLevel::Write
     );
+    // T-M3 fix: cancel_flow_run now parks for approval like every other
+    // write-class flow-run control tool.
+    assert!(CancelFlowRunTool::new(config.clone()).external_effect());
     assert_eq!(
         ResumeFlowRunTool::new(config.clone()).permission_level(),
         PermissionLevel::Execute
@@ -2650,6 +2653,154 @@ fn phase4_write_tools_have_the_right_permissions() {
     assert_eq!(
         ListFlowRunsTool::new(config.clone()).permission_level(),
         PermissionLevel::None
+    );
+}
+
+// ── cancel_flow_run ownership check (T-M3) ────────────────────────────────
+
+/// A graph that pauses at a `pending_approval` gate, so the run it produces
+/// stays non-terminal (cancellable) — mirrors `ops_tests::approval_gated_graph`.
+fn cancel_test_approval_gated_graph() -> Value {
+    json!({
+        "name": "approval-gated",
+        "nodes": [
+            { "id": "t", "kind": "trigger", "name": "Trigger" },
+            { "id": "gate", "kind": "output_parser", "name": "Gate", "config": { "requires_approval": true } },
+            { "id": "downstream", "kind": "output_parser", "name": "Downstream" }
+        ],
+        "edges": [
+            { "from_node": "t", "to_node": "gate" },
+            { "from_node": "gate", "to_node": "downstream" }
+        ]
+    })
+}
+
+/// SECURITY (T-M3): the tool must refuse to cancel a run that belongs to a
+/// DIFFERENT flow than the one the caller named — closing the "arbitrary
+/// run_id, no ownership check" gap the tool's own doc used to admit.
+#[tokio::test]
+async fn cancel_flow_run_refuses_a_run_the_caller_does_not_own() {
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    let owner_flow = ops::flows_create(
+        &config,
+        "owner".to_string(),
+        cancel_test_approval_gated_graph(),
+        false,
+    )
+    .await
+    .unwrap()
+    .value;
+    let other_flow = ops::flows_create(
+        &config,
+        "other".to_string(),
+        cancel_test_approval_gated_graph(),
+        false,
+    )
+    .await
+    .unwrap()
+    .value;
+
+    let run = ops::flows_run(
+        &config,
+        &owner_flow.id,
+        json!({}),
+        crate::openhuman::flows::FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
+    let run_id = run.value["thread_id"].as_str().unwrap().to_string();
+    assert_eq!(
+        ops::flows_get_run(&config, &run_id)
+            .await
+            .unwrap()
+            .value
+            .status,
+        "pending_approval"
+    );
+
+    let tool = CancelFlowRunTool::new(config.clone());
+    let result = tool
+        .execute(json!({ "flow_id": other_flow.id, "run_id": run_id.clone() }))
+        .await
+        .unwrap();
+    assert!(result.is_error);
+    assert!(
+        result.output().contains("belongs to flow"),
+        "{}",
+        result.output()
+    );
+
+    // The refused attempt must not have touched the run at all.
+    let run_row = ops::flows_get_run(&config, &run_id).await.unwrap().value;
+    assert_eq!(run_row.status, "pending_approval");
+}
+
+/// No-regression companion: cancelling with the CORRECT owning flow_id must
+/// still work exactly as before the T-M3 fix.
+#[tokio::test]
+async fn cancel_flow_run_cancels_when_flow_id_matches_the_owner() {
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    let flow = ops::flows_create(
+        &config,
+        "F".to_string(),
+        cancel_test_approval_gated_graph(),
+        false,
+    )
+    .await
+    .unwrap()
+    .value;
+    let run = ops::flows_run(
+        &config,
+        &flow.id,
+        json!({}),
+        crate::openhuman::flows::FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
+    let run_id = run.value["thread_id"].as_str().unwrap().to_string();
+
+    let tool = CancelFlowRunTool::new(config.clone());
+    let result = tool
+        .execute(json!({ "flow_id": flow.id, "run_id": run_id.clone() }))
+        .await
+        .unwrap();
+    assert!(!result.is_error, "{}", result.output());
+
+    let run_row = ops::flows_get_run(&config, &run_id).await.unwrap().value;
+    assert_eq!(run_row.status, "cancelled");
+}
+
+#[tokio::test]
+async fn cancel_flow_run_missing_flow_id_errs() {
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+    let tool = CancelFlowRunTool::new(config);
+    let result = tool.execute(json!({ "run_id": "some-run" })).await.unwrap();
+    assert!(result.is_error);
+    assert!(result.output().contains("flow_id"));
+}
+
+/// T-M3 (part b): the approval gate routes any `external_effect() == true`
+/// tool through `ApprovalGate` before `execute()` runs
+/// (`ApprovalSecurityMiddleware::has_external_effect` in
+/// `tinyagents::middleware`, keyed purely off `external_effect_with_args`).
+/// `cancel_flow_run` now reports `external_effect() == true`
+/// (`phase4_write_tools_have_the_right_permissions` above pins the flag
+/// itself), so it parks on any surface with a live gate — exactly like
+/// `resume_flow_run` — instead of executing unapproved.
+#[test]
+fn cancel_flow_run_is_external_effect_so_the_middleware_parks_it() {
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+    let tool = CancelFlowRunTool::new(config);
+    assert!(
+        tool.external_effect(),
+        "cancel_flow_run must be external_effect so ApprovalSecurityMiddleware routes it \
+         through ApprovalGate::intercept_audited before execute() runs"
     );
 }
 

--- a/src/openhuman/flows/memory_tools.rs
+++ b/src/openhuman/flows/memory_tools.rs
@@ -19,6 +19,12 @@
 //! [`FlowMemoryRecallTool`]'s `scope: "flows"` is read-only cross-flow
 //! visibility — it can never be used to write outside a flow's own
 //! namespace either.
+//!
+//! **T-M2 fix:** [`FlowMemoryRememberTool`] only resolves the flow id from
+//! the run's own trusted `TrustedAutomation { Workflow }` turn origin (see
+//! [`trusted_flow_id`]) — it never trusts a model-supplied `flow_id` arg.
+//! Outside a trusted workflow run (every chat/orchestrator turn) the write
+//! is refused outright, not routed to whatever `flow_id` the caller named.
 
 use std::sync::Arc;
 
@@ -43,9 +49,19 @@ use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult};
 /// agent invoking the tool directly) to name a DIFFERENT flow's namespace.
 /// When this returns `Some`, callers MUST use it — and ignore any
 /// caller-supplied `flow_id` arg — for the `scope: "flow"` / write case.
-/// Callers running outside a flow run (e.g. a chat agent with the tool
-/// wired in some other context) get `None` here and fall back to requiring
-/// the `flow_id` arg, exactly as before this invariant existed.
+///
+/// **T-M2 fix:** callers running outside a flow run (e.g. a chat/orchestrator
+/// turn with the tool wired in some other context) get `None` here. For the
+/// write path ([`FlowMemoryRememberTool`]) that used to fall back to trusting
+/// the model-supplied `flow_id` arg — which let a prompt-injected chat turn
+/// poison an unrelated flow's private dedup namespace, since the tool has no
+/// `external_effect` and therefore never parks for approval. `None` now means
+/// [`FlowMemoryRememberTool`] REFUSES the write outright; there is no
+/// legitimate chat-side use case for writing another flow's namespace, and
+/// refusing is the only fail-closed option that doesn't require inventing an
+/// ownership proof. [`FlowMemoryRecallTool`] is unaffected — it stays
+/// read-only and its `scope: "flows"` already exposes every flow's namespace
+/// by design, so an arg-supplied `flow_id` grants no new read privilege.
 fn trusted_flow_id() -> Option<String> {
     match turn_origin::current() {
         Some(AgentTurnOrigin::TrustedAutomation {
@@ -361,10 +377,10 @@ impl Tool for FlowMemoryRememberTool {
             "properties": {
                 "flow_id": {
                     "type": "string",
-                    "description": "The calling flow's id. Inside a running flow this is informational \
-                     only: the active flow's own id (from the run's trusted origin) is authoritative and \
-                     any value supplied here is ignored. Required only when this tool is invoked outside \
-                     a flow run (e.g. from a chat agent)."
+                    "description": "Informational only: inside a running flow the active flow's own id \
+                     (from the run's trusted origin) is authoritative and this value is ignored. This \
+                     tool ONLY works inside a workflow run — calling it from chat or any other context \
+                     without a trusted run origin is refused, regardless of what is passed here."
                 },
                 "key": {
                     "type": "string",
@@ -417,12 +433,16 @@ impl Tool for FlowMemoryRememberTool {
             return Ok(ToolResult::error(error));
         }
 
-        // SECURITY: resolve the namespace-governing flow id from the run's
-        // trusted origin when available — NEVER from the model-supplied
+        // SECURITY (T-M2 fix): resolve the namespace-governing flow id from
+        // the run's trusted origin ONLY — never from the model-supplied
         // `flow_id` arg. Without this, a prompt-injected caller (or another
         // agent invoking this tool directly) could pass a DIFFERENT flow's
-        // id here and poison that flow's private namespace. See
-        // `trusted_flow_id`'s doc comment for the mechanism.
+        // id here and poison that flow's private namespace, and — because
+        // this tool has no `external_effect` — the write would never park
+        // for approval. There is no legitimate chat-side caller of this
+        // write path (see `trusted_flow_id`'s doc comment): outside a
+        // trusted workflow run, refuse outright rather than trusting an
+        // arg that cannot be distinguished from an attacker's.
         let trusted = trusted_flow_id();
         let flow_id: String = match &trusted {
             Some(trusted_id) => {
@@ -435,14 +455,17 @@ impl Tool for FlowMemoryRememberTool {
                 trusted_id.clone()
             }
             None => {
-                let Some(arg) = flow_id_arg else {
-                    return Ok(ToolResult::error("Missing 'flow_id' parameter".to_string()));
-                };
-                let trimmed = arg.trim();
-                if trimmed.is_empty() {
-                    return Ok(ToolResult::error("flow_id cannot be empty".to_string()));
-                }
-                trimmed.to_string()
+                // T-M2 supersedes the arg validation that used to live here: the
+                // model-supplied `flow_id` is never trusted outside a run, so
+                // there is nothing to validate — refuse instead.
+                log::warn!(
+                    "[flows:memory:security] flow_memory_remember refused: no trusted Workflow run \
+                     origin (requested flow_id_chars={})",
+                    flow_id_arg.map_or(0, str::len)
+                );
+                return Ok(ToolResult::error(
+                    "flow memory writes are only available inside a workflow run".to_string(),
+                ));
             }
         };
         let flow_id = flow_id.as_str();
@@ -680,14 +703,30 @@ mod tests {
         assert_eq!(tool.permission_level(), PermissionLevel::Write);
     }
 
+    /// Helper: a trusted `TrustedAutomation { Workflow }` origin scoped to
+    /// `job_id`, the only source `flow_memory_remember` will act on since the
+    /// T-M2 fix.
+    fn trusted_workflow_origin(job_id: &str) -> AgentTurnOrigin {
+        AgentTurnOrigin::TrustedAutomation {
+            job_id: job_id.to_string(),
+            source: TrustedAutomationSource::Workflow {
+                require_approval: false,
+            },
+        }
+    }
+
     #[tokio::test]
     async fn remember_stores_with_external_sync_taint() {
         let (_tmp, mem) = test_mem();
         let tool = FlowMemoryRememberTool::new(mem.clone(), test_security());
-        let result = tool
-            .execute(json!({"flow_id": "f1", "key": "sent_item_42", "content": "Sent item 42"}))
-            .await
-            .unwrap();
+        let result = turn_origin::with_origin(
+            trusted_workflow_origin("f1"),
+            tool.execute(
+                json!({"flow_id": "f1", "key": "sent_item_42", "content": "Sent item 42"}),
+            ),
+        )
+        .await
+        .unwrap();
         assert!(!result.is_error);
 
         let entry = mem
@@ -703,9 +742,12 @@ mod tests {
     async fn remember_writes_only_to_own_flow_namespace() {
         let (_tmp, mem) = test_mem();
         let tool = FlowMemoryRememberTool::new(mem.clone(), test_security());
-        tool.execute(json!({"flow_id": "f1", "key": "k", "content": "f1 content"}))
-            .await
-            .unwrap();
+        turn_origin::with_origin(
+            trusted_workflow_origin("f1"),
+            tool.execute(json!({"flow_id": "f1", "key": "k", "content": "f1 content"})),
+        )
+        .await
+        .unwrap();
 
         // Never lands in another flow's namespace, the shared "flows" scope
         // namespace, or global/user memory.
@@ -713,6 +755,41 @@ mod tests {
         assert!(mem.get("global", "k").await.unwrap().is_none());
         assert!(mem
             .get("f1", "k") // raw flow_id, not the derived namespace
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    /// SECURITY (T-M2): the primary fix under test — a chat/orchestrator turn
+    /// (no trusted `Workflow` run origin) must be refused outright, never
+    /// routed to the model-supplied `flow_id`. This is the exact
+    /// prompt-injection scenario: an attacker-controlled chat turn calling
+    /// `flow_memory_remember` with another flow's id to poison its dedup
+    /// memory (e.g. mark an item as already-sent so a digest flow skips it
+    /// forever).
+    #[tokio::test]
+    async fn remember_refuses_outside_a_trusted_workflow_run() {
+        let (_tmp, mem) = test_mem();
+        let tool = FlowMemoryRememberTool::new(mem.clone(), test_security());
+
+        // No `turn_origin::with_origin` wrapper — this call has no trusted
+        // Workflow run origin, exactly like every chat/orchestrator turn.
+        let result = tool
+            .execute(json!({
+                "flow_id": "digest-flow-victim",
+                "key": "sent_item_42",
+                "content": "Sent newsletter item 42 to subscribers"
+            }))
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(result
+            .output()
+            .contains("only available inside a workflow run"));
+        // Nothing was written to the targeted namespace — or anywhere else.
+        assert!(mem
+            .get(&flow_namespace("digest-flow-victim"), "sent_item_42")
             .await
             .unwrap()
             .is_none());
@@ -781,14 +858,16 @@ mod tests {
     async fn remember_rejects_secret_like_content() {
         let (_tmp, mem) = test_mem();
         let tool = FlowMemoryRememberTool::new(mem.clone(), test_security());
-        let result = tool
-            .execute(json!({
+        let result = turn_origin::with_origin(
+            trusted_workflow_origin("f1"),
+            tool.execute(json!({
                 "flow_id": "f1",
                 "key": "api",
                 "content": "api_key=sk-123456789012345678901234567890"
-            }))
-            .await
-            .unwrap();
+            })),
+        )
+        .await
+        .unwrap();
         assert!(result.is_error);
         assert!(result.output().contains("looks like a secret"));
         assert!(mem
@@ -798,10 +877,12 @@ mod tests {
             .is_none());
     }
 
-    // T-m5: same channel-consistency fix as recall's missing-param tests
-    // above.
+    /// Outside a trusted run, `flow_id` no longer matters — the T-M2 refusal
+    /// fires regardless of whether it was supplied. (Inside a trusted run the
+    /// arg is informational only and ignored either way — see
+    /// `remember_ignores_mismatched_flow_id_arg_inside_trusted_workflow_run`.)
     #[tokio::test]
-    async fn remember_missing_flow_id_errs() {
+    async fn remember_missing_flow_id_outside_trusted_run_is_refused() {
         let (_tmp, mem) = test_mem();
         let tool = FlowMemoryRememberTool::new(mem, test_security());
         let result = tool
@@ -809,9 +890,14 @@ mod tests {
             .await
             .unwrap();
         assert!(result.is_error);
-        assert!(result.output().contains("Missing 'flow_id'"));
+        assert!(result
+            .output()
+            .contains("only available inside a workflow run"));
     }
 
+    // T-m5 (retained through the T-M2 merge): the missing-param checks run
+    // BEFORE the trusted-origin resolution, so they are still reachable outside
+    // a run and still assert the `ToolResult::error` channel rather than `Err`.
     #[tokio::test]
     async fn remember_missing_key_errs() {
         let (_tmp, mem) = test_mem();

--- a/src/openhuman/flows/ops.rs
+++ b/src/openhuman/flows/ops.rs
@@ -6319,10 +6319,14 @@ const FLOW_BUILD_TIMEOUT_SECS: u64 = 600;
 /// confirmation — the exact HITL hole #4593 closed, reopened by #4881
 /// widening the belt.
 ///
-/// `cancel_flow_run` fires no new outbound effect
-/// (`external_effect() == false`), so it isn't a gate-bypass concern the same
-/// way — but an authoring turn still has no business tearing down a run the
-/// *user* started, so it is hidden alongside the two above out of caution.
+/// `cancel_flow_run` ([`builder_tools::CancelFlowRunTool`]) is now
+/// `external_effect() == true` and ownership-checks the run against a
+/// caller-named `flow_id` (T-M3 fix) — but that gate is exactly the one this
+/// `Cli`-origin path auto-allows, same as `resume_flow_run` above, so the
+/// ownership check alone is not a substitute for a human decision here. An
+/// authoring turn still has no business tearing down a run the *user*
+/// started with zero confirmation, so it stays hidden alongside the two
+/// above out of caution.
 ///
 /// `create_workflow` / `duplicate_flow` are deliberately **left visible**:
 /// both are hard-forced **born disabled** (see [`builder_tools::CreateWorkflowTool`]
@@ -6371,20 +6375,31 @@ fn restrict_builder_toolset(agent: &mut crate::openhuman::agent::Agent) {
 /// longer need to be hidden on this path: they are reachable, but gated
 /// behind a real approval, exactly like a main-chat tool call.
 ///
-/// `cancel_flow_run` stays HIDDEN on this path, though. It reports
-/// `external_effect() == false`, so `ApprovalSecurityMiddleware` would not park
-/// it behind the approval surface — and the tool cancels an arbitrary run id
-/// (e.g. one read from `list_flow_runs`) with no ownership check. An unhidden
-/// `cancel_flow_run` would therefore let a streaming copilot turn cancel ANY
-/// in-flight or approval-parked run, unapproved — far broader than the "stop a
-/// run the copilot itself started" companion use it was meant for. Until it
-/// gains an ownership/approval guard it is kept hidden here (a user can still
-/// cancel from the Runs rail). (codex review, #5090.)
+/// `cancel_flow_run` stays HIDDEN on this path (codex review, #5090) — but for
+/// a narrower reason than before. The original justification was that it
+/// reported `external_effect() == false`, so `ApprovalSecurityMiddleware`
+/// would not park it behind the approval surface, and that it cancelled an
+/// arbitrary run id (e.g. one read from `list_flow_runs`) with no ownership
+/// check: an unhidden call would have let a streaming copilot turn cancel ANY
+/// in-flight or approval-parked run, unapproved. **The T-M3 fix closed both of
+/// those gaps** — [`builder_tools::CancelFlowRunTool`] is now
+/// `external_effect() == true` (so it would park behind the same real
+/// `WebChat` approval card as `run_flow`/`resume_flow_run` on this path) AND
+/// verifies the target run actually belongs to the caller-named `flow_id`
+/// before touching it.
+///
+/// It is nonetheless kept hidden **deliberately**. Unhiding it would be a
+/// capability expansion, not a security fix: it newly lets an authoring turn
+/// tear down a run the *user* started, which is a product decision nobody has
+/// taken — and hardening the tool is not a reason to take it implicitly. A
+/// user can still cancel from the Runs rail. Dropping this entry is now safe
+/// from a gating standpoint whenever that decision is made; that safety is
+/// what the T-M3 fix bought.
 ///
 /// `run_workflow` (the unrelated legacy skills-workflow runner sharing this
-/// belt) stays hidden on BOTH paths — belt-and-braces against a re-rename or
-/// the name ever leaking back onto the `workflow_builder` toolset; `hide_tools`
-/// no-ops on a name that isn't present.
+/// belt) stays hidden — belt-and-braces against a re-rename or the name ever
+/// leaking back onto the `workflow_builder` toolset; `hide_tools` no-ops on a
+/// name that isn't present.
 const FLOWS_BUILD_COPILOT_HIDDEN_TOOLS: &[&str] = &["run_workflow", "cancel_flow_run"];
 
 /// Strip only [`FLOWS_BUILD_COPILOT_HIDDEN_TOOLS`] from `agent`'s callable set
@@ -6394,9 +6409,10 @@ fn restrict_builder_toolset_for_copilot(agent: &mut crate::openhuman::agent::Age
     tracing::info!(
         target: "flows",
         hidden = ?FLOWS_BUILD_COPILOT_HIDDEN_TOOLS,
-        "[flows] flows_build: streaming copilot turn — run_flow/resume_flow_run stay visible \
-         (gated behind the WebChat approval surface); run_workflow + cancel_flow_run hidden \
-         (cancel_flow_run has no external_effect to park and no run-ownership guard)"
+        "[flows] flows_build: streaming copilot turn — run_flow/resume_flow_run/cancel_flow_run \
+         stay visible (all three gated behind the WebChat approval surface; cancel_flow_run also \
+         ownership-checks the target run's flow_id — T-M3 fix); only the unrelated legacy \
+         run_workflow is hidden"
     );
     agent.hide_tools(FLOWS_BUILD_COPILOT_HIDDEN_TOOLS);
 }

--- a/src/openhuman/flows/ops_tests.rs
+++ b/src/openhuman/flows/ops_tests.rs
@@ -5675,6 +5675,15 @@ async fn flows_build_hides_the_live_run_tool_from_the_builder_belt() {
         "resume_flow_run advances a real run's outbound effects, so it must be \
          external-effect for the same #4593/#4881 concern to apply"
     );
+    let canceller = crate::openhuman::flows::builder_tools::CancelFlowRunTool::new(
+        std::sync::Arc::new(config.clone()),
+    );
+    assert!(
+        canceller.external_effect(),
+        "cancel_flow_run is external-effect since the T-M3 fix — it stays hidden on THIS \
+         (Cli-origin, auto-allow) path regardless, because that gate is exactly what this \
+         origin bypasses; see restrict_builder_toolset's doc"
+    );
 
     crate::openhuman::agent::harness::AgentDefinitionRegistry::init_global(&config.workspace_dir)
         .expect("agent registry init");
@@ -5739,10 +5748,11 @@ fn flows_build_hide_lists_have_the_expected_contents() {
         FLOWS_BUILD_COPILOT_HIDDEN_TOOLS,
         ["run_workflow", "cancel_flow_run"],
         "the streaming (copilot) hide-list must hide the legacy `run_workflow` AND \
-         `cancel_flow_run` — the latter has no external_effect to park and no \
-         run-ownership guard (codex #5090), so it must NOT be exposed unapproved; \
-         only `run_flow`/`resume_flow_run` stay visible, gated by the WebChat \
-         approval surface"
+         `cancel_flow_run`. The T-M3 fix DID give the latter `external_effect() == true` \
+         plus a run-ownership guard, so it would now park safely here — but unhiding it \
+         is a capability expansion (letting an authoring turn tear down a user-started \
+         run), not a security fix, and that product decision has not been taken. Only \
+         `run_flow`/`resume_flow_run` stay visible, gated by the WebChat approval surface"
     );
     for tool in [
         "run_workflow",
@@ -5761,9 +5771,11 @@ fn flows_build_hide_lists_have_the_expected_contents() {
 /// Streaming (copilot) path: `restrict_builder_toolset_for_copilot` leaves
 /// `run_flow` / `resume_flow_run` visible on the builder's belt — they're gated
 /// by the WebChat approval surface, not hidden — while hiding the unrelated
-/// legacy `run_workflow` AND `cancel_flow_run` (the latter can't be parked and
-/// has no run-ownership guard — codex #5090) and keeping every authoring tool
-/// reachable (PR3: flows-copilot-live-run-approval).
+/// legacy `run_workflow` AND `cancel_flow_run`, and keeping every authoring
+/// tool reachable (PR3: flows-copilot-live-run-approval). The T-M3 fix made
+/// `cancel_flow_run` safe to unhide (external_effect + run-ownership guard),
+/// but doing so would newly let an authoring turn tear down a user-started
+/// run — a product decision, deliberately not taken here.
 #[tokio::test]
 async fn flows_build_copilot_toolset_unhides_the_live_run_tools() {
     let tmp = TempDir::new().unwrap();
@@ -5789,8 +5801,9 @@ async fn flows_build_copilot_toolset_unhides_the_live_run_tools() {
     for hidden in ["run_workflow", "cancel_flow_run"] {
         assert!(
             !visible.contains(hidden),
-            "`{hidden}` must stay hidden on the copilot path (legacy runner / \
-             unparkable-and-unguarded cancel — codex #5090); visible = {visible:?}"
+            "`{hidden}` must stay hidden on the copilot path (unrelated legacy runner / \
+             a cancel that is now safe to unhide but deliberately still gated behind a \
+             product decision); visible = {visible:?}"
         );
     }
     for keep in [

--- a/src/openhuman/tools/ops.rs
+++ b/src/openhuman/tools/ops.rs
@@ -399,10 +399,14 @@ pub fn all_tools_with_runtime(
         // Per-flow sandboxed memory (issue #5173): lets a running flow
         // (e.g. a scheduled newsletter-digest) remember what it already did
         // — dedupe across runs — without ever touching the user's own
-        // memory. Namespace is derived internally from `flow_id`; there is
-        // no code path by which either tool can address a namespace other
-        // than the calling flow's own (`flow_memory_recall`'s `scope:
-        // "flows"` is read-only cross-flow visibility, not a write path).
+        // memory. Namespace is derived internally from `flow_id`.
+        // `flow_memory_remember` (write) only resolves that `flow_id` from
+        // the run's own trusted `TrustedAutomation { Workflow }` turn origin
+        // (T-M2 fix) — a chat/orchestrator turn with no trusted run origin
+        // is refused outright, never routed to a model-supplied `flow_id`.
+        // `flow_memory_recall`'s `scope: "flows"` is a deliberate read-only
+        // cross-flow exception — it can see every flow's namespace by
+        // design, but can never be used to write outside a flow's own.
         #[cfg(feature = "flows")]
         Box::new(FlowMemoryRecallTool::new(memory.clone())),
         #[cfg(feature = "flows")]


### PR DESCRIPTION
## Summary

- Closes two authorization boundaries in the flow-run tool surface, both of which the code's **own comments already half-acknowledged**.
- `flow_memory_remember` no longer trusts a model-supplied `flow_id` outside a workflow run — a prompt-injected chat turn could poison another flow's private dedup memory.
- `cancel_flow_run` now reports `external_effect() == true` so it **parks for approval** instead of cancelling any run unapproved — that is the real boundary — plus an ownership check as defence-in-depth (see the honest scoping note below).
- Corrects a registration comment in `tools/ops.rs` that asserted an invariant the code did not hold.

## Problem

**T-M2 — cross-flow memory poisoning from chat.** Inside a run, `FlowMemoryRememberTool` resolves the namespace-governing flow id from the trusted `TrustedAutomation { Workflow }` turn origin and ignores the arg — airtight. But when `trusted_flow_id()` returns `None`, which is *every* chat/orchestrator turn, it fell back to the model-supplied `flow_id` and wrote into that flow's namespace.

The registration comment in `tools/ops.rs` claimed "there is no code path by which either tool can address a namespace other than the calling flow's own." That was true only inside runs.

Concretely: a prompt-injected chat turn calls `flow_memory_remember { flow_id: "<digest-flow-id>", key: "sent_item_42", … }` and the digest flow's dedup memory now says item 42 was already sent, so it silently skips it forever. The tool has no `external_effect`, so this never parked for approval.

**T-M3 — `cancel_flow_run` had no ownership check.** It cancelled an arbitrary `run_id` (its own doc comment said so), reported `external_effect() == false` so the approval gate never parked it, and was hidden only on the two `flows_build` paths — not on orchestrator delegation or main chat, which also carry the tool. Injected content could therefore cancel any in-flight or approval-parked automation.

## Solution

**T-M2** — outside a trusted workflow run the write is **refused outright** rather than routed to an arg that cannot be distinguished from an attacker's. There is no legitimate chat-side use case for writing another flow's private namespace, and refusing is the only fail-closed option that does not require inventing an ownership proof. The registration comment is corrected to describe the real invariant. `flow_memory_recall` is untouched — it stays read-only, and its `scope: "flows"` cross-flow read is deliberate.

A caller audit found nothing depending on the removed fallback; `tinyflows`'s own memory-node adapter already used this fail-closed pattern.

**T-M3** — two changes, of unequal weight:
1. **`external_effect() == true`** — so `ApprovalSecurityMiddleware` parks it wherever a gate exists. **This is the actual authorization boundary.** Pinned by an `ApprovalGate` integration test proving the call parks and TTL-denies rather than auto-executing.
2. **Ownership check** — the tool now takes `{ flow_id, run_id }`, resolves the run's actual `flow_id`, and refuses on mismatch, mirroring `resume_flow_run`/`flows_resume`'s existing shape rather than inventing a new one.

### Honest scoping: the ownership check narrows the attack, it does not close it

Review raised this and it is worth stating plainly rather than leaving the summary to imply otherwise. `list_flows` takes no arguments, is `PermissionLevel::None` and `external_effect() == false`; `list_flow_runs` returns `flow_id` inline for every run. Chaining the two reconstructs the full `run_id → flow_id` map, and both are available on exactly the surfaces `cancel_flow_run` is. So a caller that can reach `cancel_flow_run` at all can simply look up the correct `flow_id` first — the ownership check costs an attacker one extra tool round-trip, nothing more.

It is still worth having: it stops accidental cross-flow cancellation, such as a model reusing a stale or hallucinated `run_id`. But **the approval-gate parking is what actually stops an unapproved cancel**, and the same defeatable pattern already exists unchanged in `resume_flow_run`, so this PR mirrors precedent rather than introducing a new false sense of security. The in-code comments were already accurate on this point; this section brings the PR summary in line with them.

### Deliberate non-change reviewers should weigh

Both `flows_build` hide-lists are left **unchanged**. Hardening the tool makes it *safe* to unhide on the copilot path — but unhiding is a **capability expansion**, not a security fix: it would newly let an authoring turn tear down a run the *user* started. That product decision has not been taken, and hardening is not a reason to take it implicitly. A user can still cancel from the Runs rail. The entry can be dropped whenever you decide you want it; this PR is what makes doing so safe. It stays hidden on the headless path regardless, since a `Cli`-trusted origin auto-allows `external_effect` tools.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — refusal paths, the still-working in-run write, ownership mismatch, and a real `ApprovalGate` park are all covered; `cargo test --lib openhuman::flows` = 554 passed, 0 failed
- [x] Coverage matrix updated — `N/A: security hardening of existing tools, no feature rows added/removed/renamed`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature rows affected`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: agent-tool surface only`
- [x] Linked issue closed via `Closes #NNN` — `N/A: found by code review, no tracking issue filed yet`

## Impact

- **Runtime/platform:** Rust core agent-tool surface only.
- **Behaviour (breaking for agents):** `cancel_flow_run`'s schema gains a **required** `flow_id`. Any caller passing only `run_id` now gets a clear parameter error. `flow_memory_remember` called outside a run now errors instead of writing.
- **Security:** both changes are fail-closed. The `ApprovalGate` test proves the now-external-effect `cancel_flow_run` genuinely parks and times out to `Deny` rather than auto-executing.
- **Migration:** none. No schema change, no `Cargo.toml`/`Cargo.lock` change.

## Related

- Closes: `N/A`
- Follow-up PR(s)/TODOs: decide whether to unhide `cancel_flow_run` on the copilot path (now safe, deliberately deferred). The stale-approval-after-graph-swap gap (a run parked on the old graph config resuming against a rewritten node) is a separate stacked PR.
- **Merge order:** overlaps `src/openhuman/flows/ops.rs` + `ops_tests.rs` with the resume-lifecycle PR, and `builder_tools.rs` + `builder_tools_tests.rs` with the contract-drift PR. Merge the resume-lifecycle PR **first**, then this, then contract-drift.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/flows-authorization-boundaries`
- Commit SHA: `9e59c8cca`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A, no frontend files changed
- [x] `pnpm typecheck` — N/A, no TypeScript changed
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --lib openhuman::flows` → **554 passed, 0 failed**
- [x] Rust fmt/check (if changed): `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml` clean
- [x] Tauri fmt/check (if changed): N/A, `app/src-tauri` untouched

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: flow-scoped memory writes require a trusted workflow run origin; run cancellation requires proving which flow owns the run and parks for approval.
- User-visible effect: an agent asked to cancel a run must name the owning flow, and the cancel surfaces an approval card where a gate exists.

### Parity Contract

- Legacy behavior preserved: the in-run `flow_memory_remember` path is byte-for-byte unchanged and still pinned by `remember_ignores_mismatched_flow_id_arg_inside_trusted_workflow_run`; `flow_memory_recall` is untouched.
- Guard/fallback/dispatch parity checks: both `flows_build` hide-lists are unchanged and still pinned by their existing contents tests, so no path silently gained a tool.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


