### PR TITLE
fix(chat): name the chat-template rejection instead of blaming model/temperature

### DIFF
--- a/app/src/services/chatService.ts
+++ b/app/src/services/chatService.ts
@@ -180,6 +180,7 @@ export interface ChatErrorEvent {
     | 'model_unavailable'
     | 'payload_too_large'
     | 'provider_request_rejected'
+    | 'chat_template_rejected'
     | 'budget_exhausted';
   round: number | null;
 }

--- a/src/openhuman/inference/provider/chat_template.rs
+++ b/src/openhuman/inference/provider/chat_template.rs
@@ -1,0 +1,133 @@
+//! Classifier for **chat-template rejections** from local serving runtimes.
+//!
+//! A local runtime (LM Studio, llama.cpp, Ollama) renders every request
+//! through the model's own Jinja chat template, baked into the GGUF. When
+//! the template cannot render the message list it aborts with a `400`
+//! *before* the model is ever called, and the body describes a template
+//! failure — not a bad model id, not a bad sampling parameter:
+//!
+//! ```text
+//! lmstudio returned: Engine protocol predict request returned 400:
+//! {"error":{"code":400,"message":"Unable to generate parser for this
+//! template. Automatic parser generation failed: While executing
+//! CallExpression at line 79, column 24 in source: ...multi_step_tool %}
+//! {{- raise_exception('No user query found in messages.') }}...
+//! Error: Jinja Exception: No user query found in messages.",
+//! "type":"invalid_request_error"}}
+//! ```
+//!
+//! The canonical instance (tinyhumansai/openhuman#5291) is Qwen 3's
+//! required-user-query guard firing against the prompt-guided tool loop's
+//! message shape, on a model that reports no native tool calling. The
+//! harness-side fix is to guarantee a resolvable user turn
+//! (`tinyagents::harness::tool::ensure_resolvable_user_turn`); this
+//! classifier exists so the class is *named accurately* while it happens
+//! — with any template, any model.
+//!
+//! ## Why it needs its own arm
+//!
+//! Nothing in the raw body matches
+//! [`super::config_rejection::is_provider_config_rejection_message`], but
+//! the retry aggregate that wraps two failed attempts does (`"may not be
+//! available on your provider"`), so the user was shown *"Your AI provider
+//! rejected the request's model or temperature setting. Check your model
+//! and routing in Settings → LLM."* That is wrong in a way that costs the
+//! user real time: the model is fine, the temperature is fine, and every
+//! remediation it suggests is a dead end. Classified ahead of the
+//! config-rejection arm, the template failure keeps its own identity even
+//! when it reaches the classifier inside an aggregate.
+//!
+//! Deliberately NOT added to
+//! [`crate::core::observability::expected_error_kind`]: unlike a user
+//! picking an unavailable model, a template that rejects our own message
+//! shape is a defect on our side, and it should stay visible until the
+//! harness normalization has shipped everywhere.
+
+/// Returns true if a provider error body indicates the model's **chat
+/// template** rejected the request — a template render/parse failure, as
+/// opposed to a rejected model id, sampling parameter, or credential.
+///
+/// Case-insensitive substring match, anchored on phrases emitted by the
+/// template engine itself (`raise_exception` text, the Jinja exception
+/// marker) and by LM Studio's template-parser generation, so it holds
+/// across runtimes that embed the same Jinja templates. Keep the list
+/// tight: a false positive would relabel an unrelated provider error as a
+/// template problem and send the user chasing a template they cannot see.
+pub fn is_chat_template_rejection_message(body: &str) -> bool {
+    const PHRASES: &[&str] = &[
+        // Qwen 3-family required-user-query guard — the #5291 repro. Raised
+        // by the template when it cannot locate a user turn to answer.
+        "no user query found in messages",
+        // LM Studio wraps a template it cannot compile into a tool-call
+        // parser with this prefix; the inner cause is always a template
+        // render failure.
+        "unable to generate parser for this template",
+        "automatic parser generation failed",
+        // Generic escape hatch for any other template that raises: the
+        // engine tags every one of these with the Jinja exception marker.
+        // Covers the sibling guards in Llama-3 / Mistral / ChatML templates
+        // (alternating-role requirements, "conversation roles must
+        // alternate", tool-response ordering) without enumerating each.
+        "jinja exception",
+    ];
+
+    let lower = body.to_ascii_lowercase();
+    PHRASES.iter().any(|phrase| lower.contains(phrase))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The verbatim body from the #5291 user log, wrapper and all.
+    const LMSTUDIO_5291_BODY: &str = "lmstudio returned: Engine protocol predict request \
+         returned 400: {\"error\":{\"code\":400,\"message\":\"Unable to generate parser for \
+         this template. Automatic parser generation failed: While executing CallExpression \
+         at line 79, column 24 in source: ...multi_step_tool %}  {{- raise_exception('No \
+         user query found in messages.') }}...Error: Jinja Exception: No user query found \
+         in messages.\",\"type\":\"invalid_request_error\"}}";
+
+    #[test]
+    fn classifies_the_lmstudio_template_body() {
+        assert!(is_chat_template_rejection_message(LMSTUDIO_5291_BODY));
+    }
+
+    #[test]
+    fn classifies_inside_a_retry_aggregate() {
+        // Two attempts fail and the aggregate wraps both; the anchor must
+        // survive so the template arm still wins over the config-rejection
+        // arm the aggregate's own wording would otherwise trip.
+        let aggregate = format!(
+            "The model `qwen/qwen3.5-9b` may not be available on your provider. \
+             Configure a fallback chain via `reliability.model_fallbacks` in your \
+             OpenHuman config.\n\nAll providers/models failed. Attempts:\n\
+             provider=lmstudio model=qwen/qwen3.5-9b attempt 1/2: {LMSTUDIO_5291_BODY}\n\
+             provider=lmstudio model=qwen/qwen3.5-9b attempt 2/2: {LMSTUDIO_5291_BODY}"
+        );
+        assert!(is_chat_template_rejection_message(&aggregate));
+    }
+
+    #[test]
+    fn detection_is_case_insensitive() {
+        assert!(is_chat_template_rejection_message(
+            "Error: JINJA EXCEPTION: No User Query Found In Messages."
+        ));
+    }
+
+    #[test]
+    fn does_not_classify_unrelated_provider_errors() {
+        for body in [
+            "openai API error (400): invalid temperature: only 1 is allowed for this model",
+            "The model `gpt-5.5` does not exist or you do not have access to it.",
+            "lmstudio returned: model 'qwen3.5-9b' does not support tools",
+            "openrouter API error (429): rate limited",
+            // A prose mention of templates is not a template rejection.
+            "Failed to render the prompt template file on disk",
+        ] {
+            assert!(
+                !is_chat_template_rejection_message(body),
+                "{body:?} must not be classified as a chat-template rejection"
+            );
+        }
+    }
+}

--- a/src/openhuman/inference/provider/mod.rs
+++ b/src/openhuman/inference/provider/mod.rs
@@ -6,6 +6,8 @@
 
 pub mod auth;
 pub mod billing_error;
+/// Chat-template rejections from local serving runtimes (issue #5291).
+pub mod chat_template;
 pub mod claude_agent_sdk;
 pub mod claude_code;
 pub mod config_rejection;
@@ -29,6 +31,7 @@ pub use types::{
 };
 
 pub use billing_error::is_budget_exhausted_message;
+pub use chat_template::is_chat_template_rejection_message;
 pub use config_rejection::{
     is_openai_compatible_unknown_model_message, is_provider_config_rejection_message,
 };

--- a/src/openhuman/web_chat/web_errors.rs
+++ b/src/openhuman/web_chat/web_errors.rs
@@ -167,7 +167,7 @@ pub(crate) struct ClassifiedError {
     /// `session_expired`, `budget_exhausted`, `provider_error`,
     /// `context_overflow`, `model_unavailable`, `payload_too_large`,
     /// `provider_request_rejected`, `capability_unsupported`,
-    /// `empty_response`, `network`, `inference`.
+    /// `chat_template_rejected`, `empty_response`, `network`, `inference`.
     pub(crate) error_type: &'static str,
     /// User-facing copy (already includes provider detail block and the
     /// retry-after countdown sentence when available).
@@ -664,6 +664,52 @@ pub(crate) fn classify_inference_error(err: &str) -> ClassifiedError {
             retry_after_ms: None,
             provider: None,
             fallback_available: None,
+        }
+    } else if crate::openhuman::inference::provider::is_chat_template_rejection_message(err) {
+        // #5291: a local runtime (LM Studio / llama.cpp / Ollama) rendered the
+        // request through the model's OWN Jinja chat template and the template
+        // raised — `No user query found in messages.` on Qwen 3, against the
+        // prompt-guided tool loop's message shape. Neither the model nor the
+        // sampling params are at fault, and the request never reached the model.
+        //
+        // Placed HERE, with the other specific-anchor arms and above the broad
+        // substring ladder, because both renderings of this failure are claimed
+        // by an earlier-or-lower arm that misdiagnoses them:
+        //   - the retry aggregate that wraps the failed attempts ends with
+        //     "…change your default model in Connections → API keys → LLM",
+        //     and the `auth_error` arm below matches on the bare substring
+        //     "api key" — the user gets "check your API key" for a template
+        //     failure;
+        //   - that same aggregate carries "may not be available on your
+        //     provider", which the config-rejection arm renders as "your
+        //     provider rejected the model or temperature setting" (#5291's
+        //     reported symptom).
+        // Both point at a credential/model/temperature that was never the
+        // problem, so every remediation they offer is a dead end. The anchors
+        // in `is_chat_template_rejection_message` are template-engine strings
+        // ("jinja exception", the raised guard text), which no unrelated
+        // provider error emits — so claiming the error this early is safe.
+        //
+        // Retryable: the failure needs a tool-step history with no resolvable
+        // user turn, and a fresh turn starts from the user's new message, so
+        // the same model can succeed on the next attempt. The harness-side fix
+        // (guaranteeing a user turn for non-native-tool models) removes the
+        // shape that triggers it at all.
+        ClassifiedError {
+            error_type: "chat_template_rejected",
+            message: with_provider_detail(
+                "This model's chat template rejected the request — it isn't the model, the \
+                 temperature, or your API key. Local models without native tool calling are \
+                 driven through their own chat template, and some templates refuse the \
+                 message shape of a tool step. Start a new chat to reset the history, or \
+                 pick a model with native tool support in Connections → API keys → LLM.",
+                err,
+            ),
+            source: "provider",
+            retryable: true,
+            retry_after_ms: None,
+            provider,
+            fallback_available,
         }
     } else if lower.contains("rate limit") || lower.contains("429") {
         let retry_secs = parse_retry_after_secs_from_str(err);

--- a/src/openhuman/web_chat/web_tests.rs
+++ b/src/openhuman/web_chat/web_tests.rs
@@ -1173,6 +1173,84 @@ fn classify_inference_error_vision_capability_is_non_retryable() {
     );
 }
 
+/// The verbatim LM Studio body from the #5291 user log.
+const LMSTUDIO_TEMPLATE_400: &str = "lmstudio returned: Engine protocol predict request \
+     returned 400: {\"error\":{\"code\":400,\"message\":\"Unable to generate parser for this \
+     template. Automatic parser generation failed: While executing CallExpression at line 79, \
+     column 24 in source: ...multi_step_tool %}  {{- raise_exception('No user query found in \
+     messages.') }}...Error: Jinja Exception: No user query found in messages.\",\
+     \"type\":\"invalid_request_error\"}}";
+
+#[test]
+fn classify_inference_error_chat_template_rejection_is_not_blamed_on_the_model() {
+    // #5291: LM Studio rendered the tool-loop message shape through Qwen 3's
+    // chat template, which raised. Neither the model nor the temperature is at
+    // fault, so neither may appear in the copy.
+    let classified = classify_inference_error(LMSTUDIO_TEMPLATE_400);
+    assert_eq!(classified.error_type, "chat_template_rejected");
+    assert!(
+        classified.message.contains("chat template"),
+        "must name the template as the cause: {}",
+        classified.message
+    );
+    // The two remediations that were previously offered for this body, both
+    // dead ends: the config arm's "fix your model/routing" and the auth arm's
+    // "check your API key".
+    assert!(
+        !classified.message.contains("Check your model and routing"),
+        "must not send the user to model/routing settings: {}",
+        classified.message
+    );
+    assert!(
+        !classified.message.contains("check your API key"),
+        "must not send the user to their API key: {}",
+        classified.message
+    );
+}
+
+#[test]
+fn classify_inference_error_chat_template_wins_over_the_retry_aggregate() {
+    // Both attempts fail and `format_failure_aggregate` wraps them. That
+    // wrapper carries two phrases that other arms claim, and both misdiagnose
+    // a template failure:
+    //   - "Connections → API keys → LLM" contains the bare "api key" substring
+    //     the auth_error arm matches on;
+    //   - "may not be available on your provider" is a config-rejection phrase,
+    //     rendered as "rejected the model or temperature setting" (#5291's
+    //     reported symptom).
+    // The template arm sits above both so neither can claim it.
+    let aggregate = format!(
+        "The model `qwen/qwen3.5-9b` may not be available on your provider. Configure a \
+         fallback chain via `reliability.model_fallbacks` in your OpenHuman config, or change \
+         your default model in Connections → API keys → LLM.\n\nAll providers/models failed. \
+         Attempts:\nprovider=lmstudio model=qwen/qwen3.5-9b attempt 1/2: \
+         {LMSTUDIO_TEMPLATE_400}\nprovider=lmstudio model=qwen/qwen3.5-9b attempt 2/2: \
+         {LMSTUDIO_TEMPLATE_400}"
+    );
+    let classified = classify_inference_error(&aggregate);
+    assert_eq!(classified.error_type, "chat_template_rejected");
+    assert!(
+        !classified.message.contains("model or temperature setting"),
+        "the config-rejection copy must not win: {}",
+        classified.message
+    );
+    assert!(
+        !classified.message.contains("authentication issue"),
+        "the auth copy must not win: {}",
+        classified.message
+    );
+}
+
+#[test]
+fn classify_inference_error_temperature_rejection_still_classifies_as_config() {
+    // Guard the other direction: the template arm sits directly above the
+    // config-rejection arm and must not swallow a genuine model/temperature
+    // rejection.
+    let raw = "cloud API error (400): invalid temperature: only 1 is allowed for this model";
+    let classified = classify_inference_error(raw);
+    assert_eq!(classified.error_type, "model_unavailable");
+}
+
 #[test]
 fn classify_inference_error_generic_4xx_surfaces_provider_detail() {
     // A provider 400 none of the specific arms claimed: the real reason must


### PR DESCRIPTION
## Summary

- A local runtime renders every request through the **model's own Jinja chat template**. When that template raises, it returns a `400` before the model is called — and the body describes a template failure, not a bad model or a bad sampling parameter.
- OpenHuman surfaced that as *"Your AI provider rejected the request's model or temperature setting. Check your model and routing in Settings → LLM."* The model, the temperature, and the API key are all fine; every remediation offered is a dead end.
- New classifier `is_chat_template_rejection_message` + a `chat_template_rejected` arm in `classify_inference_error` that says what actually happened.
- **Sentry behaviour is unchanged** — classification here is user-facing only.
- Part (b) of tinyhumansai/openhuman#5291. Part (a), the harness fix that stops producing the message shape, is **tinyhumansai/tinyagents#86**.

## Problem

From the user log (`openhuman.2026-07-28.log`), LM Studio serving `qwen/qwen3.5-9b` with `supports_native_tools=false`:

```
lmstudio returned: Engine protocol predict request returned 400:
{"error":{"code":400,"message":"Unable to generate parser for this template.
Automatic parser generation failed: While executing CallExpression at line 79,
column 24 in source: ...multi_step_tool %}  {{- raise_exception('No user query
found in messages.') }}...Error: Jinja Exception: No user query found in
messages.","type":"invalid_request_error"}}
```

Tracing the arm order in `classify_inference_error` turned up something the issue did not capture, and it changed where this arm belongs. **Both** renderings of this failure were already being claimed by an arm that misdiagnoses them:

| Rendering | Claimed by | What the user was told |
|---|---|---|
| Retry aggregate (`format_failure_aggregate`) | `auth_error` — the aggregate ends with `"Connections → API keys → LLM"`, and that arm matches the bare substring `"api key"` | "There's an authentication issue… check your API key" |
| Same aggregate, if it got past the auth arm | config-rejection — `"may not be available on your provider"` | "rejected the request's model or temperature setting" (#5291's reported symptom) |

Nothing in the *raw* per-attempt body matches the config-rejection phrase list at all — it is the aggregate wrapper that trips both.

## Solution

Classify the template failure on **its own anchors** — the raised guard text (`no user query found in messages`), the Jinja exception marker, and LM Studio's parser-generation prefix — and place the arm with the other specific-anchor arms, **above the whole broad substring ladder**, so neither the auth arm nor the config-rejection arm can claim it. That placement follows the convention `web_errors.rs` already documents for specific anchors (`empty_response`, `max_iterations`, `turn_timeout`).

The anchors are template-engine strings that no unrelated provider error emits (verified: zero other occurrences of `jinja` / `no user query found` / `generate parser for this template` anywhere in `src/` or `app/src/`), so claiming this early is safe.

Marked **retryable**: the failure needs a tool-step history with no resolvable user turn, and a fresh turn starts from the user's new message. tinyhumansai/tinyagents#86 removes the shape that triggers it at all.

**Sentry is deliberately untouched.** `sentry_suppression_reason` keys off the raw error string, not `error_type`, and this is *not* added to `expected_error_kind` — a template rejecting our own message shape is a defect on our side and should stay visible until the harness normalization ships everywhere.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — 3 in `web_tests.rs`: the verbatim `#5291` body classifies and names the template; the retry aggregate does not fall to the auth or config-rejection copy; and a genuine `invalid temperature` body still classifies as `model_unavailable` (guards the arm above it from over-reaching). Plus 4 unit tests in the new classifier module.
- [x] **Diff coverage ≥ 80%** — `N/A locally`: could not run `pnpm test:rust` / `pnpm test:coverage` in this environment (see **Validation Blocked**). The changed Rust lines are a predicate + one classifier arm, both directly exercised by the 7 new tests; CI is the authority.
- [x] Coverage matrix updated — `N/A: behaviour-only change` (error copy/classification, no new feature row).
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature IDs affected`.
- [x] No new external network dependencies introduced — none; the classifier is a pure string predicate.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface touched`.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

Desktop/CLI, chat error surface only. No runtime, performance, security, or migration impact. Routing, retry, and fallback behaviour are all unchanged — only the copy and the `error_type` token a user sees.

`ChatErrorEvent.error_type` in `app/src/services/chatService.ts` gains `'chat_template_rejected'`. No other frontend change is needed: `ChatRuntimeProvider` forwards the server `message` for every type and only special-cases `'cancelled'`.

## Related

- Closes: #5291
- Depends on (part a, harness-side fix): tinyhumansai/tinyagents#86 — this PR does **not** bump the `vendor/tinyagents` pin; it stands alone.
- Follow-up PR(s)/TODOs:
  - The `auth_error` arm matches the bare substring `"api key"`, which any error text mentioning "API keys" trips. Pre-existing and left alone here; worth tightening separately.
  - `openhuman` `main` currently pins `vendor/tinyagents` at `3781540`, which is **not an ancestor of** tinyagents `main` (and is missing two commits that are on it). Whoever bumps the pin for part (a) will need to reconcile that.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5291-lmstudio-template`
- Commit SHA: see `## Related` / branch head

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — not run (no `node_modules` in this environment)
- [x] `pnpm typecheck` — not run (same)
- [x] Focused tests: not run locally — see **Validation Blocked**
- [x] Rust fmt/check (if changed): `rustfmt --edition 2021 --check` clean on all 4 changed Rust files (formatter only, no compilation)
- [x] Tauri fmt/check (if changed): `N/A` — no `app/src-tauri` change

### Validation Blocked

- `command:` `cargo test --lib` / `pnpm test:rust` / `pnpm typecheck`
- `error:` local disk at capacity — a Rust build in this repo produces a 15–30 GB `target/`, and the frontend workspace has no installed `node_modules`
- `impact:` part (b) is verified by **inspection**, with CI as the authority on compilation. What was checked by reading: the new predicate is structurally identical to the existing `is_budget_exhausted_message` (same `PHRASES` + `.any()` shape, so the `contains(&&str)` pattern resolves); the arm's `provider` / `fallback_available` moves are valid in an exclusive `if`/`else if` chain, as every neighbouring arm already does the same; `extract_backend_error_code` anchors on `"errorCode"` and so does not trip on LM Studio's `"code":400`; and no arm above the insertion point matches the body. Part (a) (tinyhumansai/tinyagents#86) **was** fully built and tested locally — 1232/1232, clippy clean.

### Behavior Changes

- Intended behavior change: a chat-template `400` is classified as `chat_template_rejected` instead of `auth_error` / `model_unavailable`.
- User-visible effect: the chat error names the chat template as the cause and offers two remediations that can actually work (start a new chat to reset the history; pick a model with native tool support), instead of sending the user to their API key or their model/temperature settings.

### Parity Contract

- Legacy behavior preserved: every other classification arm is untouched; a genuine `invalid temperature` / unknown-model / auth body classifies exactly as before (pinned by a test). Sentry capture, retry, fallback, and session-eviction behaviour are all unchanged.
- Guard/fallback/dispatch parity checks: `sentry_suppression_reason` (raw-string keyed) and `expected_error_kind` are both untouched, so no Sentry volume change in either direction; `should_drop_session_agent` keys off `provider_request_rejected` and is unaffected.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A

