### PR TITLE
fix(memory): store only what a person sent as a conversation memory

### DIFF
--- a/src/openhuman/agent/agent_tests.rs
+++ b/src/openhuman/agent/agent_tests.rs
@@ -349,3 +349,5 @@ fn xml_tool_response(name: &str, args: &str) -> ChatResponse {
 mod part_01_tests;
 #[path = "agent_tests_part_02_tests.rs"]
 mod part_02_tests;
+#[path = "agent_tests_part_03_tests.rs"]
+mod part_03_tests;

--- a/src/openhuman/agent/agent_tests_part_01_tests.rs
+++ b/src/openhuman/agent/agent_tests_part_01_tests.rs
@@ -320,7 +320,20 @@ async fn auto_save_stores_messages_in_memory() {
         true, // auto_save enabled
     );
 
-    let _ = agent.turn("Remember this fact").await.unwrap();
+    // Scoped like a real chat turn. The autosave only stores what a person sent
+    // (`turn_origin::current_is_user_authored`), and production entry points
+    // scope an origin — web chat `WebChat`, channels `ExternalChannel` — so a
+    // test that skipped it would be asserting a shape no caller produces.
+    let _ = crate::openhuman::agent::turn_origin::with_origin(
+        crate::openhuman::agent::turn_origin::AgentTurnOrigin::WebChat {
+            thread_id: "t-autosave".into(),
+            client_id: "c-autosave".into(),
+            request_id: None,
+        },
+        agent.turn("Remember this fact"),
+    )
+    .await
+    .unwrap();
 
     // Both user message and assistant response should be saved. The assistant
     // reply is persisted synchronously, but the user message is saved

--- a/src/openhuman/agent/agent_tests_part_03_tests.rs
+++ b/src/openhuman/agent/agent_tests_part_03_tests.rs
@@ -1,0 +1,152 @@
+use super::*;
+
+// Origin-gated conversation autosave (#5312).
+//
+// `turn()` stores the user message only when the turn's text was written by a
+// person — `turn_origin::current_is_user_authored`. These cover both directions
+// of that allowlist: the two user-authored origins that were not already pinned
+// by the `WebChat` case in part 01, and the two host-written ones that must not
+// reach the user's conversation memory.
+
+/// Poll for a `user_msg:` conversation memory over the same one-second window
+/// the positive autosave test uses, and report whether one ever landed.
+///
+/// The user message is stored fire-and-forget (`tokio::spawn` in
+/// `turn/core.rs`, #3610), so both directions need the *same* window or the
+/// negative tests are the weaker assertion: a broken guard whose spawned store
+/// lands after a short fixed sleep would pass them while failing in production.
+/// Returns as soon as one appears, so a genuinely broken guard fails fast
+/// instead of costing the full second.
+async fn poll_for_stored_user_message(mem: &Arc<dyn Memory>) -> Vec<String> {
+    let mut keys: Vec<String> = Vec::new();
+    for _ in 0..50 {
+        keys = mem
+            .list(None, None, None)
+            .await
+            .expect(
+                "memory list must succeed; an empty list here would let the \
+                     autosave assertions below pass without reading storage",
+            )
+            .into_iter()
+            .map(|e| e.key)
+            .collect();
+        if keys.iter().any(|k| k.starts_with("user_msg:")) {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    keys
+}
+
+/// `ExternalChannel` is in the user-authored allowlist alongside `WebChat`, so
+/// it needs its own positive case: a Telegram/Discord/Slack message is a person
+/// talking, and the allowlist would be half-tested if only the web thread had a
+/// stored-message assertion.
+#[tokio::test]
+async fn an_external_channel_turn_stores_the_user_message() {
+    use crate::openhuman::agent::turn_origin::{with_origin, AgentTurnOrigin};
+
+    let (mem, _tmp) = make_sqlite_memory();
+    let provider = Arc::new(ScriptedProvider::new(vec![text_response("got it")]));
+    let (mut agent, _tmp2) = build_agent_with_memory(provider, vec![], mem.clone(), true);
+
+    let origin = AgentTurnOrigin::ExternalChannel {
+        channel: "telegram".into(),
+        sender: Some("user-42".into()),
+        reply_target: "chat-7".into(),
+        message_id: "m-1".into(),
+    };
+    let _ = with_origin(origin, agent.turn("remember my flight is at nine"))
+        .await
+        .unwrap();
+
+    let keys = poll_for_stored_user_message(&mem).await;
+    assert!(
+        keys.iter().any(|k| k.starts_with("user_msg:")),
+        "a channel message is a person talking and must be stored: {keys:?}"
+    );
+}
+
+/// The desktop Settings agent-chat panel calls `openhuman.agent_chat`, which
+/// scopes `DirectChat`. That is a person typing, so it stores — the origin
+/// exists precisely because `Cli` (its previous label, chosen for the approval
+/// gate) would have dropped these messages.
+#[tokio::test]
+async fn a_direct_chat_turn_stores_the_user_message() {
+    use crate::openhuman::agent::turn_origin::{with_origin, AgentTurnOrigin};
+
+    let (mem, _tmp) = make_sqlite_memory();
+    let provider = Arc::new(ScriptedProvider::new(vec![text_response("noted")]));
+    let (mut agent, _tmp2) = build_agent_with_memory(provider, vec![], mem.clone(), true);
+
+    let _ = with_origin(
+        AgentTurnOrigin::DirectChat,
+        agent.turn("my dog is called Pip"),
+    )
+    .await
+    .unwrap();
+
+    let keys = poll_for_stored_user_message(&mem).await;
+    assert!(
+        keys.iter().any(|k| k.starts_with("user_msg:")),
+        "a direct-chat message is a person typing and must be stored: {keys:?}"
+    );
+}
+
+
+/// An internal agent runs on the same config as the chat, so it inherits
+/// `auto_save` — but its "user message" is the prompt the host wrote for it.
+/// Storing that as a conversation memory puts prompt boilerplate where the
+/// user's own words belong, and it competes for slots in every later recall
+/// (#5312). A `TrustedAutomation` turn therefore saves nothing.
+#[tokio::test]
+async fn an_automation_turn_does_not_store_its_prompt_as_the_users_memory() {
+    use crate::openhuman::agent::turn_origin::{
+        with_origin, AgentTurnOrigin, TrustedAutomationSource,
+    };
+
+    let (mem, _tmp) = make_sqlite_memory();
+    let provider = Arc::new(ScriptedProvider::new(vec![text_response("goals updated")]));
+    let (mut agent, _tmp2) = build_agent_with_memory(
+        provider,
+        vec![],
+        mem.clone(),
+        true, // auto_save enabled, exactly as a config-built internal agent gets it
+    );
+
+    let origin = AgentTurnOrigin::TrustedAutomation {
+        job_id: "memory_goals:enrich:1".into(),
+        source: TrustedAutomationSource::Subconscious,
+    };
+    let _ = with_origin(origin, agent.turn("Maintain the existing goals list."))
+        .await
+        .unwrap();
+
+    // The fire-and-forget store would land shortly after the turn returns, so
+    // give it the same one-second window the positive tests poll for before
+    // concluding it never happened.
+    let keys = poll_for_stored_user_message(&mem).await;
+    assert!(
+        !keys.iter().any(|k| k.starts_with("user_msg:")),
+        "an automation prompt must not be stored as a user message: {keys:?}"
+    );
+}
+
+/// An unscoped turn is not a user turn either. `turn_origin` documents that
+/// every entry point scopes an origin and that an unlabelled one fails closed;
+/// the autosave follows the same allowlist, so a caller that forgets cannot
+/// quietly write host text into the user's memory.
+#[tokio::test]
+async fn an_unscoped_turn_stores_no_user_message() {
+    let (mem, _tmp) = make_sqlite_memory();
+    let provider = Arc::new(ScriptedProvider::new(vec![text_response("ok")]));
+    let (mut agent, _tmp2) = build_agent_with_memory(provider, vec![], mem.clone(), true);
+
+    let _ = agent.turn("who wrote this?").await.unwrap();
+
+    let keys = poll_for_stored_user_message(&mem).await;
+    assert!(
+        !keys.iter().any(|k| k.starts_with("user_msg:")),
+        "an unscoped turn must not be credited to the user: {keys:?}"
+    );
+}

--- a/src/openhuman/agent/agent_tests_part_03_tests.rs
+++ b/src/openhuman/agent/agent_tests_part_03_tests.rs
@@ -12,16 +12,24 @@ use super::*;
 /// the positive autosave test uses, and report whether one ever landed.
 ///
 /// The user message is stored fire-and-forget (`tokio::spawn` in
-/// `turn/core.rs`, #3610), so both directions need the *same* window or the
+/// `turn/core_turn.rs`, #3610), so both directions need the *same* window or the
 /// negative tests are the weaker assertion: a broken guard whose spawned store
 /// lands after a short fixed sleep would pass them while failing in production.
 /// Returns as soon as one appears, so a genuinely broken guard fails fast
 /// instead of costing the full second.
+///
+/// Lists `CONVERSATION_RAW_NAMESPACE` explicitly rather than passing `None`.
+/// The autosave writes there (it no longer shares the default namespace), and a
+/// `None` listing comes back empty — which would make the two negative tests
+/// below pass without ever reading the store, exactly the false green this
+/// helper exists to avoid.
 async fn poll_for_stored_user_message(mem: &Arc<dyn Memory>) -> Vec<String> {
+    use crate::openhuman::agent::learning::transcript_ingest::CONVERSATION_RAW_NAMESPACE;
+
     let mut keys: Vec<String> = Vec::new();
     for _ in 0..50 {
         keys = mem
-            .list(None, None, None)
+            .list(Some(CONVERSATION_RAW_NAMESPACE), None, None)
             .await
             .expect(
                 "memory list must succeed; an empty list here would let the \
@@ -92,7 +100,6 @@ async fn a_direct_chat_turn_stores_the_user_message() {
         "a direct-chat message is a person typing and must be stored: {keys:?}"
     );
 }
-
 
 /// An internal agent runs on the same config as the chat, so it inherits
 /// `auto_save` — but its "user message" is the prompt the host wrote for it.

--- a/src/openhuman/agent/harness/session/turn/core_turn.rs
+++ b/src/openhuman/agent/harness/session/turn/core_turn.rs
@@ -224,7 +224,22 @@ impl Agent {
             );
         }
 
-        if self.auto_save {
+        // `auto_save` says the workspace keeps its chat in memory; the origin says
+        // whether this turn is chat at all. An internal agent is built from the
+        // same config (`Agent::from_config_for_agent`), so it inherits the flag —
+        // and its "user message" is the prompt the host wrote for it, not
+        // anything the user said. Live, that stored `memory_goals::enrich`'s
+        // prompt as a `Conversation` document keyed `user_msg:…`, where it then
+        // competed for slots in every later recall (#5312). Gating here rather
+        // than at each caller keeps a new internal agent from having to remember
+        // to opt out, which is a thing nobody notices forgetting.
+        //
+        // Upstream of the same-session exclusion filter `main` added alongside
+        // `CONVERSATION_RAW_NAMESPACE`: that filter stops this document echoing
+        // back inside the turn that wrote it, but a host-written prompt stored
+        // here still surfaces in a *later* session's recall. This gate is what
+        // keeps it from being written at all.
+        if self.auto_save && crate::openhuman::agent::turn_origin::current_is_user_authored() {
             // Fire-and-forget: persisting the user message to the memory store
             // does an embedding round-trip (Voyage) + memory-tree write that the
             // in-flight turn never reads back. Awaiting it delayed the start of

--- a/src/openhuman/agent/turn_origin.rs
+++ b/src/openhuman/agent/turn_origin.rs
@@ -124,6 +124,34 @@ impl AgentTurnOrigin {
             AgentTurnOrigin::Unknown => "Unknown".to_string(),
         }
     }
+
+    /// Whether the turn's text was written by a **person**.
+    ///
+    /// `WebChat` and `ExternalChannel` carry what a human sent. Every other
+    /// origin carries text the host wrote for an agent to act on: a
+    /// `TrustedAutomation` prompt (cron, subconscious, goal continuation,
+    /// workflow), a `Cli` invocation — which this module documents as
+    /// "command-line / **sub-agent** / one-off internal" — or an unscoped
+    /// `Unknown`.
+    ///
+    /// An allowlist, not a denylist, and for the same reason the permission
+    /// gate uses one: a new origin is a turn nobody has classified yet, and
+    /// mistaking a host-written prompt for a user message writes it into the
+    /// user's memory, where it is indistinguishable from something they said.
+    /// A caller that genuinely relays a person's text scopes one of the two
+    /// origins above.
+    pub fn is_user_authored(&self) -> bool {
+        matches!(
+            self,
+            AgentTurnOrigin::WebChat { .. } | AgentTurnOrigin::ExternalChannel { .. }
+        )
+    }
+}
+
+/// Whether the current turn's text was written by a person — `false` outside
+/// any origin scope, matching [`AgentTurnOrigin::is_user_authored`]'s allowlist.
+pub fn current_is_user_authored() -> bool {
+    current().is_some_and(|origin| origin.is_user_authored())
 }
 
 tokio::task_local! {

--- a/src/openhuman/agent/turn_origin.rs
+++ b/src/openhuman/agent/turn_origin.rs
@@ -63,6 +63,21 @@ pub enum AgentTurnOrigin {
     },
     /// Command-line / sub-agent / one-off internal invocation.
     Cli,
+    /// A person typing into a direct chat surface that is not the web thread —
+    /// today the `openhuman.agent_chat` RPC behind the desktop Settings agent
+    /// chat panel, and an operator running the same RPC by hand.
+    ///
+    /// Split out of [`Cli`](Self::Cli) rather than folded into it because the
+    /// two answer different questions with the same variant. `Cli` was chosen
+    /// for this RPC to tell the **approval gate** "trusted caller, do not fail
+    /// closed"; it says nothing about who wrote the text, and its own
+    /// documentation covers sub-agent and internal invocations too. Reusing it
+    /// for [`is_user_authored`](Self::is_user_authored) would have to answer
+    /// "did a person write this" with a trust answer, and would drop a real
+    /// person's message on the floor.
+    ///
+    /// Trust-wise this is exactly `Cli` — the gate treats them identically.
+    DirectChat,
     /// Unlabelled — gate fails closed. Every entry point MUST scope a real
     /// origin before invoking the agent.
     Unknown,
@@ -121,14 +136,15 @@ impl AgentTurnOrigin {
                 format!("TrustedAutomation({source:?})")
             }
             AgentTurnOrigin::Cli => "Cli".to_string(),
+            AgentTurnOrigin::DirectChat => "DirectChat".to_string(),
             AgentTurnOrigin::Unknown => "Unknown".to_string(),
         }
     }
 
     /// Whether the turn's text was written by a **person**.
     ///
-    /// `WebChat` and `ExternalChannel` carry what a human sent. Every other
-    /// origin carries text the host wrote for an agent to act on: a
+    /// `WebChat`, `ExternalChannel`, and `DirectChat` carry what a human sent.
+    /// Every other origin carries text the host wrote for an agent to act on: a
     /// `TrustedAutomation` prompt (cron, subconscious, goal continuation,
     /// workflow), a `Cli` invocation — which this module documents as
     /// "command-line / **sub-agent** / one-off internal" — or an unscoped
@@ -138,12 +154,20 @@ impl AgentTurnOrigin {
     /// gate uses one: a new origin is a turn nobody has classified yet, and
     /// mistaking a host-written prompt for a user message writes it into the
     /// user's memory, where it is indistinguishable from something they said.
-    /// A caller that genuinely relays a person's text scopes one of the two
+    /// A caller that genuinely relays a person's text scopes one of the three
     /// origins above.
+    ///
+    /// This is a **different question** from the one the approval gate asks,
+    /// and the two must not be collapsed onto one variant. The gate asks how
+    /// far to trust the caller; this asks who wrote the words. `DirectChat`
+    /// exists because `agent_chat` needs the first answer to be "trusted" and
+    /// the second to be "a person" — see that variant's note.
     pub fn is_user_authored(&self) -> bool {
         matches!(
             self,
-            AgentTurnOrigin::WebChat { .. } | AgentTurnOrigin::ExternalChannel { .. }
+            AgentTurnOrigin::WebChat { .. }
+                | AgentTurnOrigin::ExternalChannel { .. }
+                | AgentTurnOrigin::DirectChat
         )
     }
 }

--- a/src/openhuman/inference/local/ops_part_01.rs
+++ b/src/openhuman/inference/local/ops_part_01.rs
@@ -119,13 +119,23 @@ fn grant_turn_cwd(config: &mut Config, root: &std::path::Path) {
 ///
 /// An ambient origin — scoped by an in-process embedder around its
 /// `invoke("openhuman.inference_agent_chat", …)` — is the caller's own,
-/// deliberate trust statement about the turn and is kept. Absent one, the
-/// historical [`AgentTurnOrigin::Cli`] label applies: this RPC is reached by
-/// trusted clients (desktop UI, operator CLI), and leaving it unlabelled would
-/// fail the approval gate closed on every external-effect tool.
+/// deliberate trust statement about the turn and is kept. Absent one,
+/// [`AgentTurnOrigin::DirectChat`] applies: this RPC is reached by trusted
+/// clients (the desktop Settings agent-chat panel, an operator running the RPC
+/// by hand), and leaving it unlabelled would fail the approval gate closed on
+/// every external-effect tool.
+///
+/// `DirectChat` rather than the historical `Cli`, and the difference is not
+/// cosmetic. The approval gate treats the two identically, so trust is
+/// unchanged — but `message` here is something a *person* typed, and `Cli`
+/// answers "who wrote this" with a trust answer. Its own documentation covers
+/// sub-agent and internal invocations, so
+/// [`is_user_authored`](crate::openhuman::agent::turn_origin::AgentTurnOrigin::is_user_authored)
+/// reads `false` for it and the conversation autosave would silently drop a
+/// real user message.
 fn effective_agent_chat_origin() -> crate::openhuman::agent::turn_origin::AgentTurnOrigin {
     crate::openhuman::agent::turn_origin::current()
-        .unwrap_or(crate::openhuman::agent::turn_origin::AgentTurnOrigin::Cli)
+        .unwrap_or(crate::openhuman::agent::turn_origin::AgentTurnOrigin::DirectChat)
 }
 
 /// Executes a single chat turn with an AI agent.

--- a/src/openhuman/inference/local/ops_tests.rs
+++ b/src/openhuman/inference/local/ops_tests.rs
@@ -312,15 +312,29 @@ fn grant_turn_cwd_is_the_only_mutation() {
 }
 
 /// No embedder scoped an origin: this RPC is the trusted desktop / operator
-/// entry point, so the turn keeps its historical `Cli` label rather than
-/// falling through to the gate's fail-closed `Unknown` arm.
+/// entry point, so the turn gets a real label rather than falling through to
+/// the gate's fail-closed `Unknown` arm.
+///
+/// `DirectChat`, not the historical `Cli`. The approval gate treats the two
+/// identically — see the shared arm in `security/approval/gate_intercept.rs` —
+/// so trust is unchanged. What differs is the *other* question `Cli` cannot
+/// answer: whether a person wrote the text. `message` here is something the
+/// user typed into the desktop Settings agent-chat panel, and `Cli`'s own
+/// documentation covers sub-agent and internal invocations, so
+/// `is_user_authored` reads `false` for it and the conversation autosave would
+/// silently drop a real user message (#5312).
 #[tokio::test]
-async fn effective_origin_defaults_to_cli_outside_any_scope() {
+async fn effective_origin_defaults_to_direct_chat_outside_any_scope() {
     use crate::openhuman::agent::turn_origin::AgentTurnOrigin;
-    assert!(matches!(
-        effective_agent_chat_origin(),
-        AgentTurnOrigin::Cli
-    ));
+    let origin = effective_agent_chat_origin();
+    assert!(
+        matches!(origin, AgentTurnOrigin::DirectChat),
+        "unscoped agent_chat must be labelled DirectChat, got {origin:?}"
+    );
+    assert!(
+        origin.is_user_authored(),
+        "a person typed this, so it must reach conversation memory"
+    );
 }
 
 /// An in-process embedder that labelled the turn keeps its label: a workflow

--- a/src/openhuman/security/approval/gate_intercept.rs
+++ b/src/openhuman/security/approval/gate_intercept.rs
@@ -343,9 +343,15 @@ impl ApprovalGate {
                 // TTL-denies, the conservative fail-closed default for a
                 // user-forced HITL gate.
             }
-            AgentTurnOrigin::Cli => {
+            // Same trust decision for both: a local operator invoking the core
+            // directly. They differ only in whether the turn's text was written
+            // by a person (`turn_origin::is_user_authored`), which this gate
+            // does not ask. Kept as one arm so the two can never drift apart on
+            // the trust axis, which is the axis this gate owns.
+            AgentTurnOrigin::Cli | AgentTurnOrigin::DirectChat => {
                 tracing::debug!(
                     tool = tool_name,
+                    origin = %origin.class(),
                     "[approval::gate] CLI / sub-agent caller — allowing without prompt"
                 );
                 return (GateOutcome::Allow, None);

--- a/src/openhuman/security/approval/gate_tests_part_03_tests.rs
+++ b/src/openhuman/security/approval/gate_tests_part_03_tests.rs
@@ -55,6 +55,31 @@ async fn intercept_with_cli_origin_allows_without_prompt() {
     assert!(matches!(outcome, GateOutcome::Allow));
 }
 
+#[tokio::test]
+async fn intercept_with_direct_chat_origin_allows_without_prompt() {
+    // `DirectChat` shares the CLI arm: both are a local operator invoking
+    // the core directly, and this gate decides on trust, not on whether the
+    // turn's text was person-written. The arm is only sound while both
+    // origins are covered — pinning `Cli` alone would let a future split
+    // send `DirectChat` down the park-and-prompt path (or the TTL-deny one)
+    // with nothing failing.
+    let (gate, _dir) = test_gate();
+    let outcome = turn_origin::with_origin(
+        AgentTurnOrigin::DirectChat,
+        gate.intercept("shell", "run ls", serde_json::json!({})),
+    )
+    .await;
+    assert!(
+        matches!(outcome, GateOutcome::Allow),
+        "DirectChat must allow unprompted, got {outcome:?}"
+    );
+    // Allowed without prompting means nothing was parked for a decision.
+    assert!(
+        gate.list_pending().unwrap().is_empty(),
+        "an allow-without-prompt must not persist a pending approval"
+    );
+}
+
 /// Regression for #5508 / #5499: an external-effect scheduling tool
 /// (`cron_add`) that runs on a freshly-spawned, turn-less task — the exact
 /// shape of a hosted effect executor, which


### PR DESCRIPTION
## Summary

- An internal agent no longer stores its own prompt as the user's conversation memory.
- `AgentTurnOrigin::is_user_authored` names the distinction the codebase already had: `WebChat` / `ExternalChannel` carry what a person sent, every other origin carries host text.
- Gated at the session, so a new internal agent cannot forget to opt out.
- Existing rows are left alone — this is the write path only.

## Problem

`Session`'s autosave persists the turn's "user message" as a `MemoryCategory::Conversation` document keyed `user_msg:<uuid>`, gated only on `config.memory.auto_save`. An internal agent built with `Agent::from_config_for_agent(...)` inherits that flag — and its "user message" is the prompt the host wrote for it.

Found live, in the `global` namespace of a workspace with two namespaces:

```
category: "conversation"   key: "user_msg:f7cf6a07-…"
content:  "Maintain the existing goals list. Call goals_list first, then make the
           MINIMAL set of changes (goals_add / goals_edit / goals_delete) justified
           by the context below. Do not churn goals that are still valid.
           …
           ## Context
           Recent conversation recap (segment seg-18c746e3…): The user asked twice to
           search Gmail for emails from Colorado…"
```

That is `memory_goals::enrich`'s prompt, verbatim, stored as if the user had typed it. It then competes for slots in every later recall, which is what made a namespace-wide memory search read like a transcript dump.

The blast radius is every config-built internal agent, not just goals: the flag comes from config, so a caller has to remember to turn it off, and forgetting is invisible until the store is inspected.

## Solution

Gate the autosave on the turn's origin. `memory_goals::enrich` already runs under `AgentTurnOrigin::TrustedAutomation { source: Subconscious }`; a live chat turn runs under `WebChat` (web chat / TUI) or `ExternalChannel` (Telegram, Discord, …).

`is_user_authored` is an **allowlist**, for the same reason the permission gate uses one: a new origin is a turn nobody has classified yet, and mistaking host text for a user message writes it where the user's own words belong, indistinguishable afterwards. `Cli` is excluded on the strength of its own doc comment — "command-line / **sub-agent** / one-off internal invocation" — and an unscoped `Unknown` is excluded because `turn_origin` already documents that every entry point must scope a real origin.

Tradeoff: a caller that relays a person's text without scoping an origin stops autosaving. That is the same contract the permission gate enforces, and both production user paths scope one today (`web_chat/ops.rs` → `WebChat`, `channels/runtime/dispatch/processor.rs` → `ExternalChannel`).

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `an_automation_turn_does_not_store_its_prompt_as_the_users_memory`, `an_unscoped_turn_stores_no_user_message`, and the existing round-trip test now scopes `WebChat` as production does
- [x] **Diff coverage ≥ 80%** — the changed lines are the origin predicate and the autosave gate, both covered in each direction by the tests above
- [x] Coverage matrix updated — `N/A: behaviour-only change`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: behaviour-only change`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

Desktop / CLI / channels: unchanged for user turns. Internal automation turns (cron, subconscious, goal continuation, workflow) stop writing `user_msg:*` conversation documents, so the memory store keeps only what a person sent and recall stops competing with prompt boilerplate. No migration: rows written before this change are left in place deliberately.

## Related

- Closes: #5312
- Follow-up PR(s)/TODOs: `memory_recall` without a namespace and `transcript_search` now describe overlapping jobs to the model ("searches everywhere" vs "search your PAST conversations across all threads"). The stores differ — `ConversationStore`'s trigram index vs the vector namespaces — but autosave copies chat into both, so a model can pull the same content twice in one turn. `RecallOpts` already carries a `category` filter if that split is worth enforcing; noted on #5312 rather than widened into this PR.

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/autosave-user-turns-only`
- Commit SHA: `6d46baecaad7ba82cd09cb40efb40321d6906657`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend files changed
- [x] `pnpm typecheck` — N/A: no frontend files changed
- [x] Focused tests: `agent::tests` 100, `turn_origin` 3, `agent::harness::session` 205, `memory_goals` 7 — all green
- [x] Rust fmt/check (if changed): `cargo fmt --all`, `cargo clippy -p openhuman -- -D warnings` clean
- [x] Tauri fmt/check (if changed): N/A: no Tauri files changed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for identifying direct-chat messages as user-authored.
  - Direct-chat actions now proceed without an approval prompt, consistent with interactive chat.

- **Bug Fixes**
  - User messages from direct chats and external channels are now saved to conversation history.
  - Internal, automated prompts are no longer incorrectly saved as user messages.
  - Unscoped or non-user-authored turns continue to be excluded from conversation autosave.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->