### PR TITLE
fix(auth): keep the /auth/me 401 classifiable as session expiry (#5307)

### DIFF
--- a/src/openhuman/credentials/ops.rs
+++ b/src/openhuman/credentials/ops.rs
@@ -796,13 +796,29 @@ pub async fn auth_get_me(config: &Config) -> Result<RpcOutcome<serde_json::Value
     let user = client
         .fetch_current_user(&token)
         .await
-        // `{e:#}` walks the full anyhow context chain so the underlying
-        // reqwest transport error (timeout / connection reset / TLS / DNS)
-        // reaches `core::observability::is_transient_message_failure`. Bare
-        // `e.to_string()` only renders the top context layer
-        // ("GET /auth/me") and collapsed every transient transport failure
-        // into Sentry TAURI-RUST-10.
-        .map_err(|e| format!("{e:#}"))?;
+        // `flatten_authed_error` maps the typed `BackendApiError::Unauthorized`
+        // onto the `SESSION_EXPIRED:` sentinel and falls through to `{e:#}` for
+        // everything else, so both properties this call site needs are kept:
+        //
+        // * Non-401s still render the full anyhow context chain, so the
+        //   underlying reqwest transport error (timeout / connection reset /
+        //   TLS / DNS) reaches `observability::is_transient_message_failure`.
+        //   Bare `e.to_string()` renders only the top context layer
+        //   ("GET /auth/me") and collapsed every transient transport failure
+        //   into Sentry TAURI-RUST-10.
+        // * A 401 is recognised by `jsonrpc::is_session_expired_error`, which
+        //   skips the Sentry report AND publishes `DomainEvent::SessionExpired`
+        //   so `SessionExpiredSubscriber` clears the dead JWT.
+        //
+        // Until #5232 routed `fetch_current_user` through `authed_json`, a 401
+        // here surfaced as `"GET /auth/me failed (401 Unauthorized): …"`, which
+        // `is_session_expired_error` matched on its HTTP-verb prefix. The typed
+        // error renders as `"backend rejected session token on GET /auth/me"`,
+        // which matches neither classifier — so on 0.63.9 every lapsed session
+        // reported to Sentry as a code defect (TAURI-RUST-RYD) and, because the
+        // stale token was never cleared, re-fired the same 401 on the next
+        // revalidation: the forced sign-out loop in #5307.
+        .map_err(crate::api::flatten_authed_error)?;
 
     Ok(RpcOutcome::single_log(user, "current user fetched"))
 }
@@ -855,8 +871,9 @@ pub async fn auth_create_channel_link_token(
     let payload = client
         .create_channel_link_token(&channel, &token)
         .await
-        // See `auth_get_me` above for why we walk the full anyhow chain.
-        .map_err(|e| format!("{e:#}"))?;
+        // See `auth_get_me` above: same authed backend route, same need to keep
+        // the typed 401 classifiable while non-401s keep their full anyhow chain.
+        .map_err(crate::api::flatten_authed_error)?;
 
     Ok(RpcOutcome::single_log(
         payload,

--- a/src/openhuman/credentials/ops_tests.rs
+++ b/src/openhuman/credentials/ops_tests.rs
@@ -68,6 +68,46 @@ async fn spawn_auth_me_status(status: StatusCode) -> String {
     format!("http://{addr}")
 }
 
+/// Persist a live (unexpired) app-session profile for `user_id` and return the
+/// user-scoped `Config` that reads it back, mirroring the on-disk state of an
+/// already-signed-in install.
+///
+/// Written directly through `AuthService` rather than via `store_session` so the
+/// caller's mock backend only has to answer the route under test — `store_session`
+/// would additionally need `/auth/me` to succeed first, and re-scopes the profile
+/// to the resolved user directory as a side effect.
+fn store_live_session(user_id: &str) -> Config {
+    let root_dir = default_root_openhuman_dir().unwrap();
+    write_active_user_id(&root_dir, user_id).unwrap();
+    let user_dir = user_openhuman_dir(&root_dir, user_id);
+    std::fs::create_dir_all(user_dir.join("workspace")).unwrap();
+    let config = Config {
+        config_path: user_dir.join("config.toml"),
+        workspace_dir: user_dir.join("workspace"),
+        action_dir: user_dir.join("workspace"),
+        ..Config::default()
+    };
+    let token = jwt_with_payload(json!({
+        "exp": (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp()
+    }));
+    let mut metadata = std::collections::HashMap::new();
+    metadata.insert("user_id".to_string(), user_id.to_string());
+    metadata.insert(
+        "user_json".to_string(),
+        json!({ "id": user_id }).to_string(),
+    );
+    AuthService::from_config(&config)
+        .store_provider_token(
+            APP_SESSION_PROVIDER,
+            DEFAULT_AUTH_PROFILE_NAME,
+            &token,
+            metadata,
+            true,
+        )
+        .unwrap();
+    config
+}
+
 // ── secret_store_for_config ────────────────────────────────────
 
 #[test]
@@ -450,6 +490,85 @@ async fn store_session_rejects_live_jwt_when_auth_me_unauthorized() {
     );
     let state = auth_get_state(&config).await.unwrap().value;
     assert!(!state.is_authenticated);
+}
+
+/// #5307 — a lapsed session on `GET /auth/me` must stay classifiable as
+/// session expiry all the way out of `auth_get_me`.
+///
+/// The dispatcher (`core::jsonrpc::invoke_method`) keys BOTH behaviours off the
+/// error string this function returns: it skips the Sentry report and publishes
+/// `DomainEvent::SessionExpired`, which is what makes `SessionExpiredSubscriber`
+/// clear the dead JWT. Before #5232 routed `fetch_current_user` through
+/// `authed_json`, a 401 surfaced as `"GET /auth/me failed (401 Unauthorized): …"`
+/// and matched the dispatcher's HTTP-verb-prefixed 401 rule. The typed
+/// `BackendApiError::Unauthorized` renders as
+/// `"backend rejected session token on GET /auth/me"` and matches nothing, so on
+/// 0.63.9 every lapsed session reported to Sentry as a code defect
+/// (TAURI-RUST-RYD) and the stale token was never cleared — so the next
+/// revalidation re-fired the same 401 and forced the user out again, forever.
+///
+/// Pinned through the real `auth_get_me` entry point rather than on the
+/// classifier alone: `is_session_expired_error` already recognised the flattened
+/// form (`jsonrpc_tests::is_session_expired_error_matches_flattened_backend_unauthorized`)
+/// — the only thing wrong was that this call site never produced it.
+#[tokio::test]
+async fn auth_get_me_401_stays_classifiable_as_session_expiry() {
+    let _env_guard = crate::openhuman::config::TEST_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _home = EnvVarGuard::set_to_path("HOME", tmp.path());
+    let mut config = store_live_session("user-5307");
+    config.api_url = Some(spawn_auth_me_status(StatusCode::UNAUTHORIZED).await);
+
+    let err = auth_get_me(&config).await.unwrap_err();
+
+    // Assert on the sentinel specifically, not merely on
+    // `is_session_expired_message`: the local "session JWT required" guard also
+    // satisfies that predicate, so a test that only checked classification
+    // would pass even if the backend 401 were never reached.
+    assert!(
+        err.starts_with("SESSION_EXPIRED:"),
+        "a 401 from GET /auth/me must carry the SESSION_EXPIRED sentinel that \
+         `flatten_authed_error` produces, so the dispatcher suppresses the Sentry \
+         report and publishes SessionExpired (which clears the dead JWT and breaks \
+         the forced-logout loop), got: {err}"
+    );
+    assert!(
+        crate::core::observability::is_session_expired_message(&err),
+        "the flattened 401 must classify as session expiry, got: {err}"
+    );
+}
+
+/// The sibling authed route in this module must not regress the same way.
+#[tokio::test]
+async fn auth_create_channel_link_token_401_stays_classifiable_as_session_expiry() {
+    let _env_guard = crate::openhuman::config::TEST_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let _home = EnvVarGuard::set_to_path("HOME", tmp.path());
+    let mut config = store_live_session("user-5307");
+    let app = Router::new().route(
+        "/auth/channels/telegram/link-token",
+        axum::routing::post(|| async { StatusCode::UNAUTHORIZED }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    config.api_url = Some(format!("http://{addr}"));
+
+    let err = auth_create_channel_link_token(&config, "telegram")
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.starts_with("SESSION_EXPIRED:"),
+        "a 401 on the channel link-token route must carry the SESSION_EXPIRED \
+         sentinel, got: {err}"
+    );
 }
 
 // ── store_session (local session) ─────────────────────────────


### PR DESCRIPTION
> **Release-relevant — 0.63.9 regression, production users affected.** Sentry `TAURI-RUST-RYD` (+ core-side `CORE-RUST-1XW`): 280 events / 21 users, all platforms, 258/258 events on 0.63.9 and **zero on any older build**. Users are stuck in a repeating forced-logout loop that never self-heals. Opening against `main` per the standing rule; please prioritise for promotion/cherry-pick to `release` (`upstream/release` is at v0.63.9 and carries the identical defect — the patch applies cleanly there, `flatten_authed_error` is already present).

## Summary

- Restore session-expiry classification for `GET /auth/me` 401s, which 0.63.9 silently lost when #5232 routed `fetch_current_user` through `authed_json`.
- Fixes the **forced sign-out loop**: the expired JWT is once again cleared on a 401, so the user re-authenticates once instead of being signed out on every revalidation.
- Kills a new Sentry issue (`TAURI-RUST-RYD`) that reports ordinary session lapses as code defects.
- `auth_create_channel_link_token` fixed alongside it — same file, same authed backend route, same typed 401 leaking un-flattened.
- No frontend change required; `classifyRpcError` already handles the restored sentinel.

## Problem

The tokens, headers, and backend are all fine. The 401 is a genuine, ordinary session lapse. **What broke is that 0.63.9 stopped recognising it.**

`core::jsonrpc::is_session_expired_error` (`src/core/jsonrpc.rs:354`) identifies an OpenHuman-backend 401 **by the error string's shape** — an HTTP-verb prefix plus `401` plus `unauthorized`. Two behaviours hang off that classification:

| site | behaviour |
| --- | --- |
| `jsonrpc.rs:149` | skip the Sentry report (an expired session is not a code defect) |
| `jsonrpc.rs:286` | publish `DomainEvent::SessionExpired` → `SessionExpiredSubscriber` → `clear_session()` **deletes the dead JWT** |

Before 0.63.9, `fetch_current_user` issued its own request and bailed with `"GET /auth/me failed (401 Unauthorized): …"` — matched, both behaviours fired.

#5232 routed `fetch_current_user` through `authed_json`, which returns the typed `BackendApiError::Unauthorized`. `auth_get_me` flattened it with `format!("{e:#}")`, producing:

```
backend rejected session token on GET /auth/me
```

No verb prefix, no `401`, no `unauthorized` — **matches neither classifier**. So on 0.63.9:

1. **Sentry noise.** The 401 reports as a code defect. This is why `TAURI-RUST-RYD` is a *brand-new* issue first seen 07-29 with zero events on older builds — the previous wording was classified and never reached Sentry at all. The 401s themselves are not new; only their visibility is.
2. **The loop.** `DomainEvent::SessionExpired` is never published, so `clear_session` never runs and the expired JWT stays on disk. The scheduler gate still flips `signed_out false -> true` from the sibling revalidation paths (hence the breadcrumb in the Sentry trace), so the user *is* signed out — but the stale token survives, so the next revalidation re-fires the same 401 and signs them out again. Indefinitely.

The frontend mirrors the same verb-prefix rule (`app/src/services/coreRpcClient.ts:180`), so it degraded to `'unknown'` and never routed to a clean re-login either.

Only users whose session actually lapsed on 0.63.9 hit this — but for them it never resolves, which is why it reads as "the app keeps logging me out."

## Solution

Flatten through `crate::api::flatten_authed_error` instead of `format!("{e:#}")`.

That helper exists for exactly this case and is what **every other authed caller already uses** — `team`, `billing`, `announcements`, `orchestration`, `voice`, `meet_agent`. `auth_get_me` was the only one left behind. It maps the typed `Unauthorized` onto the `SESSION_EXPIRED:` sentinel and falls through to `{e:#}` for everything else, so the property this call site's original comment was protecting — the full anyhow context chain reaching `is_transient_message_failure` for transport errors (TAURI-RUST-10) — is preserved unchanged.

Design notes:

- **Keyed off the typed downcast, not wording.** Consistent with #2959's removal of brittle string-based suppression; a future change to the `#[error(...)]` text cannot silently re-break this.
- **No frontend change.** `classifyRpcError` / `classifyAuthExpiredReason` already treat `SESSION_EXPIRED` as a *confirmed* expiry, so the restored sentinel fixes the UI path for free.
- **Not widened beyond the regression.** `referral/ops.rs` and `webhooks/ops.rs` flatten with `e.to_string()` and have the same latent gap, but that predates 0.63.9 (the typed 401 existed in `authed_json` back at v0.63.1), so it is deliberately left out of a release-blocking fix. Noted as follow-up.

### On the tests

Both new tests store a live app-session profile, have the mock backend answer 401, and assert the error carries the `SESSION_EXPIRED:` sentinel.

They assert **the sentinel specifically**, not `is_session_expired_message`. The local `"session JWT required"` guard also satisfies that predicate, so a laxer assertion passes without the backend 401 ever being reached — my first draft did exactly that and the test caught it. Verified failing-before / passing-after: on the unfixed code both fail with the literal `backend rejected session token on GET /auth/me`.

The classifier itself was never wrong — `jsonrpc_tests::is_session_expired_error_matches_flattened_backend_unauthorized` already pinned it. Only the call site's flattening was. Hence the tests go through the real `auth_get_me` entry point rather than testing the classifier again.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `auth_get_me_401_stays_classifiable_as_session_expiry` (the regression) and `auth_create_channel_link_token_401_stays_classifiable_as_session_expiry` (sibling route). Both are failure-path tests; both fail on the unfixed code.
- [x] **Diff coverage ≥ 80%** — *not run locally* (local Rust builds are disabled on this machine — each build is 15–30 GB of `target/` and the disk is constrained). Left to the `rust-core-coverage` / `coverage-gate` lanes. The changed lines are two `map_err` expressions, both exercised by the new tests, so the gate is expected to pass; flagging rather than silently ticking the box.
- [x] Coverage matrix updated — `N/A: behaviour-only change` (restores pre-0.63.9 behaviour; adds no feature surface).
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced — tests use an in-process `axum` mock, consistent with the [mock policy](../gitbooks/developing/testing-strategy.md#mock-policy).
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no new surface`. `docs/RELEASE-MANUAL-SMOKE.md` already covers sign-in/sign-out; **worth re-running that section on the release cut**, since this is exactly the path that regressed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Platform:** desktop (Windows / macOS / Linux) — the Rust core's auth path. No mobile/web/CLI-specific impact; no API or schema change.
- **User-visible:** a lapsed session now prompts re-sign-in **once** instead of looping. Users currently stuck in the loop recover on upgrade — the first 401 after upgrading clears the stale token.
- **Security:** strictly tightening. The dead JWT is now removed from the profile store on rejection, as it was pre-0.63.9; on 0.63.9 it is retained indefinitely after the backend has rejected it.
- **Compatibility / migration:** none. No stored-data or wire-format change.
- **Performance:** none.
- **Sentry:** `TAURI-RUST-RYD` should stop accruing events; expected session lapses return to being suppressed rather than reported.

## Related

- Closes: #5307
- Feature IDs: `1.3.2` (Session Persistence), `1.4.1` (Session Logout)
- Regressed by: #5232 (`refactor(api): vendor tinyhumans-sdk and route the backend client through it`), shipped in v0.63.9 (`eab45dd6a`)
- Follow-up PR(s)/TODOs:
  - `referral/ops.rs` + `webhooks/ops.rs` flatten `authed_json` errors with `e.to_string()`, so their typed 401s are equally unclassifiable. Pre-existing (not a 0.63.9 regression), excluded from this fix on purpose.
  - The underlying fragility is that session-expiry classification keys off prose, in two languages (`jsonrpc.rs` and `coreRpcClient.ts`). A `BackendApiError::Unauthorized` that reaches the RPC boundary un-flattened is silently wrong and nothing fails. A typed `RpcError::SessionExpired` variant would make this unrepresentable — worth its own issue.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5307-063.9-session-rejection`
- Commit SHA: `272af778a12bea411cd2d8bf7c209a48e30a6c38`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no frontend files changed`
- [x] `pnpm typecheck` — `N/A: no TypeScript changed`
- [x] Focused tests: `cargo test --lib credentials::ops::tests` (48 passed), `credentials::` (190 passed), `core::jsonrpc` (94 passed). Failing-before confirmed by temporarily reverting both `map_err` call sites.
- [x] Rust fmt/check: `cargo fmt --check` clean; `cargo clippy --lib --tests` surfaced only pre-existing findings in files this PR does not touch.
- [x] Tauri fmt/check (if changed): `N/A: app/src-tauri unchanged`

### Validation Blocked

- `command:` `pnpm test:rust` / `pnpm test:coverage` (full suite + diff coverage)
- `error:` not attempted — local Rust builds are disabled on this machine for disk reasons (15–30 GB per `target/`)
- `impact:` the diff-coverage number is unverified locally; CI's `rust-core-coverage` / `coverage-gate` lanes are authoritative. Focused tests covering the changed lines did run and pass.

### Behavior Changes

- Intended behavior change: a `401` from `GET /auth/me` (and `POST /auth/channels/{channel}/link-token`) again surfaces as `SESSION_EXPIRED: …`, restoring pre-0.63.9 behaviour.
- User-visible effect: one clean re-sign-in prompt on session lapse instead of a repeating forced-logout loop.

### Parity Contract

- Legacy behavior preserved: yes — this restores v0.63.1 behaviour exactly. Non-401 errors are unaffected: `flatten_authed_error`'s fallback arm is `format!("{err:#}")`, byte-identical to the code it replaces, so the transient-transport context chain (TAURI-RUST-10) and the `auth_me_store_failure_is_transient` status parsing at store time both behave as before.
- Guard/fallback/dispatch parity checks: local offline sessions stay protected — `SessionExpiredSubscriber` short-circuits on `is_local_session_token` and re-enables the scheduler gate, so a non-JWT local sentinel is never torn down by this path. Downstream/provider 401s are untouched: the change is scoped to the typed `BackendApiError::Unauthorized` produced only by `authed_json`, preserving #2286's separation between backend session expiry and provider auth failures.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A

