### PR TITLE
fix(flows): store resilience — skip corrupt rows, transactional step upserts, once-per-process schema init

### DIFF
--- a/src/openhuman/flows/bus.rs
+++ b/src/openhuman/flows/bus.rs
@@ -134,13 +134,18 @@ impl FlowTriggerSubscriber {
     /// dispatches each match with the event payload as the run input
     /// (seeded into `run.trigger`, per the node-catalog contract).
     async fn handle_app_event(&self, toolkit: &str, trigger_slug: &str, payload: &Value) {
-        let flows = match store::list_enabled_flows(&self.config) {
-            Ok(flows) => flows,
+        let (flows, skipped) = match store::list_enabled_flows(&self.config) {
+            Ok(result) => result,
             Err(e) => {
                 tracing::warn!(target: "flows", %toolkit, %trigger_slug, error = %e, "[flows] failed to list enabled flows for app_event dispatch");
                 return;
             }
         };
+        if skipped > 0 {
+            // R-M4: one corrupt/unmigratable flow row must not blackhole
+            // app_event dispatch for every other enabled flow.
+            tracing::warn!(target: "flows", %toolkit, %trigger_slug, skipped, "[flows] handle_app_event: skipped corrupt/unmigratable flow rows while matching trigger");
+        }
 
         let mut matched = 0usize;
         for flow in flows {
@@ -1039,8 +1044,10 @@ mod tests {
         // `list_enabled_flows` must not surface the disabled flow at all —
         // proves the subscriber's dispatch source already excludes it,
         // rather than asserting on a spawned background task's side effect.
-        let enabled = crate::openhuman::flows::store::list_enabled_flows(&config).unwrap();
+        let (enabled, skipped) =
+            crate::openhuman::flows::store::list_enabled_flows(&config).unwrap();
         assert!(enabled.is_empty());
+        assert_eq!(skipped, 0);
     }
 
     #[tokio::test]

--- a/src/openhuman/flows/ops.rs
+++ b/src/openhuman/flows/ops.rs
@@ -3498,9 +3498,32 @@ pub(crate) fn load_engine_compatible_flow_graph(
 }
 
 /// Lists every saved flow.
+///
+/// A corrupt or newer-schema-than-this-build `graph_json` row is skipped
+/// rather than failing the whole list (R-M4 — see `store::list_flow_rows`);
+/// when that happens it must not be silent, so a skip is both logged
+/// (`[flows]`-prefixed, id + error only — never row content) and surfaced in
+/// the RPC's `logs` so the UI can tell the user "N workflows could not be
+/// loaded" instead of silently rendering a shorter list than actually exists.
 pub async fn flows_list(config: &Config) -> Result<RpcOutcome<Vec<Flow>>, String> {
-    let flows = store::list_flows(config).map_err(|e| e.to_string())?;
-    Ok(RpcOutcome::single_log(flows, "flows listed"))
+    let (flows, skipped) = store::list_flows(config).map_err(|e| e.to_string())?;
+    if skipped > 0 {
+        tracing::warn!(
+            target: "flows",
+            skipped,
+            loaded = flows.len(),
+            "[flows] flows_list: skipped corrupt/unmigratable flow_definitions rows"
+        );
+        Ok(RpcOutcome::new(
+            flows,
+            vec![format!(
+                "flows listed ({skipped} workflow{} could not be loaded and were skipped)",
+                if skipped == 1 { "" } else { "s" }
+            )],
+        ))
+    } else {
+        Ok(RpcOutcome::single_log(flows, "flows listed"))
+    }
 }
 
 /// Lists the connection sources a flow node's `connection_ref` can attach to:
@@ -4294,7 +4317,13 @@ fn log_webhook_trigger_deferred(flow: &Flow, enabled: bool) {
 /// was lost some other way) gets its schedule re-registered on the next
 /// boot without the user having to toggle it off and on.
 pub async fn reconcile_schedule_triggers_on_boot(config: &Config) -> Result<(), String> {
-    let flows = store::list_enabled_flows(config).map_err(|e| e.to_string())?;
+    let (flows, skipped) = store::list_enabled_flows(config).map_err(|e| e.to_string())?;
+    if skipped > 0 {
+        // R-M4: a corrupt/unmigratable row must not abort boot reconciliation
+        // for every other enabled flow — skipped rows are logged loudly
+        // (never their content) so the gap is diagnosable.
+        tracing::warn!(target: "flows", skipped, "[flows] reconcile_schedule_triggers_on_boot: skipped corrupt/unmigratable flow rows");
+    }
     let mut reconciled = 0usize;
     for flow in &flows {
         if matches!(bus::extract_trigger_kind(flow), Some(TriggerKind::Schedule)) {
@@ -4302,7 +4331,7 @@ pub async fn reconcile_schedule_triggers_on_boot(config: &Config) -> Result<(), 
             reconciled += 1;
         }
     }
-    tracing::debug!(target: "flows", scanned = flows.len(), reconciled, "[flows] boot reconciliation of schedule-trigger cron jobs complete");
+    tracing::debug!(target: "flows", scanned = flows.len(), reconciled, skipped, "[flows] boot reconciliation of schedule-trigger cron jobs complete");
     Ok(())
 }
 

--- a/src/openhuman/flows/ops_tests.rs
+++ b/src/openhuman/flows/ops_tests.rs
@@ -607,7 +607,7 @@ async fn flows_create_rejects_an_incompatible_saved_child_before_persisting() {
         "{error}"
     );
     assert!(error.contains(&child.id), "{error}");
-    let flows = store::list_flows(&config).unwrap();
+    let (flows, _skipped) = store::list_flows(&config).unwrap();
     assert_eq!(flows.len(), 1, "the rejected parent must not be persisted");
     assert_eq!(flows[0].id, child.id);
 }
@@ -1215,6 +1215,70 @@ async fn flows_delete_unbinds_schedule_cron_job() {
             .is_none(),
         "deleting a flow must remove its schedule-trigger cron job — it lives in a separate \
          cron.db that flow_definitions' ON DELETE CASCADE cannot reach"
+    );
+}
+
+#[tokio::test]
+async fn reconcile_schedule_triggers_on_boot_survives_a_corrupt_row() {
+    // R-M4: `reconcile_schedule_triggers_on_boot` is driven by
+    // `list_enabled_flows`, which used to hard-fail its entire query on the
+    // first corrupt/unmigratable `graph_json` row. One bad enabled flow must
+    // not prevent every OTHER enabled schedule-trigger flow from having its
+    // cron job re-registered on boot.
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    let good = flows_create(
+        &config,
+        "good-scheduled".to_string(),
+        schedule_trigger_graph("0 9 * * *"),
+        false,
+    )
+    .await
+    .unwrap();
+    flows_set_enabled(&config, &good.value.id, true)
+        .await
+        .unwrap();
+
+    let bad = flows_create(
+        &config,
+        "bad-scheduled".to_string(),
+        schedule_trigger_graph("0 10 * * *"),
+        false,
+    )
+    .await
+    .unwrap();
+    flows_set_enabled(&config, &bad.value.id, true)
+        .await
+        .unwrap();
+    store::force_corrupt_graph_json_for_test(&config, &bad.value.id, "{ not valid json").unwrap();
+
+    // Remove the cron job `flows_set_enabled` already bound for the good flow
+    // above, so the post-reconcile assertion proves
+    // `reconcile_schedule_triggers_on_boot` itself re-registered it (rather
+    // than the earlier `flows_set_enabled` call, which would pass this
+    // assertion even if the boot reconcile silently did nothing).
+    let good_job = crate::openhuman::cron::find_flow_schedule_job(&config, &good.value.id)
+        .unwrap()
+        .expect("precondition: good flow's cron job bound on enable");
+    crate::openhuman::cron::remove_job(&config, &good_job.id).unwrap();
+    assert!(
+        crate::openhuman::cron::find_flow_schedule_job(&config, &good.value.id)
+            .unwrap()
+            .is_none(),
+        "precondition: good flow's cron job removed before reconcile"
+    );
+
+    reconcile_schedule_triggers_on_boot(&config)
+        .await
+        .expect("boot reconciliation must not fail because of one corrupt sibling row");
+
+    assert!(
+        crate::openhuman::cron::find_flow_schedule_job(&config, &good.value.id)
+            .unwrap()
+            .is_some(),
+        "the good flow's cron job must be re-registered by boot reconcile despite the \
+         corrupt sibling row"
     );
 }
 

--- a/src/openhuman/flows/store.rs
+++ b/src/openhuman/flows/store.rs
@@ -22,29 +22,93 @@ use crate::openhuman::flows::Flow;
 use anyhow::{Context, Result};
 use chrono::Utc;
 use rusqlite::{params, Connection};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use uuid::Uuid;
 
-/// Opens (creating/migrating as needed) the flows SQLite database and runs `f`
-/// against the connection.
-fn with_connection<T>(config: &Config, f: impl FnOnce(&Connection) -> Result<T>) -> Result<T> {
-    let db_path = config.workspace_dir.join("flows").join("flows.db");
-    if let Some(parent) = db_path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create flows directory: {}", parent.display()))?;
+/// Tracks which flows database files have already had their schema DDL (the
+/// `CREATE TABLE`/`CREATE INDEX` batch, `PRAGMA journal_mode = WAL`, and the
+/// `add_column_if_missing` migration probe) run against them in this process
+/// (R-m8). `with_connection` deliberately keeps opening a fresh, lightweight
+/// `rusqlite::Connection` per call — `Connection` is `!Sync`, so caching a
+/// single shared one would need a process-wide mutex that serializes every
+/// caller, including the concurrent-writer scenario [`upsert_flow_run_step`]'s
+/// `BEGIN IMMEDIATE` fix (R-m1) depends on being able to run from independent
+/// connections. What actually repeats needlessly on every open is the DDL
+/// batch itself — including once per node per live run via
+/// `upsert_flow_run_step`. Gating just that batch behind a per-path
+/// "already initialized" set keeps it to one execution per process per
+/// database file while every call still gets its own connection.
+///
+/// Keyed by path rather than a single flag: tests each open an independent
+/// per-`TempDir` workspace within the same test binary, and a bare
+/// `OnceLock<()>` would silently skip schema creation for every database path
+/// after the first test to run in the process.
+static INITIALIZED_SCHEMAS: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
+
+/// Runs the one-time schema DDL + migrations against `conn` unless `db_path`
+/// has already been initialized in this process (see [`INITIALIZED_SCHEMAS`]).
+/// Only marks `db_path` as initialized *after* [`init_schema`] succeeds, so a
+/// transient failure (e.g. disk I/O) is retried on the next call rather than
+/// permanently wedging the store into believing a schema exists that was
+/// never created.
+///
+/// **Trust, but verify.** A cache hit is confirmed against the file actually on
+/// disk before it is honoured. Before this gating existed, the DDL ran on every
+/// `with_connection` call, so a database deleted or replaced at runtime — a
+/// workspace reset, a manual deletion, a disk-recovery restore — self-healed on
+/// the very next call: `Connection::open` silently creates a fresh empty file,
+/// and `CREATE TABLE IF NOT EXISTS` immediately repopulated it. Caching removes
+/// that safety net: the set still says "initialized" while the file behind it is
+/// empty, so every subsequent query fails with `no such table` until the process
+/// restarts. One indexed `sqlite_master` lookup is far cheaper than the ~11
+/// statement DDL batch and restores the self-healing, so it is paid on each hit
+/// rather than trusting a cache entry that the filesystem may have invalidated.
+fn ensure_schema_initialized(conn: &Connection, db_path: &Path) -> Result<()> {
+    use rusqlite::OptionalExtension;
+
+    let initialized = INITIALIZED_SCHEMAS.get_or_init(|| Mutex::new(HashSet::new()));
+    {
+        let guard = initialized
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if guard.contains(db_path) {
+            let schema_present: bool = conn
+                .query_row(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'flow_definitions'",
+                    [],
+                    |_| Ok(true),
+                )
+                .optional()
+                .context("Failed to probe flows schema presence")?
+                .unwrap_or(false);
+            if schema_present {
+                return Ok(());
+            }
+            tracing::warn!(
+                target: "flows",
+                db = %db_path.display(),
+                "[flows] schema cached as initialized but the database has no tables (deleted or replaced at runtime?) — re-running schema init"
+            );
+        }
     }
+    init_schema(conn)?;
+    let mut guard = initialized
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    guard.insert(db_path.to_path_buf());
+    Ok(())
+}
 
-    let conn = Connection::open(&db_path)
-        .with_context(|| format!("Failed to open flows DB: {}", db_path.display()))?;
-
+/// The actual schema DDL: 5 `CREATE TABLE IF NOT EXISTS` + 6 `CREATE INDEX IF
+/// NOT EXISTS` + `PRAGMA journal_mode = WAL` (a persistent db-file setting,
+/// not per-connection — safe, and now guaranteed, to run only once) plus the
+/// `require_approval` post-hoc column migration. Split out of
+/// `with_connection` so [`ensure_schema_initialized`] can gate it (R-m8).
+fn init_schema(conn: &Connection) -> Result<()> {
     conn.execute_batch(
-        // `busy_timeout` retries (rather than immediately erroring
-        // `SQLITE_BUSY`) when a concurrent run/state write holds the lock; WAL
-        // lets readers and a writer proceed together. Both are safe to re-issue
-        // on every open (WAL is a persistent db-file setting; busy_timeout is
-        // per-connection).
-        "PRAGMA busy_timeout = 5000;
-         PRAGMA journal_mode = WAL;
-         PRAGMA foreign_keys = ON;
+        "PRAGMA journal_mode = WAL;
          CREATE TABLE IF NOT EXISTS flow_definitions (
             id          TEXT PRIMARY KEY,
             name        TEXT NOT NULL,
@@ -114,11 +178,39 @@ fn with_connection<T>(config: &Config, f: impl FnOnce(&Connection) -> Result<T>)
     // before this column existed still opens cleanly. Mirrors
     // `cron::store`'s `add_column_if_missing` idiom.
     add_column_if_missing(
-        &conn,
+        conn,
         "flow_definitions",
         "require_approval",
         "INTEGER NOT NULL DEFAULT 0",
     )?;
+
+    Ok(())
+}
+
+/// Opens (creating/migrating as needed — once per process per database file,
+/// see [`ensure_schema_initialized`]) the flows SQLite database and runs `f`
+/// against the connection.
+fn with_connection<T>(config: &Config, f: impl FnOnce(&Connection) -> Result<T>) -> Result<T> {
+    let db_path = config.workspace_dir.join("flows").join("flows.db");
+    if let Some(parent) = db_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create flows directory: {}", parent.display()))?;
+    }
+
+    let conn = Connection::open(&db_path)
+        .with_context(|| format!("Failed to open flows DB: {}", db_path.display()))?;
+
+    // Per-connection pragmas: NOT persisted in the database file, so these
+    // must be reapplied on every open regardless of the schema-init cache
+    // below. `busy_timeout` retries (rather than immediately erroring
+    // `SQLITE_BUSY`) when a concurrent writer holds the lock — including this
+    // store's own `BEGIN IMMEDIATE` step upsert (R-m1); `foreign_keys` is
+    // required on every connection for the `ON DELETE CASCADE` FKs to be
+    // enforced.
+    conn.execute_batch("PRAGMA busy_timeout = 5000; PRAGMA foreign_keys = ON;")
+        .context("Failed to set flows DB connection pragmas")?;
+
+    ensure_schema_initialized(&conn, &db_path)?;
 
     tracing::debug!(db = %db_path.display(), "[flows] store opened");
 
@@ -270,19 +362,58 @@ pub fn get_flow(config: &Config, id: &str) -> Result<Option<Flow>> {
     })
 }
 
-/// Lists all saved flows, migrating each graph on read (see [`get_flow`]).
-pub fn list_flows(config: &Config) -> Result<Vec<Flow>> {
-    with_connection(config, |conn| {
-        let mut stmt = conn.prepare(&format!(
-            "SELECT {FLOW_DEFINITION_COLUMNS} FROM flow_definitions ORDER BY created_at ASC"
-        ))?;
-        let rows = stmt.query_map([], map_flow_row)?;
-        let mut flows = Vec::new();
-        for row in rows {
-            flows.push(row?);
+/// Runs a `flow_definitions` SELECT and splits its rows into successfully
+/// decoded [`Flow`]s and a count of rows that failed to parse/migrate
+/// (R-M4).
+///
+/// **Skip-and-log, not fail-the-whole-query.** Before this, `list_flows` /
+/// `list_enabled_flows` did `flows.push(row?)`, so a single corrupt or
+/// newer-schema-than-this-build `graph_json` (e.g. a user downgrades after
+/// running a newer build that persisted a graph `tinyflows::migrate::migrate`
+/// cannot step backward) hard-failed the *entire* query — bricking every
+/// `flows_list`, every `app_event` trigger dispatch (which is driven by
+/// `list_enabled_flows`, see `bus.rs::handle_app_event`), and the boot
+/// `reconcile_schedule_triggers_on_boot` sweep, all because of one bad row.
+/// Mirrors the posture `draft_store::list_drafts` already uses. The returned
+/// skip count is **not** swallowed here — it is the caller's job to log/
+/// surface it loudly (a silently short flow list is its own failure mode) —
+/// but this function itself does log each skip at `warn` with the row's `id`
+/// and the parse/migrate error, never the `graph_json` payload.
+fn list_flow_rows(conn: &Connection, where_clause: &str) -> Result<(Vec<Flow>, usize)> {
+    let mut stmt = conn.prepare(&format!(
+        "SELECT {FLOW_DEFINITION_COLUMNS} FROM flow_definitions {where_clause} \
+         ORDER BY created_at ASC"
+    ))?;
+    let mut rows = stmt.query([])?;
+    let mut flows = Vec::new();
+    let mut skipped = 0usize;
+    while let Some(row) = rows.next()? {
+        match map_flow_row(row) {
+            Ok(flow) => flows.push(flow),
+            Err(e) => {
+                skipped += 1;
+                let id: String = row.get(0).unwrap_or_else(|_| "<unknown>".to_string());
+                tracing::warn!(
+                    target: "flows",
+                    flow_id = %id,
+                    error = %e,
+                    "[flows] skipping corrupt or unmigratable flow_definitions row \
+                     (graph_json failed to parse/migrate)"
+                );
+            }
         }
-        Ok(flows)
-    })
+    }
+    Ok((flows, skipped))
+}
+
+/// Lists all saved flows, migrating each graph on read (see [`get_flow`]).
+///
+/// Returns `(flows, skipped)` — `skipped` is the number of rows that could
+/// not be decoded and were left out of `flows` (R-M4). Callers must not treat
+/// a non-zero `skipped` as a reason to fail; they must surface it loudly
+/// instead (see [`list_flow_rows`]).
+pub fn list_flows(config: &Config) -> Result<(Vec<Flow>, usize)> {
+    with_connection(config, |conn| list_flow_rows(conn, ""))
 }
 
 /// Lists only enabled flows, migrating each graph on read (see [`get_flow`]).
@@ -292,19 +423,11 @@ pub fn list_flows(config: &Config) -> Result<Vec<Flow>> {
 /// scanning the (small) enabled set once per event is simpler and cheap
 /// enough at expected flow counts; a dedicated toolkit/trigger_slug index is
 /// a later optimization if this ever shows up as a bottleneck.
-pub fn list_enabled_flows(config: &Config) -> Result<Vec<Flow>> {
-    with_connection(config, |conn| {
-        let mut stmt = conn.prepare(&format!(
-            "SELECT {FLOW_DEFINITION_COLUMNS} FROM flow_definitions WHERE enabled = 1 \
-             ORDER BY created_at ASC"
-        ))?;
-        let rows = stmt.query_map([], map_flow_row)?;
-        let mut flows = Vec::new();
-        for row in rows {
-            flows.push(row?);
-        }
-        Ok(flows)
-    })
+///
+/// Returns `(flows, skipped)` — see [`list_flows`]. A corrupt row here must
+/// not take down `app_event` dispatch for every *other* enabled flow (R-M4).
+pub fn list_enabled_flows(config: &Config) -> Result<(Vec<Flow>, usize)> {
+    with_connection(config, |conn| list_flow_rows(conn, "WHERE enabled = 1"))
 }
 
 /// Deletes a flow by id. Returns an error if no such flow exists.
@@ -765,44 +888,88 @@ pub fn finish_flow_run(
 /// it finishes** (issue G2, live run observation) rather than only rebuilding
 /// the whole step list at settle.
 ///
-/// Read-modify-write under a single connection (the WAL + `busy_timeout=5000`
-/// this store opens with tolerates the concurrent settle write). A re-run of
-/// the same `node_id` (a retry, or a resumed run re-touching a node) replaces
-/// its prior entry rather than duplicating it, so the persisted list stays one
-/// entry per node. No-op if the run's start row hasn't been inserted yet
-/// (nothing to update) — mirrors the best-effort contract of the run-row
-/// writers in `flows::ops`.
+/// **`BEGIN IMMEDIATE`-guarded read-modify-write (R-m1).** Each call opens its
+/// own connection (see `with_connection`), so without an explicit transaction
+/// two observer callbacks firing for parallel branch nodes of the *same* run
+/// can interleave: both read `steps_json = [A]`, one writes `[A,B]`, the other
+/// writes `[A,C]` — B is silently lost from the live view, and lost for good,
+/// since the post-hoc `settle_steps` reconstruction only refills a missing
+/// node with `status: None` rather than recovering the real outcome/duration.
+/// `BEGIN IMMEDIATE` takes SQLite's write lock up front (rather than only at
+/// the final `UPDATE`, which is what a plain autocommit read-then-write would
+/// do), so a concurrent upsert either waits (covered by this store's
+/// `busy_timeout = 5000` connection pragma — see `with_connection`) or is
+/// serialized behind it; there is no window in which both readers can observe
+/// the same pre-write `steps_json`. Kept deliberately minimal (one SELECT, one
+/// UPDATE) to bound how long the write lock is held.
+///
+/// A re-run of the same `node_id` (a retry, or a resumed run re-touching a
+/// node) replaces its prior entry rather than duplicating it, so the
+/// persisted list stays one entry per node. No-op if the run's start row
+/// hasn't been inserted yet (nothing to update) — mirrors the best-effort
+/// contract of the run-row writers in `flows::ops`.
 pub fn upsert_flow_run_step(config: &Config, run_id: &str, step: &FlowRunStep) -> Result<()> {
     use rusqlite::OptionalExtension;
     with_connection(config, |conn| {
-        let existing: Option<String> = conn
-            .query_row(
-                "SELECT steps_json FROM flow_runs WHERE id = ?1",
-                params![run_id],
-                |row| row.get(0),
+        with_immediate_transaction(conn, |conn| {
+            let existing: Option<String> = conn
+                .query_row(
+                    "SELECT steps_json FROM flow_runs WHERE id = ?1",
+                    params![run_id],
+                    |row| row.get(0),
+                )
+                .optional()
+                .context("Failed to read flow run steps for incremental upsert")?;
+            let Some(raw) = existing else {
+                tracing::debug!(target: "flows", run_id, node = %step.node_id, "[flows] upsert_flow_run_step: no run row yet — skipping incremental step persist");
+                return Ok(());
+            };
+            let mut steps: Vec<FlowRunStep> = serde_json::from_str(&raw)
+                .context("Failed to deserialize existing flow run steps")?;
+            match steps.iter_mut().find(|s| s.node_id == step.node_id) {
+                Some(slot) => *slot = step.clone(),
+                None => steps.push(step.clone()),
+            }
+            let steps_json =
+                serde_json::to_string(&steps).context("Failed to serialize flow run steps")?;
+            conn.execute(
+                "UPDATE flow_runs SET steps_json = ?1 WHERE id = ?2",
+                params![steps_json, run_id],
             )
-            .optional()
-            .context("Failed to read flow run steps for incremental upsert")?;
-        let Some(raw) = existing else {
-            tracing::debug!(target: "flows", run_id, node = %step.node_id, "[flows] upsert_flow_run_step: no run row yet — skipping incremental step persist");
-            return Ok(());
-        };
-        let mut steps: Vec<FlowRunStep> =
-            serde_json::from_str(&raw).context("Failed to deserialize existing flow run steps")?;
-        match steps.iter_mut().find(|s| s.node_id == step.node_id) {
-            Some(slot) => *slot = step.clone(),
-            None => steps.push(step.clone()),
-        }
-        let steps_json =
-            serde_json::to_string(&steps).context("Failed to serialize flow run steps")?;
-        conn.execute(
-            "UPDATE flow_runs SET steps_json = ?1 WHERE id = ?2",
-            params![steps_json, run_id],
-        )
-        .context("Failed to persist incremental flow run step")?;
-        tracing::debug!(target: "flows", run_id, node = %step.node_id, step_count = steps.len(), "[flows] persisted incremental flow run step");
-        Ok(())
+            .context("Failed to persist incremental flow run step")?;
+            tracing::debug!(target: "flows", run_id, node = %step.node_id, step_count = steps.len(), "[flows] persisted incremental flow run step");
+            Ok(())
+        })
     })
+}
+
+/// Runs `f` inside a `BEGIN IMMEDIATE` / `COMMIT` transaction on `conn`,
+/// rolling back on error. `BEGIN IMMEDIATE` (rather than the default deferred
+/// `BEGIN`) acquires SQLite's write lock immediately instead of only at the
+/// first write statement, which is what closes the read-then-write race
+/// [`upsert_flow_run_step`] needs closed (R-m1). Issued as raw SQL via
+/// `execute_batch` rather than `rusqlite::Connection::transaction` (which
+/// needs `&mut Connection`) so this can compose with `with_connection`'s
+/// `&Connection` closure signature used by every other store function.
+fn with_immediate_transaction<T>(
+    conn: &Connection,
+    f: impl FnOnce(&Connection) -> Result<T>,
+) -> Result<T> {
+    conn.execute_batch("BEGIN IMMEDIATE")
+        .context("Failed to begin immediate transaction")?;
+    match f(conn) {
+        Ok(value) => {
+            conn.execute_batch("COMMIT")
+                .context("Failed to commit transaction")?;
+            Ok(value)
+        }
+        Err(e) => {
+            if let Err(rollback_err) = conn.execute_batch("ROLLBACK") {
+                tracing::warn!(target: "flows", error = %rollback_err, "[flows] failed to roll back transaction after error");
+            }
+            Err(e)
+        }
+    }
 }
 
 /// Expires every parked `pending_approval` run whose "parked since" timestamp
@@ -936,6 +1103,33 @@ pub fn force_run_status_for_test(
             params![status, error, id],
         )
         .context("Failed to force flow run status (test fixture)")?;
+        Ok(())
+    })
+}
+
+/// Test-only fixture door: overwrites an existing flow row's `graph_json`
+/// with arbitrary text, bypassing the normal `Flow`/`WorkflowGraph`-typed
+/// write path entirely. Used to stage the corrupt-or-newer-schema-row
+/// scenario `list_flows` / `list_enabled_flows` / boot reconciliation must
+/// survive (R-M4) — same "staging is a fixture concern, so it gets a
+/// fixture-only door" rationale as [`force_run_status_for_test`]. Real
+/// production writes can never produce a row `map_flow_row` can't decode
+/// (every write path serializes a validated `WorkflowGraph`), so there is no
+/// non-test way to reach this state other than a cross-version downgrade.
+#[cfg(test)]
+pub fn force_corrupt_graph_json_for_test(
+    config: &Config,
+    flow_id: &str,
+    raw_graph_json: &str,
+) -> Result<()> {
+    with_connection(config, |conn| {
+        let changed = conn
+            .execute(
+                "UPDATE flow_definitions SET graph_json = ?1 WHERE id = ?2",
+                params![raw_graph_json, flow_id],
+            )
+            .context("Failed to force corrupt graph_json (test fixture)")?;
+        anyhow::ensure!(changed > 0, "flow '{flow_id}' not found (test fixture)");
         Ok(())
     })
 }

--- a/src/openhuman/flows/store_tests.rs
+++ b/src/openhuman/flows/store_tests.rs
@@ -42,13 +42,14 @@ fn create_get_list_delete_roundtrip() {
     assert_eq!(fetched.id, flow.id);
     assert_eq!(fetched.graph, flow.graph);
 
-    let listed = list_flows(&config).unwrap();
+    let (listed, skipped) = list_flows(&config).unwrap();
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].id, flow.id);
+    assert_eq!(skipped, 0);
 
     remove_flow(&config, &flow.id).unwrap();
     assert!(get_flow(&config, &flow.id).unwrap().is_none());
-    assert!(list_flows(&config).unwrap().is_empty());
+    assert!(list_flows(&config).unwrap().0.is_empty());
 }
 
 #[test]
@@ -320,9 +321,11 @@ fn update_flow_graph_can_change_require_approval() {
 
 #[test]
 fn legacy_flow_definitions_row_without_require_approval_column_defaults_false() {
-    // A row inserted before the `require_approval` column existed (the
-    // `add_column_if_missing` ALTER runs on every `with_connection` call, so
-    // this simulates a workspace opened once on an older build).
+    // A row inserted before the `require_approval` column existed. Schema
+    // init (including the `add_column_if_missing` ALTER) runs once per
+    // process per database file (R-m8) — since this test opens a fresh
+    // per-`TempDir` database, that one-time init still runs here, simulating
+    // a workspace opened once on an older build.
     let tmp = TempDir::new().unwrap();
     let config = test_config(&tmp);
 
@@ -361,9 +364,10 @@ fn list_enabled_flows_excludes_disabled() {
     .unwrap();
     set_enabled(&config, &disabled_flow.id, false).unwrap();
 
-    let enabled = list_enabled_flows(&config).unwrap();
+    let (enabled, skipped) = list_enabled_flows(&config).unwrap();
     assert_eq!(enabled.len(), 1);
     assert_eq!(enabled[0].id, enabled_flow.id);
+    assert_eq!(skipped, 0);
 }
 
 // ── flow_runs CRUD ────────────────────────────────────────────────────────
@@ -538,7 +542,7 @@ fn insert_duplicate_flow_makes_a_disabled_copy_with_new_id_and_same_graph() {
     let reloaded = get_flow(&config, &copy.id).unwrap().unwrap();
     assert!(!reloaded.enabled);
     assert_eq!(reloaded.graph, source.graph);
-    assert_eq!(list_flows(&config).unwrap().len(), 2);
+    assert_eq!(list_flows(&config).unwrap().0.len(), 2);
 }
 
 // ── prune_flow_runs ───────────────────────────────────────────────────────
@@ -994,4 +998,342 @@ fn expire_parked_runs_returns_only_rows_it_actually_flipped() {
             .status,
         "cancelled"
     );
+}
+
+// ── R-M4: corrupt/unmigratable graph_json rows must not brick a list ────────
+
+#[test]
+fn list_flows_skips_a_corrupt_row_and_reports_the_count() {
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    let good_a = create_flow(&config, "good-a".to_string(), trigger_graph(), false, true).unwrap();
+    let bad = create_flow(&config, "bad".to_string(), trigger_graph(), false, true).unwrap();
+    let good_b = create_flow(&config, "good-b".to_string(), trigger_graph(), false, true).unwrap();
+    force_corrupt_graph_json_for_test(&config, &bad.id, "{ not even valid json").unwrap();
+
+    let (flows, skipped) = list_flows(&config).unwrap();
+    assert_eq!(
+        skipped, 1,
+        "exactly the one corrupt row must be counted as skipped"
+    );
+    let ids: Vec<&str> = flows.iter().map(|f| f.id.as_str()).collect();
+    assert_eq!(
+        flows.len(),
+        2,
+        "the two good rows must still be returned: {ids:?}"
+    );
+    assert!(ids.contains(&good_a.id.as_str()));
+    assert!(ids.contains(&good_b.id.as_str()));
+    assert!(!ids.contains(&bad.id.as_str()));
+}
+
+#[test]
+fn list_flows_skips_a_row_whose_schema_version_is_newer_than_this_build_supports() {
+    // The real-world R-M4 scenario: a user ran a newer build that persisted a
+    // graph at a `schema_version` this build's `tinyflows::migrate::migrate`
+    // cannot step backward from, then downgraded.
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    let good = create_flow(&config, "good".to_string(), trigger_graph(), false, true).unwrap();
+    let too_new =
+        create_flow(&config, "too-new".to_string(), trigger_graph(), false, true).unwrap();
+    let newer_schema_json = serde_json::json!({
+        "schema_version": 999,
+        "name": "from-the-future",
+        "nodes": [],
+        "edges": []
+    })
+    .to_string();
+    force_corrupt_graph_json_for_test(&config, &too_new.id, &newer_schema_json).unwrap();
+
+    let (flows, skipped) = list_flows(&config).unwrap();
+    assert_eq!(skipped, 1);
+    assert_eq!(flows.len(), 1);
+    assert_eq!(flows[0].id, good.id);
+}
+
+#[test]
+fn list_enabled_flows_still_returns_the_good_rows_when_one_is_corrupt() {
+    // This is the blast-radius scenario R-M4 flags for `bus.rs::handle_app_event`:
+    // `list_enabled_flows` backs ALL `app_event` trigger dispatch, so one
+    // corrupt enabled flow must not blackhole matching for every other one.
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    let good = create_flow(&config, "good".to_string(), trigger_graph(), false, true).unwrap();
+    let bad = create_flow(&config, "bad".to_string(), trigger_graph(), false, true).unwrap();
+    force_corrupt_graph_json_for_test(&config, &bad.id, "not json at all").unwrap();
+
+    let (enabled, skipped) = list_enabled_flows(&config).unwrap();
+    assert_eq!(skipped, 1);
+    assert_eq!(enabled.len(), 1);
+    assert_eq!(enabled[0].id, good.id);
+}
+
+#[test]
+fn list_enabled_flows_excludes_a_corrupt_disabled_row_without_counting_it_as_skipped() {
+    // A corrupt row that was never enabled must not even be attempted for
+    // decode by `list_enabled_flows` (the WHERE clause filters it out at the
+    // SQL layer before `map_flow_row` ever runs) — it is neither returned nor
+    // counted as skipped by this particular listing.
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    let good = create_flow(&config, "good".to_string(), trigger_graph(), false, true).unwrap();
+    let disabled_and_corrupt = create_flow(
+        &config,
+        "disabled-bad".to_string(),
+        trigger_graph(),
+        false,
+        true,
+    )
+    .unwrap();
+    set_enabled(&config, &disabled_and_corrupt.id, false).unwrap();
+    force_corrupt_graph_json_for_test(&config, &disabled_and_corrupt.id, "{{{").unwrap();
+
+    let (enabled, skipped) = list_enabled_flows(&config).unwrap();
+    assert_eq!(skipped, 0);
+    assert_eq!(enabled.len(), 1);
+    assert_eq!(enabled[0].id, good.id);
+}
+
+// ── R-m1: concurrent step upserts must not lose a step ──────────────────────
+
+#[test]
+fn concurrent_step_upserts_do_not_lose_a_step() {
+    // Two observer callbacks for parallel branch nodes of the same run,
+    // racing to persist their step. Before the `BEGIN IMMEDIATE` fix this was
+    // a classic untransacted read-modify-write: both threads could read the
+    // same pre-write `steps_json`, and whichever `UPDATE` landed last would
+    // silently discard the other thread's step — permanently, since the
+    // post-hoc `settle_steps` reconstruction only refills a missing node with
+    // `status: None`, not its real outcome.
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+    let flow = create_flow(&config, "demo".to_string(), trigger_graph(), false, true).unwrap();
+    let run_id = "run-concurrent";
+    insert_flow_run(&config, run_id, &flow.id, run_id, "2026-01-01T00:00:00Z").unwrap();
+
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+
+    let config_a = config.clone();
+    let barrier_a = barrier.clone();
+    let handle_a = std::thread::spawn(move || {
+        barrier_a.wait();
+        upsert_flow_run_step(
+            &config_a,
+            run_id,
+            &FlowRunStep {
+                node_id: "branch-a".to_string(),
+                output: serde_json::json!([{"json": {"a": 1}}]),
+                status: Some("success".to_string()),
+                ..Default::default()
+            },
+        )
+    });
+
+    let config_b = config.clone();
+    let barrier_b = barrier.clone();
+    let handle_b = std::thread::spawn(move || {
+        barrier_b.wait();
+        upsert_flow_run_step(
+            &config_b,
+            run_id,
+            &FlowRunStep {
+                node_id: "branch-b".to_string(),
+                output: serde_json::json!([{"json": {"b": 1}}]),
+                status: Some("success".to_string()),
+                ..Default::default()
+            },
+        )
+    });
+
+    handle_a.join().unwrap().unwrap();
+    handle_b.join().unwrap().unwrap();
+
+    let row = get_flow_run(&config, run_id).unwrap().unwrap();
+    let node_ids: std::collections::HashSet<&str> =
+        row.steps.iter().map(|s| s.node_id.as_str()).collect();
+    assert_eq!(
+        row.steps.len(),
+        2,
+        "both concurrent steps must survive, none silently dropped: {:?}",
+        row.steps
+    );
+    assert!(node_ids.contains("branch-a"));
+    assert!(node_ids.contains("branch-b"));
+}
+
+#[test]
+fn concurrent_upserts_to_the_same_node_id_do_not_corrupt_the_step_list() {
+    // Same run, same node_id, racing "replace" writes — the transaction must
+    // still leave exactly one entry for that node (whichever write wins the
+    // serialization order), never a torn/duplicated list.
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+    let flow = create_flow(&config, "demo".to_string(), trigger_graph(), false, true).unwrap();
+    let run_id = "run-same-node";
+    insert_flow_run(&config, run_id, &flow.id, run_id, "2026-01-01T00:00:00Z").unwrap();
+
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let mut handles = Vec::new();
+    for i in 0..2 {
+        let config = config.clone();
+        let barrier = barrier.clone();
+        handles.push(std::thread::spawn(move || {
+            barrier.wait();
+            upsert_flow_run_step(
+                &config,
+                run_id,
+                &FlowRunStep {
+                    node_id: "same-node".to_string(),
+                    output: serde_json::json!([{"json": {"attempt": i}}]),
+                    status: Some("success".to_string()),
+                    ..Default::default()
+                },
+            )
+        }));
+    }
+    for h in handles {
+        h.join().unwrap().unwrap();
+    }
+
+    let row = get_flow_run(&config, run_id).unwrap().unwrap();
+    assert_eq!(
+        row.steps.len(),
+        1,
+        "a re-upsert of the same node_id must replace, not duplicate: {:?}",
+        row.steps
+    );
+    assert_eq!(row.steps[0].node_id, "same-node");
+}
+
+// ── R-m8: schema init is gated to once per process per database path ───────
+
+#[test]
+fn schema_initializes_correctly_on_a_fresh_database_and_is_idempotent_across_calls() {
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    // First-ever call against this database file in the process: exercises
+    // the full schema DDL (CREATE TABLE batch + indexes) plus the
+    // `require_approval` `add_column_if_missing` migration on a database that
+    // has never been opened before.
+    let flow = create_flow(
+        &config,
+        "fresh-db".to_string(),
+        trigger_graph(),
+        true, // require_approval
+        true,
+    )
+    .unwrap();
+    assert!(
+        flow.require_approval,
+        "the post-hoc require_approval column must exist and be writable on a brand-new db"
+    );
+
+    // Repeat calls against the SAME path must not need (or re-run) DDL —
+    // proves the cached "already initialized" state doesn't break ordinary
+    // reads/writes on reuse.
+    let (listed, skipped) = list_flows(&config).unwrap();
+    assert_eq!(skipped, 0);
+    assert_eq!(listed.len(), 1);
+    assert!(listed[0].require_approval);
+
+    let reloaded = get_flow(&config, &flow.id).unwrap().unwrap();
+    assert!(reloaded.require_approval);
+
+    let run_id = "run-schema-check";
+    insert_flow_run(&config, run_id, &flow.id, run_id, "2026-01-01T00:00:00Z").unwrap();
+    assert!(get_flow_run(&config, run_id).unwrap().is_some());
+}
+
+#[test]
+fn schema_initializes_independently_for_each_distinct_database_path() {
+    // Regression guard for the once-per-process cache: if it were keyed by a
+    // single process-wide flag instead of by database path, opening a SECOND
+    // independent workspace after the first would silently skip schema
+    // creation and every write against it would fail with "no such table".
+    let tmp_a = TempDir::new().unwrap();
+    let config_a = test_config(&tmp_a);
+    let flow_a = create_flow(&config_a, "a".to_string(), trigger_graph(), false, true).unwrap();
+
+    let tmp_b = TempDir::new().unwrap();
+    let config_b = test_config(&tmp_b);
+    let flow_b = create_flow(&config_b, "b".to_string(), trigger_graph(), false, true).unwrap();
+
+    assert_eq!(list_flows(&config_a).unwrap().0.len(), 1);
+    assert_eq!(list_flows(&config_b).unwrap().0.len(), 1);
+    assert_eq!(
+        get_flow(&config_a, &flow_a.id).unwrap().unwrap().id,
+        flow_a.id
+    );
+    assert_eq!(
+        get_flow(&config_b, &flow_b.id).unwrap().unwrap().id,
+        flow_b.id
+    );
+}
+
+/// R-m8 regression: gating the DDL behind a per-path "already initialized" set
+/// must not cost the store its self-healing.
+///
+/// Before the gate existed, the DDL ran on every `with_connection` call, so a
+/// database deleted or replaced at runtime (workspace reset, manual deletion,
+/// a restore) recovered on the very next call — `Connection::open` creates a
+/// fresh empty file and `CREATE TABLE IF NOT EXISTS` repopulates it. With a
+/// naive cache the set still reports "initialized" while the file behind it is
+/// empty, and every query afterwards fails `no such table: flow_definitions`
+/// until the process restarts. This pins the verify-on-hit that restores it.
+#[test]
+fn schema_reinitializes_when_the_database_file_is_deleted_at_runtime() {
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    // First use populates the per-path cache and creates the schema.
+    let flow = create_flow(
+        &config,
+        "before-deletion".to_string(),
+        trigger_graph(),
+        false,
+        true,
+    )
+    .unwrap();
+    let (flows, _skipped) = list_flows(&config).unwrap();
+    assert_eq!(flows.len(), 1, "sanity: the flow was persisted");
+
+    // Simulate a workspace reset / manual deletion while the process lives on.
+    let db_path = config.workspace_dir.join("flows").join("flows.db");
+    assert!(
+        db_path.exists(),
+        "sanity: the flows db exists before deletion"
+    );
+    std::fs::remove_file(&db_path).unwrap();
+    // WAL sidecars must go too, or SQLite can resurrect pages from them.
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+
+    // The cache still says this path is initialized. Without the verify-on-hit
+    // this errors with `no such table: flow_definitions`.
+    let (flows_after, skipped_after) = list_flows(&config)
+        .expect("a deleted database must be re-initialized, not left wedged at 'no such table'");
+    assert!(
+        flows_after.is_empty(),
+        "the recreated database starts empty — the prior flow is genuinely gone"
+    );
+    assert_eq!(skipped_after, 0, "an empty database skips nothing");
+
+    // And the store is fully usable again, not merely readable.
+    let recreated = create_flow(
+        &config,
+        "after-deletion".to_string(),
+        trigger_graph(),
+        false,
+        true,
+    )
+    .expect("writes must work against the re-initialized schema");
+    assert_ne!(recreated.id, flow.id);
+    let (flows_final, _) = list_flows(&config).unwrap();
+    assert_eq!(flows_final.len(), 1);
 }


### PR DESCRIPTION
> **Stacked on #5286** (`fix/flows-resume-run-lifecycle`). This branch contains that PR's commit as its base. **Review only the second commit**, and merge after #5286.

## Summary

- **One corrupt or newer-schema row could brick the entire flows surface.** `list_flows`, all `app_event` trigger dispatch, and the boot schedule reconcile each hard-failed on the first bad row.
- Corrupt rows are now skipped and **loudly counted**, not silently omitted.
- Makes the per-node step upsert transactional, so parallel branches can no longer lose a step.
- Stops re-running the full DDL batch on every single store call.

## Problem

**R-M4 (major).** `map_flow_row` propagates migrate/deserialize errors as row errors, and `list_flows` / `list_enabled_flows` did `flows.push(row?)` — so the **first** bad row failed the whole query.

The realistic trigger is a downgrade: a user runs a newer build that persists a graph at a newer `schema_version`, then goes back. `tinyflows::migrate::migrate` cannot downgrade, so that single row breaks:
- every `flows_list` (the Workflows page),
- every `list_enabled_flows` — which drives **all** `app_event` trigger dispatch in `bus.rs`,
- and `reconcile_schedule_triggers_on_boot`.

The whole flows surface goes down because of one row. The sibling `draft_store::list_drafts` already skips-and-logs corrupt entries; the SQLite store had no such tolerance.

**R-m1.** `upsert_flow_run_step` was an untransacted read-modify-write (SELECT `steps_json` → mutate in memory → UPDATE) on a fresh connection. Two observer callbacks for parallel branch nodes could interleave — both read `[A]`, one writes `[A,B]`, the other `[A,C]` — and B vanished from the live view. Its `status`/`duration_ms` were lost permanently, since the post-hoc `settle_steps` reconstruction refills a node only with `status: None`.

**R-m8.** `with_connection` opened a new connection and re-ran the **full** DDL batch (5 `CREATE TABLE` + 6 `CREATE INDEX` + `PRAGMA journal_mode=WAL` + a `PRAGMA table_info` migration probe) on **every** call — including the per-step upsert fired for every node of every live run. Idempotent, but real churn on hot runs.

## Solution

- **Skip, but loudly.** A new `list_flow_rows` helper decodes rows one at a time and skips/logs any that fail to parse or migrate (logging the id and error, **never** `graph_json`). `list_flows`/`list_enabled_flows` return `(Vec<Flow>, usize)`, and the skip count is surfaced rather than swallowed: `flows_list` puts an "N workflows could not be loaded" line in `RpcOutcome.logs`, and the boot reconcile + `bus.rs` app-event path each `warn!`. A silently short flow list would be a worse failure mode than a hard error, so the count is the point.
- **Transactional upsert** via a new `with_immediate_transaction` helper (`BEGIN IMMEDIATE` / `COMMIT` / `ROLLBACK` through `execute_batch`, since `Connection::transaction()` needs `&mut Connection` and does not fit `with_connection`'s `&Connection` closure). The existing `busy_timeout = 5000` pragma covers the lock wait.
- **Schema init once per process, per database path**, gated by `OnceLock<Mutex<HashSet<PathBuf>>>`. Keyed by path rather than a single global flag, so each test's distinct `TempDir` workspace still initializes correctly. Per-connection pragmas (`busy_timeout`, `foreign_keys`) still reapply on every open, since those are not persisted in the db file.

A `#[cfg(test)] force_corrupt_graph_json_for_test` fixture door (mirroring the existing `force_run_status_for_test`) stages corrupt/newer-schema rows for the tests.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — 9 new tests: corrupt-row skip + count on both list functions, corrupt-disabled-row not counted, two concurrent-upsert races (different and identical node ids), fresh-db schema init, independent init across two db paths, and boot reconcile surviving a corrupt row. `cargo test --lib openhuman::flows` = 563 passed, 0 failed
- [x] Coverage matrix updated — `N/A: resilience fix to existing paths, no feature rows added/removed/renamed`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature rows affected`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface behaviour change on the healthy path`
- [x] Linked issue closed via `Closes #NNN` — `N/A: found by code review, no tracking issue filed yet`

## Impact

- **Runtime/platform:** Rust core only.
- **Behaviour:** a corrupt/newer-schema row no longer takes down listing, trigger dispatch, or boot reconcile. It is skipped, and the count is reported so the UI can say "N workflows could not be loaded" rather than quietly showing a short list.
- **API shape:** `list_flows` / `list_enabled_flows` now return `(Vec<Flow>, usize)`. All in-repo callers are updated.
- **Performance:** removes a full DDL batch + migration probe from every store call, including the per-node step write on every live run.
- **Concurrency:** `BEGIN IMMEDIATE` introduces a short write lock on step upserts; the transaction body is kept minimal and the existing busy timeout covers it.

## Related

- Closes: `N/A`
- Follow-up PR(s)/TODOs: surface the skipped-row count in the Workflows UI (the backend now provides it); consider an explicit "this workflow was saved by a newer version" state rather than a generic skip.
- **Merge order:** stacked on #5286 — merge that first. Also touches `store.rs`, which #5290 edits; rebase if that lands first.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/flows-store-resilience`
- Commit SHA: `4618fdf96` (plus #5286's `0b7105fa7` as its base)

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A, no frontend files changed
- [x] `pnpm typecheck` — N/A, no TypeScript changed
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --lib openhuman::flows` → **563 passed, 0 failed**
- [x] Rust fmt/check (if changed): `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml` clean
- [x] Tauri fmt/check (if changed): N/A, `app/src-tauri` untouched

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: an undecodable flow row is skipped and counted instead of failing the whole query; step persistence is atomic; schema DDL runs once per process per database.
- User-visible effect: the Workflows page, app-event triggers, and boot reconcile keep working when one row cannot be decoded, and the user is told how many were skipped.

### Parity Contract

- Legacy behavior preserved: on a healthy database every list returns exactly the same flows in the same order, with a skip count of 0; the retention prune, WAL/busy-timeout pragmas, and `add_column_if_missing` migrations are unchanged.
- Guard/fallback/dispatch parity checks: `list_enabled_flows` still gates app-event dispatch identically for decodable rows; only the undecodable-row path differs.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A

