### PR TITLE
docs(flows): fix contract-drift comments and repair the workflow-builder prompt structure

### DIFF
--- a/src/openhuman/flows/agents/mod.rs
+++ b/src/openhuman/flows/agents/mod.rs
@@ -10,7 +10,12 @@
 //! with the domain.
 //!
 //! - [`workflow_builder`] — authors tinyflows [`WorkflowGraph`](tinyflows::model::WorkflowGraph)s
-//!   from natural language and returns a validated PROPOSAL (never persists).
+//!   from natural language and returns a validated PROPOSAL by default. It
+//!   also carries three narrow, deliberate persistence tools —
+//!   `create_workflow`/`duplicate_flow` (always born DISABLED) and
+//!   `save_workflow` (update-only, onto a flow that already exists) — each
+//!   gated behind the user's explicit ask; it never enables a flow. See the
+//!   module doc in `flows::builder_tools` for the full tool-by-tool table.
 //! - [`flow_discovery`] — the read-only "Flow Scout" that grounds buildable
 //!   automation ideas from the user's data.
 

--- a/src/openhuman/flows/agents/workflow_builder/builder_prompt.rs
+++ b/src/openhuman/flows/agents/workflow_builder/builder_prompt.rs
@@ -220,6 +220,27 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// Collapses runs of whitespace (including newlines and hard-wrap
+    /// indentation) to a single space and trims the ends.
+    ///
+    /// `prompt.md` is hand-wrapped prose, and several regression tests below
+    /// pin exact substrings of it (including a few that embed a literal
+    /// `\n` at a specific wrap column, e.g. "NO\n   memory access"). Pinning
+    /// against the raw file couples the suite to WHERE a line happens to
+    /// wrap, not what it says — a semantically neutral rewrap (P-m4) then
+    /// reads as a content regression and breaks tests that never should have
+    /// cared. Normalizing both sides before comparing keeps the assertions
+    /// falsifiable against actual content changes while surviving any
+    /// rewrap that doesn't change the words.
+    fn normalize_whitespace(s: &str) -> String {
+        s.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    /// Whitespace-normalized substring check — see [`normalize_whitespace`].
+    fn contains_normalized(haystack: &str, needle: &str) -> bool {
+        normalize_whitespace(haystack).contains(&normalize_whitespace(needle))
+    }
+
     fn req(mode: BuildMode) -> BuilderRequest {
         BuilderRequest {
             mode,
@@ -351,7 +372,7 @@ mod tests {
         // reappear in the standing prompt either.
         for banned in ["review card", "Accept the proposal explicitly"] {
             assert!(
-                !STANDING_PROMPT.contains(banned),
+                !contains_normalized(STANDING_PROMPT, banned),
                 "standing prompt must not carry phantom review-card phrasing `{banned}` (B27)"
             );
         }
@@ -359,14 +380,14 @@ mod tests {
         // Positive: the anti-jargon Style rule — replies must stay in plain
         // language, never leak response_format/schema/expression internals.
         assert!(
-            STANDING_PROMPT.contains("Speak to a non-technical user"),
+            contains_normalized(STANDING_PROMPT, "Speak to a non-technical user"),
             "standing prompt must teach the anti-jargon Style rule"
         );
 
         // Positive: read-only memory grounding via the raw `memory_recall`
         // tool (no `memory_store` — see the agent.toml regression test).
         assert!(
-            STANDING_PROMPT.contains("memory_recall"),
+            contains_normalized(STANDING_PROMPT, "memory_recall"),
             "standing prompt must teach the builder to ground itself with memory_recall"
         );
 
@@ -375,7 +396,10 @@ mod tests {
         // drop the "can't change their memory" guarantee this agent's tool
         // scope depends on (no `memory_store` in agent.toml).
         assert!(
-            STANDING_PROMPT.contains("Read-only — you can't change their memory"),
+            contains_normalized(
+                STANDING_PROMPT,
+                "Read-only — you can't change their memory"
+            ),
             "standing prompt must state the memory read-only guarantee, not just mention memory_recall"
         );
 
@@ -388,7 +412,7 @@ mod tests {
             "It cannot create flows,",
         ] {
             assert!(
-                !STANDING_PROMPT.contains(banned),
+                !contains_normalized(STANDING_PROMPT, banned),
                 "standing prompt must not carry the stale \"can never create a flow\" claim \
                  `{banned}` — create_workflow/duplicate_flow are on the belt (issue #6)"
             );
@@ -397,7 +421,8 @@ mod tests {
         // Positive: the accurate contract — the agent CAN create a flow, but
         // every flow it creates is always born disabled.
         assert!(
-            STANDING_PROMPT.contains("create_workflow") && STANDING_PROMPT.contains("born"),
+            contains_normalized(STANDING_PROMPT, "create_workflow")
+                && contains_normalized(STANDING_PROMPT, "born"),
             "standing prompt must accurately teach that create_workflow exists and that \
              created flows are always born disabled (issue #6)"
         );
@@ -410,9 +435,9 @@ mod tests {
         // offering-then-refusing (the confusing "want me to run it?" → "I
         // don't have access" behavior).
         assert!(
-            STANDING_PROMPT.contains("only if the tool is on your belt")
-                && STANDING_PROMPT.contains("never offer to run the flow")
-                && STANDING_PROMPT.contains("Workflows UI"),
+            contains_normalized(STANDING_PROMPT, "only if the tool is on your belt")
+                && contains_normalized(STANDING_PROMPT, "never offer to run the flow")
+                && contains_normalized(STANDING_PROMPT, "Workflows UI"),
             "standing prompt must make run_flow capability-conditional: never offer to run \
              when the tool is off the belt, and point the user to the Workflows UI Run \
              control instead (Bld §4 offer-then-refuse)"
@@ -423,7 +448,7 @@ mod tests {
         // it must not reappear (that's the exact offer-then-refuse regression
         // Bld §4 closed).
         assert!(
-            !STANDING_PROMPT.contains("`run_flow` (ask first!)"),
+            !contains_normalized(STANDING_PROMPT, "`run_flow` (ask first!)"),
             "standing prompt must not regress to the pre-Bld-§4 unconditional \
              \"ask first!\" run_flow heading"
         );
@@ -433,14 +458,18 @@ mod tests {
         // check somewhere else in the doc — bind the assertion to the two
         // halves of the actual contract (off-belt fallback, on-belt usage).
         assert!(
-            STANDING_PROMPT
-                .contains("If you do **not** have a `run_flow` tool, never offer to run the flow"),
+            contains_normalized(
+                STANDING_PROMPT,
+                "If you do **not** have a `run_flow` tool, never offer to run the flow"
+            ),
             "standing prompt must state the off-belt fallback as a direct consequence \
              of the capability check, not a generic nearby mention"
         );
         assert!(
-            STANDING_PROMPT
-                .contains("If you **do** have `run_flow`: once the user has **saved** a flow"),
+            contains_normalized(
+                STANDING_PROMPT,
+                "If you **do** have `run_flow`: once the user has **saved** a flow"
+            ),
             "standing prompt must gate the on-belt run_flow usage behind the same \
              capability check"
         );
@@ -452,18 +481,22 @@ mod tests {
         // gated `run_flow` while leaving these two unconditional would
         // reopen the same offer-then-refuse bug one hop later.
         assert!(
-            STANDING_PROMPT
-                .contains("those tools are on your belt** — `resume_flow_run` (approval-gated) or"),
+            contains_normalized(
+                STANDING_PROMPT,
+                "those tools are on your belt** — `resume_flow_run` (approval-gated) or"
+            ),
             "standing prompt must gate resume_flow_run/cancel_flow_run behind the \
              same on-your-belt capability check as run_flow"
         );
         assert!(
-            STANDING_PROMPT.contains("(if they're not available, point the"),
+            contains_normalized(STANDING_PROMPT, "(if they're not available, point the"),
             "standing prompt must state the resume/cancel off-belt fallback condition"
         );
         assert!(
-            STANDING_PROMPT
-                .contains("user to the runs list in the Workflows UI instead of offering)."),
+            contains_normalized(
+                STANDING_PROMPT,
+                "user to the runs list in the Workflows UI instead of offering)."
+            ),
             "standing prompt must point resume/cancel's off-belt fallback to the \
              Workflows UI runs list, matching run_flow's UI fallback pattern"
         );
@@ -472,7 +505,10 @@ mod tests {
         // right after `edit_workflow`, with no capability check in between —
         // must not reappear.
         assert!(
-            !STANDING_PROMPT.contains("patch with `edit_workflow`; `resume_flow_run`"),
+            !contains_normalized(
+                STANDING_PROMPT,
+                "patch with `edit_workflow`; `resume_flow_run`"
+            ),
             "standing prompt must not regress to the pre-fix unconditional \
              resume_flow_run/cancel_flow_run offer"
         );
@@ -481,16 +517,19 @@ mod tests {
         // wire "DM me" onto the connection's own `platform_user_id`, not a
         // public channel (the #general/#team-product fallback bug).
         assert!(
-            STANDING_PROMPT.contains("platform_user_id"),
+            contains_normalized(STANDING_PROMPT, "platform_user_id"),
             "standing prompt must teach that list_flow_connections surfaces \
              platform_user_id for self-DM resolution"
         );
         assert!(
-            STANDING_PROMPT.contains("DM me"),
+            contains_normalized(STANDING_PROMPT, "DM me"),
             "standing prompt must keep the \"DM me\" self-target guidance"
         );
         assert!(
-            STANDING_PROMPT.contains("Never default a personal request to a public channel"),
+            contains_normalized(
+                STANDING_PROMPT,
+                "Never default a personal request to a public channel"
+            ),
             "standing prompt must explicitly forbid falling back to a public \
              channel (e.g. #general/#team-product) for a personal \"DM me\" request"
         );
@@ -501,8 +540,10 @@ mod tests {
         // word `platform_user_id` elsewhere in the prompt and still pass the
         // looser check above.
         assert!(
-            STANDING_PROMPT
-                .contains("that id verbatim as the `channel` arg on `SLACK_SEND_MESSAGE`"),
+            contains_normalized(
+                STANDING_PROMPT,
+                "that id verbatim as the `channel` arg on `SLACK_SEND_MESSAGE`"
+            ),
             "standing prompt must explicitly instruct passing `platform_user_id` \
              verbatim as the `channel` arg on `SLACK_SEND_MESSAGE` — not just \
              mention the field name"
@@ -512,8 +553,8 @@ mod tests {
         // their member id in one question) must survive too — this is the
         // other half of the self-DM contract and must not be silently lost.
         assert!(
-            STANDING_PROMPT.contains("Only if `platform_user_id` is null")
-                && STANDING_PROMPT.contains("ask the user for their member id"),
+            contains_normalized(STANDING_PROMPT, "Only if `platform_user_id` is null")
+                && contains_normalized(STANDING_PROMPT, "ask the user for their member id"),
             "standing prompt must preserve the null-`platform_user_id` fallback: \
              ask the user for their member id in one question rather than \
              guessing a channel"
@@ -526,38 +567,38 @@ mod tests {
         // toolkit-specific slug hardcoded) — the same shape applies to
         // Slack, Discord, Telegram, or any other messaging toolkit.
         assert!(
-            STANDING_PROMPT.contains("is NOT the connected"),
+            contains_normalized(STANDING_PROMPT, "is NOT the connected"),
             "standing prompt must teach the non-owner DM case explicitly"
         );
         assert!(
-            STANDING_PROMPT.contains("platform-agnostic"),
+            contains_normalized(STANDING_PROMPT, "platform-agnostic"),
             "standing prompt must state the non-owner DM guidance is \
              platform-agnostic, not tied to one toolkit"
         );
         assert!(
-            STANDING_PROMPT.contains("search_tool_catalog { query, toolkit }"),
+            contains_normalized(STANDING_PROMPT, "search_tool_catalog { query, toolkit }"),
             "standing prompt must teach resolving the lookup action via \
              search_tool_catalog scoped to the TARGET toolkit, rather than \
              hardcoding one platform's slug"
         );
         assert!(
-            STANDING_PROMPT.contains("tool_call` node upstream of the send"),
+            contains_normalized(STANDING_PROMPT, "tool_call` node upstream of the send"),
             "standing prompt must teach wiring the lookup as a tool_call \
              node upstream of the send node"
         );
         assert!(
-            STANDING_PROMPT.contains("resolves to exactly one match"),
+            contains_normalized(STANDING_PROMPT, "resolves to exactly one match"),
             "standing prompt must require a name search to resolve to \
              exactly one match before binding it without asking"
         );
         assert!(
-            STANDING_PROMPT.contains("ask the user to confirm which person"),
+            contains_normalized(STANDING_PROMPT, "ask the user to confirm which person"),
             "standing prompt must preserve the safety rule: never message an \
              unverified same-name match, ask instead when ambiguous"
         );
         assert!(
-            STANDING_PROMPT.contains("Check the send action")
-                && STANDING_PROMPT.contains("open conversation"),
+            contains_normalized(STANDING_PROMPT, "Check the send action")
+                && contains_normalized(STANDING_PROMPT, "open conversation"),
             "standing prompt must teach checking the send tool's own contract \
              for a required open-conversation step, handled generally via the \
              contract rather than a single-platform special case"
@@ -574,7 +615,7 @@ mod tests {
             "exact_match",
         ] {
             assert!(
-                !STANDING_PROMPT.contains(banned),
+                !contains_normalized(STANDING_PROMPT, banned),
                 "standing prompt's non-owner DM guidance must not hardcode \
                  the platform-specific `{banned}` — it must stay \
                  platform-agnostic (any messaging toolkit)"
@@ -600,7 +641,7 @@ mod tests {
             "Lead with substance",
         ] {
             assert!(
-                STANDING_PROMPT.contains(rule),
+                contains_normalized(STANDING_PROMPT, rule),
                 "standing prompt must teach the reply-hygiene rule `{rule}` — the \
                  reply is the finished answer, not a thinking scratchpad (no \
                  deliberation narration, no draft-then-restate)"
@@ -629,7 +670,7 @@ mod tests {
             "zero questions is still the happy path",
         ] {
             assert!(
-                STANDING_PROMPT.contains(rule),
+                contains_normalized(STANDING_PROMPT, rule),
                 "standing prompt must teach the resolution-first rule `{rule}` — \
                  before asking for any missing value, the builder must exhaust \
                  self-resolution (recall, connections, tool catalog, runtime \
@@ -656,7 +697,7 @@ mod tests {
             "flow_memory_agent",
         ] {
             assert!(
-                STANDING_PROMPT.contains(rule),
+                contains_normalized(STANDING_PROMPT, rule),
                 "standing prompt must teach specialist selection via `{rule}` — the \
                  builder needs to know it can ground a real agent_ref with \
                  list_agent_profiles instead of hallucinating one"
@@ -675,20 +716,20 @@ mod tests {
         const STANDING_PROMPT: &str = include_str!("prompt.md");
 
         assert!(
-            STANDING_PROMPT.contains("flow_memory_agent"),
+            contains_normalized(STANDING_PROMPT, "flow_memory_agent"),
             "standing prompt must name `flow_memory_agent`"
         );
         assert!(
-            STANDING_PROMPT.contains("the PREFERRED general"),
+            contains_normalized(STANDING_PROMPT, "the PREFERRED general"),
             "standing prompt must teach flow_memory_agent as the PREFERRED general route"
         );
         assert!(
-            STANDING_PROMPT.contains("for ANY use case, not a fixed list"),
+            contains_normalized(STANDING_PROMPT, "for ANY use case, not a fixed list"),
             "standing prompt must state the routing rule is general — ANY use case, not \
              a fixed list of scenarios — or the builder will under-route to flow_memory_agent"
         );
         assert!(
-            STANDING_PROMPT.contains("narrower niche"),
+            contains_normalized(STANDING_PROMPT, "narrower niche"),
             "standing prompt must demote context_scout to its narrower structured-bundle \
              niche now that flow_memory_agent is the general route"
         );
@@ -697,11 +738,11 @@ mod tests {
         // retrieval to context_scout contradicts the rule above and trains the
         // builder to under-route to flow_memory_agent.
         assert!(
-            STANDING_PROMPT.contains("asked us before\" → `flow_memory_agent`"),
+            contains_normalized(STANDING_PROMPT, "asked us before\" → `flow_memory_agent`"),
             "the generic customer-history example must route to flow_memory_agent"
         );
         assert!(
-            !STANDING_PROMPT.contains("asked us before\" → `context_scout`"),
+            !contains_normalized(STANDING_PROMPT, "asked us before\" → `context_scout`"),
             "the generic customer-history example must NOT route to context_scout — that \
              contradicts flow_memory_agent being the general context/history route"
         );
@@ -716,9 +757,9 @@ mod tests {
         const STANDING_PROMPT: &str = include_str!("prompt.md");
 
         assert!(
-            STANDING_PROMPT.contains("specialist")
-                && (STANDING_PROMPT.contains("tool loop")
-                    || STANDING_PROMPT.contains("full persona")),
+            contains_normalized(STANDING_PROMPT, "specialist")
+                && (contains_normalized(STANDING_PROMPT, "tool loop")
+                    || contains_normalized(STANDING_PROMPT, "full persona")),
             "standing prompt must link agent_ref to the specialist's full tool loop \
              (the harness path), not just a persona/model swap"
         );
@@ -740,7 +781,7 @@ mod tests {
             "still gets tools from the node's own",
         ] {
             assert!(
-                !STANDING_PROMPT.contains(banned),
+                !contains_normalized(STANDING_PROMPT, banned),
                 "standing prompt must not carry the stale agent_ref-tool-loop \
                  phrasing `{banned}` — the harness path already gives agent_ref \
                  its full tool loop"
@@ -783,15 +824,16 @@ mod tests {
         const STANDING_PROMPT: &str = include_str!("prompt.md");
 
         assert!(
-            STANDING_PROMPT.contains("minimal viable graph"),
+            contains_normalized(STANDING_PROMPT, "minimal viable graph"),
             "standing prompt must still warn to prefer the minimal viable graph"
         );
         assert!(
-            STANDING_PROMPT.contains("3–6 nodes") || STANDING_PROMPT.contains("3-6 nodes"),
+            contains_normalized(STANDING_PROMPT, "3–6 nodes")
+                || contains_normalized(STANDING_PROMPT, "3-6 nodes"),
             "standing prompt must still carry the 3-6 node sizing guidance"
         );
         assert!(
-            STANDING_PROMPT.contains("SAME kind of work"),
+            contains_normalized(STANDING_PROMPT, "SAME kind of work"),
             "standing prompt must still warn against chaining agents doing the \
              same kind of work, even after adding specialist-selection guidance"
         );
@@ -816,7 +858,7 @@ mod tests {
             "wire\n   an `agent` node that uses memory",
         ] {
             assert!(
-                !STANDING_PROMPT.contains(banned),
+                !contains_normalized(STANDING_PROMPT, banned),
                 "standing prompt must not tell the builder a plain `agent` node can \
                  reach memory ({banned:?}) — it has no tool loop, so the model \
                  fabricates the recalled value instead of looking it up"
@@ -824,7 +866,10 @@ mod tests {
         }
 
         assert!(
-            STANDING_PROMPT.contains("A plain `agent` node has NO\n   memory access"),
+            contains_normalized(
+                STANDING_PROMPT,
+                "A plain `agent` node has NO\n   memory access"
+            ),
             "standing prompt must state outright that a plain agent node has no \
              memory access, so the builder never authors a no-op recall step"
         );
@@ -856,7 +901,7 @@ mod tests {
             "=nodes.<id>.item.json.content[0].text",
         ] {
             assert!(
-                STANDING_PROMPT.contains(rule),
+                contains_normalized(STANDING_PROMPT, rule),
                 "standing prompt must teach `{rule}` — it is one of the four \
                  mechanisms that actually read memory at flow run time, or the \
                  binding path needed to consume one"
@@ -886,27 +931,30 @@ mod tests {
         const STANDING_PROMPT: &str = include_str!("prompt.md");
 
         assert!(
-            STANDING_PROMPT.contains("can never WRITE the user's memory"),
+            contains_normalized(STANDING_PROMPT, "can never WRITE the user's memory"),
             "standing prompt must state plainly that a workflow cannot write the \
              user's PERSONAL memory, so the builder never targets scope \"user\" \
              on a remember/forget memory node"
         );
         assert!(
-            !STANDING_PROMPT.contains("agent_memory"),
+            !contains_normalized(STANDING_PROMPT, "agent_memory"),
             "standing prompt must not steer the builder to `agent_memory` as a \
              flow agent_ref: its `memory_tree` tool declares ReadOnly but exposes \
              an ingest_document write mode, so it would give prompt-injectable \
              trigger data a memory-write path"
         );
         assert!(
-            STANDING_PROMPT.contains("scope: \"flow\""),
+            contains_normalized(STANDING_PROMPT, "scope: \"flow\""),
             "standing prompt must teach that a workflow CAN write its own \
              flow-scoped memory via a `memory` node (scope: \"flow\") — this is \
              the real mechanism for a flow that \"remembers\" across runs, \
              replacing the old blanket \"memory writes are not available\" advice"
         );
         assert!(
-            STANDING_PROMPT.contains("Always place the `remember` AFTER the real action"),
+            contains_normalized(
+                STANDING_PROMPT,
+                "Always place the `remember` AFTER the real action"
+            ),
             "standing prompt must teach commit-on-success ordering: remember AFTER \
              the action it's recording, never before, so a failed action doesn't \
              get silently marked done"

--- a/src/openhuman/flows/agents/workflow_builder/prompt.md
+++ b/src/openhuman/flows/agents/workflow_builder/prompt.md
@@ -150,6 +150,38 @@ rather than a general context recall), use `memory_hybrid_search` in its
      integrations" below — you can help the user link it before you build,
      rather than dead-ending.
 
+3. **Build the graph** (see the model below).
+4. **Self-check with `dry_run_workflow`** on the draft — catch missing edges,
+   wrong ports, unreachable nodes. Fix and re-run.
+
+   **Before you call `propose_workflow` / `save_workflow`, run this checklist —
+   a graph that compiles and dry-runs "green" can still do NOTHING at runtime
+   if a binding silently resolves to null:**
+   - Every `agent` node whose output a downstream
+     `=nodes.<agent_id>.item.json.<field>` binding reads MUST declare
+     `config.output_parser.schema` naming that field under `properties`. No
+     schema ⇒ the agent's item is `{text: "..."}` and the binding is null.
+   - Every `agent` node needs its data fed via `config.input_context`
+     (`"=item"` / `"=items"` / `"=nodes.<id>.item.json"`), with `config.prompt`
+     left as a plain instruction — never a `.item`/`nodes.` reference woven
+     into prose. `save_workflow`/`propose_workflow` REJECT a `prompt` that
+     reads as prose written as a `=`-expression.
+   - If `dry_run_workflow` reports `"ok": false` with a `null_resolutions`,
+     `agent_prompt_nulls`, or `agent_input_context_nulls` list, **fix every
+     one** before proposing — add the missing schema, move data into
+     `input_context`, or rewire the expression to a real upstream field.
+     `agent_input_context_nulls` means the agent's `input_context` itself
+     resolved to null — the agent ran with NO upstream data at all, same
+     severity as a null `prompt`. Don't propose/save a graph `dry_run_workflow`
+     flagged. **Never dismiss a dry-run `ok: false` as a sandbox limitation**
+     — if `dry_run_workflow` flagged the graph, the binding/schema/path is
+     wrong and must be fixed before proposing.
+5. **`propose_workflow`** (first draft) or **`revise_workflow`** (iterating on a
+   prior draft — apply the change to the existing graph, don't regenerate from
+   scratch). If validation fails, read the error, fix the graph, call again.
+6. **Debugging a broken saved flow?** `get_flow` for its graph and
+   `get_flow_run` for a failing run's steps, then propose a repaired version.
+
 ## Your authoring tools (prefer these — don't re-emit whole graphs)
 
 You have a machine-readable belt; use it instead of relying on memory:
@@ -255,37 +287,6 @@ stop there. Do not refuse to propose over this. Do not swap the `agent` node
 for a code or transform node to work around it. Do not loop trying to resolve
 it yourself. Running the flow, not building it, is what actually needs the
 provider, and fixing that is the user's call whenever they are ready.
-3. **Build the graph** (see the model below).
-4. **Self-check with `dry_run_workflow`** on the draft — catch missing edges,
-   wrong ports, unreachable nodes. Fix and re-run.
-
-   **Before you call `propose_workflow` / `save_workflow`, run this checklist —
-   a graph that compiles and dry-runs "green" can still do NOTHING at runtime
-   if a binding silently resolves to null:**
-   - Every `agent` node whose output a downstream
-     `=nodes.<agent_id>.item.json.<field>` binding reads MUST declare
-     `config.output_parser.schema` naming that field under `properties`. No
-     schema ⇒ the agent's item is `{text: "..."}` and the binding is null.
-   - Every `agent` node needs its data fed via `config.input_context`
-     (`"=item"` / `"=items"` / `"=nodes.<id>.item.json"`), with `config.prompt`
-     left as a plain instruction — never a `.item`/`nodes.` reference woven
-     into prose. `save_workflow`/`propose_workflow` REJECT a `prompt` that
-     reads as prose written as a `=`-expression.
-   - If `dry_run_workflow` reports `"ok": false` with a `null_resolutions`,
-     `agent_prompt_nulls`, or `agent_input_context_nulls` list, **fix every
-     one** before proposing — add the missing schema, move data into
-     `input_context`, or rewire the expression to a real upstream field.
-     `agent_input_context_nulls` means the agent's `input_context` itself
-     resolved to null — the agent ran with NO upstream data at all, same
-     severity as a null `prompt`. Don't propose/save a graph `dry_run_workflow`
-     flagged. **Never dismiss a dry-run `ok: false` as a sandbox limitation**
-     — if `dry_run_workflow` flagged the graph, the binding/schema/path is
-     wrong and must be fixed before proposing.
-5. **`propose_workflow`** (first draft) or **`revise_workflow`** (iterating on a
-   prior draft — apply the change to the existing graph, don't regenerate from
-   scratch). If validation fails, read the error, fix the graph, call again.
-6. **Debugging a broken saved flow?** `get_flow` for its graph and
-   `get_flow_run` for a failing run's steps, then propose a repaired version.
 
 ## The workflow model
 

--- a/src/openhuman/flows/agents/workflow_builder/prompt.rs
+++ b/src/openhuman/flows/agents/workflow_builder/prompt.rs
@@ -79,14 +79,17 @@ mod tests {
         assert!(!body.is_empty());
     }
 
-    #[test]
-    fn prompt_teaches_the_propose_never_persist_invariant() {
-        let body = build(&ctx()).unwrap();
-        let lc = body.to_lowercase();
-        assert!(lc.contains("propose"), "prompt must teach proposing");
-        assert!(
-            lc.contains("never") && (lc.contains("persist") || lc.contains("save")),
-            "prompt must teach the never-persist invariant"
-        );
-    }
+    // A test asserting `body.to_lowercase().contains("propose")` used to live
+    // here. It was near-tautological: "propose"/"proposal"/"propose_workflow"
+    // appear dozens of times throughout the archetype regardless of whether
+    // the propose-only invariant is actually taught correctly, so the
+    // assertion could not fail in any way that mattered (P-m5). The real
+    // invariant — every authoring turn is propose-only, persistence gated
+    // behind the user's explicit ask — is pinned with specific, falsifiable
+    // substrings in `builder_prompt.rs`: `create_prompt_frames_propose_only`,
+    // `build_is_propose_only_and_injects_flow_id_as_context` (the #4596
+    // regression guard), and the `standing_prompt_*` tests that assert exact
+    // phrases like "Do NOT save_workflow" and "Do not save, enable, or run
+    // anything". Removed rather than strengthened to avoid duplicating that
+    // coverage here.
 }

--- a/src/openhuman/flows/builder_tools.rs
+++ b/src/openhuman/flows/builder_tools.rs
@@ -1,32 +1,50 @@
 //! Agent tool belt for the `workflow-builder` specialist (Phase 5b).
 //!
 //! These tools give the `workflow-builder` agent (see
-//! `agent_registry/agents/workflow_builder/`) a **deliberately narrow**,
-//! propose-or-read surface for authoring tinyflows [`WorkflowGraph`]s in chat:
+//! `agent_registry/agents/workflow_builder/`) its full authoring surface for
+//! tinyflows [`WorkflowGraph`]s in chat — 22 tools spanning propose-only
+//! validation, in-place draft mutation, live reads, one bounded real Composio
+//! call, run control, and persistence:
 //!
-//! | Tool                    | Permission              | Effect                                    |
-//! | ----------------------- | ----------------------- | ----------------------------------------- |
-//! | [`ReviseWorkflowTool`]  | `None`                  | validate a revised draft → proposal       |
-//! | [`ListFlowsTool`]       | `None`                  | read: list saved flows                    |
-//! | [`GetFlowTool`]         | `None`                  | read: fetch a saved flow's graph          |
-//! | [`GetFlowRunTool`]      | `None`                  | read: fetch a run's steps                 |
-//! | [`ListFlowConnectionsTool`] | `None`              | read: connection refs (ids/names only)    |
-//! | [`SearchToolCatalogTool`]   | `None`              | read: real Composio tool slugs (live catalog) |
-//! | [`GetToolContractTool`]     | `None`              | read: one action's FULL live contract     |
-//! | [`GetToolOutputSampleTool`] | `ReadOnly`          | ONE bounded real Composio call (Read-scope only, connected toolkit only) |
-//! | [`ListAgentProfilesTool`]   | `None`              | read: selectable agent kinds (`agent_ref`)|
-//! | [`DryRunWorkflowTool`]  | `Execute` (tier-gated)  | run a *draft* against MOCK capabilities   |
-//! | [`SaveWorkflowTool`]    | `Write`                 | persist a graph onto an EXISTING flow     |
+//! | Tool                             | Permission | Effect                                                        |
+//! | --------------------------------- | ---------- | ---------------------------------------------------------------- |
+//! | [`ReviseWorkflowTool`]            | `None`     | validate a revised draft → proposal (never persists)              |
+//! | [`EditWorkflowTool`]              | `None`     | mutate a draft in place (`add_node`/`remove_edge`/…) — never saves |
+//! | [`ValidateWorkflowTool`]          | `None`     | read: run the full gate stack without emitting a proposal card    |
+//! | [`GetFlowHistoryTool`]            | `None`     | read: a saved flow's prior graph snapshots                        |
+//! | [`ListFlowRunsTool`]              | `None`     | read: a flow's run history                                        |
+//! | [`ResumeFlowRunTool`]             | `Execute`  | advance a run parked on approval — approved nodes fire for real   |
+//! | [`CancelFlowRunTool`]             | `Write`    | stop an in-flight/parked run; fires no new outbound effect        |
+//! | [`CreateWorkflowTool`]            | `Write`    | persist a NEW flow — always born **DISABLED**                     |
+//! | [`DuplicateFlowTool`]             | `Write`    | clone a saved flow — the copy is always born **DISABLED**         |
+//! | [`ListConnectableToolkitsTool`]   | `None`     | read: which toolkits are already connected                        |
+//! | [`ListFlowsTool`]                 | `None`     | read: list saved flows                                            |
+//! | [`GetFlowTool`]                   | `None`     | read: fetch a saved flow's graph                                  |
+//! | [`GetFlowRunTool`]                | `None`     | read: fetch a run's steps                                         |
+//! | [`ListFlowConnectionsTool`]       | `None`     | read: connection refs (ids/names only)                            |
+//! | [`SearchToolCatalogTool`]         | `None`     | read: real Composio tool slugs (live catalog)                     |
+//! | [`GetToolContractTool`]           | `None`     | read: one action's FULL live contract                             |
+//! | [`GetToolOutputSampleTool`]       | `ReadOnly` | ONE bounded real Composio call (Read-scope only, connected toolkit only) |
+//! | [`ListAgentProfilesTool`]         | `None`     | read: selectable agent kinds (`agent_ref`)                        |
+//! | [`ListNodeKindsTool`]             | `None`     | read: the DSL's node kinds                                        |
+//! | [`GetNodeKindContractTool`]       | `None`     | read: one node kind's config/port/example/gotcha contract         |
+//! | [`DryRunWorkflowTool`]            | `None`     | run a *draft* against MOCK capabilities — not tier-gated (F7)     |
+//! | [`SaveWorkflowTool`]              | `Write`    | persist a graph onto an EXISTING flow                              |
 //!
-//! **Human-in-the-loop invariant (shared with [`super::tools::ProposeWorkflowTool`]),
-//! with one deliberate carve-out:** `revise_workflow` only validates and
-//! returns a proposal payload (identical contract to `propose_workflow`); the
-//! read tools are pure reads; `dry_run_workflow` executes against `tinyflows`'
-//! deterministic **mock** capabilities so no real LLM / tool / HTTP / code side
-//! effect can fire. The carve-out is [`SaveWorkflowTool`]: it persists a graph
-//! onto a flow that ALREADY exists (the Flows prompt bar's instant-create path
-//! makes the flow first and hands the agent its id) — but the agent still
-//! cannot *create* a flow, and never touches `enabled`/`require_approval`.
+//! **Human-in-the-loop invariant.** Enabling a flow is not a tool this agent
+//! has, by design, no matter which tool above it reaches for:
+//! [`CreateWorkflowTool`] and [`DuplicateFlowTool`] always produce a
+//! **DISABLED** flow, and [`SaveWorkflowTool`] never sets
+//! `enabled`/`require_approval` (it CAN auto-disable an already-enabled flow
+//! when the graph's trigger transitions from manual to automatic — see its
+//! own doc). `revise_workflow` / `edit_workflow` / `validate_workflow` only
+//! validate or mutate a draft and never persist. `dry_run_workflow` executes
+//! only against `tinyflows`' deterministic **mock** capabilities, so no real
+//! LLM / tool / HTTP / code side effect can fire from it regardless of tier
+//! (F7 — it is deliberately NOT tier-gated; see its own doc).
+//! [`ResumeFlowRunTool`] is the one place a non-persistence tool can cause a
+//! real effect: resuming a parked run lets its already-approved nodes fire,
+//! which is why it is `Execute`-gated rather than `None`/`Write`.
 //!
 //! The agent's full tool scope (see `agent_registry/agents/workflow_builder/
 //! agent.toml`) also grants the Composio **discovery/connect** tools —
@@ -56,7 +74,6 @@ use crate::openhuman::config::Config;
 use crate::openhuman::flows::ops;
 use crate::openhuman::flows::ops::validate_and_migrate_graph;
 use crate::openhuman::flows::tools;
-use crate::openhuman::security::SecurityPolicy;
 use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult};
 
 /// Wall-clock bound on a single `dry_run_workflow` mock execution. A malformed
@@ -2496,7 +2513,7 @@ impl Tool for GetNodeKindContractTool {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// dry_run_workflow — execute a DRAFT against MOCK capabilities (tier-gated)
+// dry_run_workflow — execute a DRAFT against MOCK capabilities (ungated, F7)
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// `dry_run_workflow`: compile a **draft** graph and run it against tinyflows'
@@ -2508,9 +2525,16 @@ impl Tool for GetNodeKindContractTool {
 /// capabilities are echo stubs, so nothing external ever fires regardless of
 /// the graph. The output is explicitly labeled `sandbox: true`.
 ///
-/// Autonomy-tier gated (issue: Phase 2 node gating): read-only tier refuses,
-/// mirroring the `SecurityPolicy` contract that a read-only session cannot
-/// exercise executable capability even in simulation.
+/// **Not autonomy-tier gated (F7):** `permission_level()` returns
+/// [`PermissionLevel::None`], so this tool runs on EVERY tier, read-only
+/// included — a read-only agent must be able to self-verify its own proposal.
+/// This is intentional, not an oversight: the mock capabilities never touch a
+/// real integration, so there is nothing for a tier gate to protect. See
+/// `dry_run_allowed_under_readonly_tier` in `builder_tools_tests.rs` for the
+/// pinned regression (an earlier draft of this tool *was* tier-gated via an
+/// unused `SecurityPolicy` field; the field was dead code by the time it
+/// shipped and was removed rather than wired up, since side-effect-free
+/// simulation has no tier to gate against).
 ///
 /// **Wiring preflight:** the mock tool invoker is wrapped in the host's
 /// [`PreflightToolInvoker`](crate::openhuman::tinyflows::caps::PreflightToolInvoker),
@@ -2684,13 +2708,12 @@ fn tool_call_arg_null_entries(
 }
 
 pub struct DryRunWorkflowTool {
-    security: Arc<SecurityPolicy>,
     config: Arc<Config>,
 }
 
 impl DryRunWorkflowTool {
-    pub fn new(security: Arc<SecurityPolicy>, config: Arc<Config>) -> Self {
-        Self { security, config }
+    pub fn new(config: Arc<Config>) -> Self {
+        Self { config }
     }
 }
 
@@ -3272,16 +3295,24 @@ impl CapturingObserver {
 /// an **existing, already-saved** flow via [`ops::flows_update`] — the same
 /// validate-and-migrate path the UI's Save uses.
 ///
-/// This is the deliberate, narrow exception to the belt's original
-/// "propose, never persist" invariant (added for the Flows prompt bar's
-/// instant-create path, where the host creates the flow *before* delegating and
-/// hands the agent its `flow_id`). The boundaries that remain:
+/// It was originally added as a narrow, deliberate exception to the belt's
+/// "propose, never persist" invariant (for the Flows prompt bar's
+/// instant-create path, where the host creates the flow *before* delegating
+/// and hands the agent its `flow_id`) — before [`CreateWorkflowTool`] and
+/// [`DuplicateFlowTool`] existed, this was the belt's only write. Both now
+/// exist, so `save_workflow` is one of three persistence tools, not the sole
+/// one. Its own remaining boundaries:
 ///
-/// - **Update-only.** It requires an existing `flow_id`; there is still no tool
-///   to *create* a flow, so the agent can only write where the host (or user)
-///   already made a flow.
+/// - **Update-only.** It requires an existing `flow_id`; it never fabricates
+///   one. Creating a flow is [`CreateWorkflowTool`]/[`DuplicateFlowTool`]'s
+///   job — `save_workflow` can only write onto a flow that already exists
+///   (whether the host, the user, or an earlier `create_workflow`/
+///   `duplicate_flow` call made it).
 /// - **Never touches enablement or the approval gate.** `enabled` and
-///   `require_approval` are not parameters; whatever the user set stays.
+///   `require_approval` are not parameters; whatever the user set stays —
+///   except that saving a graph whose trigger just transitioned from manual
+///   to automatic on an already-enabled flow auto-disables it (see
+///   [`ops::flows_update`]'s own doc for that guard).
 /// - **Real persistence, real consequences.** Saving a `schedule`/`app_event`
 ///   trigger onto an ENABLED flow arms it (the trigger binds and will fire on
 ///   its own) — hence `PermissionLevel::Write`. The description tells the agent

--- a/src/openhuman/flows/builder_tools_tests.rs
+++ b/src/openhuman/flows/builder_tools_tests.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::openhuman::config::Config;
-use crate::openhuman::security::{AutonomyLevel, SecurityPolicy};
 use serde_json::json;
 use tempfile::TempDir;
 
@@ -13,13 +12,6 @@ fn test_config(tmp: &TempDir) -> Arc<Config> {
     };
     std::fs::create_dir_all(&config.workspace_dir).unwrap();
     Arc::new(config)
-}
-
-fn policy(level: AutonomyLevel) -> Arc<SecurityPolicy> {
-    Arc::new(SecurityPolicy {
-        autonomy: level,
-        ..SecurityPolicy::default()
-    })
 }
 
 fn valid_graph() -> Value {
@@ -820,10 +812,7 @@ async fn get_tool_output_sample_refuses_an_unconnected_toolkit() {
 
 #[test]
 fn dry_run_is_side_effect_free_and_ungated() {
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     assert_eq!(tool.name(), "dry_run_workflow");
     // Mock-only + side-effect-free → PermissionLevel::None, available on every
     // tier including read-only (audit F7).
@@ -835,10 +824,7 @@ fn dry_run_is_side_effect_free_and_ungated() {
 async fn dry_run_allowed_under_readonly_tier() {
     // F7: dry_run is mock-only and side-effect-free, so a read-only agent must
     // be able to self-verify its own proposal (previously refused).
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::ReadOnly),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     assert_eq!(tool.permission_level(), PermissionLevel::None);
     let result = tool
         .execute(json!({ "graph": valid_graph() }))
@@ -851,10 +837,7 @@ async fn dry_run_allowed_under_readonly_tier() {
 
 #[tokio::test]
 async fn dry_run_supervised_runs_against_mock_and_labels_sandbox() {
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let result = tool
         .execute(json!({ "graph": valid_graph(), "input": { "x": 1 } }))
         .await
@@ -878,10 +861,7 @@ async fn dry_run_exercises_agent_ref_node_via_mock_agent_runner() {
     // capability; now `mock_capabilities_with_agent(MockAgentRunner)` echoes the
     // ref and the dry run goes green — proving the builder can self-test drafts
     // that use agent-kind nodes.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -913,10 +893,7 @@ async fn dry_run_plain_agent_with_output_parser_schema_is_green() {
     // validation after auto-fix: missing required property ...`, sinking a
     // correctly-built graph. Now the mock LLM synthesizes a schema-valid object,
     // and a downstream node binds the typed placeholders (non-null).
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Schedule",
@@ -977,10 +954,7 @@ async fn dry_run_plain_agent_with_output_parser_schema_is_green() {
 
 #[tokio::test]
 async fn dry_run_invalid_graph_is_error() {
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Full),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let result = tool
         .execute(json!({ "graph": { "nodes": [], "edges": [] } }))
         .await
@@ -997,7 +971,7 @@ async fn dry_run_catches_unwired_required_composio_arg() {
     seed_live_catalog_cache("gmail", vec![seeded_gmail_send_contract()]);
 
     let tmp = TempDir::new().unwrap();
-    let tool = DryRunWorkflowTool::new(policy(AutonomyLevel::Supervised), test_config(&tmp));
+    let tool = DryRunWorkflowTool::new(test_config(&tmp));
 
     let graph_with = |args: Value| {
         json!({
@@ -1049,10 +1023,7 @@ async fn dry_run_flags_tool_call_arg_null_resolved_from_unschemad_agent() {
     // The `summarize` agent has no `output_parser.schema`, so (via the
     // schema-aware mock agent) its structured output has no `channel` field —
     // the exact "builds but does nothing" shape this check exists to catch.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1116,10 +1087,7 @@ async fn dry_run_flags_composio_upstream_binding_as_unverifiable_not_a_wiring_bu
     // process-global catalog cache other tests seed for gmail/slack/etc.
     seed_live_catalog_cache("ws6up", vec![seeded_ws6_contract("WS6UP_LOOKUP", "ws6up")]);
     seed_live_catalog_cache("ws6dl", vec![seeded_ws6_contract("WS6DL_SEND", "ws6dl")]);
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1166,10 +1134,7 @@ async fn dry_run_keeps_generic_null_text_for_a_non_tool_call_upstream_binding() 
     // `unverifiable` flag — so the honest-uncertainty treatment doesn't leak
     // onto real mistakes.
     seed_live_catalog_cache("ws6dl", vec![seeded_ws6_contract("WS6DL_SEND", "ws6dl")]);
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1213,10 +1178,7 @@ async fn dry_run_passes_when_agent_schema_matches_tool_call_binding() {
     // always echoes `{ agent, request, connection }` regardless of schema)
     // this would incorrectly fail — proving the mock is what makes the check
     // accurate rather than perpetually red for correctly-built graphs.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1252,10 +1214,7 @@ async fn dry_run_passes_when_agent_schema_matches_tool_call_binding() {
 async fn dry_run_passes_when_tool_call_binds_to_upstream_tool_output() {
     // A `tool_call` binding to another `tool_call`'s real output (not an
     // agent at all) must not be affected by the agent-schema machinery above.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1301,10 +1260,7 @@ async fn dry_run_flags_tool_call_error_when_on_error_is_route() {
     // `dry_run_passes_when_tool_call_binds_to_upstream_tool_output` above.
     seed_live_catalog_cache("gmail", vec![seeded_gmail_send_contract()]);
 
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1347,10 +1303,7 @@ async fn dry_run_flags_tool_call_error_when_on_error_is_continue() {
     // converts a node failure into routed data instead of failing the run.
     seed_live_catalog_cache("gmail", vec![seeded_gmail_send_contract()]);
 
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1384,10 +1337,7 @@ async fn dry_run_passes_when_agent_enum_schema_binds_to_tool_call() {
     // must synthesize an ALLOWED value (not a generic `""` placeholder, which
     // would fail the vendored validator's `enum` check) so a correctly-built
     // graph using an enum schema dry-runs green instead of false-positiving.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1426,10 +1376,7 @@ async fn dry_run_flags_null_resolved_agent_prompt() {
     // vendored engine's own `resolve_traced` records it as a null resolution
     // at `location: "prompt"`, meaning the agent would run with an EMPTY
     // prompt. Unlike other agent-config nulls, this one must fail the dry run.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1477,10 +1424,7 @@ async fn dry_run_flags_null_resolved_agent_input_context() {
     // since #4590, so a null-resolved `input_context` is just as
     // execution-breaking as a null `prompt` — the agent runs with no
     // upstream data at all. Must fail the dry run the same way.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1518,10 +1462,7 @@ async fn dry_run_passes_when_agent_uses_input_context_instead_of_prompt_expressi
     // The FALSE-POSITIVE-PREVENTION case: the same data need, wired the
     // correct way — `input_context` carries the upstream item, `prompt`
     // stays a plain instruction with no leading `=`. This must dry-run green.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1560,10 +1501,7 @@ async fn dry_run_warns_on_unexercised_agent_after_condition() {
     // could easily carry `active: true` and take the other branch, so the
     // dry run must still surface this as a warning even though `ok` stays
     // `true` — there's nothing here that flips it to a hard reject.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1604,10 +1542,7 @@ async fn dry_run_warns_on_unexercised_agent_after_condition() {
 async fn dry_run_no_routing_divergence_warning_when_every_node_executes() {
     // FALSE-POSITIVE-PREVENTION: a condition whose taken branch under the
     // default mock input DOES reach the downstream agent must not warn.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -2658,7 +2593,7 @@ async fn dry_run_workflow_by_flow_id_runs_the_saved_flow_graph() {
         .await
         .unwrap()
         .value;
-    let tool = DryRunWorkflowTool::new(policy(AutonomyLevel::Supervised), config.clone());
+    let tool = DryRunWorkflowTool::new(config.clone());
     let result = tool.execute(json!({ "flow_id": flow.id })).await.unwrap();
     assert!(!result.is_error, "{}", result.output());
     let parsed: Value = serde_json::from_str(&result.output()).unwrap();
@@ -2731,4 +2666,63 @@ async fn revise_workflow_proposal_is_marked_unpersisted() {
     assert!(!result.is_error, "{}", result.output());
     let parsed: Value = serde_json::from_str(&result.output()).unwrap();
     assert_eq!(parsed["persisted"], false);
+}
+
+/// Docs-drift guard (T-m2): the top-of-file module doc table went stale
+/// enough to list 11 of ~22 tools, mis-describe `DryRunWorkflowTool`'s
+/// permission, and claim a `create_workflow`-adjacent invariant the code
+/// didn't hold — all silently, because nothing checked the table against the
+/// actual `impl Tool for` list. This mirrors the pattern
+/// `propose_workflow_description_matches_typed_node_contracts`
+/// (`tools_tests.rs`) established for node-kind contracts: derive the ground
+/// truth from the SAME source file rather than hardcoding a second list here
+/// (a hardcoded list would just be a new place to go stale), and fail loudly
+/// in both directions — a real tool missing from the table, or a table entry
+/// naming a tool that no longer exists.
+#[test]
+fn module_doc_tool_table_matches_registered_tools() {
+    const SOURCE: &str = include_str!("builder_tools.rs");
+
+    let module_doc: String = SOURCE
+        .lines()
+        .filter(|line| line.trim_start().starts_with("//!"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !module_doc.is_empty(),
+        "sanity: expected builder_tools.rs to carry a top-of-file `//!` module doc"
+    );
+
+    let impl_re = regex::Regex::new(r"impl Tool for (\w+)\s*\{").expect("valid regex");
+    let registered: std::collections::BTreeSet<String> = impl_re
+        .captures_iter(SOURCE)
+        .map(|c| c[1].to_string())
+        .collect();
+    assert!(
+        !registered.is_empty(),
+        "sanity: expected at least one `impl Tool for` in builder_tools.rs"
+    );
+
+    for tool in &registered {
+        assert!(
+            module_doc.contains(tool.as_str()),
+            "module doc table is missing `{tool}` — every `impl Tool for` in this file \
+             must be listed in the top-of-file doc table (T-m2)"
+        );
+    }
+
+    // The reverse direction: every `[`FooTool`]` reference in the doc must
+    // name a tool that actually still exists, so a removed/renamed tool
+    // can't leave a stale row behind.
+    let doc_ref_re = regex::Regex::new(r"\[`(\w+)`\]").expect("valid regex");
+    for cap in doc_ref_re.captures_iter(&module_doc) {
+        let name: &str = &cap[1];
+        if name.ends_with("Tool") {
+            assert!(
+                registered.contains(name),
+                "module doc table references `{name}`, but no `impl Tool for {name}` exists \
+                 in this file — the doc table has a stale entry"
+            );
+        }
+    }
 }

--- a/src/openhuman/flows/store.rs
+++ b/src/openhuman/flows/store.rs
@@ -681,11 +681,14 @@ pub fn insert_flow_run(
 }
 
 /// Prunes a flow's run history down to at most `keep` of its most-recent runs,
-/// deleting only **terminal** rows (`completed` / `failed` / `cancelled`) that
-/// fall outside the newest-`keep` window. Non-terminal runs (`running`,
-/// `pending_approval`) are never deleted — a parked `pending_approval` run must
-/// never be pruned out from under a pending `flows_resume`, and a `running` row
-/// belongs to a live task. Returns the number of rows deleted.
+/// deleting any row outside the newest-`keep` window whose `status` is NOT
+/// `running` or `pending_approval` — that is every terminal status this store
+/// can hold (`completed`, `completed_with_warnings`, `failed`, `cancelled`,
+/// `interrupted`, and any future status this host doesn't recognize yet), not
+/// just the `completed`/`failed`/`cancelled` trio. The two excluded statuses
+/// are the only ones that are never deleted — a parked `pending_approval` run
+/// must never be pruned out from under a pending `flows_resume`, and a
+/// `running` row belongs to a live task. Returns the number of rows deleted.
 ///
 /// `keep` is clamped to at least 1. Exposed for the manual `flows_prune_runs`
 /// sweep; the new-run insert path calls the connection-scoped helper directly.

--- a/src/openhuman/tinyflows/caps.rs
+++ b/src/openhuman/tinyflows/caps.rs
@@ -1506,10 +1506,16 @@ pub(crate) fn composio_connection_id(conn: &str) -> Option<&str> {
     (!id.is_empty()).then_some(id)
 }
 
-/// Parses a `"http_cred:<name>"` `connection_ref` for [`OpenHumanHttp`]. No
-/// host-side HTTP credential store exists yet — this only extracts the name
-/// so the adapter can log a clear, actionable warning instead of silently
-/// ignoring the reference. See [`OpenHumanHttp::request`]'s doc.
+/// Parses a `"http_cred:<name>"` `connection_ref` for [`OpenHumanHttp`],
+/// returning the trailing credential name. The host-side
+/// [`HttpCredentialsStore`] (encrypted-at-rest bearer/basic/header
+/// templates) is real and load-bearing — [`resolve_http_credential`] looks
+/// the extracted name up in it and injects the resolved auth header
+/// server-side. This function only does the parse; a malformed or missing
+/// name (`None`) is what lets the caller fail the request closed instead of
+/// silently sending it unauthenticated. See [`OpenHumanHttp::request`]'s doc
+/// and the "Phase 2" note on the [`OpenHumanHttp`] struct for the full
+/// resolution flow.
 pub(crate) fn http_cred_name(conn: &str) -> Option<&str> {
     let name = conn.strip_prefix("http_cred:")?.trim();
     (!name.is_empty()).then_some(name)

--- a/src/openhuman/tools/ops.rs
+++ b/src/openhuman/tools/ops.rs
@@ -376,7 +376,7 @@ pub fn all_tools_with_runtime(
         #[cfg(feature = "flows")]
         Box::new(GetNodeKindContractTool::new()),
         #[cfg(feature = "flows")]
-        Box::new(DryRunWorkflowTool::new(security.clone(), config.clone())),
+        Box::new(DryRunWorkflowTool::new(config.clone())),
         // Real end-to-end test run of a SAVED flow (Write / external-effect). The
         // workflow-builder prompt requires it to ask the user for confirmation
         // first, and the flow's own approval gate still pauses outbound nodes.


### PR DESCRIPTION
## Summary

- Fixes seven comments/docs that **asserted invariants the code does not hold** — the same drift class that let several real bugs survive earlier review.
- Repairs a structural break in the `workflow_builder` prompt where steps 3–6 of the authoring loop rendered as if they belonged to a different section.
- Makes the prompt regression pins **wrap-insensitive**, so a semantically neutral reflow can no longer break the suite (they previously matched exact hard-wrapped substrings).
- Adds a drift test that derives the tool table mechanically, so the module doc cannot silently rot again.

## Problem

Documentation in this area had drifted far enough to actively mislead both humans and agents:

- **`prompt.md`** — "## Your authoring loop" opened a numbered list (1, 2), then three full H2 sections were wedged in, so steps "3. Build the graph" … "6. Debugging a broken saved flow" rendered under *Inference provider readiness*.
- **`builder_prompt.rs`** — 49 pin assertions matched exact hard-wrapped substrings, several spanning a specific wrap column. Any reflow of `prompt.md` broke the suite for no semantic reason, which discourages exactly the prompt maintenance the file needs.
- **`prompt.rs`** — a near-tautological test (`body.contains("propose")`) that cannot meaningfully fail.
- **`builder_tools.rs`** — the module doc table listed 11 of ~22 tools, gave `DryRunWorkflowTool` the wrong permission, and asserted "the agent still cannot *create* a flow" **directly above `CreateWorkflowTool`**. A second stale "cannot create" claim also sat inside `SaveWorkflowTool`'s own doc.
- **`agents/mod.rs`** — still claimed `workflow_builder` "never persists", though `save_workflow` / `create_workflow` / `duplicate_flow` are all on its belt.
- **`caps.rs`** — `http_cred_name` claimed "No host-side HTTP credential store exists yet", while `HttpCredentialsStore` is load-bearing immediately below it.
- **`store.rs`** — the prune doc listed only `completed`/`failed`/`cancelled`, but the SQL (`NOT IN ('running','pending_approval')`) also prunes `interrupted` and `completed_with_warnings`.
- **`DryRunWorkflowTool.security`** — a dead field, never read, whose doc claimed tier-gating that both `permission_level()` and the pinned `dry_run_allowed_under_readonly_tier` test contradict.

## Solution

- Moved the three interleaved H2 sections **below** the complete 6-step loop — a pure content move, no wording changes — and verified the resulting document order end to end.
- Routed every `STANDING_PROMPT.contains(...)` assertion through a whitespace-normalizing helper. **Every assertion's intent is unchanged**; only the comparison is now wrap-insensitive. The pins for #4596 auto-save, B27 phantom review card, Bld §4 offer-then-refuse, and the self-DM `platform_user_id` rule all still pin exactly what they did.
- Deleted the tautological test (real, falsifiable coverage of the same invariant already lives in `builder_prompt.rs`) and justified it in a comment.
- Rewrote the tool table from all 22 actual `impl Tool for` registrations, removed the dead `security` field and its stale doc, and corrected the remaining false claims.
- **Added `module_doc_tool_table_matches_registered_tools`**, which derives the tool list from `impl Tool for` matches in the same source file — no hardcoded second list — and asserts both directions. This turns a recurring manual problem into a mechanical one.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — mostly doc/comment lines (not instrumented); the code changes (dead-field removal, pin normalization, new drift test) are covered. `cargo test --lib "openhuman::flows::"` = 549 passed, 0 failed
- [x] Coverage matrix updated — `N/A: documentation + dead-code removal, no feature rows added/removed/renamed`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature rows affected`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no runtime behaviour change`
- [x] Linked issue closed via `Closes #NNN` — `N/A: found by code review, no tracking issue filed yet`

## Impact

- **Runtime/platform:** Rust core. The only behavioural change is the removal of a dead, never-read field; everything else is docs, prompt structure, and tests.
- **Prompt:** the `workflow_builder` standing prompt is restructured (content move only), so the model now reads a coherent 6-step authoring loop instead of steps 3–6 apparently nested under an unrelated section.
- **Maintenance:** prompt edits no longer break pins on reflow, and the tool table is now self-checking.
- **Migration/security:** none.

## Related

- Closes: `N/A`
- Follow-up PR(s)/TODOs: the standing prompt is ~30k tokens with several rules stated 2–4× in different sections — a deliberate slimming pass (deduplicate to one canonical statement each, push per-kind reference detail into the contract tools it already defers to) is worth doing separately, with these pins as the safety net.
- **Merge order:** overlaps `builder_tools.rs` + `builder_tools_tests.rs` with the authorization-boundaries PR, and `store.rs` with the resume-lifecycle PR. Merge this one **last** of the three; it rebases cleanly.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `docs/flows-contract-drift`
- Commit SHA: `52e9f5bbe`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A, no frontend files changed
- [x] `pnpm typecheck` — N/A, no TypeScript changed
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --lib "openhuman::flows::"` → **549 passed, 0 failed** (incl. `openhuman::flows::agents` 23, `builder_tools` 91, `store` 34; `tinyflows::caps` 112 run separately for the doc-only change there)
- [x] Rust fmt/check (if changed): `GGML_NATIVE=OFF cargo check` clean; `rustfmt --check` clean on all touched files
- [x] Tauri fmt/check (if changed): N/A, `app/src-tauri` untouched

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none at runtime, apart from removing a dead field. The prompt's rendered structure changes (steps 3–6 now read as part of the authoring loop).
- User-visible effect: none directly; the builder agent reads a correctly-structured prompt.

### Parity Contract

- Legacy behavior preserved: every prompt pin retains its original intent — only the string comparison is normalized. No prompt wording was changed, only section order.
- Guard/fallback/dispatch parity checks: `dry_run_allowed_under_readonly_tier` still passes after the dead-field removal, confirming the tool's gating posture is genuinely unchanged.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified workflow authoring, persistence, duplication, and save behavior.
  * Documented the expanded workflow-builder toolkit and dry-run availability.
  * Clarified terminal run cleanup statuses and credential-reference handling.
* **Bug Fixes**
  * Dry runs are now available without security-policy gating.
  * Improved prompt checks to remain reliable across whitespace and line wrapping.
* **Tests**
  * Added coverage ensuring all registered workflow tools are documented accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->