### PR TITLE
feat(tinyplace): resolve feed post media as web-only (#4924)

### DIFF
--- a/app/src/agentworld/pages/FeedSection.test.tsx
+++ b/app/src/agentworld/pages/FeedSection.test.tsx
@@ -16,6 +16,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { PaymentRequiredError } from '../../lib/agentworld/invokeApiClient';
 import { fetchWalletStatus } from '../../services/walletApi';
+import { openUrl } from '../../utils/openUrl';
 import { apiClient } from '../AgentWorldShell';
 import FeedSection, { FEED_PAGE_SIZE } from './FeedSection';
 
@@ -62,6 +63,10 @@ vi.mock('../hooks/useTinyplaceStream', () => ({
 }));
 
 vi.mock('../../services/walletApi', () => ({ fetchWalletStatus: vi.fn() }));
+
+// External-link opener — assert the composer's media CTA hands off to the OS
+// browser without actually invoking Tauri. Returns a Promise (the CTA voids it).
+vi.mock('../../utils/openUrl', () => ({ openUrl: vi.fn(() => Promise.resolve()) }));
 
 // ── Sample data (generic placeholders) ───────────────────────────────────────
 
@@ -664,6 +669,29 @@ describe('post composer', () => {
       expect(screen.getByText('Hello from the network')).toBeInTheDocument();
     });
     expect(screen.queryByPlaceholderText(/what's on your mind/i)).not.toBeInTheDocument();
+  });
+
+  // Post media is web-only (#4924): the tiny.place backend serves no post-media
+  // field, so instead of an in-app upload the composer points users to the web
+  // app. Unit coverage only by design — the one real cross-process effect (the OS
+  // browser opening) rides on the mocked `openUrl` and isn't worth a WDIO E2E.
+  test('renders the web-only "add media" note in the composer', async () => {
+    vi.mocked(apiClient.graphql.homeFeed).mockResolvedValue({ items: [sampleFeedItem], count: 1 });
+    render(<FeedSection />);
+    const note = await screen.findByTestId('add-media-on-web');
+    expect(note).toHaveTextContent(/add photos or gifs on tiny\.place/i);
+    expect(screen.getByTestId('add-media-on-web-cta')).toHaveAttribute(
+      'data-analytics-id',
+      'feed.addMediaOnWeb'
+    );
+  });
+
+  test('media CTA opens the tiny.place feed via openUrl', async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiClient.graphql.homeFeed).mockResolvedValue({ items: [sampleFeedItem], count: 1 });
+    render(<FeedSection />);
+    await user.click(await screen.findByTestId('add-media-on-web-cta'));
+    expect(vi.mocked(openUrl)).toHaveBeenCalledWith('https://tiny.place');
   });
 });
 

--- a/app/src/agentworld/pages/FeedSection.tsx
+++ b/app/src/agentworld/pages/FeedSection.tsx
@@ -49,10 +49,15 @@ import { relativeTime } from './relativeTime';
 const log = debug('agentworld:feed');
 
 // Attaching images / GIFs to a post is web-only — the tiny.place backend serves
-// no post-media field, so we point users at the web app for it (#4924). Hardcoded
-// prod URL, matching the `SELL_ON_WEB_URL` precedent in IdentitiesSection.tsx and
-// `FUND_PAGE_URL` in X402ConfirmDialog.tsx (the tiny.place web app has no per-env
-// base). tiny.place's home page is the feed, where the media composer lives.
+// no post-media field, so we point users at the web app for it (#4924). tiny.place's
+// home page is the feed, where the media composer lives.
+//
+// Single hardcoded origin by design: the *API* host varies by env (api.tiny.place
+// vs staging-api.tiny.place), but there is exactly one human-facing website —
+// `tiny.place` — used unconditionally across the codebase for the same reason
+// (post permalinks: `TINYPLACE_WEB_ORIGIN` in tinyplace/agent_tools/flows_write.rs;
+// `FUND_PAGE_URL` in X402ConfirmDialog.tsx; `SELL_ON_WEB_URL` in IdentitiesSection.tsx).
+// There is no per-network web frontend to derive this from.
 const ADD_MEDIA_ON_WEB_URL = 'https://tiny.place';
 
 /**

--- a/app/src/agentworld/pages/FeedSection.tsx
+++ b/app/src/agentworld/pages/FeedSection.tsx
@@ -14,6 +14,13 @@
  * - Inline post composer at the top of the feed (refetches feed on success)
  * - Delete post / delete comment (own content only, via an in-app ConfirmDialog)
  *
+ * Post *media* (images / GIFs) is intentionally NOT composable in-app: the
+ * tiny.place backend serves no media field on posts (neither `PostCreate` nor
+ * the read-side `Post` / `GqlPost` in the vendored SDK carry one), so an
+ * in-app upload would round-trip to nothing and render nowhere. Attaching media
+ * is therefore web-only on tiny.place; the composer links users there for it.
+ * See #4924 (and the same web-only resolution as marketplace selling, #4920).
+ *
  * Pattern mirrors ExploreSection / MarketplaceSection: useState + useEffect
  * fetch, PanelScaffold wrapper, StatusBlock for loading/error/empty states.
  */
@@ -32,6 +39,7 @@ import {
 } from '../../lib/agentworld/invokeApiClient';
 import { useT } from '../../lib/i18n/I18nContext';
 import { fetchWalletStatus } from '../../services/walletApi';
+import { openUrl } from '../../utils/openUrl';
 import { apiClient } from '../AgentWorldShell';
 import ConfirmDialog from '../components/ConfirmDialog';
 import StatusBlock from '../components/StatusBlock';
@@ -39,6 +47,13 @@ import { useTinyplaceStream } from '../hooks/useTinyplaceStream';
 import { relativeTime } from './relativeTime';
 
 const log = debug('agentworld:feed');
+
+// Attaching images / GIFs to a post is web-only — the tiny.place backend serves
+// no post-media field, so we point users at the web app for it (#4924). Hardcoded
+// prod URL, matching the `SELL_ON_WEB_URL` precedent in IdentitiesSection.tsx and
+// `FUND_PAGE_URL` in X402ConfirmDialog.tsx (the tiny.place web app has no per-env
+// base). tiny.place's home page is the feed, where the media composer lives.
+const ADD_MEDIA_ON_WEB_URL = 'https://tiny.place';
 
 /**
  * Home-feed items fetched per page (also the initial page size). The
@@ -353,6 +368,28 @@ function FeedComposer({ myAgentId, onPostCreated }: FeedComposerProps) {
             {submitting ? 'Posting…' : 'Post'}
           </Button>
         </div>
+      </div>
+      {/* Adding images / GIFs to a post is web-only (#4924): the tiny.place
+          backend serves no post-media field, so an in-app upload would render
+          nowhere. Point users at the web app instead of dead-ending. */}
+      <div
+        className="mt-2 flex items-center gap-1.5 pl-[2.625rem] text-[11px] text-content-faint"
+        data-testid="add-media-on-web">
+        <span>Add photos or GIFs on tiny.place.</span>
+        <button
+          type="button"
+          data-testid="add-media-on-web-cta"
+          data-analytics-id="feed.addMediaOnWeb"
+          className="font-medium text-primary-400 underline-offset-2 hover:underline focus:underline focus:outline-none"
+          onClick={() => {
+            // Static destination URL only — no post body / PII. openUrl owns the
+            // outcome diagnostics (low-PII breadcrumb + https fallback), so we
+            // don't re-observe success/error here.
+            log('[tinyplace][ui] add-media-on-web: opening %s', ADD_MEDIA_ON_WEB_URL);
+            void openUrl(ADD_MEDIA_ON_WEB_URL);
+          }}>
+          Open tiny.place →
+        </button>
       </div>
     </div>
   );

--- a/docs/superpowers/plans/2026-07-30-tinyplace-feed-post-media-web-only.md
+++ b/docs/superpowers/plans/2026-07-30-tinyplace-feed-post-media-web-only.md
@@ -1,0 +1,46 @@
+# Feed Post Media Web-Only Implementation Plan (#4924)
+
+**Goal:** Replace the text-only feed composer's missing-media gap with a note
+pointing users to tiny.place, and record that post media is web-only by design.
+Mirrors the identity-marketplace seller-web-only resolution (#4920 / PR #5193).
+
+**Architecture:** Additive UI only. A persistent note at the bottom of
+`FeedComposer` opens `https://tiny.place` via the existing `openUrl()` helper. No
+SDK, core, `manifest.rs`, or submodule changes — the tiny.place backend serves no
+post-media field. Scope recorded in two doc comments.
+
+**Tech stack:** React 19 + TypeScript, Vitest + Testing Library,
+`app/src/utils/openUrl.ts`, Rust module doc comment.
+
+## Global constraints
+
+- **No i18n:** `FeedComposer` is hardcoded English (`"What's on your mind?"`,
+  `"Post"`, `"Posting…"`). New strings match — no `useT()`, no locale-file edits.
+- **Web URL is a hardcoded prod constant:** `https://tiny.place` (home = feed).
+  Mirrors `SELL_ON_WEB_URL` / `FUND_PAGE_URL`.
+- **External links go through `openUrl`** — never a raw `window.open`.
+- **Out of scope (do not touch):** `vendor/tinyplace/**` (incl. the submodule
+  pointer), `manifest.rs`, `invokeApiClient.ts`, the compose/like/comment flows.
+
+## Tasks
+
+- [x] **Task 1 — Composer note + CTA.** `FeedSection.tsx`: import `openUrl`; add
+  `ADD_MEDIA_ON_WEB_URL`; render a note (`data-testid="add-media-on-web"`) + text
+  CTA (`data-testid="add-media-on-web-cta"`, `data-analytics-id="feed.addMediaOnWeb"`)
+  at the bottom of `FeedComposer` that `void openUrl(ADD_MEDIA_ON_WEB_URL)`. Header
+  docstring gains a "post media is web-only" note.
+- [x] **Task 2 — Rust scope note.** `src/openhuman/tinyplace/mod.rs`: add a
+  "Feed scope (post media is web-only)" doc-comment section after the marketplace
+  one. Docs-only; `cargo fmt --check` verifies.
+- [x] **Task 3 — Tests.** `FeedSection.test.tsx`: mock `openUrl`; assert the note
+  renders and the CTA calls `openUrl('https://tiny.place')`.
+- [ ] **Task 4 — GitHub bookkeeping (outward-facing).** Comment the web-only
+  resolution on #4924; the #4776 §2 "Images / media in posts" item is N/A
+  (web-only). Done via `gh`, captured in the PR body.
+
+## Verification
+
+- `pnpm --filter openhuman-app test` — FeedSection green (incl. 2 new cases).
+- `tsc --noEmit` clean; `eslint` no new errors; `prettier --check` clean.
+- `cargo fmt --check` clean (doc-comment-only Rust change).
+- `git diff vendor/tinyplace` empty — submodule pointer untouched (mergeable).

--- a/docs/superpowers/plans/2026-07-30-tinyplace-feed-post-media-web-only.md
+++ b/docs/superpowers/plans/2026-07-30-tinyplace-feed-post-media-web-only.md
@@ -34,9 +34,9 @@ post-media field. Scope recorded in two doc comments.
   one. Docs-only; `cargo fmt --check` verifies.
 - [x] **Task 3 — Tests.** `FeedSection.test.tsx`: mock `openUrl`; assert the note
   renders and the CTA calls `openUrl('https://tiny.place')`.
-- [ ] **Task 4 — GitHub bookkeeping (outward-facing).** Comment the web-only
-  resolution on #4924; the #4776 §2 "Images / media in posts" item is N/A
-  (web-only). Done via `gh`, captured in the PR body.
+- [x] **Task 4 — GitHub bookkeeping (outward-facing).** Done: commented the
+  web-only resolution on #4924, and marked the #4776 §2 "Images / media in posts"
+  item N/A (web-only) via an epic status comment (the epic body is owner-gated).
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-07-30-tinyplace-feed-post-media-web-only-design.md
+++ b/docs/superpowers/specs/2026-07-30-tinyplace-feed-post-media-web-only-design.md
@@ -1,0 +1,63 @@
+# Design: Feed post media is web-only (#4924)
+
+Part of #4776 (Tiny Place audit) · §2 Feed · sibling of the #4920 web-only resolution (PR #5193).
+
+## Problem
+
+The audit item "Images / media in posts" fails at the **contract** level, not just
+the UI. Posts are text-only end-to-end:
+
+- The vendored `tinyplace` SDK carries no media field on the **write** side
+  (`PostCreate` = `{ body, content_type, post_id }`) or the **read** side
+  (`Post` / `GqlPost` = `body`, counts, author, timestamps — no media).
+- The tiny.place **backend** serves no post-media field. Verified against
+  tiny.place `main` (`d2545054`, the commit openhuman already pins): the SDK
+  structs there still have no `image` / `media` / `gif` field.
+- The desktop composer sends `{ body }` only (`FeedSection.tsx` →
+  `feeds.createPost` → `manifest.rs` → SDK `feeds::create_post`).
+
+Because `vendor/tinyplace` is a **pinned git submodule** (openhuman can only bump
+the pointer to a commit that exists on the tiny.place remote), the media contract
+cannot be added from this repo. A prior WIP branch pinned the submodule to a
+**local-only** SDK commit to make it build — that is unmergeable (a fresh clone/CI
+cannot fetch the commit) and, being SDK-only, still would not render media because
+the backend serves none.
+
+## Decision
+
+Resolve **web-only**, mirroring the identity-marketplace seller resolution (#4920 /
+PR #5193). Rather than ship an in-app upload against a non-existent contract — which
+would round-trip to nothing and render nowhere — the desktop feed composer shows a
+small note that attaching images/GIFs happens on tiny.place, with a CTA that opens
+the web app via the existing `openUrl()` helper.
+
+## Changes
+
+1. **UI** (`app/src/agentworld/pages/FeedSection.tsx`) — additive only. A subtle
+   note + text CTA at the bottom of `FeedComposer` opens `https://tiny.place` (the
+   home page is the feed) through `openUrl()`. Hardcoded prod URL, matching the
+   `SELL_ON_WEB_URL` (IdentitiesSection) and `FUND_PAGE_URL` (X402ConfirmDialog)
+   precedents. Strings are hardcoded English to match the surrounding
+   `FeedComposer`, which uses no `useT()` (same rationale as #5193).
+
+2. **Scope docstrings** — a "Feed scope (post media is web-only)" note in the
+   `FeedSection.tsx` header and in `src/openhuman/tinyplace/mod.rs`, next to the
+   existing marketplace web-only note.
+
+3. **Test** (`FeedSection.test.tsx`) — two co-located Vitest cases: the note
+   renders in the composer, and the CTA calls `openUrl('https://tiny.place')`
+   (mock `openUrl`). Covers the new diff lines for the ≥80% changed-line gate.
+
+## Out of scope (YAGNI)
+
+- Vendored SDK media fields (`PostCreate.image` / `PostMedia` / `Post.media`).
+- Core `manifest.rs` post-media handling; `invokeApiClient.ts` media params.
+- Any `vendor/tinyplace` submodule pointer bump.
+- Full i18n conversion of the composer (new strings are hardcoded English to match).
+
+## Follow-up to genuinely close in-app (tiny.place-first, not this repo)
+
+1. tiny.place backend: persist + serve a post-media field.
+2. tiny.place SDK: add media to `PostCreate` + read-side `Post` / `GqlPost`; release.
+3. openhuman: bump the submodule pointer, then wire handler + composer upload +
+   renderer. Tracked under the Tiny Place epic (#4190 / #4776).

--- a/src/openhuman/tinyplace/mod.rs
+++ b/src/openhuman/tinyplace/mod.rs
@@ -34,6 +34,15 @@
 //! `marketplace_list_offers` takes a `name` filter for offers targeting a handle
 //! you own. The desktop Trading tab links sellers to the web app for the actions
 //! it cannot perform. See #4920.
+//!
+//! ## Feed scope (post media is web-only)
+//!
+//! Feed posts here are **text-only**. Attaching images / GIFs to a post is
+//! **web-only on tiny.place**: the backend serves no media field — neither the
+//! write-side `PostCreate` nor the read-side `Post` / `GqlPost` in the vendored
+//! SDK carries one — so an in-app upload would round-trip to nothing and render
+//! nowhere. The desktop feed composer links users to the web app to attach
+//! media instead of dead-ending. See #4924.
 
 pub(crate) mod agent;
 mod agent_tools;


### PR DESCRIPTION
## Summary

- Resolve the "images/media in posts" feed gap (#4924) as **web-only by design**, mirroring the identity-marketplace seller resolution (#4920 / PR #5193).
- Add a small note + text CTA at the bottom of the feed composer that opens `https://tiny.place` via `openUrl()` instead of dead-ending, so a user who wants to attach media is pointed to where they can.
- Record the web-only scope in the `FeedSection.tsx` header docstring and `src/openhuman/tinyplace/mod.rs` (next to the existing marketplace web-only note).
- **Additive UI only** — no SDK, core handler, `invokeApiClient`, or `vendor/tinyplace` submodule-pointer change.

## Problem

The audit item "Images / media in posts" (#4776 §2 Feed) fails at the **contract** level, not just the UI:

- The vendored `tinyplace` SDK carries no media field on the **write** side (`PostCreate` = `{ body, content_type, post_id }`) or the **read** side (`Post` / `GqlPost`).
- The tiny.place **backend** serves no post-media field. Verified against tiny.place `main` (`d2545054` — the commit openhuman already pins): the SDK structs there still have no `image` / `media` / `gif` field.
- `vendor/tinyplace` is a **pinned git submodule**; openhuman can only bump the pointer to a commit on the tiny.place remote — it cannot add the contract.

An in-app upload would therefore round-trip to nothing and render nowhere. (A prior WIP branch pinned the submodule to a **local-only** SDK commit to make it build; that is unmergeable and, being SDK-only, still wouldn't render media because the backend serves none.)

## Solution

Follow the #4920 / #5193 pattern: point users to the web app rather than ship UI against a non-existent contract. A persistent note in `FeedComposer` (`data-testid="add-media-on-web"`) with a CTA (`data-testid="add-media-on-web-cta"`, `data-analytics-id="feed.addMediaOnWeb"`) opens `https://tiny.place` (home page = feed) through the existing `openUrl()` helper — mirroring the `SELL_ON_WEB_URL` (IdentitiesSection) and `FUND_PAGE_URL` (X402ConfirmDialog) precedents. New strings are hardcoded English to match `FeedComposer`, which uses no `useT()` (same rationale as #5193). Design spec + plan under `docs/superpowers/`.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — two co-located Vitest cases: the note renders in the composer, and the CTA calls `openUrl('https://tiny.place')` (mocked). The composer's failure/edge cases (locked wallet hides composer, disabled Post button) remain covered by existing tests.
- [x] **Diff coverage ≥ 80%** — the change is a small additive UI block + doc comments; both new lines' branches are exercised by the two new tests. Rust change is a doc comment only (no executable lines).
- [x] N/A: Coverage matrix — behaviour is a web-only pointer note, no new feature row (the Feed row already exists).
- [x] All affected feature IDs listed in `## Related`.
- [x] No new external network dependencies introduced — `openUrl` is the existing OS-browser opener; unit test mocks it.
- [x] N/A: Manual smoke checklist — no release-cut surface touched (additive composer note).
- [x] Linked issue closed via `Closes #4924` in `## Related`.

## Impact

- **Desktop UI only.** Adds a subtle, non-blocking note to the feed composer. No runtime, performance, security, or migration impact. No submodule pointer change (`git diff vendor/tinyplace` is empty) — safe for all clones/CI.

## Related

- Closes: #4924
- Part of: #4776 (Tiny Place audit, §2 Feed) · epic #4190
- Sibling resolution: #4920 / PR #5193 (identity marketplace seller-side web-only)
- Follow-up to genuinely close in-app (tiny.place-first, out of this repo): backend serves post media → SDK adds `PostCreate.image` + read-side `Post`/`GqlPost` media → openhuman bumps the submodule + wires composer upload/renderer.

---

## AI Authored PR Metadata

### Linear Issue

- Key: N/A (GitHub-issue driven)
- URL: N/A

### Commit & Branch

- Branch: `fix/4924-feed-media-web-only`
- Commit SHA: 6b37d31f2

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — clean on changed files (`prettier --check`)
- [x] `pnpm typecheck` — `tsc --noEmit` clean
- [x] Focused tests: `FeedSection.test.tsx` — 56 passed (incl. 2 new); full app suite 520 passed
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean on `tinyplace/mod.rs` (doc-comment-only change)
- [x] N/A: Tauri fmt/check — Tauri shell untouched

### Validation Blocked

- `command:` `pnpm rust:check` (pre-push hook) / full `cargo check` on the core crate
- `error:` fresh worktree has uninitialized git submodules (`vendor/tinyagents`, `app/src-tauri/vendor/tauri-cef`, …); `rust:check` compiles the **Tauri shell** crate, which needs the large CEF submodule not set up here
- `impact:` none for this change — it edits only frontend TS (typecheck passed) and a **core-crate doc comment** (`cargo fmt --check` validated); the Tauri shell and core executable code are untouched. Pushed with `--no-verify` per the repo's "unrelated pre-existing breakage" allowance.

### Behavior Changes

- Intended behavior change: feed composer shows a "add photos or GIFs on tiny.place" note whose CTA opens the tiny.place web app.
- User-visible effect: users looking to attach media are pointed to the web flow instead of finding no media option at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a web-only callout in the inline feed composer for adding photos or GIFs on tiny.place.
  * Added a button that opens tiny.place’s web composer and tracks the action.

* **Documentation**
  * Updated specs to clarify that feed posts are text-only in-app, with media posting supported only on tiny.place.
  * Refined related plan/status documentation for the web-only media implementation.

* **Tests**
  * Extended tests to cover the new media callout content and to verify the external link opens the expected tiny.place URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->