### PR TITLE
fix(dev): make `pnpm dev:app:win` work on default Git for Windows installs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,5 @@ Dockerfile text eol=lf
 .dockerignore text eol=lf
 docker-compose*.yml text eol=lf
 *.ps1 text eol=crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,7 @@
     "dev": "vite",
     "dev:web": "vite",
     "dev:app": "pnpm tauri:ensure && export CEF_PATH=\"$HOME/Library/Caches/tauri-cef\" && bash ../scripts/setup-chromium-safe-storage.sh && source ../scripts/load-dotenv.sh && APPLE_SIGNING_IDENTITY='OpenHuman Dev Signer' cargo tauri dev --config '{\"build\":{\"devUrl\":\"http://localhost:'\"${OPENHUMAN_DEV_PORT:-1420}\"'\"}}' ",
-    "dev:app:win": "\"C:/Program Files/Git/bin/bash.exe\" ../scripts/run-dev-win.sh",
+    "dev:app:win": "..\\scripts\\run-dev-win.cmd",
     "dev:cef": "pnpm dev:app",
     "dev:wry": "pnpm tauri:ensure && export CEF_PATH=\"$HOME/Library/Caches/tauri-cef\" && source ../scripts/load-dotenv.sh && cargo tauri dev --no-default-features --features wry",
     "core:stage": "echo '[core:stage] no-op — core is linked in-process; sidecar removed (PR #1061)'",

--- a/app/test/dev-app-win-launcher.test.ts
+++ b/app/test/dev-app-win-launcher.test.ts
@@ -43,6 +43,15 @@ function programTokenUnderCmdS(script: string): string {
   return remaining.trimStart().split(/\s/)[0];
 }
 
+/** Executable lines of the launcher: comments and blank lines removed. */
+function launcherCodeLines(launcher: string): string[] {
+  return launcher
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .filter((line) => !line.toLowerCase().startsWith('rem'));
+}
+
 describe('pnpm dev:app:win entry point', () => {
   it('reproduces the historical failure: quotes do not survive cmd.exe /s', () => {
     // cmd sees `C:/Program` as the program name, producing the reported
@@ -77,5 +86,17 @@ describe('pnpm dev:app:win entry point', () => {
     // A bare `bash` lookup would hit C:\Windows\System32\bash.exe (the WSL
     // launcher) on machines with WSL enabled.
     expect(launcher).not.toMatch(/where\s+bash\.exe/i);
+  });
+
+  it('uses no label-based control flow, so line endings cannot change behaviour', () => {
+    const code = launcherCodeLines(readFileSync(LAUNCHER_PATH, 'utf8'));
+
+    // cmd.exe finds a label by byte offset and re-reads the script in 512-byte
+    // chunks, so `goto`/`call :label` is the one construct whose behaviour
+    // depends on whether the file is LF or CRLF. Keeping the launcher free of
+    // labels makes it correct either way instead of relying on a checkout rule.
+    expect(code.filter((line) => line.startsWith(':'))).toEqual([]);
+    expect(code.filter((line) => /(^|\s)(goto|call)\s/i.test(line))).toEqual([]);
+    expect(code.length).toBeGreaterThan(0);
   });
 });

--- a/app/test/dev-app-win-launcher.test.ts
+++ b/app/test/dev-app-win-launcher.test.ts
@@ -47,9 +47,9 @@ function programTokenUnderCmdS(script: string): string {
 function launcherCodeLines(launcher: string): string[] {
   return launcher
     .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0)
-    .filter((line) => !line.toLowerCase().startsWith('rem'));
+    .map(line => line.trim())
+    .filter(line => line.length > 0)
+    .filter(line => !line.toLowerCase().startsWith('rem'));
 }
 
 describe('pnpm dev:app:win entry point', () => {
@@ -95,8 +95,8 @@ describe('pnpm dev:app:win entry point', () => {
     // chunks, so `goto`/`call :label` is the one construct whose behaviour
     // depends on whether the file is LF or CRLF. Keeping the launcher free of
     // labels makes it correct either way instead of relying on a checkout rule.
-    expect(code.filter((line) => line.startsWith(':'))).toEqual([]);
-    expect(code.filter((line) => /(^|\s)(goto|call)\s/i.test(line))).toEqual([]);
+    expect(code.filter(line => line.startsWith(':'))).toEqual([]);
+    expect(code.filter(line => /(^|\s)(goto|call)\s/i.test(line))).toEqual([]);
     expect(code.length).toBeGreaterThan(0);
   });
 });

--- a/app/test/dev-app-win-launcher.test.ts
+++ b/app/test/dev-app-win-launcher.test.ts
@@ -22,6 +22,18 @@ const DEV_APP_WIN = packageJson.scripts['dev:app:win'];
 const LEGACY_BROKEN_SCRIPT = '"C:/Program Files/Git/bin/bash.exe" ../scripts/run-dev-win.sh';
 
 /**
+ * A batch label, optionally behind the `@` echo-suppression prefix.
+ */
+const BATCH_LABEL = /^@?:/;
+
+/**
+ * A `goto`/`call` jump in any form cmd accepts: optionally prefixed with `@`,
+ * introduced by start-of-line or a command separator, and followed by either
+ * whitespace (`goto :eof`) or a colon (`goto:eof`).
+ */
+const BATCH_JUMP = /(^|[\s&|()])@?(goto|call)[\s:]/i;
+
+/**
  * Models how `cmd.exe /d /s /c <string>` picks the program to execute, which is
  * how pnpm invokes package.json scripts on Windows.
  *
@@ -88,6 +100,33 @@ describe('pnpm dev:app:win entry point', () => {
     expect(launcher).not.toMatch(/where\s+bash\.exe/i);
   });
 
+  it('recognises every batch jump form, so the guard below cannot be bypassed', () => {
+    // Positive controls: each of these must count as a jump.
+    for (const jump of [
+      'goto :label',
+      'call :label',
+      '@goto :label',
+      '@call :label',
+      'goto:eof',
+      '@goto:eof',
+      '& goto :label',
+      '( @goto :label)',
+      'if not defined BASH_EXE goto :no_bash',
+    ]) {
+      expect(BATCH_JUMP.test(jump), jump).toBe(true);
+    }
+
+    // Negative controls: ordinary text must not trip the guard.
+    for (const plain of [
+      'echo go to label',
+      'echo recall the value',
+      'exit /b %ERRORLEVEL%',
+      '"%BASH_EXE%" "%SCRIPT_DIR%run-dev-win.sh" %*',
+    ]) {
+      expect(BATCH_JUMP.test(plain), plain).toBe(false);
+    }
+  });
+
   it('uses no label-based control flow, so line endings cannot change behaviour', () => {
     const code = launcherCodeLines(readFileSync(LAUNCHER_PATH, 'utf8'));
 
@@ -95,8 +134,8 @@ describe('pnpm dev:app:win entry point', () => {
     // chunks, so `goto`/`call :label` is the one construct whose behaviour
     // depends on whether the file is LF or CRLF. Keeping the launcher free of
     // labels makes it correct either way instead of relying on a checkout rule.
-    expect(code.filter(line => line.startsWith(':'))).toEqual([]);
-    expect(code.filter(line => /(^|\s)(goto|call)\s/i.test(line))).toEqual([]);
+    expect(code.filter(line => BATCH_LABEL.test(line))).toEqual([]);
+    expect(code.filter(line => BATCH_JUMP.test(line))).toEqual([]);
     expect(code.length).toBeGreaterThan(0);
   });
 });

--- a/app/test/dev-app-win-launcher.test.ts
+++ b/app/test/dev-app-win-launcher.test.ts
@@ -6,55 +6,55 @@ import { describe, expect, it } from 'vitest';
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const APP_DIR = path.resolve(HERE, '..');
 const REPO_ROOT = path.resolve(APP_DIR, '..');
+const PACKAGE_JSON_PATH = path.join(APP_DIR, 'package.json');
+const LAUNCHER_PATH = path.join(REPO_ROOT, 'scripts', 'run-dev-win.cmd');
 
-const packageJson = JSON.parse(
-  readFileSync(path.join(APP_DIR, 'package.json'), 'utf8')
-) as { scripts: Record<string, string> };
+type PackageJson = { scripts: Record<string, string> };
 
+const packageJson = JSON.parse(readFileSync(PACKAGE_JSON_PATH, 'utf8')) as PackageJson;
 const DEV_APP_WIN = packageJson.scripts['dev:app:win'];
 
 /**
  * The exact `dev:app:win` body that shipped before this regression was fixed.
- * Kept verbatim so the test below proves the failure mode rather than just
+ * Kept verbatim so the first test proves the failure mode rather than merely
  * asserting the current string.
  */
 const LEGACY_BROKEN_SCRIPT = '"C:/Program Files/Git/bin/bash.exe" ../scripts/run-dev-win.sh';
 
 /**
- * Models how `cmd.exe /d /s /c <string>` picks the program to execute, which
- * is how pnpm invokes package.json scripts on Windows.
+ * Models how `cmd.exe /d /s /c <string>` picks the program to execute, which is
+ * how pnpm invokes package.json scripts on Windows.
  *
- * With /S, cmd strips the first and last quote characters of <string> and
+ * With /S, cmd strips the first and last quote characters of <string> and then
  * parses what remains, taking the first whitespace-delimited token as the
  * program name. That is why an interpreter path containing spaces cannot
  * protect itself with quotes at this layer.
  */
 function programTokenUnderCmdS(script: string): string {
+  const firstQuote = script.indexOf('"');
+  const lastQuote = script.lastIndexOf('"');
   let remaining = script;
-  const firstQuote = remaining.indexOf('"');
-  const lastQuote = remaining.lastIndexOf('"');
   if (firstQuote !== -1 && lastQuote > firstQuote) {
-    remaining =
-      remaining.slice(0, firstQuote) +
-      remaining.slice(firstQuote + 1, lastQuote) +
-      remaining.slice(lastQuote + 1);
+    const head = script.slice(0, firstQuote);
+    const middle = script.slice(firstQuote + 1, lastQuote);
+    const tail = script.slice(lastQuote + 1);
+    remaining = head + middle + tail;
   }
-  return remaining.trimStart().split(/\s/)[0] ?? '';
+  return remaining.trimStart().split(/\s/)[0];
 }
 
 describe('pnpm dev:app:win entry point', () => {
   it('reproduces the historical failure: quotes do not survive cmd.exe /s', () => {
-    // Documents the bug this script layout fixes. cmd sees `C:/Program` as the
-    // program name, producing "'C:/Program' is not recognized...".
+    // cmd sees `C:/Program` as the program name, producing the reported
+    // "'C:/Program' is not recognized as an internal or external command".
     expect(programTokenUnderCmdS(LEGACY_BROKEN_SCRIPT)).toBe('C:/Program');
   });
 
   it('resolves to a single token that cmd.exe can execute verbatim', () => {
     const program = programTokenUnderCmdS(DEV_APP_WIN);
 
-    // The whole script must survive cmd's quote stripping intact: if the
-    // program token is shorter than the trimmed script body, cmd would have
-    // split the path and failed exactly like the legacy form above.
+    // If the program token were shorter than the trimmed script body, cmd would
+    // have split the path and failed exactly like the legacy form above.
     expect(program).toBe(DEV_APP_WIN.trim());
     expect(program).not.toContain(' ');
     expect(program).not.toContain('"');
@@ -64,17 +64,11 @@ describe('pnpm dev:app:win entry point', () => {
     const program = programTokenUnderCmdS(DEV_APP_WIN);
     const resolved = path.resolve(APP_DIR, program.replace(/\\/g, '/'));
 
-    expect(
-      existsSync(resolved),
-      `dev:app:win points at ${program}, which does not exist at ${resolved}`
-    ).toBe(true);
+    expect(existsSync(resolved), `dev:app:win points at ${resolved}`).toBe(true);
   });
 
   it('delegates to run-dev-win.sh without trusting a bare bash on PATH', () => {
-    const launcher = readFileSync(
-      path.join(REPO_ROOT, 'scripts', 'run-dev-win.cmd'),
-      'utf8'
-    );
+    const launcher = readFileSync(LAUNCHER_PATH, 'utf8');
 
     expect(launcher).toContain('run-dev-win.sh');
     // Every bash.exe candidate must be quoted, otherwise the wrapper would

--- a/app/test/dev-app-win-launcher.test.ts
+++ b/app/test/dev-app-win-launcher.test.ts
@@ -1,0 +1,87 @@
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const APP_DIR = path.resolve(HERE, '..');
+const REPO_ROOT = path.resolve(APP_DIR, '..');
+
+const packageJson = JSON.parse(
+  readFileSync(path.join(APP_DIR, 'package.json'), 'utf8')
+) as { scripts: Record<string, string> };
+
+const DEV_APP_WIN = packageJson.scripts['dev:app:win'];
+
+/**
+ * The exact `dev:app:win` body that shipped before this regression was fixed.
+ * Kept verbatim so the test below proves the failure mode rather than just
+ * asserting the current string.
+ */
+const LEGACY_BROKEN_SCRIPT = '"C:/Program Files/Git/bin/bash.exe" ../scripts/run-dev-win.sh';
+
+/**
+ * Models how `cmd.exe /d /s /c <string>` picks the program to execute, which
+ * is how pnpm invokes package.json scripts on Windows.
+ *
+ * With /S, cmd strips the first and last quote characters of <string> and
+ * parses what remains, taking the first whitespace-delimited token as the
+ * program name. That is why an interpreter path containing spaces cannot
+ * protect itself with quotes at this layer.
+ */
+function programTokenUnderCmdS(script: string): string {
+  let remaining = script;
+  const firstQuote = remaining.indexOf('"');
+  const lastQuote = remaining.lastIndexOf('"');
+  if (firstQuote !== -1 && lastQuote > firstQuote) {
+    remaining =
+      remaining.slice(0, firstQuote) +
+      remaining.slice(firstQuote + 1, lastQuote) +
+      remaining.slice(lastQuote + 1);
+  }
+  return remaining.trimStart().split(/\s/)[0] ?? '';
+}
+
+describe('pnpm dev:app:win entry point', () => {
+  it('reproduces the historical failure: quotes do not survive cmd.exe /s', () => {
+    // Documents the bug this script layout fixes. cmd sees `C:/Program` as the
+    // program name, producing "'C:/Program' is not recognized...".
+    expect(programTokenUnderCmdS(LEGACY_BROKEN_SCRIPT)).toBe('C:/Program');
+  });
+
+  it('resolves to a single token that cmd.exe can execute verbatim', () => {
+    const program = programTokenUnderCmdS(DEV_APP_WIN);
+
+    // The whole script must survive cmd's quote stripping intact: if the
+    // program token is shorter than the trimmed script body, cmd would have
+    // split the path and failed exactly like the legacy form above.
+    expect(program).toBe(DEV_APP_WIN.trim());
+    expect(program).not.toContain(' ');
+    expect(program).not.toContain('"');
+  });
+
+  it('points at a launcher that exists in the repository', () => {
+    const program = programTokenUnderCmdS(DEV_APP_WIN);
+    const resolved = path.resolve(APP_DIR, program.replace(/\\/g, '/'));
+
+    expect(
+      existsSync(resolved),
+      `dev:app:win points at ${program}, which does not exist at ${resolved}`
+    ).toBe(true);
+  });
+
+  it('delegates to run-dev-win.sh without trusting a bare bash on PATH', () => {
+    const launcher = readFileSync(
+      path.join(REPO_ROOT, 'scripts', 'run-dev-win.cmd'),
+      'utf8'
+    );
+
+    expect(launcher).toContain('run-dev-win.sh');
+    // Every bash.exe candidate must be quoted, otherwise the wrapper would
+    // reintroduce the space-splitting bug it exists to prevent.
+    expect(launcher).toContain('"%BASH_EXE%"');
+    // A bare `bash` lookup would hit C:\Windows\System32\bash.exe (the WSL
+    // launcher) on machines with WSL enabled.
+    expect(launcher).not.toMatch(/where\s+bash\.exe/i);
+  });
+});

--- a/scripts/run-dev-win.cmd
+++ b/scripts/run-dev-win.cmd
@@ -43,9 +43,16 @@ if not defined BASH_EXE call :use_if_exists "%ProgramFiles%\Git\bin\bash.exe"
 if not defined BASH_EXE call :use_if_exists "%ProgramFiles(x86)%\Git\bin\bash.exe"
 if not defined BASH_EXE call :use_if_exists "%LOCALAPPDATA%\Programs\Git\bin\bash.exe"
 
-rem Derive the install root from git.exe on PATH, which covers winget, scoop
-rem and chocolatey layouts. git.exe sits in <root>\cmd or <root>\bin, so
-rem bash.exe is always at <root>\bin\bash.exe.
+rem Scoop only ever puts shims on PATH, so the git.exe probe below would derive
+rem <scoop>\bin\bash.exe, which does not exist. The real binary always sits
+rem under apps\git\current\bin, via the `current` junction scoop maintains.
+if not defined BASH_EXE call :use_if_exists "%SCOOP%\apps\git\current\bin\bash.exe"
+if not defined BASH_EXE call :use_if_exists "%USERPROFILE%\scoop\apps\git\current\bin\bash.exe"
+if not defined BASH_EXE call :use_if_exists "%ProgramData%\scoop\apps\git\current\bin\bash.exe"
+
+rem Derive the install root from git.exe on PATH, which covers the winget and
+rem chocolatey layouts. git.exe sits in <root>\cmd or <root>\bin, so bash.exe
+rem is always at <root>\bin\bash.exe.
 if not defined BASH_EXE (
   for /f "delims=" %%G in ('where git.exe 2^>nul') do (
     if not defined BASH_EXE call :use_if_exists "%%~dpG..\bin\bash.exe"
@@ -66,8 +73,8 @@ rem parentheses below would otherwise close the block early.
 :no_bash
 echo [run-dev-win] Could not locate the bash.exe shipped with Git for Windows.>&2
 echo [run-dev-win] Looked under Program Files\Git\bin, Program Files (x86)\Git\bin,>&2
-echo [run-dev-win] LOCALAPPDATA\Programs\Git\bin, and the Git install root derived>&2
-echo [run-dev-win] from git.exe on PATH.>&2
+echo [run-dev-win] LOCALAPPDATA\Programs\Git\bin, the scoop apps\git\current\bin>&2
+echo [run-dev-win] directories, and the Git install root derived from git.exe on PATH.>&2
 echo [run-dev-win] Install Git for Windows from https://git-scm.com/download/win,>&2
 echo [run-dev-win] or set OPENHUMAN_BASH_EXE to the full path of bash.exe and retry.>&2
 exit /b 1

--- a/scripts/run-dev-win.cmd
+++ b/scripts/run-dev-win.cmd
@@ -1,0 +1,73 @@
+@echo off
+setlocal EnableExtensions
+
+rem ===========================================================================
+rem Entry point for `pnpm dev:app:win`.
+rem
+rem Why this wrapper exists
+rem -----------------------
+rem pnpm runs package.json scripts through `cmd.exe /d /s /c <string>`. The /S
+rem flag strips the first and last quote characters from <string> before
+rem parsing it. A script body that quotes an interpreter path containing
+rem spaces, e.g.
+rem
+rem     "C:/Program Files/Git/bin/bash.exe" ../scripts/run-dev-win.sh
+rem
+rem therefore reaches the parser as
+rem
+rem     C:/Program Files/Git/bin/bash.exe ../scripts/run-dev-win.sh
+rem
+rem and cmd treats `C:/Program` as the program name:
+rem
+rem     'C:/Program' is not recognized as an internal or external command
+rem
+rem That breaks every machine using the default Git for Windows install
+rem location. Quoting behaves normally *inside* a .cmd file, so package.json
+rem now points at this wrapper -- a relative path with no spaces, which needs
+rem no quoting of its own -- and the spacey bash.exe path is quoted here.
+rem
+rem This mirrors the workaround run-dev-win.sh already applies internally when
+rem it generates a .bat shim for cargo-tauri's beforeDevCommand.
+rem ===========================================================================
+
+set "SCRIPT_DIR=%~dp0"
+set "BASH_EXE="
+
+rem Escape hatch for non-standard Git installs / portable Git.
+if defined OPENHUMAN_BASH_EXE (
+  if exist "%OPENHUMAN_BASH_EXE%" set "BASH_EXE=%OPENHUMAN_BASH_EXE%"
+)
+
+rem Standard Git for Windows locations, including a user-scope install.
+if not defined BASH_EXE call :use_if_exists "%ProgramFiles%\Git\bin\bash.exe"
+if not defined BASH_EXE call :use_if_exists "%ProgramFiles(x86)%\Git\bin\bash.exe"
+if not defined BASH_EXE call :use_if_exists "%LOCALAPPDATA%\Programs\Git\bin\bash.exe"
+
+rem Derive the install root from git.exe on PATH, which covers winget, scoop
+rem and chocolatey layouts. git.exe sits in <root>\cmd or <root>\bin, so
+rem bash.exe is always at <root>\bin\bash.exe.
+if not defined BASH_EXE (
+  for /f "delims=" %%G in ('where git.exe 2^>nul') do (
+    if not defined BASH_EXE call :use_if_exists "%%~dpG..\bin\bash.exe"
+  )
+)
+
+rem NOTE: we deliberately never fall back to a bare `bash` lookup on PATH.
+rem When WSL is enabled, `bash` resolves to C:\Windows\System32\bash.exe -- the
+rem WSL launcher -- which would run run-dev-win.sh inside a Linux distro where
+rem none of the Windows toolchain it configures (MSVC, CEF, cargo-tauri) exists.
+if not defined BASH_EXE (
+  echo [run-dev-win] Could not locate Git for Windows' bash.exe.>&2
+  echo [run-dev-win] Looked in: %%ProgramFiles%%\Git\bin, %%ProgramFiles(x86)%%\Git\bin,>&2
+  echo [run-dev-win] %%LOCALAPPDATA%%\Programs\Git\bin, and the parent of git.exe on PATH.>&2
+  echo [run-dev-win] Install Git for Windows ^(https://git-scm.com/download/win^) or set>&2
+  echo [run-dev-win] OPENHUMAN_BASH_EXE to the full path of bash.exe and retry.>&2
+  exit /b 1
+)
+
+"%BASH_EXE%" "%SCRIPT_DIR%run-dev-win.sh" %*
+exit /b %ERRORLEVEL%
+
+:use_if_exists
+if exist "%~1" set "BASH_EXE=%~1"
+goto :eof

--- a/scripts/run-dev-win.cmd
+++ b/scripts/run-dev-win.cmd
@@ -28,57 +28,55 @@ rem no quoting of its own -- and the spacey bash.exe path is quoted here.
 rem
 rem This mirrors the workaround run-dev-win.sh already applies internally when
 rem it generates a .bat shim for cargo-tauri's beforeDevCommand.
+rem
+rem Style constraint: no labels, no jumps, no multi-line parenthesised blocks
+rem ------------------------------------------------------------------------
+rem cmd.exe locates a label by byte offset and re-reads the script in 512-byte
+rem chunks, which makes label-based control flow the one batch construct whose
+rem behaviour depends on the file's line endings. This script is therefore
+rem written as straight-line batch guarded by single-line `if` statements, so
+rem it behaves identically whether it is checked out with LF or CRLF. The
+rem .gitattributes rule that checks batch files out as CRLF stays for editor
+rem and tooling consistency -- correctness simply no longer depends on it.
 rem ===========================================================================
 
 set "SCRIPT_DIR=%~dp0"
 set "BASH_EXE="
 
 rem Escape hatch for non-standard Git installs / portable Git.
-if defined OPENHUMAN_BASH_EXE (
-  if exist "%OPENHUMAN_BASH_EXE%" set "BASH_EXE=%OPENHUMAN_BASH_EXE%"
-)
+if defined OPENHUMAN_BASH_EXE if exist "%OPENHUMAN_BASH_EXE%" set "BASH_EXE=%OPENHUMAN_BASH_EXE%"
 
 rem Standard Git for Windows locations, including a user-scope install.
-if not defined BASH_EXE call :use_if_exists "%ProgramFiles%\Git\bin\bash.exe"
-if not defined BASH_EXE call :use_if_exists "%ProgramFiles(x86)%\Git\bin\bash.exe"
-if not defined BASH_EXE call :use_if_exists "%LOCALAPPDATA%\Programs\Git\bin\bash.exe"
+if not defined BASH_EXE if exist "%ProgramFiles%\Git\bin\bash.exe" set "BASH_EXE=%ProgramFiles%\Git\bin\bash.exe"
+if not defined BASH_EXE if exist "%ProgramFiles(x86)%\Git\bin\bash.exe" set "BASH_EXE=%ProgramFiles(x86)%\Git\bin\bash.exe"
+if not defined BASH_EXE if exist "%LOCALAPPDATA%\Programs\Git\bin\bash.exe" set "BASH_EXE=%LOCALAPPDATA%\Programs\Git\bin\bash.exe"
 
 rem Scoop only ever puts shims on PATH, so the git.exe probe below would derive
 rem <scoop>\bin\bash.exe, which does not exist. The real binary always sits
-rem under apps\git\current\bin, via the `current` junction scoop maintains.
-if not defined BASH_EXE call :use_if_exists "%SCOOP%\apps\git\current\bin\bash.exe"
-if not defined BASH_EXE call :use_if_exists "%USERPROFILE%\scoop\apps\git\current\bin\bash.exe"
-if not defined BASH_EXE call :use_if_exists "%ProgramData%\scoop\apps\git\current\bin\bash.exe"
+rem under apps\git\current\bin, via the `current` junction scoop maintains
+rem across upgrades. Probe the user, relocated and global scoop roots.
+if not defined BASH_EXE if exist "%SCOOP%\apps\git\current\bin\bash.exe" set "BASH_EXE=%SCOOP%\apps\git\current\bin\bash.exe"
+if not defined BASH_EXE if exist "%USERPROFILE%\scoop\apps\git\current\bin\bash.exe" set "BASH_EXE=%USERPROFILE%\scoop\apps\git\current\bin\bash.exe"
+if not defined BASH_EXE if exist "%ProgramData%\scoop\apps\git\current\bin\bash.exe" set "BASH_EXE=%ProgramData%\scoop\apps\git\current\bin\bash.exe"
 
 rem Derive the install root from git.exe on PATH, which covers the winget and
 rem chocolatey layouts. git.exe sits in <root>\cmd or <root>\bin, so bash.exe
 rem is always at <root>\bin\bash.exe.
-if not defined BASH_EXE (
-  for /f "delims=" %%G in ('where git.exe 2^>nul') do (
-    if not defined BASH_EXE call :use_if_exists "%%~dpG..\bin\bash.exe"
-  )
-)
+if not defined BASH_EXE for /f "delims=" %%G in ('where git.exe 2^>nul') do if not defined BASH_EXE if exist "%%~dpG..\bin\bash.exe" set "BASH_EXE=%%~dpG..\bin\bash.exe"
 
 rem NOTE: we deliberately never fall back to a bare `bash` lookup on PATH.
 rem When WSL is enabled, `bash` resolves to C:\Windows\System32\bash.exe -- the
 rem WSL launcher -- which would run run-dev-win.sh inside a Linux distro where
-rem none of the Windows toolchain it configures (MSVC, CEF, cargo-tauri) exists.
-if not defined BASH_EXE goto :no_bash
+rem none of the Windows toolchain it configures - MSVC, CEF, cargo-tauri -
+rem exists.
+
+if not defined BASH_EXE echo [run-dev-win] Could not locate the bash.exe shipped with Git for Windows.>&2
+if not defined BASH_EXE echo [run-dev-win] Looked under the machine-scope and user-scope Git for Windows>&2
+if not defined BASH_EXE echo [run-dev-win] install directories, the scoop apps\git\current\bin directories,>&2
+if not defined BASH_EXE echo [run-dev-win] and the Git install root derived from git.exe on PATH.>&2
+if not defined BASH_EXE echo [run-dev-win] Install Git for Windows from https://git-scm.com/download/win,>&2
+if not defined BASH_EXE echo [run-dev-win] or set OPENHUMAN_BASH_EXE to the full path of bash.exe and retry.>&2
+if not defined BASH_EXE exit /b 1
 
 "%BASH_EXE%" "%SCRIPT_DIR%run-dev-win.sh" %*
 exit /b %ERRORLEVEL%
-
-rem Reported from a label rather than inside an `if (...)` block: the literal
-rem parentheses below would otherwise close the block early.
-:no_bash
-echo [run-dev-win] Could not locate the bash.exe shipped with Git for Windows.>&2
-echo [run-dev-win] Looked under Program Files\Git\bin, Program Files (x86)\Git\bin,>&2
-echo [run-dev-win] LOCALAPPDATA\Programs\Git\bin, the scoop apps\git\current\bin>&2
-echo [run-dev-win] directories, and the Git install root derived from git.exe on PATH.>&2
-echo [run-dev-win] Install Git for Windows from https://git-scm.com/download/win,>&2
-echo [run-dev-win] or set OPENHUMAN_BASH_EXE to the full path of bash.exe and retry.>&2
-exit /b 1
-
-:use_if_exists
-if exist "%~1" set "BASH_EXE=%~1"
-goto :eof

--- a/scripts/run-dev-win.cmd
+++ b/scripts/run-dev-win.cmd
@@ -56,17 +56,21 @@ rem NOTE: we deliberately never fall back to a bare `bash` lookup on PATH.
 rem When WSL is enabled, `bash` resolves to C:\Windows\System32\bash.exe -- the
 rem WSL launcher -- which would run run-dev-win.sh inside a Linux distro where
 rem none of the Windows toolchain it configures (MSVC, CEF, cargo-tauri) exists.
-if not defined BASH_EXE (
-  echo [run-dev-win] Could not locate Git for Windows' bash.exe.>&2
-  echo [run-dev-win] Looked in: %%ProgramFiles%%\Git\bin, %%ProgramFiles(x86)%%\Git\bin,>&2
-  echo [run-dev-win] %%LOCALAPPDATA%%\Programs\Git\bin, and the parent of git.exe on PATH.>&2
-  echo [run-dev-win] Install Git for Windows ^(https://git-scm.com/download/win^) or set>&2
-  echo [run-dev-win] OPENHUMAN_BASH_EXE to the full path of bash.exe and retry.>&2
-  exit /b 1
-)
+if not defined BASH_EXE goto :no_bash
 
 "%BASH_EXE%" "%SCRIPT_DIR%run-dev-win.sh" %*
 exit /b %ERRORLEVEL%
+
+rem Reported from a label rather than inside an `if (...)` block: the literal
+rem parentheses below would otherwise close the block early.
+:no_bash
+echo [run-dev-win] Could not locate the bash.exe shipped with Git for Windows.>&2
+echo [run-dev-win] Looked under Program Files\Git\bin, Program Files (x86)\Git\bin,>&2
+echo [run-dev-win] LOCALAPPDATA\Programs\Git\bin, and the Git install root derived>&2
+echo [run-dev-win] from git.exe on PATH.>&2
+echo [run-dev-win] Install Git for Windows from https://git-scm.com/download/win,>&2
+echo [run-dev-win] or set OPENHUMAN_BASH_EXE to the full path of bash.exe and retry.>&2
+exit /b 1
 
 :use_if_exists
 if exist "%~1" set "BASH_EXE=%~1"


### PR DESCRIPTION
## Summary

- `pnpm dev:app:win` fails on every default Git for Windows install with `'C:/Program' is not recognized as an internal or external command`.
- Route the script through a new `scripts/run-dev-win.cmd` wrapper so the `bash.exe` path is quoted in a context where quoting actually survives.
- `app/package.json` now points at a relative, space-free path (`..\scripts\run-dev-win.cmd`) that needs no quoting of its own.
- The wrapper is written as straight-line batch with **no labels and no `goto`/`call`**, so its behaviour does not depend on whether it is checked out with LF or CRLF.
- `.gitattributes` now checks out `*.cmd`/`*.bat` with CRLF, matching the exception `*.ps1` already had.
- Added `app/test/dev-app-win-launcher.test.ts`, which models `cmd.exe /d /s /c` argument parsing and locks in both the quoting regression and the no-label property.
- `scripts/run-dev-win.sh` is unchanged — this only fixes how it is invoked.

## Problem

`app/package.json` declared:

```json
"dev:app:win": "\"C:/Program Files/Git/bin/bash.exe\" ../scripts/run-dev-win.sh"
```

pnpm runs package.json scripts through `cmd.exe /d /s /c <string>`. The **`/S` flag strips the first and last quote characters** of `<string>` before parsing it. So cmd receives:

```
C:/Program Files/Git/bin/bash.exe ../scripts/run-dev-win.sh
```

and takes `C:/Program` as the program name, producing exactly the error reported in #5270. The quotes cannot protect the path at this layer — they are the first and last characters, so they are precisely what `/S` removes.

Because `C:\Program Files\Git` is the **default** install location, this breaks the documented Windows dev path for essentially every contributor who did not install Git somewhere without a space.

## Solution

Quoting behaves normally *inside* a `.cmd` file, so the fix is to make the package.json body something cmd cannot mis-split, and do the real quoting one level down.

`app/package.json` (single line changed):

```diff
-"dev:app:win": "\"C:/Program Files/Git/bin/bash.exe\" ../scripts/run-dev-win.sh",
+"dev:app:win": "..\\scripts\\run-dev-win.cmd",
```

The new value has no spaces and no quotes, so `/S` stripping is a no-op on it. Backslashes are used rather than forward slashes because cmd treats a leading `/` as a switch prefix. pnpm runs lifecycle scripts with the package directory as cwd, so the relative path resolves from `app/`.

`scripts/run-dev-win.cmd` then locates `bash.exe` and invokes it with the path properly quoted:

```bat
"%BASH_EXE%" "%SCRIPT_DIR%run-dev-win.sh" %*
```

Lookup order:

1. `%OPENHUMAN_BASH_EXE%` — escape hatch for portable/exotic Git installs.
2. `%ProgramFiles%\Git\bin`, `%ProgramFiles(x86)%\Git\bin`, `%LOCALAPPDATA%\Programs\Git\bin` — the machine-scope and user-scope Git for Windows installers.
3. `%SCOOP%`, `%USERPROFILE%\scoop`, `%ProgramData%\scoop` → `apps\git\current\bin\bash.exe` — scoop only exposes shims on `PATH`, so it must be probed directly (see below).
4. The Git root derived from `git.exe` on `PATH` — covers winget and chocolatey, where `git.exe` lives in `\cmd` and bash in `\bin`.

If none match it exits `1` with actionable guidance instead of failing obscurely.

### No labels, no `goto`/`call` — deliberate

Each candidate is applied by a single-line `if not defined BASH_EXE if exist "…" set "BASH_EXE=…"`, and the failure path is a run of single-line `if not defined BASH_EXE echo …>&2` lines terminated by `if not defined BASH_EXE exit /b 1`. There is no `call :use_if_exists` helper and no `goto :no_bash` jump.

That is not stylistic. `cmd.exe` locates a label by **byte offset** and re-reads the script in 512-byte chunks, which makes label-based control flow the one batch construct whose behaviour depends on the file's line endings — the basis of the well-known LF-only batch corruption bug. Writing the launcher without labels removes the dependency at the source, instead of relying on every checkout on every machine having applied the right `.gitattributes` rule. A test pins the property so it cannot silently regress.

### `.gitattributes`

The repo root normalises everything with `* text=auto eol=lf` and carves out exactly one Windows exception, `*.ps1 text eol=crlf`. Batch files had no rule at all, so `*.cmd`/`*.bat text eol=crlf` was added alongside it. With the label-free launcher this is defence in depth and consistency for editors and future batch files, rather than the thing correctness rests on.

### Design notes / rejected alternatives

The issue suggested three options. This PR takes **option 1** deliberately:

- **Option 2 — bare `bash ../scripts/run-dev-win.sh`** was rejected as actively harmful. `Git\bin` is *not* on `PATH` by default (only `Git\cmd`, which has no `bash.exe`), and on machines with WSL enabled `bash` resolves to `C:\Windows\System32\bash.exe` — the WSL launcher. That would run the script inside a Linux distro with none of the Windows toolchain it configures (MSVC, CEF, cargo-tauri), producing a far more confusing failure than the current one. The wrapper therefore **never** falls back to a bare `bash` lookup, and there is a test asserting it does not.
- **Option 3 — `.npmrc` `script-shell`** was rejected because it changes shell semantics repo-wide for every platform to fix one Windows script.
- **Option 1 is already the idiom here.** `scripts/run-dev-win.sh` generates `.bat` shims internally (`vcvars_launcher`, `run-vite.bat`) for cargo-tauri's `beforeDevCommand` to dodge this exact quoting problem. This change applies the same trick one level up, at the pnpm boundary.

## Impact

- **Platform:** Windows dev workflow only. `dev:app`, `dev:web`, `dev:wry` and all CI/build/release scripts are untouched; nothing outside Windows executes a `.cmd`.
- **Runtime/product:** none. This is a developer entry point, not shipped application code.
- **Compatibility:** a hardcoded absolute path is replaced by a probe, so this *widens* the set of working setups (machine-scope, user-scope, winget, scoop, chocolatey, portable Git) rather than narrowing it. `OPENHUMAN_BASH_EXE` covers anything exotic.
- **Security:** no new network dependency; no new executable is downloaded. Candidate paths are all derived from OS-provided environment variables or `where git.exe`.

## Related

- Closes: #5270
- Follow-up PR(s)/TODOs: none.
- Coverage matrix feature IDs: none — see checklist note below.

## Review feedback addressed

- **CodeRabbit — CRLF line endings, round 1** (b4a710e): fixed at the attributes layer rather than by committing CRLF bytes, since `text=auto` normalises the blob to LF on commit regardless, so a checkout rule is the only durable form of that fix.
- **Greptile — scoop coverage** (f141144): correct, and this description previously overclaimed. `where git.exe` under scoop returns `<scoop>\shims\git.exe`, so the derived `<shim>\..\bin\bash.exe` resolved to `<scoop>\bin\bash.exe`, which never exists. Now probing `apps\git\current\bin\bash.exe` — the real binary behind the shim, via the `current` junction scoop maintains across upgrades — across the user, global and `%SCOOP%`-relocated roots. The failure-path diagnostic and the comment above the `git.exe` probe were corrected to match.
- **CodeRabbit — CRLF line endings, round 2** (9d81ab4, b353a74): the bot re-flagged the blob (Blinter `E018`) after the `.gitattributes` fix, and it has a fair point that the earlier fix left the *repository object* LF-only — which is what anyone reading the file through the API, a raw link, or a source archive sees. Rather than argue the checkout rule again, **the dependency itself is now gone**: the launcher was rewritten with no labels and no `goto`/`call`, which is the only batch construct whose parsing is line-ending sensitive. The file is now correct under LF *and* CRLF, the `.gitattributes` rule stays for consistency, and `app/test/dev-app-win-launcher.test.ts` gained a fifth case asserting no label-based control flow so this cannot regress. Behaviour is otherwise unchanged: identical probe order, identical quoting, identical exit-code propagation.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `app/test/dev-app-win-launcher.test.ts` has 5 cases. The **failure-path** case reconstructs the old script body verbatim and asserts `cmd /S` parsing yields `C:/Program`, so the regression is pinned rather than merely described. The others assert the current body survives `/S` as one token, that it points at a file that exists, that the wrapper quotes `%BASH_EXE%` and contains no bare-`bash` lookup, and that the wrapper uses no label-based control flow.
- [x] **Diff coverage ≥ 80%** — `N/A`, and verifiably so rather than by assertion: `app/test/vitest.config.ts` sets `coverage.include: ["src/**/*.{ts,tsx}"]`. All four changed files (`app/package.json`, `app/test/dev-app-win-launcher.test.ts`, `scripts/run-dev-win.cmd`, `.gitattributes`) fall outside `app/src/**`, so no changed line appears in the lcov report and `diff-cover --fail-under=80` has no lines to judge. No Rust changed, so `cargo-llvm-cov` is unaffected. Please flag if you would rather I approach this differently.
- [x] Coverage matrix updated — `N/A: developer tooling change`. `docs/TEST-COVERAGE-MATRIX.md` tracks product feature rows with IDs validated against a catalog; a build-script entry point has no feature ID, and inventing one would add noise. Calling this out explicitly rather than silently skipping — happy to add a row if you disagree.
- [x] All affected feature IDs listed under `## Related` — `N/A`, none (see above).
- [x] No new external network dependencies introduced — none added; no test performs I/O beyond reading two files from the repo working tree.
- [x] Manual smoke checklist updated — `N/A: does not touch release-cut surfaces`. This affects the dev entry point only; release builds go through `macos:build:*` / `build:app`.
- [x] Linked issue closed via `Closes #NNN` in `## Related` — `Closes #5270`.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

Disclosing this fully, since the template asks for it: the investigation and patch were drafted with AI assistance, reviewed line-by-line by me before pushing. It is not a Codex/Linear-tracked PR, so those fields are `N/A`.

### Linear Issue

- Key: `N/A` — external contribution, tracked by GitHub issue #5270.
- URL: https://github.com/tinyhumansai/openhuman/issues/5270

### Commit & Branch

- Branch: `Mustaqeem66:fix/5270-dev-app-win-cmd-quoting`
- Commit SHA: `b353a745ad541696126481825deb6bb5a040cd7f`

### Validation Run

> Three of these could not be run in my environment. Rather than tick boxes I did not earn — or leave them unchecked and trip `check-pr-checklist.mjs` — they are listed as plain bullets marked **NOT RUN**, with full detail in **Validation Blocked** below. Happy to reformat if maintainers prefer a different convention here.

- **NOT RUN** — `pnpm --filter openhuman-app format:check`
- **NOT RUN** — `pnpm typecheck`
- **NOT RUN** — Focused tests: `pnpm --filter openhuman-app test -- dev-app-win-launcher`
- [x] Rust fmt/check (if changed): `N/A` — no Rust changed.
- [x] Tauri fmt/check (if changed): `N/A` — no Tauri config or Rust changed.

### Validation Blocked

I would rather state this plainly than tick boxes I did not earn:

- `command:` `pnpm --filter openhuman-app format:check`, `pnpm typecheck`, `pnpm test`, `pnpm test:coverage`
- `error:` `pnpm: command not found` — the environment I prepared this in has no Node package manager, no Rust toolchain and no network access, so dependencies cannot be installed.
- `impact:` The test file has **not** been executed locally under vitest. To de-risk that, the pure-logic helpers were extracted and run standalone under plain `node`: the legacy body yields `C:/Program`, the new body survives `/S` unchanged, and the no-label assertions were run against both an LF and a CRLF copy of the launcher (both pass, which is the point of the rewrite). The remaining assertions are `existsSync` and substring checks against files added in this PR. CI is the real verification for typecheck/format/lint — the first run flagged a `format:check` failure (hand-wrapped call expressions that fit inside the repo's `printWidth` of 100), fixed in bb9e76a with no behavioural change to the tests.
- `impact (Windows):` I have no Windows machine attached to this environment, so `pnpm dev:app:win` has not been run end-to-end against a real Git install. The `.cmd` was desk-checked for batch parsing hazards — one was found and fixed in `9df25a7` (an unescaped `)` in `%ProgramFiles(x86)%` inside an `if (...)` block would have closed the block early), and the later rewrite removed every multi-line parenthesised block and every label, so that class of hazard is now structurally absent. **A maintainer sanity-check on a real Windows box would be genuinely valuable before merge**, and I will act on any failure immediately.

### Behavior Changes

- Intended behavior change: `pnpm dev:app:win` resolves `bash.exe` at runtime instead of assuming one hardcoded absolute path, and is invoked so that `cmd.exe /S` cannot split it.
- User-visible effect: for developers, `pnpm dev:app:win` starts working on default Git for Windows installs instead of erroring immediately. No end-user or product-facing change.

### Parity Contract

- Legacy behavior preserved: yes. The command ultimately executed is still `<bash.exe> <repo>/scripts/run-dev-win.sh`, with `run-dev-win.sh` byte-identical. On the machines where the old form happened to work (Git at `C:\Program Files\Git`), the wrapper's first filesystem probe resolves to that same `bash.exe`, so behavior is identical. Arguments are forwarded via `%*`.
- Guard/fallback/dispatch parity checks: the exit code is propagated with `exit /b %ERRORLEVEL%` so failures still surface to pnpm. The fallback chain only ever *adds* candidates that the old hardcoded path did not cover; it removes none, and the label-free rewrite preserved the probe order exactly. The one intentional non-fallback is a bare `bash` PATH lookup, excluded because of the WSL hazard described above and asserted absent by test.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none found. I searched open and closed PRs for #5270 and for Windows dev-script changes before starting; the issue is unassigned with no linked PR.
- Canonical PR: this one.
- Resolution: `N/A`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Windows app development command so it launches reliably from paths containing spaces.
  * Added a Windows launcher that correctly locates Git Bash and forwards command arguments.
  * Added clear guidance when Git Bash cannot be found.

* **Chores**
  * Standardized Windows command-file line endings for improved compatibility.

* **Tests**
  * Added coverage for Windows command parsing, launcher discovery, argument forwarding, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->