### PR TITLE
fix(memory): stop copying the conversation into memory; let recall answer with memories

### DIFF
--- a/src/openhuman/agent/harness/session/turn/core.rs
+++ b/src/openhuman/agent/harness/session/turn/core.rs
@@ -16,7 +16,6 @@ use crate::openhuman::agent::hooks::{self, TurnContext};
 use crate::openhuman::agent::messages::{ChatMessage, ConversationMessage};
 use crate::openhuman::agent::progress::AgentProgress;
 use crate::openhuman::memory::agent::memory_loader::collect_recall_citations;
-use crate::openhuman::memory::MemoryCategory;
 use crate::openhuman::util::truncate_with_ellipsis;
 
 use anyhow::Result;
@@ -640,59 +639,18 @@ impl Agent {
             );
         }
 
-        if self.auto_save {
-            // Fire-and-forget: persisting the user message to the memory store
-            // does an embedding round-trip (Voyage) + memory-tree write that the
-            // in-flight turn never reads back. Awaiting it delayed the start of
-            // *every* turn before recall/LLM began, so spawn it and let the chat
-            // continue immediately.
-            //
-            // Use a UNIQUE per-message key: the old fixed `"user_msg"` key
-            // upserts a single document (`upsert_document` keys by namespace+key),
-            // so concurrent turns would race on — and overwrite — one shared slot.
-            // A unique key makes each user message its own conversation document,
-            // which both removes the race and stops the autosave from only ever
-            // retaining the latest message.
-            let memory = self.memory.clone();
-            let user_msg = user_message.to_string();
-            let autosave_key = format!("user_msg:{}", uuid::Uuid::new_v4());
-            let chars = user_msg.chars().count();
-            // Captured *before* `tokio::spawn` — the ambient thread id is a
-            // `tokio::task_local` (see `tinyagents::thread_context`)
-            // and does not propagate into a spawned task, so it must be read
-            // on this (still-scoped) task and moved in explicitly. Tagging
-            // this document with the live chat thread id is what lets the
-            // same-session exclusion filter (`UnifiedMemory::recall` /
-            // `memory_hybrid_search`) recognize and drop it later this same
-            // turn, so the agent's own on-demand memory search doesn't echo
-            // its own triggering request back as a "relevant" result.
-            let session_id_for_autosave =
-                crate::openhuman::agent::tinyagents::thread_context::current_thread_id();
-            log::debug!(
-                "[agent_autosave] enqueue user-message store key={autosave_key} chars={chars} \
-                 session_id={}",
-                session_id_for_autosave.as_deref().unwrap_or("<none>")
-            );
-            tokio::spawn(async move {
-                match memory
-                    .store(
-                        "",
-                        &autosave_key,
-                        &user_msg,
-                        MemoryCategory::Conversation,
-                        session_id_for_autosave.as_deref(),
-                    )
-                    .await
-                {
-                    Ok(()) => log::debug!(
-                        "[agent_autosave] stored user-message key={autosave_key} chars={chars}"
-                    ),
-                    Err(err) => log::warn!(
-                        "[agent_autosave] user-message memory autosave failed key={autosave_key} err={err}"
-                    ),
-                }
-            });
-        }
+        // The user's message is NOT copied into the memory store. The chat
+        // transcript already holds every message verbatim, and `transcript_search`
+        // is the tool that reads it — a second copy in `memory_docs` bought
+        // nothing and cost an embedding round-trip (Voyage) per message, on text
+        // no reader wanted. Worse, it landed in the same vector space the agent
+        // searches for *facts*, so raw chat lines competed with real memories for
+        // every recall slot (#5312).
+        //
+        // What the conversation is actually worth keeping is extracted, not
+        // copied: `learning::transcript_ingest` distils preferences, decisions,
+        // commitments, and facts into the `conversation_memory` /
+        // `conversation_reflections` namespaces. Those stay, and stay recallable.
 
         log::info!("[agent] loading memory context for user message");
         const MEMORY_CITATION_LIMIT: usize = 5;
@@ -1620,13 +1578,13 @@ impl Agent {
         })
         .await;
 
-        if self.auto_save {
-            let summary = truncate_with_ellipsis(&reply, 100);
-            let _ = self
-                .memory
-                .store("", "assistant_resp", &summary, MemoryCategory::Daily, None)
-                .await;
-        }
+        // The assistant's reply is not copied into memory either, for the same
+        // reason as the user's message above — and this copy was the weaker of
+        // the two: a 100-character truncation under the FIXED key
+        // `assistant_resp`, which `upsert_document` keys by namespace+key, so
+        // every turn in the workspace overwrote the one before it. It was a
+        // single perpetually-stale row, mislabelled `Daily`, that no reader
+        // could have used as history.
 
         // Fire post-turn hooks (non-blocking), matching the legacy engine.
         if !self.post_turn_hooks.is_empty() {

--- a/src/openhuman/agent/tests.rs
+++ b/src/openhuman/agent/tests.rs
@@ -642,7 +642,16 @@ async fn history_trims_after_max_messages() {
 // ═══════════════════════════════════════════════════════════════════════════
 
 #[tokio::test]
-async fn auto_save_stores_messages_in_memory() {
+async fn a_turn_does_not_copy_the_conversation_into_memory() {
+    // The chat used to write two documents per turn: the user's message
+    // verbatim, and a 100-character truncation of the reply under the fixed
+    // key `assistant_resp`. Both were copies of text the transcript already
+    // held, and both landed in the vector space the agent searches for facts,
+    // where they competed with real memories for every recall slot (#5312).
+    //
+    // The transcript is still written, and `transcript_search` reads it. What
+    // is worth keeping from a conversation is extracted rather than copied, by
+    // `learning::transcript_ingest`, into its own namespaces.
     let (mem, _tmp) = make_sqlite_memory();
     let provider = Arc::new(ScriptedProvider::new(vec![text_response(
         "I remember everything",
@@ -652,28 +661,21 @@ async fn auto_save_stores_messages_in_memory() {
         provider,
         vec![],
         mem.clone(),
-        true, // auto_save enabled
+        true, // auto_save enabled — it must no longer mean "copy the chat"
     );
 
     let _ = agent.turn("Remember this fact").await.unwrap();
 
-    // Both user message and assistant response should be saved. The assistant
-    // reply is persisted synchronously, but the user message is saved
-    // fire-and-forget (tokio::spawn in turn/core.rs, #3610), so it may land a
-    // moment after `turn()` returns — poll briefly instead of reading once,
-    // which otherwise races on a loaded CI runner under llvm-cov instrumentation.
-    let mut count = 0;
-    for _ in 0..50 {
-        count = mem.count().await.unwrap();
-        if count >= 2 {
-            break;
-        }
+    // The writes were fire-and-forget (`tokio::spawn`), so give a stray one
+    // time to land before concluding none happened.
+    for _ in 0..25 {
+        assert_eq!(
+            mem.count().await.unwrap(),
+            0,
+            "a chat turn must write no conversation copies"
+        );
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
     }
-    assert!(
-        count >= 2,
-        "Expected at least 2 memory entries, got {count}"
-    );
 }
 
 #[tokio::test]

--- a/src/openhuman/channels/context.rs
+++ b/src/openhuman/channels/context.rs
@@ -59,10 +59,6 @@ pub(crate) struct ChannelRuntimeContext {
     pub(crate) config: Option<Arc<crate::openhuman::config::Config>>,
 }
 
-pub(crate) fn conversation_memory_key(msg: &super::traits::ChannelMessage) -> String {
-    tinychannels::context::conversation_memory_key(msg)
-}
-
 pub(crate) fn conversation_history_key(msg: &super::traits::ChannelMessage) -> String {
     tinychannels::context::conversation_history_key(msg)
 }
@@ -327,7 +323,6 @@ mod tests {
 
         let telegram = channel_message("telegram");
         let discord = channel_message("discord");
-        assert_eq!(conversation_memory_key(&telegram), "telegram_alice_m1");
         assert_eq!(conversation_history_key(&telegram), "telegram_alice_reply");
         assert_eq!(
             conversation_history_key(&discord),

--- a/src/openhuman/channels/runtime/dispatch/processor.rs
+++ b/src/openhuman/channels/runtime/dispatch/processor.rs
@@ -18,7 +18,7 @@ use crate::openhuman::agent::messages::ChatMessage;
 use crate::openhuman::agent::progress::AgentProgress;
 use crate::openhuman::channels::context::{
     build_memory_context, compact_sender_history, conversation_history_key,
-    conversation_memory_key, is_context_window_overflow_error, ChannelRuntimeContext,
+    is_context_window_overflow_error, ChannelRuntimeContext,
 };
 use crate::openhuman::channels::providers::telegram::TELEGRAM_APPROVAL_CLIENT_ID;
 use crate::openhuman::channels::routes::{
@@ -267,19 +267,16 @@ pub(crate) async fn process_channel_runtime_message(
     let memory_context =
         build_memory_context(ctx.memory.as_ref(), &msg.content, ctx.min_relevance_score).await;
 
-    if ctx.auto_save_memory {
-        let autosave_key = conversation_memory_key(&msg);
-        let _ = ctx
-            .memory
-            .store(
-                "",
-                &autosave_key,
-                &msg.content,
-                crate::openhuman::memory::MemoryCategory::Conversation,
-                None,
-            )
-            .await;
-    }
+    // An inbound channel message is not copied into the memory store — the same
+    // change as the chat path (`agent::harness::session::turn::core`). The
+    // conversation is already persisted as a transcript and searchable through
+    // `transcript_search`; a second copy in `memory_docs` only put raw message
+    // text into the vector space the agent searches for facts.
+    //
+    // This copy was additionally blind: it passed `session_id: None`, so the
+    // same-session exclusion could not recognise it, and the message the user
+    // had just sent could come back as a "relevant memory" while answering that
+    // very message.
 
     let channel_context = build_channel_context_block(&msg);
     let enriched_message = match (memory_context.is_empty(), channel_context.is_empty()) {

--- a/src/openhuman/channels/tests/memory.rs
+++ b/src/openhuman/channels/tests/memory.rs
@@ -1,6 +1,6 @@
 use super::super::context::{
-    build_memory_context, clear_sender_history, conversation_history_key, conversation_memory_key,
-    ChannelRuntimeContext, CHANNEL_MESSAGE_TIMEOUT_SECS,
+    build_memory_context, clear_sender_history, conversation_history_key, ChannelRuntimeContext,
+    CHANNEL_MESSAGE_TIMEOUT_SECS,
 };
 use super::super::runtime::process_channel_message;
 use super::super::{traits, Channel};
@@ -13,99 +13,6 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
 
-fn conversation_memory_key_uses_message_id() {
-    let msg = traits::ChannelMessage {
-        id: "msg_abc123".into(),
-        sender: "U123".into(),
-        reply_target: "C456".into(),
-        content: "hello".into(),
-        channel: "slack".into(),
-        timestamp: 1,
-        thread_ts: None,
-    };
-
-    assert_eq!(conversation_memory_key(&msg), "slack_U123_msg_abc123");
-}
-
-#[test]
-fn conversation_memory_key_is_unique_per_message() {
-    let msg1 = traits::ChannelMessage {
-        id: "msg_1".into(),
-        sender: "U123".into(),
-        reply_target: "C456".into(),
-        content: "first".into(),
-        channel: "slack".into(),
-        timestamp: 1,
-        thread_ts: None,
-    };
-    let msg2 = traits::ChannelMessage {
-        id: "msg_2".into(),
-        sender: "U123".into(),
-        reply_target: "C456".into(),
-        content: "second".into(),
-        channel: "slack".into(),
-        timestamp: 2,
-        thread_ts: None,
-    };
-
-    assert_ne!(
-        conversation_memory_key(&msg1),
-        conversation_memory_key(&msg2)
-    );
-}
-
-#[tokio::test]
-async fn autosave_keys_preserve_multiple_conversation_facts() {
-    let tmp = TempDir::new().unwrap();
-    let mem = UnifiedMemory::new(tmp.path(), Arc::new(NoopEmbedding), None).unwrap();
-
-    let msg1 = traits::ChannelMessage {
-        id: "msg_1".into(),
-        sender: "U123".into(),
-        reply_target: "C456".into(),
-        content: "I'm Paul".into(),
-        channel: "slack".into(),
-        timestamp: 1,
-        thread_ts: None,
-    };
-    let msg2 = traits::ChannelMessage {
-        id: "msg_2".into(),
-        sender: "U123".into(),
-        reply_target: "C456".into(),
-        content: "I'm 45".into(),
-        channel: "slack".into(),
-        timestamp: 2,
-        thread_ts: None,
-    };
-
-    mem.store(
-        "",
-        &conversation_memory_key(&msg1),
-        &msg1.content,
-        MemoryCategory::Conversation,
-        None,
-    )
-    .await
-    .unwrap();
-    mem.store(
-        "",
-        &conversation_memory_key(&msg2),
-        &msg2.content,
-        MemoryCategory::Conversation,
-        None,
-    )
-    .await
-    .unwrap();
-
-    assert_eq!(mem.count().await.unwrap(), 2);
-
-    let recalled = mem
-        .recall("45", 5, crate::openhuman::memory::RecallOpts::default())
-        .await
-        .unwrap();
-    assert!(recalled.iter().any(|entry| entry.content.contains("45")));
-}
-
 #[tokio::test]
 async fn build_memory_context_includes_recalled_entries() {
     let tmp = TempDir::new().unwrap();
@@ -114,7 +21,10 @@ async fn build_memory_context_includes_recalled_entries() {
         "",
         "age_fact",
         "Age is 45",
-        MemoryCategory::Conversation,
+        // A real memory, not a `Conversation` copy: recall drops verbatim chat
+        // copies from the global namespace, and this test is about whether
+        // `build_memory_context` renders what recall returns.
+        MemoryCategory::Core,
         None,
     )
     .await
@@ -211,7 +121,7 @@ async fn process_channel_message_restores_per_sender_history_on_follow_ups() {
 }
 
 #[tokio::test]
-async fn process_channel_message_uses_autosaved_memory_after_history_is_cleared() {
+async fn process_channel_message_does_not_replay_a_prior_message_from_memory() {
     let _bus_guard = super::common::use_real_agent_handler().await;
     let channel_impl = Arc::new(RecordingChannel::default());
     let channel: Arc<dyn Channel> = channel_impl.clone();
@@ -288,14 +198,15 @@ async fn process_channel_message_uses_autosaved_memory_after_history_is_cleared(
     assert_eq!(calls[1].len(), 2);
     assert_eq!(calls[1][0].0, "system");
     assert_eq!(calls[1][1].0, "user");
+    // The inbound message is no longer copied into the memory store, so once the
+    // in-process history is cleared the prior message does not come back through
+    // recall. That is the intended split: the message IS retained — the
+    // `memory_conversations` subscriber persists every `ChannelMessageReceived`
+    // into the thread transcript — and `transcript_search` is the tool that
+    // reads it. Recall answers with memories, not with a replay of the chat.
     assert!(
-        calls[1][1].1.contains("[Memory context]"),
-        "second turn should include recalled memory context: {:?}",
-        calls[1][1]
-    );
-    assert!(
-        calls[1][1].1.contains("phoenix-773"),
-        "second turn should surface the autosaved fact: {:?}",
+        !calls[1][1].1.contains("phoenix-773"),
+        "a raw prior message must not be replayed out of memory: {:?}",
         calls[1][1]
     );
     assert!(

--- a/src/openhuman/channels/tests/memory.rs
+++ b/src/openhuman/channels/tests/memory.rs
@@ -132,6 +132,7 @@ async fn process_channel_message_does_not_replay_a_prior_message_from_memory() {
     let provider_impl = Arc::new(HistoryCaptureModel::default());
     let tmp = TempDir::new().unwrap();
     let memory = Arc::new(UnifiedMemory::new(tmp.path(), Arc::new(NoopEmbedding), None).unwrap());
+    let store = memory.clone();
 
     let runtime_ctx = Arc::new(ChannelRuntimeContext {
         channels_by_name: Arc::new(channels_by_name),
@@ -213,6 +214,24 @@ async fn process_channel_message_does_not_replay_a_prior_message_from_memory() {
         calls[1][1].1.contains("What is my launch code?"),
         "current user question should remain in the final prompt: {:?}",
         calls[1][1]
+    );
+    drop(calls);
+
+    // The prompt assertion alone cannot tell "never stored" from "stored and
+    // hidden by the recall filter" — it would pass either way, which is the
+    // wrong thing for it to be indifferent about. Read the store directly.
+    let stored: i64 = {
+        let conn = store.conn.lock();
+        conn.query_row(
+            "SELECT COUNT(*) FROM memory_docs WHERE content LIKE '%phoenix-773%'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap()
+    };
+    assert_eq!(
+        stored, 0,
+        "the inbound message must not be written to the memory store at all"
     );
 }
 

--- a/src/openhuman/memory/store/memory_trait.rs
+++ b/src/openhuman/memory/store/memory_trait.rs
@@ -935,7 +935,7 @@ mod tests {
 
         let (_tmp, mem) = fresh_mem();
         mem.store(
-            "global",
+            "conversation_memory",
             "user_msg:current-turn",
             "Please look up Jordan Rivera's chat platform user ID for me.",
             MemoryCategory::Conversation,
@@ -944,7 +944,7 @@ mod tests {
         .await
         .unwrap();
         mem.store(
-            "global",
+            "conversation_memory",
             "fact:jordan-rivera-platform-id",
             "Jordan Rivera's chat platform user ID is U0000042.",
             MemoryCategory::Conversation,
@@ -958,7 +958,7 @@ mod tests {
                 "Jordan Rivera chat platform user ID",
                 10,
                 RecallOpts {
-                    namespace: Some("global"),
+                    namespace: Some("conversation_memory"),
                     min_score: Some(0.0),
                     ..Default::default()
                 },
@@ -970,8 +970,8 @@ mod tests {
 
         assert!(
             !entries.iter().any(|e| e.key == "user_msg:current-turn"),
-            "recall inside the ambient current-thread scope must exclude that thread's own \
-             autosaved request, got {entries:#?}"
+            "recall inside the ambient current-thread scope must exclude a document derived \
+             from that same thread, got {entries:#?}"
         );
         assert!(
             entries
@@ -985,7 +985,7 @@ mod tests {
     async fn recall_outside_any_thread_scope_is_unaffected() {
         let (_tmp, mem) = fresh_mem();
         mem.store(
-            "global",
+            "conversation_memory",
             "user_msg:current-turn",
             "Please look up Jordan Rivera's chat platform user ID for me.",
             MemoryCategory::Conversation,
@@ -1003,7 +1003,7 @@ mod tests {
                 "Jordan Rivera chat platform user ID",
                 10,
                 RecallOpts {
-                    namespace: Some("global"),
+                    namespace: Some("conversation_memory"),
                     min_score: Some(0.0),
                     ..Default::default()
                 },

--- a/src/openhuman/memory/store/namespace_store/query.rs
+++ b/src/openhuman/memory/store/namespace_store/query.rs
@@ -15,7 +15,6 @@ use crate::openhuman::memory::store::types::{
 };
 
 use super::events;
-use super::fts5;
 use super::UnifiedMemory;
 use crate::openhuman::memory::MemoryCategory;
 use tinycortex::memory::types::{StoredMemoryDocument, GLOBAL_NAMESPACE};
@@ -28,12 +27,6 @@ const LEGACY_ASSISTANT_REPLY_KEY: &str = "assistant_resp";
 const GRAPH_WEIGHT: f64 = 0.55;
 const VECTOR_WEIGHT: f64 = 0.30;
 const KEYWORD_WEIGHT: f64 = 0.15;
-const EPISODIC_WEIGHT: f64 = 0.20;
-
-// Adjusted weights when episodic signal is present
-const GRAPH_WEIGHT_WITH_EPISODIC: f64 = 0.45;
-const VECTOR_WEIGHT_WITH_EPISODIC: f64 = 0.25;
-const KEYWORD_WEIGHT_WITH_EPISODIC: f64 = 0.10;
 
 const RECALL_PRIORITY_WEIGHT: f64 = 0.45;
 const RECALL_GRAPH_WEIGHT: f64 = 0.30;
@@ -332,84 +325,17 @@ impl UnifiedMemory {
             });
         }
 
-        // Episodic FTS5 search — search past conversation turns.
-        // Only merge episodic results when querying the global namespace,
-        // since episodic entries are session-scoped, not namespace-scoped.
-        let episodic_hits = if ns == "global" {
-            fts5::episodic_search(&self.conn, query, limit as usize).unwrap_or_else(|e| {
-                tracing::warn!("[query] episodic search failed: {e}");
-                Vec::new()
-            })
-        } else {
-            Vec::new()
-        };
-
-        if !episodic_hits.is_empty() {
-            tracing::debug!(
-                "[query] merging {} episodic hits for '{}'",
-                episodic_hits.len(),
-                query
-            );
-
-            // Reweight existing document/KV hits when episodic signal is present.
-            let has_episodic = true;
-            if has_episodic {
-                for hit in &mut hits {
-                    if hit.kind == MemoryItemKind::Document {
-                        let bd = &hit.score_breakdown;
-                        let new_score = (bd.graph_relevance * GRAPH_WEIGHT_WITH_EPISODIC)
-                            + (bd.vector_similarity * VECTOR_WEIGHT_WITH_EPISODIC)
-                            + (bd.keyword_relevance * KEYWORD_WEIGHT_WITH_EPISODIC);
-                        hit.score = new_score;
-                        hit.score_breakdown.final_score = new_score;
-                    }
-                }
-            }
-
-            for (position_idx, entry) in episodic_hits.iter().enumerate() {
-                let freshness = Self::recency_score(entry.timestamp, now);
-                // Episodic FTS5 returns results ordered by rank (best first).
-                // Normalize position to a 0-1 relevance score.
-                let fts_relevance = 1.0 - (position_idx as f64 / episodic_hits.len().max(1) as f64);
-
-                let episodic_score = (fts_relevance * 0.7) + (freshness * 0.3);
-                let final_score = episodic_score * EPISODIC_WEIGHT;
-
-                // Truncate long episodic content for context display (UTF-8 safe).
-                let content = match entry.content.char_indices().nth(500) {
-                    Some((byte_idx, _)) => format!("{}...", &entry.content[..byte_idx]),
-                    None => entry.content.clone(),
-                };
-
-                hits.push(NamespaceMemoryHit {
-                    id: format!("episodic:{}", entry.id.unwrap_or(0)),
-                    kind: MemoryItemKind::Episodic,
-                    namespace: ns.clone(),
-                    key: format!("{}:{}", entry.session_id, entry.role),
-                    title: entry.lesson.clone(),
-                    content,
-                    category: "episodic".to_string(),
-                    source_type: Some(entry.role.clone()),
-                    updated_at: entry.timestamp,
-                    score: final_score,
-                    score_breakdown: RetrievalScoreBreakdown {
-                        keyword_relevance: 0.0,
-                        vector_similarity: 0.0,
-                        graph_relevance: 0.0,
-                        episodic_relevance: fts_relevance,
-                        freshness,
-                        final_score,
-                    },
-                    document_id: None,
-                    chunk_id: None,
-                    supporting_relations: Vec::new(),
-                    // Episodic rows are derived from user chat turns and
-                    // never carry sync-ingest content; surface as
-                    // Internal so the subconscious gate trusts them.
-                    taint: crate::openhuman::memory::MemoryTaint::Internal,
-                });
-            }
-        }
+        // The episodic log is NOT merged here. Its rows are raw chat turns —
+        // the same verbatim conversation `drop_verbatim_conversation_copies`
+        // removes from the document side a few lines up — so merging them put
+        // the copy back through a second door: `memory_hybrid_search` renders
+        // every hit it is handed, so a global query returned transcript text
+        // competing with extracted memories for the same recall slots (#5312).
+        //
+        // Reading the conversation is `transcript_search`'s job. It reads the
+        // thread transcript directly, which is complete and current, where the
+        // episodic mirror is neither. Nothing else consumes
+        // `fts5::episodic_search`, so this path is the whole of the leak.
 
         // Event FTS5 search — search extracted facts, decisions, preferences.
         let event_hits = events::event_search_fts(&self.conn, &ns, query, limit as usize)

--- a/src/openhuman/memory/store/namespace_store/query.rs
+++ b/src/openhuman/memory/store/namespace_store/query.rs
@@ -17,6 +17,13 @@ use crate::openhuman::memory::store::types::{
 use super::events;
 use super::fts5;
 use super::UnifiedMemory;
+use crate::openhuman::memory::MemoryCategory;
+use tinycortex::memory::types::{StoredMemoryDocument, GLOBAL_NAMESPACE};
+
+/// Fixed key the old assistant-reply copy was written under. Retained only so
+/// [`UnifiedMemory::drop_verbatim_conversation_copies`] can recognise the rows
+/// existing installs still carry; nothing writes it.
+const LEGACY_ASSISTANT_REPLY_KEY: &str = "assistant_resp";
 
 const GRAPH_WEIGHT: f64 = 0.55;
 const VECTOR_WEIGHT: f64 = 0.30;
@@ -114,6 +121,55 @@ impl UnifiedMemory {
         Ok(out)
     }
 
+    /// Drop documents that are a verbatim copy of something already in the
+    /// chat transcript, so recall answers with memories rather than with the
+    /// conversation itself.
+    ///
+    /// Nothing writes these any more — the chat and channel paths no longer
+    /// copy messages into the store. This is for installs that already have
+    /// them: those rows sit in the same vector space the agent searches for
+    /// facts, so without this filter every existing user keeps competing with
+    /// their own chat lines for recall slots (#5312) until someone deletes
+    /// them by hand. `transcript_search` is the tool that reads the
+    /// conversation, and it reads the transcript, not this store.
+    ///
+    /// Scoped to the **global** namespace on purpose. What is worth keeping
+    /// from a conversation is *extracted*, not copied, and
+    /// `learning::transcript_ingest` writes those distilled preferences /
+    /// decisions / commitments / facts into the dedicated
+    /// `conversation_memory` and `conversation_reflections` namespaces. They
+    /// carry the same `conversation` category, so a category-only filter would
+    /// take them out too — which would delete the useful half of the feature.
+    /// In the global namespace the category has only ever meant a raw copy.
+    ///
+    /// Two shapes, matching the two writers this replaces:
+    /// - `category = conversation` — a user or channel message, verbatim
+    ///   (keys `user_msg:*`, the legacy fixed `user_msg`, and the channel
+    ///   `{channel}_{sender}_{id}`, which has no prefix to match on).
+    /// - the fixed key `assistant_resp` — a 100-character truncation of the
+    ///   last assistant reply, mislabelled `Daily`, overwritten every turn.
+    fn drop_verbatim_conversation_copies(ns: &str, docs: &mut Vec<StoredMemoryDocument>) {
+        if ns != GLOBAL_NAMESPACE {
+            return;
+        }
+        let before = docs.len();
+        docs.retain(|doc| {
+            let is_message_copy = doc
+                .category
+                .eq_ignore_ascii_case(&MemoryCategory::Conversation.to_string());
+            let is_assistant_snapshot = doc.key == LEGACY_ASSISTANT_REPLY_KEY;
+            !(is_message_copy || is_assistant_snapshot)
+        });
+        let dropped = before - docs.len();
+        if dropped > 0 {
+            tracing::debug!(
+                "[query] dropped {dropped} verbatim conversation copy/copies from recall \
+                 namespace={ns} remaining={} (transcript_search reads the transcript instead)",
+                docs.len()
+            );
+        }
+    }
+
     /// Hybrid retrieval: returns ranked hits across documents and KV records,
     /// scored by graph relevance + vector similarity + keyword overlap +
     /// freshness.
@@ -156,6 +212,7 @@ impl UnifiedMemory {
             .map(str::trim)
             .filter(|id| !id.is_empty());
         let mut docs = self.load_documents_for_scope(&ns).await?;
+        Self::drop_verbatim_conversation_copies(&ns, &mut docs);
         if let Some(exclude) = exclude_session_id {
             let before = docs.len();
             docs.retain(|doc| doc.session_id.as_deref() != Some(exclude));
@@ -443,7 +500,10 @@ impl UnifiedMemory {
         limit: u32,
     ) -> Result<Vec<NamespaceMemoryHit>, String> {
         let ns = Self::sanitize_namespace(namespace);
-        let docs = self.load_documents_for_scope(&ns).await?;
+        let mut docs = self.load_documents_for_scope(&ns).await?;
+        // Query-less recall is still recall, so it owes the same answer as the
+        // query path above: memories, not a replay of the chat.
+        Self::drop_verbatim_conversation_copies(&ns, &mut docs);
         let kvs = self.kv_records_for_scope(&ns).await?;
         let graph_relations = self
             .graph_relations_for_scope(&ns)

--- a/src/openhuman/memory/store/namespace_store/query.rs
+++ b/src/openhuman/memory/store/namespace_store/query.rs
@@ -142,7 +142,15 @@ impl UnifiedMemory {
     /// - the fixed key `assistant_resp` — a 100-character truncation of the
     ///   last assistant reply, mislabelled `Daily`, overwritten every turn.
     fn drop_verbatim_conversation_copies(ns: &str, docs: &mut Vec<StoredMemoryDocument>) {
+        log::debug!(
+            "[memory::query] drop-copies entry namespace={ns} docs={}",
+            docs.len()
+        );
         if ns != GLOBAL_NAMESPACE {
+            log::debug!(
+                "[memory::query] drop-copies exit branch=non-global namespace={ns} docs={}",
+                docs.len()
+            );
             return;
         }
         let before = docs.len();
@@ -154,13 +162,14 @@ impl UnifiedMemory {
             !(is_message_copy || is_assistant_snapshot)
         });
         let dropped = before - docs.len();
-        if dropped > 0 {
-            tracing::debug!(
-                "[query] dropped {dropped} verbatim conversation copy/copies from recall \
-                 namespace={ns} remaining={} (transcript_search reads the transcript instead)",
-                docs.len()
-            );
-        }
+        // One exit event either way: a run that drops nothing is as much a fact
+        // about this filter as one that drops. Counts only — these documents are
+        // recalled memory and their content must not reach the log.
+        log::debug!(
+            "[memory::query] drop-copies exit branch=global namespace={ns} dropped={dropped} \
+             remaining={} (transcript_search reads the transcript instead)",
+            docs.len()
+        );
     }
 
     /// Hybrid retrieval: returns ranked hits across documents and KV records,

--- a/src/openhuman/memory/store/namespace_store/query_tests.rs
+++ b/src/openhuman/memory/store/namespace_store/query_tests.rs
@@ -1057,6 +1057,41 @@ async fn recall_keeps_extracted_conversation_memories() {
     }
 }
 
+/// The same filter runs on the query-less path, and only a test that calls it
+/// can say so. `query_namespace_ranked` passing proves nothing about
+/// `recall_namespace_memories` — they load the same documents but neither
+/// delegates to the other, so the filter is applied in two places and either
+/// could lose it alone.
+#[tokio::test]
+async fn query_less_recall_drops_the_copies_and_keeps_the_memories() {
+    let tmp = TempDir::new().unwrap();
+    let memory = UnifiedMemory::new(tmp.path(), Arc::new(NoopEmbedding), None).unwrap();
+
+    memory
+        .upsert_document(conversation_copy(
+            "",
+            "user_msg:1",
+            "my flight to Denver is Tuesday",
+        ))
+        .await
+        .unwrap();
+    let mut fact = conversation_copy("", "fact:flight", "the user's flight to Denver is Tuesday");
+    fact.category = "core".to_string();
+    memory.upsert_document(fact).await.unwrap();
+
+    let hits = memory.recall_namespace_memories("", 10).await.unwrap();
+    let keys: Vec<&str> = hits.iter().map(|h| h.key.as_str()).collect();
+
+    assert!(
+        !keys.contains(&"user_msg:1"),
+        "a verbatim copy must not come back from query-less recall either: {keys:?}"
+    );
+    assert!(
+        keys.contains(&"fact:flight"),
+        "and the real memory must still be returned: {keys:?}"
+    );
+}
+
 #[tokio::test]
 async fn a_non_conversation_global_memory_is_untouched() {
     let tmp = TempDir::new().unwrap();

--- a/src/openhuman/memory/store/namespace_store/query_tests.rs
+++ b/src/openhuman/memory/store/namespace_store/query_tests.rs
@@ -149,14 +149,19 @@ async fn recall_namespace_memories_includes_namespace_kv() {
     )));
 }
 
+/// The regression for #5312: an episodic row matching the query must not come
+/// back from a global memory search. Episodic rows are raw chat turns, and
+/// `memory_hybrid_search` renders every hit it is handed — so a merged episodic
+/// hit put the verbatim conversation back into recall through a second door,
+/// after `drop_verbatim_conversation_copies` had removed it from the document
+/// side. Reading the conversation is `transcript_search`'s job.
 #[tokio::test]
-async fn query_returns_episodic_hits_when_available() {
+async fn a_matching_episodic_row_is_not_returned_by_memory_search() {
     use crate::openhuman::memory::store::fts5::{self, EpisodicEntry};
 
     let tmp = TempDir::new().unwrap();
     let memory = UnifiedMemory::new(tmp.path(), Arc::new(NoopEmbedding), None).unwrap();
 
-    // Insert an episodic entry that matches the query.
     fts5::episodic_insert(
         &memory.conn,
         &EpisodicEntry {
@@ -172,18 +177,24 @@ async fn query_returns_episodic_hits_when_available() {
     )
     .unwrap();
 
+    // The row matches: `episodic_search` finds it directly.
+    let direct = fts5::episodic_search(&memory.conn, "Tokio async Rust", 10).unwrap();
+    assert!(
+        !direct.is_empty(),
+        "the fixture must match, or this test proves nothing"
+    );
+
     let hits = memory
         .query_namespace_hits("global", "Tokio async Rust", 10)
         .await
         .unwrap();
 
-    let episodic_hits: Vec<_> = hits
-        .iter()
-        .filter(|h| h.kind == crate::openhuman::memory::store::MemoryItemKind::Episodic)
-        .collect();
     assert!(
-        !episodic_hits.is_empty(),
-        "Expected at least one Episodic hit for 'Tokio async Rust'"
+        !hits
+            .iter()
+            .any(|h| h.kind == crate::openhuman::memory::store::MemoryItemKind::Episodic),
+        "memory search must not replay transcript rows: {:?}",
+        hits.iter().map(|h| (&h.kind, &h.key)).collect::<Vec<_>>()
     );
 }
 
@@ -226,99 +237,6 @@ async fn query_returns_event_hits_when_available() {
     assert!(
         !event_hits.is_empty(),
         "Expected at least one Event hit for 'PostgreSQL database'"
-    );
-}
-
-#[tokio::test]
-async fn query_episodic_hits_have_correct_kind() {
-    use crate::openhuman::memory::store::fts5::{self, EpisodicEntry};
-
-    let tmp = TempDir::new().unwrap();
-    let memory = UnifiedMemory::new(tmp.path(), Arc::new(NoopEmbedding), None).unwrap();
-
-    fts5::episodic_insert(
-        &memory.conn,
-        &EpisodicEntry {
-            id: None,
-            session_id: "sess-kind".into(),
-            timestamp: 2000.0,
-            role: "assistant".into(),
-            content: "The deployment pipeline uses GitHub Actions for CI".into(),
-            lesson: Some("CI runs on push to main".into()),
-            tool_calls_json: None,
-            cost_microdollars: 0,
-        },
-    )
-    .unwrap();
-
-    let hits = memory
-        .query_namespace_hits("global", "GitHub Actions deployment", 10)
-        .await
-        .unwrap();
-
-    for hit in hits.iter().filter(|h| h.id.starts_with("episodic:")) {
-        assert_eq!(
-            hit.kind,
-            crate::openhuman::memory::store::MemoryItemKind::Episodic,
-            "Hits with 'episodic:' id prefix must have kind Episodic"
-        );
-    }
-}
-
-/// Episodic FTS relevance is derived from each hit's rank position
-/// (`1.0 - idx / len`). With two equally-fresh matches the only
-/// differentiator is rank, so the relevance scores must be exactly the
-/// per-position values {1.0, 0.5}. This pins the position-indexing math
-/// for n > 1 — the single-entry tests above cannot, since idx is always 0.
-#[tokio::test]
-async fn query_episodic_relevance_tracks_rank_position() {
-    use crate::openhuman::memory::store::fts5::{self, EpisodicEntry};
-
-    let tmp = TempDir::new().unwrap();
-    let memory = UnifiedMemory::new(tmp.path(), Arc::new(NoopEmbedding), None).unwrap();
-
-    // Two distinct entries, identical timestamp (equal freshness), both
-    // matching the query so episodic_hits has len == 2.
-    for content in [
-        "I have been using Tokio for async Rust development",
-        "Tokio async runtime powers our backend services",
-    ] {
-        fts5::episodic_insert(
-            &memory.conn,
-            &EpisodicEntry {
-                id: None,
-                session_id: "sess-rank".into(),
-                timestamp: 1000.0,
-                role: "user".into(),
-                content: content.into(),
-                lesson: None,
-                tool_calls_json: None,
-                cost_microdollars: 0,
-            },
-        )
-        .unwrap();
-    }
-
-    let hits = memory
-        .query_namespace_hits("global", "Tokio async", 10)
-        .await
-        .unwrap();
-
-    let mut relevances: Vec<f64> = hits
-        .iter()
-        .filter(|h| h.kind == crate::openhuman::memory::store::MemoryItemKind::Episodic)
-        .map(|h| h.score_breakdown.episodic_relevance)
-        .collect();
-    relevances.sort_by(|a, b| a.partial_cmp(b).unwrap());
-
-    assert_eq!(
-        relevances.len(),
-        2,
-        "expected exactly two episodic hits, got {relevances:?}"
-    );
-    assert!(
-        (relevances[0] - 0.5).abs() < 1e-9 && (relevances[1] - 1.0).abs() < 1e-9,
-        "episodic relevance must be {{0.5, 1.0}} for two-element rank order, got {relevances:?}"
     );
 }
 

--- a/src/openhuman/memory/store/namespace_store/query_tests.rs
+++ b/src/openhuman/memory/store/namespace_store/query_tests.rs
@@ -863,7 +863,12 @@ fn conversation_doc_with_session(
     session_id: Option<&str>,
 ) -> NamespaceDocumentInput {
     NamespaceDocumentInput {
-        namespace: "global".to_string(),
+        // NOT the global namespace: a global `conversation` document is a
+        // verbatim message copy and recall drops it outright, so it could not
+        // demonstrate anything about session scoping. Session-tagged documents
+        // now live here — `learning::transcript_ingest` stamps each extracted
+        // candidate with the thread it came from.
+        namespace: "conversation_memory".to_string(),
         key: key.to_string(),
         title: key.to_string(),
         content: content.to_string(),
@@ -883,9 +888,11 @@ async fn excludes_same_session_document_but_keeps_unrelated_useful_doc() {
     let tmp = TempDir::new().unwrap();
     let memory = UnifiedMemory::new(tmp.path(), Arc::new(NoopEmbedding), None).unwrap();
 
-    // (a) The current turn's own auto-saved request — tagged with the live
-    // session/thread id, exactly like `agent::harness::session::turn::core`
-    // tags the `user_msg:<uuid>` autosave.
+    // (a) A document tagged with the live session/thread id. The chat autosave
+    // that originally motivated this guard is gone (messages are no longer
+    // copied into the store at all), but `learning::transcript_ingest` still
+    // stamps every extracted candidate with its source thread, so a turn can
+    // still retrieve something derived from the very request it is answering.
     memory
         .upsert_document(conversation_doc_with_session(
             "user_msg:current-turn",
@@ -911,7 +918,7 @@ async fn excludes_same_session_document_but_keeps_unrelated_useful_doc() {
     // Sanity check: without exclusion, both documents are lexically relevant
     // and both come back (this is the pre-fix, buggy shape).
     let unfiltered = memory
-        .query_namespace_hits("global", query, 10)
+        .query_namespace_hits("conversation_memory", query, 10)
         .await
         .unwrap();
     assert!(
@@ -922,7 +929,12 @@ async fn excludes_same_session_document_but_keeps_unrelated_useful_doc() {
     // With the current-session exclusion applied, the self-echo document is
     // dropped and the useful fact survives.
     let filtered = memory
-        .query_namespace_hits_excluding_session("global", query, 10, Some("thread-current"))
+        .query_namespace_hits_excluding_session(
+            "conversation_memory",
+            query,
+            10,
+            Some("thread-current"),
+        )
         .await
         .unwrap();
 
@@ -963,7 +975,7 @@ async fn no_session_context_leaves_results_unchanged() {
     let query = "Jordan Rivera chat platform user ID";
 
     let baseline = memory
-        .query_namespace_hits("global", query, 10)
+        .query_namespace_hits("conversation_memory", query, 10)
         .await
         .unwrap();
 
@@ -972,7 +984,7 @@ async fn no_session_context_leaves_results_unchanged() {
     // identically to the pre-existing `query_namespace_hits` entry point:
     // same hit count, same keys, in the same order.
     let explicit_none = memory
-        .query_namespace_hits_excluding_session("global", query, 10, None)
+        .query_namespace_hits_excluding_session("conversation_memory", query, 10, None)
         .await
         .unwrap();
 
@@ -990,7 +1002,7 @@ async fn no_session_context_leaves_results_unchanged() {
     // An empty/whitespace exclude id must also be treated as "no filter",
     // not accidentally matched against a document with `session_id: None`.
     let empty_string = memory
-        .query_namespace_hits_excluding_session("global", query, 10, Some("   "))
+        .query_namespace_hits_excluding_session("conversation_memory", query, 10, Some("   "))
         .await
         .unwrap();
     let empty_string_keys: Vec<&str> = empty_string.iter().map(|h| h.key.as_str()).collect();
@@ -998,4 +1010,148 @@ async fn no_session_context_leaves_results_unchanged() {
         baseline_keys, empty_string_keys,
         "a blank exclude_session_id must not filter anything"
     );
+}
+
+// ── Verbatim conversation copies stay out of recall (#5312) ─────────────
+//
+// Installs from before the chat/channel paths stopped copying messages into
+// the store still carry those rows. Recall must not answer with them: the
+// conversation is `transcript_search`'s to read.
+
+fn conversation_copy(namespace: &str, key: &str, content: &str) -> NamespaceDocumentInput {
+    NamespaceDocumentInput {
+        namespace: namespace.to_string(),
+        key: key.to_string(),
+        title: key.to_string(),
+        content: content.to_string(),
+        source_type: "chat".to_string(),
+        priority: "normal".to_string(),
+        tags: vec![],
+        metadata: json!({}),
+        category: "conversation".to_string(),
+        session_id: None,
+        document_id: None,
+        taint: crate::openhuman::memory::MemoryTaint::Internal,
+    }
+}
+
+#[tokio::test]
+async fn recall_drops_a_legacy_user_message_copy() {
+    let tmp = TempDir::new().unwrap();
+    let memory = UnifiedMemory::new(tmp.path(), Arc::new(NoopEmbedding), None).unwrap();
+
+    memory
+        .upsert_document(conversation_copy(
+            "",
+            "user_msg:11111111-1111-1111-1111-111111111111",
+            "my flight to Denver is on Tuesday",
+        ))
+        .await
+        .unwrap();
+
+    let results = memory
+        .query_namespace_ranked("", "flight to Denver", 5)
+        .await
+        .unwrap();
+    assert!(
+        results.is_empty(),
+        "a verbatim chat line must not answer recall: {:?}",
+        results.iter().map(|r| &r.key).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn recall_drops_a_legacy_channel_message_copy() {
+    // The channel copy's key is `{channel}_{sender}_{id}` — no prefix to match
+    // on, which is why the filter keys off the category instead.
+    let tmp = TempDir::new().unwrap();
+    let memory = UnifiedMemory::new(tmp.path(), Arc::new(NoopEmbedding), None).unwrap();
+
+    memory
+        .upsert_document(conversation_copy(
+            "",
+            "telegram_U123_msg_abc",
+            "my flight to Denver is on Tuesday",
+        ))
+        .await
+        .unwrap();
+
+    let results = memory
+        .query_namespace_ranked("", "flight to Denver", 5)
+        .await
+        .unwrap();
+    assert!(results.is_empty(), "{results:?}");
+}
+
+#[tokio::test]
+async fn recall_drops_the_legacy_assistant_reply_snapshot() {
+    // Written under a FIXED key and mislabelled `daily`, so the category test
+    // above cannot catch it — it needs its own.
+    let tmp = TempDir::new().unwrap();
+    let memory = UnifiedMemory::new(tmp.path(), Arc::new(NoopEmbedding), None).unwrap();
+
+    let mut doc = conversation_copy("", "assistant_resp", "Your flight to Denver is Tuesday…");
+    doc.category = "daily".to_string();
+    memory.upsert_document(doc).await.unwrap();
+
+    let results = memory
+        .query_namespace_ranked("", "flight to Denver", 5)
+        .await
+        .unwrap();
+    assert!(results.is_empty(), "{results:?}");
+}
+
+#[tokio::test]
+async fn recall_keeps_extracted_conversation_memories() {
+    // The half worth keeping. `learning::transcript_ingest` distils
+    // preferences / decisions / commitments / facts into dedicated namespaces
+    // under the SAME `conversation` category, so a category-only filter would
+    // have deleted them along with the raw copies.
+    let tmp = TempDir::new().unwrap();
+    let memory = UnifiedMemory::new(tmp.path(), Arc::new(NoopEmbedding), None).unwrap();
+
+    memory
+        .upsert_document(conversation_copy(
+            "conversation_memory",
+            "preference:1",
+            "[preference high] books flights on Tuesdays when travelling to Denver",
+        ))
+        .await
+        .unwrap();
+    memory
+        .upsert_document(conversation_copy(
+            "conversation_reflections",
+            "reflection:1",
+            "[high travel] recurring Denver trips cluster mid-week",
+        ))
+        .await
+        .unwrap();
+
+    for ns in ["conversation_memory", "conversation_reflections"] {
+        let results = memory
+            .query_namespace_ranked(ns, "Denver", 5)
+            .await
+            .unwrap();
+        assert!(
+            !results.is_empty(),
+            "extracted memories in `{ns}` must stay recallable"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_non_conversation_global_memory_is_untouched() {
+    let tmp = TempDir::new().unwrap();
+    let memory = UnifiedMemory::new(tmp.path(), Arc::new(NoopEmbedding), None).unwrap();
+
+    let mut doc = conversation_copy("", "fact:flight", "the user's flight to Denver is Tuesday");
+    doc.category = "core".to_string();
+    memory.upsert_document(doc).await.unwrap();
+
+    let results = memory
+        .query_namespace_ranked("", "flight to Denver", 5)
+        .await
+        .unwrap();
+    assert_eq!(results.len(), 1, "a real memory must still answer recall");
+    assert_eq!(results[0].key, "fact:flight");
 }


### PR DESCRIPTION
## Summary

- The chat turn, the channel runtime, and the post-turn hook each copied conversation text verbatim into `memory_docs`. All three writes are removed.
- `transcript_search` now owns reading the conversation; `memory_recall` / `memory_hybrid_search` answer with memories. The transcript itself is unchanged — every message is still persisted.
- Recall filters out the copies existing installs already carry, so the fix reaches current users and not only fresh ones.
- Memories *extracted* from conversations (`learning::transcript_ingest`) are untouched and stay fully recallable.

## Problem

Three writers put raw chat text into the semantic memory store:

| Writer | Key | Category |
| --- | --- | --- |
| `session::turn::core` | `user_msg:{uuid}` | `conversation` |
| `channels::runtime::dispatch::processor` | `{channel}_{sender}_{id}` | `conversation` |
| `session::turn::core` (post-turn) | `assistant_resp` (fixed) | `daily` |

Each is a duplicate of something the thread transcript already holds, and each lands in the same vector space the agent searches for facts — so raw chat lines competed with real memories for every recall slot (#5312). The user's message additionally cost an embedding round-trip (Voyage) per turn to produce a row no reader wanted.

The assistant copy was the weakest of the three: a 100-character truncation under a **fixed** key. `upsert_document` keys by `(namespace, key)`, so every turn in the workspace overwrote the one before it — a single perpetually-stale row, mislabelled `Daily`, that could not serve as history for anything.

The two tools had also drifted into doing the same job. `transcript_search` already searches every thread's messages with recency ranking and active-thread exclusion, which is exactly what the copies were trying to provide, less well.

## Solution

**Stop writing.** The three writes are removed. Nothing about transcript retention changes: `memory_conversations` persists both web chat and every `ChannelMessageReceived` into the thread transcript, and that is what `transcript_search` reads.

**Hide what is already stored.** `drop_verbatim_conversation_copies` filters the legacy rows out of recall. Two design points:

- **Where.** The filter sits in `query_namespace_hits_excluding_session`, the single layer both `Memory::recall` *and* `memory_hybrid_search` pass through. The hybrid tool does **not** go through `recall` — it calls the store directly — so a filter placed in `recall` alone would have missed the tool `context_scout` and `flow_memory_agent` are actually pointed at. `recall_namespace_memories` (query-less recall) gets it too.
- **Not by category.** Filtering on `MemoryCategory::Conversation` alone would have been wrong: `learning::transcript_ingest` writes distilled preferences, decisions, commitments, facts, and reflections under that *same* category, into the dedicated `conversation_memory` / `conversation_reflections` namespaces. Those are memories, and recall should return them. The filter is therefore scoped to the **global** namespace, where the category has only ever meant a raw copy.

The legacy `assistant_resp` row is matched by key, since its category is `daily` and no category test would catch it.

`channels::context::conversation_memory_key` is dropped — its only caller was the deleted channel write.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — see Testing below
- [x] **Diff coverage ≥ 80%** — every changed line in `query.rs` is exercised by the new `query_tests.rs` cases; the deleted write paths are covered by the inverted assertions in `agent/tests.rs` and `channels/tests/memory.rs`
- [x] N/A: behaviour-only change, no feature row added/removed/renamed — Coverage matrix updated
- [x] No new external network dependencies introduced
- [x] N/A: no release-cut surface touched — Manual smoke checklist updated
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

### Testing

New (`memory_store/namespace_store/query_tests.rs`) — one per legacy shape, plus the two that guard against over-filtering:

- `recall_drops_a_legacy_user_message_copy`
- `recall_drops_a_legacy_channel_message_copy` — the channel key has no prefix to match on, which is why the filter keys off category
- `recall_drops_the_legacy_assistant_reply_snapshot` — fixed key, `daily` category
- `recall_keeps_extracted_conversation_memories` — the failure case that matters: proves the filter does not take the `transcript_ingest` output with it
- `a_non_conversation_global_memory_is_untouched`

Rewritten to assert the new behaviour:

- `agent::tests::a_turn_does_not_copy_the_conversation_into_memory` — was `auto_save_stores_messages_in_memory`
- `channels::tests::memory::process_channel_message_does_not_replay_a_prior_message_from_memory` — was `..._uses_autosaved_memory_after_history_is_cleared`

Retargeted: the same-session exclusion tests (`memory_trait.rs`, `query_tests.rs`) move their fixtures to `conversation_memory`. That guard was written for the chat autosave, which is gone; session-tagged documents now come from `transcript_ingest`, so the tests exercise it where it still applies.

`cargo test --lib`: 12553 passed. The 3 remaining failures (`credentials::ops`, `tinyplace::manifest` ×2) reproduce identically on the base commit with no changes applied.

## Impact

- **Behaviour change, deliberate.** A raw message no longer comes back from `memory_recall` / `memory_hybrid_search`. To recall what was said, call `transcript_search`. Agents that had both tools already had the better route.
- **Cost.** One fewer embedding round-trip per user message, and per inbound channel message.
- **Migration.** None required. Legacy rows stay on disk and stop surfacing in recall; they remain visible to `memory_forget` and the memory UI, so a user who wants them gone can still remove them.
- **`memory.auto_save`** no longer gates any write in the turn path. The flag is left in place rather than removed in this PR — retiring it touches the config schema and the settings UI, and is better done on its own.
- Platform-neutral; no security or performance risk beyond the saved work.

## Related

Closes #5312


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented raw user, channel, and assistant messages from being duplicated in recalled memory.
  * Excluded legacy verbatim conversation copies while retaining extracted memories and reflections.
  * Ensured cleared conversation history is not replayed through memory recall.

* **Improvements**
  * Conversation transcripts remain available for reviewing prior exchanges.
  * Non-conversation memories continue to be stored and recalled normally.
  * Improved separation between conversation history and long-term memory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
