### PR TITLE
fix(config): stop transient active_user.toml read faults from resetting the profile

### DIFF
--- a/src/openhuman/config/schema/load/dirs.rs
+++ b/src/openhuman/config/schema/load/dirs.rs
@@ -7,8 +7,13 @@ use tokio::fs;
 
 pub use load_user_state::{
     active_user_marker_path, clear_active_user, pre_login_user_dir, read_active_user_id,
-    read_active_user_id_checked, user_openhuman_dir, write_active_user_id, PRE_LOGIN_USER_ID,
+    read_active_user_id_checked_async, user_openhuman_dir, write_active_user_id, PRE_LOGIN_USER_ID,
 };
+// Sync variant is consumed only by the `read_active_user_id` wrapper (in
+// load_user_state) and the load_tests module; the async resolver below uses
+// `read_active_user_id_checked_async`.
+#[cfg(test)]
+pub use load_user_state::read_active_user_id_checked;
 
 #[path = "../load_user_state.rs"]
 mod load_user_state;
@@ -324,15 +329,16 @@ pub(super) async fn resolve_config_dirs_ignoring_env(
     default_openhuman_dir: &Path,
     default_workspace_dir: &Path,
 ) -> Result<(PathBuf, PathBuf, ConfigResolutionSource)> {
-    // `read_active_user_id_checked` (not the lossy `read_active_user_id`): a
-    // transient read fault on an *existing* marker propagates as an error here
+    // `read_active_user_id_checked_async` (not the lossy `read_active_user_id`):
+    // a transient read fault on an *existing* marker propagates as an error here
     // instead of masquerading as "no active user". Falling through to the
     // pre-login directory in that case boots a signed-in user into a fresh,
     // empty `users/local` profile and orphans their real data under
     // `users/<id>` — the "app reset itself" symptom (#5334). Failing the boot
     // loudly (and retrying on the next launch, once the file lock clears) keeps
-    // the data intact.
-    if let Some(user_id) = read_active_user_id_checked(default_openhuman_dir)? {
+    // the data intact. The async variant is used so the transient-lock backoff
+    // does not block a tokio worker with `std::thread::sleep`.
+    if let Some(user_id) = read_active_user_id_checked_async(default_openhuman_dir).await? {
         let user_dir = user_openhuman_dir(default_openhuman_dir, &user_id);
         let user_workspace = user_dir.join("workspace");
         tracing::debug!(

--- a/src/openhuman/config/schema/load/dirs.rs
+++ b/src/openhuman/config/schema/load/dirs.rs
@@ -7,7 +7,7 @@ use tokio::fs;
 
 pub use load_user_state::{
     active_user_marker_path, clear_active_user, pre_login_user_dir, read_active_user_id,
-    user_openhuman_dir, write_active_user_id, PRE_LOGIN_USER_ID,
+    read_active_user_id_checked, user_openhuman_dir, write_active_user_id, PRE_LOGIN_USER_ID,
 };
 
 #[path = "../load_user_state.rs"]
@@ -324,7 +324,15 @@ pub(super) async fn resolve_config_dirs_ignoring_env(
     default_openhuman_dir: &Path,
     default_workspace_dir: &Path,
 ) -> Result<(PathBuf, PathBuf, ConfigResolutionSource)> {
-    if let Some(user_id) = read_active_user_id(default_openhuman_dir) {
+    // `read_active_user_id_checked` (not the lossy `read_active_user_id`): a
+    // transient read fault on an *existing* marker propagates as an error here
+    // instead of masquerading as "no active user". Falling through to the
+    // pre-login directory in that case boots a signed-in user into a fresh,
+    // empty `users/local` profile and orphans their real data under
+    // `users/<id>` — the "app reset itself" symptom (#5334). Failing the boot
+    // loudly (and retrying on the next launch, once the file lock clears) keeps
+    // the data intact.
+    if let Some(user_id) = read_active_user_id_checked(default_openhuman_dir)? {
         let user_dir = user_openhuman_dir(default_openhuman_dir, &user_id);
         let user_workspace = user_dir.join("workspace");
         tracing::debug!(

--- a/src/openhuman/config/schema/load/mod.rs
+++ b/src/openhuman/config/schema/load/mod.rs
@@ -28,6 +28,10 @@ pub(crate) use impl_load::CONFIG_OWNER_MISMATCH_MARKER;
 // Tests are a submodule of `load`, so `super::*` == this module's namespace.
 #[cfg(test)]
 pub(crate) use dirs::default_root_dir_name_pub as default_root_dir_name;
+// The strict active-user read is consumed by the resolver via `dirs`'s own
+// re-export; only the load_tests module needs it visible at this level.
+#[cfg(test)]
+pub(crate) use dirs::read_active_user_id_checked;
 #[cfg(test)]
 pub(crate) use dirs::{
     resolve_config_dir_for_workspace, resolve_runtime_config_dirs,

--- a/src/openhuman/config/schema/load_tests.rs
+++ b/src/openhuman/config/schema/load_tests.rs
@@ -38,6 +38,62 @@ fn write_and_clear_active_user_roundtrip() {
 }
 
 #[test]
+fn read_active_user_checked_returns_none_when_no_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert!(read_active_user_id_checked(tmp.path()).unwrap().is_none());
+}
+
+#[test]
+fn read_active_user_checked_returns_none_when_empty() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join(ACTIVE_USER_STATE_FILE), "").unwrap();
+    assert!(read_active_user_id_checked(tmp.path()).unwrap().is_none());
+}
+
+#[test]
+fn read_active_user_checked_returns_id_when_present() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_active_user_id(tmp.path(), "user-checked").unwrap();
+    assert_eq!(
+        read_active_user_id_checked(tmp.path()).unwrap(),
+        Some("user-checked".to_string())
+    );
+}
+
+#[test]
+fn read_active_user_checked_errors_when_marker_unreadable() {
+    // A marker that EXISTS but cannot be read as a file (here: a directory at
+    // the marker path) must surface an error rather than being laundered into
+    // "signed out". Otherwise a returning user is silently downgraded to the
+    // pre-login profile and their data under users/<id> is orphaned (#5334).
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join(ACTIVE_USER_STATE_FILE)).unwrap();
+    assert!(read_active_user_id_checked(tmp.path()).is_err());
+
+    // The best-effort wrapper still collapses to `None` for hint-only callers.
+    assert!(read_active_user_id(tmp.path()).is_none());
+}
+
+#[tokio::test]
+async fn resolve_dirs_errors_instead_of_pre_login_when_marker_unreadable() {
+    // End-to-end: an unreadable active_user.toml must make directory
+    // resolution FAIL rather than silently resolve to users/local — the path
+    // that presents a signed-in user with a fresh, empty profile (#5334).
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    std::fs::create_dir_all(root.join(ACTIVE_USER_STATE_FILE)).unwrap();
+
+    let default_workspace = root.join("workspace");
+    let result =
+        resolve_runtime_config_dirs_with(root, &default_workspace, &MapEnv::default()).await;
+
+    assert!(
+        result.is_err(),
+        "unreadable marker must not silently fall back to the pre-login profile"
+    );
+}
+
+#[test]
 fn user_openhuman_dir_builds_correct_path() {
     let root = PathBuf::from("/home/test/.openhuman");
     let dir = user_openhuman_dir(&root, "user-123");

--- a/src/openhuman/config/schema/load_user_state.rs
+++ b/src/openhuman/config/schema/load_user_state.rs
@@ -22,18 +22,95 @@ pub fn active_user_marker_path(default_openhuman_dir: &Path) -> PathBuf {
     default_openhuman_dir.join(ACTIVE_USER_STATE_FILE)
 }
 
-/// Reads the active user id from `{default_openhuman_dir}/active_user.toml`.
-/// Returns `None` when the file does not exist, is empty, or cannot be parsed.
-pub fn read_active_user_id(default_openhuman_dir: &Path) -> Option<String> {
+/// Reads the active user id, distinguishing a legitimately signed-out state
+/// (`Ok(None)`) from a transient/unexpected failure to read an *existing*
+/// marker (`Err`).
+///
+/// - `Ok(None)` — the marker is absent, empty, or holds a whitespace-only or
+///   unparseable id. The user is signed out; callers resolve to the pre-login
+///   directory.
+/// - `Ok(Some(id))` — the active user is `id`.
+/// - `Err(_)` — the marker could not be read for a reason other than "not
+///   found" (e.g. a Windows `ERROR_SHARING_VIOLATION`/`ERROR_ACCESS_DENIED`
+///   from an antivirus, backup, or search-indexer briefly locking the file, or
+///   a permission fault). The read is retried with backoff first; a persistent
+///   failure is surfaced rather than laundered into `None`.
+///
+/// Laundering a transient read fault into `None` is the root cause of the
+/// "app reset itself" data-loss reports (#5334): the directory resolver would
+/// treat "can't read the marker" as "signed out" and boot the user into
+/// `users/local` — a fresh, empty profile — while their real avatar, settings,
+/// and memory sit intact under `users/<id>`. The `config.toml` read is already
+/// retry-guarded (`read_config_with_recovery_or_default`); the marker that
+/// decides *which* config to load must be at least as resilient.
+pub fn read_active_user_id_checked(default_openhuman_dir: &Path) -> Result<Option<String>> {
     let path = active_user_marker_path(default_openhuman_dir);
-    let contents = std::fs::read_to_string(&path).ok()?;
-    let state: ActiveUserState = toml::from_str(&contents).ok()?;
+
+    let read_once = || -> Result<String> {
+        std::fs::read_to_string(&path)
+            .with_context(|| format!("read active user marker: {}", path.display()))
+    };
+
+    // `retry_with_backoff` bails immediately on a non-transient error (incl.
+    // `NotFound`), and only re-attempts the Windows file-lock class of faults —
+    // exactly the resilience the config-file read already has.
+    let contents =
+        match crate::openhuman::util::retry_with_backoff("read active_user.toml", 4, 20, read_once)
+        {
+            Ok(contents) => contents,
+            Err(err) => {
+                // A genuinely missing marker is the expected signed-out state, not a
+                // fault: fall through to the pre-login profile exactly as before.
+                let missing = err.chain().any(|cause| {
+                    cause
+                        .downcast_ref::<std::io::Error>()
+                        .is_some_and(|io| io.kind() == std::io::ErrorKind::NotFound)
+                });
+                if missing {
+                    return Ok(None);
+                }
+                tracing::warn!(
+                    path = %path.display(),
+                    error = %format!("{err:#}"),
+                    "[config] active_user.toml exists but could not be read; refusing to \
+                     downgrade to the pre-login profile so a signed-in user's data under \
+                     users/<id> is not orphaned"
+                );
+                return Err(err);
+            }
+        };
+
+    // A corrupt (unparseable) marker cannot identify the active user. Treat it
+    // as signed-out rather than an error: the id is re-established atomically on
+    // the next login, and failing the whole boot on a malformed tiny file would
+    // be worse than resolving to the pre-login profile.
+    let state: ActiveUserState = match toml::from_str(&contents) {
+        Ok(state) => state,
+        Err(parse_err) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %parse_err,
+                "[config] active_user.toml is unparseable; treating as signed out"
+            );
+            return Ok(None);
+        }
+    };
     let id = state.user_id.trim().to_string();
-    if id.is_empty() {
-        None
-    } else {
-        Some(id)
-    }
+    Ok(if id.is_empty() { None } else { Some(id) })
+}
+
+/// Best-effort variant of [`read_active_user_id_checked`]: a transient or
+/// unexpected read failure collapses to `None`.
+///
+/// Retained for callers that only need a hint (session-present guards,
+/// informational logging) and can tolerate a false "signed out" on a transient
+/// fault. The **directory-resolution** path must use
+/// [`read_active_user_id_checked`] instead so it never silently orphans a
+/// signed-in user's data (#5334).
+pub fn read_active_user_id(default_openhuman_dir: &Path) -> Option<String> {
+    read_active_user_id_checked(default_openhuman_dir)
+        .ok()
+        .flatten()
 }
 
 /// Writes the active user id to `{default_openhuman_dir}/active_user.toml`.

--- a/src/openhuman/config/schema/load_user_state.rs
+++ b/src/openhuman/config/schema/load_user_state.rs
@@ -45,40 +45,74 @@ pub fn active_user_marker_path(default_openhuman_dir: &Path) -> PathBuf {
 /// decides *which* config to load must be at least as resilient.
 pub fn read_active_user_id_checked(default_openhuman_dir: &Path) -> Result<Option<String>> {
     let path = active_user_marker_path(default_openhuman_dir);
-
-    let read_once = || -> Result<String> {
-        std::fs::read_to_string(&path)
-            .with_context(|| format!("read active user marker: {}", path.display()))
-    };
-
     // `retry_with_backoff` bails immediately on a non-transient error (incl.
     // `NotFound`), and only re-attempts the Windows file-lock class of faults —
-    // exactly the resilience the config-file read already has.
-    let contents =
-        match crate::openhuman::util::retry_with_backoff("read active_user.toml", 4, 20, read_once)
-        {
-            Ok(contents) => contents,
-            Err(err) => {
-                // A genuinely missing marker is the expected signed-out state, not a
-                // fault: fall through to the pre-login profile exactly as before.
-                let missing = err.chain().any(|cause| {
-                    cause
-                        .downcast_ref::<std::io::Error>()
-                        .is_some_and(|io| io.kind() == std::io::ErrorKind::NotFound)
-                });
-                if missing {
-                    return Ok(None);
-                }
-                tracing::warn!(
-                    path = %path.display(),
-                    error = %format!("{err:#}"),
-                    "[config] active_user.toml exists but could not be read; refusing to \
-                     downgrade to the pre-login profile so a signed-in user's data under \
-                     users/<id> is not orphaned"
-                );
-                return Err(err);
+    // exactly the resilience the config-file read already has. This variant is
+    // synchronous for the best-effort sync callers reached via
+    // [`read_active_user_id`]; async callers must use
+    // [`read_active_user_id_checked_async`] to avoid blocking sleeps.
+    let read = crate::openhuman::util::retry_with_backoff("read active_user.toml", 4, 20, || {
+        std::fs::read_to_string(&path)
+            .with_context(|| format!("read active user marker: {}", path.display()))
+    });
+    interpret_active_user_marker(&path, read)
+}
+
+/// Async counterpart of [`read_active_user_id_checked`] for callers already on
+/// the tokio executor (the config-directory resolver).
+///
+/// It retries with `retry_with_backoff_async` so a transient-lock backoff never
+/// blocks a worker thread with `std::thread::sleep` — the same reason the
+/// `config.toml` read uses the async helper
+/// (`read_config_with_recovery_or_default`). The outcome classification
+/// (missing → `Ok(None)`, other read fault → `Err`, unparseable → `Ok(None)`)
+/// is shared with the sync variant so the two cannot drift.
+pub async fn read_active_user_id_checked_async(
+    default_openhuman_dir: &Path,
+) -> Result<Option<String>> {
+    let path = active_user_marker_path(default_openhuman_dir);
+    let read =
+        crate::openhuman::util::retry_with_backoff_async("read active_user.toml", 4, 20, || {
+            let path = path.clone();
+            async move {
+                tokio::fs::read_to_string(&path)
+                    .await
+                    .with_context(|| format!("read active user marker: {}", path.display()))
             }
-        };
+        })
+        .await;
+    interpret_active_user_marker(&path, read)
+}
+
+/// Shared classification of an (already retried) active-user marker read, so the
+/// sync and async readers above cannot drift. Maps the raw read result to the
+/// active user id, applying the missing/unparseable → signed-out and
+/// unexpected-fault → error policy documented on
+/// [`read_active_user_id_checked`].
+fn interpret_active_user_marker(path: &Path, read: Result<String>) -> Result<Option<String>> {
+    let contents = match read {
+        Ok(contents) => contents,
+        Err(err) => {
+            // A genuinely missing marker is the expected signed-out state, not a
+            // fault: fall through to the pre-login profile exactly as before.
+            let missing = err.chain().any(|cause| {
+                cause
+                    .downcast_ref::<std::io::Error>()
+                    .is_some_and(|io| io.kind() == std::io::ErrorKind::NotFound)
+            });
+            if missing {
+                return Ok(None);
+            }
+            tracing::warn!(
+                path = %path.display(),
+                error = %format!("{err:#}"),
+                "[config] active_user.toml exists but could not be read; refusing to \
+                 downgrade to the pre-login profile so a signed-in user's data under \
+                 users/<id> is not orphaned"
+            );
+            return Err(err);
+        }
+    };
 
     // A corrupt (unparseable) marker cannot identify the active user. Treat it
     // as signed-out rather than an error: the id is re-established atomically on


### PR DESCRIPTION
## Summary

- Fixes user reports that the app "resets itself" — avatar, settings, and memory disappear as if freshly installed after a restart, background update, or period of inactivity.
- Root cause is **error-type laundering**, not disk corruption: `read_active_user_id` collapsed *every* `std::fs::read_to_string` error into `None`, so a transient read fault on an existing `active_user.toml` was indistinguishable from the file being genuinely absent.
- The config-directory resolver then treated that `None` as "no active user" and booted a signed-in user into the pre-login `users/local` profile, orphaning their real data under `users/<id>`.
- Adds `read_active_user_id_checked` (retry-with-backoff + surfaces non-`NotFound` faults) and wires it into `resolve_config_dirs_ignoring_env` so a transient marker-read failure fails the boot loudly and retries next launch instead of silently downgrading.

## Problem

`active_user.toml` (the root-level marker that records *which* user is active) decides whether config/memory resolve to `users/<id>` or the pre-login `users/local` directory.

`read_active_user_id` read it with `std::fs::read_to_string(&path).ok()?` — laundering `NotFound` (legitimately signed out) and a transient `ERROR_SHARING_VIOLATION` / `ERROR_ACCESS_DENIED` (a Windows antivirus, backup, or search-indexer briefly locking the file) into the same `None`. `resolve_config_dirs_ignoring_env` (`src/openhuman/config/schema/load/dirs.rs`) treats `None` as "no active user" and falls through to `pre_login_user_dir` — a fresh, empty profile — while the user's avatar, settings, and memory sit intact under `users/<id>`.

The asymmetry is the tell: the `config.toml` read is already wrapped in `retry_with_backoff_async(..., 5, 20, ...)`, but the marker that decides *which* config to load had zero resilience and silently mis-resolved on the first transient lock. This matches the reported trigger ("after a background update, restart, or prolonged inactivity") without requiring any file corruption.

## Solution

- New `read_active_user_id_checked(dir) -> Result<Option<String>>`:
  - `Ok(None)` — marker absent (`NotFound`), empty, or unparseable → legitimately signed out; resolve to pre-login as before.
  - `Ok(Some(id))` — active user is `id`.
  - `Err(_)` — marker exists but couldn't be read; retried via the shared `retry_with_backoff` (same transient-fs classification the config read uses), then surfaced rather than laundered.
- `resolve_config_dirs_ignoring_env` now calls the checked variant and propagates `Err`, so a transient marker-read fault fails the boot (recoverable on the next launch once the lock clears) instead of orphaning data. `NotFound` still falls through to pre-login, so first-run and signed-out flows are unchanged.
- `read_active_user_id` is kept as a thin best-effort wrapper (`.ok().flatten()`) for hint-only callers (session-present guards, informational logging) that can tolerate a false "signed out" on a transient fault. Those callers still benefit from the added retry.

Design decision: a corrupt/unparseable marker returns `Ok(None)` (re-established atomically on next login) rather than failing the whole boot on a malformed tiny file. Only a real read fault on an existing marker errors.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — 5 new Rust tests cover the happy path, empty/unparseable marker, absent marker, the transient-fault→`Err` surface, the lossy-wrapper fallback, and end-to-end resolver propagation. Rust-only change; `cargo-llvm-cov` lcov covers the changed lines.
- [x] Coverage matrix updated — `N/A: behaviour-only fix to an existing config-resolution path; no feature row added/removed/renamed`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature IDs touched`
- [x] No new external network dependencies introduced (reuses the in-crate `util::retry_with_backoff`)
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no new user-facing surface; internal boot-time resolution hardening`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Platform:** desktop (Windows/macOS/Linux) core. The transient-lock trigger is most common on Windows (mandatory file locking), which `retry_with_backoff` already targets.
- **Behavior change:** a transient/permission fault reading an existing `active_user.toml` now fails config resolution loudly instead of silently resolving to the pre-login profile. No change to the signed-out / first-run path (`NotFound` → pre-login as before).
- **Security/migration:** none. No schema, wire, or on-disk format change.

## Related

- Closes: #5334
- Follow-up PR(s)/TODOs: the same `read_active_user_id` hint-only callers (`security/encryption/core.rs`, `security/credentials/ops.rs`, `desktop/app_state/ops.rs`, `core/runtime/services.rs`) still collapse a transient fault to `None`; they benefit from the added retry but could adopt the checked variant where a wrong data dir matters (out of scope here to keep the change focused).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `wt-5334-data-reset`
- Commit SHA: `093ce9474` (fix), `5a4373efe` (merge of upstream/main)

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no `app/` changes
- [x] `pnpm typecheck` — N/A: no TypeScript changes
- [x] Focused tests: `cargo test --lib config::schema::load` (322 pass; 5 new pass)
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo check` + `cargo clippy --lib` clean
- [x] Tauri fmt/check (if changed): N/A: no `app/src-tauri/` changes

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: a transient/permission read fault on an existing `active_user.toml` fails config resolution instead of silently resolving to the pre-login `users/local` profile.
- User-visible effect: a returning signed-in user no longer sees a fresh/empty profile after a transient marker-read failure; their data under `users/<id>` is preserved.

### Parity Contract

- Legacy behavior preserved: absent/empty/unparseable marker still resolves to the pre-login profile (`read_active_user_returns_none_*` tests + new `_checked` equivalents pin this).
- Guard/fallback/dispatch parity checks: `read_active_user_id` retains its `Option<String>` signature for all existing best-effort callers; only the directory resolver switched to the strict variant.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration loading when the active-user marker cannot be read.
  - Persistent access errors are now reported instead of silently falling back to the pre-login profile.
  - Missing, empty, whitespace-only, or malformed markers continue to be handled safely as no active user.
  - Added retry handling for temporary marker-read failures, improving reliability during startup.
  - Synchronous and asynchronous marker reads now provide consistent error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->