### PR TITLE
feat(flows): accept declared workflow inputs on every run path

### DIFF
--- a/app/src/services/api/flowsApi.test.ts
+++ b/app/src/services/api/flowsApi.test.ts
@@ -325,7 +325,7 @@ describe('flowsApi', () => {
 
       expect(mockCallCoreRpc).toHaveBeenCalledWith({
         method: 'openhuman.flows_run',
-        params: { id: 'flow-1', input: null },
+        params: { id: 'flow-1', input: null, inputs: null },
         timeoutMs: 610_000,
       });
       expect(result).toEqual({ output: { nodes: {} }, pending_approvals: [], thread_id: 't1' });
@@ -340,7 +340,21 @@ describe('flowsApi', () => {
 
       expect(mockCallCoreRpc).toHaveBeenCalledWith({
         method: 'openhuman.flows_run',
-        params: { id: 'flow-1', input: { trigger: 'manual' } },
+        params: { id: 'flow-1', input: { trigger: 'manual' }, inputs: null },
+        timeoutMs: 610_000,
+      });
+    });
+
+    it('passes declared workflow inputs alongside the trigger payload', async () => {
+      mockCallCoreRpc.mockResolvedValue(
+        cliEnvelope({ output: null, pending_approvals: [], thread_id: 't3' })
+      );
+
+      await runFlow('flow-1', {}, { repo: 'acme/api', depth: 3 });
+
+      expect(mockCallCoreRpc).toHaveBeenCalledWith({
+        method: 'openhuman.flows_run',
+        params: { id: 'flow-1', input: {}, inputs: { repo: 'acme/api', depth: 3 } },
         timeoutMs: 610_000,
       });
     });
@@ -379,7 +393,7 @@ describe('flowsApi', () => {
 
       expect(mockCallCoreRpc).toHaveBeenCalledWith({
         method: 'openhuman.flows_run_detached',
-        params: { id: 'flow-1', input: null },
+        params: { id: 'flow-1', input: null, inputs: null },
       });
       // No `timeoutMs` key at all — asserted structurally above via
       // `toHaveBeenCalledWith` (an object with an extra `timeoutMs` key would
@@ -407,7 +421,25 @@ describe('flowsApi', () => {
 
       expect(mockCallCoreRpc).toHaveBeenCalledWith({
         method: 'openhuman.flows_run_detached',
-        params: { id: 'flow-1', input: { trigger: 'manual' } },
+        params: { id: 'flow-1', input: { trigger: 'manual' }, inputs: null },
+      });
+    });
+
+    it('passes declared workflow inputs — the only way a parameterized flow runs from the UI', async () => {
+      mockCallCoreRpc.mockResolvedValue(
+        cliEnvelope({
+          run_id: 'flow:flow-1:t4',
+          flow_id: 'flow-1',
+          status: 'running',
+          detached: true,
+        })
+      );
+
+      await runFlowDetached('flow-1', {}, { repo: 'acme/api' });
+
+      expect(mockCallCoreRpc).toHaveBeenCalledWith({
+        method: 'openhuman.flows_run_detached',
+        params: { id: 'flow-1', input: {}, inputs: { repo: 'acme/api' } },
       });
     });
 

--- a/app/src/services/api/flowsApi.ts
+++ b/app/src/services/api/flowsApi.ts
@@ -517,12 +517,22 @@ export async function getFlow(id: string): Promise<Flow> {
  * settles — prefer {@link runFlowDetached} for any UI entry point (Run
  * buttons) that must not freeze while a run is in flight; `runFlow` remains
  * for callers that genuinely want to await the final result.
+ *
+ * `input` is the free-form trigger payload. `inputs` supplies values for the
+ * flow's *declared* workflow inputs by name — read the declarations from the
+ * flow's `graph.inputs`. A missing required value, a wrong type, or a name the
+ * flow does not declare is rejected server-side before the run starts, so this
+ * rejects without leaving a run row behind.
  */
-export async function runFlow(id: string, input?: unknown): Promise<FlowResumeResult> {
-  log('runFlow: request id=%s', id);
+export async function runFlow(
+  id: string,
+  input?: unknown,
+  inputs?: Record<string, unknown>
+): Promise<FlowResumeResult> {
+  log('runFlow: request id=%s inputs=%d', id, Object.keys(inputs ?? {}).length);
   const response = await callCoreRpc<unknown>({
     method: 'openhuman.flows_run',
-    params: { id, input: input ?? null },
+    params: { id, input: input ?? null, inputs: inputs ?? null },
     timeoutMs: FLOW_RESUME_TIMEOUT_MS,
   });
   const result = unwrapCliEnvelope<FlowResumeResult>(response);
@@ -562,12 +572,23 @@ export interface FlowRunDetachedResult {
  * to yet), so callers should set up their `flow:run_progress` subscription /
  * poller using the returned `run_id` immediately after this resolves, not
  * after the run itself completes.
+ *
+ * `inputs` carries values for the flow's *declared* workflow inputs by name
+ * (see {@link runFlow}). Because this is the entry point both Run controls use,
+ * a flow with a required input is only runnable from the UI through here — the
+ * caller is expected to collect the values first. They are validated
+ * synchronously, so a bad set rejects here rather than surfacing later as a
+ * failed background run.
  */
-export async function runFlowDetached(id: string, input?: unknown): Promise<FlowRunDetachedResult> {
-  log('runFlowDetached: request id=%s', id);
+export async function runFlowDetached(
+  id: string,
+  input?: unknown,
+  inputs?: Record<string, unknown>
+): Promise<FlowRunDetachedResult> {
+  log('runFlowDetached: request id=%s inputs=%d', id, Object.keys(inputs ?? {}).length);
   const response = await callCoreRpc<unknown>({
     method: 'openhuman.flows_run_detached',
-    params: { id, input: input ?? null },
+    params: { id, input: input ?? null, inputs: inputs ?? null },
   });
   const result = unwrapCliEnvelope<FlowRunDetachedResult>(response);
   log(

--- a/src/bin/library_profile/scenarios/workflow.rs
+++ b/src/bin/library_profile/scenarios/workflow.rs
@@ -50,6 +50,7 @@ pub async fn run() -> Result<ProfileResult> {
             &fixture.config,
             &flow_id,
             json!({ "topic": "Phoenix migration" }),
+            serde_json::Map::new(),
             FlowRunTrigger::Rpc,
         )
         .await

--- a/src/openhuman/flows/builder_tools_tests.rs
+++ b/src/openhuman/flows/builder_tools_tests.rs
@@ -2706,6 +2706,7 @@ async fn cancel_flow_run_refuses_a_run_the_caller_does_not_own() {
         &config,
         &owner_flow.id,
         json!({}),
+        serde_json::Map::new(),
         crate::openhuman::flows::FlowRunTrigger::Rpc,
     )
     .await
@@ -2757,6 +2758,7 @@ async fn cancel_flow_run_cancels_when_flow_id_matches_the_owner() {
         &config,
         &flow.id,
         json!({}),
+        serde_json::Map::new(),
         crate::openhuman::flows::FlowRunTrigger::Rpc,
     )
     .await

--- a/src/openhuman/flows/bus.rs
+++ b/src/openhuman/flows/bus.rs
@@ -40,6 +40,27 @@ pub(crate) fn extract_trigger_config(flow: &Flow) -> Option<&Value> {
     Some(&flow.graph.trigger()?.config)
 }
 
+/// Values an author pinned on the trigger node for *unattended* runs, read from
+/// the trigger's `config.inputs` object.
+///
+/// A schedule tick or an inbound app event has no operator to prompt, so a flow
+/// with declared inputs would otherwise be undispatchable. Pinning values in the
+/// trigger config is how such a flow states, at author time, what an automatic
+/// run should use. Values are passed through literally — this is configuration,
+/// not an expression scope, and there is no run in flight to resolve one
+/// against.
+///
+/// Returns an empty map when the trigger declares none, in which case a required
+/// input with no default fails in `prepare_flow_run` before any run row exists,
+/// and the reason is logged and visible in the run digest.
+fn pinned_trigger_inputs(flow: &Flow) -> serde_json::Map<String, Value> {
+    extract_trigger_config(flow)
+        .and_then(|cfg| cfg.get("inputs"))
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default()
+}
+
 /// True when `flow` is an enabled `app_event` flow bound to the given
 /// Composio `toolkit`/`trigger_slug` (case-insensitive — Composio slugs are
 /// conventionally upper-case but authoring surfaces may not normalize them).
@@ -122,9 +143,11 @@ impl FlowTriggerSubscriber {
             tracing::debug!(target: "flows", %flow_id, "[flows] schedule tick for flow whose trigger is no longer `schedule` — ignoring");
             return;
         }
+        let inputs = pinned_trigger_inputs(&flow);
         self.spawn_run(
             flow_id.to_string(),
             Value::Null,
+            inputs,
             crate::openhuman::flows::FlowRunTrigger::Schedule,
         );
     }
@@ -151,9 +174,11 @@ impl FlowTriggerSubscriber {
         for flow in flows {
             if matches_app_event(&flow, toolkit, trigger_slug) {
                 matched += 1;
+                let inputs = pinned_trigger_inputs(&flow);
                 self.spawn_run(
                     flow.id.clone(),
                     payload.clone(),
+                    inputs,
                     crate::openhuman::flows::FlowRunTrigger::AppEvent,
                 );
             }
@@ -173,6 +198,7 @@ impl FlowTriggerSubscriber {
         &self,
         flow_id: String,
         input: Value,
+        inputs: serde_json::Map<String, Value>,
         trigger: crate::openhuman::flows::FlowRunTrigger,
     ) {
         let Some(guard) = self.try_acquire_dispatch(&flow_id) else {
@@ -186,7 +212,9 @@ impl FlowTriggerSubscriber {
             // on panic) by `InFlightGuard`.
             let _guard = guard;
             tracing::info!(target: "flows", %flow_id, "[flows] trigger fired — starting run");
-            match crate::openhuman::flows::ops::flows_run(&config, &flow_id, input, trigger).await {
+            match crate::openhuman::flows::ops::flows_run(&config, &flow_id, input, inputs, trigger)
+                .await
+            {
                 Ok(_) => {
                     tracing::info!(target: "flows", %flow_id, "[flows] trigger-driven run finished")
                 }
@@ -943,6 +971,48 @@ mod tests {
             last_status: None,
             require_approval: false,
         }
+    }
+
+    #[test]
+    fn pinned_trigger_inputs_reads_values_an_author_fixed_for_unattended_runs() {
+        let flow = flow_with_trigger_config(
+            "f1",
+            true,
+            json!({
+                "trigger_kind": "schedule",
+                "schedule": "0 9 * * *",
+                "inputs": { "repo": "acme/api", "depth": 3 }
+            }),
+        );
+        let inputs = pinned_trigger_inputs(&flow);
+        assert_eq!(inputs["repo"], json!("acme/api"));
+        assert_eq!(inputs["depth"], json!(3));
+    }
+
+    #[test]
+    fn pinned_trigger_inputs_is_empty_when_unset_or_malformed() {
+        // Empty, not an error: a flow declaring no inputs (the overwhelming
+        // majority) must keep dispatching on a tick exactly as before, and a
+        // malformed value is caught downstream by `prepare_flow_run`, which
+        // reports it against the flow's actual declarations.
+        for cfg in [
+            json!({ "trigger_kind": "schedule" }),
+            json!({ "trigger_kind": "schedule", "inputs": null }),
+            json!({ "trigger_kind": "schedule", "inputs": ["repo"] }),
+        ] {
+            let flow = flow_with_trigger_config("f1", true, cfg.clone());
+            assert!(
+                pinned_trigger_inputs(&flow).is_empty(),
+                "expected no pinned inputs for {cfg}"
+            );
+        }
+    }
+
+    #[test]
+    fn pinned_trigger_inputs_is_empty_for_a_graph_with_no_trigger() {
+        let mut flow = flow_with_trigger_config("f1", true, json!({ "trigger_kind": "schedule" }));
+        flow.graph.nodes.clear();
+        assert!(pinned_trigger_inputs(&flow).is_empty());
     }
 
     #[test]

--- a/src/openhuman/flows/medulla_bridge.rs
+++ b/src/openhuman/flows/medulla_bridge.rs
@@ -52,7 +52,9 @@ use super::node_contracts::{all_node_kind_contracts, node_kind_contract, NODE_KI
 use super::ops;
 use super::types::Flow;
 use crate::openhuman::config::Config;
-use crate::openhuman::socket::medulla::payloads::{CopilotOutcome, WorkflowDescriptor};
+use crate::openhuman::socket::medulla::payloads::{
+    CopilotOutcome, WorkflowDescriptor, WorkflowInputDescriptor,
+};
 use crate::openhuman::socket::medulla::workflows::{set_workflow_bridge, WorkflowBridge};
 
 /// How many runs a `runs` read returns. The orchestrator wants "did this
@@ -295,7 +297,28 @@ fn describe_flow(flow: &Flow) -> WorkflowDescriptor {
         // answer and a per-advert claim would only be redundant.
         agent_id: None,
         workspace_id: None,
+        inputs: describe_inputs(&flow.graph),
     }
+}
+
+/// Projects the graph's declared inputs onto the wire descriptors.
+///
+/// The translation exists because the medulla plane's payload module is
+/// compiled in every build while the engine is behind the `flows` gate — see
+/// [`WorkflowInputDescriptor`]'s doc. This side is gated, so it may name the
+/// engine type.
+fn describe_inputs(graph: &WorkflowGraph) -> Vec<WorkflowInputDescriptor> {
+    graph
+        .inputs
+        .iter()
+        .map(|input| WorkflowInputDescriptor {
+            name: input.name.clone(),
+            ty: input.ty.as_str().to_string(),
+            description: input.description.clone().unwrap_or_default(),
+            required: input.required,
+            default: input.default.clone(),
+        })
+        .collect()
 }
 
 /// The open-vocabulary trigger label, when the graph has exactly one trigger

--- a/src/openhuman/flows/medulla_bridge_tests.rs
+++ b/src/openhuman/flows/medulla_bridge_tests.rs
@@ -79,6 +79,48 @@ fn describe_flow_counts_every_node_and_names_the_trigger() {
 }
 
 #[test]
+fn describe_flow_projects_declared_inputs_onto_the_advert() {
+    // The orchestrator picks a workflow off the advert, so the advert has to
+    // carry what running it requires — otherwise it can only find out by
+    // fetching the graph, or by trying and failing.
+    let mut graph = graph_with_step("Ship it");
+    graph.inputs = vec![
+        tinyflows::model::WorkflowInput::new("repo", tinyflows::model::InputType::String)
+            .required()
+            .with_description("Repo to deploy"),
+        tinyflows::model::WorkflowInput::new("depth", tinyflows::model::InputType::Number)
+            .with_default(serde_json::json!(3)),
+    ];
+
+    let descriptor = describe_flow(&flow("f1", "Deploy", graph));
+    assert_eq!(descriptor.inputs.len(), 2);
+
+    let repo = &descriptor.inputs[0];
+    assert_eq!(repo.name, "repo");
+    assert_eq!(repo.ty, "string");
+    assert!(repo.required);
+    assert_eq!(repo.description, "Repo to deploy");
+    assert_eq!(repo.default, None);
+
+    let depth = &descriptor.inputs[1];
+    assert_eq!(depth.ty, "number");
+    assert!(!depth.required);
+    assert_eq!(depth.default, Some(serde_json::json!(3)));
+    assert!(
+        depth.description.is_empty(),
+        "an undescribed input sends no description rather than a null"
+    );
+}
+
+#[test]
+fn a_workflow_declaring_no_inputs_advertises_none() {
+    let descriptor = describe_flow(&flow("f1", "Deploy", graph_with_step("Ship it")));
+    assert!(descriptor.inputs.is_empty());
+    let wire = serde_json::to_value(&descriptor).unwrap();
+    assert!(wire.get("inputs").is_none());
+}
+
+#[test]
 fn a_blank_name_stays_absent_on_the_wire_rather_than_empty() {
     let descriptor = describe_flow(&flow("f1", "   ", graph_with_step("Step")));
     assert!(descriptor.name.is_empty());

--- a/src/openhuman/flows/n8n_import.rs
+++ b/src/openhuman/flows/n8n_import.rs
@@ -155,6 +155,10 @@ pub(crate) fn map_n8n_workflow(value: &Value) -> Result<N8nImportResult, String>
         schema_version: tinyflows::model::CURRENT_SCHEMA_VERSION,
         id: None,
         name,
+        // n8n has no equivalent of a declared workflow input — its workflows are
+        // parameterized through trigger/node config — so an import declares
+        // none. The author adds them afterwards if the flow needs them.
+        inputs: Vec::new(),
         nodes,
         edges,
     };

--- a/src/openhuman/flows/ops.rs
+++ b/src/openhuman/flows/ops.rs
@@ -4428,20 +4428,27 @@ async fn export_run_to_langfuse(
 /// `tool_call`/`http_request` nodes are pre-declared), not about who started
 /// the run — see `TrustedAutomationSource::Workflow`'s doc and
 /// `my_docs/ohxtf/b2-triggers-trust/01-triggers-and-trust.md` §3.
+/// `input` is the free-form trigger payload (reachable as `=run.trigger.…`);
+/// `inputs` supplies values for the flow's *declared* workflow inputs by name
+/// (reachable as `=inputs.<name>`). The two are separate channels — see
+/// [`tinyflows::engine::RunInput`]. A declared-input problem (missing required
+/// value, wrong type, undeclared key) is rejected before any run row exists.
 pub async fn flows_run(
     config: &Config,
     flow_id: &str,
     input: Value,
+    inputs: serde_json::Map<String, Value>,
     trigger: FlowRunTrigger,
 ) -> Result<RpcOutcome<Value>, String> {
-    // Prep synchronously (validate + compile-check + mint the run id), insert
-    // the initial `running` row, and announce it, then hand off to the shared
-    // run body. Both the synchronous "Run" RPC path (this fn) and the detached
-    // agent path ([`flows_run_detached`]) reuse `run_flow_body` so a single
-    // [`RunRowFinalizer`] guards the row on every exit — bug B42.
-    let prepared = prepare_flow_run(config, flow_id)?;
+    // Prep synchronously (validate + compile-check + resolve inputs + mint the
+    // run id), insert the initial `running` row, and announce it, then hand off
+    // to the shared run body. Both the synchronous "Run" RPC path (this fn) and
+    // the detached agent path ([`flows_run_detached`]) reuse `run_flow_body` so
+    // a single [`RunRowFinalizer`] guards the row on every exit — bug B42.
+    let prepared = prepare_flow_run(config, flow_id, &inputs)?;
     let thread_id = prepared.thread_id.clone();
     let no_actionable_nodes = prepared.no_actionable_nodes;
+    let resolved_inputs = prepared.inputs;
 
     // Register BEFORE the row exists, so a `flows_cancel_run` can never observe
     // a `running` row that no live run owns (see [`run_flow_body`]'s doc).
@@ -4455,6 +4462,7 @@ pub async fn flows_run(
         flow_id.to_string(),
         thread_id,
         input,
+        resolved_inputs,
         trigger,
         no_actionable_nodes,
         cancel_token,
@@ -4482,15 +4490,21 @@ pub async fn flows_run(
 /// (`flows::bus::spawn_run`) fires runs the same fire-and-forget way. Combined
 /// with B42's finalizer + boot sweep, a detached run ALWAYS settles to a
 /// terminal row even if the process dies mid-run.
+///
+/// `input` / `inputs` mean exactly what they do on [`flows_run`]: the trigger
+/// payload and the flow's declared inputs. Both are validated synchronously, so
+/// the agent still gets an immediate, actionable error for a bad call.
 pub async fn flows_run_detached(
     config: &Config,
     flow_id: &str,
     input: Value,
+    inputs: serde_json::Map<String, Value>,
     trigger: FlowRunTrigger,
 ) -> Result<RpcOutcome<Value>, String> {
-    let prepared = prepare_flow_run(config, flow_id)?;
+    let prepared = prepare_flow_run(config, flow_id, &inputs)?;
     let thread_id = prepared.thread_id.clone();
     let no_actionable_nodes = prepared.no_actionable_nodes;
+    let resolved_inputs = prepared.inputs;
 
     // Register BEFORE the `run_id` becomes observable to the agent. The spawned
     // task below may not be polled for some time, so registering inside it
@@ -4522,6 +4536,7 @@ pub async fn flows_run_detached(
             flow_id_owned,
             body_thread_id,
             input,
+            resolved_inputs,
             trigger,
             no_actionable_nodes,
             cancel_token,
@@ -4555,14 +4570,28 @@ struct PreparedFlowRun {
     flow: Flow,
     thread_id: String,
     no_actionable_nodes: bool,
+    /// The flow's declared inputs resolved against the caller's values —
+    /// defaults applied, one entry per declaration.
+    inputs: serde_json::Map<String, Value>,
 }
 
 /// Synchronous prep shared by [`flows_run`] and [`flows_run_detached`]: loads
 /// the flow, warns on an actionless graph, rejects an engine-incompatible
 /// topology, compile-checks the graph so a broken flow fails fast *before* any
-/// `running` row is inserted, and mints the run's `thread_id`. Returns an error
-/// (never a wedged row) if the flow can't run at all.
-fn prepare_flow_run(config: &Config, flow_id: &str) -> Result<PreparedFlowRun, String> {
+/// `running` row is inserted, resolves the caller's declared-input values, and
+/// mints the run's `thread_id`. Returns an error (never a wedged row) if the
+/// flow can't run at all.
+///
+/// Input resolution happens *here* rather than being left to the engine so a
+/// bad call never creates a `running` row, a thread id, or a registry entry.
+/// The engine re-resolves the same values (it is the authority on its own
+/// contract); doing it twice is cheap and keeps this host from having to trust
+/// its own copy of the rules.
+fn prepare_flow_run(
+    config: &Config,
+    flow_id: &str,
+    inputs: &serde_json::Map<String, Value>,
+) -> Result<PreparedFlowRun, String> {
     let flow = store::get_flow(config, flow_id)
         .map_err(|e| e.to_string())?
         .ok_or_else(|| format!("flow '{flow_id}' not found"))?;
@@ -4606,6 +4635,19 @@ fn prepare_flow_run(config: &Config, flow_id: &str) -> Result<PreparedFlowRun, S
     // (cheap) to actually execute.
     tinyflows::compiler::compile(&flow.graph).map_err(|e| e.to_string())?;
 
+    // Declared inputs, before anything observable exists for this run.
+    let resolved_inputs =
+        tinyflows::model::resolve_inputs(&flow.graph.inputs, inputs).map_err(|e| {
+            tracing::warn!(
+                target: "flows",
+                flow_id = %flow_id,
+                input = %e.input_name(),
+                code = %e.code(),
+                "[flows] flows_run: rejected — bad workflow input"
+            );
+            e.to_string()
+        })?;
+
     let thread_id = format!("flow:{flow_id}:{}", uuid::Uuid::new_v4());
     tracing::debug!(
         target: "flows",
@@ -4619,6 +4661,7 @@ fn prepare_flow_run(config: &Config, flow_id: &str) -> Result<PreparedFlowRun, S
         flow,
         thread_id,
         no_actionable_nodes,
+        inputs: resolved_inputs,
     })
 }
 
@@ -4748,6 +4791,7 @@ async fn run_flow_body(
     flow_id: String,
     thread_id: String,
     input: Value,
+    inputs: serde_json::Map<String, Value>,
     trigger: FlowRunTrigger,
     no_actionable_nodes: bool,
     cancel_token: tokio_util::sync::CancellationToken,
@@ -4926,7 +4970,7 @@ async fn run_flow_body(
             origin,
             tinyflows::engine::run_with_checkpointer_journaled_observed(
                 &compiled,
-                input,
+                tinyflows::engine::RunInput::new(input).with_inputs(inputs),
                 &caps,
                 checkpointer,
                 &thread_id,

--- a/src/openhuman/flows/ops_tests.rs
+++ b/src/openhuman/flows/ops_tests.rs
@@ -509,6 +509,7 @@ async fn flows_run_rejects_legacy_nested_conditional_fan_in_before_execution() {
         &config,
         &flow.id,
         json!({ "outer": true, "inner": true }),
+        serde_json::Map::new(),
         FlowRunTrigger::Rpc,
     )
     .await
@@ -544,9 +545,15 @@ async fn flows_run_rejects_an_incompatible_saved_child_before_execution() {
     )
     .unwrap();
 
-    let error = flows_run(&config, &parent.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .expect_err("an unsafe saved child must fail before root execution starts");
+    let error = flows_run(
+        &config,
+        &parent.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .expect_err("an unsafe saved child must fail before root execution starts");
     assert!(
         error.contains(UNSUPPORTED_NESTED_CONDITIONAL_FAN_IN),
         "{error}"
@@ -845,6 +852,7 @@ async fn flows_run_completes_trigger_only_graph() {
         &config,
         &created.value.id,
         json!({ "hello": "world" }),
+        serde_json::Map::new(),
         FlowRunTrigger::Rpc,
     )
     .await
@@ -876,9 +884,15 @@ async fn flows_run_on_trigger_only_graph_surfaces_no_actionable_nodes_note() {
         .await
         .unwrap();
 
-    let outcome = flows_run(&config, &created.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .unwrap();
+    let outcome = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
 
     let note = outcome.value["note"]
         .as_str()
@@ -923,9 +937,15 @@ async fn flows_run_on_graph_with_actionable_nodes_has_no_empty_flow_note() {
         .await
         .unwrap();
 
-    let outcome = flows_run(&config, &created.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .unwrap();
+    let outcome = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
 
     assert!(
         outcome.value.get("note").is_none(),
@@ -961,9 +981,15 @@ async fn flows_run_on_graph_with_disconnected_component_still_surfaces_empty_flo
         .await
         .unwrap();
 
-    let outcome = flows_run(&config, &created.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .unwrap();
+    let outcome = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
 
     let note = outcome.value["note"]
         .as_str()
@@ -1000,6 +1026,7 @@ async fn flows_run_reports_pending_approval_and_blocks_downstream() {
         &config,
         &created.value.id,
         json!({ "x": 1 }),
+        serde_json::Map::new(),
         FlowRunTrigger::Rpc,
     )
     .await
@@ -1028,10 +1055,242 @@ async fn flows_get_missing_flow_errors() {
 async fn flows_run_missing_flow_errors() {
     let tmp = TempDir::new().unwrap();
     let config = test_config(&tmp);
-    let err = flows_run(&config, "missing", json!({}), FlowRunTrigger::Rpc)
-        .await
-        .expect_err("must error");
+    let err = flows_run(
+        &config,
+        "missing",
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .expect_err("must error");
     assert!(err.contains("not found"));
+}
+
+/// A graph declaring `repo` (required) and `depth` (defaulted), whose single
+/// `transform` node copies both out via `=inputs.<name>`.
+fn parameterized_graph() -> Value {
+    json!({
+        "name": "parameterized",
+        "inputs": [
+            { "name": "repo", "type": "string", "required": true, "description": "Repo to review" },
+            { "name": "depth", "type": "number", "default": 3 }
+        ],
+        "nodes": [
+            { "id": "t", "kind": "trigger", "name": "Trigger" },
+            { "id": "shape", "kind": "transform", "name": "Shape",
+              "config": { "set": { "repo": "=inputs.repo", "depth": "=inputs.depth" } } }
+        ],
+        "edges": [ { "from_node": "t", "to_node": "shape" } ]
+    })
+}
+
+/// Collects `pairs` into the supplied-values map `flows_run` takes.
+fn input_values(pairs: &[(&str, Value)]) -> serde_json::Map<String, Value> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), v.clone()))
+        .collect()
+}
+
+#[tokio::test]
+async fn flows_run_threads_declared_inputs_into_the_run() {
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    let created = flows_create(
+        &config,
+        "parameterized".to_string(),
+        parameterized_graph(),
+        false,
+    )
+    .await
+    .unwrap();
+
+    let run = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        input_values(&[("repo", json!("acme/api"))]),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .expect("a run supplying its required input must succeed");
+
+    let output = &run.value["output"];
+    assert_eq!(
+        output["run"]["inputs"]["repo"],
+        json!("acme/api"),
+        "the supplied value must reach run.inputs"
+    );
+    assert_eq!(
+        output["run"]["inputs"]["depth"],
+        json!(3),
+        "the declared default must be applied"
+    );
+    assert_eq!(
+        output["nodes"]["shape"]["items"][0]["json"]["repo"],
+        json!("acme/api"),
+        "the node's `=inputs.repo` binding must resolve"
+    );
+}
+
+#[tokio::test]
+async fn flows_run_detached_threads_and_validates_declared_inputs_too() {
+    // `run_detached` is the entry point both UI Run controls call, so a flow
+    // with a required input is only runnable from the UI through here — it must
+    // enforce the same contract as the blocking path, synchronously, before it
+    // reports a run id the caller will go on to poll.
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    let created = flows_create(
+        &config,
+        "parameterized".to_string(),
+        parameterized_graph(),
+        false,
+    )
+    .await
+    .unwrap();
+
+    let err = flows_run_detached(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .expect_err("a missing required input must be refused before a run id is handed out");
+    assert!(err.contains("repo"), "got: {err}");
+
+    let started = flows_run_detached(
+        &config,
+        &created.value.id,
+        json!({}),
+        input_values(&[("repo", json!("acme/api"))]),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .expect("a run supplying its required input must start");
+    assert_eq!(started.value["status"], "running");
+}
+
+#[tokio::test]
+async fn flows_run_rejects_a_missing_required_input_without_creating_a_run_row() {
+    // The whole point of resolving in `prepare_flow_run`: a caller that gets
+    // this error can be certain nothing was started and nothing was recorded.
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    let created = flows_create(
+        &config,
+        "parameterized".to_string(),
+        parameterized_graph(),
+        false,
+    )
+    .await
+    .unwrap();
+
+    let err = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .expect_err("a missing required input must fail the call");
+    assert!(
+        err.contains("repo"),
+        "the error must name the offending input, got: {err}"
+    );
+
+    let runs = flows_list_runs(&config, &created.value.id, 10)
+        .await
+        .unwrap();
+    assert!(
+        runs.value.is_empty(),
+        "a rejected call must leave no run row behind, got {:?}",
+        runs.value
+    );
+    let reloaded = flows_get(&config, &created.value.id).await.unwrap();
+    assert!(
+        reloaded.value.last_run_at.is_none(),
+        "a rejected call must not stamp last_run_at"
+    );
+}
+
+#[tokio::test]
+async fn flows_run_rejects_a_wrongly_typed_or_undeclared_input() {
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    let created = flows_create(
+        &config,
+        "parameterized".to_string(),
+        parameterized_graph(),
+        false,
+    )
+    .await
+    .unwrap();
+
+    let type_err = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        input_values(&[("repo", json!("acme/api")), ("depth", json!("3"))]),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .expect_err("a string for a number input must be rejected");
+    assert!(type_err.contains("depth"), "got: {type_err}");
+
+    let unknown_err = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        input_values(&[("repo", json!("acme/api")), ("reop", json!("typo"))]),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .expect_err("an undeclared key must be rejected rather than dropped");
+    assert!(unknown_err.contains("reop"), "got: {unknown_err}");
+}
+
+#[tokio::test]
+async fn flows_run_leaves_a_flow_declaring_no_inputs_unchanged() {
+    // The pre-existing call shape — empty `inputs` against a graph that
+    // declares none — must behave exactly as before.
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    let graph = json!({
+        "name": "plain",
+        "nodes": [
+            { "id": "t", "kind": "trigger", "name": "Trigger" },
+            { "id": "shape", "kind": "transform", "name": "Shape",
+              "config": { "set": { "seen": "=run.trigger.hi" } } }
+        ],
+        "edges": [ { "from_node": "t", "to_node": "shape" } ]
+    });
+    let created = flows_create(&config, "plain".to_string(), graph, false)
+        .await
+        .unwrap();
+
+    let run = flows_run(
+        &config,
+        &created.value.id,
+        json!({ "hi": 1 }),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .expect("run");
+    assert_eq!(
+        run.value["output"]["nodes"]["shape"]["items"][0]["json"]["seen"],
+        json!(1)
+    );
 }
 
 #[tokio::test]
@@ -1055,9 +1314,15 @@ async fn flows_run_records_failed_status_when_a_node_errors() {
         .await
         .unwrap();
 
-    let err = flows_run(&config, &created.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .expect_err("a run whose node errors under on_error:stop must fail");
+    let err = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .expect_err("a run whose node errors under on_error:stop must fail");
     assert!(!err.is_empty());
 
     // The failed attempt must be recorded, not left on the prior state.
@@ -1098,9 +1363,15 @@ async fn flows_run_populates_error_when_a_continue_policy_node_errors() {
         .await
         .unwrap();
 
-    let run = flows_run(&config, &created.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .expect("on_error:continue must settle the run future Ok, not bubble up an Err");
+    let run = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .expect("on_error:continue must settle the run future Ok, not bubble up an Err");
     let thread_id = run.value["thread_id"].as_str().unwrap().to_string();
 
     let run_row = flows_get_run(&config, &thread_id).await.unwrap();
@@ -1647,6 +1918,7 @@ async fn flows_resume_continues_a_paused_run_to_completion() {
         &config,
         &created.value.id,
         json!({ "x": 1 }),
+        serde_json::Map::new(),
         FlowRunTrigger::Rpc,
     )
     .await
@@ -1703,6 +1975,7 @@ async fn flows_resume_refuses_when_the_graph_changed_after_park() {
         &config,
         &created.value.id,
         json!({ "x": 1 }),
+        serde_json::Map::new(),
         FlowRunTrigger::Rpc,
     )
     .await
@@ -1793,6 +2066,7 @@ async fn flows_resume_succeeds_when_the_graph_is_unchanged() {
         &config,
         &created.value.id,
         json!({ "x": 1 }),
+        serde_json::Map::new(),
         FlowRunTrigger::Rpc,
     )
     .await
@@ -1842,6 +2116,7 @@ async fn flows_resume_allows_a_legacy_row_with_null_graph_hash() {
         &config,
         &created.value.id,
         json!({ "x": 1 }),
+        serde_json::Map::new(),
         FlowRunTrigger::Rpc,
     )
     .await
@@ -1971,6 +2246,7 @@ async fn flows_resume_marks_an_incompatible_legacy_checkpoint_failed() {
         &config,
         &created.value.id,
         json!({ "x": 1 }),
+        serde_json::Map::new(),
         FlowRunTrigger::Rpc,
     )
     .await
@@ -2050,6 +2326,7 @@ async fn flows_resume_marks_a_checkpoint_with_an_incompatible_saved_child_failed
         &config,
         &created.value.id,
         json!({ "x": 1 }),
+        serde_json::Map::new(),
         FlowRunTrigger::Rpc,
     )
     .await
@@ -2148,6 +2425,7 @@ async fn flows_resume_with_empty_approvals_is_rejected_and_does_not_complete_the
         &config,
         &created.value.id,
         json!({ "x": 1 }),
+        serde_json::Map::new(),
         FlowRunTrigger::Rpc,
     )
     .await
@@ -2187,6 +2465,7 @@ async fn flows_resume_with_mismatched_approvals_is_rejected() {
         &config,
         &created.value.id,
         json!({ "x": 1 }),
+        serde_json::Map::new(),
         FlowRunTrigger::Rpc,
     )
     .await
@@ -2218,6 +2497,7 @@ async fn flows_resume_with_the_correct_gate_completes_and_runs_downstream() {
         &config,
         &created.value.id,
         json!({ "x": 1 }),
+        serde_json::Map::new(),
         FlowRunTrigger::Rpc,
     )
     .await
@@ -2281,6 +2561,7 @@ async fn flows_resume_denying_a_gate_routes_to_its_error_port() {
         &config,
         &created.value.id,
         json!({ "x": 1 }),
+        serde_json::Map::new(),
         FlowRunTrigger::Rpc,
     )
     .await
@@ -2331,6 +2612,7 @@ async fn flows_resume_denying_a_gate_with_no_error_port_fails_the_run() {
         &config,
         &created.value.id,
         json!({ "x": 1 }),
+        serde_json::Map::new(),
         FlowRunTrigger::Rpc,
     )
     .await
@@ -2365,9 +2647,15 @@ async fn flows_resume_rejects_a_gate_named_in_both_approvals_and_rejections() {
         .await
         .unwrap();
 
-    let run = flows_run(&config, &created.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .unwrap();
+    let run = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
     let thread_id = run.value["thread_id"].as_str().unwrap().to_string();
 
     let err = flows_resume(
@@ -2396,9 +2684,15 @@ async fn flows_resume_of_a_non_paused_run_errors_clearly() {
 
     // This run completes outright (no approval gate) — its recorded status
     // is "completed", not "pending_approval".
-    let run = flows_run(&config, &created.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .unwrap();
+    let run = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
     let thread_id = run.value["thread_id"].as_str().unwrap().to_string();
 
     let err = flows_resume(&config, &created.value.id, &thread_id, vec![], vec![])
@@ -2444,6 +2738,7 @@ async fn flows_run_persists_a_flow_run_row_queryable_via_list_and_get() {
         &config,
         &created.value.id,
         json!({ "hello": "world" }),
+        serde_json::Map::new(),
         FlowRunTrigger::Rpc,
     )
     .await
@@ -2479,12 +2774,24 @@ async fn flows_list_all_runs_aggregates_across_flows_newest_first() {
         .unwrap();
 
     // Run alpha first, then beta — beta's run is the newest.
-    flows_run(&config, &a.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .unwrap();
-    let beta_run = flows_run(&config, &b.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .unwrap();
+    flows_run(
+        &config,
+        &a.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
+    let beta_run = flows_run(
+        &config,
+        &b.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
     let beta_thread = beta_run.value["thread_id"].as_str().unwrap().to_string();
 
     let all = flows_list_all_runs(&config, 100).await.unwrap();
@@ -2525,9 +2832,15 @@ async fn flows_run_emits_pending_approval_notification() {
     .await
     .unwrap();
 
-    let run = flows_run(&config, &created.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .unwrap();
+    let run = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
     let thread_id = run.value["thread_id"].as_str().unwrap().to_string();
 
     // Filter for our notification specifically — the broadcast bus is
@@ -2578,9 +2891,15 @@ async fn flows_run_does_not_notify_when_run_completes_without_pending_approvals(
         .unwrap();
     let created_id = created.value.id.clone();
 
-    flows_run(&config, &created.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .unwrap();
+    flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
 
     let expected_prefix = format!("flow-pending-approval:{created_id}:");
     let saw_notification = tokio::time::timeout(std::time::Duration::from_millis(300), async {
@@ -2654,9 +2973,15 @@ async fn flows_run_publishes_flow_run_started_with_flow_and_run_id() {
     .await
     .unwrap();
 
-    let run = flows_run(&config, &created.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .unwrap();
+    let run = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
     let thread_id = run.value["thread_id"].as_str().unwrap().to_string();
 
     // The bus is process-global and shared with concurrently-running tests,
@@ -2745,6 +3070,7 @@ async fn flows_run_finished_event_skips_pending_approval_and_fires_once_on_resum
         &config,
         &created.value.id,
         json!({ "x": 1 }),
+        serde_json::Map::new(),
         FlowRunTrigger::Rpc,
     )
     .await
@@ -2904,6 +3230,7 @@ async fn flows_run_persists_live_steps_with_status_and_timing() {
         &config,
         &created.value.id,
         json!({ "x": 1 }),
+        serde_json::Map::new(),
         FlowRunTrigger::Rpc,
     )
     .await
@@ -2953,9 +3280,15 @@ async fn flows_cancel_run_cancels_a_parked_pending_approval_run() {
 
     // Run pauses at the gate → a durable `pending_approval` row with no live
     // task (the run future already returned): the not-in-flight cancel path.
-    let run = flows_run(&config, &created.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .unwrap();
+    let run = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
     let thread_id = run.value["thread_id"].as_str().unwrap().to_string();
     assert_eq!(
         flows_get_run(&config, &thread_id)
@@ -3004,9 +3337,15 @@ async fn flows_cancel_run_of_an_already_completed_run_errors() {
         .await
         .unwrap();
 
-    let run = flows_run(&config, &created.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .unwrap();
+    let run = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
     let thread_id = run.value["thread_id"].as_str().unwrap().to_string();
 
     let err = flows_cancel_run(&config, &thread_id)
@@ -3028,9 +3367,15 @@ async fn flows_cancel_run_of_a_completed_with_warnings_run_errors() {
         .await
         .unwrap();
 
-    let run = flows_run(&config, &created.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .unwrap();
+    let run = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
     let thread_id = run.value["thread_id"].as_str().unwrap().to_string();
 
     // Force the settled row to the warning status directly — an end-to-end
@@ -3063,9 +3408,15 @@ async fn flows_cancel_run_of_an_interrupted_run_errors() {
         .await
         .unwrap();
 
-    let run = flows_run(&config, &created.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .unwrap();
+    let run = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
     let thread_id = run.value["thread_id"].as_str().unwrap().to_string();
 
     // Force the settled row to `interrupted` directly.
@@ -3132,9 +3483,15 @@ async fn parked_run_ttl_sweep_expires_stale_runs_but_spares_fresh_ones() {
     .unwrap();
 
     // A genuinely fresh parked run (just paused now) must survive the sweep.
-    let fresh = flows_run(&config, &created.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .unwrap();
+    let fresh = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .unwrap();
     let fresh_id = fresh.value["thread_id"].as_str().unwrap().to_string();
 
     let swept = sweep_expired_parked_runs(&config).await;
@@ -4274,9 +4631,15 @@ async fn flows_run_fails_cleanly_without_invoking_engine_when_inference_not_read
         .await
         .expect("creating (authoring) an agent-node flow must succeed even when signed out");
 
-    let err = flows_run(&config, &created.value.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .expect_err("a run whose agent node cannot reach a provider must fail cleanly");
+    let err = flows_run(
+        &config,
+        &created.value.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .expect_err("a run whose agent node cannot reach a provider must fail cleanly");
     assert!(
         err.to_ascii_lowercase().contains("ai provider"),
         "error must explain the AI-provider problem: {err}"
@@ -7698,9 +8061,15 @@ async fn flows_run_detached_returns_running_run_id_and_inserts_row() {
     )
     .unwrap();
 
-    let outcome = flows_run_detached(&config, &flow.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .expect("detached run must start");
+    let outcome = flows_run_detached(
+        &config,
+        &flow.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .expect("detached run must start");
 
     assert_eq!(outcome.value["status"], json!("running"));
     assert_eq!(outcome.value["detached"], json!(true));
@@ -7734,9 +8103,15 @@ async fn flows_run_detached_registers_the_run_before_returning_its_id() {
     )
     .unwrap();
 
-    let outcome = flows_run_detached(&config, &flow.id, json!({}), FlowRunTrigger::Rpc)
-        .await
-        .expect("detached run must start");
+    let outcome = flows_run_detached(
+        &config,
+        &flow.id,
+        json!({}),
+        serde_json::Map::new(),
+        FlowRunTrigger::Rpc,
+    )
+    .await
+    .expect("detached run must start");
     let run_id = outcome.value["run_id"].as_str().unwrap().to_string();
 
     // The moment the agent can see this `run_id` it can be cancelled. If

--- a/src/openhuman/flows/schemas.rs
+++ b/src/openhuman/flows/schemas.rs
@@ -728,6 +728,16 @@ pub fn schemas(function: &str) -> ControllerSchema {
                     comment: "Trigger payload seeded into the run; defaults to null.",
                     required: false,
                 },
+                FieldSchema {
+                    name: "inputs",
+                    ty: TypeSchema::Option(Box::new(TypeSchema::Json)),
+                    comment: "Values for the flow's declared workflow inputs, keyed by name \
+                              (read the flow's `graph.inputs` for the declarations). Missing \
+                              required values, wrong types, and undeclared names are rejected \
+                              before the run starts. Distinct from `input`, which is the \
+                              free-form trigger payload.",
+                    required: false,
+                },
             ],
             outputs: vec![FieldSchema {
                 name: "result",
@@ -754,6 +764,12 @@ pub fn schemas(function: &str) -> ControllerSchema {
                     name: "input",
                     ty: TypeSchema::Option(Box::new(TypeSchema::Json)),
                     comment: "Trigger payload seeded into the run; defaults to null.",
+                    required: false,
+                },
+                FieldSchema {
+                    name: "inputs",
+                    ty: TypeSchema::Option(Box::new(TypeSchema::Json)),
+                    comment: "Values for the flow's declared workflow inputs, keyed by name                               (read the flow's `graph.inputs` for the declarations). Validated                               synchronously, so a bad set is refused here rather than surfacing                               later as a failed background run. Distinct from `input`, which is                               the free-form trigger payload.",
                     required: false,
                 },
             ],
@@ -1537,11 +1553,13 @@ fn handle_run(params: Map<String, Value>) -> ControllerFuture {
         let config = config_rpc::load_config_with_timeout().await?;
         let id = read_required::<String>(&params, "id")?;
         let input = params.get("input").cloned().unwrap_or(Value::Null);
+        let inputs = read_declared_inputs(&params)?;
         to_json(
             ops::flows_run(
                 &config,
                 id.trim(),
                 input,
+                inputs,
                 crate::openhuman::flows::FlowRunTrigger::Rpc,
             )
             .await?,
@@ -1554,16 +1572,42 @@ fn handle_run_detached(params: Map<String, Value>) -> ControllerFuture {
         let config = config_rpc::load_config_with_timeout().await?;
         let id = read_required::<String>(&params, "id")?;
         let input = params.get("input").cloned().unwrap_or(Value::Null);
+        let inputs = read_declared_inputs(&params)?;
         to_json(
             ops::flows_run_detached(
                 &config,
                 id.trim(),
                 input,
+                inputs,
                 crate::openhuman::flows::FlowRunTrigger::Rpc,
             )
             .await?,
         )
     })
+}
+
+/// Reads the optional `inputs` param — values for the flow's declared workflow
+/// inputs, keyed by name.
+///
+/// Absent or `null` means "supplied nothing", which is valid for a flow whose
+/// inputs are all optional or defaulted. A present-but-non-object value is a
+/// caller error rejected here, before it reaches `ops`, so the message names the
+/// parameter rather than surfacing as a confusing per-input complaint.
+fn read_declared_inputs(params: &Map<String, Value>) -> Result<Map<String, Value>, String> {
+    match params.get("inputs") {
+        None | Some(Value::Null) => Ok(Map::new()),
+        Some(Value::Object(map)) => Ok(map.clone()),
+        Some(other) => Err(format!(
+            "param 'inputs' must be an object keyed by declared input name, got {}",
+            match other {
+                Value::Array(_) => "an array",
+                Value::String(_) => "a string",
+                Value::Number(_) => "a number",
+                Value::Bool(_) => "a boolean",
+                _ => "a non-object",
+            }
+        )),
+    }
 }
 
 fn handle_resume(params: Map<String, Value>) -> ControllerFuture {
@@ -1924,6 +1968,52 @@ fn parse_draft_update_flow_id(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn run_schema_advertises_both_input_channels() {
+        let run = all_controller_schemas()
+            .into_iter()
+            .find(|s| s.function == "run")
+            .expect("the run controller is registered");
+        let names: Vec<_> = run.inputs.iter().map(|f| f.name).collect();
+        assert!(names.contains(&"input"), "trigger payload, got {names:?}");
+        assert!(names.contains(&"inputs"), "declared inputs, got {names:?}");
+
+        let declared = run.inputs.iter().find(|f| f.name == "inputs").unwrap();
+        assert!(
+            !declared.required,
+            "a flow with no declared inputs must still be runnable without the param"
+        );
+    }
+
+    #[test]
+    fn read_declared_inputs_accepts_absent_null_and_object() {
+        let mut params = Map::new();
+        assert!(read_declared_inputs(&params).unwrap().is_empty(), "absent");
+
+        params.insert("inputs".into(), Value::Null);
+        assert!(read_declared_inputs(&params).unwrap().is_empty(), "null");
+
+        params.insert("inputs".into(), json!({ "repo": "acme/api" }));
+        assert_eq!(
+            read_declared_inputs(&params).unwrap()["repo"],
+            json!("acme/api")
+        );
+    }
+
+    #[test]
+    fn read_declared_inputs_rejects_a_non_object_naming_the_param() {
+        // A caller sending an array or scalar has mis-shaped the call; say so
+        // here rather than letting it read as "you supplied no inputs".
+        for bad in [json!([1, 2]), json!("repo=acme"), json!(7), json!(true)] {
+            let mut params = Map::new();
+            params.insert("inputs".into(), bad.clone());
+            let err =
+                read_declared_inputs(&params).expect_err("a non-object `inputs` must be rejected");
+            assert!(err.contains("'inputs'"), "got: {err} (for {bad})");
+        }
+    }
 
     #[test]
     fn all_controller_schemas_covers_every_supported_function() {

--- a/src/openhuman/flows/tools.rs
+++ b/src/openhuman/flows/tools.rs
@@ -261,8 +261,11 @@ impl Tool for RunFlowTool {
          instead). It only works on a flow the user has already saved; pass its `flow_id`. \
          You MUST ask the user to confirm and wait for an explicit 'yes' before calling this \
          — never run a workflow unprompted. The flow's own approval gate still pauses \
-         outbound-action nodes. Params: { flow_id (required), input? }. Returns the run's \
-         status + any nodes paused for approval."
+         outbound-action nodes. If the flow declares workflow inputs (read `graph.inputs` \
+         via get_flow), pass their values in `inputs` — ask the user for any required one \
+         rather than inventing it; a missing or wrongly-typed value is rejected and nothing \
+         runs. Params: { flow_id (required), input?, inputs? }. Returns the run's status + \
+         any nodes paused for approval."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -275,6 +278,14 @@ impl Tool for RunFlowTool {
                 },
                 "input": {
                     "description": "Optional trigger input passed to the run (defaults to {})."
+                },
+                "inputs": {
+                    "type": "object",
+                    "description": "Values for the flow's DECLARED workflow inputs, keyed by \
+                                    name. Read the declarations from the flow's graph.inputs \
+                                    first; ask the user for any required value instead of \
+                                    guessing. Distinct from 'input', the free-form trigger \
+                                    payload."
                 }
             },
             "required": ["flow_id"]
@@ -302,6 +313,21 @@ impl Tool for RunFlowTool {
             }
         };
         let input = args.get("input").cloned().unwrap_or_else(|| json!({}));
+        // A non-object `inputs` is the model mis-shaping the call; say so
+        // plainly rather than silently running with none, which would produce a
+        // confusing "required input missing" for a value it thinks it sent.
+        let inputs = match args.get("inputs") {
+            None | Some(Value::Null) => serde_json::Map::new(),
+            Some(Value::Object(map)) => map.clone(),
+            Some(_) => {
+                return Ok(ToolResult::error(
+                    "'inputs' must be an object keyed by the flow's declared input names, \
+                     e.g. {\"repo\": \"acme/api\"}. Read the declarations from the flow's \
+                     graph.inputs."
+                        .to_string(),
+                ))
+            }
+        };
 
         tracing::info!(
             target: "flows",
@@ -321,6 +347,7 @@ impl Tool for RunFlowTool {
             &self.config,
             &flow_id,
             input,
+            inputs,
             crate::openhuman::flows::types::FlowRunTrigger::Rpc,
         )
         .await

--- a/src/openhuman/socket/medulla/payloads.rs
+++ b/src/openhuman/socket/medulla/payloads.rs
@@ -147,7 +147,11 @@ pub struct CapabilitiesResult {
 /// serialization when empty for exactly that reason: the Rust advert already
 /// omits its empty strings, the port therefore declares them optional, and the
 /// backend passes an absent key through as absent rather than fabricating `""`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Not `Eq`: a declared input's `default` is free-form JSON, which has no total
+/// equality (floats, and `NaN` among them). `PartialEq` is what comparisons here
+/// actually use.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkflowDescriptor {
     /// Stable identity — the only field the wire always carries and the only one
@@ -176,13 +180,50 @@ pub struct WorkflowDescriptor {
     /// Provenance: the workspace the owning agent is deployed into.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_id: Option<String>,
+    /// The workflow's declared inputs — its callable signature. Lets the reader
+    /// know what it must collect before asking for a run, rather than having to
+    /// fetch the whole graph to find out. Empty for a workflow taking none, and
+    /// omitted from the wire in that case.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inputs: Vec<WorkflowInputDescriptor>,
+}
+
+/// One declared input of an advertised workflow — what a caller must supply to
+/// run it.
+///
+/// Mirrors `tinyflows::model::WorkflowInput` field-for-field rather than
+/// re-exporting it, for the same reason [`TaskEnvelope`] keeps its envelope as
+/// raw JSON: this module is a transport vocabulary and is compiled in every
+/// build, while the engine is behind the `flows` feature gate. Naming the engine
+/// type here would make the medulla plane fail to build whenever flows is off.
+/// The mapping from the engine type lives in `flows::medulla_bridge`, which is
+/// gated and may name it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowInputDescriptor {
+    /// The input's name — the key a caller supplies it under.
+    pub name: String,
+    /// Declared JSON type: `string` | `number` | `boolean` | `json`.
+    #[serde(default, rename = "type", skip_serializing_if = "String::is_empty")]
+    pub ty: String,
+    /// Human-readable explanation; omitted when blank.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub description: String,
+    /// Whether a caller must supply it.
+    #[serde(default)]
+    pub required: bool,
+    /// Value used when the caller supplies none; omitted when there is none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default: Option<serde_json::Value>,
 }
 
 /// `medulla:register_workflows` — the workflow advert batch, sent on connect and
 /// re-sent whenever the host's store changes. The backend replaces this socket's
 /// whole entry each time and drops it on disconnect, so a shrinking store is
 /// communicated by re-sending the smaller list (never by a delete event).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Not `Eq` for the same reason as [`WorkflowDescriptor`], which it contains.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RegisterWorkflows {
     pub workflows: Vec<WorkflowDescriptor>,
@@ -367,6 +408,43 @@ mod tests {
     }
 
     #[test]
+    fn workflow_descriptor_advertises_declared_inputs_and_omits_them_when_none() {
+        // The reader needs to know what to collect before asking for a run;
+        // without this it would have to fetch the whole graph to find out.
+        let advert = WorkflowDescriptor {
+            id: "wf-1".into(),
+            name: "Review".into(),
+            description: String::new(),
+            node_count: 2,
+            enabled: Some(true),
+            trigger_kind: None,
+            agent_id: None,
+            workspace_id: None,
+            inputs: vec![WorkflowInputDescriptor {
+                name: "repo".into(),
+                ty: "string".into(),
+                description: String::new(),
+                required: true,
+                default: None,
+            }],
+        };
+        let wire = serde_json::to_value(&advert).unwrap();
+        assert_eq!(wire["inputs"][0]["name"], "repo");
+        assert_eq!(wire["inputs"][0]["type"], "string");
+        assert_eq!(wire["inputs"][0]["required"], true);
+
+        let none = WorkflowDescriptor {
+            inputs: Vec::new(),
+            ..advert
+        };
+        let wire = serde_json::to_value(&none).unwrap();
+        assert!(
+            wire.get("inputs").is_none(),
+            "a workflow taking no inputs must not send an empty key"
+        );
+    }
+
+    #[test]
     fn workflow_descriptor_omits_blank_name_and_description() {
         let advert = WorkflowDescriptor {
             id: "wf-1".into(),
@@ -377,6 +455,7 @@ mod tests {
             trigger_kind: Some("cron".into()),
             agent_id: None,
             workspace_id: None,
+            inputs: Vec::new(),
         };
         let wire = serde_json::to_value(&advert).unwrap();
         assert_eq!(wire["id"], "wf-1");

--- a/src/openhuman/socket/medulla/workflows.rs
+++ b/src/openhuman/socket/medulla/workflows.rs
@@ -566,6 +566,7 @@ mod tests {
                 trigger_kind: None,
                 agent_id: None,
                 workspace_id: None,
+                inputs: Vec::new(),
             }]
         }
 


### PR DESCRIPTION
## What

A saved flow can now declare typed parameters (tinyhumansai/tinyflows#27), and every path that runs one accepts values for them:

```jsonc
// openhuman.flows_run
{ "id": "review-a-repo",
  "input":  { /* free-form trigger payload, unchanged */ },
  "inputs": { "repo": "acme/api", "depth": 3 } }
```

Surfaced on the `flows_run` RPC, the `run_flow` agent tool, `flowsApi.runFlow`, and the medulla workflow advert.

## Why resolution happens in `prepare_flow_run`

The engine validates these itself, so the host could have left it alone. It doesn't, because by the time the engine sees them a `running` row exists, a `thread_id` is minted, and the run is in the cancel registry — a caller that mistyped an input would leave a phantom failed run in the operator's history. Resolving in `prepare_flow_run` means a rejection is provably inert; `flows_run_rejects_a_missing_required_input_without_creating_a_run_row` asserts exactly that.

## Points worth a reviewer's attention

- **Unattended triggers.** A schedule tick and an app event have no operator to prompt, so they pass values an author pinned in the trigger node's `config.inputs`. A flow with a required input and nothing pinned fails loudly at prepare time rather than dispatching with nulls — the alternative was silently running a parameterized flow with no parameters.
- **The medulla advert's input type is declared locally, not re-exported.** `socket/medulla/payloads.rs` compiles in *every* build while the engine sits behind the `flows` feature gate, so naming `tinyflows::model::WorkflowInput` there breaks the slim build. This was caught by the gate-off check (`--no-default-features --features tokenjuice-treesitter`), not by review — worth remembering for the next type that crosses that boundary. The translation lives in `flows::medulla_bridge`, which is gated and may name it.
- **`WorkflowDescriptor` drops its `Eq` derive.** A declared input's `default` is free-form JSON, which has no total equality. Nothing used `Eq`; `PartialEq` is what the comparisons here actually need.
- **The `run_flow` tool is told to ask.** Its description points the agent at `graph.inputs` and tells it to ask the user for a required value rather than invent one.

## Validation

`GGML_NATIVE=OFF cargo check --all-targets` · `cargo test --lib openhuman::flows` (561 passing) · `cargo test --lib openhuman::socket::medulla` (38 passing) · `pnpm typecheck` · `flowsApi.test.ts` (40 passing) · gate-off build `--no-default-features --features tokenjuice-treesitter`.

Depends on tinyhumansai/tinyflows#27 (the `vendor/tinyflows` bump is in this branch).