### PR TITLE
fix(flows): close residual Rust minors from the flows review

### DIFF
--- a/src/openhuman/flows/agents/mod.rs
+++ b/src/openhuman/flows/agents/mod.rs
@@ -10,7 +10,12 @@
 //! with the domain.
 //!
 //! - [`workflow_builder`] — authors tinyflows [`WorkflowGraph`](tinyflows::model::WorkflowGraph)s
-//!   from natural language and returns a validated PROPOSAL (never persists).
+//!   from natural language and returns a validated PROPOSAL by default. It
+//!   also carries three narrow, deliberate persistence tools —
+//!   `create_workflow`/`duplicate_flow` (always born DISABLED) and
+//!   `save_workflow` (update-only, onto a flow that already exists) — each
+//!   gated behind the user's explicit ask; it never enables a flow. See the
+//!   module doc in `flows::builder_tools` for the full tool-by-tool table.
 //! - [`flow_discovery`] — the read-only "Flow Scout" that grounds buildable
 //!   automation ideas from the user's data.
 

--- a/src/openhuman/flows/agents/workflow_builder/builder_prompt.rs
+++ b/src/openhuman/flows/agents/workflow_builder/builder_prompt.rs
@@ -220,6 +220,27 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// Collapses runs of whitespace (including newlines and hard-wrap
+    /// indentation) to a single space and trims the ends.
+    ///
+    /// `prompt.md` is hand-wrapped prose, and several regression tests below
+    /// pin exact substrings of it (including a few that embed a literal
+    /// `\n` at a specific wrap column, e.g. "NO\n   memory access"). Pinning
+    /// against the raw file couples the suite to WHERE a line happens to
+    /// wrap, not what it says — a semantically neutral rewrap (P-m4) then
+    /// reads as a content regression and breaks tests that never should have
+    /// cared. Normalizing both sides before comparing keeps the assertions
+    /// falsifiable against actual content changes while surviving any
+    /// rewrap that doesn't change the words.
+    fn normalize_whitespace(s: &str) -> String {
+        s.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    /// Whitespace-normalized substring check — see [`normalize_whitespace`].
+    fn contains_normalized(haystack: &str, needle: &str) -> bool {
+        normalize_whitespace(haystack).contains(&normalize_whitespace(needle))
+    }
+
     fn req(mode: BuildMode) -> BuilderRequest {
         BuilderRequest {
             mode,
@@ -351,7 +372,7 @@ mod tests {
         // reappear in the standing prompt either.
         for banned in ["review card", "Accept the proposal explicitly"] {
             assert!(
-                !STANDING_PROMPT.contains(banned),
+                !contains_normalized(STANDING_PROMPT, banned),
                 "standing prompt must not carry phantom review-card phrasing `{banned}` (B27)"
             );
         }
@@ -359,14 +380,14 @@ mod tests {
         // Positive: the anti-jargon Style rule — replies must stay in plain
         // language, never leak response_format/schema/expression internals.
         assert!(
-            STANDING_PROMPT.contains("Speak to a non-technical user"),
+            contains_normalized(STANDING_PROMPT, "Speak to a non-technical user"),
             "standing prompt must teach the anti-jargon Style rule"
         );
 
         // Positive: read-only memory grounding via the raw `memory_recall`
         // tool (no `memory_store` — see the agent.toml regression test).
         assert!(
-            STANDING_PROMPT.contains("memory_recall"),
+            contains_normalized(STANDING_PROMPT, "memory_recall"),
             "standing prompt must teach the builder to ground itself with memory_recall"
         );
 
@@ -375,7 +396,10 @@ mod tests {
         // drop the "can't change their memory" guarantee this agent's tool
         // scope depends on (no `memory_store` in agent.toml).
         assert!(
-            STANDING_PROMPT.contains("Read-only — you can't change their memory"),
+            contains_normalized(
+                STANDING_PROMPT,
+                "Read-only — you can't change their memory"
+            ),
             "standing prompt must state the memory read-only guarantee, not just mention memory_recall"
         );
 
@@ -388,7 +412,7 @@ mod tests {
             "It cannot create flows,",
         ] {
             assert!(
-                !STANDING_PROMPT.contains(banned),
+                !contains_normalized(STANDING_PROMPT, banned),
                 "standing prompt must not carry the stale \"can never create a flow\" claim \
                  `{banned}` — create_workflow/duplicate_flow are on the belt (issue #6)"
             );
@@ -397,7 +421,8 @@ mod tests {
         // Positive: the accurate contract — the agent CAN create a flow, but
         // every flow it creates is always born disabled.
         assert!(
-            STANDING_PROMPT.contains("create_workflow") && STANDING_PROMPT.contains("born"),
+            contains_normalized(STANDING_PROMPT, "create_workflow")
+                && contains_normalized(STANDING_PROMPT, "born"),
             "standing prompt must accurately teach that create_workflow exists and that \
              created flows are always born disabled (issue #6)"
         );
@@ -410,9 +435,9 @@ mod tests {
         // offering-then-refusing (the confusing "want me to run it?" → "I
         // don't have access" behavior).
         assert!(
-            STANDING_PROMPT.contains("only if the tool is on your belt")
-                && STANDING_PROMPT.contains("never offer to run the flow")
-                && STANDING_PROMPT.contains("Workflows UI"),
+            contains_normalized(STANDING_PROMPT, "only if the tool is on your belt")
+                && contains_normalized(STANDING_PROMPT, "never offer to run the flow")
+                && contains_normalized(STANDING_PROMPT, "Workflows UI"),
             "standing prompt must make run_flow capability-conditional: never offer to run \
              when the tool is off the belt, and point the user to the Workflows UI Run \
              control instead (Bld §4 offer-then-refuse)"
@@ -423,7 +448,7 @@ mod tests {
         // it must not reappear (that's the exact offer-then-refuse regression
         // Bld §4 closed).
         assert!(
-            !STANDING_PROMPT.contains("`run_flow` (ask first!)"),
+            !contains_normalized(STANDING_PROMPT, "`run_flow` (ask first!)"),
             "standing prompt must not regress to the pre-Bld-§4 unconditional \
              \"ask first!\" run_flow heading"
         );
@@ -433,14 +458,18 @@ mod tests {
         // check somewhere else in the doc — bind the assertion to the two
         // halves of the actual contract (off-belt fallback, on-belt usage).
         assert!(
-            STANDING_PROMPT
-                .contains("If you do **not** have a `run_flow` tool, never offer to run the flow"),
+            contains_normalized(
+                STANDING_PROMPT,
+                "If you do **not** have a `run_flow` tool, never offer to run the flow"
+            ),
             "standing prompt must state the off-belt fallback as a direct consequence \
              of the capability check, not a generic nearby mention"
         );
         assert!(
-            STANDING_PROMPT
-                .contains("If you **do** have `run_flow`: once the user has **saved** a flow"),
+            contains_normalized(
+                STANDING_PROMPT,
+                "If you **do** have `run_flow`: once the user has **saved** a flow"
+            ),
             "standing prompt must gate the on-belt run_flow usage behind the same \
              capability check"
         );
@@ -452,18 +481,22 @@ mod tests {
         // gated `run_flow` while leaving these two unconditional would
         // reopen the same offer-then-refuse bug one hop later.
         assert!(
-            STANDING_PROMPT
-                .contains("those tools are on your belt** — `resume_flow_run` (approval-gated) or"),
+            contains_normalized(
+                STANDING_PROMPT,
+                "those tools are on your belt** — `resume_flow_run` (approval-gated) or"
+            ),
             "standing prompt must gate resume_flow_run/cancel_flow_run behind the \
              same on-your-belt capability check as run_flow"
         );
         assert!(
-            STANDING_PROMPT.contains("(if they're not available, point the"),
+            contains_normalized(STANDING_PROMPT, "(if they're not available, point the"),
             "standing prompt must state the resume/cancel off-belt fallback condition"
         );
         assert!(
-            STANDING_PROMPT
-                .contains("user to the runs list in the Workflows UI instead of offering)."),
+            contains_normalized(
+                STANDING_PROMPT,
+                "user to the runs list in the Workflows UI instead of offering)."
+            ),
             "standing prompt must point resume/cancel's off-belt fallback to the \
              Workflows UI runs list, matching run_flow's UI fallback pattern"
         );
@@ -472,7 +505,10 @@ mod tests {
         // right after `edit_workflow`, with no capability check in between —
         // must not reappear.
         assert!(
-            !STANDING_PROMPT.contains("patch with `edit_workflow`; `resume_flow_run`"),
+            !contains_normalized(
+                STANDING_PROMPT,
+                "patch with `edit_workflow`; `resume_flow_run`"
+            ),
             "standing prompt must not regress to the pre-fix unconditional \
              resume_flow_run/cancel_flow_run offer"
         );
@@ -481,16 +517,19 @@ mod tests {
         // wire "DM me" onto the connection's own `platform_user_id`, not a
         // public channel (the #general/#team-product fallback bug).
         assert!(
-            STANDING_PROMPT.contains("platform_user_id"),
+            contains_normalized(STANDING_PROMPT, "platform_user_id"),
             "standing prompt must teach that list_flow_connections surfaces \
              platform_user_id for self-DM resolution"
         );
         assert!(
-            STANDING_PROMPT.contains("DM me"),
+            contains_normalized(STANDING_PROMPT, "DM me"),
             "standing prompt must keep the \"DM me\" self-target guidance"
         );
         assert!(
-            STANDING_PROMPT.contains("Never default a personal request to a public channel"),
+            contains_normalized(
+                STANDING_PROMPT,
+                "Never default a personal request to a public channel"
+            ),
             "standing prompt must explicitly forbid falling back to a public \
              channel (e.g. #general/#team-product) for a personal \"DM me\" request"
         );
@@ -501,8 +540,10 @@ mod tests {
         // word `platform_user_id` elsewhere in the prompt and still pass the
         // looser check above.
         assert!(
-            STANDING_PROMPT
-                .contains("that id verbatim as the `channel` arg on `SLACK_SEND_MESSAGE`"),
+            contains_normalized(
+                STANDING_PROMPT,
+                "that id verbatim as the `channel` arg on `SLACK_SEND_MESSAGE`"
+            ),
             "standing prompt must explicitly instruct passing `platform_user_id` \
              verbatim as the `channel` arg on `SLACK_SEND_MESSAGE` — not just \
              mention the field name"
@@ -512,8 +553,8 @@ mod tests {
         // their member id in one question) must survive too — this is the
         // other half of the self-DM contract and must not be silently lost.
         assert!(
-            STANDING_PROMPT.contains("Only if `platform_user_id` is null")
-                && STANDING_PROMPT.contains("ask the user for their member id"),
+            contains_normalized(STANDING_PROMPT, "Only if `platform_user_id` is null")
+                && contains_normalized(STANDING_PROMPT, "ask the user for their member id"),
             "standing prompt must preserve the null-`platform_user_id` fallback: \
              ask the user for their member id in one question rather than \
              guessing a channel"
@@ -526,38 +567,38 @@ mod tests {
         // toolkit-specific slug hardcoded) — the same shape applies to
         // Slack, Discord, Telegram, or any other messaging toolkit.
         assert!(
-            STANDING_PROMPT.contains("is NOT the connected"),
+            contains_normalized(STANDING_PROMPT, "is NOT the connected"),
             "standing prompt must teach the non-owner DM case explicitly"
         );
         assert!(
-            STANDING_PROMPT.contains("platform-agnostic"),
+            contains_normalized(STANDING_PROMPT, "platform-agnostic"),
             "standing prompt must state the non-owner DM guidance is \
              platform-agnostic, not tied to one toolkit"
         );
         assert!(
-            STANDING_PROMPT.contains("search_tool_catalog { query, toolkit }"),
+            contains_normalized(STANDING_PROMPT, "search_tool_catalog { query, toolkit }"),
             "standing prompt must teach resolving the lookup action via \
              search_tool_catalog scoped to the TARGET toolkit, rather than \
              hardcoding one platform's slug"
         );
         assert!(
-            STANDING_PROMPT.contains("tool_call` node upstream of the send"),
+            contains_normalized(STANDING_PROMPT, "tool_call` node upstream of the send"),
             "standing prompt must teach wiring the lookup as a tool_call \
              node upstream of the send node"
         );
         assert!(
-            STANDING_PROMPT.contains("resolves to exactly one match"),
+            contains_normalized(STANDING_PROMPT, "resolves to exactly one match"),
             "standing prompt must require a name search to resolve to \
              exactly one match before binding it without asking"
         );
         assert!(
-            STANDING_PROMPT.contains("ask the user to confirm which person"),
+            contains_normalized(STANDING_PROMPT, "ask the user to confirm which person"),
             "standing prompt must preserve the safety rule: never message an \
              unverified same-name match, ask instead when ambiguous"
         );
         assert!(
-            STANDING_PROMPT.contains("Check the send action")
-                && STANDING_PROMPT.contains("open conversation"),
+            contains_normalized(STANDING_PROMPT, "Check the send action")
+                && contains_normalized(STANDING_PROMPT, "open conversation"),
             "standing prompt must teach checking the send tool's own contract \
              for a required open-conversation step, handled generally via the \
              contract rather than a single-platform special case"
@@ -574,7 +615,7 @@ mod tests {
             "exact_match",
         ] {
             assert!(
-                !STANDING_PROMPT.contains(banned),
+                !contains_normalized(STANDING_PROMPT, banned),
                 "standing prompt's non-owner DM guidance must not hardcode \
                  the platform-specific `{banned}` — it must stay \
                  platform-agnostic (any messaging toolkit)"
@@ -600,7 +641,7 @@ mod tests {
             "Lead with substance",
         ] {
             assert!(
-                STANDING_PROMPT.contains(rule),
+                contains_normalized(STANDING_PROMPT, rule),
                 "standing prompt must teach the reply-hygiene rule `{rule}` — the \
                  reply is the finished answer, not a thinking scratchpad (no \
                  deliberation narration, no draft-then-restate)"
@@ -629,7 +670,7 @@ mod tests {
             "zero questions is still the happy path",
         ] {
             assert!(
-                STANDING_PROMPT.contains(rule),
+                contains_normalized(STANDING_PROMPT, rule),
                 "standing prompt must teach the resolution-first rule `{rule}` — \
                  before asking for any missing value, the builder must exhaust \
                  self-resolution (recall, connections, tool catalog, runtime \
@@ -656,7 +697,7 @@ mod tests {
             "flow_memory_agent",
         ] {
             assert!(
-                STANDING_PROMPT.contains(rule),
+                contains_normalized(STANDING_PROMPT, rule),
                 "standing prompt must teach specialist selection via `{rule}` — the \
                  builder needs to know it can ground a real agent_ref with \
                  list_agent_profiles instead of hallucinating one"
@@ -675,20 +716,20 @@ mod tests {
         const STANDING_PROMPT: &str = include_str!("prompt.md");
 
         assert!(
-            STANDING_PROMPT.contains("flow_memory_agent"),
+            contains_normalized(STANDING_PROMPT, "flow_memory_agent"),
             "standing prompt must name `flow_memory_agent`"
         );
         assert!(
-            STANDING_PROMPT.contains("the PREFERRED general"),
+            contains_normalized(STANDING_PROMPT, "the PREFERRED general"),
             "standing prompt must teach flow_memory_agent as the PREFERRED general route"
         );
         assert!(
-            STANDING_PROMPT.contains("for ANY use case, not a fixed list"),
+            contains_normalized(STANDING_PROMPT, "for ANY use case, not a fixed list"),
             "standing prompt must state the routing rule is general — ANY use case, not \
              a fixed list of scenarios — or the builder will under-route to flow_memory_agent"
         );
         assert!(
-            STANDING_PROMPT.contains("narrower niche"),
+            contains_normalized(STANDING_PROMPT, "narrower niche"),
             "standing prompt must demote context_scout to its narrower structured-bundle \
              niche now that flow_memory_agent is the general route"
         );
@@ -697,11 +738,11 @@ mod tests {
         // retrieval to context_scout contradicts the rule above and trains the
         // builder to under-route to flow_memory_agent.
         assert!(
-            STANDING_PROMPT.contains("asked us before\" → `flow_memory_agent`"),
+            contains_normalized(STANDING_PROMPT, "asked us before\" → `flow_memory_agent`"),
             "the generic customer-history example must route to flow_memory_agent"
         );
         assert!(
-            !STANDING_PROMPT.contains("asked us before\" → `context_scout`"),
+            !contains_normalized(STANDING_PROMPT, "asked us before\" → `context_scout`"),
             "the generic customer-history example must NOT route to context_scout — that \
              contradicts flow_memory_agent being the general context/history route"
         );
@@ -716,9 +757,9 @@ mod tests {
         const STANDING_PROMPT: &str = include_str!("prompt.md");
 
         assert!(
-            STANDING_PROMPT.contains("specialist")
-                && (STANDING_PROMPT.contains("tool loop")
-                    || STANDING_PROMPT.contains("full persona")),
+            contains_normalized(STANDING_PROMPT, "specialist")
+                && (contains_normalized(STANDING_PROMPT, "tool loop")
+                    || contains_normalized(STANDING_PROMPT, "full persona")),
             "standing prompt must link agent_ref to the specialist's full tool loop \
              (the harness path), not just a persona/model swap"
         );
@@ -740,7 +781,7 @@ mod tests {
             "still gets tools from the node's own",
         ] {
             assert!(
-                !STANDING_PROMPT.contains(banned),
+                !contains_normalized(STANDING_PROMPT, banned),
                 "standing prompt must not carry the stale agent_ref-tool-loop \
                  phrasing `{banned}` — the harness path already gives agent_ref \
                  its full tool loop"
@@ -783,15 +824,16 @@ mod tests {
         const STANDING_PROMPT: &str = include_str!("prompt.md");
 
         assert!(
-            STANDING_PROMPT.contains("minimal viable graph"),
+            contains_normalized(STANDING_PROMPT, "minimal viable graph"),
             "standing prompt must still warn to prefer the minimal viable graph"
         );
         assert!(
-            STANDING_PROMPT.contains("3–6 nodes") || STANDING_PROMPT.contains("3-6 nodes"),
+            contains_normalized(STANDING_PROMPT, "3–6 nodes")
+                || contains_normalized(STANDING_PROMPT, "3-6 nodes"),
             "standing prompt must still carry the 3-6 node sizing guidance"
         );
         assert!(
-            STANDING_PROMPT.contains("SAME kind of work"),
+            contains_normalized(STANDING_PROMPT, "SAME kind of work"),
             "standing prompt must still warn against chaining agents doing the \
              same kind of work, even after adding specialist-selection guidance"
         );
@@ -816,7 +858,7 @@ mod tests {
             "wire\n   an `agent` node that uses memory",
         ] {
             assert!(
-                !STANDING_PROMPT.contains(banned),
+                !contains_normalized(STANDING_PROMPT, banned),
                 "standing prompt must not tell the builder a plain `agent` node can \
                  reach memory ({banned:?}) — it has no tool loop, so the model \
                  fabricates the recalled value instead of looking it up"
@@ -824,7 +866,10 @@ mod tests {
         }
 
         assert!(
-            STANDING_PROMPT.contains("A plain `agent` node has NO\n   memory access"),
+            contains_normalized(
+                STANDING_PROMPT,
+                "A plain `agent` node has NO\n   memory access"
+            ),
             "standing prompt must state outright that a plain agent node has no \
              memory access, so the builder never authors a no-op recall step"
         );
@@ -856,7 +901,7 @@ mod tests {
             "=nodes.<id>.item.json.content[0].text",
         ] {
             assert!(
-                STANDING_PROMPT.contains(rule),
+                contains_normalized(STANDING_PROMPT, rule),
                 "standing prompt must teach `{rule}` — it is one of the four \
                  mechanisms that actually read memory at flow run time, or the \
                  binding path needed to consume one"
@@ -886,27 +931,30 @@ mod tests {
         const STANDING_PROMPT: &str = include_str!("prompt.md");
 
         assert!(
-            STANDING_PROMPT.contains("can never WRITE the user's memory"),
+            contains_normalized(STANDING_PROMPT, "can never WRITE the user's memory"),
             "standing prompt must state plainly that a workflow cannot write the \
              user's PERSONAL memory, so the builder never targets scope \"user\" \
              on a remember/forget memory node"
         );
         assert!(
-            !STANDING_PROMPT.contains("agent_memory"),
+            !contains_normalized(STANDING_PROMPT, "agent_memory"),
             "standing prompt must not steer the builder to `agent_memory` as a \
              flow agent_ref: its `memory_tree` tool declares ReadOnly but exposes \
              an ingest_document write mode, so it would give prompt-injectable \
              trigger data a memory-write path"
         );
         assert!(
-            STANDING_PROMPT.contains("scope: \"flow\""),
+            contains_normalized(STANDING_PROMPT, "scope: \"flow\""),
             "standing prompt must teach that a workflow CAN write its own \
              flow-scoped memory via a `memory` node (scope: \"flow\") — this is \
              the real mechanism for a flow that \"remembers\" across runs, \
              replacing the old blanket \"memory writes are not available\" advice"
         );
         assert!(
-            STANDING_PROMPT.contains("Always place the `remember` AFTER the real action"),
+            contains_normalized(
+                STANDING_PROMPT,
+                "Always place the `remember` AFTER the real action"
+            ),
             "standing prompt must teach commit-on-success ordering: remember AFTER \
              the action it's recording, never before, so a failed action doesn't \
              get silently marked done"

--- a/src/openhuman/flows/agents/workflow_builder/prompt.md
+++ b/src/openhuman/flows/agents/workflow_builder/prompt.md
@@ -150,6 +150,38 @@ rather than a general context recall), use `memory_hybrid_search` in its
      integrations" below — you can help the user link it before you build,
      rather than dead-ending.
 
+3. **Build the graph** (see the model below).
+4. **Self-check with `dry_run_workflow`** on the draft — catch missing edges,
+   wrong ports, unreachable nodes. Fix and re-run.
+
+   **Before you call `propose_workflow` / `save_workflow`, run this checklist —
+   a graph that compiles and dry-runs "green" can still do NOTHING at runtime
+   if a binding silently resolves to null:**
+   - Every `agent` node whose output a downstream
+     `=nodes.<agent_id>.item.json.<field>` binding reads MUST declare
+     `config.output_parser.schema` naming that field under `properties`. No
+     schema ⇒ the agent's item is `{text: "..."}` and the binding is null.
+   - Every `agent` node needs its data fed via `config.input_context`
+     (`"=item"` / `"=items"` / `"=nodes.<id>.item.json"`), with `config.prompt`
+     left as a plain instruction — never a `.item`/`nodes.` reference woven
+     into prose. `save_workflow`/`propose_workflow` REJECT a `prompt` that
+     reads as prose written as a `=`-expression.
+   - If `dry_run_workflow` reports `"ok": false` with a `null_resolutions`,
+     `agent_prompt_nulls`, or `agent_input_context_nulls` list, **fix every
+     one** before proposing — add the missing schema, move data into
+     `input_context`, or rewire the expression to a real upstream field.
+     `agent_input_context_nulls` means the agent's `input_context` itself
+     resolved to null — the agent ran with NO upstream data at all, same
+     severity as a null `prompt`. Don't propose/save a graph `dry_run_workflow`
+     flagged. **Never dismiss a dry-run `ok: false` as a sandbox limitation**
+     — if `dry_run_workflow` flagged the graph, the binding/schema/path is
+     wrong and must be fixed before proposing.
+5. **`propose_workflow`** (first draft) or **`revise_workflow`** (iterating on a
+   prior draft — apply the change to the existing graph, don't regenerate from
+   scratch). If validation fails, read the error, fix the graph, call again.
+6. **Debugging a broken saved flow?** `get_flow` for its graph and
+   `get_flow_run` for a failing run's steps, then propose a repaired version.
+
 ## Your authoring tools (prefer these — don't re-emit whole graphs)
 
 You have a machine-readable belt; use it instead of relying on memory:
@@ -255,37 +287,6 @@ stop there. Do not refuse to propose over this. Do not swap the `agent` node
 for a code or transform node to work around it. Do not loop trying to resolve
 it yourself. Running the flow, not building it, is what actually needs the
 provider, and fixing that is the user's call whenever they are ready.
-3. **Build the graph** (see the model below).
-4. **Self-check with `dry_run_workflow`** on the draft — catch missing edges,
-   wrong ports, unreachable nodes. Fix and re-run.
-
-   **Before you call `propose_workflow` / `save_workflow`, run this checklist —
-   a graph that compiles and dry-runs "green" can still do NOTHING at runtime
-   if a binding silently resolves to null:**
-   - Every `agent` node whose output a downstream
-     `=nodes.<agent_id>.item.json.<field>` binding reads MUST declare
-     `config.output_parser.schema` naming that field under `properties`. No
-     schema ⇒ the agent's item is `{text: "..."}` and the binding is null.
-   - Every `agent` node needs its data fed via `config.input_context`
-     (`"=item"` / `"=items"` / `"=nodes.<id>.item.json"`), with `config.prompt`
-     left as a plain instruction — never a `.item`/`nodes.` reference woven
-     into prose. `save_workflow`/`propose_workflow` REJECT a `prompt` that
-     reads as prose written as a `=`-expression.
-   - If `dry_run_workflow` reports `"ok": false` with a `null_resolutions`,
-     `agent_prompt_nulls`, or `agent_input_context_nulls` list, **fix every
-     one** before proposing — add the missing schema, move data into
-     `input_context`, or rewire the expression to a real upstream field.
-     `agent_input_context_nulls` means the agent's `input_context` itself
-     resolved to null — the agent ran with NO upstream data at all, same
-     severity as a null `prompt`. Don't propose/save a graph `dry_run_workflow`
-     flagged. **Never dismiss a dry-run `ok: false` as a sandbox limitation**
-     — if `dry_run_workflow` flagged the graph, the binding/schema/path is
-     wrong and must be fixed before proposing.
-5. **`propose_workflow`** (first draft) or **`revise_workflow`** (iterating on a
-   prior draft — apply the change to the existing graph, don't regenerate from
-   scratch). If validation fails, read the error, fix the graph, call again.
-6. **Debugging a broken saved flow?** `get_flow` for its graph and
-   `get_flow_run` for a failing run's steps, then propose a repaired version.
 
 ## The workflow model
 

--- a/src/openhuman/flows/agents/workflow_builder/prompt.rs
+++ b/src/openhuman/flows/agents/workflow_builder/prompt.rs
@@ -79,14 +79,17 @@ mod tests {
         assert!(!body.is_empty());
     }
 
-    #[test]
-    fn prompt_teaches_the_propose_never_persist_invariant() {
-        let body = build(&ctx()).unwrap();
-        let lc = body.to_lowercase();
-        assert!(lc.contains("propose"), "prompt must teach proposing");
-        assert!(
-            lc.contains("never") && (lc.contains("persist") || lc.contains("save")),
-            "prompt must teach the never-persist invariant"
-        );
-    }
+    // A test asserting `body.to_lowercase().contains("propose")` used to live
+    // here. It was near-tautological: "propose"/"proposal"/"propose_workflow"
+    // appear dozens of times throughout the archetype regardless of whether
+    // the propose-only invariant is actually taught correctly, so the
+    // assertion could not fail in any way that mattered (P-m5). The real
+    // invariant — every authoring turn is propose-only, persistence gated
+    // behind the user's explicit ask — is pinned with specific, falsifiable
+    // substrings in `builder_prompt.rs`: `create_prompt_frames_propose_only`,
+    // `build_is_propose_only_and_injects_flow_id_as_context` (the #4596
+    // regression guard), and the `standing_prompt_*` tests that assert exact
+    // phrases like "Do NOT save_workflow" and "Do not save, enable, or run
+    // anything". Removed rather than strengthened to avoid duplicating that
+    // coverage here.
 }

--- a/src/openhuman/flows/builder_tools.rs
+++ b/src/openhuman/flows/builder_tools.rs
@@ -283,7 +283,10 @@ impl Tool for EditWorkflowTool {
          saved flow; or an inline graph) plus ops[]: a list of edits applied in \
          order. Op shapes (each is { \"op\": <type>, ... }): add_node {node}, update_node_config \
          {id, config} (JSON merge-patch — a null value deletes that config key), set_node_name \
-         {id, name}, rename_node {id, new_id} (rewires edges), remove_node {id} (drops its edges), \
+         {id, name}, rename_node {id, new_id} (rewires EDGES onto the new id, but does NOT rewrite \
+         `=nodes.<old_id>...` binding expressions inside OTHER nodes' config — re-point those \
+         yourself, or validate_workflow will catch the dangling reference), remove_node {id} \
+         (drops its edges), \
          add_edge {edge}, remove_edge {from_node, to_node, from_port?, to_port?}, set_node_position \
          {id, position}. PERSISTENCE: the applied edit is written to a DRAFT, never onto the saved \
          flow — this tool NEVER saves. Editing a flow_id SEEDS A NEW DRAFT from that flow's graph \
@@ -564,9 +567,13 @@ impl Tool for EditWorkflowTool {
             }
         };
 
-        let write_edit_to_draft = || -> anyhow::Result<()> {
+        // T-m6: returns `Err` (rather than only `warn!`-logging) when the
+        // draft write-back itself fails, so callers can surface the failure
+        // instead of telling the agent "Edits live on draft {id}" when the
+        // draft still holds the PREVIOUS graph.
+        let write_edit_to_draft = || -> Result<(), String> {
             if let Some(ref draft_id) = write_back_draft {
-                let edited_json = serde_json::to_value(&edited)?;
+                let edited_json = serde_json::to_value(&edited).map_err(|e| e.to_string())?;
                 if let Err(e) = ops::flows_draft_update(
                     &self.config,
                     draft_id,
@@ -575,6 +582,7 @@ impl Tool for EditWorkflowTool {
                     None,
                 ) {
                     tracing::warn!(target: "flows", %draft_id, error = %e, "[flows] edit_workflow: could not write edit back to draft");
+                    return Err(e);
                 }
             }
             Ok(())
@@ -585,7 +593,16 @@ impl Tool for EditWorkflowTool {
         if !structural.is_empty() {
             // Preserve the longstanding working-copy contract: an applied edit
             // survives for the next repair turn even when structurally invalid.
-            write_edit_to_draft()?;
+            // T-m6: surface (not just log) a write-back failure here too, so the
+            // agent knows the draft may still hold the PREVIOUS graph rather than
+            // this attempted (invalid) edit.
+            let write_back_note = match write_edit_to_draft() {
+                Ok(()) => String::new(),
+                Err(e) => format!(
+                    "\n\nNote: the edit could also NOT be written back to the draft ({e}) — the \
+                     draft still holds the PREVIOUS graph, not this attempted edit."
+                ),
+            };
             let messages: Vec<String> = structural.iter().map(ToString::to_string).collect();
             tracing::debug!(
                 target: "flows",
@@ -594,7 +611,7 @@ impl Tool for EditWorkflowTool {
                 "[flows] edit_workflow: the edited graph is structurally invalid"
             );
             return Ok(ToolResult::error(format!(
-                "The edited graph is invalid:\n\n{}\n\nFix the ops and call edit_workflow again.",
+                "The edited graph is invalid:\n\n{}\n\nFix the ops and call edit_workflow again.{write_back_note}",
                 messages.join("\n")
             )));
         }
@@ -621,7 +638,28 @@ impl Tool for EditWorkflowTool {
         // Write the accepted structural edit back to the draft (the durable
         // working copy), so it survives across turns/reloads even if a later
         // binding/connection/contract gate flags something to fix next.
-        write_edit_to_draft()?;
+        //
+        // T-m6: a failure here MUST short-circuit rather than fall through to
+        // the proposal payload below — that payload's `next` text tells the
+        // agent "Edits live on draft {id}", which would be false if the write
+        // never landed, leaving the next turn silently iterating on a stale
+        // draft.
+        if let Some(draft_id) = write_back_draft.as_deref() {
+            if let Err(e) = write_edit_to_draft() {
+                tracing::warn!(
+                    target: "flows",
+                    %name,
+                    %draft_id,
+                    error = %e,
+                    "[flows] edit_workflow: draft write-back failed after validation passed"
+                );
+                return Ok(ToolResult::error(format!(
+                    "The edit passed validation, but could NOT be written back to draft \
+                     {draft_id}: {e}\n\nThe draft still holds the PREVIOUS graph, not this edit. \
+                     Retry edit_workflow."
+                )));
+            }
+        }
 
         // Full builder hard-gate stack + proposal payload (shared with revise).
         // Thread the persistence-state handles so the payload carries draft_id /
@@ -800,16 +838,35 @@ impl Tool for ValidateWorkflowTool {
         let validation = ops::flows_validate(graph_json.clone()).value;
 
         // Only run the (expensive) hard gates on a structurally-valid graph.
-        let gate_errors = if validation.valid {
+        // A migrate/deserialize error here must fail CLOSED: `validation.valid`
+        // only proves the graph passed structural checks, not that the hard
+        // gates (unresolvable bindings, unreal tool slugs, unwired required
+        // args) ran. Treating the empty `gate_errors` from a caught `Err` as
+        // "gates passed" previously reported `ok: true` while silently
+        // skipping every hard gate.
+        let (gate_errors, gate_check_failed) = if validation.valid {
             match ops::migrate_and_deserialize_graph(graph_json) {
-                Ok(graph) => ops::run_builder_gates(&self.config, &graph).await,
-                Err(_) => Vec::new(),
+                Ok(graph) => (ops::run_builder_gates(&self.config, &graph).await, false),
+                Err(e) => {
+                    tracing::warn!(
+                        target: "flows",
+                        error = %e,
+                        "[flows] validate_workflow: graph passed structural validation but \
+                         failed to migrate/deserialize for gate checks; failing closed"
+                    );
+                    (
+                        vec![format!(
+                            "hard gates could not run: graph failed to migrate/deserialize ({e})"
+                        )],
+                        true,
+                    )
+                }
             }
         } else {
-            Vec::new()
+            (Vec::new(), false)
         };
 
-        let ok = validation.valid && gate_errors.is_empty();
+        let ok = validate_workflow_report_is_ok(validation.valid, &gate_errors, gate_check_failed);
         let report = json!({
             "ok": ok,
             "structurally_valid": validation.valid,
@@ -820,6 +877,21 @@ impl Tool for ValidateWorkflowTool {
         });
         Ok(ToolResult::success(serde_json::to_string_pretty(&report)?))
     }
+}
+
+/// `validate_workflow`'s aggregate verdict (T-m4): `ok` must be true only when
+/// the graph is structurally valid, every hard gate ran, AND every hard gate
+/// passed. Pulled out as a pure function so the fail-closed invariant — a
+/// gate-check failure (e.g. a migrate/deserialize error) must never be
+/// reported as `ok: true` — is unit-testable independent of the async gate
+/// execution and the (currently unreachable, pending future per-node schema
+/// migrations) path that produces `gate_check_failed`.
+fn validate_workflow_report_is_ok(
+    structurally_valid: bool,
+    gate_errors: &[String],
+    gate_check_failed: bool,
+) -> bool {
+    structurally_valid && gate_errors.is_empty() && !gate_check_failed
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1181,22 +1253,66 @@ impl Tool for CreateWorkflowTool {
         };
 
         // Force born-disabled: enable stays human-only, even for a manual-trigger
-        // graph that flows_create would otherwise create enabled.
+        // graph that flows_create would otherwise create enabled. `flows_create`
+        // and this force-disable are two separate writes — not one transaction —
+        // so there is necessarily a brief window between them where the row is
+        // persisted `enabled: true` before this call disables it. This fix does
+        // not close that window; it only stops MISREPORTING the outcome when the
+        // disable itself fails.
+        //
+        // T-m3: `flows_set_enabled(.., false)` can fail (store error, flow
+        // deleted concurrently, …). That used to be only `warn!`-logged while
+        // the response unconditionally claimed `"enabled": false` — so a
+        // manual-trigger flow that flows_create left enabled would stay
+        // enabled while the agent told the user it was disabled. Track the
+        // real post-attempt state and report THAT.
+        let mut disable_succeeded = true;
         if flow.enabled {
-            if let Err(e) = ops::flows_set_enabled(&self.config, &flow.id, false).await {
-                tracing::warn!(target: "flows", flow_id = %flow.id, error = %e, "[flows] create_workflow: could not force-disable the new flow");
+            match ops::flows_set_enabled(&self.config, &flow.id, false).await {
+                Ok(_) => {}
+                Err(e) => {
+                    disable_succeeded = false;
+                    tracing::warn!(
+                        target: "flows",
+                        flow_id = %flow.id,
+                        error = %e,
+                        "[flows] create_workflow: could not force-disable the new flow — it \
+                         remains ENABLED; reporting the true state, not the intended one"
+                    );
+                }
             }
         }
+        let (enabled, note) = create_workflow_report(flow.enabled, disable_succeeded);
 
         Ok(ToolResult::success(serde_json::to_string_pretty(&json!({
             "type": "workflow_created",
             "flow_id": flow.id,
             "name": flow.name,
-            "enabled": false,
+            "enabled": enabled,
             "require_approval": flow.require_approval,
-            "note": "Flow created DISABLED. The user must enable it explicitly before it can run.",
+            "note": note,
         }))?))
     }
+}
+
+/// `create_workflow`'s reported `enabled` state + note (T-m3): derived from
+/// whether the flow was born enabled (`born_enabled`, from `flows_create`'s
+/// Rule 1) and whether the subsequent force-disable attempt succeeded
+/// (`disable_succeeded`, ignored when no attempt was made). Pulled out as a
+/// pure function so the fail-HONEST invariant — the response must reflect
+/// the flow's real post-attempt state, not the intended one — is
+/// unit-testable without forcing a genuine concurrent store failure between
+/// `flows_create` and `flows_set_enabled`.
+fn create_workflow_report(born_enabled: bool, disable_succeeded: bool) -> (bool, &'static str) {
+    let enabled = born_enabled && !disable_succeeded;
+    let note = if enabled {
+        "Flow created, but it could NOT be force-disabled (see the tool result for the \
+         underlying error) — it is currently ENABLED. Tell the user and ask them to disable it \
+         manually if that was not intended."
+    } else {
+        "Flow created DISABLED. The user must enable it explicitly before it can run."
+    };
+    (enabled, note)
 }
 
 /// `duplicate_flow`: create an independent, DISABLED copy of a saved flow — the
@@ -2229,6 +2345,20 @@ impl Tool for GetToolOutputSampleTool {
         PermissionLevel::ReadOnly
     }
 
+    // T-m8: this DOES perform a real outbound Composio network call (see the
+    // struct doc's B12 carve-out) despite declaring `external_effect() ==
+    // false` — that is deliberate, not an oversight, and it never parks for
+    // approval as a result. `external_effect` gates on WORLD-MUTATING
+    // effects (a message sent, a record created/updated/deleted) that the
+    // approval system exists to keep a human in the loop for; a probe here
+    // is hard-restricted, independent of the approval gate, to Read-scope
+    // actions only (`probe_tool_output_sample`'s own scope check, which
+    // ignores the user's toggled write/admin scope preference) against a
+    // toolkit the user has ALREADY connected — so there is nothing for a
+    // human to approve: no side effect this call could possibly produce is
+    // one the user hasn't already consented to by connecting the toolkit.
+    // "Real network call" and "external_effect" are answering different
+    // questions here on purpose.
     fn external_effect(&self) -> bool {
         false
     }

--- a/src/openhuman/flows/builder_tools.rs
+++ b/src/openhuman/flows/builder_tools.rs
@@ -1,32 +1,50 @@
 //! Agent tool belt for the `workflow-builder` specialist (Phase 5b).
 //!
 //! These tools give the `workflow-builder` agent (see
-//! `agent_registry/agents/workflow_builder/`) a **deliberately narrow**,
-//! propose-or-read surface for authoring tinyflows [`WorkflowGraph`]s in chat:
+//! `agent_registry/agents/workflow_builder/`) its full authoring surface for
+//! tinyflows [`WorkflowGraph`]s in chat — 22 tools spanning propose-only
+//! validation, in-place draft mutation, live reads, one bounded real Composio
+//! call, run control, and persistence:
 //!
-//! | Tool                    | Permission              | Effect                                    |
-//! | ----------------------- | ----------------------- | ----------------------------------------- |
-//! | [`ReviseWorkflowTool`]  | `None`                  | validate a revised draft → proposal       |
-//! | [`ListFlowsTool`]       | `None`                  | read: list saved flows                    |
-//! | [`GetFlowTool`]         | `None`                  | read: fetch a saved flow's graph          |
-//! | [`GetFlowRunTool`]      | `None`                  | read: fetch a run's steps                 |
-//! | [`ListFlowConnectionsTool`] | `None`              | read: connection refs (ids/names only)    |
-//! | [`SearchToolCatalogTool`]   | `None`              | read: real Composio tool slugs (live catalog) |
-//! | [`GetToolContractTool`]     | `None`              | read: one action's FULL live contract     |
-//! | [`GetToolOutputSampleTool`] | `ReadOnly`          | ONE bounded real Composio call (Read-scope only, connected toolkit only) |
-//! | [`ListAgentProfilesTool`]   | `None`              | read: selectable agent kinds (`agent_ref`)|
-//! | [`DryRunWorkflowTool`]  | `Execute` (tier-gated)  | run a *draft* against MOCK capabilities   |
-//! | [`SaveWorkflowTool`]    | `Write`                 | persist a graph onto an EXISTING flow     |
+//! | Tool                             | Permission | Effect                                                        |
+//! | --------------------------------- | ---------- | ---------------------------------------------------------------- |
+//! | [`ReviseWorkflowTool`]            | `None`     | validate a revised draft → proposal (never persists)              |
+//! | [`EditWorkflowTool`]              | `None`     | mutate a draft in place (`add_node`/`remove_edge`/…) — never saves |
+//! | [`ValidateWorkflowTool`]          | `None`     | read: run the full gate stack without emitting a proposal card    |
+//! | [`GetFlowHistoryTool`]            | `None`     | read: a saved flow's prior graph snapshots                        |
+//! | [`ListFlowRunsTool`]              | `None`     | read: a flow's run history                                        |
+//! | [`ResumeFlowRunTool`]             | `Execute`  | advance a run parked on approval — approved nodes fire for real   |
+//! | [`CancelFlowRunTool`]             | `Write`    | stop an in-flight/parked run; fires no new outbound effect        |
+//! | [`CreateWorkflowTool`]            | `Write`    | persist a NEW flow — always born **DISABLED**                     |
+//! | [`DuplicateFlowTool`]             | `Write`    | clone a saved flow — the copy is always born **DISABLED**         |
+//! | [`ListConnectableToolkitsTool`]   | `None`     | read: which toolkits are already connected                        |
+//! | [`ListFlowsTool`]                 | `None`     | read: list saved flows                                            |
+//! | [`GetFlowTool`]                   | `None`     | read: fetch a saved flow's graph                                  |
+//! | [`GetFlowRunTool`]                | `None`     | read: fetch a run's steps                                         |
+//! | [`ListFlowConnectionsTool`]       | `None`     | read: connection refs (ids/names only)                            |
+//! | [`SearchToolCatalogTool`]         | `None`     | read: real Composio tool slugs (live catalog)                     |
+//! | [`GetToolContractTool`]           | `None`     | read: one action's FULL live contract                             |
+//! | [`GetToolOutputSampleTool`]       | `ReadOnly` | ONE bounded real Composio call (Read-scope only, connected toolkit only) |
+//! | [`ListAgentProfilesTool`]         | `None`     | read: selectable agent kinds (`agent_ref`)                        |
+//! | [`ListNodeKindsTool`]             | `None`     | read: the DSL's node kinds                                        |
+//! | [`GetNodeKindContractTool`]       | `None`     | read: one node kind's config/port/example/gotcha contract         |
+//! | [`DryRunWorkflowTool`]            | `None`     | run a *draft* against MOCK capabilities — not tier-gated (F7)     |
+//! | [`SaveWorkflowTool`]              | `Write`    | persist a graph onto an EXISTING flow                              |
 //!
-//! **Human-in-the-loop invariant (shared with [`super::tools::ProposeWorkflowTool`]),
-//! with one deliberate carve-out:** `revise_workflow` only validates and
-//! returns a proposal payload (identical contract to `propose_workflow`); the
-//! read tools are pure reads; `dry_run_workflow` executes against `tinyflows`'
-//! deterministic **mock** capabilities so no real LLM / tool / HTTP / code side
-//! effect can fire. The carve-out is [`SaveWorkflowTool`]: it persists a graph
-//! onto a flow that ALREADY exists (the Flows prompt bar's instant-create path
-//! makes the flow first and hands the agent its id) — but the agent still
-//! cannot *create* a flow, and never touches `enabled`/`require_approval`.
+//! **Human-in-the-loop invariant.** Enabling a flow is not a tool this agent
+//! has, by design, no matter which tool above it reaches for:
+//! [`CreateWorkflowTool`] and [`DuplicateFlowTool`] always produce a
+//! **DISABLED** flow, and [`SaveWorkflowTool`] never sets
+//! `enabled`/`require_approval` (it CAN auto-disable an already-enabled flow
+//! when the graph's trigger transitions from manual to automatic — see its
+//! own doc). `revise_workflow` / `edit_workflow` / `validate_workflow` only
+//! validate or mutate a draft and never persist. `dry_run_workflow` executes
+//! only against `tinyflows`' deterministic **mock** capabilities, so no real
+//! LLM / tool / HTTP / code side effect can fire from it regardless of tier
+//! (F7 — it is deliberately NOT tier-gated; see its own doc).
+//! [`ResumeFlowRunTool`] is the one place a non-persistence tool can cause a
+//! real effect: resuming a parked run lets its already-approved nodes fire,
+//! which is why it is `Execute`-gated rather than `None`/`Write`.
 //!
 //! The agent's full tool scope (see `agent_registry/agents/workflow_builder/
 //! agent.toml`) also grants the Composio **discovery/connect** tools —
@@ -56,7 +74,6 @@ use crate::openhuman::config::Config;
 use crate::openhuman::flows::ops;
 use crate::openhuman::flows::ops::validate_and_migrate_graph;
 use crate::openhuman::flows::tools;
-use crate::openhuman::security::SecurityPolicy;
 use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult};
 
 /// Wall-clock bound on a single `dry_run_workflow` mock execution. A malformed
@@ -2496,7 +2513,7 @@ impl Tool for GetNodeKindContractTool {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// dry_run_workflow — execute a DRAFT against MOCK capabilities (tier-gated)
+// dry_run_workflow — execute a DRAFT against MOCK capabilities (ungated, F7)
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// `dry_run_workflow`: compile a **draft** graph and run it against tinyflows'
@@ -2508,9 +2525,16 @@ impl Tool for GetNodeKindContractTool {
 /// capabilities are echo stubs, so nothing external ever fires regardless of
 /// the graph. The output is explicitly labeled `sandbox: true`.
 ///
-/// Autonomy-tier gated (issue: Phase 2 node gating): read-only tier refuses,
-/// mirroring the `SecurityPolicy` contract that a read-only session cannot
-/// exercise executable capability even in simulation.
+/// **Not autonomy-tier gated (F7):** `permission_level()` returns
+/// [`PermissionLevel::None`], so this tool runs on EVERY tier, read-only
+/// included — a read-only agent must be able to self-verify its own proposal.
+/// This is intentional, not an oversight: the mock capabilities never touch a
+/// real integration, so there is nothing for a tier gate to protect. See
+/// `dry_run_allowed_under_readonly_tier` in `builder_tools_tests.rs` for the
+/// pinned regression (an earlier draft of this tool *was* tier-gated via an
+/// unused `SecurityPolicy` field; the field was dead code by the time it
+/// shipped and was removed rather than wired up, since side-effect-free
+/// simulation has no tier to gate against).
 ///
 /// **Wiring preflight:** the mock tool invoker is wrapped in the host's
 /// [`PreflightToolInvoker`](crate::openhuman::tinyflows::caps::PreflightToolInvoker),
@@ -2684,13 +2708,12 @@ fn tool_call_arg_null_entries(
 }
 
 pub struct DryRunWorkflowTool {
-    security: Arc<SecurityPolicy>,
     config: Arc<Config>,
 }
 
 impl DryRunWorkflowTool {
-    pub fn new(security: Arc<SecurityPolicy>, config: Arc<Config>) -> Self {
-        Self { security, config }
+    pub fn new(config: Arc<Config>) -> Self {
+        Self { config }
     }
 }
 
@@ -3272,16 +3295,24 @@ impl CapturingObserver {
 /// an **existing, already-saved** flow via [`ops::flows_update`] — the same
 /// validate-and-migrate path the UI's Save uses.
 ///
-/// This is the deliberate, narrow exception to the belt's original
-/// "propose, never persist" invariant (added for the Flows prompt bar's
-/// instant-create path, where the host creates the flow *before* delegating and
-/// hands the agent its `flow_id`). The boundaries that remain:
+/// It was originally added as a narrow, deliberate exception to the belt's
+/// "propose, never persist" invariant (for the Flows prompt bar's
+/// instant-create path, where the host creates the flow *before* delegating
+/// and hands the agent its `flow_id`) — before [`CreateWorkflowTool`] and
+/// [`DuplicateFlowTool`] existed, this was the belt's only write. Both now
+/// exist, so `save_workflow` is one of three persistence tools, not the sole
+/// one. Its own remaining boundaries:
 ///
-/// - **Update-only.** It requires an existing `flow_id`; there is still no tool
-///   to *create* a flow, so the agent can only write where the host (or user)
-///   already made a flow.
+/// - **Update-only.** It requires an existing `flow_id`; it never fabricates
+///   one. Creating a flow is [`CreateWorkflowTool`]/[`DuplicateFlowTool`]'s
+///   job — `save_workflow` can only write onto a flow that already exists
+///   (whether the host, the user, or an earlier `create_workflow`/
+///   `duplicate_flow` call made it).
 /// - **Never touches enablement or the approval gate.** `enabled` and
-///   `require_approval` are not parameters; whatever the user set stays.
+///   `require_approval` are not parameters; whatever the user set stays —
+///   except that saving a graph whose trigger just transitioned from manual
+///   to automatic on an already-enabled flow auto-disables it (see
+///   [`ops::flows_update`]'s own doc for that guard).
 /// - **Real persistence, real consequences.** Saving a `schedule`/`app_event`
 ///   trigger onto an ENABLED flow arms it (the trigger binds and will fire on
 ///   its own) — hence `PermissionLevel::Write`. The description tells the agent

--- a/src/openhuman/flows/builder_tools_tests.rs
+++ b/src/openhuman/flows/builder_tools_tests.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::openhuman::config::Config;
-use crate::openhuman::security::{AutonomyLevel, SecurityPolicy};
 use serde_json::json;
 use tempfile::TempDir;
 
@@ -13,13 +12,6 @@ fn test_config(tmp: &TempDir) -> Arc<Config> {
     };
     std::fs::create_dir_all(&config.workspace_dir).unwrap();
     Arc::new(config)
-}
-
-fn policy(level: AutonomyLevel) -> Arc<SecurityPolicy> {
-    Arc::new(SecurityPolicy {
-        autonomy: level,
-        ..SecurityPolicy::default()
-    })
 }
 
 fn valid_graph() -> Value {
@@ -820,10 +812,7 @@ async fn get_tool_output_sample_refuses_an_unconnected_toolkit() {
 
 #[test]
 fn dry_run_is_side_effect_free_and_ungated() {
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     assert_eq!(tool.name(), "dry_run_workflow");
     // Mock-only + side-effect-free → PermissionLevel::None, available on every
     // tier including read-only (audit F7).
@@ -835,10 +824,7 @@ fn dry_run_is_side_effect_free_and_ungated() {
 async fn dry_run_allowed_under_readonly_tier() {
     // F7: dry_run is mock-only and side-effect-free, so a read-only agent must
     // be able to self-verify its own proposal (previously refused).
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::ReadOnly),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     assert_eq!(tool.permission_level(), PermissionLevel::None);
     let result = tool
         .execute(json!({ "graph": valid_graph() }))
@@ -851,10 +837,7 @@ async fn dry_run_allowed_under_readonly_tier() {
 
 #[tokio::test]
 async fn dry_run_supervised_runs_against_mock_and_labels_sandbox() {
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let result = tool
         .execute(json!({ "graph": valid_graph(), "input": { "x": 1 } }))
         .await
@@ -878,10 +861,7 @@ async fn dry_run_exercises_agent_ref_node_via_mock_agent_runner() {
     // capability; now `mock_capabilities_with_agent(MockAgentRunner)` echoes the
     // ref and the dry run goes green — proving the builder can self-test drafts
     // that use agent-kind nodes.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -913,10 +893,7 @@ async fn dry_run_plain_agent_with_output_parser_schema_is_green() {
     // validation after auto-fix: missing required property ...`, sinking a
     // correctly-built graph. Now the mock LLM synthesizes a schema-valid object,
     // and a downstream node binds the typed placeholders (non-null).
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Schedule",
@@ -977,10 +954,7 @@ async fn dry_run_plain_agent_with_output_parser_schema_is_green() {
 
 #[tokio::test]
 async fn dry_run_invalid_graph_is_error() {
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Full),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let result = tool
         .execute(json!({ "graph": { "nodes": [], "edges": [] } }))
         .await
@@ -997,7 +971,7 @@ async fn dry_run_catches_unwired_required_composio_arg() {
     seed_live_catalog_cache("gmail", vec![seeded_gmail_send_contract()]);
 
     let tmp = TempDir::new().unwrap();
-    let tool = DryRunWorkflowTool::new(policy(AutonomyLevel::Supervised), test_config(&tmp));
+    let tool = DryRunWorkflowTool::new(test_config(&tmp));
 
     let graph_with = |args: Value| {
         json!({
@@ -1049,10 +1023,7 @@ async fn dry_run_flags_tool_call_arg_null_resolved_from_unschemad_agent() {
     // The `summarize` agent has no `output_parser.schema`, so (via the
     // schema-aware mock agent) its structured output has no `channel` field —
     // the exact "builds but does nothing" shape this check exists to catch.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1116,10 +1087,7 @@ async fn dry_run_flags_composio_upstream_binding_as_unverifiable_not_a_wiring_bu
     // process-global catalog cache other tests seed for gmail/slack/etc.
     seed_live_catalog_cache("ws6up", vec![seeded_ws6_contract("WS6UP_LOOKUP", "ws6up")]);
     seed_live_catalog_cache("ws6dl", vec![seeded_ws6_contract("WS6DL_SEND", "ws6dl")]);
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1166,10 +1134,7 @@ async fn dry_run_keeps_generic_null_text_for_a_non_tool_call_upstream_binding() 
     // `unverifiable` flag — so the honest-uncertainty treatment doesn't leak
     // onto real mistakes.
     seed_live_catalog_cache("ws6dl", vec![seeded_ws6_contract("WS6DL_SEND", "ws6dl")]);
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1213,10 +1178,7 @@ async fn dry_run_passes_when_agent_schema_matches_tool_call_binding() {
     // always echoes `{ agent, request, connection }` regardless of schema)
     // this would incorrectly fail — proving the mock is what makes the check
     // accurate rather than perpetually red for correctly-built graphs.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1252,10 +1214,7 @@ async fn dry_run_passes_when_agent_schema_matches_tool_call_binding() {
 async fn dry_run_passes_when_tool_call_binds_to_upstream_tool_output() {
     // A `tool_call` binding to another `tool_call`'s real output (not an
     // agent at all) must not be affected by the agent-schema machinery above.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1301,10 +1260,7 @@ async fn dry_run_flags_tool_call_error_when_on_error_is_route() {
     // `dry_run_passes_when_tool_call_binds_to_upstream_tool_output` above.
     seed_live_catalog_cache("gmail", vec![seeded_gmail_send_contract()]);
 
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1347,10 +1303,7 @@ async fn dry_run_flags_tool_call_error_when_on_error_is_continue() {
     // converts a node failure into routed data instead of failing the run.
     seed_live_catalog_cache("gmail", vec![seeded_gmail_send_contract()]);
 
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1384,10 +1337,7 @@ async fn dry_run_passes_when_agent_enum_schema_binds_to_tool_call() {
     // must synthesize an ALLOWED value (not a generic `""` placeholder, which
     // would fail the vendored validator's `enum` check) so a correctly-built
     // graph using an enum schema dry-runs green instead of false-positiving.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1426,10 +1376,7 @@ async fn dry_run_flags_null_resolved_agent_prompt() {
     // vendored engine's own `resolve_traced` records it as a null resolution
     // at `location: "prompt"`, meaning the agent would run with an EMPTY
     // prompt. Unlike other agent-config nulls, this one must fail the dry run.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1477,10 +1424,7 @@ async fn dry_run_flags_null_resolved_agent_input_context() {
     // since #4590, so a null-resolved `input_context` is just as
     // execution-breaking as a null `prompt` — the agent runs with no
     // upstream data at all. Must fail the dry run the same way.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1518,10 +1462,7 @@ async fn dry_run_passes_when_agent_uses_input_context_instead_of_prompt_expressi
     // The FALSE-POSITIVE-PREVENTION case: the same data need, wired the
     // correct way — `input_context` carries the upstream item, `prompt`
     // stays a plain instruction with no leading `=`. This must dry-run green.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1560,10 +1501,7 @@ async fn dry_run_warns_on_unexercised_agent_after_condition() {
     // could easily carry `active: true` and take the other branch, so the
     // dry run must still surface this as a warning even though `ok` stays
     // `true` — there's nothing here that flips it to a hard reject.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -1604,10 +1542,7 @@ async fn dry_run_warns_on_unexercised_agent_after_condition() {
 async fn dry_run_no_routing_divergence_warning_when_every_node_executes() {
     // FALSE-POSITIVE-PREVENTION: a condition whose taken branch under the
     // default mock input DOES reach the downstream agent must not warn.
-    let tool = DryRunWorkflowTool::new(
-        policy(AutonomyLevel::Supervised),
-        test_config(&TempDir::new().unwrap()),
-    );
+    let tool = DryRunWorkflowTool::new(test_config(&TempDir::new().unwrap()));
     let graph = json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -2658,7 +2593,7 @@ async fn dry_run_workflow_by_flow_id_runs_the_saved_flow_graph() {
         .await
         .unwrap()
         .value;
-    let tool = DryRunWorkflowTool::new(policy(AutonomyLevel::Supervised), config.clone());
+    let tool = DryRunWorkflowTool::new(config.clone());
     let result = tool.execute(json!({ "flow_id": flow.id })).await.unwrap();
     assert!(!result.is_error, "{}", result.output());
     let parsed: Value = serde_json::from_str(&result.output()).unwrap();
@@ -2731,4 +2666,63 @@ async fn revise_workflow_proposal_is_marked_unpersisted() {
     assert!(!result.is_error, "{}", result.output());
     let parsed: Value = serde_json::from_str(&result.output()).unwrap();
     assert_eq!(parsed["persisted"], false);
+}
+
+/// Docs-drift guard (T-m2): the top-of-file module doc table went stale
+/// enough to list 11 of ~22 tools, mis-describe `DryRunWorkflowTool`'s
+/// permission, and claim a `create_workflow`-adjacent invariant the code
+/// didn't hold — all silently, because nothing checked the table against the
+/// actual `impl Tool for` list. This mirrors the pattern
+/// `propose_workflow_description_matches_typed_node_contracts`
+/// (`tools_tests.rs`) established for node-kind contracts: derive the ground
+/// truth from the SAME source file rather than hardcoding a second list here
+/// (a hardcoded list would just be a new place to go stale), and fail loudly
+/// in both directions — a real tool missing from the table, or a table entry
+/// naming a tool that no longer exists.
+#[test]
+fn module_doc_tool_table_matches_registered_tools() {
+    const SOURCE: &str = include_str!("builder_tools.rs");
+
+    let module_doc: String = SOURCE
+        .lines()
+        .filter(|line| line.trim_start().starts_with("//!"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !module_doc.is_empty(),
+        "sanity: expected builder_tools.rs to carry a top-of-file `//!` module doc"
+    );
+
+    let impl_re = regex::Regex::new(r"impl Tool for (\w+)\s*\{").expect("valid regex");
+    let registered: std::collections::BTreeSet<String> = impl_re
+        .captures_iter(SOURCE)
+        .map(|c| c[1].to_string())
+        .collect();
+    assert!(
+        !registered.is_empty(),
+        "sanity: expected at least one `impl Tool for` in builder_tools.rs"
+    );
+
+    for tool in &registered {
+        assert!(
+            module_doc.contains(tool.as_str()),
+            "module doc table is missing `{tool}` — every `impl Tool for` in this file \
+             must be listed in the top-of-file doc table (T-m2)"
+        );
+    }
+
+    // The reverse direction: every `[`FooTool`]` reference in the doc must
+    // name a tool that actually still exists, so a removed/renamed tool
+    // can't leave a stale row behind.
+    let doc_ref_re = regex::Regex::new(r"\[`(\w+)`\]").expect("valid regex");
+    for cap in doc_ref_re.captures_iter(&module_doc) {
+        let name: &str = &cap[1];
+        if name.ends_with("Tool") {
+            assert!(
+                registered.contains(name),
+                "module doc table references `{name}`, but no `impl Tool for {name}` exists \
+                 in this file — the doc table has a stale entry"
+            );
+        }
+    }
 }

--- a/src/openhuman/flows/builder_tools_tests.rs
+++ b/src/openhuman/flows/builder_tools_tests.rs
@@ -2395,6 +2395,35 @@ async fn validate_workflow_requires_a_base() {
     assert!(result.output().contains("flow_id"));
 }
 
+// T-m4: a gate-check failure (e.g. a migrate/deserialize error surfaced after
+// structural validation passed) must fail CLOSED — `ok` must never be true
+// when the hard gates did not actually run. Regression test for the bug
+// where `Err(_) => Vec::new()` let an empty `gate_errors` masquerade as
+// "gates passed".
+#[test]
+fn validate_workflow_report_fails_closed_when_gate_check_errors() {
+    assert!(!validate_workflow_report_is_ok(true, &[], true));
+}
+
+#[test]
+fn validate_workflow_report_ok_when_structurally_valid_and_gates_pass() {
+    assert!(validate_workflow_report_is_ok(true, &[], false));
+}
+
+#[test]
+fn validate_workflow_report_not_ok_when_structurally_invalid() {
+    assert!(!validate_workflow_report_is_ok(false, &[], false));
+}
+
+#[test]
+fn validate_workflow_report_not_ok_when_gate_errors_present() {
+    assert!(!validate_workflow_report_is_ok(
+        true,
+        &["unresolvable binding".to_string()],
+        false
+    ));
+}
+
 #[tokio::test]
 async fn edit_workflow_edits_a_draft_and_writes_back() {
     use crate::openhuman::flows::DraftOrigin;
@@ -2430,6 +2459,74 @@ async fn edit_workflow_edits_a_draft_and_writes_back() {
     assert_eq!(reloaded.graph["nodes"].as_array().unwrap().len(), 3);
 }
 
+// T-m6: when the draft write-back itself fails (here: a genuine permission
+// denial on the drafts dir, not a mock), the response must surface the
+// failure instead of claiming "Edits live on draft {id}" — the exact
+// wording that used to ship regardless of whether the write actually landed.
+#[cfg(unix)]
+#[tokio::test]
+async fn edit_workflow_surfaces_draft_write_back_failure() {
+    use crate::openhuman::flows::DraftOrigin;
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    let draft = ops::flows_draft_create(
+        &config,
+        None,
+        "Draft flow".to_string(),
+        valid_graph(),
+        DraftOrigin::Chat,
+    )
+    .unwrap()
+    .value;
+
+    // Force the final `flows_draft_update` write to genuinely fail: strip
+    // write permission from the drafts dir after the draft file already
+    // exists in it (create_dir_all is a no-op; the write of the new tmp
+    // file inside it is what fails).
+    let drafts_dir = config.workspace_dir.join("flows").join("drafts");
+    std::fs::set_permissions(&drafts_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
+    let probe = drafts_dir.join(".write_probe");
+    let write_is_blocked = std::fs::write(&probe, b"x").is_err();
+    let _ = std::fs::remove_file(&probe);
+    if !write_is_blocked {
+        // Running as root — permissions are ignored, assertion is moot.
+        std::fs::set_permissions(&drafts_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+        return;
+    }
+
+    let tool = EditWorkflowTool::new(config.clone());
+    let result = tool
+        .execute(json!({
+            "draft_id": draft.id,
+            "ops": [ { "op": "add_node", "node": { "id": "b", "kind": "merge", "name": "Join" } } ]
+        }))
+        .await
+        .unwrap();
+
+    // Restore so the tempdir can be cleaned up.
+    std::fs::set_permissions(&drafts_dir, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    assert!(result.is_error, "{}", result.output());
+    assert!(
+        !result.output().contains("Edits live on draft"),
+        "must not claim the edit landed on the draft when the write-back failed: {}",
+        result.output()
+    );
+    assert!(
+        result.output().contains("PREVIOUS graph"),
+        "{}",
+        result.output()
+    );
+
+    // The draft on disk still holds the original (pre-edit) graph — the
+    // write genuinely never landed.
+    let reloaded = ops::flows_draft_get(&config, &draft.id).unwrap().value;
+    assert_eq!(reloaded.graph["nodes"].as_array().unwrap().len(), 2);
+}
+
 // ── Phase 4: gated create / duplicate / debug loop (F4) ──────────────────────
 
 #[tokio::test]
@@ -2451,6 +2548,38 @@ async fn create_workflow_creates_a_disabled_flow() {
     let flow_id = parsed["flow_id"].as_str().unwrap();
     let flow = ops::flows_get(&config, flow_id).await.unwrap().value;
     assert!(!flow.enabled, "agent-created flows are born disabled");
+}
+
+// T-m3: when the force-disable write itself fails, the response must
+// report the flow's REAL state (still enabled) rather than unconditionally
+// claiming "enabled": false. Exercised directly on the pure decision
+// function `create_workflow_report` — reaching the true failure via a
+// genuine concurrent store error would need a test-only seam inside
+// `execute()` that production code shouldn't carry.
+#[test]
+fn create_workflow_report_is_honest_when_force_disable_fails() {
+    let (enabled, note) = create_workflow_report(true, false);
+    assert!(enabled, "must report the flow as still enabled");
+    assert!(
+        note.contains("ENABLED"),
+        "note must surface the real state, not the intended DISABLED one: {note}"
+    );
+}
+
+#[test]
+fn create_workflow_report_reports_disabled_on_success() {
+    let (enabled, note) = create_workflow_report(true, true);
+    assert!(!enabled);
+    assert!(note.contains("DISABLED"));
+}
+
+#[test]
+fn create_workflow_report_never_attempted_disable_stays_disabled() {
+    // born_enabled = false: flows_create already created it disabled
+    // (e.g. an automatic-trigger graph), so no force-disable is attempted.
+    let (enabled, note) = create_workflow_report(false, true);
+    assert!(!enabled);
+    assert!(note.contains("DISABLED"));
 }
 
 #[tokio::test]

--- a/src/openhuman/flows/memory_tools.rs
+++ b/src/openhuman/flows/memory_tools.rs
@@ -247,13 +247,18 @@ impl Tool for FlowMemoryRecallTool {
     }
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
-        let query = args
-            .get("query")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| anyhow::anyhow!("Missing 'query' parameter"))?
-            .trim();
+        // T-m5: input-validation problems report via `ToolResult::error`
+        // uniformly (never `Err(anyhow!)`) — matching every other tool on
+        // this belt (recall's own scope-error arms below, remember's
+        // flow_id/key checks). An `Err` return surfaces to the model as a
+        // hard tool-invocation failure rather than a normal tool result the
+        // agent can read and react to in-turn.
+        let query = match args.get("query").and_then(|v| v.as_str()) {
+            Some(q) => q.trim(),
+            None => return Ok(ToolResult::error("Missing 'query' parameter".to_string())),
+        };
         if query.is_empty() {
-            return Err(anyhow::anyhow!("query cannot be empty"));
+            return Ok(ToolResult::error("query cannot be empty".to_string()));
         }
 
         let flow_id_arg = args.get("flow_id").and_then(|v| v.as_str()).map(str::trim);
@@ -275,10 +280,11 @@ impl Tool for FlowMemoryRecallTool {
                 trusted_id.clone()
             }
             None => {
-                let arg =
-                    flow_id_arg.ok_or_else(|| anyhow::anyhow!("Missing 'flow_id' parameter"))?;
+                let Some(arg) = flow_id_arg else {
+                    return Ok(ToolResult::error("Missing 'flow_id' parameter".to_string()));
+                };
                 if arg.is_empty() {
-                    return Err(anyhow::anyhow!("flow_id cannot be empty"));
+                    return Ok(ToolResult::error("flow_id cannot be empty".to_string()));
                 }
                 arg.to_string()
             }
@@ -382,15 +388,15 @@ impl Tool for FlowMemoryRememberTool {
     }
 
     async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult> {
+        // T-m5: uniform `ToolResult::error` for input-validation problems —
+        // see the matching note on `FlowMemoryRecallTool::execute`.
         let flow_id_arg = args.get("flow_id").and_then(|v| v.as_str());
-        let key = args
-            .get("key")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| anyhow::anyhow!("Missing 'key' parameter"))?;
-        let content = args
-            .get("content")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| anyhow::anyhow!("Missing 'content' parameter"))?;
+        let Some(key) = args.get("key").and_then(|v| v.as_str()) else {
+            return Ok(ToolResult::error("Missing 'key' parameter".to_string()));
+        };
+        let Some(content) = args.get("content").and_then(|v| v.as_str()) else {
+            return Ok(ToolResult::error("Missing 'content' parameter".to_string()));
+        };
 
         let category = match args.get("category").and_then(|v| v.as_str()) {
             Some("core") | None => MemoryCategory::Core,
@@ -429,8 +435,9 @@ impl Tool for FlowMemoryRememberTool {
                 trusted_id.clone()
             }
             None => {
-                let arg =
-                    flow_id_arg.ok_or_else(|| anyhow::anyhow!("Missing 'flow_id' parameter"))?;
+                let Some(arg) = flow_id_arg else {
+                    return Ok(ToolResult::error("Missing 'flow_id' parameter".to_string()));
+                };
                 let trimmed = arg.trim();
                 if trimmed.is_empty() {
                     return Ok(ToolResult::error("flow_id cannot be empty".to_string()));
@@ -633,20 +640,27 @@ mod tests {
         assert!(result.output().contains("Found 2"));
     }
 
+    // T-m5: a missing/invalid input param reports via `ToolResult::error`
+    // (an `Ok(..)` the model can read and react to in-turn), never
+    // `Err(anyhow!)` (a hard tool-invocation failure) — matching every other
+    // input-validation problem on this belt (see the scope/empty-value
+    // tests above, which already used this channel before the fix).
     #[tokio::test]
     async fn recall_missing_query_errs() {
         let (_tmp, mem) = test_mem();
         let tool = FlowMemoryRecallTool::new(mem);
-        let result = tool.execute(json!({"flow_id": "f1"})).await;
-        assert!(result.is_err());
+        let result = tool.execute(json!({"flow_id": "f1"})).await.unwrap();
+        assert!(result.is_error);
+        assert!(result.output().contains("Missing 'query'"));
     }
 
     #[tokio::test]
     async fn recall_missing_flow_id_errs() {
         let (_tmp, mem) = test_mem();
         let tool = FlowMemoryRecallTool::new(mem);
-        let result = tool.execute(json!({"query": "anything"})).await;
-        assert!(result.is_err());
+        let result = tool.execute(json!({"query": "anything"})).await.unwrap();
+        assert!(result.is_error);
+        assert!(result.output().contains("Missing 'flow_id'"));
     }
 
     // ── FlowMemoryRememberTool ──────────────────────────────────────
@@ -784,19 +798,41 @@ mod tests {
             .is_none());
     }
 
+    // T-m5: same channel-consistency fix as recall's missing-param tests
+    // above.
     #[tokio::test]
     async fn remember_missing_flow_id_errs() {
         let (_tmp, mem) = test_mem();
         let tool = FlowMemoryRememberTool::new(mem, test_security());
-        let result = tool.execute(json!({"key": "k", "content": "c"})).await;
-        assert!(result.is_err());
+        let result = tool
+            .execute(json!({"key": "k", "content": "c"}))
+            .await
+            .unwrap();
+        assert!(result.is_error);
+        assert!(result.output().contains("Missing 'flow_id'"));
+    }
+
+    #[tokio::test]
+    async fn remember_missing_key_errs() {
+        let (_tmp, mem) = test_mem();
+        let tool = FlowMemoryRememberTool::new(mem, test_security());
+        let result = tool
+            .execute(json!({"flow_id": "f1", "content": "c"}))
+            .await
+            .unwrap();
+        assert!(result.is_error);
+        assert!(result.output().contains("Missing 'key'"));
     }
 
     #[tokio::test]
     async fn remember_missing_content_errs() {
         let (_tmp, mem) = test_mem();
         let tool = FlowMemoryRememberTool::new(mem, test_security());
-        let result = tool.execute(json!({"flow_id": "f1", "key": "k"})).await;
-        assert!(result.is_err());
+        let result = tool
+            .execute(json!({"flow_id": "f1", "key": "k"}))
+            .await
+            .unwrap();
+        assert!(result.is_error);
+        assert!(result.output().contains("Missing 'content'"));
     }
 }

--- a/src/openhuman/flows/ops.rs
+++ b/src/openhuman/flows/ops.rs
@@ -3886,30 +3886,26 @@ async fn flows_update_inner(
         }
     };
     // B29 Rule 1 analogue: disarm every manual/none → automatic trigger
-    // transition, unconditionally — see the doc comment above for why this
-    // must NOT gate on the (possibly stale) `existing.enabled` read.
-    let was_auto = trigger_is_automatic(&existing.graph);
+    // transition, unconditionally. `now_auto` is safe to compute here (it
+    // only depends on `graph`, THIS call's own incoming graph — never
+    // stale). The "was it automatic before" half of the transition,
+    // however, is NOT decided here: R-m2 found that gating on the
+    // ops-level `existing.graph` read let a concurrent write race this
+    // call and slip an automatic-trigger graph through with `enabled: true`
+    // — `existing` can be arbitrarily stale by the time
+    // `store::update_flow_graph` actually performs its guarded write. That
+    // decision now lives inside `update_flow_graph`, computed against the
+    // row it just re-read there (see its doc comment).
     let now_auto = trigger_is_automatic(&graph);
-    let is_manual_to_auto_transition = now_auto && !was_auto;
     let forced_automatic_disarm = disarm_automatic && now_auto;
-    let enabled_override =
-        (is_manual_to_auto_transition || forced_automatic_disarm).then_some(false);
-    // Best-effort flag for the info log / result message below: whether the
-    // flow *appeared* live going into this update. Not used for the
-    // override decision itself (that's unconditional, see above) — only to
-    // avoid telling the user "flow was auto-disabled" when it was already
-    // disabled going in.
-    let should_disarm = enabled_override == Some(false) && existing.enabled;
     tracing::debug!(
         target: "flows",
         flow_id = %id,
-        was_auto,
         now_auto,
         currently_enabled = existing.enabled,
-        is_manual_to_auto_transition,
         forced_automatic_disarm,
-        should_disarm,
-        "[flows] flows_update: auto-trigger disarm decision inputs"
+        "[flows] flows_update: auto-trigger disarm decision inputs (transition itself decided \
+         store-side against a fresh read, see update_flow_graph)"
     );
 
     // Rule 2 analogue (compound-bypass closure): re-apply the same outbound
@@ -3937,21 +3933,32 @@ async fn flows_update_inner(
         side_effect_forced,
         "[flows] flows_update: persisting changes"
     );
-    // `enabled_override` is threaded into the same guarded UPDATE as the
-    // graph/name/require_approval write (see `store::update_flow_graph`)
-    // rather than a follow-up `flows_set_enabled` call, so the disarm can
-    // never race a concurrent read/write of `enabled`.
+    // The auto-disarm decision (both the unconditional manual→automatic
+    // transition and `disarm_automatic`'s forced-remote-authoring variant)
+    // is made INSIDE `update_flow_graph`, against the row it re-reads right
+    // before its guarded UPDATE — see R-m2 above and that function's doc
+    // comment. `enabled_override: None` here means "no explicit force from
+    // this caller"; the disarm, if any, still applies on top of that.
     let updated = store::update_flow_graph(
         config,
         id,
         new_name,
         graph,
         effective_require_approval,
-        enabled_override,
+        None,
+        disarm_automatic,
         expected_version.as_deref(),
     )
     .map_err(map_flow_update_error)?;
 
+    // Best-effort, POST-write: did the flow actually transition from
+    // enabled to disabled as part of this update? Derived from the real
+    // before/after state (`existing.enabled` vs `updated.enabled`) rather
+    // than re-predicting the decision — the decision itself already
+    // happened store-side against a fresh read, so this is purely for the
+    // info log / result message wording below and can't desync from what
+    // was actually persisted.
+    let should_disarm = now_auto && existing.enabled && !updated.enabled;
     if should_disarm {
         tracing::info!(
             target: "flows",

--- a/src/openhuman/flows/ops_tests.rs
+++ b/src/openhuman/flows/ops_tests.rs
@@ -1648,6 +1648,7 @@ async fn flows_resume_marks_an_incompatible_legacy_checkpoint_failed() {
         structurally_valid_graph(nested_conditional_fan_in_graph()),
         created.value.require_approval,
         None,
+        false,
         None,
     )
     .unwrap();
@@ -1707,6 +1708,7 @@ async fn flows_resume_marks_a_checkpoint_with_an_incompatible_saved_child_failed
         structurally_valid_graph(referenced_child_graph(&child.id)),
         created.value.require_approval,
         None,
+        false,
         None,
     )
     .unwrap();
@@ -6487,6 +6489,7 @@ fn referenced_child_compatibility_stops_at_saved_workflow_cycles() {
         structurally_valid_graph(referenced_child_graph(&flow_b.id)),
         false,
         None,
+        false,
         None,
     )
     .unwrap();
@@ -6497,6 +6500,7 @@ fn referenced_child_compatibility_stops_at_saved_workflow_cycles() {
         structurally_valid_graph(referenced_child_graph(&flow_a.id)),
         false,
         None,
+        false,
         None,
     )
     .unwrap();

--- a/src/openhuman/flows/schemas.rs
+++ b/src/openhuman/flows/schemas.rs
@@ -1759,9 +1759,7 @@ fn handle_draft_update(params: Map<String, Value>) -> ControllerFuture {
             .map_err(|e| format!("invalid 'name': {e}"))?;
         let graph = params.get("graph").filter(|v| !v.is_null()).cloned();
         // A present `flow_id` (even null) re-links the draft; absent leaves it.
-        let flow_id = params
-            .get("flow_id")
-            .map(|v| v.as_str().filter(|s| !s.is_empty()).map(str::to_string));
+        let flow_id = parse_draft_update_flow_id(&params)?;
         to_json(ops::flows_draft_update(
             &config,
             id.trim(),
@@ -1806,6 +1804,38 @@ fn read_required<T: DeserializeOwned>(params: &Map<String, Value>, key: &str) ->
 
 fn to_json<T: serde::Serialize>(outcome: RpcOutcome<T>) -> Result<Value, String> {
     outcome.into_cli_compatible_json()
+}
+
+/// Parses `draft_update`'s `flow_id` param (R-m7). The outer `Option`
+/// mirrors `ops::flows_draft_update`'s "present vs absent" contract — absent
+/// leaves the draft's existing link untouched; the inner `Option` is the new
+/// link (`None` unlinks).
+///
+/// A present-but-non-string `flow_id` (a number, or an object from a buggy
+/// client) is REJECTED rather than silently coerced into `Some(None)` via
+/// `Value::as_str()` returning `None` on a type mismatch — that shape used
+/// to be indistinguishable from an explicit `flow_id: null` unlink, and
+/// `update_draft` treats `Some(None)` as exactly that: unlinking the draft
+/// from its flow. A later `draft_promote` then creates a brand-new flow
+/// instead of updating the one the caller actually meant.
+fn parse_draft_update_flow_id(
+    params: &Map<String, Value>,
+) -> Result<Option<Option<String>>, String> {
+    match params.get("flow_id") {
+        None => Ok(None),
+        Some(Value::Null) => Ok(Some(None)),
+        Some(Value::String(s)) => {
+            let s = s.trim();
+            Ok(Some(if s.is_empty() {
+                None
+            } else {
+                Some(s.to_string())
+            }))
+        }
+        Some(other) => Err(format!(
+            "invalid 'flow_id': expected a string or null, got {other}"
+        )),
+    }
 }
 
 #[cfg(test)]
@@ -2148,5 +2178,56 @@ mod tests {
         let params = Map::new();
         let err = read_required::<String>(&params, "id").unwrap_err();
         assert!(err.contains("missing required param 'id'"));
+    }
+
+    // ── R-m7: parse_draft_update_flow_id ─────────────────────────────────────
+
+    #[test]
+    fn parse_draft_update_flow_id_absent_leaves_link_untouched() {
+        let params = Map::new();
+        assert_eq!(parse_draft_update_flow_id(&params).unwrap(), None);
+    }
+
+    #[test]
+    fn parse_draft_update_flow_id_null_is_an_explicit_unlink() {
+        let mut params = Map::new();
+        params.insert("flow_id".to_string(), Value::Null);
+        assert_eq!(parse_draft_update_flow_id(&params).unwrap(), Some(None));
+    }
+
+    #[test]
+    fn parse_draft_update_flow_id_string_links_to_that_flow() {
+        let mut params = Map::new();
+        params.insert("flow_id".to_string(), Value::String("flow-123".to_string()));
+        assert_eq!(
+            parse_draft_update_flow_id(&params).unwrap(),
+            Some(Some("flow-123".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_draft_update_flow_id_empty_string_is_an_explicit_unlink() {
+        let mut params = Map::new();
+        params.insert("flow_id".to_string(), Value::String("   ".to_string()));
+        assert_eq!(parse_draft_update_flow_id(&params).unwrap(), Some(None));
+    }
+
+    // Regression for R-m7: a number must be REJECTED, not silently coerced
+    // into `Some(None)` (an explicit unlink) the way `Value::as_str()`
+    // returning `None` on a type mismatch used to produce.
+    #[test]
+    fn parse_draft_update_flow_id_rejects_a_number() {
+        let mut params = Map::new();
+        params.insert("flow_id".to_string(), Value::from(42));
+        let err = parse_draft_update_flow_id(&params).unwrap_err();
+        assert!(err.contains("invalid 'flow_id'"), "{err}");
+    }
+
+    #[test]
+    fn parse_draft_update_flow_id_rejects_an_object() {
+        let mut params = Map::new();
+        params.insert("flow_id".to_string(), serde_json::json!({ "id": "flow-1" }));
+        let err = parse_draft_update_flow_id(&params).unwrap_err();
+        assert!(err.contains("invalid 'flow_id'"), "{err}");
     }
 }

--- a/src/openhuman/flows/store.rs
+++ b/src/openhuman/flows/store.rs
@@ -681,11 +681,14 @@ pub fn insert_flow_run(
 }
 
 /// Prunes a flow's run history down to at most `keep` of its most-recent runs,
-/// deleting only **terminal** rows (`completed` / `failed` / `cancelled`) that
-/// fall outside the newest-`keep` window. Non-terminal runs (`running`,
-/// `pending_approval`) are never deleted — a parked `pending_approval` run must
-/// never be pruned out from under a pending `flows_resume`, and a `running` row
-/// belongs to a live task. Returns the number of rows deleted.
+/// deleting any row outside the newest-`keep` window whose `status` is NOT
+/// `running` or `pending_approval` — that is every terminal status this store
+/// can hold (`completed`, `completed_with_warnings`, `failed`, `cancelled`,
+/// `interrupted`, and any future status this host doesn't recognize yet), not
+/// just the `completed`/`failed`/`cancelled` trio. The two excluded statuses
+/// are the only ones that are never deleted — a parked `pending_approval` run
+/// must never be pruned out from under a pending `flows_resume`, and a
+/// `running` row belongs to a live task. Returns the number of rows deleted.
 ///
 /// `keep` is clamped to at least 1. Exposed for the manual `flows_prune_runs`
 /// sweep; the new-run insert path calls the connection-scoped helper directly.

--- a/src/openhuman/flows/store.rs
+++ b/src/openhuman/flows/store.rs
@@ -377,12 +377,25 @@ impl std::fmt::Display for FlowUpdateError {
 ///
 /// `enabled_override`, when `Some`, forces the persisted `enabled` flag to
 /// that value in the *same* guarded `UPDATE` as the graph/name/
-/// `require_approval` write — used by `ops::flows_update`'s B29 Rule 1
-/// analogue (auto-disarming a flow whose trigger just changed from manual to
-/// automatic) so the disarm can never race a concurrent read/write of
-/// `enabled` (a separate `set_enabled` call after this one would leave a
-/// TOCTOU window). `None` leaves `enabled` untouched, matching the previous
-/// behaviour for every other caller.
+/// `require_approval` write. `None` leaves `enabled` untouched (falls back to
+/// the freshly re-read `current.enabled`), matching the previous behaviour
+/// for every other caller.
+///
+/// `force_disarm_if_automatic`, when `true`, unconditionally disarms
+/// (`enabled: false`) if the resulting graph (`graph`) has an automatic
+/// trigger — used by `ops::flows_update_disarming_automatic` for remote
+/// authoring surfaces.
+///
+/// **R-m2:** independent of `force_disarm_if_automatic`, this ALWAYS disarms
+/// on a manual/none → automatic trigger transition (the B29 Rule 1 analogue)
+/// — computed here, against the row this call just re-read
+/// (`current.graph`), rather than trusting a transition flag the caller
+/// derived from an earlier, possibly-stale read. `update_flow_graph`'s own
+/// guarded `UPDATE` below keys its `WHERE` clause on this exact `current`
+/// row, so this is the only read of "was it automatic before" that can't
+/// have gone stale between computing the decision and writing it. An
+/// `enabled_override` supplied by the caller can never re-arm a graph this
+/// check disarms — the disarm always wins.
 pub fn update_flow_graph(
     config: &Config,
     id: &str,
@@ -390,6 +403,7 @@ pub fn update_flow_graph(
     graph: tinyflows::model::WorkflowGraph,
     require_approval: bool,
     enabled_override: Option<bool>,
+    force_disarm_if_automatic: bool,
     expected_updated_at: Option<&str>,
 ) -> std::result::Result<Flow, FlowUpdateError> {
     let current = get_flow(config, id)
@@ -404,13 +418,40 @@ pub fn update_flow_graph(
         }
     }
 
+    // R-m2: `was_auto` MUST come from `current` (just re-read above, right
+    // before the guarded UPDATE below), never from a caller-observed
+    // snapshot — a concurrent write between an ops-level read and this call
+    // would otherwise let a manual→automatic transition slip past
+    // undetected and persist `enabled: true` on an automatic-trigger graph.
+    let now_auto = super::ops::trigger_is_automatic(&graph);
+    let was_auto = super::ops::trigger_is_automatic(&current.graph);
+    let is_manual_to_auto_transition = now_auto && !was_auto;
+    let forced_automatic_disarm = force_disarm_if_automatic && now_auto;
+    let auto_disarm = is_manual_to_auto_transition || forced_automatic_disarm;
+    if auto_disarm {
+        tracing::debug!(
+            target: "flows",
+            flow_id = %id,
+            was_auto,
+            now_auto,
+            is_manual_to_auto_transition,
+            forced_automatic_disarm,
+            "[flows] update_flow_graph: disarming — automatic-trigger transition detected \
+             against the freshly re-read row (R-m2)"
+        );
+    }
+
     let graph_json = serde_json::to_string(&graph)
         .context("Failed to serialize graph")
         .map_err(FlowUpdateError::Store)?;
     let prior_graph_json =
         serde_json::to_string(&current.graph).unwrap_or_else(|_| "null".to_string());
     let now = Utc::now().to_rfc3339();
-    let new_enabled = enabled_override.unwrap_or(current.enabled);
+    let new_enabled = if auto_disarm {
+        false
+    } else {
+        enabled_override.unwrap_or(current.enabled)
+    };
 
     with_connection(config, |conn| {
         // Guarded UPDATE keyed on the observed updated_at (race-safe even

--- a/src/openhuman/flows/store_tests.rs
+++ b/src/openhuman/flows/store_tests.rs
@@ -29,6 +29,24 @@ fn trigger_graph() -> WorkflowGraph {
     }
 }
 
+/// An automatic-trigger (`schedule`) graph — `trigger_is_automatic` returns
+/// `true` for this, unlike [`trigger_graph`]'s manual (no `trigger_kind`)
+/// trigger.
+fn automatic_schedule_graph() -> WorkflowGraph {
+    WorkflowGraph {
+        nodes: vec![Node {
+            id: "t".to_string(),
+            kind: NodeKind::Trigger,
+            type_version: 1,
+            name: "Trigger".to_string(),
+            config: serde_json::json!({ "trigger_kind": "schedule", "schedule": "0 9 * * *" }),
+            ports: Vec::new(),
+            position: None,
+        }],
+        ..Default::default()
+    }
+}
+
 #[test]
 fn create_get_list_delete_roundtrip() {
     let tmp = TempDir::new().unwrap();
@@ -98,6 +116,7 @@ fn update_flow_graph_bumps_updated_at_and_preserves_created_at() {
         new_graph,
         false,
         None,
+        false,
         None,
     )
     .unwrap();
@@ -124,7 +143,8 @@ fn update_flow_graph_with_none_override_preserves_current_enabled_column() {
         flow.name.clone(),
         trigger_graph(),
         false,
-        None, // enabled_override
+        None,  // enabled_override
+        false, // force_disarm_if_automatic
         None,
     )
     .unwrap();
@@ -155,6 +175,7 @@ fn update_flow_graph_with_some_false_override_forces_disabled() {
         trigger_graph(),
         false,
         Some(false), // enabled_override
+        false,       // force_disarm_if_automatic
         None,
     )
     .unwrap();
@@ -199,6 +220,7 @@ fn update_flow_graph_override_wins_over_concurrently_enabled_row() {
         trigger_graph(),
         false,
         Some(false), // the unconditional disarm override
+        false,       // force_disarm_if_automatic
         None,
     )
     .unwrap();
@@ -209,6 +231,89 @@ fn update_flow_graph_override_wins_over_concurrently_enabled_row() {
     );
     let reloaded = get_flow(&config, &flow.id).unwrap().unwrap();
     assert!(!reloaded.enabled);
+}
+
+/// R-m2 regression: the manual→automatic disarm decision must be computed
+/// against the row `update_flow_graph` JUST re-read (`current`), never a
+/// caller-supplied belief about the flow's prior state. Before the fix,
+/// `ops::flows_update` computed this transition from an OUTER `existing`
+/// read taken before calling into the store — a concurrent write between
+/// that read and this call could make the transition invisible to the
+/// caller, letting an automatic-trigger graph persist `enabled: true`.
+///
+/// Proven here without needing to fake a race: the disarm must fire from
+/// `current.graph` (MANUAL) vs the new `graph` (automatic) alone, and must
+/// WIN over an `enabled_override` that explicitly asks to stay enabled —
+/// exactly the shape of override a stale caller-side decision could
+/// otherwise have smuggled through.
+#[test]
+fn update_flow_graph_disarms_transition_from_the_fresh_row_even_when_override_asks_to_stay_enabled()
+{
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+    let flow = create_flow(&config, "demo".to_string(), trigger_graph(), false, true).unwrap();
+    assert!(flow.enabled, "flow created enabled");
+
+    let updated = update_flow_graph(
+        &config,
+        &flow.id,
+        flow.name.clone(),
+        automatic_schedule_graph(),
+        false,
+        Some(true), // caller explicitly asks to stay enabled
+        false,      // force_disarm_if_automatic (the remote-authoring flag) OFF —
+        // proving the unconditional Rule 1 transition-disarm fires on its own
+        None,
+    )
+    .unwrap();
+
+    assert!(
+        !updated.enabled,
+        "a manual->automatic transition must disarm even when enabled_override asks to stay \
+         enabled — the disarm always wins (R-m2)"
+    );
+    let reloaded = get_flow(&config, &flow.id).unwrap().unwrap();
+    assert!(!reloaded.enabled);
+}
+
+/// Sibling of the above: when there is NO transition (the row was already
+/// automatic before this call, matching what's actually in the DB right
+/// now), an ordinary `enabled_override` is honoured normally — the fix must
+/// not over-disarm every automatic-trigger update, only genuine
+/// manual/none → automatic transitions (unless `force_disarm_if_automatic`
+/// is also set).
+#[test]
+fn update_flow_graph_does_not_disarm_an_automatic_to_automatic_update() {
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+    let flow = create_flow(
+        &config,
+        "demo".to_string(),
+        automatic_schedule_graph(),
+        false,
+        false,
+    )
+    .unwrap();
+    assert!(!flow.enabled, "born disabled — armed explicitly next");
+    let armed = set_enabled(&config, &flow.id, true).unwrap();
+    assert!(armed.enabled);
+
+    let updated = update_flow_graph(
+        &config,
+        &flow.id,
+        flow.name.clone(),
+        automatic_schedule_graph(),
+        false,
+        None,  // no explicit override — preserve current.enabled
+        false, // force_disarm_if_automatic OFF
+        None,
+    )
+    .unwrap();
+
+    assert!(
+        updated.enabled,
+        "an automatic->automatic update (no transition) must not be auto-disarmed"
+    );
 }
 
 #[test]
@@ -309,6 +414,7 @@ fn update_flow_graph_can_change_require_approval() {
         trigger_graph(),
         true,
         None,
+        false,
         None,
     )
     .unwrap();

--- a/src/openhuman/rhai_workflows/bridge.rs
+++ b/src/openhuman/rhai_workflows/bridge.rs
@@ -223,6 +223,30 @@ impl TaTool<()> for RhaiToolAdapter {
 /// Runs an openhuman tool for a `.ragsh` `tool_call`, routing any external-effect
 /// tool through the [`ApprovalGate`] first (fail-closed on denial) since the
 /// repl bridge sits outside the harness approval middleware.
+///
+/// **E-m4: a Supervised-tier park from inside a cell is practically
+/// unanswerable.** This calls [`ApprovalGate::intercept_audited`] — the
+/// UNBOUNDED variant, which awaits up to the gate's own TTL (10 minutes by
+/// default, `DEFAULT_APPROVAL_TTL` in `approval/gate.rs`) — from inside a
+/// Rhai cell whose own wall-clock deadline is `rhai_workflows::policy`'s
+/// `DEFAULT_RHAI_TIMEOUT_SECS` (300s, i.e. 5 minutes) unless the caller
+/// passed a longer `timeout_secs`. With the default cell timeout, the cell
+/// times out and is torn down at 5 minutes — well before a human could
+/// plausibly see, read, and act on the approval card — so in practice a
+/// Supervised-tier `tool_call`/`code`/native-tool capability invoked from a
+/// cell either gets approved within the cell's own timeout window (a very
+/// fast human response) or the cell dies waiting, and the approval decision
+/// (if it eventually comes) lands on a session and cell that no longer
+/// exist. Compounding this: per E-M1/E-M2's session-timeout-ordering bugs,
+/// a cell that times out this way can also lose the whole Rhai session's
+/// bindings, not just this one call.
+///
+/// [`ApprovalGate::intercept_audited_bounded`] exists precisely to cap the
+/// park window below a caller's own deadline — this bridge does not use it,
+/// which is the gap this comment documents rather than fixes (bounding the
+/// park to the cell's remaining timeout, or refusing to park at all from
+/// inside a cell, is tracked as follow-up, not applied in this doc-only
+/// pass).
 async fn gated_execute(
     tool: &dyn OhTool,
     call: TaToolCall,

--- a/src/openhuman/tinyflows/caps.rs
+++ b/src/openhuman/tinyflows/caps.rs
@@ -1506,10 +1506,16 @@ pub(crate) fn composio_connection_id(conn: &str) -> Option<&str> {
     (!id.is_empty()).then_some(id)
 }
 
-/// Parses a `"http_cred:<name>"` `connection_ref` for [`OpenHumanHttp`]. No
-/// host-side HTTP credential store exists yet — this only extracts the name
-/// so the adapter can log a clear, actionable warning instead of silently
-/// ignoring the reference. See [`OpenHumanHttp::request`]'s doc.
+/// Parses a `"http_cred:<name>"` `connection_ref` for [`OpenHumanHttp`],
+/// returning the trailing credential name. The host-side
+/// [`HttpCredentialsStore`] (encrypted-at-rest bearer/basic/header
+/// templates) is real and load-bearing — [`resolve_http_credential`] looks
+/// the extracted name up in it and injects the resolved auth header
+/// server-side. This function only does the parse; a malformed or missing
+/// name (`None`) is what lets the caller fail the request closed instead of
+/// silently sending it unauthenticated. See [`OpenHumanHttp::request`]'s doc
+/// and the "Phase 2" note on the [`OpenHumanHttp`] struct for the full
+/// resolution flow.
 pub(crate) fn http_cred_name(conn: &str) -> Option<&str> {
     let name = conn.strip_prefix("http_cred:")?.trim();
     (!name.is_empty()).then_some(name)

--- a/src/openhuman/tinyflows/caps.rs
+++ b/src/openhuman/tinyflows/caps.rs
@@ -1813,9 +1813,15 @@ async fn resolve_composio_account(
 ///   now parsed and forwarded to `direct_execute` (Composio Direct mode).
 ///   Backend mode's `execute_tool` still has no per-call account-scoping
 ///   path — that's a backend API gap, not something this seam can close
-///   alone — so a `connection_ref` under Backend mode logs a warning and
-///   falls back to the ambient signed-in account (documented stub; see
-///   `composio_connection_id`).
+///   alone — so under Backend mode, a `connection_ref` naming a SPECIFIC
+///   connected account is NOT honored: the call executes against whatever
+///   account happens to be the ambient signed-in session instead (E-m3),
+///   which — when the flow author connected/expected a *different* account
+///   for this action — means the action runs as the wrong identity, not a
+///   graceful no-op. This proceeds rather than failing closed; it logs a
+///   `warn!` naming both the requested and actually-used account so the
+///   mismatch is at least visible in logs, but nothing currently blocks the
+///   call. Documented backend-API-gap stub; see `composio_connection_id`.
 /// - **Trust gate**: invocation is also routed through the OpenHuman
 ///   `ApprovalGate` (mirrors `tinyagents/middleware.rs::ApprovalSecurityMiddleware`)
 ///   before dispatch, closing the Codex P1 finding that flow tool nodes
@@ -1911,10 +1917,58 @@ pub struct ToolContract {
     pub is_curated: bool,
 }
 
+/// A [`LIVE_CATALOG_CACHE`] / [`PROBE_CACHE`] entry, timestamped so a lookup
+/// can tell a fresh hit from an expired one (E-m8).
+#[derive(Debug, Clone)]
+struct CacheEntry<T> {
+    value: T,
+    cached_at: std::time::Instant,
+}
+
+impl<T> CacheEntry<T> {
+    fn fresh(value: T) -> Self {
+        Self {
+            value,
+            cached_at: std::time::Instant::now(),
+        }
+    }
+
+    /// `Some(&value)` while still within [`COMPOSIO_CATALOG_CACHE_TTL`],
+    /// `None` once expired — callers treat an expired entry as a cache miss
+    /// and re-fetch, same as no entry at all.
+    fn if_fresh(&self) -> Option<&T> {
+        (self.cached_at.elapsed() < COMPOSIO_CATALOG_CACHE_TTL).then_some(&self.value)
+    }
+
+    /// Backdates a fresh entry by `age` — test-only seam for exercising TTL
+    /// expiry deterministically, without a mockable clock or a real 30-minute
+    /// sleep (E-m8).
+    #[cfg(test)]
+    fn backdated_by(mut self, age: std::time::Duration) -> Self {
+        self.cached_at -= age;
+        self
+    }
+}
+
+/// TTL for [`LIVE_CATALOG_CACHE`] and [`PROBE_CACHE`] entries (E-m8). Both
+/// caches were previously permanent for the life of the process: a Composio
+/// action published to a toolkit (or a corrected probe result) after the
+/// first fetch stayed invisible — rejected by `flow_tool_allowed` Path B, or
+/// serving a stale `primary_array_path`/`output_fields` — until the next
+/// core restart. A support-visible gotcha, not a correctness bug: the
+/// rejection direction is fail-CLOSED (an unknown/stale action is refused,
+/// never silently permitted), so a bounded TTL only changes how long that
+/// staleness can persist before self-healing, never which way an ambiguous
+/// case resolves. 30 minutes comfortably outlasts a single builder session's
+/// worth of repeat lookups (the reason these are caches at all) while
+/// keeping "add a Composio action, come back later today" working without a
+/// restart.
+const COMPOSIO_CATALOG_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
 /// Process-level cache backing [`fetch_live_toolkit_catalog`]: lowercase
 /// toolkit slug → every [`ToolContract`] the LIVE Composio catalog published
-/// for it. One fetch per toolkit per process — schemas are effectively
-/// static within a session.
+/// for it. One fetch per toolkit per TTL window — schemas are effectively
+/// static within a session, but not forever (E-m8).
 ///
 /// Replaces the narrower `REQUIRED_ARGS_CACHE` / `RESPONSE_FIELDS_CACHE`
 /// pair (single-purpose, args-only / fields-only) that predated this fix:
@@ -1922,7 +1976,7 @@ pub struct ToolContract {
 /// delegate to this one cache/fetch instead of each running its own
 /// independent `composio_list_tools` round trip.
 static LIVE_CATALOG_CACHE: std::sync::OnceLock<
-    std::sync::Mutex<std::collections::HashMap<String, Vec<ToolContract>>>,
+    std::sync::Mutex<std::collections::HashMap<String, CacheEntry<Vec<ToolContract>>>>,
 > = std::sync::OnceLock::new();
 
 /// Seeds the live-catalog cache for a toolkit — test hook so preflight /
@@ -1935,7 +1989,25 @@ pub(crate) fn seed_live_catalog_cache(toolkit: &str, contracts: Vec<ToolContract
         .get_or_init(Default::default)
         .lock()
         .expect("live catalog cache poisoned")
-        .insert(toolkit.trim().to_ascii_lowercase(), contracts);
+        .insert(
+            toolkit.trim().to_ascii_lowercase(),
+            CacheEntry::fresh(contracts),
+        );
+}
+
+/// Like [`seed_live_catalog_cache`], but backdates the entry so it is
+/// already expired — E-m8 TTL-expiry test seam.
+#[cfg(test)]
+pub(crate) fn seed_live_catalog_cache_expired(toolkit: &str, contracts: Vec<ToolContract>) {
+    LIVE_CATALOG_CACHE
+        .get_or_init(Default::default)
+        .lock()
+        .expect("live catalog cache poisoned")
+        .insert(
+            toolkit.trim().to_ascii_lowercase(),
+            CacheEntry::fresh(contracts)
+                .backdated_by(COMPOSIO_CATALOG_CACHE_TTL + std::time::Duration::from_secs(1)),
+        );
 }
 
 /// Fetches a toolkit's tool schemas STRAIGHT from the Composio client,
@@ -2024,11 +2096,12 @@ pub(crate) async fn fetch_live_toolkit_catalog(
         .lock()
         .ok()?
         .get(&key)
+        .and_then(CacheEntry::if_fresh)
     {
         return Some(cached.clone());
     }
 
-    tracing::debug!(target: "flows", toolkit = %key, "[flows] live catalog: fetching (cache miss)");
+    tracing::debug!(target: "flows", toolkit = %key, "[flows] live catalog: fetching (cache miss or expired)");
     let resp = fetch_raw_toolkit_tools(config, &key).await?;
 
     let curated_catalog = get_provider(&key)
@@ -2072,7 +2145,7 @@ pub(crate) async fn fetch_live_toolkit_catalog(
         .collect();
 
     if let Ok(mut cache) = LIVE_CATALOG_CACHE.get_or_init(Default::default).lock() {
-        cache.insert(key, contracts.clone());
+        cache.insert(key, CacheEntry::fresh(contracts.clone()));
     }
     Some(contracts)
 }
@@ -2265,14 +2338,14 @@ pub(crate) struct ProbedOutputSample {
 
 /// Process-level cache backing [`probe_tool_output_sample`]: action slug
 /// (uppercased) → the [`ProbedOutputSample`] it produced. One real probe per
-/// slug per process — mirrors [`LIVE_CATALOG_CACHE`]'s one-fetch-per-process
-/// shape, and for the same reason: a probe is a real, potentially
-/// rate-limited/billed external call, not something to repeat every turn.
+/// slug per TTL window (E-m8) — mirrors [`LIVE_CATALOG_CACHE`]'s shape, and
+/// for the same reason: a probe is a real, potentially rate-limited/billed
+/// external call, not something to repeat every turn.
 ///
 /// Entries here always have `sample` redacted to `Value::Null` — see
 /// [`cache_probe_result`] and [`ProbedOutputSample::sample`]'s doc.
 static PROBE_CACHE: std::sync::OnceLock<
-    std::sync::Mutex<std::collections::HashMap<String, ProbedOutputSample>>,
+    std::sync::Mutex<std::collections::HashMap<String, CacheEntry<ProbedOutputSample>>>,
 > = std::sync::OnceLock::new();
 
 /// Seeds the probe cache for a slug — test hook so [`apply_probe_override`]
@@ -2285,7 +2358,22 @@ pub(crate) fn seed_probe_cache(slug: &str, sample: ProbedOutputSample) {
         .get_or_init(Default::default)
         .lock()
         .expect("probe cache poisoned")
-        .insert(slug.trim().to_ascii_uppercase(), sample);
+        .insert(slug.trim().to_ascii_uppercase(), CacheEntry::fresh(sample));
+}
+
+/// Like [`seed_probe_cache`], but backdates the entry so it is already
+/// expired — E-m8 TTL-expiry test seam.
+#[cfg(test)]
+pub(crate) fn seed_probe_cache_expired(slug: &str, sample: ProbedOutputSample) {
+    PROBE_CACHE
+        .get_or_init(Default::default)
+        .lock()
+        .expect("probe cache poisoned")
+        .insert(
+            slug.trim().to_ascii_uppercase(),
+            CacheEntry::fresh(sample)
+                .backdated_by(COMPOSIO_CATALOG_CACHE_TTL + std::time::Duration::from_secs(1)),
+        );
 }
 
 /// Caches the DERIVED metadata from a real probe — never the raw `sample`
@@ -2300,19 +2388,21 @@ fn cache_probe_result(slug: &str, sample: ProbedOutputSample) {
         ..sample
     };
     if let Ok(mut cache) = PROBE_CACHE.get_or_init(Default::default).lock() {
-        cache.insert(slug.trim().to_ascii_uppercase(), cached);
+        cache.insert(slug.trim().to_ascii_uppercase(), CacheEntry::fresh(cached));
     }
 }
 
 /// Looks up a cached [`ProbedOutputSample`] for `slug`, or `None` when
-/// [`probe_tool_output_sample`] has never successfully probed it this
-/// process.
+/// [`probe_tool_output_sample`] has never successfully probed it within the
+/// current TTL window (E-m8) — an expired probe is treated exactly like a
+/// process that never probed it at all, and re-probes on next use.
 pub(crate) fn probed_output_sample(slug: &str) -> Option<ProbedOutputSample> {
     PROBE_CACHE
         .get_or_init(Default::default)
         .lock()
         .ok()?
         .get(&slug.trim().to_ascii_uppercase())
+        .and_then(CacheEntry::if_fresh)
         .cloned()
 }
 
@@ -2848,7 +2938,7 @@ impl ToolInvoker for OpenHumanTools {
             let tier_decision = enforce_node_tier_gate(&self.security, class, "tool_call")?;
             let summary = crate::openhuman::approval::summarize_action(tool_name, &args);
             let redacted = crate::openhuman::approval::redact_args(&args);
-            let (outcome, _request_id) =
+            let (outcome, audit_id) =
                 gate_call_for_tier(tier_decision, tool_name, &summary, redacted).await;
             if let crate::openhuman::approval::GateOutcome::Deny { reason } = outcome {
                 return Err(EngineError::Capability(reason));
@@ -2860,16 +2950,52 @@ impl ToolInvoker for OpenHumanTools {
                 ?tier_decision,
                 "[flows] tool_call: dispatching NATIVE OpenHuman tool"
             );
-            let outcome = crate::openhuman::runtime_node::ops::execute_tool(
+            let exec_result = crate::openhuman::runtime_node::ops::execute_tool(
                 &self.config,
                 tool_name,
                 args,
                 false,
             )
             .await
-            .map_err(EngineError::Capability)?;
-            return reject_failed_native_tool_result(slug, &outcome.result)
-                .map(|_| native_tool_payload(&outcome.result));
+            .map_err(EngineError::Capability)
+            .and_then(|outcome| {
+                reject_failed_native_tool_result(slug, &outcome.result)
+                    .map(|_| native_tool_payload(&outcome.result))
+            });
+
+            // E-m1: close out the approval audit row (unlike the http/code/
+            // Composio paths, this used to discard the request id and never
+            // call `record_execution`, leaving every prompted-and-approved
+            // native `oh:` tool_call's audit trail stuck open with no
+            // Success/Failure terminal outcome).
+            if let Some(id) = &audit_id {
+                if let Some(gate) = crate::openhuman::approval::ApprovalGate::try_global() {
+                    let exec = if exec_result.is_ok() {
+                        crate::openhuman::approval::ExecutionOutcome::Success
+                    } else {
+                        crate::openhuman::approval::ExecutionOutcome::Failure
+                    };
+                    tracing::debug!(
+                        target: "flows",
+                        %tool_name,
+                        audit_id = %id,
+                        success = exec_result.is_ok(),
+                        "[flows] tool_call: recording native tool execution outcome on the \
+                         approval audit trail"
+                    );
+                    gate.record_execution(
+                        id,
+                        exec,
+                        exec_result
+                            .as_ref()
+                            .err()
+                            .map(ToString::to_string)
+                            .as_deref(),
+                    );
+                }
+            }
+
+            return exec_result;
         }
 
         // Autonomy-tier gate (Phase 2, made effect-aware): the node's
@@ -2986,19 +3112,25 @@ impl ToolInvoker for OpenHumanTools {
                             %slug,
                             connection_id = %id,
                             %toolkit,
-                            account = label.as_deref().unwrap_or("<unlabeled>"),
-                            "[flows] tool_call: connection_ref resolves to a specific account, but \
-                             backend mode has no per-call account-scoping path yet — using the \
-                             ambient session account instead (documented stub, see caps.rs's \
-                             OpenHumanTools doc)"
+                            requested_account = label.as_deref().unwrap_or("<unlabeled>"),
+                            "[flows] tool_call: EXECUTING ON THE WRONG ACCOUNT — connection_ref \
+                             names a specific connected account, but backend mode has no per-call \
+                             account-scoping path yet, so this call runs against the AMBIENT \
+                             signed-in session account instead of the one requested (E-m3, \
+                             documented backend-API-gap stub, see caps.rs's OpenHumanTools doc). \
+                             Proceeds rather than failing closed."
                         ),
                         None => tracing::warn!(
                             target: "flows",
                             %slug,
                             connection_id = %id,
-                            "[flows] tool_call: connection_ref set but backend mode has no per-call \
-                             account-scoping path yet — using the ambient session account \
-                             (documented stub, see caps.rs's OpenHumanTools doc)"
+                            "[flows] tool_call: POSSIBLY EXECUTING ON THE WRONG ACCOUNT — \
+                             connection_ref names a connection id not found among the user's live \
+                             connected accounts, and backend mode has no per-call account-scoping \
+                             path to validate it against anyway — this call runs against the \
+                             AMBIENT signed-in session account regardless (E-m3, documented \
+                             backend-API-gap stub, see caps.rs's OpenHumanTools doc). Proceeds \
+                             rather than failing closed."
                         ),
                     }
                 }
@@ -4281,6 +4413,51 @@ mod tests {
         );
     }
 
+    /// E-m8: an EXPIRED `LIVE_CATALOG_CACHE` entry must be treated as a cache
+    /// miss, not a permanent hit. Before the TTL fix, seeding the cache once
+    /// (as `connected_uncatalogued_toolkit_now_passes` does above) made a
+    /// slug pass forever, for the life of the process — a Composio action
+    /// added after the first fetch would stay invisible until restart. Here
+    /// the seeded entry is pre-expired, so `fetch_live_toolkit_catalog` must
+    /// re-fetch — which fails in this test (no live Composio backend) — and
+    /// `flow_tool_allowed` must fail CLOSED, unlike the fresh-seed case above
+    /// which passes.
+    #[tokio::test]
+    async fn expired_live_catalog_entry_is_treated_as_a_cache_miss() {
+        use crate::openhuman::memory_sync::composio::providers::{
+            catalog_for_toolkit, get_provider,
+        };
+        assert!(catalog_for_toolkit("flowsexpiredkit").is_none());
+        assert!(get_provider("flowsexpiredkit").is_none());
+
+        let config = Config::default();
+        seed_live_catalog_cache_expired(
+            "flowsexpiredkit",
+            vec![ToolContract {
+                slug: "FLOWSEXPIREDKIT_DO_THING".to_string(),
+                toolkit: "flowsexpiredkit".to_string(),
+                description: None,
+                required_args: Vec::new(),
+                input_schema: None,
+                output_fields: Vec::new(),
+                output_schema: None,
+                primary_array_path: None,
+                is_curated: false,
+            }],
+        );
+
+        assert!(
+            !flow_tool_allowed(
+                &config,
+                "FLOWSEXPIREDKIT_DO_THING",
+                Some(&["flowsexpiredkit".to_string()])
+            )
+            .await,
+            "an expired cache entry must be re-fetched (and, with no live backend in this test, \
+             fail closed) rather than served as a permanent hit"
+        );
+    }
+
     /// A CONNECTED but uncatalogued toolkit still rejects a slug that shares
     /// its prefix but isn't a genuine action in the LIVE catalog — the
     /// systemic tool-contract fix's tightening: connection alone is no longer
@@ -5447,6 +5624,31 @@ mod tests {
         let overridden = apply_probe_override(contract.clone());
         assert_eq!(overridden.primary_array_path, contract.primary_array_path);
         assert_eq!(overridden.output_fields, contract.output_fields);
+    }
+
+    /// E-m8: an EXPIRED `PROBE_CACHE` entry must behave exactly like "never
+    /// probed" — `apply_probe_override` must NOT apply it. Before the TTL
+    /// fix a probe result was permanent for the process's lifetime, so a
+    /// corrected/changed real response stayed masked by the first-ever probe
+    /// until restart.
+    #[test]
+    fn apply_probe_override_ignores_an_expired_cached_probe() {
+        seed_probe_cache_expired(
+            "PROBETEST_EXPIRED_ACTION",
+            ProbedOutputSample {
+                primary_array_path: Some("data.issues".to_string()),
+                output_fields: vec!["issues".to_string()],
+                sample: json!({ "data": { "issues": [] } }),
+            },
+        );
+        let contract = bare_contract("PROBETEST_EXPIRED_ACTION");
+        let overridden = apply_probe_override(contract.clone());
+        assert_eq!(
+            overridden.primary_array_path, contract.primary_array_path,
+            "an expired probe must not overlay onto the contract"
+        );
+        assert_eq!(overridden.output_fields, contract.output_fields);
+        assert!(probed_output_sample("PROBETEST_EXPIRED_ACTION").is_none());
     }
 
     /// CodeRabbit (PR #4702 review): a probe that OBSERVED the real response

--- a/src/openhuman/tinyflows/memory_adapter.rs
+++ b/src/openhuman/tinyflows/memory_adapter.rs
@@ -39,7 +39,9 @@ use crate::openhuman::agent::harness::memory_context_safety::{
     is_potentially_untrusted, wrap_untrusted_for_agent,
 };
 use crate::openhuman::agent::turn_origin::{self, AgentTurnOrigin, TrustedAutomationSource};
-use crate::openhuman::approval::{redact_args, summarize_action, GateOutcome};
+use crate::openhuman::approval::{
+    redact_args, summarize_action, ApprovalGate, ExecutionOutcome, GateOutcome,
+};
 use crate::openhuman::config::Config;
 use crate::openhuman::flows::{cross_flow_recall, flow_namespace};
 use crate::openhuman::memory::tools::flavour::{lookup_flavour, FlavourLookup};
@@ -139,18 +141,58 @@ impl OpenHumanMemory {
     /// `require_approval: true` toggle set, and only `intercept_audited`
     /// (reached via `gate_call_for_tier`) consults that. Mirrors
     /// `OpenHumanCode::run`'s gating exactly.
-    async fn tier_gate_write(&self, op: &str, action: &Value) -> Result<()> {
+    ///
+    /// Returns the approval audit request id (`None` when no
+    /// [`ApprovalGate`] is installed, or the tier decision never went
+    /// through a `Prompt` round-trip). Callers MUST thread it into
+    /// [`Self::record_write_execution`] once the actual write resolves —
+    /// see that function's doc for why (E-m1).
+    async fn tier_gate_write(&self, op: &str, action: &Value) -> Result<Option<String>> {
         let tool_name = format!("flows_memory_{op}");
         let tier_decision = enforce_node_tier_gate(&self.security, CommandClass::Write, op)?;
         let summary = summarize_action(&tool_name, action);
         let redacted = redact_args(action);
-        let (outcome, _audit_id) =
+        let (outcome, audit_id) =
             gate_call_for_tier(tier_decision, &tool_name, &summary, redacted).await;
         if let GateOutcome::Deny { reason } = outcome {
             tracing::warn!(target: "flows", op, "{LOG_PREFIX} write: approval gate denied");
             return Err(EngineError::Capability(reason));
         }
-        Ok(())
+        Ok(audit_id)
+    }
+
+    /// Closes out the approval audit row opened by [`Self::tier_gate_write`]
+    /// (E-m1): unlike the http/code/Composio node paths, this used to
+    /// discard the request id (`_audit_id`) and never call
+    /// `record_execution`, so an approved `remember`/`forget` left its audit
+    /// row stuck open with no terminal Success/Failure outcome. A no-op when
+    /// `audit_id` is `None` (no gate installed, or the decision never
+    /// prompted). Takes `success`/`error` rather than a `Result` so callers
+    /// don't need `EngineError: Clone` to both record the outcome and
+    /// propagate the original error.
+    fn record_write_execution(
+        op: &str,
+        audit_id: Option<&str>,
+        success: bool,
+        error: Option<&str>,
+    ) {
+        let Some(id) = audit_id else { return };
+        let Some(gate) = ApprovalGate::try_global() else {
+            return;
+        };
+        let exec = if success {
+            ExecutionOutcome::Success
+        } else {
+            ExecutionOutcome::Failure
+        };
+        tracing::debug!(
+            target: "flows",
+            op,
+            audit_id = %id,
+            success,
+            "{LOG_PREFIX} write: recording execution outcome on the approval audit trail"
+        );
+        gate.record_execution(id, exec, error);
     }
 
     /// Shapes a batch of [`MemoryEntry`] hits into the node's `recall`/
@@ -418,11 +460,11 @@ impl MemoryProvider for OpenHumanMemory {
         }
 
         let action = json!({ "operation": "remember", "scope": scope, "key": key });
-        self.tier_gate_write("remember", &action).await?;
+        let audit_id = self.tier_gate_write("remember", &action).await?;
 
         let namespace = self.flow_memory_namespace()?;
         let memory = self.memory().await?;
-        memory
+        let store_result = memory
             .store_with_taint(
                 &namespace,
                 key,
@@ -432,7 +474,18 @@ impl MemoryProvider for OpenHumanMemory {
                 MemoryTaint::ExternalSync,
             )
             .await
-            .map_err(|e| EngineError::Capability(format!("memory node: remember failed: {e}")))?;
+            .map_err(|e| EngineError::Capability(format!("memory node: remember failed: {e}")));
+        Self::record_write_execution(
+            "remember",
+            audit_id.as_deref(),
+            store_result.is_ok(),
+            store_result
+                .as_ref()
+                .err()
+                .map(ToString::to_string)
+                .as_deref(),
+        );
+        store_result?;
 
         tracing::debug!(
             target: "flows",
@@ -467,14 +520,25 @@ impl MemoryProvider for OpenHumanMemory {
         }
 
         let action = json!({ "operation": "forget", "scope": scope, "key": key });
-        self.tier_gate_write("forget", &action).await?;
+        let audit_id = self.tier_gate_write("forget", &action).await?;
 
         let namespace = self.flow_memory_namespace()?;
         let memory = self.memory().await?;
-        let removed = memory
+        let forget_result = memory
             .forget(&namespace, key)
             .await
-            .map_err(|e| EngineError::Capability(format!("memory node: forget failed: {e}")))?;
+            .map_err(|e| EngineError::Capability(format!("memory node: forget failed: {e}")));
+        Self::record_write_execution(
+            "forget",
+            audit_id.as_deref(),
+            forget_result.is_ok(),
+            forget_result
+                .as_ref()
+                .err()
+                .map(ToString::to_string)
+                .as_deref(),
+        );
+        let removed = forget_result?;
 
         tracing::debug!(
             target: "flows",

--- a/src/openhuman/tools/ops.rs
+++ b/src/openhuman/tools/ops.rs
@@ -376,7 +376,7 @@ pub fn all_tools_with_runtime(
         #[cfg(feature = "flows")]
         Box::new(GetNodeKindContractTool::new()),
         #[cfg(feature = "flows")]
-        Box::new(DryRunWorkflowTool::new(security.clone(), config.clone())),
+        Box::new(DryRunWorkflowTool::new(config.clone())),
         // Real end-to-end test run of a SAVED flow (Write / external-effect). The
         // workflow-builder prompt requires it to ask the user for confirmation
         // first, and the flow's own approval gate still pauses outbound nodes.


### PR DESCRIPTION
> **Stacked on #5290** (`docs/flows-contract-drift`). This branch contains that PR's commit as its base. **Review only the second commit**, and merge after #5290.

## Summary

- Closes the remaining twelve Rust findings from the flows review — the long tail after the criticals and majors.
- Highlights: `validate_workflow` **failed open**, two approval audit trails were never closed out, and `flows_update`'s auto-disarm read was racy.
- Four of the twelve are documentation-only corrections where the code was right and the comment lied.

## Problem & Solution

**Fail-open validation (T-m4).** `validate_workflow` reported `valid: true` when `migrate_and_deserialize_graph` errored, because the error path yielded an empty `gate_errors` — so every hard gate was silently skipped and the report said "ok". Now fails closed. The triggering path is currently unreachable in production (`migrate()` has no failing per-node migrations yet, per its own doc), so the decision logic was extracted and unit-tested directly rather than faked; that limitation is documented at the code.

**Unfinished approval audit trails (E-m1).** The native `oh:` tool path in `caps.rs` discarded its audit id (`let (outcome, _request_id) = …`) and never called `record_execution` after executing — unlike the sibling http, code, and Composio paths, which all close out Success/Failure. `memory_adapter.rs` had the same gap for `remember`/`forget`. Both now close their audit rows.

**Racy auto-disarm (R-m2).** `flows_update` computed `was_auto` from the ops-level read while `store::update_flow_graph` re-read the row and keyed its guarded UPDATE on *that* read. A concurrent automatic→manual flip let an automatic graph persist `enabled: true`. The transition decision now happens inside `update_flow_graph` against the freshly-read row (new `force_disarm_if_automatic` param; nine call sites updated).

**The rest:** `create_workflow` reported `"enabled": false` even when force-disable failed (T-m3); `edit_workflow` told the agent "edits live on draft X" after a swallowed write-back failure, so the next turn iterated a stale draft (T-m6); `handle_draft_update` treated a non-string `flow_id` as an explicit unlink, so a later promote created a *new* flow (R-m7); the Composio catalog and probe caches never expired, so an action added after first fetch was rejected until restart (E-m8); and `memory_tools.rs` mixed `Err(anyhow!)` with `ToolResult::error` for input problems (T-m5).

**Documentation-only (code was correct, comments were not):** `rename_node` doesn't rewrite `=nodes.<id>` bindings and `edit_workflow`'s description now says so (T-m7); `get_tool_output_sample` makes a real network call while reporting `external_effect() == false` — deliberate and hard-gated, now explained (T-m8); Composio Backend mode's `connection_ref` mismatch now says plainly that it **executes on the wrong account** rather than softly "falls back" (E-m3); and the rhai cell-timeout vs approval-TTL mismatch that makes in-cell approvals practically unanswerable is now documented at `gated_execute`, pointing at the unused `intercept_audited_bounded` as the fix path (E-m4).

### Known test gap, flagged rather than hidden

**E-m1 has no dedicated test.** Reaching that code requires installing the process-wide `ApprovalGate` singleton (`OnceLock`, install-once-per-process), which this codebase deliberately never does in unit tests — it would leak into every other test in the same `cargo test --lib` binary and risk parking unrelated tests for up to the gate's TTL. Zero existing tests do it for the sibling http/code/Composio paths this change mirrors, and `gate_call_for_tier`'s own doc states the live-gate path is intentionally untested with only its pure decision core covered. The change is verified by compilation and by the full suite staying green.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — 28 new tests, each also re-run individually by name to confirm they are not incidentally green; `openhuman::flows` 566 passed, `openhuman::tinyflows` 177 passed. The one uncovered change (E-m1) is explained above.
- [x] Coverage matrix updated — `N/A: bug fixes + doc corrections to existing paths, no feature rows added/removed/renamed`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature rows affected`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface behaviour change`
- [x] Linked issue closed via `Closes #NNN` — `N/A: found by code review, no tracking issue filed yet`

## Impact

- **Runtime/platform:** Rust core only.
- **Behaviour:** validation fails closed; approval audit rows get a terminal outcome; `create_workflow` / `edit_workflow` stop reporting success they didn't achieve; a non-string `flow_id` is rejected instead of silently unlinking a draft; Composio catalog/probe caches expire after 30 minutes.
- **API shape:** `store::update_flow_graph` gains a `force_disarm_if_automatic` parameter (nine in-repo call sites updated). `memory_tools`' recall/remember return `ToolResult::error` where they previously returned `Err` for input problems — two existing tests that asserted the old behaviour were corrected.
- **Security:** the audit-trail and fail-closed changes both move in the safe direction; cache expiry is fail-closed (an expired entry is a miss).

## Related

- Closes: `N/A`
- Follow-up PR(s)/TODOs: use `intercept_audited_bounded` so an approval raised inside a rhai cell is answerable within the cell's deadline (E-m4 documents the mismatch; fixing it is a behaviour change out of scope here).
- **Merge order:** stacked on #5290 — merge that first. `store.rs` is also touched by #5293 and #5294, and `ops.rs`/`builder_tools.rs` by #5286/#5287, so expect a rebase depending on merge order. This PR is the natural **last** of the batch.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/flows-rust-minors`
- Commit SHA: `a03ac21fc` (plus #5290's `52e9f5bbe` as its base)

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A, no frontend files changed
- [x] `pnpm typecheck` — N/A, no TypeScript changed
- [x] Focused tests: `cargo test --lib openhuman::flows` → **566 passed, 0 failed**; `cargo test --lib openhuman::tinyflows` → **177 passed, 0 failed, 1 ignored** (needs a `node` binary on PATH — pre-existing)
- [x] Rust fmt/check (if changed): `cargo check` clean; `cargo fmt --check` clean
- [x] Tauri fmt/check (if changed): N/A, `app/src-tauri` untouched

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: validation fails closed; audit trails close; tool results stop over-reporting success; draft `flow_id` parsing is strict; Composio caches expire.
- User-visible effect: an agent is told the truth when a flow could not be force-disabled or a draft could not be written, instead of proceeding on a false premise.

### Parity Contract

- Legacy behavior preserved: every happy path is unchanged — validation of a decodable graph, a successful create/edit, and a well-formed `flow_id` all behave exactly as before.
- Guard/fallback/dispatch parity checks: the auto-disarm outcome is unchanged for the non-racy case, pinned by a test showing automatic→automatic re-edits are *not* over-disarmed.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A
