### PR TITLE
feat(deep-link): confirm the tokenmaxxxing download when the app opens

### DIFF
--- a/app/src/services/api/waitlistApi.test.ts
+++ b/app/src/services/api/waitlistApi.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPost = vi.fn();
+
+vi.mock('../apiClient', () => ({
+  apiClient: {
+    post: (...args: unknown[]) => mockPost(...args),
+  },
+}));
+
+describe('confirmWaitlistDownload', () => {
+  beforeEach(() => {
+    mockPost.mockReset();
+  });
+
+  it('posts the token to the confirm endpoint', async () => {
+    mockPost.mockResolvedValueOnce({ success: true, data: {} });
+
+    const { confirmWaitlistDownload } = await import('./waitlistApi');
+    await confirmWaitlistDownload('tok_abc123');
+
+    const [endpoint, body] = mockPost.mock.calls[0];
+    expect(endpoint).toBe('/waitlist/tasks/download/confirm');
+    expect(body).toEqual({ token: 'tok_abc123' });
+  });
+
+  it('sends no session bearer — the download token is the credential', async () => {
+    mockPost.mockResolvedValueOnce({ success: true, data: {} });
+
+    const { confirmWaitlistDownload } = await import('./waitlistApi');
+    await confirmWaitlistDownload('tok_abc123');
+
+    const options = mockPost.mock.calls[0][2] as { requireAuth?: boolean; timeout?: number };
+    expect(options.requireAuth).toBe(false);
+  });
+
+  it('bounds the request so it cannot hold up app startup', async () => {
+    mockPost.mockResolvedValueOnce({ success: true, data: {} });
+
+    const { confirmWaitlistDownload } = await import('./waitlistApi');
+    await confirmWaitlistDownload('tok_abc123');
+
+    const options = mockPost.mock.calls[0][2] as { timeout?: number };
+    expect(options.timeout).toBeGreaterThan(0);
+    expect(options.timeout).toBeLessThan(120_000);
+  });
+
+  it('propagates failures so the caller decides how to degrade', async () => {
+    mockPost.mockRejectedValueOnce({ success: false, error: 'Waitlist entry not found' });
+
+    const { confirmWaitlistDownload } = await import('./waitlistApi');
+    await expect(confirmWaitlistDownload('tok_missing')).rejects.toEqual({
+      success: false,
+      error: 'Waitlist entry not found',
+    });
+  });
+});

--- a/app/src/services/api/waitlistApi.test.ts
+++ b/app/src/services/api/waitlistApi.test.ts
@@ -1,16 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockPost = vi.fn();
+// Hoisted: `vi.mock` is lifted above this file's declarations, so the factory
+// needs a binding that already exists when it runs.
+const { mockLog } = vi.hoisted(() => ({ mockLog: vi.fn() }));
 
-vi.mock('../apiClient', () => ({
-  apiClient: {
-    post: (...args: unknown[]) => mockPost(...args),
-  },
-}));
+vi.mock('debug', () => ({ default: () => mockLog }));
+vi.mock('../apiClient', () => ({ apiClient: { post: (...args: unknown[]) => mockPost(...args) } }));
 
 describe('confirmWaitlistDownload', () => {
   beforeEach(() => {
     mockPost.mockReset();
+    mockLog.mockReset();
   });
 
   it('posts the token to the confirm endpoint', async () => {
@@ -34,15 +35,24 @@ describe('confirmWaitlistDownload', () => {
     expect(options.requireAuth).toBe(false);
   });
 
-  it('bounds the request so it cannot hold up app startup', async () => {
+  it('bounds the request at ten seconds so it cannot hold up app startup', async () => {
     mockPost.mockResolvedValueOnce({ success: true, data: {} });
 
     const { confirmWaitlistDownload } = await import('./waitlistApi');
     await confirmWaitlistDownload('tok_abc123');
 
     const options = mockPost.mock.calls[0][2] as { timeout?: number };
-    expect(options.timeout).toBeGreaterThan(0);
-    expect(options.timeout).toBeLessThan(120_000);
+    expect(options.timeout).toBe(10_000);
+  });
+
+  it('logs the token length and never the token', async () => {
+    mockPost.mockResolvedValueOnce({ success: true, data: {} });
+
+    const { confirmWaitlistDownload } = await import('./waitlistApi');
+    await confirmWaitlistDownload('tok_abc123');
+
+    expect(mockLog).toHaveBeenCalledWith(expect.stringContaining('tokenLength'), 10);
+    expect(JSON.stringify(mockLog.mock.calls)).not.toContain('tok_abc123');
   });
 
   it('propagates failures so the caller decides how to degrade', async () => {

--- a/app/src/services/api/waitlistApi.ts
+++ b/app/src/services/api/waitlistApi.ts
@@ -1,0 +1,40 @@
+import createDebug from 'debug';
+
+import type { ApiResponse } from '../../types/api';
+import { apiClient } from '../apiClient';
+
+const log = createDebug('waitlist:api');
+
+/**
+ * This runs while the app is opening, so it gets a short leash rather than the
+ * client's two-minute default. Nothing downstream waits on the result.
+ */
+const CONFIRM_TIMEOUT_MS = 10_000;
+
+/**
+ * POST /waitlist/tasks/download/confirm — report that the desktop app was opened
+ * from a tokenmaxxxing download link, which is what releases the download reward
+ * on the waitlist entry that link belongs to.
+ *
+ * Unauthenticated on purpose. The download token *is* the credential here, and
+ * whoever follows the link has usually never signed in — `requireAuth: false`
+ * keeps the app's session bearer off a request that has no use for it, rather
+ * than leaking it to an endpoint that does not expect one.
+ *
+ * Idempotent server-side, so opening the same link twice is harmless and a
+ * failed attempt can simply be retried by opening it again.
+ *
+ * The response body is deliberately untyped beyond the envelope: the caller
+ * needs to know only whether this succeeded, and pinning a shape that is still
+ * being built would be a guess this module would then have to keep in step.
+ */
+export async function confirmWaitlistDownload(token: string): Promise<void> {
+  // Length only — a download token is a credential and must not reach a log.
+  log('confirming waitlist download tokenLength=%d', token.length);
+
+  await apiClient.post<ApiResponse<unknown>>(
+    '/waitlist/tasks/download/confirm',
+    { token },
+    { requireAuth: false, timeout: CONFIRM_TIMEOUT_MS }
+  );
+}

--- a/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
+++ b/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
@@ -138,18 +138,18 @@ describe('desktopDeepLinkListener', () => {
   });
 
   it('keeps the download token out of the logs on failure', async () => {
-    const logged: string[] = [];
-    const warn = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
-      logged.push(args.map(a => JSON.stringify(a)).join(' '));
-    });
     // The token in the message is the point: a rejection on this path can carry
     // the credential, and `sanitizeError` would have preserved it.
     vi.mocked(confirmWaitlistDownload).mockRejectedValue(new Error('super-secret-token'));
 
     await handleDeepLinkUrls(['openhuman://waitlist?token=super-secret-token']);
 
-    expect(logged.join(' ')).not.toContain('super-secret-token');
-    warn.mockRestore();
+    // Reads the suite-wide console spy from `src/test/setup.ts` rather than
+    // installing its own. A local spy would have to be restored, and restoring
+    // it un-spies `console.warn` for every test that runs after this one —
+    // `restoreMocks` is off, so nothing puts it back.
+    expect(console.warn).toHaveBeenCalledWith('[DeepLink][waitlist] Could not confirm download');
+    expect(JSON.stringify(vi.mocked(console.warn).mock.calls)).not.toContain('super-secret-token');
   });
 
   it('waits for the core before confirming, and skips the call when it never comes up', async () => {

--- a/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
+++ b/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
@@ -142,15 +142,26 @@ describe('desktopDeepLinkListener', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
       logged.push(args.map(a => JSON.stringify(a)).join(' '));
     });
-    vi.mocked(confirmWaitlistDownload).mockRejectedValue({
-      success: false,
-      error: 'Waitlist entry not found',
-    });
+    // The token in the message is the point: a rejection on this path can carry
+    // the credential, and `sanitizeError` would have preserved it.
+    vi.mocked(confirmWaitlistDownload).mockRejectedValue(new Error('super-secret-token'));
 
     await handleDeepLinkUrls(['openhuman://waitlist?token=super-secret-token']);
 
     expect(logged.join(' ')).not.toContain('super-secret-token');
     warn.mockRestore();
+  });
+
+  it('waits for the core before confirming, and skips the call when it never comes up', async () => {
+    // Cold open from a download link runs before BootCheckGate starts the core,
+    // and the backend base resolves through it — confirming early would post to
+    // nothing and be swallowed as an ordinary failure.
+    waitForOAuthAuthReadiness.mockResolvedValue({ ready: false, reason: 'core_unreachable' });
+
+    await handleDeepLinkUrls(['openhuman://waitlist?token=dl-token-123']);
+
+    expect(confirmWaitlistDownload).not.toHaveBeenCalled();
+    expect(windowControls.setFocus).toHaveBeenCalled();
   });
 
   it('turns Twitter OAuth error deep links into actionable UI and event diagnostics', async () => {

--- a/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
+++ b/app/src/utils/__tests__/desktopDeepLinkListener.test.ts
@@ -2,6 +2,7 @@ import { isTauri } from '@tauri-apps/api/core';
 import { getCurrent, onOpenUrl } from '@tauri-apps/plugin-deep-link';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { confirmWaitlistDownload } from '../../services/api/waitlistApi';
 import { clearCoreRpcTokenCache, clearCoreRpcUrlCache } from '../../services/coreRpcClient';
 import {
   completeDeepLinkAuthProcessing,
@@ -26,6 +27,7 @@ vi.mock('../../services/coreRpcClient', () => ({
   clearCoreRpcTokenCache: vi.fn(),
 }));
 vi.mock('../openUrl', () => ({ openUrl: vi.fn() }));
+vi.mock('../../services/api/waitlistApi', () => ({ confirmWaitlistDownload: vi.fn() }));
 
 // Build an `openhuman://auth` deep link bound to a freshly registered state
 // nonce, mirroring how the real OAuth button registers the loopback/deep-link
@@ -89,6 +91,8 @@ describe('desktopDeepLinkListener', () => {
     vi.mocked(clearCoreRpcTokenCache).mockClear();
     vi.mocked(openUrl).mockReset();
     vi.mocked(openUrl).mockResolvedValue(undefined);
+    vi.mocked(confirmWaitlistDownload).mockReset();
+    vi.mocked(confirmWaitlistDownload).mockResolvedValue(undefined);
     windowControls.show.mockClear();
     windowControls.unminimize.mockClear();
     windowControls.setFocus.mockClear();
@@ -106,6 +110,47 @@ describe('desktopDeepLinkListener', () => {
     await handleDeepLinkUrls(['openhuman://payment/cancel']);
 
     expect(openUrl).toHaveBeenCalledWith(BILLING_DASHBOARD_URL);
+  });
+
+  it('confirms the download and focuses the window for a waitlist deep link', async () => {
+    await handleDeepLinkUrls(['openhuman://waitlist?token=dl-token-123']);
+
+    expect(confirmWaitlistDownload).toHaveBeenCalledWith('dl-token-123');
+    expect(windowControls.setFocus).toHaveBeenCalled();
+  });
+
+  it('still opens the app when the confirmation fails', async () => {
+    // Startup must survive an offline launch: the reward is idempotent and the
+    // next open retries it, but the window has to appear either way.
+    vi.mocked(confirmWaitlistDownload).mockRejectedValue({ success: false, error: 'offline' });
+
+    await expect(
+      handleDeepLinkUrls(['openhuman://waitlist?token=dl-token-123'])
+    ).resolves.toBeUndefined();
+    expect(windowControls.setFocus).toHaveBeenCalled();
+  });
+
+  it('does not call the backend when the waitlist link carries no token', async () => {
+    await handleDeepLinkUrls(['openhuman://waitlist']);
+
+    expect(confirmWaitlistDownload).not.toHaveBeenCalled();
+    expect(windowControls.setFocus).toHaveBeenCalled();
+  });
+
+  it('keeps the download token out of the logs on failure', async () => {
+    const logged: string[] = [];
+    const warn = vi.spyOn(console, 'warn').mockImplementation((...args: unknown[]) => {
+      logged.push(args.map(a => JSON.stringify(a)).join(' '));
+    });
+    vi.mocked(confirmWaitlistDownload).mockRejectedValue({
+      success: false,
+      error: 'Waitlist entry not found',
+    });
+
+    await handleDeepLinkUrls(['openhuman://waitlist?token=super-secret-token']);
+
+    expect(logged.join(' ')).not.toContain('super-secret-token');
+    warn.mockRestore();
   });
 
   it('turns Twitter OAuth error deep links into actionable UI and event diagnostics', async () => {

--- a/app/src/utils/desktopDeepLinkListener.ts
+++ b/app/src/utils/desktopDeepLinkListener.ts
@@ -21,7 +21,6 @@ import {
 } from './oauthAppVersionGate';
 import { clearOAuthReturnRoute, takeOAuthReturnRoute } from './oauthReturnRoute';
 import { openUrl } from './openUrl';
-import { sanitizeError } from './sanitize';
 import { storeSession } from './tauriCommands';
 import { isTauri as coreIsTauri } from './tauriCommands/common';
 
@@ -612,13 +611,31 @@ const handleWaitlistDeepLink = async (parsed: URL) => {
     return;
   }
 
+  // A cold open from a download link is the path this feature exists for, and it
+  // is the one that would have failed: `setupDesktopDeepLinkListener` runs before
+  // `bootRender`, so this fires before BootCheckGate has started the core — and
+  // `apiClient` resolves its base URL from that core over RPC. Confirming
+  // straight away would post to a base that is not resolvable yet, and the
+  // catch below would swallow it as an ordinary failure.
+  //
+  // This is the same gate the auth deep link waits on, for the same reason: it
+  // commits a core mode, starts the local core, and polls `core.ping`. The name
+  // says OAuth but the behaviour is core readiness and nothing more.
+  const readiness = await waitForOAuthAuthReadiness();
+  if (!readiness.ready) {
+    console.warn('[DeepLink][waitlist] Core not ready; leaving the reward for a later open');
+    return;
+  }
+
   try {
     await confirmWaitlistDownload(token);
     console.log('[DeepLink][waitlist] Download confirmed');
-  } catch (error) {
-    // Sanitized rather than raw: the failure is worth knowing about, the token
-    // that produced it is not.
-    console.warn('[DeepLink][waitlist] Could not confirm download:', sanitizeError(error));
+  } catch {
+    // No error detail, deliberately. A rejection on this path can carry the
+    // token in its message — `sanitizeError` preserves `Error.message` — and a
+    // credential must never reach a log. That the confirmation failed is the
+    // whole of what is safe to record here.
+    console.warn('[DeepLink][waitlist] Could not confirm download');
   }
 };
 

--- a/app/src/utils/desktopDeepLinkListener.ts
+++ b/app/src/utils/desktopDeepLinkListener.ts
@@ -4,6 +4,7 @@ import { getCurrent, onOpenUrl } from '@tauri-apps/plugin-deep-link';
 
 import { getCoreStateSnapshot, patchCoreStateSnapshot } from '../lib/coreState/store';
 import { consumeLoginToken } from '../services/api/authApi';
+import { confirmWaitlistDownload } from '../services/api/waitlistApi';
 import { clearCoreRpcTokenCache, clearCoreRpcUrlCache } from '../services/coreRpcClient';
 import {
   beginDeepLinkAuthProcessing,
@@ -20,6 +21,7 @@ import {
 } from './oauthAppVersionGate';
 import { clearOAuthReturnRoute, takeOAuthReturnRoute } from './oauthReturnRoute';
 import { openUrl } from './openUrl';
+import { sanitizeError } from './sanitize';
 import { storeSession } from './tauriCommands';
 import { isTauri as coreIsTauri } from './tauriCommands/common';
 
@@ -586,6 +588,41 @@ const handleOAuthDeepLink = async (parsed: URL) => {
 };
 
 /**
+ * `openhuman://waitlist?token=...` — the app was opened from a tokenmaxxxing
+ * download link.
+ *
+ * Unlike the auth and oauth hosts, there is nothing here to apply to the app:
+ * the token is a one-time download handle belonging to a waitlist entry, not a
+ * session credential, and it is never stored. The only job is to tell the
+ * backend the app really was opened, which is what releases that entry's
+ * download reward.
+ *
+ * The window is focused first and regardless of the outcome. Someone who just
+ * launched the app should see it whatever the network did, and the reward is
+ * idempotent — a confirmation that fails now is simply retried the next time the
+ * link is opened. Nothing in this path may throw: it runs during startup, and a
+ * missed reward is a far smaller failure than an app that will not open.
+ */
+const handleWaitlistDeepLink = async (parsed: URL) => {
+  await focusMainWindow();
+
+  const token = parsed.searchParams.get('token');
+  if (!token) {
+    console.warn('[DeepLink][waitlist] URL did not contain a token query parameter');
+    return;
+  }
+
+  try {
+    await confirmWaitlistDownload(token);
+    console.log('[DeepLink][waitlist] Download confirmed');
+  } catch (error) {
+    // Sanitized rather than raw: the failure is worth knowing about, the token
+    // that produced it is not.
+    console.warn('[DeepLink][waitlist] Could not confirm download:', sanitizeError(error));
+  }
+};
+
+/**
  * Handle a list of deep link URLs delivered by the Tauri deep-link plugin.
  * Routes to the appropriate handler based on the URL hostname:
  *   - `openhuman://auth?token=...` → login flow
@@ -593,6 +630,7 @@ const handleOAuthDeepLink = async (parsed: URL) => {
  *   - `openhuman://oauth/error?...` → OAuth failure
  *   - `openhuman://payment/success?session_id=...` → Stripe payment confirmation
  *   - `openhuman://payment/cancel` → Stripe payment cancellation
+ *   - `openhuman://waitlist?token=...` → tokenmaxxxing download confirmation
  */
 export const handleDeepLinkUrls = async (
   urls: string[] | null | undefined,
@@ -620,6 +658,9 @@ export const handleDeepLinkUrls = async (
         break;
       case 'payment':
         await handlePaymentDeepLink(parsed);
+        break;
+      case 'waitlist':
+        await handleWaitlistDeepLink(parsed);
         break;
       default:
         console.warn('[DeepLink] Unknown deep link hostname:', parsed.hostname);

--- a/docs/TEST-COVERAGE-MATRIX.md
+++ b/docs/TEST-COVERAGE-MATRIX.md
@@ -34,6 +34,7 @@ Canonical mapping of every product feature to its test source(s). Drives gap-fil
 | 0.1.1 | Direct Download Access       | MS    | release-manual-smoke (see #971) | 🚫     | DMG hosting + version landing page    |
 | 0.1.2 | Version Compatibility Check  | MS    | release-manual-smoke            | 🚫     | Driver cannot assert OS-version gates |
 | 0.1.3 | Corrupted Installer Handling | MS    | release-manual-smoke            | 🚫     | Mutated DMG validation; manual repro  |
+| 0.1.4 | Download Reward Confirmation | VU    | `app/src/utils/__tests__/desktopDeepLinkListener.test.ts`, `app/src/services/api/waitlistApi.test.ts` | ✅ | `openhuman://waitlist` open confirms the tokenmaxxxing download |
 
 ### 0.2 Installation & Launch
 


### PR DESCRIPTION
## Summary

- Adds a `waitlist` case to the deep-link hostname switch, alongside `auth`, `oauth` and `payment`.
- `openhuman://waitlist?token=...` now POSTs to `/waitlist/tasks/download/confirm`, which is what releases the tokenmaxxxing download reward on the waitlist entry the link belongs to.
- The confirmation waits for the core to be up first, because a cold open from a download link fires before BootCheckGate has started it.
- The window is focused regardless of the outcome, and no failure on this path can block startup.
- The download token never reaches a log — asserted at both layers.

## Problem

`app/src/utils/desktopDeepLinkListener.ts` switches on `parsed.hostname` with cases `auth`, `oauth` and `payment`, and a `default` that warns `Unknown deep link hostname`. `waitlist` fell through to that warning.

The scheme is registered and the OS does launch the app for `openhuman://waitlist?token=...` — it simply ignored the token once open, so the reward the link exists to release was never credited. The landing page fires this link from the download click ([tinyhumansai/landing#20](https://github.com/tinyhumansai/landing/pull/20)); this is the app-side half.

## Solution

**`app/src/services/api/waitlistApi.ts`** — `confirmWaitlistDownload(token)`, a single POST through `apiClient`, so the base URL comes from `getBackendUrl()` exactly like every other call in the app and staging/production resolve the way they already do. Nothing is hardcoded.

`requireAuth: false` is deliberate: the download token *is* the credential here, and whoever follows the link has usually never signed in. Sending the app's session bearer would hand a session to an endpoint that has no use for it.

Bounded at 10s rather than the client's two-minute default — this runs while the app is opening, and a hung connection must not sit across startup.

**`app/src/utils/desktopDeepLinkListener.ts`** — `handleWaitlistDeepLink`, following `handlePaymentDeepLink`'s shape. Unlike the auth hosts there is nothing to apply to the app: the token is a one-time download handle, not a session credential, and it is never stored.

**Core readiness.** `setupDesktopDeepLinkListener` runs in `main.tsx` before `bootRender`, so a cold open from a download link reaches this handler before BootCheckGate has started the core — and `apiClient` resolves its base URL from that core over RPC. Confirming immediately would post to a base that cannot resolve yet, and the catch would swallow it with no retry, so the reward would never land on the fresh-install path this feature exists for. The handler waits on the same gate the auth deep link uses (commits a core mode, starts the local core, polls `core.ping`), which exists because the auth path had this identical bug.

The window is focused first and regardless of outcome. Someone who just launched the app should see it whatever the network did, and the endpoint is idempotent, so a confirmation lost to being offline is simply retried the next time the link is opened. Nothing in this path throws.

**Security.** The token is not logged anywhere. The api layer logs only its length; the handler logs only that a confirmation happened; the failure path logs no error contents at all, because `sanitizeError` preserves `Error.message` and a rejection carrying the token would have put a live credential in the log. Both properties have tests, and the handler's regression test rejects with `new Error('super-secret-token')` so the assertion has something real to catch.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — 10 Vitest cases cover both new files and the new branch, including the failure, missing-token, core-not-ready and token-redaction paths. **Not verified locally**, see Validation Blocked.
- [x] Coverage matrix updated — new row `0.1.4 Download Reward Confirmation` under `0.1 Application Download`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced — `apiClient` is mocked in both suites; no test reaches the network
- [x] N/A: not a release-cut surface — no installer, updater or first-run UI behaviour changes, so `docs/RELEASE-MANUAL-SMOKE.md` is unaffected
- [x] N/A: no tracking issue exists — this came from manual testing of the landing download flow, so there is no `Closes #NNN` to add

## Impact

Desktop only. No new dependency, no migration, no change to any existing deep-link host — `default` still warns for genuinely unknown hostnames.

Security: one new unauthenticated outbound POST carrying a backend-minted download token, deliberately without the session bearer. The token is not persisted and not logged.

Startup: the handler now awaits core readiness before confirming. It is fired without being awaited by the caller and focuses the window before waiting, so it cannot delay the app appearing.

**The confirm endpoint is still being built and 404s on staging today.** That is already the graceful path — a 404 logs and returns, leaving the app open and focused — so this can merge before or after the backend without breaking anything.

## Related

- Coverage matrix IDs: `0.1.4` — Download Reward Confirmation (`0.1 Application Download`)
- Closes: N/A — no tracking issue; found during manual testing of the landing download flow
- Follow-up PR(s)/TODOs: backend `POST /waitlist/tasks/download/confirm` (tinyhumansai/backend#1184); landing-side click handler in tinyhumansai/landing#20

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/waitlist-deeplink-confirm`
- Commit SHA: 7fc43e15e

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` not run — instead the repo's pinned prettier (3.8.1) and `@trivago/prettier-plugin-sort-imports` (6.0.2) were run against `app/.prettierrc` over the four changed files, which reproduced the CI failure and now reports `All matched files use Prettier code style!`
- [x] N/A: `pnpm typecheck` not run — local builds were disallowed for this task, see Validation Blocked
- [x] N/A: focused tests not run — local builds were disallowed for this task, see Validation Blocked
- [x] N/A: Rust fmt/check not applicable — no Rust changed
- [x] N/A: Tauri fmt/check not applicable — no Tauri shell code changed

### Validation Blocked

- `command:` `pnpm typecheck`, `pnpm test`
- `error:` not attempted — local builds were explicitly disallowed for this task (disk and machine load), overriding the AGENTS.md workflow
- `impact:` **CI is the first compile and the first test run for this branch.** The change was written against the existing patterns in the files it touches — `apiClient`/`getBackendUrl` as used by `authApi` and `feedbackApi`, `handlePaymentDeepLink` for handler shape, `waitForOAuthAuthReadiness` as the auth deep link uses it, and the existing mock setup in `desktopDeepLinkListener.test.ts`. Imports were checked to resolve and to sit in the file's sort order, and formatting is verified as above, but nothing here has been type-checked or executed.

### Behavior Changes

- Intended behavior change: `openhuman://waitlist?token=...` now confirms the download with the backend, once the core is up, instead of hitting the unknown-hostname warning.
- User-visible effect: opening the app from a tokenmaxxxing download link credits the +75 download reward. The app launches and focuses as before either way.

### Parity Contract

- Legacy behavior preserved: `auth`, `oauth` and `payment` are untouched; `default` still warns for unknown hostnames.
- Guard/fallback/dispatch parity checks: a missing `token` returns early without calling the backend; a core that never comes up returns without calling the backend; every failure is caught, so the handler cannot reject into `handleDeepLinkUrls`.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A — no duplicates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for waitlist download links received through desktop deep links.
  * The app now confirms eligible downloads automatically after receiving a valid link.
  * The app focuses its window when handling waitlist links and remains resilient if confirmation fails or startup services are unavailable.

* **Tests**
  * Added coverage for successful confirmations, invalid or missing tokens, failures, timeouts, and safe error logging.
  * Documented waitlist download confirmation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->