### PR TITLE
fix(flows): expose flows_run_detached over RPC and switch both UI Run controls to it

### DIFF
--- a/app/src/components/flows/canvas/FlowCanvas.tsx
+++ b/app/src/components/flows/canvas/FlowCanvas.tsx
@@ -9,8 +9,17 @@
  *    {@link EditableFlowCanvas}, which lifts nodes/edges into controlled state
  *    and wires drag/connect/add/delete/save on top.
  *
- * The `editable` prop defaults to `false` so every existing read-only consumer
- * (the `/flows/:id` viewer) keeps its exact behavior — only the builder opts in.
+ * The `editable` prop defaults to `false`, but as of the F-m5 audit
+ * (`my_docs/flows_review_2026-07-30.md`) there is exactly one production
+ * consumer — `FlowCanvasPage.tsx` — and it always passes `editable`. The
+ * `/flows/:id` route this doc block used to claim as the read-only viewer's
+ * consumer IS `FlowCanvasPage`, and it is NOT read-only. `ReadonlyFlowCanvas`
+ * below is therefore currently unreachable in the shipped app; it's kept
+ * (rather than deleted) because it's small, self-contained, and covered by
+ * its own smoke tests (`__tests__/FlowCanvas.test.tsx`) — a future
+ * share/embed/public-viewer surface is a plausible reason to want a
+ * non-editable render path again. Delete both it and its tests together if
+ * no such consumer materializes.
  */
 import {
   Background,

--- a/app/src/components/flows/canvas/__tests__/flowCanvasOutlines.test.ts
+++ b/app/src/components/flows/canvas/__tests__/flowCanvasOutlines.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Guard: the flow canvas draws every one of its status rings with `outline`,
+ * so a global `outline` suppression silently kills all of them at once.
+ *
+ * `app/src/index.css` previously carried `outline: none !important` on the bare
+ * universal selector. Its comment says it exists to hide the browser focus
+ * ring — but `!important` on `*` outranks every component rule, so it also
+ * suppressed the live run overlay (`.flow-node-running` / `-success` /
+ * `-failed`), the validation ring (`.flow-node-error`) and the copilot diff
+ * overlay (`.flow-node-added` / `-removed`). All four rendered nothing, in
+ * every build, with no test failing — the classes were applied correctly to the
+ * DOM the whole time, so only a human looking at the canvas could notice.
+ *
+ * jsdom does not implement the cascade well enough to assert the computed
+ * outline, so this asserts the source invariant instead: focus-ring suppression
+ * must be scoped to a focus state, never applied unconditionally to `*`.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// Vitest runs with `app/` as cwd (see test/vitest.config.ts).
+const INDEX_CSS = resolve(process.cwd(), 'src/index.css');
+const CANVAS_CSS = resolve(process.cwd(), 'src/components/flows/canvas/flowCanvasStyles.css');
+
+/** Strips comments so prose mentioning a rule is never mistaken for the rule. */
+function withoutComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+describe('flow canvas status rings', () => {
+  it('are not suppressed by an unconditional universal outline reset', () => {
+    const css = withoutComments(readFileSync(INDEX_CSS, 'utf8'));
+    // Find every `*` block that is NOT tied to a focus state.
+    const universalBlocks = [...css.matchAll(/(^|\})\s*\*\s*\{([^}]*)\}/g)].map(m => m[2]);
+    for (const block of universalBlocks) {
+      expect(
+        /outline\s*:/.test(block),
+        'index.css must not set `outline` on the bare `*` selector — with `!important` it ' +
+          'outranks every flow-node ring rule and silently blanks the canvas overlays. ' +
+          'Scope focus-ring suppression to `*:focus` (and the explicit element list) instead.'
+      ).toBe(false);
+    }
+  });
+
+  it('still declare an outline for each run/validation/diff state', () => {
+    const css = withoutComments(readFileSync(CANVAS_CSS, 'utf8'));
+    for (const cls of [
+      'flow-node-running',
+      'flow-node-success',
+      'flow-node-failed',
+      'flow-node-error',
+      'flow-node-added',
+      'flow-node-removed',
+    ]) {
+      const rule = new RegExp(`\\.${cls}\\s*\\{[^}]*outline\\s*:`);
+      expect(rule.test(css), `${cls} must declare an outline`).toBe(true);
+    }
+  });
+
+  it('keeps the running state animated so an executing node is distinguishable', () => {
+    const css = withoutComments(readFileSync(CANVAS_CSS, 'utf8'));
+    expect(/\.flow-node-running\s*\{[^}]*animation\s*:/.test(css)).toBe(true);
+    expect(css).toContain('@keyframes flow-node-run-pulse');
+  });
+});

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -132,9 +132,18 @@
 
   /* Suppress the default browser focus ring (outline + tap highlight) but
      leave borders and box-shadows alone — components rely on those for
-     selected / focus-visible styling (e.g. the runtime picker cards). */
+     selected / focus-visible styling (e.g. the runtime picker cards).
+     Deliberate outlines are left alone too. This block used to carry
+     `outline: none !important` on the bare `*`, which suppressed EVERY outline
+     in the app, not just the focus ring it was aimed at — `!important` on a
+     universal selector outranks any component rule. That silently killed all
+     four flow-canvas rings, which are drawn with `outline`: the live run
+     overlay (`.flow-node-running` / `-success` / `-failed`), the validation
+     ring (`.flow-node-error`), and the copilot diff overlay
+     (`.flow-node-added` / `-removed`). None of them could ever paint. The
+     focus-ring suppression this comment actually describes is fully covered by
+     the `*:focus` rule below plus the explicit element list after it. */
   * {
-    outline: none !important;
     -webkit-tap-highlight-color: transparent !important;
   }
 

--- a/app/src/lib/flows/graphAdapter.test.ts
+++ b/app/src/lib/flows/graphAdapter.test.ts
@@ -7,6 +7,7 @@ import {
   type FlowEdge,
   type FlowNode,
   isValidFlowConnection,
+  normalizeWorkflowGraphForDirtyCheck,
   workflowGraphToXyflow,
   xyflowToWorkflowGraph,
 } from './graphAdapter';
@@ -258,6 +259,74 @@ describe('graphAdapter', () => {
       const result = xyflowToWorkflowGraph([], [], { schema_version: 1, id: undefined, name: '' });
       expect(result.nodes).toEqual([]);
       expect(result.edges).toEqual([]);
+    });
+  });
+
+  describe('normalizeWorkflowGraphForDirtyCheck (F-m3)', () => {
+    it('backfills auto-layout positions on a graph saved without them', () => {
+      const withoutPositions = graph({
+        nodes: [
+          node({ id: 't', kind: 'trigger', name: 'Trigger' }),
+          node({ id: 'a', name: 'Agent' }),
+        ],
+        edges: [edge({ from_node: 't', to_node: 'a' })],
+      });
+      const meta = { schema_version: 1, id: 'wf_1', name: 'demo' };
+
+      const normalized = normalizeWorkflowGraphForDirtyCheck(withoutPositions, meta);
+
+      // Every node has a concrete position — exactly what the canvas's own
+      // mount-time `onGraphChange` would report back.
+      for (const n of normalized.nodes) {
+        expect(n.position).toBeDefined();
+        expect(typeof n.position?.x).toBe('number');
+        expect(typeof n.position?.y).toBe('number');
+      }
+      // And it's deterministic: normalizing again is a no-op (idempotent),
+      // which is what lets a REMOUNTED canvas's `editorGraph` (already
+      // normalized once) compare equal to `persistedGraphRef.current`
+      // normalized fresh — the two happen at different points in time but
+      // must still match.
+      expect(normalizeWorkflowGraphForDirtyCheck(normalized, meta)).toEqual(normalized);
+    });
+
+    it('is a no-op (beyond re-stamping meta) for a graph that already carries positions', () => {
+      const withPositions = graph({
+        nodes: [
+          node({ id: 't', kind: 'trigger', name: 'Trigger', position: { x: 40, y: 80 } }),
+          node({ id: 'a', name: 'Agent', position: { x: 320, y: 80 } }),
+        ],
+        edges: [edge({ from_node: 't', to_node: 'a' })],
+      });
+      const meta = { schema_version: 1, id: 'wf_1', name: 'demo' };
+
+      const normalized = normalizeWorkflowGraphForDirtyCheck(withPositions, meta);
+
+      expect(normalized.nodes[0].position).toEqual({ x: 40, y: 80 });
+      expect(normalized.nodes[1].position).toEqual({ x: 320, y: 80 });
+    });
+
+    it('lets a position-less graph and its own canvas-reported (positioned) copy compare equal once both are normalized', () => {
+      // This is the exact F-m3 scenario: the server graph has no positions,
+      // but the canvas always reports one back (via `workflowGraphToXyflow` +
+      // `xyflowToWorkflowGraph`) the moment it mounts.
+      const serverGraph = graph({
+        nodes: [
+          node({ id: 't', kind: 'trigger', name: 'Trigger' }),
+          node({ id: 'a', name: 'Agent' }),
+        ],
+        edges: [edge({ from_node: 't', to_node: 'a' })],
+      });
+      const meta = { schema_version: 1, id: 'wf_1', name: 'demo' };
+      const { nodes, edges } = workflowGraphToXyflow(serverGraph);
+      const canvasReported = xyflowToWorkflowGraph(nodes, edges, meta);
+
+      expect(JSON.stringify(normalizeWorkflowGraphForDirtyCheck(serverGraph, meta))).toBe(
+        JSON.stringify(normalizeWorkflowGraphForDirtyCheck(canvasReported, meta))
+      );
+      // Without normalizing the server side, they would NOT compare equal —
+      // pinning that this test is actually exercising the fix, not a tautology.
+      expect(JSON.stringify(serverGraph)).not.toBe(JSON.stringify(canvasReported));
     });
   });
 

--- a/app/src/lib/flows/graphAdapter.ts
+++ b/app/src/lib/flows/graphAdapter.ts
@@ -326,6 +326,30 @@ export function xyflowToWorkflowGraph(
 }
 
 /**
+ * Round-trips `graph` through {@link workflowGraphToXyflow} /
+ * {@link xyflowToWorkflowGraph} — the exact conversion the editable canvas
+ * itself performs on mount — so a caller comparing `graph` against a LATER
+ * canvas serialization (to decide "is this dirty?") compares like with like.
+ *
+ * F-m3 fix: a graph saved without per-node `position` (e.g. authored by the
+ * agent, which never sets one) gets concrete auto-layout coordinates baked in
+ * the moment the canvas mounts it (`workflowGraphToXyflow`'s `autoLayout`
+ * fallback) — `EditableFlowCanvas`'s mount-time `onGraphChange` reports that
+ * position-filled graph immediately. A dirty check that diffs the canvas's
+ * report against the RAW, positionless server graph reads that fill-in as an
+ * edit and shows "Unsaved" with zero real changes. Normalizing the baseline
+ * through this same round-trip before comparing eliminates that false
+ * positive, since both sides then agree on where every node landed.
+ */
+export function normalizeWorkflowGraphForDirtyCheck(
+  graph: WorkflowGraph,
+  meta: WorkflowGraphMeta
+): WorkflowGraph {
+  const { nodes, edges } = workflowGraphToXyflow(graph);
+  return xyflowToWorkflowGraph(nodes, edges, meta);
+}
+
+/**
  * Assigns a `{x, y}` position to every node in `nodes`, via a simple BFS
  * layering over `edges`: `y = depth * 160`, `x = column * 280` where
  * `column` is the node's index within its depth layer (assigned in

--- a/app/src/pages/FlowCanvasPage.tsx
+++ b/app/src/pages/FlowCanvasPage.tsx
@@ -42,11 +42,20 @@ import Button from '../components/ui/Button';
 import { CenteredLoadingState, ErrorBanner } from '../components/ui/LoadingState';
 import { useFlowPreauthorization } from '../hooks/useFlowPreauthorization';
 import { asFlowCanvasDraftState } from '../lib/flows/canvasDraft';
-import { workflowGraphToXyflow } from '../lib/flows/graphAdapter';
+import {
+  normalizeWorkflowGraphForDirtyCheck,
+  workflowGraphToXyflow,
+} from '../lib/flows/graphAdapter';
 import { buildPreviewGraph, diffGraphs } from '../lib/flows/graphDiff';
 import type { WorkflowGraph } from '../lib/flows/types';
 import { useT } from '../lib/i18n/I18nContext';
-import { createFlow, type Flow, getFlow, runFlow, updateFlow } from '../services/api/flowsApi';
+import {
+  createFlow,
+  type Flow,
+  getFlow,
+  runFlowDetached,
+  updateFlow,
+} from '../services/api/flowsApi';
 import type { WorkflowProposal } from '../store/chatRuntimeSlice';
 import type { ToastNotification } from '../types/intelligence';
 
@@ -443,7 +452,19 @@ function FlowEditor({
   // nodes — "graph appears later". `graphRevealed` latches true the first time
   // a proposal preview arrives or the draft gains a node beyond the lone
   // trigger, and never flips back (so rejecting a proposal can't re-hide it).
-  const chatFirst = initialBuildSeed?.chatFirst === true;
+  //
+  // F-m2 fix: `chatFirst` itself must ALSO latch at mount, not re-derive from
+  // the live `initialBuildSeed` prop every render. `onBuildSeedConsumed`
+  // (`clearBuildSeed` in the parent) strips `copilotBuild` from
+  // `location.state` once the copilot has dispatched the seeded build turn —
+  // deliberately, so a later remount doesn't re-fire it. But if that turn's
+  // FIRST reply was a clarifying question (no proposal yet, so `graphRevealed`
+  // is still false), re-deriving `chatFirst` from the now-cleared prop flipped
+  // it to `false` mid-conversation, which un-hid the blank trigger-only canvas
+  // while the user was still answering the agent's question. Reading
+  // `initialBuildSeed` only inside a `useState` initializer freezes the value
+  // as of first mount, immune to the prop later going away.
+  const [chatFirst] = useState(() => initialBuildSeed?.chatFirst === true);
   const [graphRevealed, setGraphRevealed] = useState(!chatFirst);
   if (!graphRevealed && (preview !== null || draftGraph.nodes.length > 1)) {
     setGraphRevealed(true);
@@ -895,11 +916,26 @@ function FlowEditor({
   // `name` without yet persisting it (`persistedNameRef` only advances on a
   // real Save/rename) — a name-only proposal (same graph, new name) must
   // still enable Save, or the adopted title can never be persisted.
+  //
+  // F-m3 fix: normalize BOTH sides through the same `workflowGraphToXyflow` /
+  // `xyflowToWorkflowGraph` round-trip the canvas itself performs (see
+  // `normalizeWorkflowGraphForDirtyCheck`'s doc comment) before comparing,
+  // rather than diffing `editorGraph` against the raw, possibly
+  // position-less `persistedGraphRef.current` directly. A graph saved
+  // without per-node `position` (e.g. agent-authored) otherwise reads as
+  // dirty the instant a REMOUNTED canvas instance (e.g. after a copilot
+  // Reject) reports its now-positioned `editorGraph` back — even with zero
+  // real edits — because `persistedGraphRef.current` was never updated to
+  // match. Normalizing here (rather than pre-normalizing the ref at seed
+  // time) keeps this correct on the very FIRST mount too, where `editorGraph`
+  // is still raw and `persistedGraphRef.current` must compare equal to it
+  // before any canvas effect has run.
   const initialDirty = useMemo(
     () =>
-      JSON.stringify(editorGraph) !== JSON.stringify(persistedGraphRef.current) ||
+      JSON.stringify(normalizeWorkflowGraphForDirtyCheck(editorGraph, meta)) !==
+        JSON.stringify(normalizeWorkflowGraphForDirtyCheck(persistedGraphRef.current, meta)) ||
       name !== persistedNameRef.current,
-    [editorGraph, name]
+    [editorGraph, name, meta]
   );
 
   // Repair seed for the copilot: bind the run context to the CURRENT draft.
@@ -930,19 +966,28 @@ function FlowEditor({
     return () => window.removeEventListener('beforeunload', handler);
   }, [dirty]);
 
-  // Run the *persisted* flow and hand its thread_id to the canvas so it can
+  // Run the *persisted* flow and hand its run id to the canvas so it can
   // overlay live per-node status (Phase 3e). Runs the saved version — not the
   // (possibly dirty) draft — matching the "Save is explicit, running is live"
   // model. The durable run row + poller remain the source of truth.
+  //
+  // F-M1 fix: uses `runFlowDetached` (`openhuman.flows_run_detached`), which
+  // registers the run and returns its id immediately, INSTEAD of the old
+  // `runFlow` (`openhuman.flows_run`), which blocked until the run reached a
+  // terminal status — by the time that resolved, every `flow:run_progress`
+  // event for the run had already fired and been dropped, because
+  // `useFlowRunProgress` only subscribes once `activeRunId` is set (see its
+  // doc comment). `setActiveRunId` below now runs BEFORE the engine has
+  // executed a single node, so the subscription is live for the whole run.
   const handleRun = useCallback(async () => {
     if (flowId === null) return; // drafts aren't runnable until saved
     setRunning(true);
     setRunError(null);
     try {
-      log('run: starting flow id=%s', flowId);
-      const result = await runFlow(flowId);
-      log('run: started flow id=%s thread_id=%s', flowId, result.thread_id);
-      setActiveRunId(result.thread_id);
+      log('run: starting (detached) flow id=%s', flowId);
+      const result = await runFlowDetached(flowId);
+      log('run: started (detached) flow id=%s run_id=%s', flowId, result.run_id);
+      setActiveRunId(result.run_id);
     } catch (err) {
       const message = errorMessage(err);
       log('run: failed id=%s err=%o', flowId, err);

--- a/app/src/pages/FlowsPage.test.tsx
+++ b/app/src/pages/FlowsPage.test.tsx
@@ -1,15 +1,18 @@
 /**
  * FlowsPage (issue B5a / B5a.1 / B5b.1) — the Workflows list page. Asserts
  * the loading/empty/error/list states, that toggling a flow calls
- * `setFlowEnabled` and refreshes the row, that Run fires `runFlow`, shows a
- * "Workflow started" toast, and refetches the list, that "View runs" opens
- * `FlowRunsDrawer` for the clicked flow, that clicking a flow's name
- * navigates to its read-only Workflow Canvas (`/flows/:id`, issue B5b.1),
- * and that "New workflow" (header + empty state) opens the Phase 4a chooser
- * (start from scratch / template / describe), with the empty state also
- * surfacing the Phase 4c template gallery inline.
+ * `setFlowEnabled` and refreshes the row, that Run fires `runFlowDetached`
+ * (F-M1/F-M2 — the non-blocking `flows_run_detached` RPC, not the old
+ * blocking `flows_run`), shows a "Workflow started" toast immediately, that
+ * a run in flight on one row does NOT disable any other row's actions
+ * (F-M2's core regression), that "View runs" opens `FlowRunsDrawer` for the
+ * clicked flow, that clicking a flow's name navigates to its read-only
+ * Workflow Canvas (`/flows/:id`, issue B5b.1), and that "New workflow"
+ * (header + empty state) opens the Phase 4a chooser (start from scratch /
+ * template / describe), with the empty state also surfacing the Phase 4c
+ * template gallery inline.
  */
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { FLOW_TEMPLATES } from '../lib/flows/templates';
@@ -19,7 +22,7 @@ import FlowsPage from './FlowsPage';
 
 const listFlows = vi.hoisted(() => vi.fn());
 const setFlowEnabled = vi.hoisted(() => vi.fn());
-const runFlow = vi.hoisted(() => vi.fn());
+const runFlowDetached = vi.hoisted(() => vi.fn());
 const listFlowRuns = vi.hoisted(() => vi.fn());
 const createFlow = vi.hoisted(() => vi.fn());
 const importFlow = vi.hoisted(() => vi.fn());
@@ -33,7 +36,7 @@ const markSuggestionBuilt = vi.hoisted(() => vi.fn());
 vi.mock('../services/api/flowsApi', () => ({
   listFlows,
   setFlowEnabled,
-  runFlow,
+  runFlowDetached,
   listFlowRuns,
   createFlow,
   importFlow,
@@ -137,23 +140,26 @@ describe('FlowsPage', () => {
     );
   });
 
-  it('runs a flow, shows a "Workflow started" toast, and refetches the list', async () => {
+  it('runs a flow via the non-blocking flows_run_detached RPC and shows a "Workflow started" toast', async () => {
     listFlows.mockResolvedValue([makeFlow()]);
-    runFlow.mockResolvedValue({ output: null, pending_approvals: [], thread_id: 't1' });
+    runFlowDetached.mockResolvedValue({
+      run_id: 'flow:flow-1:t1',
+      flow_id: 'flow-1',
+      status: 'running',
+      detached: true,
+    });
     renderWithProviders(<FlowsPage />, { initialEntries: ['/?view=main'] });
 
     await waitFor(() => expect(screen.getByTestId('flow-run-flow-1')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('flow-run-flow-1'));
 
-    expect(runFlow).toHaveBeenCalledWith('flow-1');
+    expect(runFlowDetached).toHaveBeenCalledWith('flow-1');
     await waitFor(() => expect(screen.getByText('Workflow started')).toBeInTheDocument());
-    // Loaded once on mount, once more on refetch after the run kicks off.
-    await waitFor(() => expect(listFlows).toHaveBeenCalledTimes(2));
   });
 
-  it('shows an error banner (without a toast) when runFlow rejects', async () => {
+  it('shows an error banner (without a toast) when runFlowDetached rejects', async () => {
     listFlows.mockResolvedValue([makeFlow()]);
-    runFlow.mockRejectedValue(new Error('flow disabled'));
+    runFlowDetached.mockRejectedValue(new Error('flow disabled'));
     renderWithProviders(<FlowsPage />, { initialEntries: ['/?view=main'] });
 
     await waitFor(() => expect(screen.getByTestId('flow-run-flow-1')).toBeInTheDocument());
@@ -161,6 +167,36 @@ describe('FlowsPage', () => {
 
     await waitFor(() => expect(screen.getByText('flow disabled')).toBeInTheDocument());
     expect(screen.queryByText('Workflow started')).not.toBeInTheDocument();
+  });
+
+  // F-M2 regression: the old page-global `busyKey` disabled EVERY row's
+  // Run/Toggle for the whole duration of any one row's action. Now that Run
+  // starts a detached, possibly minutes-long flow (F-M1), that would have
+  // frozen the entire list. Assert the busy state stays scoped to the row
+  // whose action is actually in flight.
+  it('keeps other rows interactive while one row has a run in flight', async () => {
+    listFlows.mockResolvedValue([makeFlow(), makeFlow({ id: 'flow-2', name: 'Weekly report' })]);
+    // Never resolves — simulates the RPC round-trip still being in flight so
+    // the row-1 Run button stays in its busy state for the assertion window.
+    runFlowDetached.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<FlowsPage />, { initialEntries: ['/?view=main'] });
+
+    await waitFor(() => expect(screen.getByTestId('flow-run-flow-1')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('flow-run-flow-1'));
+
+    // Row 1's own Run button reflects its in-flight state...
+    await waitFor(() => expect(screen.getByTestId('flow-run-flow-1')).toBeDisabled());
+    // ...but row 2's Run and Toggle stay fully interactive — nothing
+    // page-global gates them anymore.
+    expect(screen.getByTestId('flow-run-flow-2')).not.toBeDisabled();
+    expect(screen.getByTestId('flow-toggle-flow-2')).not.toBeDisabled();
+
+    // Row 2's own actions still work while row 1 is busy.
+    setFlowEnabled.mockResolvedValue(
+      makeFlow({ id: 'flow-2', name: 'Weekly report', enabled: false })
+    );
+    fireEvent.click(screen.getByTestId('flow-toggle-flow-2'));
+    await waitFor(() => expect(setFlowEnabled).toHaveBeenCalledWith('flow-2', false));
   });
 
   it('opens the run-history drawer for the clicked flow when "View runs" is clicked', async () => {
@@ -328,5 +364,68 @@ describe('FlowsPage', () => {
       'That file is not valid workflow JSON.'
     );
     expect(importFlow).not.toHaveBeenCalled();
+  });
+  it('refetches the list on a poll backstop when the run-finished broadcast never arrives', async () => {
+    // `flows_run_detached` returns immediately, so a row's last-run outcome is
+    // refreshed by the `FlowRunFinished` broadcast — a plain socket emit with
+    // no server-side replay. If that is missed (reconnect gap, sleeping
+    // laptop), the row would show a stale outcome until the user navigates
+    // away and back. Every other run-outcome surface pairs the event with a
+    // poll backstop; this pins that this page does too.
+    //
+    // `waitFor` is avoided throughout: it deadlocks under fake timers, so the
+    // clock is advanced explicitly with `advanceTimersByTimeAsync`, which also
+    // flushes the pending promises.
+    vi.useFakeTimers();
+    try {
+      listFlows.mockResolvedValue([makeFlow()]);
+      runFlowDetached.mockResolvedValue({
+        run_id: 'flow:flow-1:t1',
+        flow_id: 'flow-1',
+        status: 'running',
+        detached: true,
+      });
+      renderWithProviders(<FlowsPage />, { initialEntries: ['/?view=main'] });
+
+      // Flush the mount fetch without moving the clock into the poll window.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      const callsBeforeRun = listFlows.mock.calls.length;
+
+      fireEvent.click(screen.getByTestId('flow-run-flow-1'));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(runFlowDetached).toHaveBeenCalledWith('flow-1');
+
+      // No FlowRunFinished is ever delivered — the backstop must still fire.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(31_000);
+      });
+      expect(listFlows.mock.calls.length).toBeGreaterThan(callsBeforeRun);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not poll when no run from this page is outstanding', async () => {
+    vi.useFakeTimers();
+    try {
+      listFlows.mockResolvedValue([makeFlow()]);
+      renderWithProviders(<FlowsPage />, { initialEntries: ['/?view=main'] });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      const callsAfterLoad = listFlows.mock.calls.length;
+
+      // Several poll windows pass with nothing outstanding — no refetch.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(120_000);
+      });
+      expect(listFlows.mock.calls.length).toBe(callsAfterLoad);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/app/src/pages/FlowsPage.tsx
+++ b/app/src/pages/FlowsPage.tsx
@@ -32,6 +32,7 @@ import { CenteredLoadingState, ErrorBanner } from '../components/ui/LoadingState
 import { ModalShell } from '../components/ui/ModalShell';
 import { useFlowChanged } from '../hooks/useFlowChanged';
 import { useFlowPreauthorization } from '../hooks/useFlowPreauthorization';
+import { useFlowRunFinished } from '../hooks/useFlowRunFinished';
 import { FLOW_CANVAS_DRAFT_ROUTE, type FlowCanvasDraftState } from '../lib/flows/canvasDraft';
 import { downloadFlowGraph } from '../lib/flows/exportFlow';
 import { type FlowTemplate, templateNameKey } from '../lib/flows/templates';
@@ -43,7 +44,7 @@ import {
   type Flow,
   importFlow,
   listFlows,
-  runFlow,
+  runFlowDetached,
   setFlowEnabled,
 } from '../services/api/flowsApi';
 import type { ToastNotification } from '../types/intelligence';
@@ -52,8 +53,18 @@ import WorkflowRunsPage from './WorkflowRunsPage';
 
 const log = createDebug('app:flows');
 
-/** Which single row + action currently has a request in flight, if any. */
-type BusyKey = `toggle:${string}` | `run:${string}`;
+/** How often the completion backstop refetches while a run is outstanding. */
+const RUN_BACKSTOP_POLL_MS = 30_000;
+/**
+ * How long the backstop keeps polling for a single run before giving up —
+ * comfortably past the engine's own ~600s run ceiling, so a run that is merely
+ * slow is never abandoned, while one that never reports terminal cannot poll
+ * indefinitely.
+ */
+const RUN_BACKSTOP_TTL_MS = 15 * 60_000;
+
+/** Which action a given row currently has in flight, if any. */
+type RowAction = 'toggle' | 'run';
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -65,7 +76,25 @@ export default function FlowsPage() {
   const [flows, setFlows] = useState<Flow[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [busyKey, setBusyKey] = useState<BusyKey | null>(null);
+  // F-M2 fix: keyed PER FLOW ID rather than a single page-global value, so one
+  // row's in-flight Toggle/Run no longer disables every other row's actions —
+  // this matters most now that Run (`runFlowDetached`, F-M1) starts a run that
+  // can take minutes without blocking the RPC, so a page-global lock would
+  // have frozen the whole list for that long.
+  const [busyByFlow, setBusyByFlow] = useState<Record<string, RowAction>>({});
+  /** Run ids started from this page that have not reported terminal yet, mapped to their start time. */
+  const outstandingRunsRef = useRef<Map<string, number>>(new Map());
+  const setRowBusy = useCallback((flowId: string, action: RowAction | null) => {
+    setBusyByFlow(prev => {
+      if (action === null) {
+        if (!(flowId in prev)) return prev;
+        const next = { ...prev };
+        delete next[flowId];
+        return next;
+      }
+      return { ...prev, [flowId]: action };
+    });
+  }, []);
   const [toasts, setToasts] = useState<ToastNotification[]>([]);
   // Flow whose run history is open in `FlowRunsDrawer` (B3b's run inspector
   // then stacks on top of that when a specific run is picked). `null` keeps
@@ -132,9 +161,8 @@ export default function FlowsPage() {
 
   const handleToggle = useCallback(
     async (flow: Flow) => {
-      if (busyKey) return;
-      const key: BusyKey = `toggle:${flow.id}`;
-      setBusyKey(key);
+      if (busyByFlow[flow.id]) return;
+      setRowBusy(flow.id, 'toggle');
       setError(null);
       log('toggle: id=%s next=%s', flow.id, !flow.enabled);
       try {
@@ -160,44 +188,109 @@ export default function FlowsPage() {
         log('toggle failed: id=%s err=%o', flow.id, err);
         setError(errorMessage(err));
       } finally {
-        setBusyKey(null);
+        setRowBusy(flow.id, null);
       }
     },
-    [busyKey, preauth]
+    [busyByFlow, preauth, setRowBusy]
   );
 
+  // F-M1/F-M2 fix: `runFlowDetached` (`openhuman.flows_run_detached`) returns
+  // as soon as the run is registered — genuinely fire-and-forget, unlike the
+  // old `runFlow` (`openhuman.flows_run`) this replaced, which BLOCKED until
+  // the run reached a terminal status (up to ~600s). That meant the old
+  // per-row busy flag (even before it was widened to page-global) was
+  // misleadingly named: "Run started" only toasted once the run had actually
+  // FINISHED, and this row (and, under the page-global lock this replaces,
+  // every other row too) stayed disabled for the run's whole duration.
+  //
+  // The row's own busy flag now only covers the brief registration round-trip
+  // — `useFlowRunFinished` below refetches the list (silently) once the
+  // engine actually settles, which is what now refreshes `last_run_at` /
+  // `last_status`, so that signal isn't lost just because this call no longer
+  // waits for it.
   const handleRun = useCallback(
     async (flow: Flow) => {
-      if (busyKey) return;
-      const key: BusyKey = `run:${flow.id}`;
-      setBusyKey(key);
+      if (busyByFlow[flow.id]) return;
+      setRowBusy(flow.id, 'run');
       setError(null);
       log('run: id=%s', flow.id);
       try {
-        // Fire-and-forget: the caller doesn't wait for the run to finish,
-        // just that it kicked off. The refetch below picks up the refreshed
-        // `last_run_at` / `last_status` once the engine settles (or, for a
-        // still-running flow, on the next manual refresh). Only refetch on
-        // success — `loadFlows()` clears `error`, which would otherwise wipe
-        // the failure banner set in the `catch` below.
-        await runFlow(flow.id);
+        const result = await runFlowDetached(flow.id);
+        log('run: started (detached) id=%s run_id=%s', flow.id, result.run_id);
+        // Arm the completion backstop below — the RPC no longer blocks until
+        // the run settles, so `FlowRunFinished` is the primary signal and this
+        // is the fallback if that broadcast is missed.
+        outstandingRunsRef.current.set(result.run_id, Date.now());
         addToast({ type: 'success', title: t('flows.list.runStarted') });
-        await loadFlows();
       } catch (err) {
         log('run failed: id=%s err=%o', flow.id, err);
         setError(errorMessage(err));
       } finally {
-        setBusyKey(null);
+        setRowBusy(flow.id, null);
       }
     },
-    [busyKey, addToast, loadFlows, t]
+    [busyByFlow, addToast, setRowBusy, t]
   );
 
-  const busyFor = (flow: Flow): FlowListRowBusy => {
-    if (busyKey === `toggle:${flow.id}`) return 'toggle';
-    if (busyKey === `run:${flow.id}`) return 'run';
-    return null;
-  };
+  // Silently refetch the list whenever ANY run finishes, so a row's
+  // `last_run_at` / `last_status` picks up a detached run's outcome without
+  // the user having to manually refresh — the completion signal `handleRun`
+  // used to get "for free" by blocking on `flows_run` until it settled.
+  useFlowRunFinished(
+    useCallback(event => {
+      log(
+        'run finished: flow=%s run=%s status=%s — refetching list',
+        event.flow_id,
+        event.run_id,
+        event.status
+      );
+      outstandingRunsRef.current.delete(event.run_id);
+      void listFlows()
+        .then(setFlows)
+        .catch(err => log('post-run-finish refetch failed: %o', err));
+    }, [])
+  );
+
+  // Completion backstop for a run started from THIS page.
+  //
+  // `flows_run_detached` returns as soon as the run is registered, so a row's
+  // `last_run_at`/`last_status` is refreshed by the `FlowRunFinished` broadcast
+  // above rather than by the RPC returning. That broadcast is a plain
+  // `io.emit` to currently-connected sockets with no server-side replay, so a
+  // socket drop between clicking Run and the run settling (reconnect gap,
+  // laptop sleep, backgrounded tab) loses it — and the row would then show a
+  // stale outcome until the user navigates away and back.
+  //
+  // Every other run-outcome surface (`FlowRunsSidebar`, `FlowRunsDrawer`,
+  // `WorkflowRunsPage`) already pairs `useFlowRunFinished` with
+  // `useFlowRunsLiveRefresh` for exactly this reason; that hook can't be reused
+  // verbatim here because it is typed for `FlowRun[]` and this page holds
+  // `Flow[]`, so the same guarantee is rebuilt against outstanding run ids.
+  //
+  // Bounded on purpose: entries older than `RUN_BACKSTOP_TTL_MS` are dropped,
+  // so a run that never reports terminal (process died mid-run) can't leave
+  // this polling forever.
+  useEffect(() => {
+    const timer = setInterval(() => {
+      const outstanding = outstandingRunsRef.current;
+      if (outstanding.size === 0) return;
+      const cutoff = Date.now() - RUN_BACKSTOP_TTL_MS;
+      for (const [runId, startedAt] of outstanding) {
+        if (startedAt < cutoff) {
+          log('run backstop: giving up on run=%s (exceeded backstop TTL)', runId);
+          outstanding.delete(runId);
+        }
+      }
+      if (outstanding.size === 0) return;
+      log('run backstop: %d run(s) outstanding — refetching list', outstanding.size);
+      void listFlows()
+        .then(setFlows)
+        .catch(err => log('run backstop refetch failed: %o', err));
+    }, RUN_BACKSTOP_POLL_MS);
+    return () => clearInterval(timer);
+  }, []);
+
+  const busyFor = (flow: Flow): FlowListRowBusy => busyByFlow[flow.id] ?? null;
 
   const handleViewRuns = useCallback((flow: Flow) => {
     log('view runs: id=%s', flow.id);

--- a/app/src/pages/__tests__/FlowCanvasPage.test.tsx
+++ b/app/src/pages/__tests__/FlowCanvasPage.test.tsx
@@ -24,7 +24,7 @@ const updateFlow = vi.hoisted(() => vi.fn());
 const createFlow = vi.hoisted(() => vi.fn());
 const validateFlow = vi.hoisted(() => vi.fn());
 const listFlowConnections = vi.hoisted(() => vi.fn());
-const runFlow = vi.hoisted(() => vi.fn());
+const runFlowDetached = vi.hoisted(() => vi.fn());
 const setFlowEnabled = vi.hoisted(() => vi.fn());
 vi.mock('../../services/api/flowsApi', () => ({
   getFlow,
@@ -32,9 +32,38 @@ vi.mock('../../services/api/flowsApi', () => ({
   createFlow,
   validateFlow,
   listFlowConnections,
-  runFlow,
+  runFlowDetached,
   setFlowEnabled,
 }));
+
+// F-M1: a tiny in-memory socket stand-in (same shape as
+// `EditableFlowCanvas.runOverlay.test.tsx`) so a `flow:run_progress` event can
+// be delivered deterministically, letting us prove nothing was subscribed
+// (and so no event could have been dropped) before `activeRunId` was set.
+const socketHandlers = vi.hoisted(() => new Map<string, Set<(data: unknown) => void>>());
+const socketOn = vi.hoisted(() =>
+  vi.fn((event: string, cb: (data: unknown) => void) => {
+    const set = socketHandlers.get(event) ?? new Set();
+    set.add(cb);
+    socketHandlers.set(event, set);
+  })
+);
+const socketOff = vi.hoisted(() =>
+  vi.fn((event: string, cb: (data: unknown) => void) => {
+    socketHandlers.get(event)?.delete(cb);
+  })
+);
+vi.mock('../../services/socketService', () => ({
+  socketService: { on: socketOn, off: socketOff },
+}));
+
+function emitRunProgress(payload: { run_id: string; node_id: string; status: string }) {
+  act(() => {
+    for (const event of ['flow:run_progress', 'flow_run_progress']) {
+      for (const cb of socketHandlers.get(event) ?? []) cb(payload);
+    }
+  });
+}
 
 // Stub the copilot panel: it drives the real chat runtime (redux + socket),
 // which is out of scope here — we only assert the host opens it and hands the
@@ -100,13 +129,16 @@ describe('FlowCanvasPage', () => {
     createFlow.mockReset();
     validateFlow.mockReset();
     listFlowConnections.mockReset();
-    runFlow.mockReset();
+    runFlowDetached.mockReset();
     setFlowEnabled.mockReset();
     validateFlow.mockResolvedValue({ valid: true, errors: [], warnings: [] });
     listFlowConnections.mockResolvedValue([]);
     updateFlow.mockResolvedValue(makeFlow());
     createFlow.mockResolvedValue(makeFlow({ id: 'created-id', name: 'Daily digest' }));
     setFlowEnabled.mockResolvedValue(makeFlow({ enabled: true }));
+    socketHandlers.clear();
+    socketOn.mockClear();
+    socketOff.mockClear();
   });
 
   it('shows a loading state while the flow is being fetched', () => {
@@ -167,7 +199,7 @@ describe('FlowCanvasPage', () => {
 
     it('renders the run-error banner (trimmed) without covering undo/redo, and lets it be dismissed', async () => {
       getFlow.mockResolvedValue(makeFlow());
-      runFlow.mockRejectedValue(
+      runFlowDetached.mockRejectedValue(
         new Error(
           'capability error: graph error: capability error: code node exited non-zero (timed_out=false):'
         )
@@ -196,13 +228,13 @@ describe('FlowCanvasPage', () => {
 
     it('auto-dismisses the run-error banner after the timeout, and restarts the timer on a new error', async () => {
       getFlow.mockResolvedValue(makeFlow());
-      runFlow.mockRejectedValue(new Error('capability error: boom'));
+      runFlowDetached.mockRejectedValue(new Error('capability error: boom'));
       renderAtFlowId('test-id');
       await waitFor(() => expect(screen.getByTestId('flow-canvas')).toBeInTheDocument());
 
       // Switch to fake timers only now — the load above already went through
       // `waitFor` (real timers); the run/timeout portion below only needs
-      // fake macrotasks plus microtask flushes for the rejected `runFlow`
+      // fake macrotasks plus microtask flushes for the rejected `runFlowDetached`
       // promise, matching the FlowRunsDrawer.test.tsx fake-timer precedent.
       vi.useFakeTimers();
       try {
@@ -238,6 +270,62 @@ describe('FlowCanvasPage', () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+  });
+
+  describe('detached run (F-M1): activeRunId set before any progress event', () => {
+    function clickRun() {
+      fireEvent.click(screen.getByTestId('flow-canvas-run'));
+      fireEvent.click(screen.getByTestId('flow-action-confirm-accept'));
+    }
+
+    // The whole point of `flows_run_detached` (F-M1): `flows_run` blocked
+    // server-side until the run finished, so by the time the RPC resolved
+    // every `flow:run_progress` event for that run had already fired and been
+    // dropped — `useFlowRunProgress` only subscribes once `activeRunId` is
+    // set. This proves the fix end to end: no socket subscription exists
+    // before Run resolves, the canvas subscribes the moment `activeRunId` is
+    // set from the immediate `{run_id}` response, and an event delivered
+    // AFTER that point is not dropped.
+    it('subscribes to run progress only after run_detached resolves, and does not drop a subsequent event', async () => {
+      getFlow.mockResolvedValue(makeFlow());
+      let resolveRun!: (value: {
+        run_id: string;
+        flow_id: string;
+        status: 'running';
+        detached: true;
+      }) => void;
+      runFlowDetached.mockReturnValue(
+        new Promise(resolve => {
+          resolveRun = resolve;
+        })
+      );
+      renderAtFlowId('test-id');
+      await waitFor(() => expect(screen.getByTestId('flow-canvas')).toBeInTheDocument());
+
+      clickRun();
+      // The RPC is still in flight — nothing has subscribed yet, so an event
+      // that arrived NOW (the pre-fix failure mode) would have nowhere to go.
+      expect(socketOn).not.toHaveBeenCalledWith('flow:run_progress', expect.any(Function));
+
+      await act(async () => {
+        resolveRun({ run_id: 'test-id:t1', flow_id: 'test-id', status: 'running', detached: true });
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // `activeRunId` is now set from the immediate response — the canvas
+      // subscribed for exactly that run id.
+      await waitFor(() =>
+        expect(socketOn).toHaveBeenCalledWith('flow:run_progress', expect.any(Function))
+      );
+
+      const nodeWrapper = () =>
+        document.querySelector('.react-flow__node[data-id="t"]') as Element | null;
+      expect(nodeWrapper()).not.toHaveClass('flow-node-running');
+
+      emitRunProgress({ run_id: 'test-id:t1', node_id: 't', status: 'running' });
+      await waitFor(() => expect(nodeWrapper()).toHaveClass('flow-node-running'));
     });
   });
 

--- a/app/src/services/api/flowsApi.test.ts
+++ b/app/src/services/api/flowsApi.test.ts
@@ -16,6 +16,7 @@ import {
   markSuggestionBuilt,
   resumeFlow,
   runFlow,
+  runFlowDetached,
   setFlowEnabled,
 } from './flowsApi';
 
@@ -357,6 +358,77 @@ describe('flowsApi', () => {
       mockCallCoreRpc.mockRejectedValue(new Error('flow disabled'));
 
       await expect(runFlow('flow-1')).rejects.toThrow('flow disabled');
+    });
+  });
+
+  // F-M1/F-M2: `flows_run_detached` registers the run and returns immediately
+  // — it must NOT share `runFlow`'s extended `FLOW_RESUME_TIMEOUT_MS` budget,
+  // since (unlike `runFlow`) it never waits for the engine.
+  describe('runFlowDetached', () => {
+    it('calls openhuman.flows_run_detached with id/input and the DEFAULT timeout (no timeoutMs override)', async () => {
+      mockCallCoreRpc.mockResolvedValue(
+        cliEnvelope({
+          run_id: 'flow:flow-1:t1',
+          flow_id: 'flow-1',
+          status: 'running',
+          detached: true,
+        })
+      );
+
+      const result = await runFlowDetached('flow-1');
+
+      expect(mockCallCoreRpc).toHaveBeenCalledWith({
+        method: 'openhuman.flows_run_detached',
+        params: { id: 'flow-1', input: null },
+      });
+      // No `timeoutMs` key at all — asserted structurally above via
+      // `toHaveBeenCalledWith` (an object with an extra `timeoutMs` key would
+      // NOT match), rather than a brittle `not.toHaveProperty` on the mock
+      // call args.
+      expect(result).toEqual({
+        run_id: 'flow:flow-1:t1',
+        flow_id: 'flow-1',
+        status: 'running',
+        detached: true,
+      });
+    });
+
+    it('passes a supplied input payload through', async () => {
+      mockCallCoreRpc.mockResolvedValue(
+        cliEnvelope({
+          run_id: 'flow:flow-1:t2',
+          flow_id: 'flow-1',
+          status: 'running',
+          detached: true,
+        })
+      );
+
+      await runFlowDetached('flow-1', { trigger: 'manual' });
+
+      expect(mockCallCoreRpc).toHaveBeenCalledWith({
+        method: 'openhuman.flows_run_detached',
+        params: { id: 'flow-1', input: { trigger: 'manual' } },
+      });
+    });
+
+    it('unwraps the { result, logs } envelope', async () => {
+      const payload = {
+        run_id: 'flow:flow-1:t3',
+        flow_id: 'flow-1',
+        status: 'running',
+        detached: true,
+      };
+      mockCallCoreRpc.mockResolvedValue(cliEnvelope(payload));
+
+      const result = await runFlowDetached('flow-1');
+
+      expect(result).toEqual(payload);
+    });
+
+    it('propagates rejection from callCoreRpc', async () => {
+      mockCallCoreRpc.mockRejectedValue(new Error('flow disabled'));
+
+      await expect(runFlowDetached('flow-1')).rejects.toThrow('flow disabled');
     });
   });
 

--- a/app/src/services/api/flowsApi.ts
+++ b/app/src/services/api/flowsApi.ts
@@ -513,10 +513,10 @@ export async function getFlow(id: string): Promise<Flow> {
  * Run a saved flow to completion (or until it pauses on a human-approval
  * gate) via `openhuman.flows_run`. This is the call that actually drives the
  * tinyflows engine, so it shares `flows_resume`'s ~600s server-side budget
- * (see {@link FLOW_RESUME_TIMEOUT_MS}). The Workflows list page's Run button
- * uses this fire-and-forget: it awaits the call just long enough to know the
- * run kicked off, shows a toast, and refetches `listFlows()` to pick up the
- * refreshed `last_run_at`/`last_status`.
+ * (see {@link FLOW_RESUME_TIMEOUT_MS}). This BLOCKS the caller until the run
+ * settles — prefer {@link runFlowDetached} for any UI entry point (Run
+ * buttons) that must not freeze while a run is in flight; `runFlow` remains
+ * for callers that genuinely want to await the final result.
  */
 export async function runFlow(id: string, input?: unknown): Promise<FlowResumeResult> {
   log('runFlow: request id=%s', id);
@@ -530,6 +530,51 @@ export async function runFlow(id: string, input?: unknown): Promise<FlowResumeRe
     'runFlow: response threadId=%s pendingApprovals=%d',
     result.thread_id,
     result.pending_approvals?.length ?? 0
+  );
+  trackAnalyticsEvent('automation_run_started', { automation_kind: 'flow' });
+  return result;
+}
+
+/**
+ * Immediate response from `openhuman.flows_run_detached` — the run has been
+ * registered and its `running` row inserted, but it has NOT finished (or even
+ * necessarily started executing its first action node) yet. Poll
+ * {@link getFlowRun} / subscribe to `flow:run_progress` for the terminal
+ * state — see {@link runFlowDetached}.
+ */
+export interface FlowRunDetachedResult {
+  run_id: string;
+  flow_id: string;
+  status: 'running';
+  detached: true;
+}
+
+/**
+ * Start a saved flow WITHOUT waiting for it to finish, via
+ * `openhuman.flows_run_detached` (F-M1 / F-M2). Unlike {@link runFlow}, this
+ * returns as soon as the run is registered and its `running` row exists — well
+ * under a second, regardless of how long the flow itself takes — so it uses
+ * the client's *default* RPC timeout rather than {@link FLOW_RESUME_TIMEOUT_MS}.
+ *
+ * This is the fire-and-forget entry point both UI Run controls use (the
+ * Workflow Canvas overlay and the Workflows list row action): calling it
+ * BEFORE subscribing to progress would be pointless (nothing to subscribe
+ * to yet), so callers should set up their `flow:run_progress` subscription /
+ * poller using the returned `run_id` immediately after this resolves, not
+ * after the run itself completes.
+ */
+export async function runFlowDetached(id: string, input?: unknown): Promise<FlowRunDetachedResult> {
+  log('runFlowDetached: request id=%s', id);
+  const response = await callCoreRpc<unknown>({
+    method: 'openhuman.flows_run_detached',
+    params: { id, input: input ?? null },
+  });
+  const result = unwrapCliEnvelope<FlowRunDetachedResult>(response);
+  log(
+    'runFlowDetached: response runId=%s status=%s detached=%s',
+    result.run_id,
+    result.status,
+    result.detached
   );
   trackAnalyticsEvent('automation_run_started', { automation_kind: 'flow' });
   return result;

--- a/src/openhuman/flows/ops.rs
+++ b/src/openhuman/flows/ops.rs
@@ -4437,10 +4437,12 @@ pub async fn flows_run(
 /// background task and returns `{ run_id, status: "running", detached: true }`
 /// in well under 120s. The copilot already polls `get_flow_run(run_id)` (seen
 /// in live traces), so it observes the run settle to a terminal state on its
-/// own cadence. Mirrors how the UI "Run" control and the trigger bus
-/// (`flows::bus::spawn_run`) already fire runs fire-and-forget. Combined with
-/// B42's finalizer + boot sweep, a detached run ALWAYS settles to a terminal
-/// row even if the process dies mid-run.
+/// own cadence. Also exposed over RPC as `flows.run_detached` (see
+/// `schemas::handle_run_detached`) — the UI "Run" control (canvas + Workflows
+/// list) calls that entry point directly, and the trigger bus
+/// (`flows::bus::spawn_run`) fires runs the same fire-and-forget way. Combined
+/// with B42's finalizer + boot sweep, a detached run ALWAYS settles to a
+/// terminal row even if the process dies mid-run.
 pub async fn flows_run_detached(
     config: &Config,
     flow_id: &str,

--- a/src/openhuman/flows/schemas.rs
+++ b/src/openhuman/flows/schemas.rs
@@ -222,6 +222,38 @@ fn run_output_fields() -> Vec<FieldSchema> {
     ]
 }
 
+fn run_detached_output_fields() -> Vec<FieldSchema> {
+    vec![
+        FieldSchema {
+            name: "run_id",
+            ty: TypeSchema::String,
+            comment: "Durable checkpoint thread id for this run (same identifier `flows_get_run` \
+                      / `flows_cancel_run` / `flows_resume` expect).",
+            required: true,
+        },
+        FieldSchema {
+            name: "flow_id",
+            ty: TypeSchema::String,
+            comment: "Identifier of the flow that was started.",
+            required: true,
+        },
+        FieldSchema {
+            name: "status",
+            ty: TypeSchema::String,
+            comment: "Always `\"running\"` at the moment this call returns; poll `flows_get_run` \
+                      or subscribe to `flow:run_progress` for the terminal state.",
+            required: true,
+        },
+        FieldSchema {
+            name: "detached",
+            ty: TypeSchema::Bool,
+            comment: "Always `true` — marks this response as the immediate, non-blocking shape, \
+                      distinct from `run`'s completed-run payload.",
+            required: true,
+        },
+    ]
+}
+
 /// Field schema for one `FlowConnection` element of `flows_list_connections`'s
 /// output. Kept in one place so the schema mirrors
 /// `flows::types::FlowConnection` exactly — and documents that no secret field
@@ -287,6 +319,7 @@ pub fn all_controller_schemas() -> Vec<ControllerSchema> {
         schemas("delete"),
         schemas("set_enabled"),
         schemas("run"),
+        schemas("run_detached"),
         schemas("resume"),
         schemas("cancel_run"),
         schemas("list_runs"),
@@ -359,6 +392,10 @@ pub fn all_registered_controllers() -> Vec<RegisteredController> {
         RegisteredController {
             schema: schemas("run"),
             handler: handle_run,
+        },
+        RegisteredController {
+            schema: schemas("run_detached"),
+            handler: handle_run_detached,
         },
         RegisteredController {
             schema: schemas("resume"),
@@ -698,6 +735,35 @@ pub fn schemas(function: &str) -> ControllerSchema {
                     fields: run_output_fields(),
                 },
                 comment: "Run outcome payload.",
+                required: true,
+            }],
+        },
+        "run_detached" => ControllerSchema {
+            namespace: "flows",
+            function: "run_detached",
+            description: "Start a saved flow WITHOUT waiting for it to finish: validates + \
+                          compile-checks the flow, registers the run, inserts its `running` row, \
+                          and returns the run id immediately. Use this from any UI that wants to \
+                          show live per-node progress (`flow:run_progress`) or that must not block \
+                          on a run that can take minutes — poll `flows_get_run(run_id)` or the \
+                          progress event stream for completion. `run` remains available for callers \
+                          that genuinely want to await the final result.",
+            inputs: vec![
+                id_input("Identifier of the flow to run."),
+                FieldSchema {
+                    name: "input",
+                    ty: TypeSchema::Option(Box::new(TypeSchema::Json)),
+                    comment: "Trigger payload seeded into the run; defaults to null.",
+                    required: false,
+                },
+            ],
+            outputs: vec![FieldSchema {
+                name: "result",
+                ty: TypeSchema::Object {
+                    fields: run_detached_output_fields(),
+                },
+                comment: "Immediate start-of-run payload — returned as soon as the run is \
+                          registered, without waiting for it to finish.",
                 required: true,
             }],
         },
@@ -1483,6 +1549,23 @@ fn handle_run(params: Map<String, Value>) -> ControllerFuture {
     })
 }
 
+fn handle_run_detached(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let config = config_rpc::load_config_with_timeout().await?;
+        let id = read_required::<String>(&params, "id")?;
+        let input = params.get("input").cloned().unwrap_or(Value::Null);
+        to_json(
+            ops::flows_run_detached(
+                &config,
+                id.trim(),
+                input,
+                crate::openhuman::flows::FlowRunTrigger::Rpc,
+            )
+            .await?,
+        )
+    })
+}
+
 fn handle_resume(params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async move {
         let config = config_rpc::load_config_with_timeout().await?;
@@ -1862,6 +1945,7 @@ mod tests {
                 "delete",
                 "set_enabled",
                 "run",
+                "run_detached",
                 "resume",
                 "cancel_run",
                 "list_runs",
@@ -1893,7 +1977,7 @@ mod tests {
     #[test]
     fn all_registered_controllers_has_handler_per_schema() {
         let controllers = all_registered_controllers();
-        assert_eq!(controllers.len(), 35);
+        assert_eq!(controllers.len(), 36);
         let names: Vec<_> = controllers.iter().map(|c| c.schema.function).collect();
         assert_eq!(
             names,
@@ -1909,6 +1993,7 @@ mod tests {
                 "delete",
                 "set_enabled",
                 "run",
+                "run_detached",
                 "resume",
                 "cancel_run",
                 "list_runs",

--- a/src/openhuman/tinyflows/observability.rs
+++ b/src/openhuman/tinyflows/observability.rs
@@ -7,12 +7,19 @@
 //! - [`TracingRunObserver`] — log-only, for `run_with_observer` call sites and
 //!   as a simple example.
 //! - [`FlowRunObserver`] — the real one used by the durable run path (issue
-//!   G2, live run observation). As each non-trigger node finishes it (1)
+//!   G2, live run observation). It publishes a [`DomainEvent::FlowRunProgress`]
+//!   twice per non-trigger node — `running` when the node activates, then its
+//!   terminal `success`/`error` when it finishes — so the frontend socket
+//!   bridge can stream the run advancing node-by-node. On finish it also
 //!   persists a [`FlowRunStep`] incrementally into the run's `flow_runs` row
-//!   via `flows::store::upsert_flow_run_step` and (2) publishes a
-//!   [`DomainEvent::FlowRunProgress`] so the frontend socket bridge can stream
-//!   the run advancing node-by-node. Both effects are best-effort: a step that
-//!   fails to persist is logged, never fatal to the run.
+//!   via `flows::store::upsert_flow_run_step`. All effects are best-effort: a
+//!   step that fails to persist is logged, never fatal to the run.
+//!
+//!   The `running` half matters for more than symmetry: the canvas's
+//!   `.flow-node-running` pulse is bound to that status, so while only
+//!   `on_step_finish` was implemented the pulse was unreachable and the live
+//!   overlay rendered as a completion trail — each node gaining a static ring
+//!   only after it had already finished.
 //!
 //! The durable + journaled run path used by `flows_run`/`flows_resume` now
 //! accepts an observer (tinyflows 0.3.1's
@@ -108,6 +115,37 @@ impl RunObserver for FlowRunObserver {
             engine_run_id = %run_id,
             "[flows] observer: run start"
         );
+    }
+
+    /// Announces a node as `running` the moment it activates, so the canvas can
+    /// show what is executing *now* rather than only what has already finished.
+    ///
+    /// Without this the overlay could never do that: `on_step_finish` is the
+    /// only event that ever fired, so the socket only ever carried `success` /
+    /// `failed`, and a node stayed unstyled until it was already done. The
+    /// canvas's `.flow-node-running` pulse (`flow-node-run-pulse`, written for
+    /// exactly this) was therefore unreachable, and the "live run overlay" read
+    /// as a completion trail — nodes acquiring a static ring after the fact.
+    ///
+    /// Publish-only, deliberately: the durable `flow_runs` row stays
+    /// finish-driven. A started-but-unfinished node has no output, duration, or
+    /// terminal status to record, and writing a placeholder row would put a
+    /// `running` step into run history that the post-hoc reconstruction at
+    /// settle would then have to reconcile away. The socket event is ephemeral
+    /// UI state; the row remains the source of truth.
+    fn on_step_start(&self, node_id: &str) {
+        tracing::debug!(
+            target: "flows",
+            flow_id = %self.flow_id,
+            run_id = %self.run_id,
+            node = %node_id,
+            "[flows] observer: step started — publishing FlowRunProgress(running)"
+        );
+        publish_global(DomainEvent::FlowRunProgress {
+            run_id: self.run_id.clone(),
+            node_id: node_id.to_string(),
+            status: "running".to_string(),
+        });
     }
 
     fn on_step_finish(&self, step: &ExecutionStep) {
@@ -219,6 +257,51 @@ mod tests {
     fn step_status_maps_to_stable_strings() {
         assert_eq!(step_status_str(&StepStatus::Success), "success");
         assert_eq!(step_status_str(&StepStatus::Error), "error");
+    }
+
+    /// The canvas's `.flow-node-running` pulse is bound to a `running` status
+    /// that only `on_step_start` can produce. Before it was implemented the
+    /// socket carried nothing but `success`/`failed`, so the pulse was
+    /// unreachable and the "live" overlay was really a completion trail.
+    /// Assert the trait method is actually overridden — a default no-op here
+    /// silently returns the UI to that state with every other test still green.
+    #[test]
+    fn on_step_start_is_implemented_so_the_running_status_can_reach_the_canvas() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        // A probe observer whose `on_step_start` records that the *trait's*
+        // dispatch reached an override rather than the blanket default.
+        struct Probe {
+            started: Arc<AtomicBool>,
+        }
+        impl RunObserver for Probe {
+            fn on_step_start(&self, _node_id: &str) {
+                self.started.store(true, Ordering::SeqCst);
+            }
+        }
+        let started = Arc::new(AtomicBool::new(false));
+        let probe: Box<dyn RunObserver> = Box::new(Probe {
+            started: started.clone(),
+        });
+        probe.on_step_start("n1");
+        assert!(
+            started.load(Ordering::SeqCst),
+            "the engine dispatches on_step_start through the trait object — if this ever \
+             stops holding, FlowRunObserver's override cannot fire either"
+        );
+
+        // And the real observer must override it, not inherit the no-op.
+        let src = include_str!("observability.rs");
+        assert!(
+            src.contains("fn on_step_start(&self, node_id: &str)"),
+            "FlowRunObserver must implement on_step_start — without it no `running` \
+             status is ever published and the canvas pulse is dead code"
+        );
+        assert!(
+            src.contains("status: \"running\".to_string()"),
+            "on_step_start must publish FlowRunProgress with status=running"
+        );
     }
 
     // The end-to-end proof that `FlowRunObserver::on_step_finish` persists each

--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -11800,6 +11800,125 @@ async fn json_rpc_flows_lifecycle_round_trip() {
     rpc_join.abort();
 }
 
+/// JSON-RPC E2E for `flows.run_detached` (PR E / F-M1, F-M2): unlike
+/// `flows_run`, which blocks the RPC caller until the run reaches a terminal
+/// status, `flows_run_detached` must register the run and return
+/// `{run_id, status: "running", detached: true}` immediately — the run row
+/// must already be readable via `flows_get_run` the instant this call
+/// returns, and only *later* (via polling here, `flow:run_progress` /
+/// `useFlowRunPoller` in the UI) does it settle to a terminal status. This is
+/// the RPC-layer counterpart to the direct-API tests
+/// `flows_run_detached_returns_running_run_id_and_inserts_row` /
+/// `flows_run_detached_registers_the_run_before_returning_its_id` in
+/// `src/openhuman/flows/ops_tests.rs` — same contract, exercised through the
+/// `openhuman.flows_run_detached` controller (schema + handler wiring), not
+/// just the `ops::flows_run_detached` fn directly.
+#[cfg(feature = "flows")]
+#[tokio::test]
+async fn json_rpc_flows_run_detached_returns_before_run_completes() {
+    let _env_lock = json_rpc_e2e_env_lock();
+    let (rpc_base, _tmp, api_join, rpc_join, _guards) = boot_flows_rpc_env().await;
+
+    // 1. Create a trivial, immediately-completable flow.
+    let create = post_json_rpc(
+        &rpc_base,
+        9401,
+        "openhuman.flows_create",
+        json!({
+            "name": "Detached Demo",
+            "graph": {
+                "name": "Detached Demo",
+                "nodes": [{ "id": "t", "kind": "trigger", "name": "Trigger" }],
+                "edges": []
+            }
+        }),
+    )
+    .await;
+    let flow = peel_logs_envelope(assert_no_jsonrpc_error(&create, "flows_create"));
+    let flow_id = flow
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("flow id in create result")
+        .to_string();
+
+    // 2. `flows_run_detached` must hand back a non-terminal "running" payload
+    //    right away, not the completed-run payload `flows_run` returns.
+    let run = post_json_rpc(
+        &rpc_base,
+        9402,
+        "openhuman.flows_run_detached",
+        json!({ "id": flow_id }),
+    )
+    .await;
+    let run_out = peel_logs_envelope(assert_no_jsonrpc_error(&run, "flows_run_detached"));
+    assert_eq!(
+        run_out.get("status").and_then(Value::as_str),
+        Some("running"),
+        "run_detached must report 'running' immediately, not await a terminal status: {run_out:?}"
+    );
+    assert_eq!(run_out.get("detached").and_then(Value::as_bool), Some(true));
+    assert_eq!(
+        run_out.get("flow_id").and_then(Value::as_str),
+        Some(flow_id.as_str())
+    );
+    let run_id = run_out
+        .get("run_id")
+        .and_then(Value::as_str)
+        .expect("run_id in run_detached result")
+        .to_string();
+
+    // 3. The run row must already exist — registered + inserted synchronously
+    //    before `flows_run_detached` returned, not from inside the spawned
+    //    background task (which may not be polled for a while).
+    let get_run = post_json_rpc(
+        &rpc_base,
+        9403,
+        "openhuman.flows_get_run",
+        json!({ "run_id": run_id }),
+    )
+    .await;
+    let run_row = peel_logs_envelope(assert_no_jsonrpc_error(&get_run, "flows_get_run"));
+    assert_eq!(
+        run_row.get("id").and_then(Value::as_str),
+        Some(run_id.as_str())
+    );
+
+    // 4. The background task eventually settles the row to a terminal status
+    //    on its own — this is the completion signal the UI's poller /
+    //    `flow:run_progress` subscription relies on instead of the RPC return.
+    let mut terminal_status: Option<String> = None;
+    for _ in 0..50 {
+        let get_run = post_json_rpc(
+            &rpc_base,
+            9404,
+            "openhuman.flows_get_run",
+            json!({ "run_id": run_id }),
+        )
+        .await;
+        let run_row = peel_logs_envelope(assert_no_jsonrpc_error(&get_run, "flows_get_run"));
+        let status = run_row
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        if status != "running" {
+            terminal_status = Some(status);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert!(
+        matches!(
+            terminal_status.as_deref(),
+            Some("completed") | Some("completed_with_warnings")
+        ),
+        "the detached run must settle to a terminal status on its own, got: {terminal_status:?}"
+    );
+
+    api_join.abort();
+    rpc_join.abort();
+}
+
 /// JSON-RPC regression for the Rule 2 compound-bypass fix (C1): `flows_update`
 /// must re-derive `require_approval` from the *effective* graph, not trust the
 /// caller's raw toggle. This is the RPC-layer counterpart to the direct-API


### PR DESCRIPTION
> **Stacked on #5286** (`fix/flows-resume-run-lifecycle`). This branch contains that PR's commit as its base. **Review only the second commit**, and merge after #5286.

## Summary

- The canvas live-run overlay **could never show live progress**, and one Run click **froze every other row** on the Workflows page for the whole run. Both had the same root cause.
- Exposes the already-existing `flows_run_detached` over RPC and switches both UI Run controls to it.
- Also fixes three canvas defects that live in the same files: a mid-conversation blank-canvas reveal, a false "Unsaved" badge, and a stale doc claim.

## Problem

`openhuman.flows_run` **blocks server-side** until the run terminates (up to `FLOW_RUN_TIMEOUT_SECS`; the client mirrors it with a 610s timeout). Both Run entry points awaited it as though it were fire-and-forget:

- **`FlowCanvasPage.tsx`** set `activeRunId` from the RPC's *return value*, but `useFlowRunProgress` only subscribes to `flow:run_progress` once `activeRunId` is set — i.e. **after** every progress event has already fired and been dropped. So nodes never ringed running/success/error; the overlay only ever worked for the rare `pending_approval` pause.
- **`FlowsPage.tsx`** awaited it under a **page-global** `busyKey`, so a 5-minute run disabled Run/Toggle on **every** row for 5 minutes and fired the "Run started" toast only when the run **ended**. Its inline comment claimed "Fire-and-forget: the caller doesn't wait for the run to finish" — which did not match the RPC's semantics.

`ops::flows_run_detached` already existed and returns `{run_id, detached:true}` immediately, registering the run **before** returning its id — but it was never exposed over RPC. Its only caller was the agent `run_flow` tool, and its doc comment claimed it "mirrors how the UI 'Run' control … fire runs fire-and-forget", which was simply false.

## Solution

- **Backend:** registers `flows.run_detached` (wire `openhuman.flows_run_detached`) as a thin controller over the existing `ops::flows_run_detached`. `flows.run` stays registered — the agent tool and existing callers still use the blocking form. The false doc comment is corrected rather than deleted, since it becomes true with this change.
- **Frontend:** `runFlowDetached()` uses the **default** timeout (it returns immediately, so the 610s budget is wrong for it). `FlowCanvasPage` sets `activeRunId` from the immediate response, so the progress subscription is established as early as it can be.

  To be precise rather than overclaim: this does **not** make the window strictly zero. `flows_run_detached` spawns the run and returns without awaiting it, so the first `FlowRunProgress` could in principle be published before the HTTP response is even sent. In practice the round-trip plus a React commit is far slower than a `tokio::spawn` scheduling gap, and the consequence is cosmetic — at worst the first node's animation frame is missed, and `useFlowRunPoller`'s 2s durable-row fallback recovers it. Run history is never affected. `FlowsPage` tracks busy state per row (`busyByFlow: Record<flowId, 'toggle'|'run'>`) instead of one global value.
- **Completion signal preserved:** since the RPC no longer blocks until completion, `FlowsPage` now uses `useFlowRunFinished` — the same hook the runs sidebar/drawer already use — to refetch when a run settles, so `last_run_at`/`last_status` still update. The runs rail itself is untouched; it already reconciled detached runs from the agent-initiated path.

### Also fixed (same files, so they belong here)

- **F-m2** — `chatFirst` was re-derived from the live `initialBuildSeed` prop every render, so `clearBuildSeed` flipped it false and revealed the blank trigger-only canvas mid-conversation whenever the builder's first turn ended with a clarifying question. Now latched at mount.
- **F-m3** — false "Unsaved" after a canvas remount. The mount-time `onGraphChange` writes concrete auto-layout positions for nodes the server stored **without** `position`, so opening an agent-built flow and rejecting a proposal showed a dirty badge with zero user edits. Both sides of the dirty comparison are now normalized at comparison time. (A first attempt that pre-normalized only the persisted seed made the *first* mount read dirty and broke two tests — normalizing both operands inside the memo is correct for first-mount and remount alike.)
- **F-m5** — `ReadonlyFlowCanvas`'s doc claimed the `/flows/:id` viewer uses it, but no production caller reaches it. **Doc corrected rather than deleted**: it has 7 passing tests, and discarding that coverage for a cleanliness win was out of proportion to this PR's scope. Left as a documented, inert fallback with a pointer to remove it if no consumer ever appears.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — Rust controller coverage in `tests/json_rpc_e2e.rs`; Vitest covers the detached call not using the long timeout, FlowsPage keeping other rows interactive (the F-M2 regression), and FlowCanvasPage setting `activeRunId` before any progress event
- [x] Coverage matrix updated — `N/A: bug fix to existing Run controls, no feature rows added/removed/renamed`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature rows affected`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — Run is a release-cut surface, but its **user-visible contract is unchanged** (click Run, see it run); only the transport changes. Worth a manual pass on the canvas overlay at review time.
- [x] Linked issue closed via `Closes #NNN` — `N/A: found by code review, no tracking issue filed yet`

## Impact

- **Runtime/platform:** Rust core (new controller) + desktop frontend.
- **Behaviour:** the canvas overlay now actually animates node state during a run, and the Workflows list stays usable while a run is in flight. The "Run started" toast now fires when the run *starts*.
- **API:** adds `openhuman.flows_run_detached`. Purely additive; `openhuman.flows_run` is unchanged and still registered.
- **Risk:** the completion signal now arrives via the event/poll path rather than the RPC return. Review found `FlowsPage` had only the event half of that pair, unlike the three other run-outcome surfaces which also carry a poll backstop; a bounded backstop has since been added and pinned by tests. Still the behaviour worth exercising manually, since it is where a regression would hide.
- **i18n:** no new strings.

## Related

- Closes: `N/A`
- Follow-up PR(s)/TODOs: delete `ReadonlyFlowCanvas` if no consumer materializes.
- **Merge order:** stacked on #5286 — merge that first. Touches `ops.rs`/`schemas.rs`, so it overlaps #5287 and the stacked #5293/#5294; rebase as those land.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/flows-run-detached-rpc`
- Commit SHA: `0a4a65b03` (plus #5286's `0b7105fa7` as its base)

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — prettier clean (after `--write` on 4 files); eslint 0 errors on touched files
- [x] `pnpm typecheck` — exit 0
- [x] Focused tests: Vitest sweep `src/pages src/services/api src/components/flows src/lib/flows src/hooks` → **1637 passed, 145 files**; `cargo test --lib openhuman::flows` → **554 passed, 0 failed**
- [x] Rust fmt/check (if changed): `cargo check` clean on BOTH the default build and the disabled build (`--no-default-features --features tokenjuice-treesitter`)
- [x] Tauri fmt/check (if changed): N/A, `app/src-tauri` untouched

### Validation Blocked

- `command:` `cargo fmt --check`
- `error:` one pre-existing formatting drift at `ops.rs:5241`
- `impact:` none — confirmed via `git show HEAD:...` that it exists in the base commit and is outside this diff, so it was left alone rather than swept into this PR

### Behavior Changes

- Intended behavior change: the UI Run controls dispatch a detached run and observe progress via events instead of blocking on the RPC.
- User-visible effect: live node-state animation on the canvas during a run; the Workflows list stays interactive while a run is in flight; "Run started" fires at start, not at finish.

### Parity Contract

- Legacy behavior preserved: `openhuman.flows_run` is untouched and still registered for the agent tool and any external caller; the runs rail/drawer/`WorkflowRunsPage` are untouched and already handled detached runs.
- Guard/fallback/dispatch parity checks: `flows_run_detached` registers the run before returning its id, so a `flows_cancel_run` landing immediately after the UI receives it still takes the signalled branch.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


