### PR TITLE
fix(auth): bound store-time /auth/me validation so a slow backend defers instead of bouncing sign-in (#5166)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,6 +118,12 @@ OPENHUMAN_TEMPERATURE=0.7
 # research turns). The window resets on every token, so valid long responses are
 # never cut. Leave unset to use the default.
 # OPENHUMAN_INFERENCE_STREAM_IDLE_TIMEOUT_SECS=
+# [optional] Wall-clock budget (milliseconds) for the store-time GET /auth/me
+# validation during sign-in (default 12000). Kept well under the desktop sign-in
+# RPC timeout so a reachable-but-slow backend fails fast into deferred
+# revalidation for a live-exp JWT instead of hanging until the RPC bounces the
+# user back to sign-in (#5166). Leave unset to use the default.
+# OPENHUMAN_AUTH_ME_STORE_TIMEOUT_MS=12000
 # [optional] Headless update restart contract: self_replace | supervisor
 # OPENHUMAN_AUTO_UPDATE_RESTART_STRATEGY=self_replace
 # [optional] Allow bearer-authenticated RPC callers to invoke update.apply/update.run

--- a/src/openhuman/security/credentials/ops.rs
+++ b/src/openhuman/security/credentials/ops.rs
@@ -24,6 +24,25 @@ use crate::openhuman::memory::conversations;
 const AUTH_ME_STORE_RETRY_DELAY: Duration = Duration::from_millis(150);
 const AUTH_ME_STORE_TRANSIENT_STATUSES: &[u16] = &[408, 429, 500, 502, 503, 504, 520];
 
+/// Wall-clock budget for the store-time `GET /auth/me` validation (issue #5166).
+///
+/// The shared backend client allows a 120s request timeout + 15s connect timeout
+/// (`api::rest`), but the desktop sign-in RPC that drives `auth_store_session`
+/// gives up far sooner — `AUTH_STORE_TIMEOUT_MS` (25s) × `AUTH_STORE_RETRIES` in
+/// `desktopDeepLinkListener.ts`. If the backend is reachable but slow, that 120s
+/// ceiling lets `/auth/me` hang past the frontend's patience: the RPC times out
+/// and bounces a genuinely-authenticated user back to sign-in *before* the
+/// deferred-validation fallback in `store_session_inner` ever gets a chance to
+/// fire (the exact `auth_me_timeout` bounce in Sentry `TAURI-REACT-1V`).
+///
+/// Capping store-time validation well under the frontend budget makes a slow
+/// backend fail *fast* into the caller-authorized pending-session path (for a
+/// live-`exp` JWT), so the user lands in the app with deferred revalidation
+/// instead of being bounced. Overridable via `OPENHUMAN_AUTH_ME_STORE_TIMEOUT_MS`
+/// for ops tuning and tests.
+const AUTH_ME_STORE_VALIDATION_BUDGET: Duration = Duration::from_secs(12);
+const AUTH_ME_STORE_VALIDATION_BUDGET_ENV: &str = "OPENHUMAN_AUTH_ME_STORE_TIMEOUT_MS";
+
 /// Start all login-gated background services (local AI, voice, and
 /// orchestration). Called both from the initial boot path (when an existing
 /// session is detected) and from `store_session()` on fresh login.
@@ -610,7 +629,55 @@ async fn store_session_inner(
     Ok(RpcOutcome::new(summarize_auth_profile(&profile), logs))
 }
 
+/// Store-time `GET /auth/me` budget resolver. Reads the
+/// `OPENHUMAN_AUTH_ME_STORE_TIMEOUT_MS` override (positive integer milliseconds),
+/// otherwise the `AUTH_ME_STORE_VALIDATION_BUDGET` default.
+fn auth_me_store_validation_budget() -> Duration {
+    std::env::var(AUTH_ME_STORE_VALIDATION_BUDGET_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|ms| *ms > 0)
+        .map(Duration::from_millis)
+        .unwrap_or(AUTH_ME_STORE_VALIDATION_BUDGET)
+}
+
+/// Validate the freshly minted session token against `GET /auth/me`, bounded by
+/// `auth_me_store_validation_budget()`. On budget exhaustion returns a
+/// transient-classified timeout error so `store_session_inner` routes a
+/// live-`exp` JWT into the deferred-validation fallback rather than hanging until
+/// the desktop sign-in RPC times out and bounces the user (issue #5166).
 async fn fetch_current_user_for_session_store(
+    client: &BackendOAuthClient,
+    token: &str,
+) -> Result<Value, String> {
+    let budget = auth_me_store_validation_budget();
+    match tokio::time::timeout(
+        budget,
+        fetch_current_user_for_session_store_inner(client, token),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_elapsed) => {
+            // Message must contain a `TRANSIENT_TRANSPORT_PHRASES` phrase
+            // ("timeout") so `auth_me_store_failure_is_transient` buckets it as
+            // transient and the deferred-validation path can take over.
+            let reason = format!(
+                "GET /auth/me validation timeout after {}ms (store-time budget exceeded)",
+                budget.as_millis()
+            );
+            tracing::warn!(
+                domain = "credentials",
+                operation = "fetch_current_user_for_session_store",
+                budget_ms = budget.as_millis() as u64,
+                "[credentials][auth-store] {reason}"
+            );
+            Err(reason)
+        }
+    }
+}
+
+async fn fetch_current_user_for_session_store_inner(
     client: &BackendOAuthClient,
     token: &str,
 ) -> Result<Value, String> {

--- a/src/openhuman/security/credentials/ops_tests.rs
+++ b/src/openhuman/security/credentials/ops_tests.rs
@@ -378,9 +378,10 @@ async fn store_session_defers_live_jwt_when_auth_me_hangs_past_budget() {
         .await
         .unwrap();
     // The 200ms budget must cap the 60s hang — proves the timeout fired rather
-    // than the store awaiting the backend.
+    // than the store awaiting the backend. Bound safely above the 200ms budget
+    // but below the 12s default so a multi-second regression still fails.
     assert!(
-        started.elapsed() < std::time::Duration::from_secs(10),
+        started.elapsed() < std::time::Duration::from_secs(2),
         "store-time validation should be capped by the budget, took {:?}",
         started.elapsed()
     );

--- a/src/openhuman/security/credentials/ops_tests.rs
+++ b/src/openhuman/security/credentials/ops_tests.rs
@@ -20,6 +20,12 @@ impl EnvVarGuard {
         unsafe { std::env::set_var(key, path) };
         Self { key, previous }
     }
+
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
 }
 
 impl Drop for EnvVarGuard {
@@ -60,6 +66,25 @@ fn count_reembed_backfill_jobs(config: &Config) -> i64 {
 
 async fn spawn_auth_me_status(status: StatusCode) -> String {
     let app = Router::new().route("/auth/me", get(move || async move { status }));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+/// A backend that accepts the connection but never answers `/auth/me`, modelling
+/// a reachable-but-slow backend whose request hangs far past the store-time
+/// validation budget (issue #5166).
+async fn spawn_auth_me_hang() -> String {
+    let app = Router::new().route(
+        "/auth/me",
+        get(|| async {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            StatusCode::OK
+        }),
+    );
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
@@ -324,6 +349,84 @@ async fn store_session_defers_minimal_live_jwt_when_auth_me_transient_and_allowe
         Some(json!({ "pendingBackendValidation": true })),
         "deferred fallback must not copy identity claims from an unverified JWT or callback payload"
     );
+}
+
+#[tokio::test]
+async fn store_session_defers_live_jwt_when_auth_me_hangs_past_budget() {
+    // Issue #5166: a reachable-but-slow backend must not hang store-time
+    // validation until the desktop sign-in RPC times out. Capping the budget
+    // makes the hang fail fast (as transient) into the deferred-validation path
+    // so a live-`exp` JWT still persists instead of bouncing the user.
+    let _env_guard = crate::openhuman::config::TEST_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let _budget = EnvVarGuard::set(AUTH_ME_STORE_VALIDATION_BUDGET_ENV, "200");
+    let tmp = TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join("workspace")).unwrap();
+    let _home = EnvVarGuard::set_to_path("HOME", tmp.path());
+    let mut config = test_config(&tmp);
+    config.api_url = Some(spawn_auth_me_hang().await);
+    let token = jwt_with_payload(json!({
+        "sub": "unverified-jwt-user",
+        "email": "jwt@example.test",
+        "name": "Unverified JWT User",
+        "exp": (chrono::Utc::now() + chrono::Duration::hours(1)).timestamp()
+    }));
+
+    let started = std::time::Instant::now();
+    let result = store_session_with_deferred_validation(&config, &token, None, Some(json!({})))
+        .await
+        .unwrap();
+    // The 200ms budget must cap the 60s hang — proves the timeout fired rather
+    // than the store awaiting the backend.
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(10),
+        "store-time validation should be capped by the budget, took {:?}",
+        started.elapsed()
+    );
+
+    assert!(result.value.has_token);
+    let log_text = result.logs.join(" ");
+    assert!(
+        log_text.contains("session JWT accepted with deferred GET /auth/me validation"),
+        "expected deferred validation log after budget timeout, got: {log_text}"
+    );
+    let state = auth_get_state(&config).await.unwrap().value;
+    assert!(state.is_authenticated);
+    assert_eq!(
+        state.user,
+        Some(json!({ "pendingBackendValidation": true })),
+        "budget-timeout fallback must not copy identity claims from an unverified JWT"
+    );
+}
+
+#[test]
+fn auth_me_store_validation_budget_reads_env_override() {
+    let _env_guard = crate::openhuman::config::TEST_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    {
+        let _guard = EnvVarGuard::set(AUTH_ME_STORE_VALIDATION_BUDGET_ENV, "750");
+        assert_eq!(
+            auth_me_store_validation_budget(),
+            std::time::Duration::from_millis(750)
+        );
+    }
+    // Invalid / non-positive overrides fall back to the compiled default.
+    {
+        let _guard = EnvVarGuard::set(AUTH_ME_STORE_VALIDATION_BUDGET_ENV, "0");
+        assert_eq!(
+            auth_me_store_validation_budget(),
+            AUTH_ME_STORE_VALIDATION_BUDGET
+        );
+    }
+    {
+        let _guard = EnvVarGuard::set(AUTH_ME_STORE_VALIDATION_BUDGET_ENV, "not-a-number");
+        assert_eq!(
+            auth_me_store_validation_budget(),
+            AUTH_ME_STORE_VALIDATION_BUDGET
+        );
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Bound the store-time `GET /auth/me` sign-in validation to a **12s budget** (was the shared backend client's 120s request ceiling), well under the desktop sign-in RPC timeout.
- On budget exhaustion, return a transient-classified timeout so a live-`exp` JWT routes into the existing caller-authorized **deferred-validation** path instead of hanging.
- Net effect: a reachable-but-slow backend no longer bounces a genuinely-authenticated user back to sign-in — they land in the app with deferred revalidation.
- Budget is overridable via `OPENHUMAN_AUTH_ME_STORE_TIMEOUT_MS` (documented in `.env.example`).

## Problem

Sentry `TAURI-REACT-1V` — `Error: auth store failed: auth_me_timeout` (26 events, 4 users, production).

Tracing the invariant *"a valid, OAuth-succeeded session must not bounce back to sign-in"* backward:

- Store-time `GET /auth/me` validation in `fetch_current_user_for_session_store` (`src/openhuman/security/credentials/ops.rs`) runs on the shared `BackendOAuthClient`'s **120s** request timeout (`src/api/rest.rs:279-280`).
- The desktop sign-in RPC that drives `auth_store_session` gives up far sooner — `AUTH_STORE_TIMEOUT_MS` (25s) × `AUTH_STORE_RETRIES` (2) in `app/src/utils/desktopDeepLinkListener.ts`.
- So a **reachable-but-slow** backend lets `/auth/me` hang past the frontend's patience: the RPC times out and bounces the user **before** the existing `allowPendingBackendValidation` deferred-validation fallback (ops.rs, which persists a live-`exp` JWT for later revalidation) ever gets a chance to fire.

PR #5171 already downgraded the Sentry level to `warning` for transient kinds — that reduced noise but did not close the user-facing bounce, because the fast-fail-into-deferred path still couldn't trigger under a slow backend.

## Solution

- Wrap the store-time `/auth/me` call in `tokio::time::timeout(auth_me_store_validation_budget())`; the prior body becomes `fetch_current_user_for_session_store_inner`.
- On elapse, return `"GET /auth/me validation timeout after {ms}ms (store-time budget exceeded)"` — worded to contain a `TRANSIENT_TRANSPORT_PHRASES` phrase (`"timeout"`) so the existing `auth_me_store_failure_is_transient` classifier buckets it as transient and `store_session_inner` routes a live-`exp` JWT into the deferred-validation branch.
- Default budget **12s** (`AUTH_ME_STORE_VALIDATION_BUDGET`), comfortably under the frontend's 25s outer bound; overridable via `OPENHUMAN_AUTH_ME_STORE_TIMEOUT_MS` for ops tuning/tests. Invalid/non-positive overrides fall back to the default.
- Logic lives in the Rust core (per repo convention); no frontend change needed — the 25s RPC bound stays correct and now covers the 12s inner budget with headroom.

Design note: the fallback still requires a locally-valid JWT (`jwt_exp_live_at`) and stores only `{ pendingBackendValidation: true }` — it does **not** copy identity claims from an unverified token, so this does not weaken the auth contract. A genuine `401`/non-transient failure is unaffected and still hard-fails to sign-in.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy
- [x] **Diff coverage ≥ 80%** — new lines exercised by the two new tests (`pnpm test:rust` locally); the timeout `Err` branch, budget resolver, and warn path are all covered
- [x] N/A — Coverage matrix: behaviour-only change to an existing sign-in path (no added/removed/renamed feature row)
- [x] All affected feature IDs from the matrix are listed under `## Related` — N/A (behaviour-only)
- [x] No new external network dependencies introduced (tests use an in-process axum mock backend)
- [x] N/A — Manual smoke checklist: no release-cut surface changed (internal timeout bound + env var only)
- [x] Linked issue closed via `Closes #5166` in `## Related`

## Impact

- **Desktop sign-in (all platforms).** A slow-but-reachable backend now yields a successful pending-validation sign-in within ~12s instead of a ~50s bounce to the login page. No behaviour change on a healthy backend (healthy `/auth/me` responds well under 1s).
- **Security:** unchanged — deferred fallback still gated on a live-`exp` JWT and never copies identity claims; non-transient (`401`) failures still hard-fail.
- **Migration/compat:** none. New env var is optional with a safe default.

## Related

- Closes: #5166
- Follow-up PR(s)/TODOs: optional JSON-RPC E2E assertion for the budget path (unit coverage currently sufficient)

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/auth-me-store-timeout-5166`
- Commit SHA: 87fd774ec

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A (no `app/src` changes)
- [x] `pnpm typecheck` — N/A (no TS changes)
- [x] Focused tests: `cargo test --lib security::credentials::ops` — 50 passed
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean, `cargo clippy --lib` clean
- [x] Tauri fmt/check (if changed): N/A (core crate only)

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: slow-backend store-time `/auth/me` fails fast into deferred validation instead of hanging until the sign-in RPC bounces the user.
- User-visible effect: sign-in succeeds (pending revalidation) under a slow backend rather than returning to the login page.

### Parity Contract

- Legacy behavior preserved: healthy backend, `401`/non-transient failures, and non-live-`exp` tokens behave exactly as before.
- Guard/fallback/dispatch parity checks: `auth_me_store_failure_is_transient` classification and the `jwt_exp_live_at` gate are unchanged; only the trigger (timeout vs. upstream error) is new.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution: complements #5171 (Sentry level downgrade); does not supersede it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable 12-second timeout for sign-in session validation.
  * Added support for customizing the timeout through `OPENHUMAN_AUTH_ME_STORE_TIMEOUT_MS`.
  * Slow validation services now defer eligible live-session checks rather than blocking sign-in.

* **Bug Fixes**
  * Preserved valid sessions when authentication validation times out.
  * Prevented unverified identity information from being reused after validation timeouts.

* **Documentation**
  * Added the new timeout setting and its default value to the example configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->