### PR TITLE
fix(rhai): restore the documented timeout ordering and honour a reused session's policy

### DIFF
--- a/src/openhuman/rhai_workflows/README.md
+++ b/src/openhuman/rhai_workflows/README.md
@@ -29,18 +29,43 @@ the tool result. The orchestrator's own turn loop *is* the CodeAct driver loop.
 Every failure mode returns a **model-consumable tool result** — never a panic,
 never a hung turn:
 
-- **Layered time bounds:** (1) rhai `on_progress` deadline for pure script
-  loops; (2) `bridge_block_on` timer race for hung capability futures;
-  (3) an outer `tokio::time::timeout(policy.timeout + 5s)` around
-  `spawn_blocking`; (4) the harness `ToolTimeout::Secs` backstop above all of
-  them. The tool's own timeout is always set below the harness backstop.
+- **Layered time bounds, strictly ordered `inner < outer < harness`:**
+  (1) the **inner** deadline — rhai `on_progress` for pure script loops and
+  the `bridge_block_on` timer race for hung capability futures, both driven
+  by `policy.timeout` (`policy.rs::resolve_policy`); (2) the **outer**
+  `tokio::time::timeout` around `spawn_blocking` in `ops.rs`, at
+  `policy.timeout + OUTER_TIMEOUT_GRACE_SECS` (`policy::outer_backstop_secs`);
+  (3) the **harness** `ToolTimeout::Secs` backstop the agent tool-execution
+  loop enforces, at `outer_backstop_secs + HARNESS_TIMEOUT_GRACE_SECS`
+  (`policy::harness_backstop_secs`, wired in `tools.rs::timeout_policy`) —
+  strictly above both inner layers. Each grace exists so the *next* layer out
+  only ever fires if every layer inside it already failed to enforce its own
+  deadline: the inner deadline is the primary enforcement point, the outer
+  backstop defends against a hung/poisoned inner layer (dropping the session
+  on fire), and the harness backstop is a last resort — if it ever won the
+  race it would drop the whole tool-execution future, skipping the
+  `RhaiError::Timeout` taxonomy, `finish_cell` accounting, `close_session`,
+  and the outer-backstop session cleanup entirely (E-M1).
 - **Bounded sessions:** LRU cap (16) + idle TTL (30 min); a second concurrent
   call on a busy session returns a typed "session busy" error rather than
-  deadlocking; a poisoned/errored session is dropped, never reused.
+  deadlocking; a poisoned/errored session is dropped, never reused. Neither
+  sweep ever evicts a slot whose cell is currently in flight (its session
+  `Mutex` held) — the cap/TTL can be exceeded, logged, while every live slot
+  is genuinely busy, but a running cell's session is never pulled out from
+  under it (E-m6).
 - **Bounded work per session:** `ReplPolicy` caps on operations, output bytes,
   script bytes, and per-kind call counts. `full` tier may raise call-count
   limits up to a hard 2× ceiling via the tool's `limits` arg; `readonly` tier
   does not get the tool at all.
+- **Reused sessions keep their own policy:** `ReplSession` exposes no
+  re-policy operation after construction (only builder-style `with_policy`),
+  so `sessions::SlotHandle` carries the policy a session was actually built
+  with. A cell that reuses a `session_id` with a *different* resolved policy
+  (e.g. a different `timeout_secs`/`limits`) logs a warning and every bound
+  for that call — the outer backstop, `limits_remaining` — is computed from
+  the session's live policy, never the newly-resolved one (E-M2). This is
+  deliberate: keying the session cache on a policy fingerprint instead would
+  silently fragment sessions and lose bindings by design.
 - **Cancellation end-to-end:** the turn's run-cancellation token drives a
   `ReplCancelFlag` watcher, so a user cancel drops an in-flight cell (script or
   capability call) promptly; the session is left resumable.

--- a/src/openhuman/rhai_workflows/bridge.rs
+++ b/src/openhuman/rhai_workflows/bridge.rs
@@ -20,6 +20,8 @@
 //! `run_workflow`/`await_workflow`. `ToolScope::CliRpcOnly` tools are excluded
 //! too.
 
+use std::cell::RefCell;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -58,7 +60,8 @@ fn is_excluded_tool(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::is_excluded_tool;
+    use super::*;
+    use crate::openhuman::tools::traits::ToolResult as OhToolResult;
 
     #[test]
     fn recursion_and_duplication_hazards_are_excluded() {
@@ -78,6 +81,153 @@ mod tests {
             assert!(!is_excluded_tool(name), "{name} should be callable");
         }
     }
+
+    // ── Per-cell outcome tracking (E-m5) ──────────────────────────────────
+
+    #[test]
+    fn outcome_tracking_round_trips_and_resets() {
+        // Untracked (no `begin_call_outcome_tracking`) is a safe no-op.
+        record_call_outcome("orphan", false);
+        assert!(take_call_outcomes().is_empty());
+
+        begin_call_outcome_tracking();
+        record_call_outcome("a", true);
+        record_call_outcome("b", false);
+        let outcomes = take_call_outcomes();
+        assert_eq!(outcomes.get("a"), Some(&true));
+        assert_eq!(outcomes.get("b"), Some(&false));
+
+        // `take` ends tracking — a later record without a new `begin` is a
+        // no-op again, so it can never bleed into the next cell on the same
+        // (possibly reused) thread-pool thread.
+        record_call_outcome("c", true);
+        assert!(take_call_outcomes().is_empty());
+    }
+
+    /// A minimal openhuman [`OhTool`] whose success/failure is driven by its
+    /// `fail` argument, for exercising [`RhaiToolAdapter::dispatch`] end to
+    /// end.
+    struct FlakyTool;
+
+    #[async_trait]
+    impl OhTool for FlakyTool {
+        fn name(&self) -> &str {
+            "flaky"
+        }
+        fn description(&self) -> &str {
+            "fails when called with fail: true"
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({ "type": "object" })
+        }
+        async fn execute(&self, args: serde_json::Value) -> anyhow::Result<OhToolResult> {
+            if args.get("fail").and_then(serde_json::Value::as_bool) == Some(true) {
+                Ok(OhToolResult::error("boom"))
+            } else {
+                Ok(OhToolResult::json(serde_json::json!({ "ok": true })))
+            }
+        }
+    }
+
+    fn flaky_adapter() -> RhaiToolAdapter {
+        let tools: Arc<Vec<Box<dyn OhTool>>> = Arc::new(vec![Box::new(FlakyTool)]);
+        RhaiToolAdapter::new(tools.clone(), tools[0].as_ref())
+    }
+
+    fn call(id: &str, fail: bool) -> TaToolCall {
+        TaToolCall {
+            id: id.to_string(),
+            name: "flaky".to_string(),
+            arguments: serde_json::json!({ "fail": fail }),
+            invalid: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_records_a_successful_call_as_ok() {
+        let adapter = flaky_adapter();
+        begin_call_outcome_tracking();
+        let result = adapter.dispatch(call("c-ok", false), None).await;
+        assert!(result.error.is_none());
+        assert_eq!(take_call_outcomes().get("c-ok"), Some(&true));
+    }
+
+    #[tokio::test]
+    async fn dispatch_records_a_failed_call_as_not_ok() {
+        let adapter = flaky_adapter();
+        begin_call_outcome_tracking();
+        let result = adapter.dispatch(call("c-fail", true), None).await;
+        assert!(result.error.is_some());
+        assert_eq!(
+            take_call_outcomes().get("c-fail"),
+            Some(&false),
+            "a tool-reported failure must be tracked as not ok even though the vendor REPL \
+             records the call regardless of `result.error`"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_records_an_unknown_tool_as_not_ok() {
+        let tools: Arc<Vec<Box<dyn OhTool>>> = Arc::new(Vec::new());
+        let missing_tool = FlakyTool;
+        let adapter = RhaiToolAdapter::new(tools, &missing_tool);
+        begin_call_outcome_tracking();
+        let result = adapter.dispatch(call("c-missing", false), None).await;
+        assert!(result.error.is_some());
+        assert_eq!(take_call_outcomes().get("c-missing"), Some(&false));
+    }
+}
+
+// ── Per-cell tool-call outcome tracking (E-m5) ──────────────────────────────
+//
+// The vendor REPL's `tool_call_impl` records a `ReplCallRecord` for a tool
+// call *before* it checks whether the tool itself reported an error (so a
+// try/catch-wrapped failure still lands in `ReplResult::calls`), and
+// `tool_call_batched_impl` records + keeps going on a per-item tool failure
+// without ever raising at all. `ReplCallRecord` carries no success flag
+// either way, so `ops::summarize_calls` cannot tell a caught/per-batch-item
+// failure from a success by looking at the vendor record alone. This tracks
+// the real outcome on our side, keyed by the same `call_id` the vendor record
+// carries, as each call is dispatched through [`RhaiToolAdapter::dispatch`].
+
+thread_local! {
+    /// Per-cell outcome map (`call_id` -> `ok`). `None` means "not currently
+    /// tracking" (a call dispatched outside an `eval_cell` — defensive only,
+    /// should not happen) so `record_call_outcome` is a safe no-op; `ops.rs`
+    /// defaults an untracked `call_id` to `ok: true`, matching every other
+    /// capability kind (model/agent/graph/emit), which the vendor session
+    /// only ever records on success.
+    static CALL_OUTCOMES: RefCell<Option<HashMap<String, bool>>> = const { RefCell::new(None) };
+}
+
+/// Begins per-cell tool-call outcome tracking on the current thread. Call
+/// once, immediately before `ReplSession::eval_cell`, matched by
+/// [`take_call_outcomes`] after it returns.
+///
+/// Confined to a single OS thread by construction: `eval_cell` and every tool
+/// dispatch it drives run synchronously on the `spawn_blocking` thread that
+/// calls this — the vendor REPL's capability bridge blocks that same thread
+/// to completion (`futures::executor::block_on`, see
+/// `session/builtins/mod.rs`'s module doc) rather than yielding to another
+/// worker thread.
+pub(super) fn begin_call_outcome_tracking() {
+    CALL_OUTCOMES.with(|cell| *cell.borrow_mut() = Some(HashMap::new()));
+}
+
+/// Ends tracking and returns everything recorded since the matching
+/// [`begin_call_outcome_tracking`] (empty if tracking was never begun).
+pub(super) fn take_call_outcomes() -> HashMap<String, bool> {
+    CALL_OUTCOMES
+        .with(|cell| cell.borrow_mut().take())
+        .unwrap_or_default()
+}
+
+fn record_call_outcome(call_id: &str, ok: bool) {
+    CALL_OUTCOMES.with(|cell| {
+        if let Some(map) = cell.borrow_mut().as_mut() {
+            map.insert(call_id.to_string(), ok);
+        }
+    });
 }
 
 /// Builds the `CapabilityRegistry<()>` a session binds against from the parent
@@ -171,7 +321,7 @@ impl RhaiToolAdapter {
         context: Option<&ToolExecutionContext>,
     ) -> TaToolResult {
         let found = self.tools.iter().find(|t| t.name() == self.name);
-        match found {
+        let result = match found {
             Some(tool) => gated_execute(tool.as_ref(), call, context).await,
             None => {
                 tracing::warn!(tool = %self.name, "[rhai_workflows] bridged tool not found at call time");
@@ -184,7 +334,14 @@ impl RhaiToolAdapter {
                     elapsed_ms: 0,
                 }
             }
-        }
+        };
+        // Record the real outcome (E-m5) — the vendor REPL records a
+        // `ReplCallRecord` for this call_id regardless of `result.error`, so
+        // `ops::summarize_calls` needs this side channel to report a
+        // caught/per-batch-item tool failure as `ok: false` instead of the
+        // vendor type's implicit (wrong) "recorded == succeeded".
+        record_call_outcome(&result.call_id, result.error.is_none());
+        result
     }
 }
 

--- a/src/openhuman/rhai_workflows/ops.rs
+++ b/src/openhuman/rhai_workflows/ops.rs
@@ -16,15 +16,10 @@ use crate::openhuman::security::live_policy;
 use crate::openhuman::security::policy::AutonomyLevel;
 use crate::openhuman::tinyagents::run_cancellation_context::current_run_cancellation;
 
-use super::bridge::build_capability_registry;
-use super::policy::{resolve_policy, DEFAULT_RHAI_TIMEOUT_SECS};
+use super::bridge::{begin_call_outcome_tracking, build_capability_registry, take_call_outcomes};
+use super::policy::{outer_backstop_secs, resolve_policy, DEFAULT_RHAI_TIMEOUT_SECS};
 use super::sessions::RhaiSessionManager;
 use super::types::{RhaiCallSummary, RhaiEvalRequest, RhaiEvalResponse, RhaiLimitsRemaining};
-
-/// Grace added to the inner policy timeout for the outer `spawn_blocking`
-/// backstop — the inner deadline should always fire first; this defends against
-/// bugs in the inner layers, and if it ever fires the session is dropped.
-const OUTER_TIMEOUT_GRACE: Duration = Duration::from_secs(5);
 
 /// Hard cap on the characters returned to the model in `stdout`, so a runaway
 /// print cannot flood the context window even within the byte policy.
@@ -124,8 +119,13 @@ impl RhaiAvailable {
 /// The internal result of the blocking cell task, distinguishing a lock
 /// contention / poison from an actual evaluation outcome.
 enum CellRun {
-    /// The cell ran; carries the raw evaluation result.
-    Completed(Result<ReplResult, TinyAgentsError>),
+    /// The cell ran; carries the raw evaluation result plus the per-call
+    /// tool-outcome side channel recorded during it (E-m5 — see
+    /// [`super::bridge`]).
+    Completed(
+        Result<ReplResult, TinyAgentsError>,
+        std::collections::HashMap<String, bool>,
+    ),
     /// Another cell holds the session lock.
     Busy,
     /// The session mutex was poisoned by a prior panic.
@@ -189,7 +189,6 @@ async fn run_cell(
     // session builder (used only on a fresh session; a reused session keeps its
     // own registry).
     let available = RhaiAvailable::from_registry(&registry);
-    let policy_for_build = policy.clone();
 
     tracing::info!(
         session_key = %key,
@@ -199,12 +198,19 @@ async fn run_cell(
         "[rhai_workflows] eval_rhai_cell: start"
     );
 
-    let handle = manager.get_or_create(&key, move || {
+    // `get_or_create` only uses `policy` to build a *fresh* session; a reused
+    // session keeps whatever policy it was actually built with, returned on
+    // `handle.policy` (E-M2 — see `sessions::SlotHandle`). Every bound below
+    // is computed from `handle.policy`, never from the `policy` this call
+    // just resolved, so a reused session's live bounds can never regress
+    // out from under it.
+    let handle = manager.get_or_create(&key, policy, move |resolved_policy| {
         let capabilities = ReplCapabilities::new(Arc::new(registry));
         ReplSession::<()>::new()
             .with_capabilities(capabilities)
-            .with_policy(policy_for_build)
+            .with_policy(resolved_policy)
     });
+    let session_policy = handle.policy.clone();
 
     // Fresh per-cell cancel flag (sticky flags would leave a reused session
     // permanently cancelled), wired to the turn's run-cancellation token.
@@ -223,10 +229,11 @@ async fn run_cell(
     let session = handle.session.clone();
     let script = req.script.clone();
     let flag_for_cell = cell_flag.clone();
-    let outer_bound = policy
+    let inner_secs = session_policy
         .timeout
-        .unwrap_or(Duration::from_secs(DEFAULT_RHAI_TIMEOUT_SECS))
-        + OUTER_TIMEOUT_GRACE;
+        .map(|d| d.as_secs())
+        .unwrap_or(DEFAULT_RHAI_TIMEOUT_SECS);
+    let outer_bound = Duration::from_secs(outer_backstop_secs(inner_secs));
 
     let join = tokio::task::spawn_blocking(move || {
         let mut guard = match session.try_lock() {
@@ -236,7 +243,10 @@ async fn run_cell(
         };
         // Install this cell's fresh cancel flag before running.
         guard.set_cancel_flag(flag_for_cell);
-        CellRun::Completed(guard.eval_cell(&script))
+        begin_call_outcome_tracking();
+        let eval = guard.eval_cell(&script);
+        let outcomes = take_call_outcomes();
+        CellRun::Completed(eval, outcomes)
     });
 
     let run = match tokio::time::timeout(outer_bound, join).await {
@@ -264,8 +274,8 @@ async fn run_cell(
         }
     };
 
-    let eval = match run {
-        CellRun::Completed(eval) => eval,
+    let (eval, outcomes) = match run {
+        CellRun::Completed(eval, outcomes) => (eval, outcomes),
         CellRun::Busy => {
             tracing::info!(session_key = %key, "[rhai_workflows] session busy — concurrent cell rejected");
             return Err(RhaiError::SessionBusy(format!(
@@ -299,15 +309,21 @@ async fn run_cell(
         stdout: truncate_chars(&result.stdout, MAX_RHAI_RESULT_CHARS),
         value: result.value.as_ref().map(|v| v.to_json()),
         variables_changed: result.variables_changed,
-        calls: summarize_calls(&result.calls),
+        calls: summarize_calls(&result.calls, &outcomes),
         final_answer: result.final_answer,
         elapsed_ms: result.elapsed.as_millis() as u64,
         cells_used: stats.cells,
         limits_remaining: RhaiLimitsRemaining {
-            cells: policy.max_iterations.saturating_sub(stats.cells),
-            model_calls: policy.max_model_calls.saturating_sub(stats.model_calls),
-            tool_calls: policy.max_tool_calls.saturating_sub(stats.tool_calls),
-            agent_calls: policy.max_agent_calls.saturating_sub(stats.agent_calls),
+            cells: session_policy.max_iterations.saturating_sub(stats.cells),
+            model_calls: session_policy
+                .max_model_calls
+                .saturating_sub(stats.model_calls),
+            tool_calls: session_policy
+                .max_tool_calls
+                .saturating_sub(stats.tool_calls),
+            agent_calls: session_policy
+                .max_agent_calls
+                .saturating_sub(stats.agent_calls),
         },
         closed: req.close_session,
     };
@@ -351,14 +367,27 @@ fn map_eval_error(err: TinyAgentsError, available: &RhaiAvailable) -> RhaiError 
 
 /// Summarizes recorded calls into the model-visible shape — kind, name, timing,
 /// success only, never raw arguments/payloads.
-fn summarize_calls(calls: &[ReplCallRecord]) -> Vec<RhaiCallSummary> {
+///
+/// `outcomes` (`call_id` -> `ok`, from [`super::bridge::take_call_outcomes`])
+/// is the only source of truth for a *tool* call's real success/failure
+/// (E-m5): the vendor `ReplCallRecord` the session hands back carries no
+/// success flag, and for a tool call specifically "recorded" does not imply
+/// "succeeded" — `tool_call_impl` records before checking the tool's own
+/// error, and `tool_call_batched_impl` records + continues on a per-item tool
+/// failure without ever raising. A call with no tracked outcome (every other
+/// capability kind — model/agent/graph/emit — which the vendor session only
+/// ever records on success) defaults to `ok: true`.
+fn summarize_calls(
+    calls: &[ReplCallRecord],
+    outcomes: &std::collections::HashMap<String, bool>,
+) -> Vec<RhaiCallSummary> {
     calls
         .iter()
         .map(|c| RhaiCallSummary {
             kind: call_kind_str(c.kind).to_string(),
             name: c.name.clone(),
             elapsed_ms: c.elapsed.as_millis() as u64,
-            ok: true,
+            ok: outcomes.get(c.call_id.as_str()).copied().unwrap_or(true),
         })
         .collect()
 }
@@ -396,7 +425,9 @@ fn truncate_chars(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
     use std::sync::Arc;
+    use tinyagents::harness::ids::CallId;
     use tinyagents::harness::tool::{
         Tool as TaTool, ToolCall as TaToolCall, ToolResult as TaToolResult, ToolSchema,
     };
@@ -456,6 +487,55 @@ mod tests {
         // Unknown-tool errors list the live tool names for the model.
         let msg = map_eval_error(TinyAgentsError::ToolNotFound("nope".into()), &avail).message();
         assert!(msg.contains("read_file") && msg.contains("grep"), "{msg}");
+    }
+
+    /// E-m5: the vendor `ReplCallRecord` carries no success flag, and for a
+    /// tool call specifically the vendor session records the call before (or
+    /// regardless of) checking the tool's own error — so `summarize_calls`
+    /// must consult the side-channel `outcomes` map (from
+    /// `bridge::take_call_outcomes`) rather than assuming every recorded call
+    /// succeeded.
+    #[test]
+    fn summarize_calls_reports_a_failed_call_as_not_ok() {
+        let calls = vec![
+            ReplCallRecord {
+                call_id: CallId::new("call-1"),
+                kind: ReplCallKind::Tool,
+                name: "flaky_tool".into(),
+                detail: serde_json::Value::Null,
+                elapsed: Duration::from_millis(5),
+            },
+            ReplCallRecord {
+                call_id: CallId::new("call-2"),
+                kind: ReplCallKind::Tool,
+                name: "ok_tool".into(),
+                detail: serde_json::Value::Null,
+                elapsed: Duration::from_millis(5),
+            },
+            ReplCallRecord {
+                call_id: CallId::new("call-3"),
+                kind: ReplCallKind::Emit,
+                name: "progress".into(),
+                detail: serde_json::Value::Null,
+                elapsed: Duration::default(),
+            },
+        ];
+        let mut outcomes = HashMap::new();
+        outcomes.insert("call-1".to_string(), false);
+        outcomes.insert("call-2".to_string(), true);
+        // `call-3` (an `emit`) is deliberately untracked — only tool calls go
+        // through the outcome side channel.
+
+        let summaries = summarize_calls(&calls, &outcomes);
+        assert!(
+            !summaries[0].ok,
+            "a tracked failure must be reported as ok: false"
+        );
+        assert!(summaries[1].ok, "a tracked success stays ok: true");
+        assert!(
+            summaries[2].ok,
+            "an untracked call kind defaults to ok: true, matching every other capability kind"
+        );
     }
 
     // ── End-to-end `run_cell` matrix (with a hand-built registry) ────────────
@@ -656,11 +736,125 @@ mod tests {
         assert_eq!(manager.len(), 0, "close_session dropped the session");
     }
 
+    /// E-M2: `ReplSession` cannot be re-policied after construction
+    /// (`with_policy` is builder-style, consumed at build time), so a reused
+    /// session must report `limits_remaining` against the policy it was
+    /// *actually built with* — not whatever a later call happens to resolve.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reused_session_uses_its_own_policy_for_bounds() {
+        let manager = RhaiSessionManager::new_for_test();
+        let original_policy = ReplPolicy {
+            max_tool_calls: 5,
+            ..ReplPolicy::default()
+        };
+        let first = run_cell(
+            RhaiEvalRequest {
+                script: "let acc = 1; acc".into(),
+                session_id: Some("bounds".into()),
+                ..Default::default()
+            },
+            original_policy.clone(),
+            echo_registry(),
+            "t",
+            &manager,
+        )
+        .await
+        .expect("cell 1");
+        assert_eq!(first.limits_remaining.tool_calls, 5);
+
+        // A later call on the same session resolves a very different
+        // policy — as a cell passing `timeout_secs`/`limits` overrides would.
+        let different_policy = ReplPolicy {
+            max_tool_calls: 999,
+            ..ReplPolicy::default()
+        };
+        let second = run_cell(
+            RhaiEvalRequest {
+                script: "acc".into(),
+                session_id: Some("bounds".into()),
+                ..Default::default()
+            },
+            different_policy,
+            echo_registry(),
+            "t",
+            &manager,
+        )
+        .await
+        .expect("cell 2");
+        assert_eq!(
+            second.limits_remaining.tool_calls, 5,
+            "reused session must report bounds from its own live policy (5), \
+             not the newly-requested one (999)"
+        );
+    }
+
+    /// E-M2's binding-loss scenario: a session built with a long timeout is
+    /// reused by a cell that resolves a much shorter `timeout_secs`. With the
+    /// bug, the outer backstop and `limits_remaining` were computed from the
+    /// freshly-resolved (short) policy, so a slow-but-legitimate cell under
+    /// the *original* budget could trip the outer backstop and drop the whole
+    /// session, losing every binding. After the fix, both are computed from
+    /// the session's own stored policy, so the session survives and its
+    /// bindings are still visible.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn reused_session_with_a_shorter_requested_timeout_does_not_drop_the_session() {
+        let manager = RhaiSessionManager::new_for_test();
+        let long_policy = ReplPolicy {
+            timeout: Some(Duration::from_secs(300)),
+            ..ReplPolicy::default()
+        };
+        run_cell(
+            RhaiEvalRequest {
+                script: "let acc = 42; acc".into(),
+                session_id: Some("no-drop".into()),
+                ..Default::default()
+            },
+            long_policy,
+            echo_registry(),
+            "t",
+            &manager,
+        )
+        .await
+        .expect("cell 1");
+        assert_eq!(manager.len(), 1);
+
+        let short_policy = ReplPolicy {
+            timeout: Some(Duration::from_secs(1)),
+            ..ReplPolicy::default()
+        };
+        let second = run_cell(
+            RhaiEvalRequest {
+                script: "acc".into(),
+                session_id: Some("no-drop".into()),
+                ..Default::default()
+            },
+            short_policy,
+            echo_registry(),
+            "t",
+            &manager,
+        )
+        .await
+        .expect("cell 2 must not be dropped by a mismatched shorter timeout request");
+
+        assert_eq!(
+            second.value,
+            Some(serde_json::json!(42)),
+            "the binding from cell 1 must survive reuse under a different requested timeout"
+        );
+        assert_eq!(
+            manager.len(),
+            1,
+            "the session must still be live, not dropped"
+        );
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn concurrent_cell_on_a_busy_session_is_rejected() {
         let manager = RhaiSessionManager::new_for_test();
         let key = RhaiSessionManager::session_key("t", "busy");
-        let handle = manager.get_or_create(&key, || tinyagents::ReplSession::<()>::new());
+        let handle = manager.get_or_create(&key, ReplPolicy::default(), |policy| {
+            tinyagents::ReplSession::<()>::new().with_policy(policy)
+        });
         // Hold the session lock to simulate an in-flight cell.
         let _guard = handle.session.lock().unwrap();
 

--- a/src/openhuman/rhai_workflows/policy.rs
+++ b/src/openhuman/rhai_workflows/policy.rs
@@ -21,6 +21,36 @@ use super::types::RhaiLimitsOverride;
 /// deadline and the harness backstop agree.
 pub const DEFAULT_RHAI_TIMEOUT_SECS: u64 = 300;
 
+/// Grace added to the resolved inner [`ReplPolicy::timeout`] deadline for the
+/// outer `spawn_blocking` wall-clock backstop in `ops.rs` — the inner deadline
+/// should always fire first; the outer backstop only defends against bugs in
+/// the inner layers (a hung/poisoned session that never observes its own
+/// deadline). See [`outer_backstop_secs`] and the README's
+/// `inner < outer < harness` invariant.
+pub const OUTER_TIMEOUT_GRACE_SECS: u64 = 5;
+
+/// Additional grace layered on top of the outer backstop for the harness
+/// `ToolTimeout::Secs` deadline in `tools.rs`, so the harness enforcement
+/// (which drops the whole tool-execution future with no `RhaiError` taxonomy,
+/// `finish_cell` accounting, or session cleanup) only ever fires if *both*
+/// inner layers already failed to enforce their own deadlines — never as the
+/// primary enforcement point. See [`harness_backstop_secs`].
+pub const HARNESS_TIMEOUT_GRACE_SECS: u64 = 5;
+
+/// The outer `spawn_blocking` wall-clock backstop for a resolved inner
+/// deadline of `inner_secs` — strictly above `inner_secs`. Shared by `ops.rs`
+/// (which enforces it) and `tools.rs` (which must sit strictly above it).
+pub fn outer_backstop_secs(inner_secs: u64) -> u64 {
+    inner_secs.saturating_add(OUTER_TIMEOUT_GRACE_SECS)
+}
+
+/// The harness `ToolTimeout::Secs` backstop for a resolved inner deadline of
+/// `inner_secs` — strictly above [`outer_backstop_secs`], so the ordering
+/// `inner < outer < harness` documented in README.md always holds.
+pub fn harness_backstop_secs(inner_secs: u64) -> u64 {
+    outer_backstop_secs(inner_secs).saturating_add(HARNESS_TIMEOUT_GRACE_SECS)
+}
+
 /// Hard upper bound on batched concurrency, regardless of tier or override.
 pub const MAX_RHAI_CONCURRENCY: usize = 8;
 
@@ -199,5 +229,24 @@ mod tests {
     fn depth_respects_the_spawn_ceiling() {
         let p = resolve_policy(AutonomyLevel::Full, None, None).expect("policy");
         assert!(p.max_depth <= RHAI_MAX_DEPTH);
+    }
+
+    /// E-M1: the harness `ToolTimeout::Secs` backstop must sit strictly above
+    /// the outer `spawn_blocking` backstop, which must sit strictly above the
+    /// inner `ReplPolicy.timeout` deadline — matching README.md's stated
+    /// `inner < outer < harness` invariant. Asserted directly over the three
+    /// computed bounds so the constants can never drift back into the
+    /// `harness == inner < outer` inversion the review found.
+    #[test]
+    fn harness_backstop_is_strictly_above_outer_which_is_strictly_above_inner() {
+        for inner in [1, DEFAULT_RHAI_TIMEOUT_SECS, 3600] {
+            let outer = outer_backstop_secs(inner);
+            let harness = harness_backstop_secs(inner);
+            assert!(inner < outer, "inner {inner} should be < outer {outer}");
+            assert!(
+                outer < harness,
+                "outer {outer} should be < harness {harness}"
+            );
+        }
     }
 }

--- a/src/openhuman/rhai_workflows/sessions.rs
+++ b/src/openhuman/rhai_workflows/sessions.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock, PoisonError};
 use std::time::{Duration, Instant};
 
-use tinyagents::{ReplCallKind, ReplCancelFlag, ReplResult, ReplSession};
+use tinyagents::{ReplCallKind, ReplCancelFlag, ReplPolicy, ReplResult, ReplSession};
 
 /// Maximum number of live sessions before the least-recently-used one is
 /// evicted on the next access.
@@ -30,6 +30,14 @@ struct SessionSlot {
     /// The session's cancel flag (a clone of the one installed on the session),
     /// so a run-cancellation watcher can abort an in-flight cell.
     cancel: ReplCancelFlag,
+    /// The [`ReplPolicy`] the session was actually built with. `ReplSession`
+    /// only exposes builder-style `with_policy(mut self) -> Self` (no
+    /// re-policy after construction — vendor `session/mod.rs`), so a reused
+    /// session cannot adopt a newly-resolved policy; this is the durable
+    /// record of the one that is actually live, read back on every reuse
+    /// (E-M2) instead of trusting whatever policy the caller happened to
+    /// resolve for *this* call.
+    policy: ReplPolicy,
     /// Last time the session was accessed, for idle-TTL and LRU eviction.
     last_access: Instant,
     /// Cells evaluated so far (for `cells_used`).
@@ -41,11 +49,19 @@ struct SessionSlot {
     agent_calls: usize,
 }
 
-/// A handle to a resolved session: the shared session and its cancel flag, plus
-/// whether it was newly created this call.
+/// A handle to a resolved session: the shared session and its cancel flag,
+/// the policy actually live on the session, and whether it was newly created
+/// this call.
 pub(super) struct SlotHandle {
     pub(super) session: Arc<Mutex<ReplSession>>,
     pub(super) cancel: ReplCancelFlag,
+    /// The session's *live* policy — on a fresh session this is exactly what
+    /// was requested; on a reused session it is the one the session was
+    /// originally built with, which may differ from what this call resolved
+    /// (E-M2). Callers must compute any per-call bound (outer backstop,
+    /// `limits_remaining`) from this field, never from a freshly-resolved
+    /// policy.
+    pub(super) policy: ReplPolicy,
     pub(super) fresh: bool,
 }
 
@@ -85,18 +101,36 @@ impl RhaiSessionManager {
 
     /// Resolves the session for `key`, building a fresh one with `build` if
     /// absent. Runs an eviction sweep first so idle/over-cap sessions are
-    /// reclaimed. The `build` closure must produce a session that already has
-    /// its cancel flag installed (read back via `cancel_flag()`).
+    /// reclaimed. The `build` closure receives `policy` and must produce a
+    /// session that already has its cancel flag installed (read back via
+    /// `cancel_flag()`).
+    ///
+    /// `policy` is only ever used to build a **fresh** session. A reused
+    /// session keeps the policy it was actually built with (`ReplSession`
+    /// exposes no re-policy operation — see [`SlotHandle::policy`]); if the
+    /// caller's newly-resolved `policy` differs from the live one, this logs
+    /// a warning and returns the session's own policy rather than silently
+    /// applying the mismatch to bounds the session was never built to honor
+    /// (E-M2).
     pub(super) fn get_or_create(
         &self,
         key: &str,
-        build: impl FnOnce() -> ReplSession,
+        policy: ReplPolicy,
+        build: impl FnOnce(ReplPolicy) -> ReplSession,
     ) -> SlotHandle {
         let mut map = self.lock();
         Self::evict(&mut map, key);
         let now = Instant::now();
         if let Some(slot) = map.get_mut(key) {
             slot.last_access = now;
+            if slot.policy != policy {
+                tracing::warn!(
+                    session_key = key,
+                    "[rhai_workflows] reused session's requested policy differs from its live \
+                     policy; keeping the session's original policy (bindings preserved) rather \
+                     than the newly-requested one"
+                );
+            }
             tracing::debug!(
                 session_key = key,
                 "[rhai_workflows] reusing existing session"
@@ -104,10 +138,11 @@ impl RhaiSessionManager {
             return SlotHandle {
                 session: slot.session.clone(),
                 cancel: slot.cancel.clone(),
+                policy: slot.policy.clone(),
                 fresh: false,
             };
         }
-        let session = build();
+        let session = build(policy.clone());
         let cancel = session.cancel_flag();
         let session = Arc::new(Mutex::new(session));
         map.insert(
@@ -115,6 +150,7 @@ impl RhaiSessionManager {
             SessionSlot {
                 session: session.clone(),
                 cancel: cancel.clone(),
+                policy: policy.clone(),
                 last_access: now,
                 cells: 0,
                 model_calls: 0,
@@ -130,6 +166,7 @@ impl RhaiSessionManager {
         SlotHandle {
             session,
             cancel,
+            policy,
             fresh: true,
         }
     }
@@ -169,9 +206,24 @@ impl RhaiSessionManager {
     /// Evicts idle (past [`IDLE_TTL`]) sessions, then — if still at or above the
     /// [`MAX_SESSIONS`] cap and `incoming` is not already present — the
     /// least-recently-used session, so inserting `incoming` stays within cap.
+    ///
+    /// A slot whose cell is still in flight (its session `Mutex` is currently
+    /// held by the `spawn_blocking` task running that cell — see `ops.rs`) is
+    /// never a candidate for either sweep: evicting it would drop the session
+    /// out from under the running cell, so `finish_cell` would return `None`
+    /// (phantom-fresh `limits_remaining`) and, worse, a same-key call arriving
+    /// while the cell is still running would build a *new* session against the
+    /// same key that the evicted cell's completion would then be scored
+    /// against (E-m6). Skipping busy slots means the cap/TTL can be exceeded
+    /// while every live slot is genuinely in flight — a bounded, logged
+    /// overshoot is preferable to corrupting an in-flight run.
     fn evict(map: &mut HashMap<String, SessionSlot>, incoming: &str) {
         let now = Instant::now();
         map.retain(|k, slot| {
+            if slot.session.try_lock().is_err() {
+                // In flight — never evict, even past the idle TTL.
+                return true;
+            }
             let keep = now.duration_since(slot.last_access) < IDLE_TTL;
             if !keep {
                 tracing::debug!(session_key = %k, "[rhai_workflows] evicting idle session (TTL)");
@@ -181,14 +233,25 @@ impl RhaiSessionManager {
         if map.contains_key(incoming) || map.len() < MAX_SESSIONS {
             return;
         }
-        // Drop the least-recently-used slot to make room for the incoming one.
-        if let Some(lru_key) = map
+        // Drop the least-recently-used *idle* slot to make room for the
+        // incoming one; a busy (in-flight) slot is never a candidate.
+        let lru_key = map
             .iter()
+            .filter(|(_, slot)| slot.session.try_lock().is_ok())
             .min_by_key(|(_, slot)| slot.last_access)
-            .map(|(k, _)| k.clone())
-        {
-            map.remove(&lru_key);
-            tracing::debug!(session_key = %lru_key, "[rhai_workflows] evicting LRU session (cap)");
+            .map(|(k, _)| k.clone());
+        match lru_key {
+            Some(lru_key) => {
+                map.remove(&lru_key);
+                tracing::debug!(session_key = %lru_key, "[rhai_workflows] evicting LRU session (cap)");
+            }
+            None => {
+                tracing::warn!(
+                    live_sessions = map.len(),
+                    "[rhai_workflows] session cap reached but every session is in flight — \
+                     admitting one over cap rather than evicting a running cell"
+                );
+            }
         }
     }
 
@@ -196,6 +259,12 @@ impl RhaiSessionManager {
     #[cfg(test)]
     pub(super) fn len(&self) -> usize {
         self.lock().len()
+    }
+
+    /// Whether a session is currently live under `key` (for tests).
+    #[cfg(test)]
+    pub(super) fn contains(&self, key: &str) -> bool {
+        self.lock().contains_key(key)
     }
 
     /// A standalone (non-global) manager instance, so tests are isolated from
@@ -213,8 +282,8 @@ mod tests {
     use super::*;
     use tinyagents::{ReplPolicy, ReplSession, ReplValue};
 
-    fn build_session() -> ReplSession {
-        ReplSession::<()>::new()
+    fn build_session(policy: ReplPolicy) -> ReplSession {
+        ReplSession::<()>::new().with_policy(policy)
     }
 
     #[test]
@@ -222,7 +291,7 @@ mod tests {
         let manager = RhaiSessionManager::new_for_test();
         let key = RhaiSessionManager::session_key("t", "s1");
 
-        let handle = manager.get_or_create(&key, build_session);
+        let handle = manager.get_or_create(&key, ReplPolicy::default(), build_session);
         assert!(handle.fresh);
         handle
             .session
@@ -233,7 +302,7 @@ mod tests {
 
         // Reusing the same key returns the same (non-fresh) session, so the
         // binding is still visible.
-        let handle = manager.get_or_create(&key, build_session);
+        let handle = manager.get_or_create(&key, ReplPolicy::default(), build_session);
         assert!(!handle.fresh);
         let result = handle
             .session
@@ -247,11 +316,19 @@ mod tests {
     #[test]
     fn distinct_session_keys_are_isolated() {
         let manager = RhaiSessionManager::new_for_test();
-        let a = manager.get_or_create(&RhaiSessionManager::session_key("t", "a"), build_session);
+        let a = manager.get_or_create(
+            &RhaiSessionManager::session_key("t", "a"),
+            ReplPolicy::default(),
+            build_session,
+        );
         a.session.lock().unwrap().eval_cell("let x = 1;").unwrap();
 
         // A different key has its own namespace, so `x` is undefined there.
-        let b = manager.get_or_create(&RhaiSessionManager::session_key("t", "b"), build_session);
+        let b = manager.get_or_create(
+            &RhaiSessionManager::session_key("t", "b"),
+            ReplPolicy::default(),
+            build_session,
+        );
         assert!(b.session.lock().unwrap().eval_cell("x").is_err());
     }
 
@@ -261,8 +338,8 @@ mod tests {
         let k1 = RhaiSessionManager::session_key("thread-1", "shared");
         let k2 = RhaiSessionManager::session_key("thread-2", "shared");
         assert_ne!(k1, k2);
-        manager.get_or_create(&k1, build_session);
-        let h2 = manager.get_or_create(&k2, build_session);
+        manager.get_or_create(&k1, ReplPolicy::default(), build_session);
+        let h2 = manager.get_or_create(&k2, ReplPolicy::default(), build_session);
         assert!(
             h2.fresh,
             "same session_id under a different thread is a fresh namespace"
@@ -275,6 +352,7 @@ mod tests {
         for i in 0..(MAX_SESSIONS + 5) {
             manager.get_or_create(
                 &RhaiSessionManager::session_key("t", &format!("s{i}")),
+                ReplPolicy::default(),
                 build_session,
             );
         }
@@ -289,12 +367,16 @@ mod tests {
     fn close_drops_the_session() {
         let manager = RhaiSessionManager::new_for_test();
         let key = RhaiSessionManager::session_key("t", "closeme");
-        manager.get_or_create(&key, build_session);
+        manager.get_or_create(&key, ReplPolicy::default(), build_session);
         assert_eq!(manager.len(), 1);
         manager.close(&key);
         assert_eq!(manager.len(), 0);
         // Re-creating after close is a fresh session.
-        assert!(manager.get_or_create(&key, build_session).fresh);
+        assert!(
+            manager
+                .get_or_create(&key, ReplPolicy::default(), build_session)
+                .fresh
+        );
     }
 
     #[test]
@@ -302,9 +384,7 @@ mod tests {
         let manager = RhaiSessionManager::new_for_test();
         let key = RhaiSessionManager::session_key("t", "stats");
         let policy = ReplPolicy::default();
-        let handle = manager.get_or_create(&key, || {
-            ReplSession::<()>::new().with_policy(policy.clone())
-        });
+        let handle = manager.get_or_create(&key, policy.clone(), build_session);
         let result = handle
             .session
             .lock()
@@ -316,5 +396,121 @@ mod tests {
         // `emit` is not a model/tool/agent call, so those stay zero.
         assert_eq!(stats.tool_calls, 0);
         assert_eq!(stats.model_calls, 0);
+    }
+
+    /// E-M2: `ReplSession` cannot be re-policied after construction, so a
+    /// reused session must keep the policy it was actually built with — not
+    /// silently adopt whatever a later caller resolves for that call.
+    #[test]
+    fn reused_session_keeps_its_own_stored_policy() {
+        let manager = RhaiSessionManager::new_for_test();
+        let key = RhaiSessionManager::session_key("t", "s1");
+
+        let original = ReplPolicy {
+            max_tool_calls: 5,
+            timeout: Some(Duration::from_secs(300)),
+            ..ReplPolicy::default()
+        };
+        let handle = manager.get_or_create(&key, original.clone(), build_session);
+        assert!(handle.fresh);
+        assert_eq!(handle.policy, original);
+
+        // A later call on the same key resolves a very different policy
+        // (e.g. a cell passing `timeout_secs: 30` and a tighter tool-call
+        // budget) — the session must keep serving the original one.
+        let different = ReplPolicy {
+            max_tool_calls: 999,
+            timeout: Some(Duration::from_secs(30)),
+            ..ReplPolicy::default()
+        };
+        let handle2 = manager.get_or_create(&key, different, build_session);
+        assert!(!handle2.fresh);
+        assert_eq!(
+            handle2.policy, original,
+            "reused session must report its own live policy, not the newly requested one"
+        );
+    }
+
+    /// E-m6: an in-flight cell's slot (its session `Mutex` currently held)
+    /// must never be chosen as the LRU eviction candidate — evicting it would
+    /// drop the session out from under the running cell.
+    #[test]
+    fn lru_eviction_skips_an_in_flight_cell() {
+        let manager = RhaiSessionManager::new_for_test();
+        let policy = ReplPolicy::default();
+
+        let mut first_handle = None;
+        for i in 0..MAX_SESSIONS {
+            let handle = manager.get_or_create(
+                &RhaiSessionManager::session_key("t", &format!("s{i}")),
+                policy.clone(),
+                build_session,
+            );
+            if i == 0 {
+                first_handle = Some(handle);
+            }
+        }
+        let handle = first_handle.expect("first handle recorded");
+        let s0_key = RhaiSessionManager::session_key("t", "s0");
+        let s1_key = RhaiSessionManager::session_key("t", "s1");
+
+        // `s0` is the least-recently-used slot (created first). Hold its
+        // session lock to simulate an in-flight cell.
+        let _held = handle.session.lock().unwrap();
+
+        // One more insert pushes past the cap; eviction must skip the busy
+        // `s0` slot and remove the next-LRU idle slot (`s1`) instead.
+        manager.get_or_create(
+            &RhaiSessionManager::session_key("t", "new"),
+            policy.clone(),
+            build_session,
+        );
+
+        assert!(
+            manager.contains(&s0_key),
+            "in-flight session must not be evicted"
+        );
+        assert!(
+            !manager.contains(&s1_key),
+            "the next-LRU idle session should have been evicted instead"
+        );
+        assert!(manager.contains(&RhaiSessionManager::session_key("t", "new")));
+        assert_eq!(
+            manager.len(),
+            MAX_SESSIONS,
+            "cap is still honored by evicting an idle slot instead"
+        );
+    }
+
+    /// When every live slot is in flight, eviction admits one over cap rather
+    /// than corrupting a running cell.
+    #[test]
+    fn lru_eviction_admits_over_cap_when_every_slot_is_busy() {
+        let manager = RhaiSessionManager::new_for_test();
+        let policy = ReplPolicy::default();
+        // Keep the `Arc<Mutex<_>>`s alive in `sessions` so the guards taken
+        // from them below can outlive each loop iteration.
+        let mut sessions = Vec::new();
+        for i in 0..MAX_SESSIONS {
+            let handle = manager.get_or_create(
+                &RhaiSessionManager::session_key("t", &format!("s{i}")),
+                policy.clone(),
+                build_session,
+            );
+            sessions.push(handle.session);
+        }
+        let _guards: Vec<_> = sessions.iter().map(|s| s.lock().unwrap()).collect();
+
+        manager.get_or_create(
+            &RhaiSessionManager::session_key("t", "new"),
+            policy,
+            build_session,
+        );
+
+        assert_eq!(
+            manager.len(),
+            MAX_SESSIONS + 1,
+            "admits one over cap when nothing idle can be evicted"
+        );
     }
 }

--- a/src/openhuman/rhai_workflows/tools.rs
+++ b/src/openhuman/rhai_workflows/tools.rs
@@ -10,7 +10,7 @@ use serde_json::{json, Value};
 
 use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult, ToolScope, ToolTimeout};
 
-use super::policy::DEFAULT_RHAI_TIMEOUT_SECS;
+use super::policy::{harness_backstop_secs, DEFAULT_RHAI_TIMEOUT_SECS};
 use super::types::RhaiEvalRequest;
 
 /// The `rhai_workflows` language-workflow tool. Stateless: it resolves the parent turn
@@ -133,7 +133,15 @@ pipeline over results. Pass a `session_id` to continue a prior cell's bindings; 
             crate::openhuman::tool_timeout::MAX_TIMEOUT_SECS,
         )
         .unwrap_or(DEFAULT_RHAI_TIMEOUT_SECS);
-        ToolTimeout::Secs(secs)
+        // The harness backstop must sit strictly above the outer
+        // `spawn_blocking` backstop in `ops.rs` (itself strictly above the
+        // inner `ReplPolicy.timeout` deadline resolved identically to `secs`
+        // in `policy::resolve_policy`) — see README's `inner < outer <
+        // harness` invariant (E-M1). If the harness ever won this race it
+        // would drop the whole tool-execution future, skipping the
+        // `RhaiError::Timeout` taxonomy, `finish_cell` accounting,
+        // `close_session`, and the outer-backstop session cleanup.
+        ToolTimeout::Secs(harness_backstop_secs(secs))
     }
 
     fn display_label(&self, _args: &Value) -> Option<String> {
@@ -190,6 +198,7 @@ pipeline over results. Pass a `session_id` to continue a prior cell's bindings; 
 
 #[cfg(test)]
 mod tests {
+    use super::super::policy::outer_backstop_secs;
     use super::*;
 
     #[test]
@@ -206,17 +215,44 @@ mod tests {
         let tool = RhaiTool::new();
         assert_eq!(
             tool.timeout_policy(&json!({})),
-            ToolTimeout::Secs(DEFAULT_RHAI_TIMEOUT_SECS)
+            ToolTimeout::Secs(harness_backstop_secs(DEFAULT_RHAI_TIMEOUT_SECS))
         );
         assert_eq!(
             tool.timeout_policy(&json!({ "timeout_secs": 42 })),
-            ToolTimeout::Secs(42)
+            ToolTimeout::Secs(harness_backstop_secs(42))
         );
         // Out-of-range requests are clamped, never unbounded.
         assert_eq!(
             tool.timeout_policy(&json!({ "timeout_secs": 100000 })),
-            ToolTimeout::Secs(3600)
+            ToolTimeout::Secs(harness_backstop_secs(3600))
         );
+    }
+
+    /// E-M1: the harness backstop this tool declares must always sit
+    /// strictly above the outer `spawn_blocking` backstop `ops.rs` enforces
+    /// for the same resolved inner deadline.
+    #[test]
+    fn harness_backstop_is_always_above_the_outer_backstop() {
+        let tool = RhaiTool::new();
+        for requested in [None, Some(1u64), Some(42), Some(3600), Some(100_000)] {
+            let secs = crate::openhuman::tool_timeout::explicit_call_timeout_secs(
+                requested,
+                crate::openhuman::tool_timeout::MAX_TIMEOUT_SECS,
+            )
+            .unwrap_or(DEFAULT_RHAI_TIMEOUT_SECS);
+            let args = match requested {
+                Some(r) => json!({ "timeout_secs": r }),
+                None => json!({}),
+            };
+            let ToolTimeout::Secs(harness_secs) = tool.timeout_policy(&args) else {
+                panic!("rhai_workflows must always declare an explicit ToolTimeout::Secs bound");
+            };
+            let outer_secs = outer_backstop_secs(secs);
+            assert!(
+                outer_secs < harness_secs,
+                "outer {outer_secs} should be < harness {harness_secs} for requested {requested:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/openhuman/rhai_workflows/types.rs
+++ b/src/openhuman/rhai_workflows/types.rs
@@ -79,8 +79,15 @@ pub struct RhaiCallSummary {
     pub name: String,
     /// Wall-clock time the call took, in milliseconds.
     pub elapsed_ms: u64,
-    /// Whether the call was recorded (calls that errored abort the cell, so a
-    /// recorded call is a completed one).
+    /// Whether the capability call itself succeeded. For model/agent/graph
+    /// calls the vendor session only ever records a call on success, so an
+    /// uncaught failure aborts the cell before it would appear here. Tool
+    /// calls are different: the vendor REPL records the call *before*
+    /// checking the tool's own error (a caught `tool_call` failure) or keeps
+    /// going on a per-item failure without ever raising (`tool_call_batched`)
+    /// — `ops::summarize_calls` tracks the real outcome separately
+    /// (`bridge::take_call_outcomes`) so a failed-but-caught tool call is
+    /// still reported here as `ok: false` rather than defaulting to success.
     pub ok: bool,
 }
 


### PR DESCRIPTION
## Summary

- Restores the timeout ordering `rhai_workflows`' own README promises — the three bounds had collapsed so the harness could win the race and drop the cell future mid-cleanup.
- A **reused** REPL session now has its bounds computed from the policy it was actually built with, fixing a path that silently **dropped the session and lost every binding**.
- `summarize_calls` no longer reports a failed capability call to the model as `ok: true`.
- LRU eviction can no longer evict a session whose cell is still running.

## Problem

**E-M1 — the layering was inverted.** `README.md` states the harness `ToolTimeout::Secs` backstop sits above all other bounds and the tool's own timeout below it. In fact `timeout_policy()` handed the harness the **same** clamped `secs` as the inner `ReplPolicy.timeout`, while the outer `spawn_blocking` backstop was `secs + 5`. So `harness == inner < outer`.

When the harness won that tie it dropped the `run_cell` future, skipping the `RhaiError::Timeout` taxonomy, `finish_cell` accounting, `close_session`, and the outer-backstop `manager.close` cleanup — while the detached blocking thread kept holding the session mutex until the inner deadline, so follow-up calls got `SessionBusy`.

**E-M2 — reused sessions ran on a stale policy while the wrapper enforced a new one.** `get_or_create`'s build closure only runs for a *fresh* session, so a reused session keeps its original `ReplPolicy` — yet `outer_bound` and `limits_remaining` were computed from the newly resolved one.

Concretely: a session built with 300s, reused by a cell passing `timeout_secs: 30` that runs 60s, hits the 35s outer backstop while its inner deadline is still 300s. The outer-backstop arm calls `manager.close(&key)` — **dropping the whole session and losing all its bindings**, which is exactly the "inner should fire first" invariant the code's own comment says it defends.

**E-m5 / E-m6** — `summarize_calls` hardcoded `ok: true` (the vendor's `ReplCallRecord` carries no success flag), so a failed-but-caught capability call was summarized to the model as successful; and LRU eviction could evict an in-flight slot, after which `finish_cell` returned `None` and `limits_remaining` reported a full budget for a session that had just done work.

## Solution

- **One source for the three bounds** — `outer_backstop_secs(inner) = inner + 5`, `harness_backstop_secs(inner) = outer + 5`. Ordering is now `inner < outer < harness` for every input, pinned both as a pure assertion over the computed values and through the live `RhaiTool::timeout_policy()`. README rewritten in the same commit to match.
- **`SlotHandle` carries the policy its session was built with**, and every per-call bound is computed from that, warning when a caller requests a different one. The session cache is deliberately **not** keyed on a policy fingerprint: that would fragment sessions and lose bindings *by design* rather than by bug.
- **Call outcomes tracked host-side** as calls dispatch through the bridge, so `summarize_calls` reports real success/failure.
- **Busy slots are ineligible** for both the idle-TTL sweep and the cap eviction; if every slot is busy the incoming session is admitted one over cap rather than evicting a running cell.

Nothing under `vendor/` is modified. Two items are worth filing upstream instead: a success flag on `ReplCallRecord`, and a `set_policy` on `ReplSession` — the absence of the latter is precisely why E-M2 is fixed host-side.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — each changed mechanism has a direct test; `cargo test --lib openhuman::rhai_workflows` = 42 passed, 0 failed
- [x] Coverage matrix updated — `N/A: behaviour-only bug fix, no feature rows added/removed/renamed`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature rows affected`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: agent-tool internal; the rhai tool is orchestrator-surface only (ToolScope::AgentOnly)`
- [x] Linked issue closed via `Closes #NNN` — `N/A: found by code review, no tracking issue filed yet`

## Impact

- **Runtime/platform:** Rust core, `openhuman::rhai_workflows` only.
- **Behaviour:** a long-running cell now reliably hits its own inner deadline first, so it produces a proper `RhaiError::Timeout` with accounting and cleanup instead of a dropped future and a wedged mutex. A reused session with a differing requested policy keeps its bindings and logs a warning rather than being destroyed.
- **Performance:** the effective harness ceiling for a rhai call rises by 10s (inner + 10) so the inner deadline can always fire first. Deliberate — that headroom is what makes the cleanup path reachable.
- **Security:** unchanged. Tier gating, the tool exclusion list, and the kill switches are untouched.

## Related

- Closes: `N/A`
- Follow-up PR(s)/TODOs: upstream `tinyagents` — add a success flag to `ReplCallRecord` and a `set_policy` to `ReplSession`.
- **Merge order:** fully independent — touches only `src/openhuman/rhai_workflows/`, no overlap with the other PRs in this batch.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/rhai-timeout-and-session-policy`
- Commit SHA: `ed11b94ec`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A, no frontend files changed
- [x] `pnpm typecheck` — N/A, no TypeScript changed
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --lib openhuman::rhai_workflows` → **42 passed, 0 failed**
- [x] Rust fmt/check (if changed): `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml` clean
- [x] Tauri fmt/check (if changed): N/A, `app/src-tauri` untouched

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: the inner rhai deadline always fires before the outer backstop, which always fires before the harness timeout; a reused session's own policy governs its bounds.
- User-visible effect: a timed-out rhai cell reports a real timeout with intact session state instead of intermittently wedging the session into `SessionBusy`.

### Parity Contract

- Legacy behavior preserved: clamping, tier gating, the excluded-tool list, kill switches, LRU cap / idle TTL values, and the session-key scheme are all unchanged.
- Guard/fallback/dispatch parity checks: the existing `timeout_is_always_bounded` and session-isolation tests still pass unmodified in intent.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved timeout handling with consistent safeguards across workflow execution layers.
  * Preserved session policies when sessions are reused and protected active sessions from eviction.
  * Improved handling and reporting of failed or unknown tool calls.

* **Documentation**
  * Clarified timeout ordering, session policy behavior, cleanup, and tool-call success reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->