### PR TITLE
fix(composio): let a provider reshape supersede the backend markdown rendering

### DIFF
--- a/src/openhuman/integrations/composio/action_tool.rs
+++ b/src/openhuman/integrations/composio/action_tool.rs
@@ -155,7 +155,14 @@ impl Tool for ComposioActionTool {
         // slug) routes through the `ApprovalGate` before it runs; a pure read
         // flows through unprompted. Without this the model could send mail /
         // create records via a per-action tool with no approval prompt at all.
-        super::tools::action_mutates_external_state(&self.action_name)
+        let mutates = super::tools::action_mutates_external_state(&self.action_name);
+        tracing::debug!(
+            target: "composio",
+            tool = %self.action_name,
+            external_effect = mutates,
+            "[composio] per-action approval classification"
+        );
+        mutates
     }
 
     fn category(&self) -> ToolCategory {
@@ -327,6 +334,12 @@ impl Tool for ComposioActionTool {
                 // record, and `reshape_supersedes_markdown` would then clear the
                 // backend's error rendering on behalf of a reshape that found
                 // nothing — leaving the model neither.
+                tracing::debug!(
+                    target: "composio",
+                    tool = %self.action_name,
+                    successful = resp.successful,
+                    "[composio] reshape provider selection"
+                );
                 if let Some(provider) =
                     super::providers::provider_for_reshape(&self.action_name, resp.successful)
                 {
@@ -343,6 +356,7 @@ impl Tool for ComposioActionTool {
                         .reshape_supersedes_markdown(&self.action_name, reshape_args.as_ref())
                     {
                         tracing::debug!(
+                            target: "composio",
                             tool = %&self.action_name,
                             "[composio] provider reshape supersedes the backend markdown rendering"
                         );

--- a/src/openhuman/integrations/composio/action_tool.rs
+++ b/src/openhuman/integrations/composio/action_tool.rs
@@ -321,8 +321,14 @@ impl Tool for ComposioActionTool {
                 // per-action Gmail fetch doesn't drop a full MIME tree into the
                 // agent's context. Only the raw-JSON fallback body serializes
                 // `resp.data`; a backend-rendered markdown body is unaffected.
-                if let Some(provider) = super::providers::toolkit_from_slug(&self.action_name)
-                    .and_then(|tk| super::providers::get_provider(&tk))
+                // Only a successful response is reshaped. A failure carries the
+                // provider's diagnostics in `data`, which a reshaper written for
+                // the success shape rewrites into an empty or wrong-shaped
+                // record, and `reshape_supersedes_markdown` would then clear the
+                // backend's error rendering on behalf of a reshape that found
+                // nothing — leaving the model neither.
+                if let Some(provider) =
+                    super::providers::provider_for_reshape(&self.action_name, resp.successful)
                 {
                     provider.post_process_action_result(
                         &self.action_name,

--- a/src/openhuman/integrations/composio/action_tool.rs
+++ b/src/openhuman/integrations/composio/action_tool.rs
@@ -333,7 +333,9 @@ impl Tool for ComposioActionTool {
                     // provider says its version supersedes: the body below
                     // prefers `markdownFormatted` and only falls back to the
                     // JSON envelope when it is absent.
-                    if provider.reshape_supersedes_markdown(&self.action_name) {
+                    if provider
+                        .reshape_supersedes_markdown(&self.action_name, reshape_args.as_ref())
+                    {
                         tracing::debug!(
                             tool = %&self.action_name,
                             "[composio] provider reshape supersedes the backend markdown rendering"

--- a/src/openhuman/integrations/composio/action_tool.rs
+++ b/src/openhuman/integrations/composio/action_tool.rs
@@ -316,15 +316,6 @@ impl Tool for ComposioActionTool {
 
         match res {
             Ok(mut resp) => {
-                crate::core::event_bus::publish_global(
-                    crate::core::event_bus::DomainEvent::ComposioActionExecuted {
-                        tool: self.action_name.clone(),
-                        success: resp.successful,
-                        error: resp.error.clone(),
-                        cost_usd: resp.cost_usd,
-                        elapsed_ms,
-                    },
-                );
                 // Slim the provider envelope before it can become the tool body
                 // (#2585) — the same reshape `ComposioExecuteTool` runs, so a
                 // per-action Gmail fetch doesn't drop a full MIME tree into the
@@ -339,6 +330,20 @@ impl Tool for ComposioActionTool {
                         &mut resp.data,
                     );
                 }
+                // Published after the reshape, matching `ComposioExecuteTool`.
+                // The payload names no reshaped field today, so the order is not
+                // observable — but the two surfaces describing the same action
+                // must not disagree about which snapshot the event saw, or the
+                // first field added here diverges silently between them.
+                crate::core::event_bus::publish_global(
+                    crate::core::event_bus::DomainEvent::ComposioActionExecuted {
+                        tool: self.action_name.clone(),
+                        success: resp.successful,
+                        error: resp.error.clone(),
+                        cost_usd: resp.cost_usd,
+                        elapsed_ms,
+                    },
+                );
                 // Mirror `ComposioExecuteTool::execute` (composio/tools.rs):
                 // prefer the backend-rendered `markdownFormatted` for LLM
                 // consumption when present, fall back to the raw JSON

--- a/src/openhuman/integrations/composio/action_tool.rs
+++ b/src/openhuman/integrations/composio/action_tool.rs
@@ -149,6 +149,15 @@ impl Tool for ComposioActionTool {
         PermissionLevel::Write
     }
 
+    fn external_effect_with_args(&self, _args: &Value) -> bool {
+        // The per-action surface must gate on the approval card exactly like the
+        // `composio_execute` dispatcher: a write/admin action (this tool's own
+        // slug) routes through the `ApprovalGate` before it runs; a pure read
+        // flows through unprompted. Without this the model could send mail /
+        // create records via a per-action tool with no approval prompt at all.
+        super::tools::action_mutates_external_state(&self.action_name)
+    }
+
     fn category(&self) -> ToolCategory {
         ToolCategory::Workflow
     }
@@ -292,6 +301,9 @@ impl Tool for ComposioActionTool {
         let effective_connection_id = runtime_connection_id
             .as_deref()
             .or(self.connection_id.as_deref());
+        // Kept for the post-dispatch envelope reshape (#2585): the dispatch
+        // consumes `args`, but the reshape reads it for the `raw_html` opt-out.
+        let reshape_args = args.clone();
         let res = super::execute_dispatch::execute_composio_action_kind_with_connection(
             kind,
             &self.action_name,
@@ -303,7 +315,7 @@ impl Tool for ComposioActionTool {
         let elapsed_ms = started.elapsed().as_millis() as u64;
 
         match res {
-            Ok(resp) => {
+            Ok(mut resp) => {
                 crate::core::event_bus::publish_global(
                     crate::core::event_bus::DomainEvent::ComposioActionExecuted {
                         tool: self.action_name.clone(),
@@ -313,6 +325,20 @@ impl Tool for ComposioActionTool {
                         elapsed_ms,
                     },
                 );
+                // Slim the provider envelope before it can become the tool body
+                // (#2585) — the same reshape `ComposioExecuteTool` runs, so a
+                // per-action Gmail fetch doesn't drop a full MIME tree into the
+                // agent's context. Only the raw-JSON fallback body serializes
+                // `resp.data`; a backend-rendered markdown body is unaffected.
+                if let Some(provider) = super::providers::toolkit_from_slug(&self.action_name)
+                    .and_then(|tk| super::providers::get_provider(&tk))
+                {
+                    provider.post_process_action_result(
+                        &self.action_name,
+                        reshape_args.as_ref(),
+                        &mut resp.data,
+                    );
+                }
                 // Mirror `ComposioExecuteTool::execute` (composio/tools.rs):
                 // prefer the backend-rendered `markdownFormatted` for LLM
                 // consumption when present, fall back to the raw JSON
@@ -744,5 +770,26 @@ mod tests {
             !direct_msg.contains("no backend session"),
             "direct-mode tool must not surface backend-session artifacts: {direct_msg}"
         );
+    }
+
+    #[test]
+    fn per_action_tool_gates_writes_but_not_reads() {
+        // The per-action surface must gate on the approval card exactly like the
+        // dispatcher: a write action routes through the gate, a read does not.
+        let send = ComposioActionTool::new(
+            fake_config(),
+            "GMAIL_SEND_EMAIL".to_string(),
+            "send".to_string(),
+            None,
+        );
+        assert!(send.external_effect_with_args(&serde_json::json!({})));
+
+        let read = ComposioActionTool::new(
+            fake_config(),
+            "GMAIL_FETCH_EMAILS".to_string(),
+            "fetch".to_string(),
+            None,
+        );
+        assert!(!read.external_effect_with_args(&serde_json::json!({})));
     }
 }

--- a/src/openhuman/integrations/composio/action_tool.rs
+++ b/src/openhuman/integrations/composio/action_tool.rs
@@ -329,6 +329,17 @@ impl Tool for ComposioActionTool {
                         reshape_args.as_ref(),
                         &mut resp.data,
                     );
+                    // A reshape the backend also renders is invisible unless the
+                    // provider says its version supersedes: the body below
+                    // prefers `markdownFormatted` and only falls back to the
+                    // JSON envelope when it is absent.
+                    if provider.reshape_supersedes_markdown(&self.action_name) {
+                        tracing::debug!(
+                            tool = %&self.action_name,
+                            "[composio] provider reshape supersedes the backend markdown rendering"
+                        );
+                        resp.markdown_formatted = None;
+                    }
                 }
                 // Published after the reshape, matching `ComposioExecuteTool`.
                 // The payload names no reshaped field today, so the order is not

--- a/src/openhuman/integrations/composio/tools.rs
+++ b/src/openhuman/integrations/composio/tools.rs
@@ -1550,7 +1550,7 @@ impl Tool for ComposioExecuteTool {
                     // provider says its version supersedes: the body below
                     // prefers `markdownFormatted` and only falls back to the
                     // JSON envelope when it is absent.
-                    if provider.reshape_supersedes_markdown(&tool) {
+                    if provider.reshape_supersedes_markdown(&tool, reshape_args.as_ref()) {
                         tracing::debug!(
                             tool = %&tool,
                             "[composio] provider reshape supersedes the backend markdown rendering"

--- a/src/openhuman/integrations/composio/tools.rs
+++ b/src/openhuman/integrations/composio/tools.rs
@@ -42,7 +42,7 @@ use crate::openhuman::tools::traits::{
 use super::client::{create_composio_client, direct_list_connections, ComposioClientKind};
 use super::providers::{
     catalog_for_toolkit, classify_unknown, find_curated, get_provider, load_user_scope_or_default,
-    toolkit_from_slug, ToolScope, UserScopePref,
+    provider_for_reshape, toolkit_from_slug, ToolScope, UserScopePref,
 };
 use super::types::ComposioToolsResponse;
 
@@ -1540,7 +1540,13 @@ impl Tool for ComposioExecuteTool {
                 // already clean and unaffected. The sync path applies the same
                 // reshape via `ReshapingExecutor`; here we run it inline on the
                 // agent's direct call.
-                if let Some(provider) = toolkit_from_slug(&tool).and_then(|tk| get_provider(&tk)) {
+                // Only a successful response is reshaped. A failure carries the
+                // provider's diagnostics in `data`, which a reshaper written for
+                // the success shape rewrites into an empty or wrong-shaped
+                // record, and `reshape_supersedes_markdown` would then clear the
+                // backend's error rendering on behalf of a reshape that found
+                // nothing — leaving the model neither.
+                if let Some(provider) = provider_for_reshape(&tool, resp.successful) {
                     provider.post_process_action_result(
                         &tool,
                         reshape_args.as_ref(),

--- a/src/openhuman/integrations/composio/tools.rs
+++ b/src/openhuman/integrations/composio/tools.rs
@@ -74,6 +74,15 @@ enum ToolDecision {
 /// blocking rather than letting a potentially-mutating action slip
 /// through uncategorised.
 pub(super) async fn resolve_action_scope(slug: &str) -> ToolScope {
+    resolve_action_scope_sync(slug)
+}
+
+/// Synchronous core of [`resolve_action_scope`]. Every lookup it makes —
+/// `toolkit_from_slug`, the provider/curated-catalog resolution, and the
+/// `classify_unknown` heuristic — is over static data with no `await`, so a
+/// caller that cannot be `async` (the `Tool::external_effect_with_args`
+/// gate-decision hook) can classify a slug directly.
+pub(super) fn resolve_action_scope_sync(slug: &str) -> ToolScope {
     let Some(toolkit) = toolkit_from_slug(slug) else {
         return ToolScope::Write;
     };
@@ -86,6 +95,18 @@ pub(super) async fn resolve_action_scope(slug: &str) -> ToolScope {
         }
     }
     classify_unknown(slug)
+}
+
+/// Whether a Composio action slug mutates external state, i.e. is
+/// `Write`/`Admin`-scoped. This is the predicate the approval gate keys off —
+/// a write/admin Composio action must route through the human-in-the-loop
+/// `ApprovalGate` before it runs, while a pure `Read` flows through unprompted
+/// (matching the `external_effect` contract on the `Tool` trait).
+pub(super) fn action_mutates_external_state(slug: &str) -> bool {
+    matches!(
+        resolve_action_scope_sync(slug),
+        ToolScope::Write | ToolScope::Admin
+    )
 }
 
 /// Decide whether a Composio action slug should be visible / executable
@@ -1313,6 +1334,18 @@ impl Tool for ComposioExecuteTool {
         // as write-level to respect channel permission caps.
         PermissionLevel::Write
     }
+    fn external_effect_with_args(&self, args: &Value) -> bool {
+        // Route a write/admin Composio action (send mail, create issue, delete,
+        // …) through the approval gate; a pure read flows through unprompted.
+        // The action slug is the `tool` argument. An empty/absent slug errs on
+        // the side of gating rather than letting a possibly-mutating call slip
+        // past the prompt.
+        args.get("tool")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|slug| !slug.is_empty())
+            .is_none_or(action_mutates_external_state)
+    }
     fn category(&self) -> ToolCategory {
         ToolCategory::Workflow
     }
@@ -1441,6 +1474,10 @@ impl Tool for ComposioExecuteTool {
             Some(since) => super::task_window::apply_window_args(&tool, arguments, since),
             None => arguments,
         };
+        // Kept for the post-dispatch envelope reshape (#2585): the dispatch
+        // below consumes `arguments`, but the reshape reads it for the
+        // `raw_html` opt-out.
+        let reshape_args = arguments.clone();
 
         // Resolve the client through the mode-aware factory on every
         // call so a direct-mode toggle takes effect immediately
@@ -1490,10 +1527,26 @@ impl Tool for ComposioExecuteTool {
                 // than the window. No-op unless a window is installed AND the
                 // slug is a curated task-fetch action. Runs before the
                 // markdown/JSON body decision so the agent reads filtered data.
-                let resp = match task_window_since {
+                let mut resp = match task_window_since {
                     Some(since) => super::task_window::filter_response(&tool, resp, since),
                     None => resp,
                 };
+                // Slim the provider envelope before it can become the tool body
+                // (#2585). A verbose Composio payload — Gmail's full MIME tree
+                // under `payload.parts[]`, dozens of `Received:` headers — is
+                // reshaped into one clean record per message. Only the fallback
+                // body path serializes `resp.data`, so this shrinks exactly the
+                // raw-JSON case; a backend-rendered `markdown_formatted` body is
+                // already clean and unaffected. The sync path applies the same
+                // reshape via `ReshapingExecutor`; here we run it inline on the
+                // agent's direct call.
+                if let Some(provider) = toolkit_from_slug(&tool).and_then(|tk| get_provider(&tk)) {
+                    provider.post_process_action_result(
+                        &tool,
+                        reshape_args.as_ref(),
+                        &mut resp.data,
+                    );
+                }
                 tracing::info!(
                     tool = %tool,
                     successful = resp.successful,

--- a/src/openhuman/integrations/composio/tools.rs
+++ b/src/openhuman/integrations/composio/tools.rs
@@ -1546,6 +1546,12 @@ impl Tool for ComposioExecuteTool {
                 // record, and `reshape_supersedes_markdown` would then clear the
                 // backend's error rendering on behalf of a reshape that found
                 // nothing — leaving the model neither.
+                tracing::debug!(
+                    target: "composio",
+                    tool = %tool,
+                    successful = resp.successful,
+                    "[composio] reshape provider selection"
+                );
                 if let Some(provider) = provider_for_reshape(&tool, resp.successful) {
                     provider.post_process_action_result(
                         &tool,
@@ -1558,6 +1564,7 @@ impl Tool for ComposioExecuteTool {
                     // JSON envelope when it is absent.
                     if provider.reshape_supersedes_markdown(&tool, reshape_args.as_ref()) {
                         tracing::debug!(
+                            target: "composio",
                             tool = %&tool,
                             "[composio] provider reshape supersedes the backend markdown rendering"
                         );

--- a/src/openhuman/integrations/composio/tools.rs
+++ b/src/openhuman/integrations/composio/tools.rs
@@ -1546,6 +1546,17 @@ impl Tool for ComposioExecuteTool {
                         reshape_args.as_ref(),
                         &mut resp.data,
                     );
+                    // A reshape the backend also renders is invisible unless the
+                    // provider says its version supersedes: the body below
+                    // prefers `markdownFormatted` and only falls back to the
+                    // JSON envelope when it is absent.
+                    if provider.reshape_supersedes_markdown(&tool) {
+                        tracing::debug!(
+                            tool = %&tool,
+                            "[composio] provider reshape supersedes the backend markdown rendering"
+                        );
+                        resp.markdown_formatted = None;
+                    }
                 }
                 tracing::info!(
                     tool = %tool,

--- a/src/openhuman/integrations/composio/tools_tests.rs
+++ b/src/openhuman/integrations/composio/tools_tests.rs
@@ -1123,3 +1123,28 @@ fn parse_composio_connect_timeout_honors_override_and_zero_opt_out() {
     // `0` → opt out of the composio-side bound (fall back to the gate TTL).
     assert_eq!(parse_composio_connect_timeout(Some("0")), None);
 }
+
+#[test]
+fn execute_tool_gates_writes_but_not_reads_via_external_effect() {
+    // The approval gate keys off `external_effect_with_args`. A write/admin
+    // Composio action (send/create/delete) must route through the gate; a pure
+    // read (fetch/list) must flow through unprompted. Regression: neither
+    // surface declared external_effect, so mail sends fired with no approval.
+    let t = ComposioExecuteTool::new(fake_config_arc());
+    assert!(
+        t.external_effect_with_args(&serde_json::json!({ "tool": "GMAIL_SEND_EMAIL" })),
+        "a send action must be gated"
+    );
+    assert!(
+        t.external_effect_with_args(&serde_json::json!({ "tool": "GMAIL_DELETE_MESSAGE" })),
+        "a delete action must be gated"
+    );
+    assert!(
+        !t.external_effect_with_args(&serde_json::json!({ "tool": "GMAIL_FETCH_EMAILS" })),
+        "a read action must not prompt"
+    );
+    assert!(
+        t.external_effect_with_args(&serde_json::json!({})),
+        "an absent slug errs on the side of gating"
+    );
+}

--- a/src/openhuman/memory/sync/composio/providers/gmail/post_process.rs
+++ b/src/openhuman/memory/sync/composio/providers/gmail/post_process.rs
@@ -65,10 +65,17 @@ pub fn post_process(slug: &str, arguments: Option<&Value>, data: &mut Value) {
         );
         return;
     }
-    match slug {
-        "GMAIL_FETCH_EMAILS" => reshape_fetch_emails(data),
-        "GMAIL_LIST_THREADS" => reshape_list_threads(data),
-        _ => {}
+    // Case-insensitive, because the slug reaching here is whatever the model
+    // wrote. `composio_execute` takes the action as an argument, so a lowercase
+    // `gmail_list_threads` arrives verbatim; a case-sensitive match dropped it
+    // to the no-op arm while `reshape_supersedes_markdown` — which folds case —
+    // still cleared the backend rendering, handing the model the raw MIME tree
+    // with neither the reshape nor the markdown. The action is the same action
+    // whatever the model capitalises; only one of the two may decide that.
+    if slug.eq_ignore_ascii_case("GMAIL_FETCH_EMAILS") {
+        reshape_fetch_emails(data);
+    } else if slug.eq_ignore_ascii_case("GMAIL_LIST_THREADS") {
+        reshape_list_threads(data);
     }
 }
 
@@ -379,7 +386,7 @@ fn validate_segments_against_hints(segments: &[String], hints: &[Value]) -> bool
 
 /// Returns true when the caller explicitly set `raw_html: true` (or the
 /// camelCase `rawHtml: true`) in the `arguments` object.
-fn is_raw_html_flag_set(arguments: Option<&Value>) -> bool {
+pub(super) fn is_raw_html_flag_set(arguments: Option<&Value>) -> bool {
     let Some(obj) = arguments.and_then(|v| v.as_object()) else {
         return false;
     };

--- a/src/openhuman/memory/sync/composio/providers/gmail/post_process.rs
+++ b/src/openhuman/memory/sync/composio/providers/gmail/post_process.rs
@@ -65,9 +65,128 @@ pub fn post_process(slug: &str, arguments: Option<&Value>, data: &mut Value) {
         );
         return;
     }
-    if slug == "GMAIL_FETCH_EMAILS" {
-        reshape_fetch_emails(data)
+    match slug {
+        "GMAIL_FETCH_EMAILS" => reshape_fetch_emails(data),
+        "GMAIL_LIST_THREADS" => reshape_list_threads(data),
+        _ => {}
     }
+}
+
+/// Rewrite a `GMAIL_LIST_THREADS` `data` object in place so each thread carries
+/// what a list is read for: who it is from, what it is about, and when.
+///
+/// The upstream shape has neither of those at the top level. With `verbose`
+/// off a thread is `{historyId, id, snippet}`; with it on the sender and
+/// subject are buried in `messages[].payload.headers[]` alongside the full MIME
+/// tree and ~40 `Received:` headers. Composio's own markdown rendering of this
+/// action is a bare list of thread ids and nothing else, so an agent that ran a
+/// search got back a page of hex strings and had to fetch every thread in full
+/// just to learn which one it wanted. Observed live: a search over 20 threads
+/// answered "not found" after opening the first four.
+///
+/// So this lifts the headers out and drops `payload` entirely. `verbose` still
+/// decides how much there is to lift, but the envelope is the same either way.
+fn reshape_list_threads(data: &mut Value) {
+    let container = match data.get_mut("threads") {
+        Some(_) => data,
+        None => match data.get_mut("data").and_then(|v| v.as_object_mut()) {
+            Some(_) => data.get_mut("data").unwrap(),
+            None => return,
+        },
+    };
+
+    let Some(obj) = container.as_object_mut() else {
+        return;
+    };
+
+    let raw_threads = obj
+        .remove("threads")
+        .and_then(|v| match v {
+            Value::Array(arr) => Some(arr),
+            _ => None,
+        })
+        .unwrap_or_default();
+    let next_page_token = obj.remove("nextPageToken").unwrap_or(Value::Null);
+    let result_size_estimate = obj.remove("resultSizeEstimate").unwrap_or(Value::Null);
+
+    let threads: Vec<Value> = raw_threads.into_iter().map(reshape_thread).collect();
+    tracing::debug!(
+        threads = threads.len(),
+        "[composio:gmail][post-process] GMAIL_LIST_THREADS reshaped"
+    );
+
+    let mut envelope = Map::new();
+    envelope.insert("threads".into(), Value::Array(threads));
+    if !next_page_token.is_null() {
+        envelope.insert("nextPageToken".into(), next_page_token);
+    }
+    if !result_size_estimate.is_null() {
+        envelope.insert("resultSizeEstimate".into(), result_size_estimate);
+    }
+
+    *container = Value::Object(envelope);
+}
+
+/// Map one raw thread to its slim counterpart.
+///
+/// `subject` / `from` / `date` / `labels` come from the thread's newest message
+/// (the one a list view is about), picked by `internalDate` because the action's
+/// own contract states message order is not guaranteed. They are absent
+/// entirely when the caller did not ask for `verbose`, since the upstream sends
+/// no messages to read them from — `snippet` is then the only content there is.
+fn reshape_thread(raw: Value) -> Value {
+    let Value::Object(obj) = raw else {
+        return raw;
+    };
+
+    let mut out = Map::new();
+    out.insert("id".into(), obj.get("id").cloned().unwrap_or(Value::Null));
+
+    let messages = obj.get("messages").and_then(|v| v.as_array());
+    let newest = messages.and_then(|arr| {
+        arr.iter().filter_map(|m| m.as_object()).max_by_key(|m| {
+            m.get("internalDate")
+                .and_then(|v| v.as_str())
+                .and_then(|s| s.parse::<i64>().ok())
+                .unwrap_or(0)
+        })
+    });
+
+    if let Some(msg) = newest {
+        if let Some(subject) = pick_header(msg, "Subject") {
+            out.insert("subject".into(), subject);
+        }
+        if let Some(from) = pick_header(msg, "From") {
+            out.insert("from".into(), from);
+        }
+        let date = pick_header(msg, "Date").unwrap_or(Value::Null);
+        if !date.is_null() {
+            if let Some(local) = date.as_str().and_then(format_email_local_time) {
+                out.insert("date_local".into(), Value::String(local));
+            }
+            out.insert("date".into(), date);
+        }
+        if let Some(labels) = msg.get("labelIds").cloned() {
+            out.insert("labels".into(), labels);
+        }
+    }
+
+    // The thread-level snippet is what `verbose` off gives; a verbose response
+    // carries it per message instead, so fall back to the newest message's.
+    let snippet = obj
+        .get("snippet")
+        .cloned()
+        .or_else(|| newest.and_then(|m| m.get("snippet").cloned()))
+        .unwrap_or(Value::Null);
+    if !snippet.is_null() {
+        out.insert("snippet".into(), snippet);
+    }
+
+    if let Some(count) = messages.map(|m| m.len()) {
+        out.insert("messageCount".into(), Value::from(count));
+    }
+
+    Value::Object(out)
 }
 
 /// Stash per-message slices of the response-level `markdownFormatted`

--- a/src/openhuman/memory/sync/composio/providers/gmail/provider.rs
+++ b/src/openhuman/memory/sync/composio/providers/gmail/provider.rs
@@ -99,8 +99,14 @@ impl ComposioProvider for GmailProvider {
     /// `GMAIL_FETCH_EMAILS` is deliberately absent: its reshape *reads*
     /// `markdownFormatted` for the message body (`extract_markdown_body`), so
     /// clearing it there would throw away the body rather than reveal it.
-    fn reshape_supersedes_markdown(&self, slug: &str) -> bool {
+    fn reshape_supersedes_markdown(&self, slug: &str, arguments: Option<&Value>) -> bool {
+        // `raw_html` makes `post_process` pass the response through untouched,
+        // so there is no reshape to supersede anything. Clearing the rendering
+        // anyway left the model with neither the backend summary nor the slim
+        // envelope — just the raw MIME tree, which is the opposite of what the
+        // flag is for.
         slug.eq_ignore_ascii_case("GMAIL_LIST_THREADS")
+            && !super::post_process::is_raw_html_flag_set(arguments)
     }
 
     async fn fetch_user_profile(
@@ -215,16 +221,16 @@ impl ComposioProvider for GmailProvider {
 #[cfg(test)]
 mod supersede_tests {
     use super::*;
-    use crate::openhuman::memory_sync::composio::providers::ComposioProvider;
+    use crate::openhuman::memory::sync::composio::providers::ComposioProvider;
 
     /// The rendering for a thread list is a bare id list, so the reshape — which
     /// lifts the subject, sender, date, and snippet the same payload carries —
     /// has to replace it or the model never sees any of them.
     #[test]
     fn the_thread_list_reshape_supersedes_the_backend_rendering() {
-        assert!(GmailProvider.reshape_supersedes_markdown("GMAIL_LIST_THREADS"));
+        assert!(GmailProvider.reshape_supersedes_markdown("GMAIL_LIST_THREADS", None));
         // The model's casing varies; the action does not.
-        assert!(GmailProvider.reshape_supersedes_markdown("gmail_list_threads"));
+        assert!(GmailProvider.reshape_supersedes_markdown("gmail_list_threads", None));
     }
 
     /// The failure case that matters. `reshape_fetch_emails` READS
@@ -232,8 +238,70 @@ mod supersede_tests {
     /// throw the body away instead of revealing it.
     #[test]
     fn the_message_fetch_reshape_does_not() {
-        assert!(!GmailProvider.reshape_supersedes_markdown("GMAIL_FETCH_EMAILS"));
-        assert!(!GmailProvider.reshape_supersedes_markdown("GMAIL_FETCH_MESSAGE_BY_THREAD_ID"));
-        assert!(!GmailProvider.reshape_supersedes_markdown("GMAIL_SEND_EMAIL"));
+        assert!(!GmailProvider.reshape_supersedes_markdown("GMAIL_FETCH_EMAILS", None));
+        assert!(
+            !GmailProvider.reshape_supersedes_markdown("GMAIL_FETCH_MESSAGE_BY_THREAD_ID", None)
+        );
+        assert!(!GmailProvider.reshape_supersedes_markdown("GMAIL_SEND_EMAIL", None));
+    }
+
+    /// `raw_html` makes `post_process` pass the response through untouched, so
+    /// there is no reshape to supersede. Answering `true` anyway cleared the
+    /// rendering on behalf of a reshape that never ran, and the model was handed
+    /// the raw MIME tree with neither the backend summary nor the slim envelope.
+    #[test]
+    fn a_raw_html_call_supersedes_nothing() {
+        let raw = json!({ "raw_html": true });
+        assert!(!GmailProvider.reshape_supersedes_markdown("GMAIL_LIST_THREADS", Some(&raw)));
+        // The camelCase spelling the model also sends.
+        let camel = json!({ "rawHtml": true });
+        assert!(!GmailProvider.reshape_supersedes_markdown("GMAIL_LIST_THREADS", Some(&camel)));
+        // Explicitly off is the ordinary call, and still supersedes.
+        let off = json!({ "raw_html": false });
+        assert!(GmailProvider.reshape_supersedes_markdown("GMAIL_LIST_THREADS", Some(&off)));
+    }
+}
+
+#[cfg(test)]
+mod dispatch_case_tests {
+    use super::*;
+    use crate::openhuman::memory::sync::composio::providers::ComposioProvider;
+
+    /// The slug reaching `post_process` is whatever the model wrote —
+    /// `composio_execute` takes the action as an argument, so a lowercase spelling
+    /// arrives verbatim. A case-sensitive dispatch fell through to the no-op arm
+    /// while `reshape_supersedes_markdown` folded case and still cleared the
+    /// backend rendering: the model got the raw MIME tree and nothing else.
+    #[test]
+    fn a_lowercase_slug_is_reshaped_like_its_uppercase_spelling() {
+        let payload = || {
+            json!({
+                "threads": [{
+                    "id": "abc",
+                    "snippet": "hello",
+                    "messages": [{
+                        "payload": { "headers": [
+                            { "name": "Subject", "value": "Quarterly report" },
+                            { "name": "From", "value": "a@example.com" }
+                        ]}
+                    }]
+                }]
+            })
+        };
+
+        let mut upper = payload();
+        GmailProvider.post_process_action_result("GMAIL_LIST_THREADS", None, &mut upper);
+        let mut lower = payload();
+        GmailProvider.post_process_action_result("gmail_list_threads", None, &mut lower);
+
+        assert_eq!(
+            upper, lower,
+            "the action is the same action whatever the model capitalises"
+        );
+        // And the reshape actually ran, so the assertion above is not two no-ops.
+        assert!(
+            upper.to_string().contains("Quarterly report"),
+            "the reshape lifts the subject out of the MIME tree: {upper}"
+        );
     }
 }

--- a/src/openhuman/memory/sync/composio/providers/gmail/provider.rs
+++ b/src/openhuman/memory/sync/composio/providers/gmail/provider.rs
@@ -80,6 +80,29 @@ impl ComposioProvider for GmailProvider {
         super::post_process::post_process(slug, arguments, data);
     }
 
+    /// Only `GMAIL_LIST_THREADS`, and only because its rendering throws away
+    /// the answer.
+    ///
+    /// The backend renders a thread list as bare ids — captured verbatim:
+    ///
+    /// ```text
+    /// **Gmail Threads** — 2 returned
+    /// - `19fbd08f6a3e635b`
+    /// - `19fbc77215064e91`
+    /// ```
+    ///
+    /// The payload behind that list carries each thread's subject, sender,
+    /// date, labels, and snippet, and `reshape_list_threads` lifts them. Live,
+    /// a sub-agent searching for a mail that does exist got the ids, had
+    /// nothing to recognise the thread by, and reported it could not be found.
+    ///
+    /// `GMAIL_FETCH_EMAILS` is deliberately absent: its reshape *reads*
+    /// `markdownFormatted` for the message body (`extract_markdown_body`), so
+    /// clearing it there would throw away the body rather than reveal it.
+    fn reshape_supersedes_markdown(&self, slug: &str) -> bool {
+        slug.eq_ignore_ascii_case("GMAIL_LIST_THREADS")
+    }
+
     async fn fetch_user_profile(
         &self,
         ctx: &ProviderContext,
@@ -188,3 +211,29 @@ impl ComposioProvider for GmailProvider {
 // the sole consumer; the `sync_depth_days` date floor (`epoch_floor_from_depth`)
 // stays in `super::super::helpers` because `gmail::source` builds an
 // `after:<epoch>` filter from it.
+
+#[cfg(test)]
+mod supersede_tests {
+    use super::*;
+    use crate::openhuman::memory_sync::composio::providers::ComposioProvider;
+
+    /// The rendering for a thread list is a bare id list, so the reshape — which
+    /// lifts the subject, sender, date, and snippet the same payload carries —
+    /// has to replace it or the model never sees any of them.
+    #[test]
+    fn the_thread_list_reshape_supersedes_the_backend_rendering() {
+        assert!(GmailProvider.reshape_supersedes_markdown("GMAIL_LIST_THREADS"));
+        // The model's casing varies; the action does not.
+        assert!(GmailProvider.reshape_supersedes_markdown("gmail_list_threads"));
+    }
+
+    /// The failure case that matters. `reshape_fetch_emails` READS
+    /// `markdownFormatted` for the message body, so clearing it here would
+    /// throw the body away instead of revealing it.
+    #[test]
+    fn the_message_fetch_reshape_does_not() {
+        assert!(!GmailProvider.reshape_supersedes_markdown("GMAIL_FETCH_EMAILS"));
+        assert!(!GmailProvider.reshape_supersedes_markdown("GMAIL_FETCH_MESSAGE_BY_THREAD_ID"));
+        assert!(!GmailProvider.reshape_supersedes_markdown("GMAIL_SEND_EMAIL"));
+    }
+}

--- a/src/openhuman/memory/sync/composio/providers/mod.rs
+++ b/src/openhuman/memory/sync/composio/providers/mod.rs
@@ -278,7 +278,8 @@ pub fn agent_ready_toolkits() -> Vec<&'static str> {
 pub use descriptions::toolkit_description;
 pub(crate) use helpers::{first_array_str, merge_extra, pick_str};
 pub use registry::{
-    all_providers, get_provider, init_default_providers, register_provider, ProviderArc,
+    all_providers, get_provider, init_default_providers, provider_for_reshape, register_provider,
+    ProviderArc,
 };
 pub use scope_lookup::{curated_scope_for, toolkit_has_scope};
 pub use tool_scope::{classify_unknown, find_curated, toolkit_from_slug, CuratedTool, ToolScope};

--- a/src/openhuman/memory/sync/composio/providers/registry.rs
+++ b/src/openhuman/memory/sync/composio/providers/registry.rs
@@ -179,13 +179,19 @@ mod tests {
     /// behalf of a reshape that had found nothing, so the model got neither.
     #[test]
     fn a_failed_response_selects_no_provider_to_reshape_with() {
-        register_provider(Arc::new(DummyProvider { slug: "gmail" }));
+        // A toolkit of this test's own, not `gmail`: the registry is process-
+        // global, so registering a `DummyProvider` under a real slug would hand
+        // it to any parallel test that looks Gmail up. `toolkit_from_slug`
+        // splits on the first `_`, so the slug below resolves to this toolkit.
+        register_provider(Arc::new(DummyProvider {
+            slug: "reshapeprobe",
+        }));
 
         assert!(
-            provider_for_reshape("GMAIL_LIST_THREADS", true).is_some(),
+            provider_for_reshape("RESHAPEPROBE_LIST_THINGS", true).is_some(),
             "the success case must still reshape, or this test proves nothing"
         );
-        assert!(provider_for_reshape("GMAIL_LIST_THREADS", false).is_none());
+        assert!(provider_for_reshape("RESHAPEPROBE_LIST_THINGS", false).is_none());
     }
 
     /// An unregistered toolkit has nothing to reshape with either way — the

--- a/src/openhuman/memory/sync/composio/providers/registry.rs
+++ b/src/openhuman/memory/sync/composio/providers/registry.rs
@@ -53,6 +53,28 @@ pub fn register_provider(provider: ProviderArc) {
 }
 
 /// Look up the provider for a toolkit slug, if one is registered.
+/// The provider that should reshape an action response, or `None`.
+///
+/// Two conditions, and the second is the one that is easy to forget at a call
+/// site: the slug must map to a registered provider, **and** the response must
+/// have succeeded. [`ComposioProvider::post_process_action_result`] and
+/// [`ComposioProvider::reshape_supersedes_markdown`] are both written against
+/// the success shape. A failure carries the provider's diagnostics in `data`
+/// instead, so a reshaper run on it rewrites them into an empty or wrong-shaped
+/// record — and `reshape_supersedes_markdown` then clears the backend's error
+/// rendering on behalf of a reshape that found nothing, leaving the model with
+/// neither the error nor the diagnostics.
+///
+/// Named rather than inlined so both execute paths (`ComposioExecuteTool` and
+/// `ComposioActionTool`) state the same rule, and so the rule is testable
+/// without a live client.
+pub fn provider_for_reshape(slug: &str, successful: bool) -> Option<ProviderArc> {
+    if !successful {
+        return None;
+    }
+    super::toolkit_from_slug(slug).and_then(|toolkit| get_provider(&toolkit))
+}
+
 pub fn get_provider(toolkit: &str) -> Option<ProviderArc> {
     let key = toolkit.trim();
     if key.is_empty() {
@@ -149,5 +171,28 @@ mod tests {
     fn empty_slug_is_rejected() {
         register_provider(Arc::new(DummyProvider { slug: "" }));
         assert!(get_provider("").is_none());
+    }
+
+    /// The regression for the failure path. A `GMAIL_LIST_THREADS` that failed
+    /// carries the provider's diagnostics in `data`; reshaping it rewrote them
+    /// into the success shape and then cleared the backend's error rendering on
+    /// behalf of a reshape that had found nothing, so the model got neither.
+    #[test]
+    fn a_failed_response_selects_no_provider_to_reshape_with() {
+        register_provider(Arc::new(DummyProvider { slug: "gmail" }));
+
+        assert!(
+            provider_for_reshape("GMAIL_LIST_THREADS", true).is_some(),
+            "the success case must still reshape, or this test proves nothing"
+        );
+        assert!(provider_for_reshape("GMAIL_LIST_THREADS", false).is_none());
+    }
+
+    /// An unregistered toolkit has nothing to reshape with either way — the
+    /// success flag does not manufacture a provider.
+    #[test]
+    fn an_unknown_slug_selects_no_provider_even_on_success() {
+        assert!(provider_for_reshape("NOT_A_REAL_ACTION", true).is_none());
+        assert!(provider_for_reshape("", true).is_none());
     }
 }

--- a/src/openhuman/memory/sync/composio/providers/traits.rs
+++ b/src/openhuman/memory/sync/composio/providers/traits.rs
@@ -252,10 +252,21 @@ pub trait ComposioProvider: Send + Sync {
     /// rendered as a bare list of thread ids that discards the subjects,
     /// senders, dates, and snippets the same payload carries.
     ///
+    /// `arguments` is the caller's original argument object, because the answer
+    /// is a property of the **call**, not of the slug alone: the same action can
+    /// be invoked in a way that skips the reshape entirely. Gmail's `raw_html`
+    /// opt-out is the live example — `post_process` returns early and leaves
+    /// `data` untouched, so a slug-only `true` cleared the rendering on behalf
+    /// of a reshape that never ran and the model got neither.
+    ///
     /// Default `false`: a provider that has not thought about it keeps the
     /// existing behaviour.
-    fn reshape_supersedes_markdown(&self, slug: &str) -> bool {
-        let _ = slug;
+    fn reshape_supersedes_markdown(
+        &self,
+        slug: &str,
+        arguments: Option<&serde_json::Value>,
+    ) -> bool {
+        let _ = (slug, arguments);
         false
     }
 

--- a/src/openhuman/memory/sync/composio/providers/traits.rs
+++ b/src/openhuman/memory/sync/composio/providers/traits.rs
@@ -234,6 +234,31 @@ pub trait ComposioProvider: Send + Sync {
         let _ = (slug, arguments, data);
     }
 
+    /// Whether [`Self::post_process_action_result`]'s rewrite of `data`
+    /// **replaces** the backend's `markdownFormatted` rendering for `slug`.
+    ///
+    /// Both Composio dispatch paths — `ComposioActionTool` and the
+    /// `composio_execute` dispatcher — build the model-facing body by
+    /// preferring `markdownFormatted` and falling back to the JSON envelope
+    /// only when it is absent. A reshape of an action the backend also renders
+    /// is therefore **invisible** to the model unless the provider says so
+    /// here; `data` is rewritten, and then nothing reads it.
+    ///
+    /// Answer `true` only where the reshape carries something the rendering
+    /// drops. It is deliberately per-action rather than per-toolkit, because
+    /// within one toolkit the answer differs: Gmail's `GMAIL_FETCH_EMAILS`
+    /// reshape *consumes* `markdownFormatted` (it is the message body, already
+    /// URL-shortened and footer-stripped), while `GMAIL_LIST_THREADS` is
+    /// rendered as a bare list of thread ids that discards the subjects,
+    /// senders, dates, and snippets the same payload carries.
+    ///
+    /// Default `false`: a provider that has not thought about it keeps the
+    /// existing behaviour.
+    fn reshape_supersedes_markdown(&self, slug: &str) -> bool {
+        let _ = slug;
+        false
+    }
+
     /// Hook fired when a Composio trigger webhook arrives for this
     /// toolkit. `payload` is the raw provider payload as forwarded by
     /// the backend. Implementations should be defensive — payload


### PR DESCRIPTION
> **Stacked on #5259**, which owns the `post_process_action_result` call sites in both dispatch paths. Review that one first; the diff here is the two 11-line hooks plus the provider surface.

## Summary

- `reshape_list_threads` rewrites `GMAIL_LIST_THREADS` into a usable thread summary, and nothing read it. This makes it reach the model.
- New `ComposioProvider::reshape_supersedes_markdown(slug)` lets a provider declare that its rewrite replaces the backend's rendering; both dispatch paths clear `markdown_formatted` when it answers true.
- Deliberately per **action**, not per toolkit.

## Problem

Both Composio dispatch paths build the model-facing body the same way: prefer the backend's `markdownFormatted`, fall back to the JSON envelope only when it is absent or the call failed. `post_process_action_result` receives only `data`, so a provider cannot clear that field. The reshape runs, rewrites `data`, and the model is handed the backend rendering instead.

For a thread list the rendering is the whole problem. Captured verbatim from a live verbose response:

```
**Gmail Threads** — 2 returned
- `19fbd08f6a3e635b`
- `19fbc77215064e91`

_nextPageToken: 16343739521893202356_
_resultSizeEstimate: 201_
```

Bare ids. The subjects, senders, dates, labels, and snippets are all present in the payload behind that list, and all discarded. Live, a sub-agent searching for a mail that does exist got the ids, had nothing to recognise the thread by, and reported it could not be found.

## Solution

A provider answers `reshape_supersedes_markdown(slug)`; the two call sites clear `resp.markdown_formatted` when it does. Default `false`, so a provider that has not thought about it keeps today's behaviour.

**Per action, not per toolkit**, because within Gmail the answer differs. `GMAIL_FETCH_EMAILS`'s reshape *reads* `markdownFormatted` for the message body (`extract_markdown_body`) — it is already URL-shortened and footer-stripped by the backend, and clearing it there would throw the body away rather than reveal it. Only `GMAIL_LIST_THREADS` returns true.

The trait doc states the trap directly, because it is not visible from the reshape's own file: a reshape of an action the backend also renders is invisible unless the provider says otherwise.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case)
- [x] **Diff coverage ≥ 80%** — both branches of the new predicate are covered, plus the reshape itself
- [x] N/A: behaviour-only change, no feature row added/removed/renamed — Coverage matrix updated
- [x] No new external network dependencies introduced
- [x] N/A: no release-cut surface touched — Manual smoke checklist updated
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

### Testing

- `the_thread_list_reshape_supersedes_the_backend_rendering` — including the case-insensitive form, since the model's casing varies and the action does not.
- `the_message_fetch_reshape_does_not` — the failure case that matters: `GMAIL_FETCH_EMAILS`, `GMAIL_FETCH_MESSAGE_BY_THREAD_ID`, and a write action must all stay false, or the body is thrown away.

## Impact

- Changes what the model sees for `GMAIL_LIST_THREADS` only. Every other action, and every other toolkit, is byte-identical.
- The reshaped summary is *smaller* than the raw envelope it replaces (it drops `payload`), so context cost goes down, not up.

## Related

Closes #5319


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added provider-specific response formatting for external actions.
  * Gmail thread lists now show concise details, including subject, sender, date, labels, snippets, message counts, and pagination.
  * Gmail action matching now works regardless of letter casing.

* **Bug Fixes**
  * Write and administrative actions now require approval, while read-only actions proceed without prompting.
  * Improved handling of missing or invalid action details.
  * Preserved raw HTML behavior when explicitly requested.
  * Prevented duplicate backend formatting when provider-specific output takes precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
