### PR TITLE
fix(config): surface a user notice when a corrupt config.toml is reset (#5167)

### DIFF
--- a/app/src/lib/configRecoveryNotice.test.ts
+++ b/app/src/lib/configRecoveryNotice.test.ts
@@ -3,6 +3,11 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { store } from '../store';
 import { __resetForTests, maybeSurfaceConfigRecovery } from './configRecoveryNotice';
 
+// Fallback translator matching `useT()`'s `t(key, fallback?)` contract: return
+// the English fallback so assertions read the default copy, and echo the key
+// when no fallback is given so key wiring is observable.
+const t = (key: string, fallback?: string): string => fallback ?? key;
+
 describe('maybeSurfaceConfigRecovery', () => {
   beforeEach(() => {
     __resetForTests();
@@ -10,26 +15,38 @@ describe('maybeSurfaceConfigRecovery', () => {
   });
 
   it('surfaces a single system notice when config was recovered', () => {
-    maybeSurfaceConfigRecovery(true);
+    maybeSurfaceConfigRecovery(true, t);
     const items = store.getState().notifications.items;
     expect(items).toHaveLength(1);
     expect(items[0].id).toBe('config-recovered');
     expect(items[0].category).toBe('system');
-    expect(items[0].title).toBe('Settings were reset');
+    expect(items[0].title).toBe('Settings file recovered');
+    // Copy must be accurate for both recovery outcomes (backup restore OR
+    // defaults reset) — it must not hard-claim "reset to defaults" (#5167).
+    expect(items[0].body).toContain('restored from a backup or reset to');
     expect(items[0].read).toBe(false);
     expect(items[0].deepLink).toBe('/settings');
   });
 
+  it('localizes via the translator keys', () => {
+    // A key-echoing translator proves the notice pulls copy from i18n keys
+    // rather than hardcoded strings.
+    maybeSurfaceConfigRecovery(true, key => key);
+    const item = store.getState().notifications.items[0];
+    expect(item.title).toBe('notifications.configRecovered.title');
+    expect(item.body).toBe('notifications.configRecovered.body');
+  });
+
   it('is a one-shot — repeated polls do not re-dispatch', () => {
-    maybeSurfaceConfigRecovery(true);
-    maybeSurfaceConfigRecovery(true);
-    maybeSurfaceConfigRecovery(true);
+    maybeSurfaceConfigRecovery(true, t);
+    maybeSurfaceConfigRecovery(true, t);
+    maybeSurfaceConfigRecovery(true, t);
     expect(store.getState().notifications.items).toHaveLength(1);
   });
 
   it('does nothing when configRecovered is false or absent', () => {
-    maybeSurfaceConfigRecovery(false);
-    maybeSurfaceConfigRecovery(undefined);
+    maybeSurfaceConfigRecovery(false, t);
+    maybeSurfaceConfigRecovery(undefined, t);
     expect(store.getState().notifications.items).toHaveLength(0);
   });
 });

--- a/app/src/lib/configRecoveryNotice.test.ts
+++ b/app/src/lib/configRecoveryNotice.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { store } from '../store';
+import { __resetForTests, maybeSurfaceConfigRecovery } from './configRecoveryNotice';
+
+describe('maybeSurfaceConfigRecovery', () => {
+  beforeEach(() => {
+    __resetForTests();
+    store.dispatch({ type: 'notifications/clearAll' });
+  });
+
+  it('surfaces a single system notice when config was recovered', () => {
+    maybeSurfaceConfigRecovery(true);
+    const items = store.getState().notifications.items;
+    expect(items).toHaveLength(1);
+    expect(items[0].id).toBe('config-recovered');
+    expect(items[0].category).toBe('system');
+    expect(items[0].title).toBe('Settings were reset');
+    expect(items[0].read).toBe(false);
+    expect(items[0].deepLink).toBe('/settings');
+  });
+
+  it('is a one-shot — repeated polls do not re-dispatch', () => {
+    maybeSurfaceConfigRecovery(true);
+    maybeSurfaceConfigRecovery(true);
+    maybeSurfaceConfigRecovery(true);
+    expect(store.getState().notifications.items).toHaveLength(1);
+  });
+
+  it('does nothing when configRecovered is false or absent', () => {
+    maybeSurfaceConfigRecovery(false);
+    maybeSurfaceConfigRecovery(undefined);
+    expect(store.getState().notifications.items).toHaveLength(0);
+  });
+});

--- a/app/src/lib/configRecoveryNotice.ts
+++ b/app/src/lib/configRecoveryNotice.ts
@@ -14,6 +14,25 @@ const log = debug('config-recovery-notice');
 const NOTICE_ID = 'config-recovered';
 
 /**
+ * i18n keys for the notice copy. English fallbacks are passed alongside so the
+ * notice still renders if a locale lacks the key (the `t(key, fallback)`
+ * contract). Wording is deliberately accurate for *both* recovery outcomes —
+ * the core sets one `configRecovered` flag whether it restored the previous
+ * settings from a `.bak` backup or reset to defaults, so the copy must not
+ * claim a hard "reset to defaults" that would be wrong in the backup case
+ * (#5167).
+ */
+const TITLE_KEY = 'notifications.configRecovered.title';
+const BODY_KEY = 'notifications.configRecovered.body';
+const TITLE_FALLBACK = 'Settings file recovered';
+const BODY_FALLBACK =
+  'Your settings file could not be read, so it was restored from a backup or reset to ' +
+  'defaults. The unreadable file was kept with a ".corrupted" suffix in case you need it.';
+
+/** Minimal translator contract — matches `useT()`'s `t(key, fallback?)`. */
+type TranslateFn = (key: string, fallback?: string) => string;
+
+/**
  * One-shot guard: the core latches `configRecovered` for the whole process
  * lifetime, so every `app_state_snapshot` poll (~every few seconds) reports it.
  * Without this guard each poll would re-dispatch the notice, resetting it to
@@ -29,8 +48,14 @@ let surfaced = false;
  * Rendered in the in-app notification center (System category) and, when the
  * window is unfocused, as an OS banner — the same surface as other
  * core-originated system notices.
+ *
+ * `t` localizes the copy against the active locale; pass it from a hook-aware
+ * caller (e.g. `CoreStateProvider` via `useT()`).
  */
-export function maybeSurfaceConfigRecovery(configRecovered: boolean | undefined): void {
+export function maybeSurfaceConfigRecovery(
+  configRecovered: boolean | undefined,
+  t: TranslateFn
+): void {
   if (!configRecovered || surfaced) return;
   surfaced = true;
   log('surfacing config-recovery notice');
@@ -38,8 +63,8 @@ export function maybeSurfaceConfigRecovery(configRecovered: boolean | undefined)
     notificationReceived({
       id: NOTICE_ID,
       category: 'system',
-      title: 'Settings were reset',
-      body: 'Your settings file could not be read and was reset to defaults. The previous file was kept with a ".corrupted" suffix in case you need it.',
+      title: t(TITLE_KEY, TITLE_FALLBACK),
+      body: t(BODY_KEY, BODY_FALLBACK),
       timestamp: Date.now(),
       read: false,
       deepLink: '/settings',

--- a/app/src/lib/configRecoveryNotice.ts
+++ b/app/src/lib/configRecoveryNotice.ts
@@ -1,0 +1,53 @@
+import debug from 'debug';
+
+import { store } from '../store';
+import { notificationReceived } from '../store/notificationSlice';
+
+const log = debug('config-recovery-notice');
+
+/**
+ * Stable id so repeated snapshot polls that carry the latched
+ * `configRecovered` flag collapse onto a single notification-center row
+ * (`notificationReceived` dedupes by id). The once-guard below is the primary
+ * defence; this id keeps things idempotent even across it.
+ */
+const NOTICE_ID = 'config-recovered';
+
+/**
+ * One-shot guard: the core latches `configRecovered` for the whole process
+ * lifetime, so every `app_state_snapshot` poll (~every few seconds) reports it.
+ * Without this guard each poll would re-dispatch the notice, resetting it to
+ * unread and re-firing the native banner. Surface it exactly once per app run.
+ */
+let surfaced = false;
+
+/**
+ * Raise a single user-visible notice when the core reports it recovered a
+ * corrupted `config.toml` this session (#5167). No-op when `configRecovered`
+ * is false/absent or the notice was already shown this run.
+ *
+ * Rendered in the in-app notification center (System category) and, when the
+ * window is unfocused, as an OS banner — the same surface as other
+ * core-originated system notices.
+ */
+export function maybeSurfaceConfigRecovery(configRecovered: boolean | undefined): void {
+  if (!configRecovered || surfaced) return;
+  surfaced = true;
+  log('surfacing config-recovery notice');
+  store.dispatch(
+    notificationReceived({
+      id: NOTICE_ID,
+      category: 'system',
+      title: 'Settings were reset',
+      body: 'Your settings file could not be read and was reset to defaults. The previous file was kept with a ".corrupted" suffix in case you need it.',
+      timestamp: Date.now(),
+      read: false,
+      deepLink: '/settings',
+    })
+  );
+}
+
+/** Test-only: reset the once-guard between runs. */
+export function __resetForTests(): void {
+  surfaced = false;
+}

--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -7076,6 +7076,9 @@ const messages: TranslationMap = {
   'sync.pipeline.extractionFailed': 'فشل استخراج بنية الذاكرة. قد يكون الويكي غير مكتمل.',
   'sync.pipeline.treeDegraded': 'شجرة الذاكرة متدهورة. قد يُرجع الاسترجاع نتائج قديمة.',
   'sync.pipeline.viewHealth': 'عرض حالة الذاكرة',
+  'notifications.configRecovered.title': 'تمت استعادة ملف الإعدادات',
+  'notifications.configRecovered.body':
+    'تعذّرت قراءة ملف الإعدادات، لذا تمت استعادته من نسخة احتياطية أو إعادة تعيينه إلى الإعدادات الافتراضية. تم الاحتفاظ بالملف غير القابل للقراءة باللاحقة ".corrupted" في حال احتجت إليه.',
 };
 
 export default messages;

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -7236,6 +7236,9 @@ const messages: TranslationMap = {
   'sync.pipeline.extractionFailed': 'মেমরি কাঠামো নিষ্কাশন ব্যর্থ হয়েছে। উইকি অসম্পূর্ণ হতে পারে।',
   'sync.pipeline.treeDegraded': 'মেমরি ট্রি অবনমিত। পুনরুদ্ধার পুরনো ফলাফল দিতে পারে।',
   'sync.pipeline.viewHealth': 'মেমরির স্বাস্থ্য দেখুন',
+  'notifications.configRecovered.title': 'সেটিংস ফাইল পুনরুদ্ধার করা হয়েছে',
+  'notifications.configRecovered.body':
+    'আপনার সেটিংস ফাইল পড়া যায়নি, তাই এটি একটি ব্যাকআপ থেকে পুনরুদ্ধার করা হয়েছে বা ডিফল্টে রিসেট করা হয়েছে। অপঠনযোগ্য ফাইলটি, প্রয়োজনে ব্যবহারের জন্য, ".corrupted" প্রত্যয় সহ রাখা হয়েছে।',
 };
 
 export default messages;

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -7442,6 +7442,9 @@ const messages: TranslationMap = {
   'sync.pipeline.treeDegraded':
     'Speicherbaum beeinträchtigt. Die Abfrage liefert möglicherweise veraltete Ergebnisse.',
   'sync.pipeline.viewHealth': 'Speicherzustand anzeigen',
+  'notifications.configRecovered.title': 'Einstellungsdatei wiederhergestellt',
+  'notifications.configRecovered.body':
+    'Deine Einstellungsdatei konnte nicht gelesen werden und wurde daher aus einer Sicherung wiederhergestellt oder auf die Standardwerte zurückgesetzt. Die unlesbare Datei wurde mit der Endung ".corrupted" aufbewahrt, falls du sie noch brauchst.',
 };
 
 export default messages;

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -7562,6 +7562,9 @@ const en: TranslationMap = {
   'memorySources.codingSessions.moreRemaining':
     'The session batch limit was reached. Run ingestion again to continue importing your history.',
   'memorySources.codingSessions.failed': 'Coding-session ingestion failed',
+  'notifications.configRecovered.title': 'Settings file recovered',
+  'notifications.configRecovered.body':
+    'Your settings file could not be read, so it was restored from a backup or reset to defaults. The unreadable file was kept with a ".corrupted" suffix in case you need it.',
 };
 
 export default en;

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -7388,6 +7388,9 @@ const messages: TranslationMap = {
   'sync.pipeline.treeDegraded':
     'Árbol de memoria degradado. La recuperación puede devolver resultados obsoletos.',
   'sync.pipeline.viewHealth': 'Ver estado de la memoria',
+  'notifications.configRecovered.title': 'Se recuperó el archivo de configuración',
+  'notifications.configRecovered.body':
+    'No se pudo leer tu archivo de configuración, por lo que se restauró desde una copia de seguridad o se restableció a los valores predeterminados. El archivo ilegible se conservó con el sufijo ".corrupted" por si lo necesitas.',
 };
 
 export default messages;

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -7421,6 +7421,9 @@ const messages: TranslationMap = {
   'sync.pipeline.treeDegraded':
     'Arbre mémoire dégradé. La récupération peut renvoyer des résultats obsolètes.',
   'sync.pipeline.viewHealth': "Voir l'état de la mémoire",
+  'notifications.configRecovered.title': 'Fichier de paramètres récupéré',
+  'notifications.configRecovered.body':
+    'Votre fichier de paramètres n\'a pas pu être lu ; il a donc été restauré à partir d\'une sauvegarde ou réinitialisé aux valeurs par défaut. Le fichier illisible a été conservé avec le suffixe ".corrupted" au cas où vous en auriez besoin.',
 };
 
 export default messages;

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -7235,6 +7235,9 @@ const messages: TranslationMap = {
   'sync.pipeline.extractionFailed': 'मेमोरी संरचना निष्कर्षण विफल रहा। विकी अपूर्ण हो सकता है।',
   'sync.pipeline.treeDegraded': 'मेमोरी ट्री अवक्रमित। पुनर्प्राप्ति पुराने परिणाम दे सकती है।',
   'sync.pipeline.viewHealth': 'मेमोरी स्वास्थ्य देखें',
+  'notifications.configRecovered.title': 'सेटिंग फ़ाइल पुनर्प्राप्त की गई',
+  'notifications.configRecovered.body':
+    'आपकी सेटिंग फ़ाइल पढ़ी नहीं जा सकी, इसलिए इसे बैकअप से पुनर्स्थापित किया गया या डिफ़ॉल्ट पर रीसेट कर दिया गया। न पढ़ी जा सकने वाली फ़ाइल को, ज़रूरत पड़ने पर, ".corrupted" प्रत्यय के साथ रखा गया है।',
 };
 
 export default messages;

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -7274,6 +7274,9 @@ const messages: TranslationMap = {
   'sync.pipeline.treeDegraded':
     'Pohon memori menurun. Pengambilan mungkin mengembalikan hasil usang.',
   'sync.pipeline.viewHealth': 'Lihat kesehatan memori',
+  'notifications.configRecovered.title': 'File pengaturan dipulihkan',
+  'notifications.configRecovered.body':
+    'File pengaturan Anda tidak dapat dibaca, jadi dipulihkan dari cadangan atau disetel ulang ke default. File yang tidak terbaca disimpan dengan akhiran ".corrupted" jika Anda membutuhkannya.',
 };
 
 export default messages;

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -7375,6 +7375,9 @@ const messages: TranslationMap = {
   'sync.pipeline.treeDegraded':
     'Albero di memoria degradato. Il recupero potrebbe restituire risultati obsoleti.',
   'sync.pipeline.viewHealth': 'Visualizza lo stato della memoria',
+  'notifications.configRecovered.title': 'File delle impostazioni recuperato',
+  'notifications.configRecovered.body':
+    'Non è stato possibile leggere il tuo file delle impostazioni, quindi è stato ripristinato da un backup o reimpostato ai valori predefiniti. Il file illeggibile è stato conservato con il suffisso ".corrupted" nel caso ti servisse.',
 };
 
 export default messages;

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -7156,6 +7156,9 @@ const messages: TranslationMap = {
   'sync.pipeline.treeDegraded':
     '메모리 트리가 저하되었습니다. 검색이 오래된 결과를 반환할 수 있습니다.',
   'sync.pipeline.viewHealth': '메모리 상태 보기',
+  'notifications.configRecovered.title': '설정 파일 복구됨',
+  'notifications.configRecovered.body':
+    '설정 파일을 읽을 수 없어 백업에서 복원하거나 기본값으로 재설정했습니다. 읽을 수 없는 파일은 필요할 경우를 대비해 ".corrupted" 접미사를 붙여 보관했습니다.',
 };
 
 export default messages;

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -7345,6 +7345,9 @@ const messages: TranslationMap = {
   'sync.pipeline.treeDegraded':
     'Drzewo pamięci osłabione. Wyszukiwanie może zwracać nieaktualne wyniki.',
   'sync.pipeline.viewHealth': 'Zobacz kondycję pamięci',
+  'notifications.configRecovered.title': 'Odzyskano plik ustawień',
+  'notifications.configRecovered.body':
+    'Nie można było odczytać pliku ustawień, więc został przywrócony z kopii zapasowej lub zresetowany do wartości domyślnych. Nieczytelny plik zachowano z sufiksem ".corrupted" na wypadek, gdybyś go potrzebował.',
 };
 
 export default messages;

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -7356,6 +7356,9 @@ const messages: TranslationMap = {
   'sync.pipeline.treeDegraded':
     'Árvore de memória degradada. A recuperação pode retornar resultados desatualizados.',
   'sync.pipeline.viewHealth': 'Ver a saúde da memória',
+  'notifications.configRecovered.title': 'Arquivo de configurações recuperado',
+  'notifications.configRecovered.body':
+    'Não foi possível ler seu arquivo de configurações, então ele foi restaurado de um backup ou redefinido para os padrões. O arquivo ilegível foi mantido com o sufixo ".corrupted" caso você precise dele.',
 };
 
 export default messages;

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -7316,6 +7316,9 @@ const messages: TranslationMap = {
   'sync.pipeline.treeDegraded':
     'Дерево памяти деградировало. Поиск может возвращать устаревшие результаты.',
   'sync.pipeline.viewHealth': 'Показать состояние памяти',
+  'notifications.configRecovered.title': 'Файл настроек восстановлен',
+  'notifications.configRecovered.body':
+    'Не удалось прочитать файл настроек, поэтому он был восстановлен из резервной копии или сброшен к значениям по умолчанию. Нечитаемый файл сохранён с суффиксом ".corrupted" на случай, если он вам понадобится.',
 };
 
 export default messages;

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -6848,6 +6848,9 @@ const messages: TranslationMap = {
   'sync.pipeline.extractionFailed': '记忆结构提取失败。维基可能不完整。',
   'sync.pipeline.treeDegraded': '记忆树已降级。检索可能返回过时的结果。',
   'sync.pipeline.viewHealth': '查看记忆健康状况',
+  'notifications.configRecovered.title': '已恢复设置文件',
+  'notifications.configRecovered.body':
+    '无法读取你的设置文件，因此已从备份恢复或重置为默认值。无法读取的文件已保留并加上 ".corrupted" 后缀，以备你需要。',
 };
 
 export default messages;

--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -294,13 +294,15 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
   const refreshCore = useCallback(async () => {
     const requestId = ++snapshotRequestIdRef.current;
     const rawSnapshot = await fetchCoreAppSnapshot();
-    // Raise a one-shot notice if the core recovered a corrupted config.toml
-    // this session (#5167). Guarded internally so repeated polls don't re-fire.
-    maybeSurfaceConfigRecovery(rawSnapshot.configRecovered, t);
     const snapshot = normalizeSnapshot(rawSnapshot);
     if (!isMountedRef.current) {
       return;
     }
+    // Raise a one-shot notice if the core recovered a corrupted config.toml
+    // this session (#5167). Placed after the mount guard so a superseded or
+    // unmounted refresh doesn't dispatch; the core latches configRecovered, so
+    // the next live poll still surfaces it. Guarded internally against re-fire.
+    maybeSurfaceConfigRecovery(rawSnapshot.configRecovered, t);
     if (!snapshot.sessionToken) {
       logoutGuardUntilRef.current = 0;
     }

--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -16,6 +16,7 @@ import {
   getCoreStateSnapshot,
   setCoreStateSnapshot,
 } from '../lib/coreState/store';
+import { useT } from '../lib/i18n/I18nContext';
 import { syncAnalyticsConsent } from '../services/analytics';
 import type { AuthExpiredReason } from '../services/coreRpcClient';
 import {
@@ -265,6 +266,10 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
   const bootstrapFailCountRef = useRef(0);
   const refreshInFlightRef = useRef<Promise<void> | null>(null);
   const isMountedRef = useRef(true);
+  // Translator for user-visible strings dispatched outside JSX (e.g. the
+  // config-recovery notice below). Read here so `refreshCore` can localize the
+  // notice via the active locale rather than hardcoding English (#5167).
+  const { t } = useT();
   const commitState = useCallback((updater: (previous: CoreState) => CoreState) => {
     if (!isMountedRef.current) {
       return;
@@ -291,7 +296,7 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
     const rawSnapshot = await fetchCoreAppSnapshot();
     // Raise a one-shot notice if the core recovered a corrupted config.toml
     // this session (#5167). Guarded internally so repeated polls don't re-fire.
-    maybeSurfaceConfigRecovery(rawSnapshot.configRecovered);
+    maybeSurfaceConfigRecovery(rawSnapshot.configRecovered, t);
     const snapshot = normalizeSnapshot(rawSnapshot);
     if (!isMountedRef.current) {
       return;
@@ -457,7 +462,7 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
         console.warn('[core-state] memory client sync failed during refresh:', error);
       }
     }
-  }, [commitState]);
+  }, [commitState, t]);
 
   /** Serialized refresh — all callers share the same in-flight promise. */
   const refresh = useCallback(async () => {

--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -9,6 +9,7 @@ import {
   useState,
 } from 'react';
 
+import { maybeSurfaceConfigRecovery } from '../lib/configRecoveryNotice';
 import {
   type CoreAppSnapshot,
   type CoreState,
@@ -288,6 +289,9 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
   const refreshCore = useCallback(async () => {
     const requestId = ++snapshotRequestIdRef.current;
     const rawSnapshot = await fetchCoreAppSnapshot();
+    // Raise a one-shot notice if the core recovered a corrupted config.toml
+    // this session (#5167). Guarded internally so repeated polls don't re-fire.
+    maybeSurfaceConfigRecovery(rawSnapshot.configRecovered);
     const snapshot = normalizeSnapshot(rawSnapshot);
     if (!isMountedRef.current) {
       return;

--- a/app/src/providers/__tests__/CoreStateProvider.test.tsx
+++ b/app/src/providers/__tests__/CoreStateProvider.test.tsx
@@ -4,7 +4,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as coreStateApi from '../../services/coreStateApi';
 import * as tauriCommands from '../../utils/tauriCommands';
+import { __resetForTests as resetConfigRecoveryNotice } from '../../lib/configRecoveryNotice';
 import { getCoreStateSnapshot, setCoreStateSnapshot } from '../../lib/coreState/store';
+import { store } from '../../store';
+import { notificationReceived } from '../../store/notificationSlice';
 import { setActiveUserId } from '../../store/userScopedStorage';
 import CoreStateProvider, {
   coreStatePollFailureDebugMessage,
@@ -940,6 +943,96 @@ describe('coreStatePollFailureWarningMessage', () => {
         expect(Number(attempt)).toBeLessThanOrEqual(Number(max));
       }
     }
+  });
+});
+
+describe('CoreStateProvider — config recovery notice (#5167)', () => {
+  const fetchSnapshot = vi.mocked(coreStateApi.fetchCoreAppSnapshot);
+  const listTeams = vi.mocked(coreStateApi.listTeams);
+  const getTeamMembers = vi.mocked(coreStateApi.getTeamMembers);
+  const getTeamInvites = vi.mocked(coreStateApi.getTeamInvites);
+
+  beforeEach(() => {
+    fetchSnapshot.mockReset();
+    listTeams.mockReset();
+    getTeamMembers.mockReset();
+    getTeamInvites.mockReset();
+    listTeams.mockResolvedValue([]);
+    getTeamMembers.mockResolvedValue([]);
+    getTeamInvites.mockResolvedValue([]);
+    resetCoreStateStore();
+    setActiveUserId(null);
+    // Clear the module-level one-shot guard and any prior notices so each test
+    // observes a clean slate.
+    resetConfigRecoveryNotice();
+    store.dispatch({ type: 'notifications/clearAll' });
+  });
+
+  function recoveryItems() {
+    return store.getState().notifications.items.filter(i => i.id === 'config-recovered');
+  }
+
+  it('forwards configRecovered → exactly one system recovery notice', async () => {
+    fetchSnapshot.mockResolvedValue({
+      ...makeSnapshot({ userId: 'u1', sessionToken: 'tok1' }),
+      configRecovered: true,
+    });
+
+    render(
+      <CoreStateProvider>
+        <Consumer />
+      </CoreStateProvider>
+    );
+
+    await waitFor(() => expect(recoveryItems()).toHaveLength(1));
+    const item = recoveryItems()[0];
+    expect(item.category).toBe('system');
+    expect(item.deepLink).toBe('/settings');
+    expect(item.read).toBe(false);
+  });
+
+  it('stays one-shot across repeated refreshes (single dispatch)', async () => {
+    fetchSnapshot.mockResolvedValue({
+      ...makeSnapshot({ userId: 'u1', sessionToken: 'tok1' }),
+      configRecovered: true,
+    });
+    const dispatchSpy = vi.spyOn(store, 'dispatch');
+
+    let ctx: CoreStateContextValue | undefined;
+    render(
+      <CoreStateProvider>
+        <Consumer
+          captureCtx={next => {
+            ctx = next;
+          }}
+        />
+      </CoreStateProvider>
+    );
+
+    await waitFor(() => expect(recoveryItems()).toHaveLength(1));
+    await act(async () => {
+      await ctx!.refresh();
+      await ctx!.refresh();
+    });
+
+    const recoveryDispatches = dispatchSpy.mock.calls.filter(
+      ([action]) => notificationReceived.match(action) && action.payload.id === 'config-recovered'
+    );
+    expect(recoveryDispatches).toHaveLength(1);
+    dispatchSpy.mockRestore();
+  });
+
+  it('does not dispatch when the snapshot omits configRecovered', async () => {
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'u1', sessionToken: 'tok1' }));
+
+    render(
+      <CoreStateProvider>
+        <Consumer />
+      </CoreStateProvider>
+    );
+
+    await waitFor(() => expect(screen.getByTestId('user').textContent).toBe('u1'));
+    expect(recoveryItems()).toHaveLength(0);
   });
 });
 

--- a/app/src/services/coreStateApi.ts
+++ b/app/src/services/coreStateApi.ts
@@ -65,6 +65,14 @@ interface AppStateSnapshotResult {
    * gracefully — the daemon store simply isn't refreshed from those.
    */
   health?: RawHealthSnapshot;
+  /**
+   * `true` when the core recovered a corrupted `config.toml` this session — the
+   * on-disk settings were unreadable/unparseable, so the file was renamed to
+   * `.corrupted.<ts>` and reset to defaults (#5167). Latched at boot so it stays
+   * reported after the file is healed. Optional so older cores that omit it
+   * degrade to "no recovery". `CoreStateProvider` raises a one-shot notice.
+   */
+  configRecovered?: boolean;
 }
 
 /** Raw (snake_case) health payload embedded in the app-state snapshot. */

--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -2333,6 +2333,11 @@ pub async fn bootstrap_core_runtime(
     // DomainSet still installs its newly-enabled groups).
     register_domain_subscribers(workspace_dir.clone(), cfg.clone(), embedded_core, domains);
 
+    // Latch the config-corruption recovery signal (#5167) so `app_state_snapshot`
+    // keeps reporting it after the loader heals the file on this same boot; the
+    // frontend raises a one-shot "settings were reset" notice off it.
+    crate::openhuman::desktop::app_state::latch_from_config(&cfg);
+
     // --- Turn-state recovery -------------------------------------------
     // Any per-thread turn snapshots left on disk from a previous process
     // are stale by definition — there is no live driver to resume them.

--- a/src/openhuman/config/schema/load/impl_load.rs
+++ b/src/openhuman/config/schema/load/impl_load.rs
@@ -402,6 +402,10 @@ impl Config {
             config.config_path = config_path.clone();
             config.workspace_dir = workspace_dir;
             config.action_dir = resolve_action_dir(&config.action_dir_override);
+            // Runtime-only signal consumed once at boot to raise a user-visible
+            // "settings were reset" notice (#5167). Set before env overrides so a
+            // later override can never mask that recovery happened.
+            config.recovered_from_corruption = config_was_corrupted;
             migrate_legacy_inference_url(&mut config);
             migrate_cloud_provider_slugs(&mut config);
             config.apply_env_overrides_from(env);
@@ -593,6 +597,7 @@ impl Config {
         config.config_path = config_path;
         config.workspace_dir = workspace_dir;
         config.action_dir = resolve_action_dir(&config.action_dir_override);
+        config.recovered_from_corruption = config_was_corrupted;
         migrate_legacy_inference_url(&mut config);
         migrate_cloud_provider_slugs(&mut config);
         config.apply_env_overrides_from(&ProcessEnvWithoutWorkspace);

--- a/src/openhuman/config/schema/load_tests.rs
+++ b/src/openhuman/config/schema/load_tests.rs
@@ -1704,6 +1704,10 @@ default_temperature = 0.7
         Some("gpt-valid"),
         "valid config must load normally without recovery"
     );
+    assert!(
+        !config.recovered_from_corruption,
+        "a valid config must not set the recovery flag"
+    );
 }
 
 #[tokio::test]
@@ -1893,6 +1897,13 @@ async fn load_or_init_recovers_from_non_utf8_config() {
         "must load defaults from non-UTF-8 config"
     );
 
+    // The runtime recovery flag must be set so the boot path can surface a
+    // user-visible notice (#5167).
+    assert!(
+        config.recovered_from_corruption,
+        "recovered_from_corruption must be set after non-UTF-8 recovery"
+    );
+
     // The original binary file should have been renamed to .corrupted.<ts>.
     let dir = std::fs::read_dir(root).unwrap();
     let mut found_corrupted = false;
@@ -2026,6 +2037,29 @@ default_temperature = 0.7
     assert!(
         bak_contents.contains("preserve-backup-test"),
         "backup content must be preserved: {bak_contents}"
+    );
+}
+
+#[tokio::test]
+async fn load_from_config_path_sets_recovery_flag_on_non_utf8() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let workspace = root.join("workspace");
+
+    // The snapshot-reload path (`load_from_config_path`) must also flag recovery
+    // so a long-lived runtime that reloads a since-corrupted config surfaces the
+    // notice (#5167).
+    let config_path = root.join("config.toml");
+    let binary_bytes: Vec<u8> = vec![0xff, 0xfe, 0x00, 0x01, 0x02];
+    write_binary(&config_path, &binary_bytes).await;
+
+    let config = Config::load_from_config_path(&config_path, &workspace)
+        .await
+        .expect("load_from_config_path must recover, not error");
+
+    assert!(
+        config.recovered_from_corruption,
+        "load_from_config_path must set the recovery flag on non-UTF-8 content"
     );
 }
 

--- a/src/openhuman/config/schema/load_tests.rs
+++ b/src/openhuman/config/schema/load_tests.rs
@@ -2046,9 +2046,12 @@ async fn load_from_config_path_sets_recovery_flag_on_non_utf8() {
     let root = tmp.path();
     let workspace = root.join("workspace");
 
-    // The snapshot-reload path (`load_from_config_path`) must also flag recovery
-    // so a long-lived runtime that reloads a since-corrupted config surfaces the
-    // notice (#5167).
+    // The snapshot-reload path (`load_from_config_path`) must set the per-load
+    // recovery flag on the returned `Config`. This test asserts only that flag;
+    // the surfacing itself is wired one layer up in `app_state_snapshot`, which
+    // latches this flag on every poll (see `desktop::app_state::recovery_signal`
+    // and its `latch_from_config` call in `snapshot`), so a long-lived runtime
+    // that reloads a since-corrupted config does surface the notice (#5167).
     let config_path = root.join("config.toml");
     let binary_bytes: Vec<u8> = vec![0xff, 0xfe, 0x00, 0x01, 0x02];
     write_binary(&config_path, &binary_bytes).await;

--- a/src/openhuman/config/schema/types.rs
+++ b/src/openhuman/config/schema/types.rs
@@ -94,6 +94,14 @@ pub struct Config {
     pub action_dir_override: Option<PathBuf>,
     #[serde(skip)]
     pub config_path: PathBuf,
+    /// Runtime only — `true` when this config was produced by the loader's
+    /// corruption-recovery path: the on-disk `config.toml` was unreadable
+    /// (non-UTF-8) or unparseable, so it was renamed to `.corrupted.<ts>` and the
+    /// config was reset to defaults (or restored from `.bak`). Never persisted and
+    /// recomputed on every load. Read once at boot by `bootstrap_core_runtime` to
+    /// raise a user-visible "settings were reset" notice (#5167).
+    #[serde(skip)]
+    pub recovered_from_corruption: bool,
     /// Workspace data-schema version. Bumped each time a one-shot data
     /// migration under [`crate::openhuman::config::migrations`] runs successfully.
     /// `#[serde(default)]` so existing `config.toml` files (which predate
@@ -736,6 +744,7 @@ impl Default for Config {
             action_dir: crate::openhuman::config::default_action_dir(),
             action_dir_override: None,
             config_path: openhuman_dir.join("config.toml"),
+            recovered_from_corruption: false,
             schema_version: 0,
             api_url: None,
             api_key: None,

--- a/src/openhuman/desktop/app_state/mod.rs
+++ b/src/openhuman/desktop/app_state/mod.rs
@@ -1,9 +1,11 @@
 //! Core-owned app state exposed to the React shell via polling.
 
 mod ops;
+mod recovery_signal;
 mod schemas;
 
 pub use ops::*;
+pub use recovery_signal::{config_recovered_this_session, latch_from_config};
 pub use schemas::{
     all_app_state_controller_schemas, all_app_state_registered_controllers, app_state_schemas,
 };

--- a/src/openhuman/desktop/app_state/ops.rs
+++ b/src/openhuman/desktop/app_state/ops.rs
@@ -923,6 +923,13 @@ pub async fn snapshot() -> Result<RpcOutcome<AppStateSnapshot>, String> {
 
     let t_config = Instant::now();
     let config = config_rpc::load_config_with_timeout().await?;
+    // Latch corruption recovery from *this* poll's load, not only from boot.
+    // `load_config_with_timeout` re-reads config.toml on every snapshot, so a
+    // config that becomes corrupt after boot is healed here — carrying a fresh
+    // `recovered_from_corruption`. Without this, that mid-session recovery would
+    // be dropped (the boot latch never saw it) and the notice never surfaces
+    // (#5167). No-op when the load was clean; idempotent once latched.
+    super::latch_from_config(&config);
     let config_ms = t_config.elapsed().as_millis();
 
     let t_auth = Instant::now();

--- a/src/openhuman/desktop/app_state/ops.rs
+++ b/src/openhuman/desktop/app_state/ops.rs
@@ -173,6 +173,12 @@ pub struct AppStateSnapshot {
     /// second `health_snapshot` poller. Fields stay snake_case (the type has no
     /// camelCase rename) to match the frontend's existing health parser.
     pub health: crate::openhuman::platform::health::HealthSnapshot,
+    /// `true` when this session's config loader had to recover a corrupted
+    /// `config.toml` (renamed to `.corrupted.<ts>` and reset to defaults / a
+    /// backup). Latched at boot so it stays reported even after the file is
+    /// healed; the frontend raises a one-shot "settings were reset" notice
+    /// (#5167). Serialized as `configRecovered`.
+    pub config_recovered: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1187,6 +1193,7 @@ pub async fn snapshot() -> Result<RpcOutcome<AppStateSnapshot>, String> {
             keyring_status,
             runtime,
             health,
+            config_recovered: super::config_recovered_this_session(),
         },
         vec!["core app state snapshot fetched".to_string()],
     ))

--- a/src/openhuman/desktop/app_state/recovery_signal.rs
+++ b/src/openhuman/desktop/app_state/recovery_signal.rs
@@ -11,6 +11,11 @@
 //! from the boot config, and every later snapshot reports it, so the notice
 //! surfaces even though the underlying config is already healthy.
 //!
+//! `app_state_snapshot` also latches from each poll's freshly-loaded config, so
+//! corruption that first appears *after* boot (the running config.toml is
+//! edited/damaged and healed on a later reload) is caught too, not just the
+//! boot-time case.
+//!
 //! [`Config::recovered_from_corruption`]:
 //! crate::openhuman::config::Config::recovered_from_corruption
 
@@ -30,20 +35,24 @@ fn mark_config_recovered() {
     CONFIG_RECOVERED.store(true, Ordering::Relaxed);
 }
 
-/// Latch the session recovery signal from a freshly-loaded boot config.
+/// Latch the session recovery signal from a freshly-loaded config.
 ///
-/// Called once from `bootstrap_core_runtime` with the config returned by
-/// `Config::load_or_init`, whose `recovered_from_corruption` is authoritative
-/// for this boot. No-op when the config loaded cleanly. Logs at warn so the
-/// reset is visible in local logs (it is a Sentry breadcrumb, not an event —
-/// the read failure it stems from is expected user-environment state, #5167).
+/// Called from `bootstrap_core_runtime` with the boot config returned by
+/// `Config::load_or_init`, and from every `app_state_snapshot` poll with the
+/// config that poll just loaded — whichever load's `recovered_from_corruption`
+/// is authoritative wins, so both boot-time and mid-session recovery latch.
+/// No-op when the config loaded cleanly. Logs at warn (once, on the load that
+/// actually recovered) so the recovery is visible in local logs (it is a Sentry
+/// breadcrumb, not an event — the read failure it stems from is expected
+/// user-environment state, #5167).
 pub fn latch_from_config(config: &Config) {
     if !config.recovered_from_corruption {
         return;
     }
     log::warn!(
-        "[app_state] config.toml was unreadable/corrupt on boot and was reset to \
-         defaults (previous file kept as .corrupted.<ts>); surfacing a user notice (#5167)"
+        "[app_state] config.toml was unreadable/corrupt and was recovered \
+         (restored from .bak or reset to defaults; previous file kept as \
+         .corrupted.<ts>); surfacing a user notice (#5167)"
     );
     mark_config_recovered();
 }
@@ -63,10 +72,22 @@ pub fn reset_for_tests() {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
+
+    /// Both tests below reset and mutate the process-global [`CONFIG_RECOVERED`]
+    /// atomic. Rust runs unit tests in parallel by default, so without
+    /// serialization one test's `reset_for_tests()` could clear a value the
+    /// other just set, between its write and assertion. Hold this guard for the
+    /// whole body of each test. Recover from poisoning (a panicking test still
+    /// releases the latch state via the next `reset_for_tests`) so one failure
+    /// doesn't cascade into spurious lock-poison failures.
+    static TEST_GUARD: Mutex<()> = Mutex::new(());
 
     #[test]
     fn latch_defaults_false_and_marks_true() {
+        let _guard = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         reset_for_tests();
         assert!(
             !config_recovered_this_session(),
@@ -85,6 +106,7 @@ mod tests {
 
     #[test]
     fn latch_from_config_only_marks_when_recovered() {
+        let _guard = TEST_GUARD.lock().unwrap_or_else(|e| e.into_inner());
         reset_for_tests();
 
         let mut clean = Config::default();

--- a/src/openhuman/desktop/app_state/recovery_signal.rs
+++ b/src/openhuman/desktop/app_state/recovery_signal.rs
@@ -30,9 +30,12 @@ static CONFIG_RECOVERED: AtomicBool = AtomicBool::new(false);
 
 /// Record that config-corruption recovery happened this session.
 ///
-/// Idempotent and safe to call repeatedly.
-fn mark_config_recovered() {
-    CONFIG_RECOVERED.store(true, Ordering::Relaxed);
+/// Returns `true` only on the first call this process (the `false`→`true`
+/// transition); subsequent calls return `false`. Lets a caller invoked on every
+/// snapshot poll act (e.g. log) exactly once. Idempotent and safe to call
+/// repeatedly.
+fn mark_config_recovered() -> bool {
+    !CONFIG_RECOVERED.swap(true, Ordering::Relaxed)
 }
 
 /// Latch the session recovery signal from a freshly-loaded config.
@@ -41,20 +44,27 @@ fn mark_config_recovered() {
 /// `Config::load_or_init`, and from every `app_state_snapshot` poll with the
 /// config that poll just loaded — whichever load's `recovered_from_corruption`
 /// is authoritative wins, so both boot-time and mid-session recovery latch.
-/// No-op when the config loaded cleanly. Logs at warn (once, on the load that
-/// actually recovered) so the recovery is visible in local logs (it is a Sentry
-/// breadcrumb, not an event — the read failure it stems from is expected
-/// user-environment state, #5167).
+/// No-op when the config loaded cleanly.
+///
+/// Logs at warn **once per process**, gated on the latch's `false`→`true`
+/// transition rather than on `recovered_from_corruption` itself. That matters
+/// because this runs on every snapshot poll (~every few seconds): when a corrupt
+/// config cannot be healed — `impl_load` skips the heal if the rename to
+/// `.corrupted.<ts>` fails (e.g. a Windows sharing violation, os error 32) and
+/// retries on the next load — every poll re-recovers, and an ungated warn would
+/// emit indefinitely. It is a Sentry breadcrumb, not an event (the read failure
+/// it stems from is expected user-environment state, #5167).
 pub fn latch_from_config(config: &Config) {
     if !config.recovered_from_corruption {
         return;
     }
-    log::warn!(
-        "[app_state] config.toml was unreadable/corrupt and was recovered \
-         (restored from .bak or reset to defaults; previous file kept as \
-         .corrupted.<ts>); surfacing a user notice (#5167)"
-    );
-    mark_config_recovered();
+    if mark_config_recovered() {
+        tracing::warn!(
+            "[app_state] config.toml was unreadable/corrupt and was recovered \
+             (restored from .bak or reset to defaults; previous file kept as \
+             .corrupted.<ts>); surfacing a user notice (#5167)"
+        );
+    }
 }
 
 /// Whether config-corruption recovery happened this session. Read by
@@ -93,13 +103,20 @@ mod tests {
             !config_recovered_this_session(),
             "latch must default to false"
         );
-        mark_config_recovered();
+        assert!(
+            mark_config_recovered(),
+            "first mark reports the false->true transition"
+        );
         assert!(
             config_recovered_this_session(),
             "latch must report true after mark"
         );
-        // Idempotent — a second mark keeps it true.
-        mark_config_recovered();
+        // Idempotent — a second mark keeps the latch true but reports no
+        // transition, so callers (latch_from_config) log exactly once.
+        assert!(
+            !mark_config_recovered(),
+            "second mark reports no transition (already latched)"
+        );
         assert!(config_recovered_this_session());
         reset_for_tests();
     }

--- a/src/openhuman/desktop/app_state/recovery_signal.rs
+++ b/src/openhuman/desktop/app_state/recovery_signal.rs
@@ -1,0 +1,107 @@
+//! Process-lifetime latch recording whether the config loader recovered a
+//! corrupted `config.toml` during this session (#5167).
+//!
+//! The loader (`config::schema::load`) heals a corrupt config on the *first*
+//! read of the process by renaming it to `.corrupted.<ts>` and resetting to
+//! defaults, so the per-load [`Config::recovered_from_corruption`] flag is only
+//! `true` on that first load and `false` on every subsequent read of the
+//! now-healed file. The frontend, however, polls `app_state_snapshot` and may
+//! not do so until after the heal — by which point the flag would already read
+//! `false`. This latch bridges that gap: `bootstrap_core_runtime` sets it once
+//! from the boot config, and every later snapshot reports it, so the notice
+//! surfaces even though the underlying config is already healthy.
+//!
+//! [`Config::recovered_from_corruption`]:
+//! crate::openhuman::config::Config::recovered_from_corruption
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::openhuman::config::Config;
+
+/// `true` once the config loader recovered a corrupted `config.toml` this
+/// process lifetime. Never reset in production (a recovery is a one-time,
+/// session-scoped fact); tests clear it via [`reset_for_tests`].
+static CONFIG_RECOVERED: AtomicBool = AtomicBool::new(false);
+
+/// Record that config-corruption recovery happened this session.
+///
+/// Idempotent and safe to call repeatedly.
+fn mark_config_recovered() {
+    CONFIG_RECOVERED.store(true, Ordering::Relaxed);
+}
+
+/// Latch the session recovery signal from a freshly-loaded boot config.
+///
+/// Called once from `bootstrap_core_runtime` with the config returned by
+/// `Config::load_or_init`, whose `recovered_from_corruption` is authoritative
+/// for this boot. No-op when the config loaded cleanly. Logs at warn so the
+/// reset is visible in local logs (it is a Sentry breadcrumb, not an event —
+/// the read failure it stems from is expected user-environment state, #5167).
+pub fn latch_from_config(config: &Config) {
+    if !config.recovered_from_corruption {
+        return;
+    }
+    log::warn!(
+        "[app_state] config.toml was unreadable/corrupt on boot and was reset to \
+         defaults (previous file kept as .corrupted.<ts>); surfacing a user notice (#5167)"
+    );
+    mark_config_recovered();
+}
+
+/// Whether config-corruption recovery happened this session. Read by
+/// `app_state_snapshot` so the frontend can raise a one-shot user notice.
+pub fn config_recovered_this_session() -> bool {
+    CONFIG_RECOVERED.load(Ordering::Relaxed)
+}
+
+/// Reset the latch. Test-only: the static is process-global, so a test that
+/// asserts the un-recovered default must clear state a prior test may have set.
+#[cfg(test)]
+pub fn reset_for_tests() {
+    CONFIG_RECOVERED.store(false, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn latch_defaults_false_and_marks_true() {
+        reset_for_tests();
+        assert!(
+            !config_recovered_this_session(),
+            "latch must default to false"
+        );
+        mark_config_recovered();
+        assert!(
+            config_recovered_this_session(),
+            "latch must report true after mark"
+        );
+        // Idempotent — a second mark keeps it true.
+        mark_config_recovered();
+        assert!(config_recovered_this_session());
+        reset_for_tests();
+    }
+
+    #[test]
+    fn latch_from_config_only_marks_when_recovered() {
+        reset_for_tests();
+
+        let mut clean = Config::default();
+        clean.recovered_from_corruption = false;
+        latch_from_config(&clean);
+        assert!(
+            !config_recovered_this_session(),
+            "a clean boot config must not latch the signal"
+        );
+
+        let mut recovered = Config::default();
+        recovered.recovered_from_corruption = true;
+        latch_from_config(&recovered);
+        assert!(
+            config_recovered_this_session(),
+            "a recovered boot config must latch the signal"
+        );
+        reset_for_tests();
+    }
+}


### PR DESCRIPTION
## Summary

- Surface a **user-visible notice** when the core recovers a corrupted `config.toml`, closing the last unmet requirement of #5167 (the Sentry flood and auto-recovery were already fixed in #5171).
- Core carries a runtime-only `Config::recovered_from_corruption` flag, set by the loader on the corruption-recovery path (both `load_or_init` and `load_from_config_path`).
- A boot-time process latch (`desktop::app_state::recovery_signal`) keeps the signal reported after the loader heals the file on the same boot, and `app_state_snapshot` exposes it as `configRecovered`.
- The frontend raises a single "Settings were reset" System notice in the notification center, guarded so the latched flag doesn't re-fire on every snapshot poll.

## Problem

Two Windows users' `config.toml` files failed UTF-8 validation and generated ~946 Sentry events. #5171 already fixed the flood: the loader rate-limits the error, renames the corrupt file to `.corrupted.<ts>`, and resets to defaults / a `.bak` backup. But that recovery was **silent** — the user was never told their settings had been reset, which was requirement (3) of the issue.

Delivering the notice is non-trivial because recovery happens at **core boot, before the frontend socket connects**, so a live `core_notification` publish would be lost. The persisted-notification path (#3805) is also not wired to a frontend sync-down, so persistence alone wouldn't surface it either.

## Solution

A pull-based, race-free signal rather than a push:

- `Config::recovered_from_corruption` (`#[serde(skip)]`, runtime-only) is set in the loader's recovery branches. Per-load and pollution-free, so both the "recovered" and "clean" cases are unit-tested directly.
- `desktop::app_state::recovery_signal` holds a process latch. `bootstrap_core_runtime` calls `latch_from_config(&cfg)` once at boot from the authoritative boot config; the latch bridges the gap that the per-load flag reads `false` on subsequent (now-healed) loads.
- `app_state_snapshot` — which `BootCheckGate`/`CoreStateProvider` already fetch on boot — reports `configRecovered`. No new poller, no new RPC.
- `CoreStateProvider.refreshCore` calls a one-shot `maybeSurfaceConfigRecovery`, dispatching one System notification into the existing notification center (respects category prefs; deduped by stable id; guarded so repeated polls don't re-fire).

Design note: a notification-bus approach was considered but rejected — it would have required activating the dormant #3805 sync-down, which on first boot would dump the entire backlog of previously-persisted-but-unread core notifications. The snapshot-flag approach is strictly scoped to this issue.

## Submission Checklist

- [x] Tests added or updated (happy path + failure/edge case): loader sets the flag on non-UTF-8 recovery via both `load_or_init` and `load_from_config_path`, and does **not** set it for a valid config; `recovery_signal` latch unit tests; frontend one-shot dispatch test (surfaces once, no-op on repeat / when false).
- [x] **Diff coverage ≥ 80%** — passed CI (Rust Core Coverage cargo-llvm-cov + Frontend Checks green). Changed lines are covered by the added unit tests plus existing e2e coverage of the `app_state_snapshot` builder (`app_state_credentials_raw_coverage_e2e.rs`, `json_rpc_e2e.rs`) and the core-runtime bootstrap path.
- [x] Coverage matrix updated — `N/A`: behaviour-only change to an existing surface; no new feature ID.
- [x] All affected feature IDs listed under `## Related` — `N/A`: none.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — `N/A`: no new release-cut surface (reuses the existing app-state snapshot + notification center).
- [x] Linked issue closed via `Closes #NNN` in `## Related`.

## Impact

- Desktop only in practice (the reported corruption is Windows `config.toml`), but the mechanism is platform-agnostic. No migration, no config-format change.
- Wire change: one additive optional field `configRecovered` on `app_state_snapshot`; older/newer clients degrade to "no recovery". The `Config` field is `#[serde(skip)]` — never persisted.
- No new network calls; the notice rides the existing boot snapshot poll.

## Related

- Closes: #5167
- Follow-up PR(s)/TODOs: the #3805 persisted-core-notification frontend sync-down remains unwired (out of scope here).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `wt-5167`
- Commit SHA: see PR head

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck` (`pnpm compile` / `tsc --noEmit`)
- [x] Focused tests: `cargo test --lib` (recover / latch / non_utf8 groups) + `vitest run src/lib/configRecoveryNotice.test.ts`
- [x] Rust fmt/check (if changed): `cargo fmt --check` + `cargo clippy -p openhuman -- -D warnings`
- [x] Tauri fmt/check (if changed): `cargo clippy --manifest-path app/src-tauri/Cargo.toml -- -D warnings` (no Tauri Rust changed)

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: raise a one-shot user notice when a corrupt `config.toml` is auto-reset.
- User-visible effect: a "Settings were reset" System notification in the notification center after recovery.

### Parity Contract

- Legacy behavior preserved: recovery/heal/rate-limit behavior from #5171 is unchanged; this only adds the notice.
- Guard/fallback/dispatch parity checks: notice deduped by stable id + one-shot guard; respects notification category prefs; snapshot field is additive/optional.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localized notification when the app recovers unreadable configuration settings.
  * Notifications explain whether settings were restored or reset and link to Settings.
  * Preserves the original unreadable configuration file with a `.corrupted` suffix when applicable.
  * Notification appears only once per session and remains marked as unread.

* **Documentation**
  * Added translations for Arabic, Bengali, Chinese, English, French, German, Hindi, Indonesian, Italian, Korean, Polish, Portuguese, Russian, and Spanish.

* **Tests**
  * Added coverage for recovery detection, notification behavior, localization, and repeated refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->