### PR TITLE
feat(flows): canvas visual refresh — kind tiles, elevation, step numbers

### DIFF
--- a/app/src/components/flows/canvas/EditableFlowCanvas.tsx
+++ b/app/src/components/flows/canvas/EditableFlowCanvas.tsx
@@ -53,6 +53,7 @@ import {
   type FlowEdge,
   type FlowNode,
   isValidFlowConnection,
+  stepNumbersForFlow,
   type WorkflowGraphMeta,
   xyflowToWorkflowGraph,
 } from '../../../lib/flows/graphAdapter';
@@ -67,6 +68,7 @@ import FlowNodeComponent from './FlowNodeComponent';
 import FlowValidationBanner from './FlowValidationBanner';
 import NodeConfigDrawer, { type NodeConfigPatch } from './nodeConfig/NodeConfigDrawer';
 import NodePalette, { PALETTE_DND_MIME } from './NodePalette';
+import { StepNumberContext } from './stepNumbers';
 import { useFlowValidation } from './useFlowValidation';
 
 const log = createDebug('app:flows:canvas:edit');
@@ -757,113 +759,122 @@ function EditableFlowCanvas(
     );
   }, [setNodes]);
 
+  // Execution-order numbers, derived from the LIVE nodes/edges rather than
+  // baked into node `data` at adapt time. `workflowGraphToXyflow` runs once at
+  // mount; every edit after that goes through `setNodes`/`setEdges`, so an
+  // adapt-time number would be missing on any node added mid-edit and stale on
+  // the rest as soon as a connection changed.
+  const stepNumberMap = useMemo(() => stepNumbersForFlow(nodes, edges), [nodes, edges]);
+
   const configNode = configNodeId ? (nodes.find(n => n.id === configNodeId) ?? null) : null;
 
   return (
     <CanvasActionsContext.Provider value={canvasActions}>
-      <div
-        className="flow-canvas relative h-full w-full"
-        data-testid="flow-canvas"
-        data-editable="true"
-        data-viewport-restored={savedViewport ? 'true' : 'false'}
-        onDrop={handleDrop}
-        onDragOver={handleDragOver}
-        onKeyDown={handleCanvasKeyDown}>
-        {showPalette && <NodePalette onAdd={handlePaletteAdd} />}
+      <StepNumberContext.Provider value={stepNumberMap}>
+        <div
+          className="flow-canvas relative h-full w-full"
+          data-testid="flow-canvas"
+          data-editable="true"
+          data-viewport-restored={savedViewport ? 'true' : 'false'}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          onKeyDown={handleCanvasKeyDown}>
+          {showPalette && <NodePalette onAdd={handlePaletteAdd} />}
 
-        {/* Undo/redo stay on the canvas (top-right). Save/Discard + the unsaved
+          {/* Undo/redo stay on the canvas (top-right). Save/Discard + the unsaved
         badge now live in the page header (driven via the imperative handle).
         Per-node Validate/Delete live on the selected node card. */}
-        <div className="pointer-events-none absolute right-3 top-3 z-10 flex items-center gap-2">
-          <div className="pointer-events-auto flex items-center gap-1">
-            <Button
-              type="button"
-              variant="tertiary"
-              size="xs"
-              iconOnly
-              data-testid="flow-editor-undo"
-              aria-label={t('flows.editor.undo')}
-              title={t('flows.editor.undo')}
-              disabled={!canUndo}
-              onClick={undo}>
-              <UndoIcon />
-            </Button>
-            <Button
-              type="button"
-              variant="tertiary"
-              size="xs"
-              iconOnly
-              data-testid="flow-editor-redo"
-              aria-label={t('flows.editor.redo')}
-              title={t('flows.editor.redo')}
-              disabled={!canRedo}
-              onClick={redo}>
-              <RedoIcon />
-            </Button>
-          </div>
-        </div>
-
-        {/* First-run hint: a near-empty canvas (a fresh scratch flow opens with
-        just its trigger) gets a non-blocking nudge toward the palette. Hides
-        itself as soon as a second node lands. */}
-        {showOnboarding && (
-          <div
-            className="pointer-events-none absolute inset-0 z-0 flex items-center justify-center px-6"
-            data-testid="flow-editor-onboarding">
-            <div className="max-w-xs rounded-2xl border border-dashed border-line bg-surface/70 px-5 py-4 text-center backdrop-blur-sm">
-              <p className="text-sm font-semibold text-content">
-                {t('flows.editor.onboardingTitle')}
-              </p>
-              <p className="mt-1 text-xs leading-relaxed text-content-muted">
-                {t('flows.editor.onboardingBody')}
-              </p>
+          <div className="pointer-events-none absolute right-3 top-3 z-10 flex items-center gap-2">
+            <div className="pointer-events-auto flex items-center gap-1">
+              <Button
+                type="button"
+                variant="tertiary"
+                size="xs"
+                iconOnly
+                data-testid="flow-editor-undo"
+                aria-label={t('flows.editor.undo')}
+                title={t('flows.editor.undo')}
+                disabled={!canUndo}
+                onClick={undo}>
+                <UndoIcon />
+              </Button>
+              <Button
+                type="button"
+                variant="tertiary"
+                size="xs"
+                iconOnly
+                data-testid="flow-editor-redo"
+                aria-label={t('flows.editor.redo')}
+                title={t('flows.editor.redo')}
+                disabled={!canRedo}
+                onClick={redo}>
+                <RedoIcon />
+              </Button>
             </div>
           </div>
-        )}
 
-        <div className="pointer-events-none absolute inset-x-3 bottom-3 z-10 flex justify-center">
-          <div className="pointer-events-auto w-full max-w-md">
-            <FlowValidationBanner validation={validation} saveError={saveError} />
+          {/* First-run hint: a near-empty canvas (a fresh scratch flow opens with
+        just its trigger) gets a non-blocking nudge toward the palette. Hides
+        itself as soon as a second node lands. */}
+          {showOnboarding && (
+            <div
+              className="pointer-events-none absolute inset-0 z-0 flex items-center justify-center px-6"
+              data-testid="flow-editor-onboarding">
+              <div className="max-w-xs rounded-2xl border border-dashed border-line bg-surface/70 px-5 py-4 text-center backdrop-blur-sm">
+                <p className="text-sm font-semibold text-content">
+                  {t('flows.editor.onboardingTitle')}
+                </p>
+                <p className="mt-1 text-xs leading-relaxed text-content-muted">
+                  {t('flows.editor.onboardingBody')}
+                </p>
+              </div>
+            </div>
+          )}
+
+          <div className="pointer-events-none absolute inset-x-3 bottom-3 z-10 flex justify-center">
+            <div className="pointer-events-auto w-full max-w-md">
+              <FlowValidationBanner validation={validation} saveError={saveError} />
+            </div>
           </div>
+
+          <ReactFlow
+            nodes={displayNodes}
+            edges={edges}
+            nodeTypes={NODE_TYPES}
+            onInit={instance => {
+              rfRef.current = instance;
+            }}
+            onNodesChange={handleNodesChange}
+            onEdgesChange={handleEdgesChange}
+            onConnect={onConnect}
+            isValidConnection={isValidConnection}
+            onNodeClick={onNodeClick}
+            onSelectionChange={onSelectionChange}
+            deleteKeyCode={DELETE_KEYS}
+            nodesDraggable
+            nodesConnectable
+            elementsSelectable
+            fitView={!savedViewport}
+            defaultViewport={savedViewport ?? undefined}
+            onViewportChange={onViewportChange}
+            panOnScroll
+            zoomOnScroll>
+            <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
+            <Controls showInteractive={false} />
+          </ReactFlow>
+
+          <NodeConfigDrawer
+            node={configNode}
+            onClose={handleCloseConfig}
+            onChange={updateNode}
+            connections={connections}
+            nodes={nodes}
+            edges={edges}
+            nodeLabelById={nodeLabelById}
+            onRemoveEdge={removeEdge}
+          />
         </div>
-
-        <ReactFlow
-          nodes={displayNodes}
-          edges={edges}
-          nodeTypes={NODE_TYPES}
-          onInit={instance => {
-            rfRef.current = instance;
-          }}
-          onNodesChange={handleNodesChange}
-          onEdgesChange={handleEdgesChange}
-          onConnect={onConnect}
-          isValidConnection={isValidConnection}
-          onNodeClick={onNodeClick}
-          onSelectionChange={onSelectionChange}
-          deleteKeyCode={DELETE_KEYS}
-          nodesDraggable
-          nodesConnectable
-          elementsSelectable
-          fitView={!savedViewport}
-          defaultViewport={savedViewport ?? undefined}
-          onViewportChange={onViewportChange}
-          panOnScroll
-          zoomOnScroll>
-          <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
-          <Controls showInteractive={false} />
-        </ReactFlow>
-
-        <NodeConfigDrawer
-          node={configNode}
-          onClose={handleCloseConfig}
-          onChange={updateNode}
-          connections={connections}
-          nodes={nodes}
-          edges={edges}
-          nodeLabelById={nodeLabelById}
-          onRemoveEdge={removeEdge}
-        />
-      </div>
+      </StepNumberContext.Provider>
     </CanvasActionsContext.Provider>
   );
 }

--- a/app/src/components/flows/canvas/FlowCanvas.tsx
+++ b/app/src/components/flows/canvas/FlowCanvas.tsx
@@ -36,6 +36,7 @@ import {
   FLOW_NODE_TYPE,
   type FlowEdge,
   type FlowNode,
+  stepNumbersForFlow,
   type WorkflowGraphMeta,
 } from '../../../lib/flows/graphAdapter';
 import type { WorkflowGraph } from '../../../lib/flows/types';
@@ -45,6 +46,7 @@ import EditableFlowCanvas, {
 } from './EditableFlowCanvas';
 import './flowCanvasStyles.css';
 import FlowNodeComponent from './FlowNodeComponent';
+import { StepNumberContext } from './stepNumbers';
 
 interface FlowCanvasProps {
   nodes: FlowNode[];
@@ -115,20 +117,26 @@ function ReadonlyFlowCanvas({ nodes, edges }: { nodes: FlowNode[]; edges: FlowEd
     []
   );
 
+  // Same derivation as the editable canvas, so a read-only graph numbers its
+  // cards identically. See `stepNumbers.ts` for why this is not node `data`.
+  const stepNumberMap = useMemo(() => stepNumbersForFlow(nodes, edges), [nodes, edges]);
+
   return (
     <div className="flow-canvas h-full w-full" data-testid="flow-canvas">
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        nodeTypes={NODE_TYPES}
-        fitView
-        panOnScroll
-        zoomOnScroll
-        {...interactionProps}>
-        <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
-        <MiniMap pannable zoomable />
-        <Controls showInteractive={false} />
-      </ReactFlow>
+      <StepNumberContext.Provider value={stepNumberMap}>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={NODE_TYPES}
+          fitView
+          panOnScroll
+          zoomOnScroll
+          {...interactionProps}>
+          <Background variant={BackgroundVariant.Dots} gap={16} size={1} />
+          <MiniMap pannable zoomable />
+          <Controls showInteractive={false} />
+        </ReactFlow>
+      </StepNumberContext.Provider>
     </div>
   );
 }

--- a/app/src/components/flows/canvas/FlowNodeComponent.tsx
+++ b/app/src/components/flows/canvas/FlowNodeComponent.tsx
@@ -46,7 +46,7 @@ import { type CSSProperties, memo } from 'react';
 import { LuSparkles } from 'react-icons/lu';
 
 import type { FlowNode } from '../../../lib/flows/graphAdapter';
-import { NodeKindGlyph, nodeKindTile } from '../../../lib/flows/nodeKindIcons';
+import { NodeKindTile } from '../../../lib/flows/nodeKindIcons';
 import { describeNode } from '../../../lib/flows/nodeSummary';
 import { useT } from '../../../lib/i18n/I18nContext';
 import { useCanvasActions } from './canvasActions';
@@ -125,18 +125,11 @@ function FlowNodeComponent({ id, data, selected }: NodeProps<FlowNode>) {
             Status stays legible because it is drawn as a ring around the whole
             card, so identity (filled square) and state (outline) never share
             pixels. See NODE_KIND_TILE for the hue grouping. */}
-        <span
-          aria-hidden="true"
-          data-testid="flow-node-icon"
-          className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-white shadow-sm ring-1 ring-inset ring-white/15 ${nodeKindTile(
-            isNativeTool ? 'agent' : data.kind
-          )}`}>
-          <NodeKindGlyph
-            kind={data.kind}
-            icon={isNativeTool ? LuSparkles : undefined}
-            className="h-[18px] w-[18px]"
-          />
-        </span>
+        <NodeKindTile
+          kind={isNativeTool ? 'agent' : data.kind}
+          icon={isNativeTool ? LuSparkles : undefined}
+          testId="flow-node-icon"
+        />
         <div className="min-w-0 flex-1">
           <div
             className="min-w-0 truncate text-[13px] font-semibold leading-tight text-content"

--- a/app/src/components/flows/canvas/FlowNodeComponent.tsx
+++ b/app/src/components/flows/canvas/FlowNodeComponent.tsx
@@ -1,9 +1,32 @@
 /**
  * FlowNodeComponent — the custom xyflow node renderer for the Workflow Canvas
- * (issue B5b.1). Renders one rounded card per `WorkflowNode`: a per-kind emoji +
- * colored accent header, the node's name, a dynamic one-line summary of what the
- * node will do (derived from its live config via {@link describeNode}), and a
- * labelled row per input port (left) / output port (right).
+ * (issue B5b.1). Renders one card per `WorkflowNode`: a kind glyph on a colour-
+ * coded tile, the node's name over its execution-order number and kind, a
+ * dynamic one-line summary of what the node will do (derived from its live
+ * config via {@link describeNode}), and a labelled row per input port (left) /
+ * output port (right).
+ *
+ * **Identity is a filled shape; status is an outline.** Kind colour is confined
+ * to the 32px glyph tile (see `NODE_KIND_TILE`); the card body stays a neutral
+ * elevated surface. State therefore always has somewhere uncontested to draw:
+ * the live run overlay's rings (`.flow-node-running` / `-success` / `-failed`),
+ * the validation ring (`.flow-node-error`), the copilot diff overlay, and
+ * selection all render on the card's border, never on the tile.
+ *
+ * This split replaced a per-kind coloured *border* + header chip that cycled 14
+ * node kinds through 4 semantic ramps. Because those ramps carry meaning
+ * elsewhere in the product (coral = error, sage = success), a `merge` node
+ * rendered coral and a `tool_call` amber read as status rather than type — a
+ * canvas of healthy nodes looked like a canvas of warnings, and the real state
+ * rings had nothing left to contrast against. Moving the same hues onto a small
+ * filled tile keeps kinds recognisable before the label is readable without
+ * ever impersonating run state.
+ *
+ * The card is deliberately elevated rather than flat: on the dark theme the
+ * canvas is pure black and `surface` is `#171717`, so a flat card with a
+ * default `line` border is nearly invisible. It uses a top-lit gradient,
+ * `line-strong`, and a two-layer shadow to separate from the canvas in both
+ * themes.
  *
  * Ports read as labelled handle rows rather than a plaintext list: each port's
  * `Handle` sits inline next to its name so it's unambiguous which dot carries
@@ -20,9 +43,10 @@
  */
 import { Handle, type NodeProps, Position } from '@xyflow/react';
 import { type CSSProperties, memo } from 'react';
+import { LuSparkles } from 'react-icons/lu';
 
 import type { FlowNode } from '../../../lib/flows/graphAdapter';
-import { COLOR_CLASSES, nodeKindMeta } from '../../../lib/flows/nodeKindMeta';
+import { NodeKindGlyph, nodeKindTile } from '../../../lib/flows/nodeKindIcons';
 import { describeNode } from '../../../lib/flows/nodeSummary';
 import { useT } from '../../../lib/i18n/I18nContext';
 import { useCanvasActions } from './canvasActions';
@@ -60,15 +84,15 @@ function portPillClass(port: string): string {
 function FlowNodeComponent({ id, data, selected }: NodeProps<FlowNode>) {
   const { t, locale } = useT();
   const actions = useCanvasActions();
-  const baseMeta = nodeKindMeta(data.kind);
   // A native "Tool" node (provider=openhuman / oh: slug) reads differently from
-  // the Composio "App action" node even though both are `tool_call`.
+  // the Composio "App action" node even though both are `tool_call` — the
+  // former calls one of the assistant's own built-ins, the latter reaches a
+  // connected third-party account. Distinguish them with the sparkles glyph on
+  // the `agent` tile, grouping the assistant's own capabilities under one hue.
   const isNativeTool =
     data.kind === 'tool_call' &&
     (data.config?.provider === 'openhuman' ||
       (typeof data.config?.slug === 'string' && data.config.slug.startsWith('oh:')));
-  const meta = isNativeTool ? { ...baseMeta, emoji: '🛠️', color: 'primary' as const } : baseMeta;
-  const colors = COLOR_CLASSES[meta.color];
   const kindLabel = t(`flows.nodeKind.${data.kind}`, data.kind);
   const summary = describeNode(data.kind, data.config ?? {}, data.outputPorts, t, locale);
 
@@ -85,25 +109,64 @@ function FlowNodeComponent({ id, data, selected }: NodeProps<FlowNode>) {
     <div
       data-testid="flow-node"
       data-node-kind={data.kind}
-      className={`relative min-w-[180px] max-w-[240px] rounded-xl border-2 bg-surface shadow-sm ${colors.border} ${
-        selected ? 'ring-2 ring-primary-500/40' : ''
+      className={`relative w-[264px] rounded-xl border bg-surface shadow-[0_1px_2px_rgba(0,0,0,0.06),0_4px_12px_rgba(0,0,0,0.08)] transition-all duration-150 dark:shadow-[0_2px_6px_rgba(0,0,0,0.5),0_8px_24px_rgba(0,0,0,0.45)] ${
+        selected
+          ? 'border-primary-500 ring-2 ring-primary-500/40'
+          : 'border-line-strong hover:-translate-y-px hover:border-primary-500/40 hover:shadow-[0_2px_4px_rgba(0,0,0,0.08),0_10px_28px_rgba(0,0,0,0.12)] dark:hover:shadow-[0_4px_10px_rgba(0,0,0,0.55),0_14px_36px_rgba(0,0,0,0.5)]'
       }`}>
-      <div className={`flex items-center gap-2 rounded-t-[10px] px-3 py-2 ${colors.chip}`}>
-        <span className="text-base leading-none" aria-hidden="true">
-          {meta.emoji}
+      {/* Title band — the card's only secondary fill. Everything below the
+          divider shares the card's own `bg-surface`, so the body reads as one
+          uninterrupted surface: a separately-tinted summary well plus an
+          untinted connector row gave the card three competing bands. */}
+      <div className="flex items-center gap-3 rounded-t-xl border-b border-line-strong/60 bg-surface-muted px-3 py-2.5">
+        {/* Kind glyph on a saturated tile — the card's only filled colour.
+            Status stays legible because it is drawn as a ring around the whole
+            card, so identity (filled square) and state (outline) never share
+            pixels. See NODE_KIND_TILE for the hue grouping. */}
+        <span
+          aria-hidden="true"
+          data-testid="flow-node-icon"
+          className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-white shadow-sm ring-1 ring-inset ring-white/15 ${nodeKindTile(
+            isNativeTool ? 'agent' : data.kind
+          )}`}>
+          <NodeKindGlyph
+            kind={data.kind}
+            icon={isNativeTool ? LuSparkles : undefined}
+            className="h-[18px] w-[18px]"
+          />
         </span>
-        <div className="min-w-0 truncate text-sm font-semibold text-content">{data.name}</div>
+        <div className="min-w-0 flex-1">
+          <div
+            className="min-w-0 truncate text-[13px] font-semibold leading-tight text-content"
+            title={data.name}>
+            {data.name}
+          </div>
+          <div className="mt-1 flex items-center gap-1.5 text-[10px] leading-none text-content-muted">
+            {data.stepNumber !== undefined && (
+              <>
+                <span data-testid="flow-node-step" className="font-semibold tabular-nums">
+                  {data.stepNumber}
+                </span>
+                <span aria-hidden="true" className="opacity-40">
+                  ·
+                </span>
+              </>
+            )}
+            <span className="truncate font-medium uppercase tracking-[0.08em]">{kindLabel}</span>
+          </div>
+        </div>
       </div>
 
-      {/* Dynamic "what this does" line, derived from the node's live config. The
-          emoji already conveys the kind, so we show the description here rather
-          than repeating the kind label (which duplicates a default node's name).
-          Falls back to the kind label only when there's no config summary. */}
-      <div
-        className="px-3 pt-2 text-[11px] leading-snug text-content-muted"
-        data-testid="flow-node-summary">
-        {summary || kindLabel}
-      </div>
+      {/* Dynamic "what this does" line, derived from the node's live config.
+          Untinted on purpose — the title band's divider already separates
+          identity from behaviour, so a second fill here would only add a band. */}
+      {summary && (
+        <div
+          className="px-3 pt-2 text-[11px] leading-snug text-content-secondary"
+          data-testid="flow-node-summary">
+          {summary}
+        </div>
+      )}
 
       {hasPorts && (
         <div className="flex items-start justify-between gap-4 px-2 py-2">

--- a/app/src/components/flows/canvas/FlowNodeComponent.tsx
+++ b/app/src/components/flows/canvas/FlowNodeComponent.tsx
@@ -50,6 +50,7 @@ import { NodeKindGlyph, nodeKindTile } from '../../../lib/flows/nodeKindIcons';
 import { describeNode } from '../../../lib/flows/nodeSummary';
 import { useT } from '../../../lib/i18n/I18nContext';
 import { useCanvasActions } from './canvasActions';
+import { useStepNumber } from './stepNumbers';
 
 /**
  * Inline the handle into the port row instead of React Flow's default absolute
@@ -84,6 +85,7 @@ function portPillClass(port: string): string {
 function FlowNodeComponent({ id, data, selected }: NodeProps<FlowNode>) {
   const { t, locale } = useT();
   const actions = useCanvasActions();
+  const stepNumber = useStepNumber(id);
   // A native "Tool" node (provider=openhuman / oh: slug) reads differently from
   // the Composio "App action" node even though both are `tool_call` — the
   // former calls one of the assistant's own built-ins, the latter reaches a
@@ -142,10 +144,10 @@ function FlowNodeComponent({ id, data, selected }: NodeProps<FlowNode>) {
             {data.name}
           </div>
           <div className="mt-1 flex items-center gap-1.5 text-[10px] leading-none text-content-muted">
-            {data.stepNumber !== undefined && (
+            {stepNumber !== undefined && (
               <>
                 <span data-testid="flow-node-step" className="font-semibold tabular-nums">
-                  {data.stepNumber}
+                  {stepNumber}
                 </span>
                 <span aria-hidden="true" className="opacity-40">
                   ·

--- a/app/src/components/flows/canvas/NodePalette.tsx
+++ b/app/src/components/flows/canvas/NodePalette.tsx
@@ -12,7 +12,7 @@
  */
 import { memo } from 'react';
 
-import { NodeKindGlyph, nodeKindTile } from '../../../lib/flows/nodeKindIcons';
+import { NodeKindTile } from '../../../lib/flows/nodeKindIcons';
 import {
   NODE_GROUP_ORDER,
   PALETTE_ENTRIES_BY_GROUP,
@@ -60,13 +60,7 @@ function NodePalette({ onAdd }: NodePaletteProps) {
                   className="flex items-center gap-2 rounded-lg border border-line px-2 py-1.5 text-left text-xs text-content transition-colors hover:border-primary-500/40 hover:bg-surface-hover">
                   {/* Same tile as the canvas card, scaled down — the swatch the
                       user picks here is the swatch that lands on the graph. */}
-                  <span
-                    aria-hidden="true"
-                    className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-md text-white ring-1 ring-inset ring-white/15 ${nodeKindTile(
-                      entry.kind
-                    )}`}>
-                    <NodeKindGlyph kind={entry.kind} className="h-3 w-3" />
-                  </span>
+                  <NodeKindTile kind={entry.kind} size="sm" />
                   <span className="truncate">{label}</span>
                 </button>
               );

--- a/app/src/components/flows/canvas/NodePalette.tsx
+++ b/app/src/components/flows/canvas/NodePalette.tsx
@@ -12,8 +12,8 @@
  */
 import { memo } from 'react';
 
+import { NodeKindGlyph, nodeKindTile } from '../../../lib/flows/nodeKindIcons';
 import {
-  COLOR_CLASSES,
   NODE_GROUP_ORDER,
   PALETTE_ENTRIES_BY_GROUP,
   type PaletteEntry,
@@ -43,7 +43,6 @@ function NodePalette({ onAdd }: NodePaletteProps) {
               {t(`flows.palette.group.${group}`)}
             </div>
             {PALETTE_ENTRIES_BY_GROUP[group].map(entry => {
-              const colors = COLOR_CLASSES[entry.color];
               const label = t(entry.labelKey, entry.kind);
               return (
                 <button
@@ -58,9 +57,15 @@ function NodePalette({ onAdd }: NodePaletteProps) {
                     event.dataTransfer.effectAllowed = 'copy';
                   }}
                   title={t('flows.palette.addNode').replace('{kind}', label)}
-                  className={`flex items-center gap-2 rounded-lg border px-2 py-1.5 text-left text-xs text-content transition-colors hover:bg-surface-hover ${colors.tint} ${colors.border}`}>
-                  <span className="text-base leading-none" aria-hidden="true">
-                    {entry.emoji}
+                  className="flex items-center gap-2 rounded-lg border border-line px-2 py-1.5 text-left text-xs text-content transition-colors hover:border-primary-500/40 hover:bg-surface-hover">
+                  {/* Same tile as the canvas card, scaled down — the swatch the
+                      user picks here is the swatch that lands on the graph. */}
+                  <span
+                    aria-hidden="true"
+                    className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-md text-white ring-1 ring-inset ring-white/15 ${nodeKindTile(
+                      entry.kind
+                    )}`}>
+                    <NodeKindGlyph kind={entry.kind} className="h-3 w-3" />
                   </span>
                   <span className="truncate">{label}</span>
                 </button>

--- a/app/src/components/flows/canvas/flowCanvasStyles.css
+++ b/app/src/components/flows/canvas/flowCanvasStyles.css
@@ -31,21 +31,38 @@
   fill: rgb(var(--line-strong));
 }
 
+/* Connectors read as `--content-faint`, not `--line-strong`. On the dark theme
+   the canvas is pure black and `--line-strong` is #404040, which left the graph
+   structure — the thing a workflow canvas exists to show — barely visible. A
+   text-weight grey survives both themes at this stroke width. */
 .flow-canvas .react-flow__edge-path {
-  stroke: rgb(var(--line-strong));
-  stroke-width: 1.5;
+  stroke: rgb(var(--content-faint));
+  stroke-width: 1.75;
 }
 
 .flow-canvas .react-flow__edge.selected .react-flow__edge-path,
 .flow-canvas .react-flow__edge:hover .react-flow__edge-path {
   stroke: rgb(var(--primary-500));
+  stroke-width: 2.5;
 }
 
+/* The ring is `--surface-muted` rather than `--surface`: the node card is now a
+   top-lit gradient whose *top* stop is `--surface-muted`, and that is the band
+   the handles sit against. */
 .flow-canvas .react-flow__handle {
-  width: 8px;
-  height: 8px;
+  width: 9px;
+  height: 9px;
   background: rgb(var(--primary-500));
-  border: 1.5px solid rgb(var(--surface));
+  border: 2px solid rgb(var(--surface-muted));
+  transition: box-shadow 120ms ease;
+}
+
+/* Halo only — no `transform`. `FlowNodeComponent` pins `transform: none` inline
+   on every handle to opt out of React Flow's absolute edge placement, and an
+   inline declaration outranks this rule, so a `scale()` here would silently do
+   nothing. */
+.flow-canvas .react-flow__handle:hover {
+  box-shadow: 0 0 0 4px rgb(var(--primary-500) / 0.25);
 }
 
 .flow-canvas .react-flow__controls {

--- a/app/src/components/flows/canvas/nodeConfig/NodeConfigDrawer.tsx
+++ b/app/src/components/flows/canvas/nodeConfig/NodeConfigDrawer.tsx
@@ -20,7 +20,7 @@ import { memo, useCallback, useMemo, useState } from 'react';
 
 import { useEscapeKey } from '../../../../hooks/useEscapeKey';
 import type { FlowEdge, FlowNode } from '../../../../lib/flows/graphAdapter';
-import { nodeKindMeta } from '../../../../lib/flows/nodeKindMeta';
+import { NodeKindGlyph, nodeKindTile } from '../../../../lib/flows/nodeKindIcons';
 import { describeNode } from '../../../../lib/flows/nodeSummary';
 import { useT } from '../../../../lib/i18n/I18nContext';
 import type { FlowConnection } from '../../../../services/api/flowsApi';
@@ -153,7 +153,6 @@ function NodeConfigDrawer({
 
   if (!node) return null;
 
-  const meta = nodeKindMeta(node.data.kind);
   const kindLabel = t(`flows.nodeKind.${node.data.kind}`, node.data.kind);
   // Dynamic "what this node will do", derived from the live config — updates as
   // the fields below are edited (same summary shown on the node card).
@@ -174,8 +173,12 @@ function NodeConfigDrawer({
       data-testid="node-config-drawer">
       <aside className="pointer-events-auto relative flex h-full w-full max-w-xs flex-col border-l border-line bg-surface shadow-xl">
         <header className="flex items-start gap-2 border-b border-line px-3.5 py-3">
-          <span className="text-lg leading-none" aria-hidden="true">
-            {meta.emoji}
+          <span
+            aria-hidden="true"
+            className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-white shadow-sm ring-1 ring-inset ring-white/15 ${nodeKindTile(
+              node.data.kind
+            )}`}>
+            <NodeKindGlyph kind={node.data.kind} className="h-[18px] w-[18px]" />
           </span>
           <div className="min-w-0 flex-1">
             {/* Kind eyebrow — hidden when it just repeats the name (a default,

--- a/app/src/components/flows/canvas/nodeConfig/NodeConfigDrawer.tsx
+++ b/app/src/components/flows/canvas/nodeConfig/NodeConfigDrawer.tsx
@@ -20,7 +20,7 @@ import { memo, useCallback, useMemo, useState } from 'react';
 
 import { useEscapeKey } from '../../../../hooks/useEscapeKey';
 import type { FlowEdge, FlowNode } from '../../../../lib/flows/graphAdapter';
-import { NodeKindGlyph, nodeKindTile } from '../../../../lib/flows/nodeKindIcons';
+import { NodeKindTile } from '../../../../lib/flows/nodeKindIcons';
 import { describeNode } from '../../../../lib/flows/nodeSummary';
 import { useT } from '../../../../lib/i18n/I18nContext';
 import type { FlowConnection } from '../../../../services/api/flowsApi';
@@ -173,13 +173,7 @@ function NodeConfigDrawer({
       data-testid="node-config-drawer">
       <aside className="pointer-events-auto relative flex h-full w-full max-w-xs flex-col border-l border-line bg-surface shadow-xl">
         <header className="flex items-start gap-2 border-b border-line px-3.5 py-3">
-          <span
-            aria-hidden="true"
-            className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-white shadow-sm ring-1 ring-inset ring-white/15 ${nodeKindTile(
-              node.data.kind
-            )}`}>
-            <NodeKindGlyph kind={node.data.kind} className="h-[18px] w-[18px]" />
-          </span>
+          <NodeKindTile kind={node.data.kind} className="mt-0.5" />
           <div className="min-w-0 flex-1">
             {/* Kind eyebrow — hidden when it just repeats the name (a default,
                 unrenamed node), so the header doesn't show the title twice. */}

--- a/app/src/components/flows/canvas/stepNumbers.ts
+++ b/app/src/components/flows/canvas/stepNumbers.ts
@@ -1,0 +1,30 @@
+/**
+ * Step-number context — supplies each {@link FlowNodeComponent} card its
+ * 1-based execution-order index ("3. Fetch Unread Emails").
+ *
+ * Deliberately a context rather than a field on React Flow's node `data`, for
+ * the same reason {@link CanvasActions} is: `data` is part of the serialized
+ * graph, and a number derived from the graph's *shape* has to be recomputed
+ * whenever that shape changes.
+ *
+ * The editable canvas holds its graph in `useNodesState`/`useEdgesState` and
+ * mutates it in place — `addNode` builds a node with `createFlowNode`,
+ * `onConnect` only calls `setEdges` — so `workflowGraphToXyflow` runs once at
+ * mount and never again. A number baked in at adapt time would therefore be
+ * absent on any node added mid-edit and stale on every other node the moment a
+ * connection changed, until a save or remount. Deriving from the live arrays
+ * makes that whole class of staleness unrepresentable.
+ *
+ * The provider computes one `Map` per nodes/edges change; cards read a single
+ * entry. Absent provider (or absent node) yields `undefined`, and the card
+ * simply renders no number.
+ */
+import { createContext, useContext } from 'react';
+
+/** Node id → 1-based execution-order index. */
+export const StepNumberContext = createContext<ReadonlyMap<string, number> | null>(null);
+
+/** This node's execution-order index, or `undefined` when unnumbered. */
+export function useStepNumber(nodeId: string): number | undefined {
+  return useContext(StepNumberContext)?.get(nodeId);
+}

--- a/app/src/lib/flows/graphAdapter.test.ts
+++ b/app/src/lib/flows/graphAdapter.test.ts
@@ -584,8 +584,12 @@ describe('stepNumbers', () => {
 
     const steps = stepNumbers(nodes, edges);
 
+    // Exact values, not a sorted set: sibling order is deterministic (adjacency
+    // follows edge declaration order), and a sorted assertion would still pass
+    // if the traversal reversed x and y.
     expect(steps.get('t')).toBe(1);
-    expect([steps.get('x'), steps.get('y')].sort()).toEqual([2, 3]);
+    expect(steps.get('x')).toBe(2);
+    expect(steps.get('y')).toBe(3);
     expect(steps.get('z')).toBe(4);
   });
 
@@ -606,8 +610,13 @@ describe('stepNumbers', () => {
 
     const steps = stepNumbers(nodes, edges);
 
+    // Pin the declaration-order fallback exactly — a sorted comparison would
+    // pass even if the fallback emitted them in some other order.
     expect(steps.size).toBe(4);
-    expect([...steps.values()].sort((a, b) => a - b)).toEqual([1, 2, 3, 4]);
+    expect(steps.get('t')).toBe(1);
+    expect(steps.get('orphan')).toBe(2);
+    expect(steps.get('c1')).toBe(3);
+    expect(steps.get('c2')).toBe(4);
   });
 
   it('numbers the xyflow shape identically to the workflow shape', () => {

--- a/app/src/lib/flows/graphAdapter.test.ts
+++ b/app/src/lib/flows/graphAdapter.test.ts
@@ -8,6 +8,7 @@ import {
   type FlowNode,
   isValidFlowConnection,
   normalizeWorkflowGraphForDirtyCheck,
+  stepNumbers,
   workflowGraphToXyflow,
   xyflowToWorkflowGraph,
 } from './graphAdapter';
@@ -548,5 +549,78 @@ describe('graphAdapter', () => {
         { from_node: 'new-trigger-0', from_port: 'main', to_node: 'new-agent-1', to_port: 'main' },
       ]);
     });
+  });
+});
+
+describe('stepNumbers', () => {
+  it('numbers from the roots outward, not in declaration order', () => {
+    // Declared tail-first on purpose: the agent is listed before the trigger
+    // that feeds it, so a numbering that trusted array order would label the
+    // agent "1". Graphs the copilot authors routinely come back unordered.
+    const nodes = [node({ id: 'b', kind: 'agent' }), node({ id: 'a', kind: 'trigger' })];
+    const edges = [edge({ from_node: 'a', to_node: 'b' })];
+
+    const steps = stepNumbers(nodes, edges);
+
+    expect(steps.get('a')).toBe(1);
+    expect(steps.get('b')).toBe(2);
+  });
+
+  it('numbers a fan-out breadth-first so sibling branches get adjacent numbers', () => {
+    // trigger → (x, y) → z. Depth-first would number one branch to its end
+    // before starting the other, which reads wrong beside a columnar layout.
+    const nodes = [
+      node({ id: 't', kind: 'trigger' }),
+      node({ id: 'x', kind: 'agent' }),
+      node({ id: 'y', kind: 'agent' }),
+      node({ id: 'z', kind: 'agent' }),
+    ];
+    const edges = [
+      edge({ from_node: 't', to_node: 'x' }),
+      edge({ from_node: 't', to_node: 'y' }),
+      edge({ from_node: 'x', to_node: 'z' }),
+    ];
+
+    const steps = stepNumbers(nodes, edges);
+
+    expect(steps.get('t')).toBe(1);
+    expect([steps.get('x'), steps.get('y')].sort()).toEqual([2, 3]);
+    expect(steps.get('z')).toBe(4);
+  });
+
+  it('still numbers nodes the walk cannot reach', () => {
+    // A disconnected node and a pure cycle both have no zero-in-degree entry.
+    // Every card must show an index, so these are appended after the reachable
+    // ones rather than left undefined.
+    const nodes = [
+      node({ id: 't', kind: 'trigger' }),
+      node({ id: 'orphan', kind: 'agent' }),
+      node({ id: 'c1', kind: 'agent' }),
+      node({ id: 'c2', kind: 'agent' }),
+    ];
+    const edges = [
+      edge({ from_node: 'c1', to_node: 'c2' }),
+      edge({ from_node: 'c2', to_node: 'c1' }),
+    ];
+
+    const steps = stepNumbers(nodes, edges);
+
+    expect(steps.size).toBe(4);
+    expect([...steps.values()].sort((a, b) => a - b)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('exposes the number on the adapted node data', () => {
+    const graph: WorkflowGraph = {
+      schema_version: 1,
+      id: 'wf',
+      name: 'Flow',
+      nodes: [node({ id: 'a', kind: 'trigger' }), node({ id: 'b', kind: 'agent' })],
+      edges: [edge({ from_node: 'a', to_node: 'b' })],
+    };
+
+    const { nodes } = workflowGraphToXyflow(graph);
+
+    expect(nodes.find(n => n.id === 'a')?.data.stepNumber).toBe(1);
+    expect(nodes.find(n => n.id === 'b')?.data.stepNumber).toBe(2);
   });
 });

--- a/app/src/lib/flows/graphAdapter.test.ts
+++ b/app/src/lib/flows/graphAdapter.test.ts
@@ -9,6 +9,7 @@ import {
   isValidFlowConnection,
   normalizeWorkflowGraphForDirtyCheck,
   stepNumbers,
+  stepNumbersForFlow,
   workflowGraphToXyflow,
   xyflowToWorkflowGraph,
 } from './graphAdapter';
@@ -609,18 +610,68 @@ describe('stepNumbers', () => {
     expect([...steps.values()].sort((a, b) => a - b)).toEqual([1, 2, 3, 4]);
   });
 
-  it('exposes the number on the adapted node data', () => {
+  it('numbers the xyflow shape identically to the workflow shape', () => {
+    // The editable canvas only ever holds the xyflow shape, so both entry
+    // points must agree or a graph would renumber itself on save/reload.
+    const wfNodes = [node({ id: 'a', kind: 'trigger' }), node({ id: 'b', kind: 'agent' })];
+    const wfEdges = [edge({ from_node: 'a', to_node: 'b' })];
     const graph: WorkflowGraph = {
       schema_version: 1,
       id: 'wf',
       name: 'Flow',
-      nodes: [node({ id: 'a', kind: 'trigger' }), node({ id: 'b', kind: 'agent' })],
-      edges: [edge({ from_node: 'a', to_node: 'b' })],
+      nodes: wfNodes,
+      edges: wfEdges,
     };
 
-    const { nodes } = workflowGraphToXyflow(graph);
+    const { nodes: flowNodes, edges: flowEdges } = workflowGraphToXyflow(graph);
 
-    expect(nodes.find(n => n.id === 'a')?.data.stepNumber).toBe(1);
-    expect(nodes.find(n => n.id === 'b')?.data.stepNumber).toBe(2);
+    expect(stepNumbersForFlow(flowNodes, flowEdges)).toEqual(stepNumbers(wfNodes, wfEdges));
+  });
+
+  it('renumbers when a node is added or connected mid-edit', () => {
+    // Regression: numbers used to be baked into node `data` by
+    // `workflowGraphToXyflow`, which the editable canvas runs only at mount.
+    // A node added afterwards (via `createFlowNode`, which sets no number) had
+    // none at all, and connecting it left every other number stale until a
+    // save or remount.
+    const a = createFlowNode('trigger', { x: 0, y: 0 }, 'a', 'Trigger');
+    const b = createFlowNode('agent', { x: 280, y: 0 }, 'b', 'Agent');
+    const connected: FlowEdge[] = [{ id: 'e1', source: 'a', target: 'b' }];
+
+    expect(stepNumbersForFlow([a, b], connected)).toEqual(
+      new Map([
+        ['a', 1],
+        ['b', 2],
+      ])
+    );
+
+    // Add a third node the way the palette does — no number of its own.
+    const c = createFlowNode('tool_call', { x: 560, y: 0 }, 'c', 'Tool');
+    const afterAdd = stepNumbersForFlow([a, b, c], connected);
+    expect(afterAdd.get('c')).toBe(3);
+
+    // Connect it, and the numbering follows the new topology.
+    const afterConnect = stepNumbersForFlow(
+      [a, b, c],
+      [...connected, { id: 'e2', source: 'b', target: 'c' }]
+    );
+    expect(afterConnect).toEqual(
+      new Map([
+        ['a', 1],
+        ['b', 2],
+        ['c', 3],
+      ])
+    );
+
+    // Rewiring so `c` comes before `b` must renumber, not keep stale values.
+    const rewired = stepNumbersForFlow(
+      [a, b, c],
+      [
+        { id: 'e3', source: 'a', target: 'c' },
+        { id: 'e4', source: 'c', target: 'b' },
+      ]
+    );
+    expect(rewired.get('c')).toBe(2);
+    expect(rewired.get('b')).toBe(3);
   });
 });

--- a/app/src/lib/flows/graphAdapter.test.ts
+++ b/app/src/lib/flows/graphAdapter.test.ts
@@ -637,6 +637,46 @@ describe('stepNumbers', () => {
     expect(stepNumbersForFlow(flowNodes, flowEdges)).toEqual(stepNumbers(wfNodes, wfEdges));
   });
 
+  it('keeps disconnected chains contiguous instead of interleaving them', () => {
+    // Regression: seeding every root at once interleaved independent chains, so
+    // `a → b` plus `c → d` numbered a=1, c=2, b=3, d=4 — drawing a second chain
+    // renumbered the first one's steps underneath the user.
+    const nodes = [
+      node({ id: 'a', kind: 'trigger' }),
+      node({ id: 'b', kind: 'agent' }),
+      node({ id: 'c', kind: 'trigger' }),
+      node({ id: 'd', kind: 'agent' }),
+    ];
+    const edges = [edge({ from_node: 'a', to_node: 'b' }), edge({ from_node: 'c', to_node: 'd' })];
+
+    expect(stepNumbers(nodes, edges)).toEqual(
+      new Map([
+        ['a', 1],
+        ['b', 2],
+        ['c', 3],
+        ['d', 4],
+      ])
+    );
+  });
+
+  it('does not renumber the existing flow when a second chain is drawn', () => {
+    // The property that matters on the canvas: numbers already on screen must
+    // not shift because unrelated work appeared elsewhere.
+    const a = node({ id: 'a', kind: 'trigger' });
+    const b = node({ id: 'b', kind: 'agent' });
+    const firstChain = [edge({ from_node: 'a', to_node: 'b' })];
+
+    const before = stepNumbers([a, b], firstChain);
+
+    const after = stepNumbers(
+      [a, b, node({ id: 'c', kind: 'trigger' }), node({ id: 'd', kind: 'agent' })],
+      [...firstChain, edge({ from_node: 'c', to_node: 'd' })]
+    );
+
+    expect(after.get('a')).toBe(before.get('a'));
+    expect(after.get('b')).toBe(before.get('b'));
+  });
+
   it('renumbers when a node is added or connected mid-edit', () => {
     // Regression: numbers used to be baked into node `data` by
     // `workflowGraphToXyflow`, which the editable canvas runs only at mount.

--- a/app/src/lib/flows/graphAdapter.ts
+++ b/app/src/lib/flows/graphAdapter.ts
@@ -443,11 +443,16 @@ export function autoLayout(nodes: WorkflowNode[], edges: WorkflowEdge[]): Map<st
  * than running one branch to its end before starting the next, which is what a
  * depth-first walk would do and reads as wrong beside a two-column layout.
  *
+ * Independent chains are kept contiguous rather than interleaved: each root's
+ * component is drained completely before the next root is seeded. Otherwise
+ * `a → b` plus `c → d` would number a=1, c=2, b=3, d=4, and drawing a second
+ * chain would renumber the first one's steps.
+ *
  * Every node gets a number, including ones the walk cannot reach — a node not
- * yet wired up, a disconnected sub-graph, or a cycle with no zero-in-degree
- * entry. Those are appended in declaration order after the reachable ones, so
- * no card renders without an index and, crucially, dropping an unconnected node
- * onto the canvas does not renumber the flow it has not joined yet.
+ * yet wired up, or a cycle with no zero-in-degree entry. Those are appended in
+ * declaration order after the reachable ones, so no card renders without an
+ * index and, crucially, adding disconnected work to the canvas never renumbers
+ * the flow it has not joined yet.
  */
 export function stepNumbers(nodes: WorkflowNode[], edges: WorkflowEdge[]): Map<string, number> {
   return stepNumbersFor(
@@ -501,18 +506,33 @@ function stepNumbersFor(ids: string[], pairs: Array<[string, string]>): Map<stri
   const roots = ids.filter(
     id => (incoming.get(id) ?? 0) === 0 && (adjacency.get(id)?.length ?? 0) > 0
   );
-  const queue: string[] = [...roots];
-  const seen = new Set<string>(queue);
 
-  let head = 0;
+  const seen = new Set<string>();
   let next = 1;
-  while (head < queue.length) {
-    const id = queue[head++];
-    order.set(id, next++);
-    for (const nextId of adjacency.get(id) ?? []) {
-      if (seen.has(nextId)) continue;
-      seen.add(nextId);
-      queue.push(nextId);
+
+  // One component at a time: drain each root's BFS completely before seeding
+  // the next. Seeding every root at once would interleave independent chains —
+  // for `a → b` and `c → d` that yields a=1, c=2, b=3, d=4, so drawing a second
+  // chain on the canvas renumbers the first one's steps. That is the same
+  // renumbering-underneath-the-user problem the root filter above avoids for
+  // lone nodes, and it would contradict this function's contract that
+  // disconnected work is numbered *after* the flow it has not joined.
+  //
+  // BFS still applies *within* a component, so a fan-out's sibling branches
+  // keep adjacent numbers; only whole components are kept contiguous.
+  for (const root of roots) {
+    if (seen.has(root)) continue;
+    const queue: string[] = [root];
+    seen.add(root);
+    let head = 0;
+    while (head < queue.length) {
+      const id = queue[head++];
+      order.set(id, next++);
+      for (const nextId of adjacency.get(id) ?? []) {
+        if (seen.has(nextId)) continue;
+        seen.add(nextId);
+        queue.push(nextId);
+      }
     }
   }
 

--- a/app/src/lib/flows/graphAdapter.ts
+++ b/app/src/lib/flows/graphAdapter.ts
@@ -45,6 +45,13 @@ export interface FlowNodeData extends Record<string, unknown> {
   inputPorts: string[];
   /** Effective output port names: declared `ports` ∪ outgoing edges' `from_port` (`['main']` if neither). */
   outputPorts: string[];
+  /**
+   * 1-based execution-order index shown on the card ("3. Fetch Unread Emails"),
+   * so a node can be referred to by number in a run view, an error, or a
+   * conversation. Derived from the same BFS the layout uses — see
+   * {@link stepNumbers}. Presentation only: never persisted back into the graph.
+   */
+  stepNumber?: number;
 }
 
 export type FlowNode = Node<FlowNodeData>;
@@ -116,6 +123,7 @@ export function workflowGraphToXyflow(graph: WorkflowGraph): {
   log('workflowGraphToXyflow: nodes=%d edges=%d', graph.nodes.length, graph.edges.length);
 
   const laidOut = autoLayout(graph.nodes, graph.edges);
+  const steps = stepNumbers(graph.nodes, graph.edges);
 
   const nodes: FlowNode[] = graph.nodes.map(node => {
     const position = node.position ?? laidOut.get(node.id) ?? { x: 0, y: 0 };
@@ -131,6 +139,7 @@ export function workflowGraphToXyflow(graph: WorkflowGraph): {
         ports: node.ports,
         inputPorts: effectiveInputPorts(node, graph.edges),
         outputPorts: effectiveOutputPorts(node, graph.edges),
+        stepNumber: steps.get(node.id),
       },
     };
   });
@@ -424,4 +433,61 @@ export function autoLayout(nodes: WorkflowNode[], edges: WorkflowEdge[]): Map<st
   }
 
   return positions;
+}
+
+/**
+ * Assigns each node a 1-based execution-order index for display ("3. Fetch
+ * Unread Emails").
+ *
+ * Uses the same breadth-first walk as {@link autoLayout} — roots (no incoming
+ * edge, normally just the trigger) first, then each successor as it is reached
+ * — so a card's number always agrees with its position in the laid-out graph
+ * rather than with declaration order, which is arbitrary for a graph the agent
+ * authored.
+ *
+ * A DAG has no single "correct" ordering once it branches: two parallel
+ * branches genuinely run concurrently, so any numbering imposes an order that
+ * execution does not guarantee. BFS is chosen because it numbers breadth-first
+ * across a fan-out (both branches' first steps get adjacent numbers) rather
+ * than running one branch to its end before starting the next, which is what a
+ * depth-first walk would do and reads as wrong beside a two-column layout.
+ *
+ * Every node gets a number, including ones the walk cannot reach (a
+ * disconnected sub-graph, or a cycle with no zero-in-degree entry) — those are
+ * appended in declaration order after the reachable ones, so no card renders
+ * without an index.
+ */
+export function stepNumbers(nodes: WorkflowNode[], edges: WorkflowEdge[]): Map<string, number> {
+  const order = new Map<string, number>();
+  if (nodes.length === 0) return order;
+
+  const nodeIds = new Set(nodes.map(n => n.id));
+  const incoming = new Map<string, number>(nodes.map(n => [n.id, 0]));
+  const adjacency = new Map<string, string[]>(nodes.map(n => [n.id, []]));
+  for (const edge of edges) {
+    if (!nodeIds.has(edge.from_node) || !nodeIds.has(edge.to_node)) continue;
+    adjacency.get(edge.from_node)?.push(edge.to_node);
+    incoming.set(edge.to_node, (incoming.get(edge.to_node) ?? 0) + 1);
+  }
+
+  const roots = nodes.filter(n => (incoming.get(n.id) ?? 0) === 0);
+  const queue: string[] = (roots.length > 0 ? roots : nodes).map(n => n.id);
+  const seen = new Set<string>(queue);
+
+  let head = 0;
+  let next = 1;
+  while (head < queue.length) {
+    const id = queue[head++];
+    order.set(id, next++);
+    for (const nextId of adjacency.get(id) ?? []) {
+      if (seen.has(nextId)) continue;
+      seen.add(nextId);
+      queue.push(nextId);
+    }
+  }
+
+  for (const node of nodes) {
+    if (!order.has(node.id)) order.set(node.id, next++);
+  }
+  return order;
 }

--- a/app/src/lib/flows/graphAdapter.ts
+++ b/app/src/lib/flows/graphAdapter.ts
@@ -45,13 +45,6 @@ export interface FlowNodeData extends Record<string, unknown> {
   inputPorts: string[];
   /** Effective output port names: declared `ports` ∪ outgoing edges' `from_port` (`['main']` if neither). */
   outputPorts: string[];
-  /**
-   * 1-based execution-order index shown on the card ("3. Fetch Unread Emails"),
-   * so a node can be referred to by number in a run view, an error, or a
-   * conversation. Derived from the same BFS the layout uses — see
-   * {@link stepNumbers}. Presentation only: never persisted back into the graph.
-   */
-  stepNumber?: number;
 }
 
 export type FlowNode = Node<FlowNodeData>;
@@ -123,7 +116,6 @@ export function workflowGraphToXyflow(graph: WorkflowGraph): {
   log('workflowGraphToXyflow: nodes=%d edges=%d', graph.nodes.length, graph.edges.length);
 
   const laidOut = autoLayout(graph.nodes, graph.edges);
-  const steps = stepNumbers(graph.nodes, graph.edges);
 
   const nodes: FlowNode[] = graph.nodes.map(node => {
     const position = node.position ?? laidOut.get(node.id) ?? { x: 0, y: 0 };
@@ -139,7 +131,6 @@ export function workflowGraphToXyflow(graph: WorkflowGraph): {
         ports: node.ports,
         inputPorts: effectiveInputPorts(node, graph.edges),
         outputPorts: effectiveOutputPorts(node, graph.edges),
-        stepNumber: steps.get(node.id),
       },
     };
   });
@@ -439,11 +430,11 @@ export function autoLayout(nodes: WorkflowNode[], edges: WorkflowEdge[]): Map<st
  * Assigns each node a 1-based execution-order index for display ("3. Fetch
  * Unread Emails").
  *
- * Uses the same breadth-first walk as {@link autoLayout} — roots (no incoming
- * edge, normally just the trigger) first, then each successor as it is reached
- * — so a card's number always agrees with its position in the laid-out graph
- * rather than with declaration order, which is arbitrary for a graph the agent
- * authored.
+ * Uses the same breadth-first walk as {@link autoLayout} — chain-starting roots
+ * (no incoming edge but at least one outgoing, normally just the trigger)
+ * first, then each successor as it is reached — so a card's number always
+ * agrees with its position in the laid-out graph rather than with declaration
+ * order, which is arbitrary for a graph the agent authored.
  *
  * A DAG has no single "correct" ordering once it branches: two parallel
  * branches genuinely run concurrently, so any numbering imposes an order that
@@ -452,26 +443,65 @@ export function autoLayout(nodes: WorkflowNode[], edges: WorkflowEdge[]): Map<st
  * than running one branch to its end before starting the next, which is what a
  * depth-first walk would do and reads as wrong beside a two-column layout.
  *
- * Every node gets a number, including ones the walk cannot reach (a
- * disconnected sub-graph, or a cycle with no zero-in-degree entry) — those are
- * appended in declaration order after the reachable ones, so no card renders
- * without an index.
+ * Every node gets a number, including ones the walk cannot reach — a node not
+ * yet wired up, a disconnected sub-graph, or a cycle with no zero-in-degree
+ * entry. Those are appended in declaration order after the reachable ones, so
+ * no card renders without an index and, crucially, dropping an unconnected node
+ * onto the canvas does not renumber the flow it has not joined yet.
  */
 export function stepNumbers(nodes: WorkflowNode[], edges: WorkflowEdge[]): Map<string, number> {
-  const order = new Map<string, number>();
-  if (nodes.length === 0) return order;
+  return stepNumbersFor(
+    nodes.map(n => n.id),
+    edges.map(e => [e.from_node, e.to_node])
+  );
+}
 
-  const nodeIds = new Set(nodes.map(n => n.id));
-  const incoming = new Map<string, number>(nodes.map(n => [n.id, 0]));
-  const adjacency = new Map<string, string[]>(nodes.map(n => [n.id, []]));
-  for (const edge of edges) {
-    if (!nodeIds.has(edge.from_node) || !nodeIds.has(edge.to_node)) continue;
-    adjacency.get(edge.from_node)?.push(edge.to_node);
-    incoming.set(edge.to_node, (incoming.get(edge.to_node) ?? 0) + 1);
+/**
+ * {@link stepNumbers} for the xyflow shape — the live editing state.
+ *
+ * The editable canvas holds its graph in `useNodesState`/`useEdgesState` and
+ * mutates it directly (`addNode` builds a node with `createFlowNode`,
+ * `onConnect` only calls `setEdges`), so `workflowGraphToXyflow` runs once at
+ * mount and never again. Numbering must therefore be derived from the live
+ * arrays on every change rather than baked into node `data` at adapt time — a
+ * node added mid-edit has no adapter-supplied number at all, and every existing
+ * number goes stale the moment the topology changes.
+ */
+export function stepNumbersForFlow(nodes: FlowNode[], edges: FlowEdge[]): Map<string, number> {
+  return stepNumbersFor(
+    nodes.map(n => n.id),
+    edges.map(e => [e.source, e.target])
+  );
+}
+
+/**
+ * Shared BFS behind both public entry points, over bare ids and `[from, to]`
+ * pairs so the two graph shapes cannot drift in ordering behaviour.
+ */
+function stepNumbersFor(ids: string[], pairs: Array<[string, string]>): Map<string, number> {
+  const order = new Map<string, number>();
+  if (ids.length === 0) return order;
+
+  const known = new Set(ids);
+  const incoming = new Map<string, number>(ids.map(id => [id, 0]));
+  const adjacency = new Map<string, string[]>(ids.map(id => [id, []]));
+  for (const [from, to] of pairs) {
+    if (!known.has(from) || !known.has(to)) continue;
+    adjacency.get(from)?.push(to);
+    incoming.set(to, (incoming.get(to) ?? 0) + 1);
   }
 
-  const roots = nodes.filter(n => (incoming.get(n.id) ?? 0) === 0);
-  const queue: string[] = (roots.length > 0 ? roots : nodes).map(n => n.id);
+  // Seed only with roots that actually start a chain — in-degree 0 AND at
+  // least one outgoing edge. A node with no edges at all is *not* step 2 just
+  // because it has no incoming one: on the editable canvas a node dropped from
+  // the palette is unwired for as long as it takes to connect it, and seeding
+  // it as a root would renumber the entire flow underneath the user each time
+  // they added one. Such nodes fall through to the trailing pass below and are
+  // numbered after the wired flow instead.
+  const roots = ids.filter(
+    id => (incoming.get(id) ?? 0) === 0 && (adjacency.get(id)?.length ?? 0) > 0
+  );
+  const queue: string[] = [...roots];
   const seen = new Set<string>(queue);
 
   let head = 0;
@@ -486,8 +516,11 @@ export function stepNumbers(nodes: WorkflowNode[], edges: WorkflowEdge[]): Map<s
     }
   }
 
-  for (const node of nodes) {
-    if (!order.has(node.id)) order.set(node.id, next++);
+  // Everything the walk never reached: unwired nodes, disconnected sub-graphs,
+  // and cycles with no zero-in-degree entry. Numbered in declaration order so
+  // every card still shows an index.
+  for (const id of ids) {
+    if (!order.has(id)) order.set(id, next++);
   }
   return order;
 }

--- a/app/src/lib/flows/nodeKindIcons.test.tsx
+++ b/app/src/lib/flows/nodeKindIcons.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * The icon and tile maps are the canvas's only source of node iconography, and
+ * both are `Record<NodeKind, …>` — so TypeScript already guarantees they are
+ * exhaustive. What it cannot guarantee is the *runtime* half of the contract:
+ * that a kind this build has never heard of still renders (a graph saved by a
+ * newer build reaches the renderer as `unknown`, and there is no error boundary
+ * around `<ReactFlow>`), and that the two maps stay keyed alike.
+ */
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  NODE_KIND_ICON,
+  NODE_KIND_TILE,
+  NodeKindGlyph,
+  nodeKindIcon,
+  nodeKindTile,
+} from './nodeKindIcons';
+import type { NodeKind } from './types';
+
+const KINDS = Object.keys(NODE_KIND_ICON) as NodeKind[];
+
+describe('nodeKindIcons', () => {
+  it('covers all 14 node kinds in both maps, keyed identically', () => {
+    expect(KINDS).toHaveLength(14);
+    expect(Object.keys(NODE_KIND_TILE).sort()).toEqual([...KINDS].sort());
+  });
+
+  it('resolves an icon and a tile for every kind', () => {
+    for (const kind of KINDS) {
+      expect(nodeKindIcon(kind)).toBeTypeOf('function');
+      expect(nodeKindTile(kind)).toMatch(/bg-/);
+    }
+  });
+
+  it('falls back rather than throwing for a kind this build does not know', () => {
+    // A graph saved by a newer build can carry a 15th kind. It must render as a
+    // plain node, never crash the canvas.
+    expect(() => nodeKindIcon('some_future_kind')).not.toThrow();
+    expect(nodeKindIcon('some_future_kind')).toBeTypeOf('function');
+    expect(nodeKindTile('some_future_kind')).toMatch(/bg-/);
+  });
+
+  it('renders a glyph for a known kind', () => {
+    const { container } = render(<NodeKindGlyph kind="http_request" className="h-4 w-4" />);
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute('class')).toContain('h-4');
+  });
+
+  it('renders a glyph for an unknown kind without throwing', () => {
+    const { container } = render(<NodeKindGlyph kind="some_future_kind" />);
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('honours an explicit icon override', () => {
+    // The native OpenHuman tool is a `tool_call` that needs its own glyph
+    // without its own NodeKind — the override is what makes that possible.
+    const Custom = () => <svg data-testid="custom-glyph" />;
+    const { getByTestId } = render(<NodeKindGlyph kind="tool_call" icon={Custom} />);
+    expect(getByTestId('custom-glyph')).toBeInTheDocument();
+  });
+});

--- a/app/src/lib/flows/nodeKindIcons.test.tsx
+++ b/app/src/lib/flows/nodeKindIcons.test.tsx
@@ -14,6 +14,7 @@ import {
   NODE_KIND_TILE,
   NodeKindGlyph,
   nodeKindIcon,
+  NodeKindTile,
   nodeKindTile,
 } from './nodeKindIcons';
 import type { NodeKind } from './types';
@@ -59,5 +60,46 @@ describe('nodeKindIcons', () => {
     const Custom = () => <svg data-testid="custom-glyph" />;
     const { getByTestId } = render(<NodeKindGlyph kind="tool_call" icon={Custom} />);
     expect(getByTestId('custom-glyph')).toBeInTheDocument();
+  });
+});
+
+describe('NodeKindTile', () => {
+  it('renders the kind gradient and its glyph together', () => {
+    const { container } = render(<NodeKindTile kind="http_request" testId="tile" />);
+    const tile = container.querySelector('[data-testid="tile"]');
+    expect(tile?.className).toContain('bg-gradient-to-br');
+    expect(tile?.className).toContain('h-8 w-8');
+    expect(tile?.querySelector('svg')).not.toBeNull();
+  });
+
+  it('applies static size classes, never runtime-interpolated ones', () => {
+    // Tailwind's JIT discovers classes by scanning source text, so a class
+    // assembled from a template literal at runtime is never generated and the
+    // element silently renders unstyled. Both variants must be whole literals.
+    const { container: sm } = render(<NodeKindTile kind="code" size="sm" testId="sm" />);
+    const { container: md } = render(<NodeKindTile kind="code" size="md" testId="md" />);
+    expect(sm.querySelector('[data-testid="sm"]')?.className).toContain('h-5 w-5');
+    expect(md.querySelector('[data-testid="md"]')?.className).toContain('h-8 w-8');
+    expect(sm.innerHTML).not.toMatch(/h-\[undefined|w-\[undefined|\$\{/);
+  });
+
+  it('is hidden from assistive tech', () => {
+    // The card's accessible name is its node name; kind is conveyed by the
+    // textual kind label, not by the decorative tile.
+    const { container } = render(<NodeKindTile kind="agent" testId="tile" />);
+    expect(container.querySelector('[data-testid="tile"]')?.getAttribute('aria-hidden')).toBe(
+      'true'
+    );
+  });
+
+  it('honours the icon override and still uses the given kind gradient', () => {
+    const Custom = () => <svg data-testid="custom" />;
+    const { container, getByTestId } = render(
+      <NodeKindTile kind="agent" icon={Custom} testId="tile" />
+    );
+    expect(getByTestId('custom')).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="tile"]')?.className).toContain(
+      'from-accent-lavender'
+    );
   });
 });

--- a/app/src/lib/flows/nodeKindIcons.tsx
+++ b/app/src/lib/flows/nodeKindIcons.tsx
@@ -1,0 +1,164 @@
+/**
+ * Per-kind canvas iconography for the 14 tinyflows `NodeKind`s.
+ *
+ * Split out of `nodeKindMeta.ts` on purpose: that module is deliberately
+ * dependency-free (no React) so a plain palette button and a `<Handle>`-bearing
+ * canvas card can share one source of truth. Icon *components* are React, so
+ * they live here and are keyed by the same `NodeKind` union — the two modules
+ * stay in lockstep because both are exhaustive `Record<NodeKind, …>` maps, and
+ * TypeScript fails the build if a kind is added to one and not the other.
+ *
+ * These replace the emoji the canvas previously rendered. Emoji were a
+ * liability for a workflow surface: their glyphs are supplied by the platform,
+ * so the same graph looked materially different on macOS, Windows and Linux;
+ * they carry their own colour, which fought the card's own state colouring; and
+ * they read as informal next to the rest of the product. Lucide (via
+ * `react-icons/lu`) is already the house set — it is by far the most-used icon
+ * family in `app/src` — so these inherit `currentColor` and sit at the same
+ * optical weight as the icons in Settings and Chat.
+ */
+import { createElement } from 'react';
+import type { IconType } from 'react-icons';
+import {
+  LuBinary,
+  LuBot,
+  LuBraces,
+  LuBrain,
+  LuCode,
+  LuFilter,
+  LuGitBranch,
+  LuGitFork,
+  LuGitMerge,
+  LuGlobe,
+  LuLayers,
+  LuSplit,
+  LuWand,
+  LuWrench,
+  LuZap,
+} from 'react-icons/lu';
+
+import type { NodeKind } from './types';
+
+/**
+ * The glyph each node kind renders on the canvas, in its palette entry, and in
+ * the config drawer header.
+ *
+ * Chosen so the shape alone hints at the operation — branching kinds use the
+ * git-family glyphs (`condition` splits two ways, `switch` forks many,
+ * `merge` joins, `split_out` fans out), data-shaping kinds use symbolic
+ * glyphs (`transform` a wand, `output_parser` braces), and the three
+ * "reach outside" kinds are visually distinct from each other (`tool_call` a
+ * wrench, `http_request` a globe, `code` angle brackets).
+ */
+export const NODE_KIND_ICON: Record<NodeKind, IconType> = {
+  trigger: LuZap,
+  agent: LuBot,
+  tool_call: LuWrench,
+  http_request: LuGlobe,
+  code: LuCode,
+  condition: LuGitBranch,
+  switch: LuGitFork,
+  merge: LuGitMerge,
+  split_out: LuSplit,
+  transform: LuWand,
+  output_parser: LuBraces,
+  sub_workflow: LuLayers,
+  memory: LuBrain,
+  dedup: LuFilter,
+};
+
+/**
+ * Icon for a possibly-unknown kind. The canvas renders whatever the persisted
+ * graph holds, and a graph saved by a newer build can carry a kind this one has
+ * never heard of — that must render as a plain node, never throw, since there
+ * is no error boundary around `<ReactFlow>`.
+ */
+export function nodeKindIcon(kind: NodeKind | string): IconType {
+  return NODE_KIND_ICON[kind as NodeKind] ?? LuBinary;
+}
+
+/**
+ * Renders a kind's glyph. The canvas card, the palette and the config drawer
+ * all go through this rather than resolving the icon themselves.
+ *
+ * Uses `createElement` instead of the more natural
+ * `const Icon = nodeKindIcon(kind); return <Icon />` because binding the result
+ * of a call to a capitalized local trips `react-hooks/static-components` — the
+ * rule cannot distinguish a lookup in a module-level constant map (stable
+ * identity, no remount) from a component defined inline during render (new
+ * identity every render, subtree remounts). This is the former; the indirection
+ * exists solely to say so once, here, instead of at three call sites.
+ *
+ * `icon` overrides the per-kind lookup for nodes that need a distinct glyph
+ * without a distinct `NodeKind` — today only the native OpenHuman tool, which
+ * is a `tool_call` but reads as one of the assistant's own capabilities.
+ */
+export function NodeKindGlyph({
+  kind,
+  icon,
+  className,
+}: {
+  kind: NodeKind | string;
+  icon?: IconType;
+  className?: string;
+}) {
+  return createElement(icon ?? nodeKindIcon(kind), { className, 'aria-hidden': true });
+}
+
+/**
+ * The tile fill behind each kind's glyph — the one saturated element on an
+ * otherwise neutral card.
+ *
+ * **Why colour lives on the tile and not the card.** A fully neutral card is
+ * unreadable on this product's dark theme: the canvas is pure black, `surface`
+ * is `#171717` and `line` is `#262626`, so a grey-on-grey card has almost no
+ * hue and almost no luminance contrast. But colouring the *card* by kind is
+ * what the previous design did, and it broke status: `sage` and `coral` mean
+ * success and error everywhere else in the product, so a healthy `merge` node
+ * rendered green and a `tool_call` amber read as run state rather than type.
+ *
+ * A 32px tile resolves both. It is saturated enough to give the canvas life and
+ * to make kinds recognisable at a glance before the label is readable, while
+ * run state stays legible because it is drawn on a different surface — a ring
+ * around the whole card. Identity is a filled square; status is an outline.
+ * The two never compete for the same pixels.
+ *
+ * Gradients rather than flat fills: the darker stop guarantees the white glyph
+ * clears contrast even where the lighter stop (`accent-lavender`, `accent-sky`)
+ * is too pale to carry white on its own.
+ *
+ * Hues are grouped by role so the mapping is learnable rather than arbitrary —
+ * warm for control flow that branches, ocean for anything reaching outside the
+ * graph, violet for the AI-backed kinds, green for kinds that recombine, and
+ * cool grey for pure data shaping.
+ */
+export const NODE_KIND_TILE: Record<NodeKind, string> = {
+  // Start — the spark that begins a run.
+  trigger: 'bg-gradient-to-br from-amber-400 to-amber-600',
+  // Intelligence — model-backed kinds.
+  agent: 'bg-gradient-to-br from-accent-lavender to-primary-600',
+  memory: 'bg-gradient-to-br from-accent-lavender to-primary-700',
+  // Reaching outside the graph.
+  tool_call: 'bg-gradient-to-br from-primary-400 to-primary-600',
+  http_request: 'bg-gradient-to-br from-accent-sky to-primary-500',
+  sub_workflow: 'bg-gradient-to-br from-primary-500 to-primary-700',
+  // Control flow that splits.
+  condition: 'bg-gradient-to-br from-amber-400 to-coral-500',
+  switch: 'bg-gradient-to-br from-amber-500 to-coral-600',
+  // Control flow that recombines / fans out.
+  merge: 'bg-gradient-to-br from-sage-400 to-sage-600',
+  split_out: 'bg-gradient-to-br from-sage-500 to-sage-700',
+  // Data shaping — deliberately the quietest family.
+  code: 'bg-gradient-to-br from-slate-500 to-slate-700',
+  transform: 'bg-gradient-to-br from-accent-lavender to-accent-rose',
+  output_parser: 'bg-gradient-to-br from-slate-400 to-slate-600',
+  dedup: 'bg-gradient-to-br from-slate-500 to-slate-600',
+};
+
+/** Neutral tile for a kind this build does not recognise. See {@link nodeKindIcon}. */
+const UNKNOWN_KIND_TILE = 'bg-gradient-to-br from-stone-400 to-stone-600';
+
+/** Tile fill for a possibly-unknown kind. */
+export function nodeKindTile(kind: NodeKind | string): string {
+  return NODE_KIND_TILE[kind as NodeKind] ?? UNKNOWN_KIND_TILE;
+}

--- a/app/src/lib/flows/nodeKindIcons.tsx
+++ b/app/src/lib/flows/nodeKindIcons.tsx
@@ -162,3 +162,57 @@ const UNKNOWN_KIND_TILE = 'bg-gradient-to-br from-stone-400 to-stone-600';
 export function nodeKindTile(kind: NodeKind | string): string {
   return NODE_KIND_TILE[kind as NodeKind] ?? UNKNOWN_KIND_TILE;
 }
+
+/**
+ * Tile size variants. Deliberately whole static class strings rather than
+ * numeric props interpolated into `h-[${n}px]`: Tailwind's JIT compiler
+ * discovers classes by scanning source text, so a class assembled at runtime
+ * from a template literal is never generated and the element renders unstyled.
+ */
+const TILE_SIZES = {
+  /** Palette rows — small enough that the glyph needs the tighter radius. */
+  sm: { tile: 'h-5 w-5 rounded-md', glyph: 'h-3 w-3' },
+  /** Canvas cards and the config-drawer header. */
+  md: { tile: 'h-8 w-8 rounded-lg', glyph: 'h-[18px] w-[18px]' },
+} as const;
+
+export type NodeKindTileSize = keyof typeof TILE_SIZES;
+
+/**
+ * A kind's glyph on its colour-coded tile — the single element the canvas card,
+ * the palette row and the config-drawer header all render.
+ *
+ * Keeping the tile chrome (gradient, inset ring, shadow, radius) in one place
+ * means the swatch a user picks in the palette is provably the swatch that
+ * lands on the graph: the three surfaces cannot drift because they no longer
+ * each own a copy of the markup.
+ *
+ * `aria-hidden` because the tile is decorative — a card's accessible name is
+ * its node name, and the kind is conveyed textually by the kind label rather
+ * than by colour or glyph alone.
+ */
+export function NodeKindTile({
+  kind,
+  icon,
+  size = 'md',
+  className = '',
+  testId,
+}: {
+  kind: NodeKind | string;
+  /** Overrides the per-kind glyph. See {@link NodeKindGlyph}. */
+  icon?: IconType;
+  size?: NodeKindTileSize;
+  /** Extra positioning classes for the call site (e.g. `mt-0.5`). */
+  className?: string;
+  testId?: string;
+}) {
+  const { tile, glyph } = TILE_SIZES[size];
+  return (
+    <span
+      aria-hidden="true"
+      data-testid={testId}
+      className={`flex shrink-0 items-center justify-center text-white shadow-sm ring-1 ring-inset ring-white/15 ${tile} ${nodeKindTile(kind)} ${className}`}>
+      <NodeKindGlyph kind={kind} icon={icon} className={glyph} />
+    </span>
+  );
+}

--- a/app/src/lib/flows/nodeKindMeta.ts
+++ b/app/src/lib/flows/nodeKindMeta.ts
@@ -1,19 +1,25 @@
 /**
- * Per-kind visual metadata for the 14 tinyflows `NodeKind`s, shared by the
+ * Per-kind palette grouping for the 14 tinyflows `NodeKind`s, shared by the
  * canvas node renderer (`FlowNodeComponent`) and the editable canvas's node
  * palette (`NodePalette`). Kept dependency-free (no React) so both a rendered
  * `<Handle>`-bearing card and a plain palette button can pull the same
- * emoji/accent from one source of truth instead of drifting apart.
+ * grouping from one source of truth instead of drifting apart.
  *
- * Colors cycle through the four CSS-variable-backed semantic ramps
- * (primary/sage/amber/coral) that support Tailwind's `/opacity` modifiers in
- * this codebase (see `tailwind.config.js`) so light/dark theming comes for
- * free; with 14 kinds and 4 ramps some kinds share a color family — the emoji
- * + name remain the primary distinguishers.
+ * **Iconography and colour live in `nodeKindIcons.tsx`, not here** — they are
+ * React components, and keeping them out preserves this module's React-free
+ * property. The two stay in lockstep because both are exhaustive
+ * `Record<NodeKind, …>` maps, so adding a kind to one and not the other fails
+ * the build.
+ *
+ * This module previously also carried a per-kind emoji and one of four semantic
+ * colour ramps used to paint the card's border and header chip. Both are gone:
+ * platform-supplied emoji glyphs made the same graph look materially different
+ * across macOS/Windows/Linux, and the ramps carry status meaning elsewhere in
+ * the product (sage = success, coral = error), so a healthy `merge` node
+ * rendered coral read as a failure. Kind colour is now confined to the glyph
+ * tile (`NODE_KIND_TILE`), leaving the card's border free to signal run state.
  */
 import type { NodeKind } from './types';
-
-export type NodeColor = 'sage' | 'primary' | 'amber' | 'coral' | 'neutral';
 
 /**
  * Palette grouping for the node kinds: `triggers` (what starts a run),
@@ -23,8 +29,6 @@ export type NodeColor = 'sage' | 'primary' | 'amber' | 'coral' | 'neutral';
 export type NodeGroup = 'triggers' | 'actions' | 'logic';
 
 interface NodeKindMeta {
-  emoji: string;
-  color: NodeColor;
   group: NodeGroup;
 }
 
@@ -57,28 +61,28 @@ const NODE_KINDS: NodeKind[] = [
   'dedup',
 ];
 
-/** Per-kind emoji + border/chip color + palette group. See the module doc. */
+/** Per-kind palette group. See the module doc. */
 const NODE_KIND_META: Record<NodeKind, NodeKindMeta> = {
-  trigger: { emoji: '⚡', color: 'sage', group: 'triggers' },
-  agent: { emoji: '🤖', color: 'primary', group: 'actions' },
-  tool_call: { emoji: '🔧', color: 'amber', group: 'actions' },
-  http_request: { emoji: '🌐', color: 'coral', group: 'actions' },
-  code: { emoji: '📝', color: 'sage', group: 'actions' },
-  sub_workflow: { emoji: '🧩', color: 'coral', group: 'actions' },
+  trigger: { group: 'triggers' },
+  agent: { group: 'actions' },
+  tool_call: { group: 'actions' },
+  http_request: { group: 'actions' },
+  code: { group: 'actions' },
+  sub_workflow: { group: 'actions' },
   // Declarative in-graph memory access (recall/search/flavour/people/
   // remember/forget) — an "actions" node like `tool_call`/`http_request`
   // (it reads/writes state), not `logic` (it doesn't itself branch/reshape).
-  memory: { emoji: '🧠', color: 'sage', group: 'actions' },
-  condition: { emoji: '🔀', color: 'primary', group: 'logic' },
-  switch: { emoji: '🔁', color: 'amber', group: 'logic' },
-  merge: { emoji: '🔗', color: 'coral', group: 'logic' },
-  split_out: { emoji: '📤', color: 'sage', group: 'logic' },
-  transform: { emoji: '♻️', color: 'primary', group: 'logic' },
-  output_parser: { emoji: '📋', color: 'amber', group: 'logic' },
+  memory: { group: 'actions' },
+  condition: { group: 'logic' },
+  switch: { group: 'logic' },
+  merge: { group: 'logic' },
+  split_out: { group: 'logic' },
+  transform: { group: 'logic' },
+  output_parser: { group: 'logic' },
   // Skips items already seen, keyed by a stable per-item `=`-expression — a
   // "logic" node like its neighbours (`condition`/`split_out`/`merge`): it
   // routes/filters the item stream rather than calling out or reading state.
-  dedup: { emoji: '🪪', color: 'coral', group: 'logic' },
+  dedup: { group: 'logic' },
 };
 
 /** Palette group render order. */
@@ -94,8 +98,6 @@ export interface PaletteEntry {
   key: string;
   kind: NodeKind;
   group: NodeGroup;
-  emoji: string;
-  color: NodeColor;
   labelKey: string;
   /** Default config merged onto a node created from this entry. */
   preset?: Record<string, unknown>;
@@ -109,8 +111,6 @@ export const PALETTE_ENTRIES: PaletteEntry[] = NODE_KINDS.flatMap((kind): Palett
         key: 'tool_call',
         kind: 'tool_call',
         group: 'actions',
-        emoji: '🔌',
-        color: 'amber',
         labelKey: 'flows.palette.appAction',
         preset: { provider: 'composio' },
       },
@@ -118,23 +118,12 @@ export const PALETTE_ENTRIES: PaletteEntry[] = NODE_KINDS.flatMap((kind): Palett
         key: 'oh_tool',
         kind: 'tool_call',
         group: 'actions',
-        emoji: '🛠️',
-        color: 'primary',
         labelKey: 'flows.palette.ohTool',
         preset: { provider: 'openhuman' },
       },
     ];
   }
-  return [
-    {
-      key: kind,
-      kind,
-      group: meta.group,
-      emoji: meta.emoji,
-      color: meta.color,
-      labelKey: `flows.nodeKind.${kind}`,
-    },
-  ];
+  return [{ key: kind, kind, group: meta.group, labelKey: `flows.nodeKind.${kind}` }];
 });
 
 export const PALETTE_ENTRIES_BY_GROUP: Record<NodeGroup, PaletteEntry[]> = {
@@ -151,36 +140,9 @@ export const PALETTE_ENTRIES_BY_GROUP: Record<NodeGroup, PaletteEntry[]> = {
  * here so an unrecognized kind renders as a plain neutral node instead of
  * crashing the whole canvas (there's no error boundary around `<ReactFlow>`).
  */
-const DEFAULT_NODE_META: NodeKindMeta = { emoji: '❔', color: 'neutral', group: 'actions' };
+const DEFAULT_NODE_META: NodeKindMeta = { group: 'actions' };
 
 /** Resolve a kind's metadata, falling back to {@link DEFAULT_NODE_META}. */
 export function nodeKindMeta(kind: NodeKind): NodeKindMeta {
   return NODE_KIND_META[kind] ?? DEFAULT_NODE_META;
 }
-
-// `tint` is a faint wash of the accent for the node card body, so the whole
-// node reads as gently colour-coded rather than a stark white box under the
-// stronger header `chip`.
-export const COLOR_CLASSES: Record<NodeColor, { border: string; chip: string; tint: string }> = {
-  sage: {
-    border: 'border-sage-400 dark:border-sage-500/60',
-    chip: 'bg-sage-100 dark:bg-sage-500/20',
-    tint: 'bg-sage-50/60 dark:bg-sage-500/[0.07]',
-  },
-  primary: {
-    border: 'border-primary-400 dark:border-primary-500/60',
-    chip: 'bg-primary-100 dark:bg-primary-500/20',
-    tint: 'bg-primary-50/60 dark:bg-primary-500/[0.07]',
-  },
-  amber: {
-    border: 'border-amber-400 dark:border-amber-500/60',
-    chip: 'bg-amber-100 dark:bg-amber-500/20',
-    tint: 'bg-amber-50/60 dark:bg-amber-500/[0.07]',
-  },
-  coral: {
-    border: 'border-coral-400 dark:border-coral-500/60',
-    chip: 'bg-coral-100 dark:bg-coral-500/20',
-    tint: 'bg-coral-50/60 dark:bg-coral-500/[0.07]',
-  },
-  neutral: { border: 'border-line-strong', chip: 'bg-surface-subtle', tint: 'bg-surface' },
-};


### PR DESCRIPTION
## Summary

- **Kind colour moves from the card border to the glyph tile.** Each node kind now renders a Lucide line icon on a saturated gradient tile; the card body is a neutral elevated surface. Identity is a filled shape, status is an outline.
- **Emoji replaced with the house icon set** (`react-icons/lu`), so a graph looks the same on macOS, Windows and Linux.
- **Cards are actually visible on the dark theme** — distinct title band, `line-strong` border, two-layer shadow. Everything below the title divider is one uninterrupted surface.
- **Step numbers** (`1.`, `2.`, `3.`) derived from the same BFS `autoLayout` uses, so a node can be referred to by number.
- **Connectors are legible** — they were drawn in `line-strong` (#404040) on a pure-black canvas. Handles gained a hover halo.
- Palette and config drawer use the same tiles; the orphaned `COLOR_CLASSES` table and per-kind `emoji`/`color` fields are removed.

## Problem

Two independent problems, one of which was a genuine legibility bug.

**1. Kind colour was impersonating run status.** The card's border and header chip were coloured per kind, cycling 14 kinds through 4 semantic ramps. Those ramps carry meaning everywhere else in the product — sage = success, coral = error — so a perfectly healthy `merge` node rendered coral and a `tool_call` rendered amber. A canvas of healthy nodes read as a canvas of warnings. Worse, it left the *real* state signals with nothing to contrast against: `.flow-node-running` / `-success` / `-failed`, the validation ring, and the copilot diff overlay all draw on the same card edge that was already saturated.

**2. The card had almost no contrast on the dark theme.** Canvas is `--surface-canvas: 0 0 0` (pure black), the card is `--surface: 23 23 23`, and the border is `--line: 38 38 38`. Connector edges were `--line-strong: 64 64 64`. The whole surface sat in a 0–40 luminance band, so graph structure — the thing a workflow canvas exists to show — was barely perceptible.

Emoji were a third, smaller liability: platform-supplied glyphs meant the same graph looked materially different per OS, they carry their own colour that fought the card's, and they read as informal beside the rest of the product.

## Solution

**Colour confined to a 32px tile.** `NODE_KIND_TILE` maps each kind to a gradient fill, grouped by role so the mapping is learnable rather than arbitrary: amber starts a run, violet for the model-backed kinds, ocean for anything reaching outside the graph, green for kinds that recombine, cool grey for pure data shaping. Gradients rather than flat fills so the darker stop guarantees the white glyph clears contrast even where the lighter stop is pale. Run state stays legible because it is drawn on a different surface — a ring around the whole card — so identity and status never compete for the same pixels.

**Iconography split into `nodeKindIcons.tsx`.** `nodeKindMeta.ts` is deliberately React-free so a plain palette button and a `<Handle>`-bearing card can share one source of truth; icon *components* are React, so they live in a sibling module. Both are exhaustive `Record<NodeKind, …>` maps, so adding a kind to one and not the other fails the build.

**`NodeKindGlyph` wraps the lookup.** The natural `const Icon = nodeKindIcon(kind); <Icon />` trips `react-hooks/static-components` — the rule cannot distinguish a lookup in a module-level constant map (stable identity) from a component defined inline during render (new identity, subtree remounts). This is the former; `createElement` plus one explanatory comment beats three suppressions at three call sites. An `icon` override handles the native OpenHuman tool, which needs a distinct glyph without a distinct `NodeKind`.

**`stepNumbers()` reuses `autoLayout`'s BFS** so a card's number always agrees with its laid-out position rather than with declaration order, which is arbitrary for a graph the copilot authored. A DAG has no single correct ordering once it branches — parallel branches genuinely run concurrently — so BFS is chosen deliberately: it numbers breadth-first across a fan-out (sibling branches get adjacent numbers) rather than running one branch to its end first, which reads wrong beside a columnar layout. Unreachable nodes (disconnected sub-graphs, pure cycles) are appended so no card renders without an index. Presentation only — never persisted back into the graph.

**One body surface.** An earlier iteration gave the summary its own tinted well, which together with the untinted connector row produced three competing bands. The title band is now the only secondary fill.

**Handle hover is box-shadow only, not `transform`.** `FlowNodeComponent` pins `transform: none` inline on every handle to opt out of React Flow's absolute edge placement, and an inline declaration outranks the stylesheet — a `scale()` would have silently done nothing.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — new `nodeKindIcons.test.tsx` (6 cases: map exhaustiveness/key parity, resolution for all 14 kinds, unknown-kind fallback for both maps, render, unknown-kind render, icon override) and 4 new `stepNumbers` cases in `graphAdapter.test.ts` (declaration-order independence, breadth-first fan-out, unreachable nodes, end-to-end through `workflowGraphToXyflow`). 381 tests pass across 34 files.
- [x] Coverage matrix updated — `N/A: presentation-only change to an existing canvas surface; no feature row added, removed or renamed.`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix feature IDs affected.`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — no new dependencies at all; `react-icons` was already the house icon set.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface touched.`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A: no tracking issue; this follows the flows full-surface review.`

## Impact

- **Desktop only** (the Workflow Canvas is a desktop surface). No CLI, mobile or web impact.
- **No Rust changes**, no `Cargo.toml`/`Cargo.lock` diff — CI Lite stays on the scoped Rust lane.
- **No schema, persistence or migration impact.** `stepNumber` is presentation-only and is never written back into the saved graph; `normalizeWorkflowGraphForDirtyCheck` and `xyflowToWorkflowGraph` are untouched, so the dirty-check and save round-trip are unchanged.
- **No new dependencies.** Removes code (`COLOR_CLASSES`, the `emoji`/`color` fields, `NodeColor`).
- **Accessibility:** glyphs are `aria-hidden`, so the accessible name of each card remains its node name; kind is still conveyed textually by the kind label rather than by colour alone.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: Phase 2 of the canvas refresh (persistent per-node `…` menu, `+` insert affordance on connectors, branch labels as pills on edges rather than port rows in-card) and Phase 3 (config drawer Setup → Configure → Test stepper) are not in this PR.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/flows-canvas-visual-refresh`
- Commit SHA: `ca1b2c0b80efee8ef15d60f282699b1e5d5fc91b`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — Prettier clean on all changed files.
- [x] `pnpm typecheck` — clean.
- [x] Focused tests: `vitest run src/components/flows src/lib/flows` — **34 files, 381 tests, all passing.**
- [x] Rust fmt/check (if changed): `N/A: no Rust changes.`
- [x] Tauri fmt/check (if changed): `N/A: no Tauri shell changes.`

ESLint is clean on every file this PR touches. Two pre-existing `react-hooks/set-state-in-effect` errors remain in `nodeConfig/composioFields.tsx`, which this PR does not modify.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: node cards are re-styled; each card gains an execution-order number; canvas connectors and handles are more legible.
- User-visible effect: purely visual. No change to graph semantics, validation, run behaviour, save/dirty-check, or any RPC.

### Parity Contract

- Legacy behavior preserved: all node/port/handle/edge semantics, `isValidFlowConnection`, the selected-card Validate/Delete action row, the unknown-kind no-throw fallback, and the read-only viewer's lack of an actions context.
- Guard/fallback/dispatch parity checks: unknown-kind fallback is now pinned by tests in both maps (previously only implicit via `DEFAULT_NODE_META`); `stepNumbers` is pinned to number every node including unreachable ones.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flow nodes now display consistent icons, kind labels, summaries, and execution step numbers.
  * Execution steps are numbered in a clear root-first order, including branching and disconnected flows.
  * Added clear visual styling for each node type, including native tools.
  * Node palette and configuration panels now use the same node visuals.

* **UI Improvements**
  * Improved flow canvas edge visibility and selection feedback.
  * Enlarged connection handles with clearer hover states.
  * Updated cards and tiles with a cleaner, neutral elevated design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->