### PR TITLE
fix(context-scout): stop out-of-credits background scouts paging Sentry (#5308)

### DIFF
--- a/src/openhuman/agent_orchestration/tools/agent_prepare_context.rs
+++ b/src/openhuman/agent_orchestration/tools/agent_prepare_context.rs
@@ -17,7 +17,7 @@ use crate::openhuman::agent::harness::fork_context::{
     current_agent_context_prepared_sources, current_parent, AgentContextPreparedSource,
 };
 use crate::openhuman::agent::harness::subagent_runner::{
-    run_subagent, SubagentRunOptions, SubagentRunStatus,
+    run_subagent, SubagentRunError, SubagentRunOptions, SubagentRunStatus,
 };
 use crate::openhuman::agent::progress::AgentProgress;
 use crate::openhuman::tinyagents::thread_context::current_thread_id;
@@ -152,6 +152,79 @@ pub async fn run_context_scout_with_catalog(
     tool_catalog: &str,
 ) -> anyhow::Result<ToolResult> {
     run_context_scout_with_catalog_and_workspace(question, focus, tool_catalog, None).await
+}
+
+/// The text [`log_scout_failure`] classifies: a failed run flattened into one
+/// string, `source` chain included.
+///
+/// The billing classifiers key on the **provider wire body**
+/// (`… "errorCode":"USER_INSUFFICIENT_CREDITS"`), which arrives inside
+/// [`SubagentRunError::Provider`]'s `anyhow` error — often as a *cause* under a
+/// context layer, so `to_string()` alone renders only `"provider call failed:
+/// <top-level context>"` and would miss the very failure this exists to demote.
+/// Walk `anyhow`'s chain for that variant; every other variant is a flat
+/// `thiserror` message already. Used for classification only — the
+/// user-visible `message` stays `err.to_string()`, unchanged.
+fn scout_failure_signal(err: &SubagentRunError) -> String {
+    let SubagentRunError::Provider(inner) = err else {
+        return err.to_string();
+    };
+    let mut chain = inner.to_string();
+    for cause in inner.chain().skip(1) {
+        chain.push_str(": ");
+        chain.push_str(&cause.to_string());
+    }
+    chain
+}
+
+/// Is a failed `context_scout` run just the user being out of credits?
+///
+/// Two billing shapes reach here, both **user-state, not defects**:
+/// * the managed OpenHuman backend's budget-exhausted 400
+///   (`{"error":"Insufficient budget","errorCode":"USER_INSUFFICIENT_CREDITS"}`),
+///   matched by [`crate::openhuman::inference::provider::is_budget_exhausted_message`];
+/// * a BYO provider's insufficient-credits 402, matched by
+///   [`crate::core::observability::is_insufficient_credits_message`].
+///
+/// Both delegate to the crate's single-source classifiers so the phrase sets
+/// can't drift from the cron halt / `before_send` nets that share them.
+fn is_expected_billing_failure(message: &str) -> bool {
+    crate::openhuman::inference::provider::is_budget_exhausted_message(message)
+        || crate::core::observability::is_insufficient_credits_message(message)
+}
+
+/// Log a failed `context_scout` run at the severity its cause deserves.
+///
+/// The scout is a **background/best-effort** pass: every caller already
+/// degrades to the un-augmented message on failure. When the cause is the user
+/// being out of credits (`USER_INSUFFICIENT_CREDITS`) that is a preventable
+/// billing state OpenHuman has no lever over, yet `tracing::error!` maps to
+/// `EventFilter::Event` in `core::logging::sentry_tracing_layer` — so every
+/// tick of every out-of-credits user paged Sentry (TAURI-RUST-HMW: 8314 events
+/// / 13 users, #5308). The existing `is_budget_event` `before_send` net cannot
+/// catch it: that filter is tag-gated (`failure=non_2xx` + `status=400`) and
+/// keys on the event *message*, but this event's message is the static
+/// `"context_scout run failed"` with the wire body only in a breadcrumb.
+///
+/// So demote at the emit site: `warn!` maps to `EventFilter::Breadcrumb`, which
+/// keeps the local log line (and the Sentry breadcrumb trail for any *real*
+/// error that follows) without raising an issue. Every other cause still
+/// `error!`s and keeps paging.
+fn log_scout_failure(error_kind: &str, message: &str) {
+    if is_expected_billing_failure(message) {
+        // Metadata-only — never log the raw provider body (see CLAUDE.md).
+        tracing::warn!(
+            target: "agent_prepare_context",
+            error_kind = %error_kind,
+            "[agent_prepare_context] context_scout run skipped — account is out of credits (expected user-state, not reported)"
+        );
+        return;
+    }
+    tracing::error!(
+        target: "agent_prepare_context",
+        error_kind = %error_kind,
+        "[agent_prepare_context] context_scout run failed"
+    );
 }
 
 async fn run_context_scout_with_catalog_and_workspace(
@@ -475,11 +548,7 @@ async fn run_context_scout_with_catalog_and_workspace(
                 .next()
                 .map(str::trim)
                 .unwrap_or("unknown");
-            tracing::error!(
-                target: "agent_prepare_context",
-                error_kind = %error_kind,
-                "[agent_prepare_context] context_scout run failed"
-            );
+            log_scout_failure(error_kind, &scout_failure_signal(&err));
             crate::openhuman::agent_orchestration::subagent_events::publish_subagent_failed(
                 parent_session.clone(),
                 task_id.clone(),
@@ -900,5 +969,124 @@ mod tests {
                 .as_deref(),
             Some("[context_bundle]\nsummary: x\n[/context_bundle]")
         );
+    }
+
+    // ── Credits-exhausted scout failures stay off Sentry (#5308) ────────
+
+    /// Verbatim wire body from Sentry TAURI-RUST-HMW's breadcrumb — the
+    /// managed backend's budget-exhausted 400. Pinning the exact string makes a
+    /// backend phrasing drift fail CI rather than silently re-flood Sentry.
+    const CREDITS_400_BODY: &str = "OpenHuman returned HTTP 400: \
+        {\"success\":false,\"error\":\"Insufficient budget\",\
+        \"errorCode\":\"USER_INSUFFICIENT_CREDITS\"}";
+
+    #[test]
+    fn classifies_managed_credits_400_and_byo_402_as_expected_billing() {
+        assert!(
+            is_expected_billing_failure(CREDITS_400_BODY),
+            "the managed USER_INSUFFICIENT_CREDITS 400 is user-state, not a defect"
+        );
+        // The BYO sibling: a provider 402 whose body names the credit shortfall.
+        assert!(is_expected_billing_failure(
+            "openrouter API error (402 Payment Required): {\"error\":\"Insufficient credits\"}"
+        ));
+    }
+
+    #[test]
+    fn real_scout_failures_are_not_classified_as_billing() {
+        for message in [
+            "provider call failed: connection reset by peer",
+            "agent definition 'context_scout' not found in registry",
+            "sub-agent exceeded maximum iterations (8)",
+            "OpenHuman returned HTTP 400: {\"error\":\"model not found\"}",
+            // A healthy-balance readout must not be swallowed.
+            "You have 100 remaining credits this month",
+            "",
+        ] {
+            assert!(
+                !is_expected_billing_failure(message),
+                "{message:?} must keep paging Sentry"
+            );
+        }
+    }
+
+    #[test]
+    fn scout_failure_signal_flattens_the_provider_cause_chain() {
+        // The wire body arrives as a *cause* under the runner's own context, so
+        // `to_string()` alone loses it — the classifier would then miss the very
+        // failure the demotion exists for.
+        let inner = anyhow::Error::msg(CREDITS_400_BODY).context("chat completion failed");
+        let err = SubagentRunError::Provider(inner);
+
+        assert!(
+            !err.to_string().contains("USER_INSUFFICIENT_CREDITS"),
+            "precondition: the flat Display drops the cause carrying the wire body"
+        );
+        let signal = scout_failure_signal(&err);
+        assert!(signal.contains("USER_INSUFFICIENT_CREDITS"));
+        assert!(is_expected_billing_failure(&signal));
+
+        // Non-`Provider` variants are already flat thiserror messages.
+        assert_eq!(
+            scout_failure_signal(&SubagentRunError::MaxIterationsExceeded(8)),
+            "sub-agent exceeded maximum iterations (8)"
+        );
+    }
+
+    /// The regression this issue is about: a background `context_scout` run that
+    /// fails on exhausted credits must NOT become a Sentry error event, while
+    /// every other failure still does.
+    ///
+    /// Asserted end-to-end through the real `sentry-tracing` bridge (mirroring
+    /// `core::logging::sentry_tracing_layer`'s level mapping) rather than by
+    /// inspecting the log level, because the level→event mapping *is* the
+    /// mechanism: `ERROR` → `EventFilter::Event`, `WARN` → `Breadcrumb`.
+    #[cfg(feature = "crash-reporting")]
+    #[test]
+    fn credits_exhausted_scout_failure_does_not_reach_sentry() {
+        use sentry::test::TestTransport;
+        use std::sync::Arc;
+        use tracing::Level;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let transport = TestTransport::new();
+        let options = sentry::ClientOptions {
+            dsn: Some("https://public@sentry.invalid/1".parse().unwrap()),
+            transport: Some(Arc::new(transport.clone())),
+            ..Default::default()
+        };
+        let hub = Arc::new(sentry::Hub::new(
+            Some(Arc::new(options.into())),
+            Arc::new(Default::default()),
+        ));
+        let _hub_guard = sentry::HubSwitchGuard::new(hub);
+
+        let subscriber = tracing_subscriber::registry().with(
+            sentry::integrations::tracing::layer().event_filter(|metadata| {
+                match *metadata.level() {
+                    Level::ERROR => sentry::integrations::tracing::EventFilter::Event,
+                    Level::WARN | Level::INFO => {
+                        sentry::integrations::tracing::EventFilter::Breadcrumb
+                    }
+                    _ => sentry::integrations::tracing::EventFilter::Ignore,
+                }
+            }),
+        );
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
+        log_scout_failure("provider call failed", CREDITS_400_BODY);
+        assert!(
+            transport.fetch_and_clear_events().is_empty(),
+            "an out-of-credits background scout must not page Sentry (TAURI-RUST-HMW)"
+        );
+
+        log_scout_failure("provider call failed", "connection reset by peer");
+        let events = transport.fetch_and_clear_events();
+        assert_eq!(
+            events.len(),
+            1,
+            "a genuine scout failure must still reach Sentry"
+        );
+        assert_eq!(events[0].level, sentry::Level::Error);
     }
 }

--- a/src/openhuman/subconscious/profiles/memory.rs
+++ b/src/openhuman/subconscious/profiles/memory.rs
@@ -48,6 +48,38 @@ const SUBCONSCIOUS_TOOL_CATALOG: &str = "\
 - spawn_subagent: Delegate deeper research or multi-step work (runs inline; its result comes back to you).
 ";
 
+/// Provider-routing role this background tick runs under (`subconscious_provider`).
+const SUBCONSCIOUS_ROLE: &str = "subconscious";
+
+/// Should stage 2 skip spawning the `context_scout` because the user's managed
+/// OpenHuman credits are exhausted?
+///
+/// The tick is a background surface the user never asked for, so attempting a
+/// model call that is *certain* to come back
+/// `400 {"errorCode":"USER_INSUFFICIENT_CREDITS"}` buys nothing: the scout dies,
+/// the tick proceeds without a bundle anyway, and every tick of every
+/// out-of-credits user burned a backend round-trip and a Sentry error
+/// (TAURI-RUST-HMW, #5308). Gating here stops the load at source; the
+/// emit-site demotion in `agent_prepare_context` remains the backstop for the
+/// races this can't see (a balance that runs out mid-flight, or the 30s
+/// [`crate::openhuman::team::managed_tool_budget_exhausted`] cache being stale).
+///
+/// Scoped to *managed* funding: a `subconscious_provider` pointing at a BYO key
+/// or a local runtime is unaffected by the OpenHuman balance, so
+/// [`role_bypasses_managed_credits`] short-circuits the probe entirely and the
+/// scout runs as before. A failed probe reports "not exhausted", so a backend
+/// outage degrades to today's attempt-and-fail rather than silently disabling
+/// the scout.
+async fn credits_gate_blocks_scout(config: &Config) -> bool {
+    if crate::openhuman::inference::provider::factory::role_bypasses_managed_credits(
+        SUBCONSCIOUS_ROLE,
+        config,
+    ) {
+        return false;
+    }
+    crate::openhuman::team::managed_tool_budget_exhausted(config).await
+}
+
 /// Construct the live `memory` instance from config (used by the registry /
 /// bootstrap). The only place `MemoryProfile` is wired into a runner.
 pub fn memory_instance(config: &Config) -> SubconsciousInstance {
@@ -77,13 +109,23 @@ impl MemoryProfile {
 
     /// Stage 2: run the read-only `context_scout` over the world diff to gather
     /// grounding context. Best-effort — on any error the decision agent simply
-    /// runs without a prepared-context section.
+    /// runs without a prepared-context section, and the same fallback covers a
+    /// scout skipped by the managed-credits gate ([`credits_gate_blocks_scout`]).
     ///
     /// The tick is a controller-spawned background surface with **no enclosing
     /// agent turn**, so the scout spawn has no ambient `current_parent()`. We
     /// establish a root parent via [`with_root_parent`] — without it every
     /// tick's scout died with `NoParentContext` (Sentry TAURI-RUST-HMW; #4337).
     async fn run_scout(&self, config: &Config, world_diff: &str) -> String {
+        // Preventable user-state: don't spawn a scout whose model call is
+        // certain to 400 on exhausted credits. See `credits_gate_blocks_scout`.
+        if credits_gate_blocks_scout(config).await {
+            debug!(
+                "[subconscious:memory] skipping context scout — managed OpenHuman credits exhausted"
+            );
+            return String::new();
+        }
+
         let question = format!(
             "Background awareness check. Here is what changed in the user's connected sources \
              since the last check:\n\n{world_diff}\n\nSurface what the user should be aware of or \

--- a/src/openhuman/subconscious/profiles/memory_tests.rs
+++ b/src/openhuman/subconscious/profiles/memory_tests.rs
@@ -122,3 +122,24 @@ fn render_world_diff_caps_items_and_falls_back_to_item_id() {
     assert!(rendered.contains("[added] item_0"), "uses item_id fallback");
     assert!(rendered.contains("…and 3 more"), "caps the per-source list");
 }
+
+// ── Managed-credits gate on the background scout (#5308, TAURI-RUST-HMW) ─
+
+/// A `subconscious_provider` on a local on-device runtime is funded by the
+/// user's own hardware, so an exhausted OpenHuman balance is irrelevant: the
+/// gate must short-circuit *before* the usage probe and let the scout run.
+///
+/// This is also the assertion that keeps the gate honest about network cost —
+/// `role_bypasses_managed_credits` resolving to a local runtime needs no key
+/// lookup and no backend call, so the test runs fully offline. If someone
+/// reorders the gate to probe first, this test starts hitting the network.
+#[tokio::test]
+async fn local_subconscious_route_is_not_gated_by_managed_credits() {
+    let mut config = Config::default();
+    config.subconscious_provider = Some("ollama:qwen3:8b".to_string());
+
+    assert!(
+        !credits_gate_blocks_scout(&config).await,
+        "a BYO/local-funded subconscious route must never be gated on the managed balance"
+    );
+}


### PR DESCRIPTION
## Summary

- Stop the background `context_scout` from raising a Sentry **error** when its model call comes back `400 USER_INSUFFICIENT_CREDITS` — 8314 events / 13 users on `TAURI-RUST-HMW`, all of them out-of-credits users.
- Demote at the emit site: `log_scout_failure` sends a budget-exhausted 400 / insufficient-credits 402 to `warn!` (kept as a local log + Sentry breadcrumb); every other cause still `error!`s and keeps paging.
- Classify over the flattened `anyhow` **source chain**, because the wire body arrives as a cause under `SubagentRunError::Provider`'s own context and the top-level string alone does not contain it.
- Gate the background scout: the subconscious memory tick now skips stage 2 outright when managed credits are exhausted, instead of spawning a scout whose model call is certain to fail.
- No behaviour change for anyone with credits, and no change to the tool's return value, `ToolResult`, or sub-agent lifecycle events.

## Problem

`src/openhuman/agent_orchestration/tools/agent_prepare_context.rs` logged **every** `context_scout` failure with `tracing::error!`:

```
[agent_prepare_context] context_scout run failed
```

`core::logging::sentry_tracing_layer` maps `Level::ERROR` → `EventFilter::Event`, so each failure became a Sentry issue. The underlying cause (visible in the breadcrumb) is:

```
OpenHuman returned HTTP 400: {"success":false,"error":"Insufficient budget","errorCode":"USER_INSUFFICIENT_CREDITS"}
```

That is **preventable user-state (billing)**, not a defect — and the scout is a *background* pass every caller already treats as best-effort (the subconscious tick and the graph's `SuperContextMiddleware` both fall back to the un-augmented message). So an out-of-credits user paged Sentry on every tick, forever.

Two existing nets both miss it:

- `core::observability::is_budget_event` (the `before_send` filter) is **tag-gated** on `failure=non_2xx` + `status=400`, tags a `tracing::error!` from this call site never carries — and it keys on the **event message**, which here is the static `"context_scout run failed"` with the body only in a breadcrumb.
- `classify_expected_error`'s `BudgetExhausted` demotion runs on `report_error_or_expected` call sites; this is a bare `tracing::error!`.

This is the same shape as the cron scheduler's `is_budget_exhausted_failure` halt (`TAURI-RUST-BMW`), which needed its own emit-site suppression for exactly this reason.

## Solution

### 1. Emit-site classification (`agent_prepare_context.rs`)

- **`log_scout_failure(error_kind, message)`** — routes billing causes to `warn!` (→ `EventFilter::Breadcrumb`: local log line survives, no issue raised), everything else to the original `error!`. Metadata-only; the raw provider body is never logged.
- **`is_expected_billing_failure(message)`** — delegates to the crate's two single-source classifiers so the phrase sets cannot drift from the cron halt and `before_send` nets that share them:
  - `inference::provider::is_budget_exhausted_message` — managed backend's budget-exhausted 400,
  - `core::observability::is_insufficient_credits_message` — BYO provider's insufficient-credits 402.
- **`scout_failure_signal(err)`** — flattens `SubagentRunError::Provider`'s `anyhow` error **including its `source` chain**. This is load-bearing, not defensive: `SubagentRunError::Provider` renders as `"provider call failed: <top-level context>"`, so classifying `err.to_string()` alone would miss the wire body and the fix would be a silent no-op. Other variants are flat `thiserror` messages already. Used for classification only — the user-visible `message` stays `err.to_string()`.

`publish_subagent_failed`, the `AgentProgress::SubagentFailed` send, and the returned `ToolResult::error` are all unchanged, so the failure stays fully visible to the parent agent and the UI.

### 2. Gate the background scout (`subconscious/profiles/memory.rs`)

`credits_gate_blocks_scout(config)` short-circuits stage 2 when managed credits are exhausted. The tick already proceeds without a bundle on any scout failure, so the skip costs nothing behaviourally and removes the load (a backend round-trip + a failed sub-agent run per tick) at source.

Design notes:

- **Scoped to managed funding.** `role_bypasses_managed_credits("subconscious", config)` short-circuits **before** the usage probe, so a `subconscious_provider` on a BYO key or a local runtime is never gated on the OpenHuman balance and never pays for a probe.
- **Fails open.** `managed_tool_budget_exhausted` reports "not exhausted" on a failed probe, so a backend outage degrades to today's attempt-and-fail rather than silently disabling the scout. It also carries a 30s cache, so this adds at most one `GET /teams/me/usage` per 30s.
- **The emit-site demotion stays as the backstop** for races the gate cannot see: a balance that runs out mid-flight, a stale probe cache, and the other scout entry points (the `agent_prepare_context` tool and `SuperContextMiddleware`).

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/ci-lite.yml`](../.github/workflows/ci-lite.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge. — see **Validation Blocked**: not run locally (disk capacity); the three new pure helpers and the gate's bypass branch are directly unit-tested, the two uncovered lines are the `managed_tool_budget_exhausted` probe call and the `run_scout` early return, both of which need a live backend.
- [x] Coverage matrix updated — `N/A: behaviour-only change` — a Sentry-noise fix on an existing path; no feature added, removed, or renamed, and no matrix row currently covers the context scout.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A`: no existing matrix row covers `agent_prepare_context` / `context_scout` (grepped `docs/TEST-COVERAGE-MATRIX.md` for `scout`, `agent_prepare`, `super context` — no hits).
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — the Sentry test uses `sentry::test::TestTransport` (no network); the gate test resolves a local runtime and short-circuits before any probe, deliberately asserting the offline path.
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A`: no user-facing surface changes; log severity + a background skip only.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Platform**: desktop + headless core (Rust). No UI, no frontend, no schema/RPC surface change.
- **Observability**: `TAURI-RUST-HMW` should stop accruing events from the credits path. Genuine scout failures (provider outage, registry miss, iteration cap) still page at `error` level, and the credits case still leaves a `warn` breadcrumb — so it remains visible in the trail of any real error that follows.
- **Performance**: strictly fewer backend calls for out-of-credits users (one cached usage probe per tick replaces a full sub-agent run + model call). Users with credits see one extra `GET /teams/me/usage` per 30s at most, and BYO/local subconscious routes see none.
- **Security / migration / compatibility**: none. No config, no persistence, no wire-format change.

## Related

- Closes: #5308
- Sentry issue: `TAURI-RUST-HMW` (8314 events, 13 users, first seen 2026-06-26)
- Prior art followed: the cron scheduler's `is_budget_exhausted_failure` terminal billing-halt (`TAURI-RUST-BMW`) in `src/openhuman/cron/scheduler.rs`
- Related but distinct: #4337 (`NoParentContext` — a *different* failure that shared this Sentry fingerprint because the event message is static; already closed)
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: `N/A` (tracked on GitHub as #5308)
- URL: https://github.com/tinyhumansai/openhuman/issues/5308

### Commit & Branch

- Branch: `fix/5308-context-scout-credits-noise`
- Commit SHA: `961a379fc`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A`: no `app/` files changed.
- [x] `pnpm typecheck` — `N/A`: no TypeScript changed.
- [x] Focused tests: **not run locally** — see Validation Blocked.
- [x] Rust fmt/check (if changed): `cargo fmt --check` **passes**. `cargo check --manifest-path Cargo.toml` **passed clean** over the full core crate, covering all three new functions and both call sites — but it ran before the local-build stop and does **not** compile `#[cfg(test)]` code.
- [x] Tauri fmt/check (if changed): `N/A`: no `app/src-tauri/` files changed.

### Validation Blocked

- `command:` `cargo test --lib openhuman::agent_orchestration::tools::agent_prepare_context` (and the `memory_tests` sibling)
- `error:` not a compile error — the local build was stopped for disk capacity (each Rust build is 15–30 GB of `target/`).
- `impact:` **the new test bodies have not been type-checked; CI is the first real check on them.** Non-test code is compiler-verified and `cargo fmt --check` passes, so the test blocks are syntactically valid. They were written against the verbatim `sentry` + `tracing` harness in `src/core/jsonrpc_tests.rs` (`thread_not_found_rpc_error_does_not_report_to_sentry`) and the `Config`/role patterns in `src/openhuman/inference/provider/factory_tests.rs`.

### Behavior Changes

- **Intended behavior change:** a `context_scout` failure caused by exhausted credits is logged at `warn` instead of `error` (so it is a Sentry breadcrumb, not an issue), and the subconscious memory tick skips the scout entirely when managed credits are exhausted.
- **User-visible effect:** none in the app. The scout already degraded to "no prepared context" on failure and still does; the parent agent still receives the same `ToolResult::error` and the same sub-agent lifecycle events.

### Parity Contract

- **Legacy behavior preserved:** every non-billing failure keeps the identical `tracing::error!` call — same target, same `error_kind` field, same static message — so existing Sentry grouping and alerting for real failures is untouched. `publish_subagent_failed`, the `AgentProgress::SubagentFailed` send, and the returned `ToolResult::error` string are byte-identical.
- **Guard/fallback/dispatch parity checks:** both billing predicates delegate to the crate's existing single-source classifiers rather than re-declaring phrases, so they cannot drift from `is_budget_event` / the cron halt. The gate fails open (failed probe ⇒ "not exhausted" ⇒ scout runs), and `role_bypasses_managed_credits` keeps BYO/local routes on the pre-change path.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: `N/A`

