### PR TITLE
fix(json-schema): gate flow-only helper exports

### DIFF
--- a/src/openhuman/json_schema/mod.rs
+++ b/src/openhuman/json_schema/mod.rs
@@ -40,6 +40,7 @@ mod ops;
 mod ops_tests;
 
 pub(crate) use ops::{
-    compute_primary_array_path, compute_primary_array_path_from_value, missing_required_args,
-    response_fields_from_schema, unsupported_arg_names,
+    compute_primary_array_path, compute_primary_array_path_from_value, response_fields_from_schema,
 };
+#[cfg(any(feature = "flows", test))]
+pub(crate) use ops::{missing_required_args, unsupported_arg_names};


### PR DESCRIPTION
## Summary

- gate flow-only JSON-schema helper re-exports behind the `flows` feature
- keep the helpers available to their unit tests
- preserve warning-free downstream builds using the narrower `medulla` feature set

## Root cause

The kernel family reorganization re-exported `missing_required_args` and `unsupported_arg_names` unconditionally, although their only non-test consumer is feature-gated behind `flows`. Downstream builds without that feature therefore emitted unused-import warnings.

## Validation

- `cargo fmt --all --check`
- downstream `cargo clippy --all-targets -- -D warnings` in Medulla