### PR TITLE
fix(memory-sources): count chunks_pending from the embedding sidecar, not a dead column

### DIFF
--- a/app/src/components/intelligence/sourcePipelineStatus.ts
+++ b/app/src/components/intelligence/sourcePipelineStatus.ts
@@ -12,9 +12,11 @@
  * verdict so the row can honestly say "Ingested only" instead of "synced":
  *
  * 1. **Per-source, precise** — `SourceStatus.chunks_pending` is the SQL count
- *    of this source's chunks whose `embedding IS NULL` (see
- *    `memory_sources/status.rs`). `> 0` in a settled state means those chunks
- *    were stored WITHOUT vectors → semantic search can't reach them.
+ *    of this source's chunks that have no vector in the
+ *    `mem_tree_chunk_embeddings` sidecar under the active model signature, and
+ *    no terminal marker (re-embed tombstone / dropped) explaining the absence
+ *    (see `memory/sources/status.rs`). `> 0` in a settled state means those
+ *    chunks were stored WITHOUT vectors → semantic search can't reach them.
  * 2. **Global pipeline health** — `memory_tree_pipeline_status` (the same RPC
  *    that drives the Brain > Memory > Sync "Degraded" panel) carries the
  *    process-wide `degraded` snapshot + `first_blocking_cause`. Embedding /
@@ -77,9 +79,10 @@ export function deriveSourcePipelineHealth(
 
   const issues: SourcePipelineIssueKind[] = [];
 
-  // Layer 1 — embeddings. Precise per-source signal (chunks with NULL
-  // embedding) OR the global "semantic recall degraded" latch (no usable
-  // embeddings provider). Either means this source's chunks aren't vector-searchable.
+  // Layer 1 — embeddings. Precise per-source signal (chunks with no vector for
+  // the active embedding signature) OR the global "semantic recall degraded"
+  // latch (no usable embeddings provider). Either means this source's chunks
+  // aren't vector-searchable.
   const storedWithoutVectors =
     (status?.chunks_pending ?? 0) > 0 || degraded?.semantic_recall === true;
   if (storedWithoutVectors) {

--- a/src/openhuman/memory/sources/status.rs
+++ b/src/openhuman/memory/sources/status.rs
@@ -7,12 +7,14 @@
 //!   (e.g. `gmail:user@example.com:msg_xxx`), so we match by toolkit
 //!   prefix instead.
 //!
-//! "Pending" means *not yet resolved for the active embedding signature*: the
-//! chunk has no vector in the `mem_tree_chunk_embeddings` sidecar under
-//! [`tree_active_signature`], no re-embed tombstone for that signature, and was
-//! not dropped by the admission gate. This mirrors the resolution rule the
+//! "Pending" means *not yet resolved for the active embedding signature*. A
+//! chunk is resolved when it has a vector in the `mem_tree_chunk_embeddings`
+//! sidecar under [`tree_active_signature`], has a re-embed tombstone for that
+//! signature, was dropped by the admission gate, or still carries a legacy
+//! pre-sidecar `embedding` blob. This mirrors the resolution rule the
 //! provider-level sibling (`tinycortex::memory::sync::list_sync_statuses`) and
-//! `has_uncovered_reembed_work` already use, so a settled store reports zero.
+//! `has_uncovered_reembed_work` already use, so a settled store reports zero
+//! instead of reporting every ingested chunk as pending forever.
 
 use serde::Serialize;
 
@@ -67,7 +69,7 @@ pub async fn source_status(
 
     tokio::task::spawn_blocking(move || {
         // Embeddings are scoped per (chunk, model signature); a vector stored
-        // under a superseded signature is unreachable for the active vector
+        // under a superseded signature is unreachable in the active vector
         // space, so it must still read as pending.
         let signature = tree_active_signature(&cfg);
 
@@ -76,6 +78,13 @@ pub async fn source_status(
 
             // Surface real query errors so status telemetry doesn't lie about
             // a healthy zero-row state when the DB is actually broken.
+            //
+            // The trailing `c.embedding IS NOT NULL` term is a compatibility
+            // clause for vaults that predate the embedding sidecar:
+            // `migrate_legacy_embeddings_to_sidecar` copies those blobs into
+            // `mem_tree_chunk_embeddings` but deliberately preserves the legacy
+            // column, so it remains a valid "this chunk was embedded" signal.
+            // It is inert for anything ingested after the sidecar landed.
             let (synced, pending, last_ts): (i64, i64, Option<i64>) = conn.query_row(
                 "SELECT \
                        COUNT(*), \
@@ -88,6 +97,7 @@ pub async fn source_status(
                                      WHERE s.chunk_id = c.id \
                                        AND s.model_signature = ?2) \
                                  OR c.lifecycle_status = ?3 \
+                                 OR c.embedding IS NOT NULL \
                                 THEN 0 ELSE 1 END), \
                        MAX(c.timestamp_ms) \
                      FROM mem_tree_chunks c \
@@ -262,9 +272,9 @@ mod tests {
         assert_eq!(source_id_prefix(&entry), "gmail:%");
     }
 
-    /// The reported bug (#5329): the old query read the vestigial
-    /// `mem_tree_chunks.embedding` column, which no production writer ever
-    /// populates, so `pending` always equalled `synced`. Reading the sidecar
+    /// The reported bug (#5329): the old query counted pending as
+    /// `mem_tree_chunks.embedding IS NULL`, and no production writer populates
+    /// that column, so `pending` always equalled `synced`. Reading the sidecar
     /// lets a fully-embedded source settle at zero.
     #[tokio::test]
     async fn pending_reaches_zero_once_every_chunk_has_an_active_embedding() {
@@ -316,6 +326,28 @@ mod tests {
         let status = status_of(&cfg, "src_terminal").await;
         assert_eq!(status.chunks_synced, 3);
         assert_eq!(status.chunks_pending, 1, "only the untouched chunk pends");
+    }
+
+    /// Vaults created before the embedding sidecar keep their vector in the
+    /// legacy `mem_tree_chunks.embedding` column, which
+    /// `migrate_legacy_embeddings_to_sidecar` preserves. Those chunks stay
+    /// resolved so an old vault does not regress to "everything pending".
+    #[tokio::test]
+    async fn pending_treats_a_legacy_pre_sidecar_embedding_as_resolved() {
+        let (_tmp, cfg) = test_config();
+        let chunks = seed(&cfg, "src_legacy", 2);
+        with_connection(&cfg, |conn| {
+            conn.execute(
+                "UPDATE mem_tree_chunks SET embedding = X'00010203' WHERE id = ?1",
+                [&chunks[0].id],
+            )?;
+            Ok(())
+        })
+        .unwrap();
+
+        let status = status_of(&cfg, "src_legacy").await;
+        assert_eq!(status.chunks_synced, 2);
+        assert_eq!(status.chunks_pending, 1);
     }
 
     /// A source with no chunks at all must report zeroes rather than erroring

--- a/src/openhuman/memory/sources/status.rs
+++ b/src/openhuman/memory/sources/status.rs
@@ -6,12 +6,21 @@
 //! - Composio sources tag chunks with the toolkit-specific id
 //!   (e.g. `gmail:user@example.com:msg_xxx`), so we match by toolkit
 //!   prefix instead.
+//!
+//! "Pending" means *not yet resolved for the active embedding signature*: the
+//! chunk has no vector in the `mem_tree_chunk_embeddings` sidecar under
+//! [`tree_active_signature`], no re-embed tombstone for that signature, and was
+//! not dropped by the admission gate. This mirrors the resolution rule the
+//! provider-level sibling (`tinycortex::memory::sync::list_sync_statuses`) and
+//! `has_uncovered_reembed_work` already use, so a settled store reports zero.
 
 use serde::Serialize;
 
 use crate::openhuman::config::Config;
 use crate::openhuman::memory::sources::types::{MemorySourceEntry, SourceKind};
-use crate::openhuman::memory::store::chunks::store::with_connection;
+use crate::openhuman::memory::store::chunks::store::{
+    tree_active_signature, with_connection, CHUNK_STATUS_DROPPED,
+};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -57,6 +66,11 @@ pub async fn source_status(
     let source_clone = source.clone();
 
     tokio::task::spawn_blocking(move || {
+        // Embeddings are scoped per (chunk, model signature); a vector stored
+        // under a superseded signature is unreachable for the active vector
+        // space, so it must still read as pending.
+        let signature = tree_active_signature(&cfg);
+
         with_connection(&cfg, |conn| {
             let prefix = source_id_prefix(&source_clone);
 
@@ -65,11 +79,20 @@ pub async fn source_status(
             let (synced, pending, last_ts): (i64, i64, Option<i64>) = conn.query_row(
                 "SELECT \
                        COUNT(*), \
-                       SUM(CASE WHEN embedding IS NULL THEN 1 ELSE 0 END), \
-                       MAX(timestamp_ms) \
-                     FROM mem_tree_chunks \
-                     WHERE source_id LIKE ?1",
-                [&prefix],
+                       SUM(CASE WHEN EXISTS ( \
+                                    SELECT 1 FROM mem_tree_chunk_embeddings e \
+                                     WHERE e.chunk_id = c.id \
+                                       AND e.model_signature = ?2) \
+                                 OR EXISTS ( \
+                                    SELECT 1 FROM mem_tree_chunk_reembed_skipped s \
+                                     WHERE s.chunk_id = c.id \
+                                       AND s.model_signature = ?2) \
+                                 OR c.lifecycle_status = ?3 \
+                                THEN 0 ELSE 1 END), \
+                       MAX(c.timestamp_ms) \
+                     FROM mem_tree_chunks c \
+                     WHERE c.source_id LIKE ?1",
+                rusqlite::params![prefix, signature, CHUNK_STATUS_DROPPED],
                 |r| {
                     Ok((
                         r.get(0)?,
@@ -138,7 +161,78 @@ fn source_id_prefix(source: &MemorySourceEntry) -> String {
 
 #[cfg(test)]
 mod tests {
+    use chrono::{TimeZone, Utc};
+    use tempfile::TempDir;
+
     use super::*;
+    use crate::openhuman::memory::store::chunks::store::{
+        mark_chunk_reembed_skipped, set_chunk_embedding_for_signature, set_chunk_lifecycle_status,
+        upsert_chunks,
+    };
+    use crate::openhuman::memory::store::chunks::types::{
+        chunk_id, Chunk, Metadata, SourceKind as ChunkSourceKind,
+    };
+
+    fn test_config() -> (TempDir, Config) {
+        let tmp = TempDir::new().unwrap();
+        let mut cfg = Config::default();
+        cfg.workspace_dir = tmp.path().to_path_buf();
+        (tmp, cfg)
+    }
+
+    fn source_entry(id: &str) -> MemorySourceEntry {
+        MemorySourceEntry {
+            id: id.into(),
+            kind: SourceKind::Folder,
+            label: "x".into(),
+            enabled: true,
+            toolkit: None,
+            connection_id: None,
+            path: Some("/tmp".into()),
+            glob: None,
+            url: None,
+            branch: None,
+            paths: Vec::new(),
+            query: None,
+            since_days: None,
+            max_items: None,
+            max_commits: None,
+            max_issues: None,
+            max_prs: None,
+            selector: None,
+            max_tokens_per_sync: None,
+            max_cost_per_sync_usd: None,
+            sync_depth_days: None,
+        }
+    }
+
+    fn chunk(source_id: &str, seq: u32, timestamp_ms: i64) -> Chunk {
+        let ts = Utc.timestamp_millis_opt(timestamp_ms).unwrap();
+        let content = format!("status chunk {source_id} #{seq}");
+        Chunk {
+            id: chunk_id(ChunkSourceKind::Document, source_id, seq, &content),
+            content,
+            metadata: Metadata::point_in_time(ChunkSourceKind::Document, source_id, "test", ts),
+            token_count: 1,
+            seq_in_source: seq,
+            created_at: ts,
+            partial_message: false,
+        }
+    }
+
+    fn seed(cfg: &Config, source: &str, count: u32) -> Vec<Chunk> {
+        let mut chunks = Vec::new();
+        for seq in 0..count {
+            let source_id = format!("mem_src:{source}:item-{seq}");
+            chunks.push(chunk(&source_id, seq, 1_700_000_000_000 + i64::from(seq)));
+        }
+        upsert_chunks(cfg, &chunks).unwrap();
+        chunks
+    }
+
+    async fn status_of(cfg: &Config, id: &str) -> SourceStatus {
+        source_status(cfg, &source_entry(id)).await.unwrap()
+    }
 
     #[test]
     fn freshness_thresholds() {
@@ -160,33 +254,79 @@ mod tests {
 
     #[test]
     fn source_id_prefix_dispatch() {
-        let mut entry = MemorySourceEntry {
-            id: "src_abc".into(),
-            kind: SourceKind::Folder,
-            label: "x".into(),
-            enabled: true,
-            toolkit: None,
-            connection_id: None,
-            path: Some("/tmp".into()),
-            glob: None,
-            url: None,
-            branch: None,
-            paths: Vec::new(),
-            query: None,
-            since_days: None,
-            max_items: None,
-            max_commits: None,
-            max_issues: None,
-            max_prs: None,
-            selector: None,
-            max_tokens_per_sync: None,
-            max_cost_per_sync_usd: None,
-            sync_depth_days: None,
-        };
+        let mut entry = source_entry("src_abc");
         assert_eq!(source_id_prefix(&entry), "mem_src:src_abc:%");
 
         entry.kind = SourceKind::Composio;
         entry.toolkit = Some("gmail".into());
         assert_eq!(source_id_prefix(&entry), "gmail:%");
+    }
+
+    /// The reported bug (#5329): the old query read the vestigial
+    /// `mem_tree_chunks.embedding` column, which no production writer ever
+    /// populates, so `pending` always equalled `synced`. Reading the sidecar
+    /// lets a fully-embedded source settle at zero.
+    #[tokio::test]
+    async fn pending_reaches_zero_once_every_chunk_has_an_active_embedding() {
+        let (_tmp, cfg) = test_config();
+        let chunks = seed(&cfg, "src_done", 2);
+        let active = tree_active_signature(&cfg);
+        for c in &chunks {
+            set_chunk_embedding_for_signature(&cfg, &c.id, &active, &[0.5]).unwrap();
+        }
+
+        let status = status_of(&cfg, "src_done").await;
+        assert_eq!(status.chunks_synced, 2);
+        assert_eq!(
+            status.chunks_pending, 0,
+            "pre-fix this reported pending == synced"
+        );
+    }
+
+    /// A vector stored under a superseded model signature does not make the
+    /// chunk reachable in the active vector space, so it must stay pending.
+    #[tokio::test]
+    async fn pending_ignores_embeddings_from_a_superseded_signature() {
+        let (_tmp, cfg) = test_config();
+        let chunks = seed(&cfg, "src_mixed", 3);
+        let active = tree_active_signature(&cfg);
+        set_chunk_embedding_for_signature(&cfg, &chunks[0].id, &active, &[0.1, 0.2]).unwrap();
+        set_chunk_embedding_for_signature(&cfg, &chunks[1].id, "stale/model@7", &[0.3]).unwrap();
+
+        let status = status_of(&cfg, "src_mixed").await;
+        assert_eq!(status.chunks_synced, 3);
+        assert_eq!(
+            status.chunks_pending, 2,
+            "only the active-signature vector resolves a chunk"
+        );
+    }
+
+    /// Chunks that will never be embedded — a re-embed tombstone for the active
+    /// signature, or a chunk the admission gate dropped — must not be counted,
+    /// otherwise the counter can never drain. Matches the resolution rule in
+    /// `tinycortex::memory::sync::list_sync_statuses`.
+    #[tokio::test]
+    async fn pending_excludes_tombstoned_and_dropped_chunks() {
+        let (_tmp, cfg) = test_config();
+        let chunks = seed(&cfg, "src_terminal", 3);
+        let active = tree_active_signature(&cfg);
+        mark_chunk_reembed_skipped(&cfg, &chunks[0].id, &active, "too large").unwrap();
+        set_chunk_lifecycle_status(&cfg, &chunks[1].id, CHUNK_STATUS_DROPPED).unwrap();
+
+        let status = status_of(&cfg, "src_terminal").await;
+        assert_eq!(status.chunks_synced, 3);
+        assert_eq!(status.chunks_pending, 1, "only the untouched chunk pends");
+    }
+
+    /// A source with no chunks at all must report zeroes rather than erroring
+    /// on the `SUM`/`MAX` NULLs an empty scan produces.
+    #[tokio::test]
+    async fn empty_source_reports_zeroed_status() {
+        let (_tmp, cfg) = test_config();
+        let status = status_of(&cfg, "src_empty").await;
+        assert_eq!(status.chunks_synced, 0);
+        assert_eq!(status.chunks_pending, 0);
+        assert_eq!(status.last_chunk_at_ms, None);
+        assert_eq!(status.freshness, FreshnessLabel::Idle);
     }
 }


### PR DESCRIPTION
## Summary

- `source_status` counted pending chunks as `SUM(CASE WHEN embedding IS NULL THEN 1 ELSE 0 END)` over `mem_tree_chunks`. Nothing in production writes that column, so `chunks_pending` was always exactly equal to `chunks_synced`.
- Pending is now derived from the `mem_tree_chunk_embeddings` sidecar, scoped to the **active model signature**, with terminal states (re-embed tombstone, `dropped` lifecycle) treated as resolved.
- Fixes a **permanently stuck, unclearable warning in the Data Sync UI**: `chunks_pending > 0` drives `stored_without_vectors` in `deriveSourcePipelineHealth`, so every source row with chunks showed "Ingested only" forever, even on a perfectly healthy vault.
- Adds five focused `#[tokio::test]` cases in `status.rs` covering the regression, signature scoping, terminal states, legacy vaults, and the empty-source path.
- Corrects the stale doc comments in `app/src/components/intelligence/sourcePipelineStatus.ts` (comment-only, no behaviour change).

## Problem

`mem_tree_chunks.embedding` is not in the canonical tinycortex schema (`vendor/tinycortex/src/memory/chunks/schema.rs`). It only exists at runtime because `apply_schema` re-adds it defensively:

```rust
// vendor/tinycortex/src/memory/chunks/connection.rs
add_column_if_missing(conn, "mem_tree_chunks", "embedding", "BLOB")?;
```

Production embeddings are written to the sidecar `mem_tree_chunk_embeddings (chunk_id, model_signature, vector, dim, created_at)` via `upsert_chunk_embedding_conn`. The legacy column therefore stays NULL for everything ingested after the sidecar landed, and `pending == synced` for every source, always — exactly as #5329 reports.

**The user-visible half of this is worse than the issue states.** `app/src/components/intelligence/sourcePipelineStatus.ts` does:

```ts
const storedWithoutVectors =
  (status?.chunks_pending ?? 0) > 0 || degraded?.semantic_recall === true;
```

so any source with at least one chunk is permanently pinned to `state: 'ingested_only'` with the `sync.pipeline.storedWithoutVectors` warning. There is no state a user can reach that clears it.

## Solution

A chunk counts as **resolved** (not pending) when any of the following holds:

1. it has a vector in `mem_tree_chunk_embeddings` for the active signature — the condition #5329 asks for, and the one `has_uncovered_reembed_work` already uses;
2. it has a re-embed tombstone in `mem_tree_chunk_reembed_skipped` for that signature;
3. its `lifecycle_status` is `dropped`;
4. it still carries a legacy pre-sidecar `embedding` blob.

`chunks_synced` stays `COUNT(*)` — unchanged, and the frontend only uses it as a `> 0` gate, so no UI change is needed beyond the warning correctly clearing.

**Two design decisions worth a reviewer's attention:**

**(a) Terms 2 and 3 go beyond the issue's literal ask.** I took them from `vendor/tinycortex/src/memory/sync/status.rs::list_sync_statuses`, which is the *sibling implementation of this same `chunks_pending` concept* at the provider level and already resolves on `embedding-exists OR lifecycle_status='dropped' OR tombstone-exists`. Without them the counter still can never drain, because tombstoned and dropped chunks are never embedded — which reproduces the issue's core complaint ("the number is not a signal") in a narrower form. Matching the sibling also means the two surfaces stop disagreeing. **Happy to drop them to the bare sidecar check if you'd rather keep this PR minimal** — it's a two-line deletion plus one test.

**(b) Term 4 (legacy column) is deliberate, and it's the one I'd most like a second opinion on.** `migrate_legacy_embeddings_to_sidecar` explicitly *preserves* the legacy column after copying it ("the legacy column is preserved"), so on a pre-sidecar vault a non-NULL blob is still a valid "this was embedded" signal, and dropping the term would regress those vaults to "everything pending" — the very bug being fixed. It is inert for anything ingested after the sidecar landed. The known imperfection: a **dim-mismatched** legacy blob is skipped by that migration and stranded (documented there as audit finding SC-10), and this term will read it as resolved even though it has no usable vector. I judged that acceptable versus regressing every legacy vault, but I'd defer to a maintainer. Scoping it with `length(c.embedding) = dim * 4` would close that hole if you prefer strictness.

Keeping term 4 also means `memory_source_status_counts_reader_and_composio_prefixes` (which seeds that column directly via raw SQL) keeps passing untouched.

## Impact

- **Runtime:** desktop/CLI, core only. No schema change, no migration, no new dependency.
- **Query cost:** two correlated `EXISTS` subqueries per row instead of a column read. Both hit the existing `(chunk_id, model_signature)` primary keys on the sidecar and tombstone tables, so each is a point lookup. This runs once per source in `status_list`.
- **API/wire compatibility:** `SourceStatus` is unchanged. Only the *value* of `chunks_pending` changes — it can now be lower than `chunks_synced`, which is the point.
- **Interaction with open PR #5243:** that PR rewrites this exact query into a single batched scan and lists "counts `embedding IS NULL` as pending" under its Parity Contract, i.e. it preserves this bug by design. If #5243 lands first this fix needs re-applying to its batched query; the corrected predicate transplants directly since it's expressed in the same `mem_tree_chunks c` scan. Flagging so the two don't silently cancel out.

## Related

- Closes: #5329
- Related: #5243 (perf refactor of the same query — see Impact)
- Follow-up PR(s)/TODOs: if term 4 above is judged too lenient, tighten it to a dim-match check and update `pending_treats_a_legacy_pre_sidecar_embedding_as_resolved`.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — five new `#[tokio::test]` cases: the direct regression guard (all embedded → `pending == 0`, which fails on `main`), superseded-signature scoping, tombstoned/dropped resolution, the legacy-vault path, and the empty-source `SUM`/`MAX`-NULL edge case.
- [x] **Diff coverage ≥ 80%** — every changed Rust line is exercised by the new tests; the `.ts` change is comment-only and contributes no coverable lines. Not verified locally (see Validation Blocked); relying on CI to confirm.
- [x] Coverage matrix updated — `N/A: no feature rows added, removed, or renamed; this corrects the value of an existing counter.`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature IDs touched.`
- [x] No new external network dependencies introduced — tests are hermetic (`TempDir` + `Config::default()`), no network, no mock backend needed.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface changed; the Data Sync row rendering path is unchanged, only the counter feeding it.`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

This PR was authored with AI assistance (GitHub Copilot CLI), directed and reviewed by me. Disclosed here because this section is mandatory in the template. Every claim below is what I actually did or actually could not do — nothing is marked as run that wasn't.

### Linear Issue

- Key: `N/A` — external contribution, tracked by GitHub issue #5329.
- URL: https://github.com/tinyhumansai/openhuman/issues/5329

### Commit & Branch

- Branch: `Mustaqeem66:fix/5329-chunks-pending-embedding-sidecar`
- Commit SHA: `583dbf1` (see the commit list for the full series)

### Validation Run

Nothing in this section was run — my environment has no Rust or Node toolchain (see Validation Blocked). Listing them as unchecked boxes rather than false checkmarks:

- **NOT RUN** — `pnpm --filter openhuman-app format:check`
- **NOT RUN** — `pnpm typecheck`
- **NOT RUN** — Focused tests: `cargo test -p openhuman memory::sources::status`
- **NOT RUN** — Rust fmt/check: `cargo fmt --check && cargo clippy`
- **N/A** — Tauri fmt/check: no Tauri surface changed.

In place of local runs I desk-checked against the authoritative sources: every helper signature used in the tests (`set_chunk_embedding_for_signature`, `mark_chunk_reembed_skipped`, `set_chunk_lifecycle_status`, `upsert_chunks`, `tree_active_signature`, `CHUNK_STATUS_DROPPED`) was read from `src/openhuman/memory/store/chunks/{store,embeddings}.rs`; the `Chunk`/`Metadata` literal shape and the `SourceKind`-collision alias follow the existing pattern in `tests/raw_coverage/memory_threads_raw_coverage_e2e.rs`; and line widths/chain formatting were checked against rustfmt's `max_width` and `chain_width` defaults using formatted code in this repo as the reference. CI is the real verification — I'll fix anything it turns up promptly.

### Validation Blocked

- `command:` `cargo fmt --check`, `cargo clippy`, `cargo test`, `pnpm typecheck`, `pnpm test:coverage`
- `error:` toolchain unavailable in my environment — no `cargo`, `rustc`, `pnpm`, `npm`, or `git`, and no network access to install them.
- `impact:` I could not execute the new tests locally or confirm rustfmt/clippy cleanliness before pushing. The logic was verified by reading upstream implementations rather than by running. If CI reports a formatting or compile nit, it's mine and I'll turn it around quickly.

### Behavior Changes

- Intended behavior change: `chunks_pending` reflects real embedding coverage for the active model signature instead of a constant equal to `chunks_synced`.
- User-visible effect: Data Sync source rows on a healthy vault stop showing the permanent "Ingested only / stored without vectors" warning and correctly render as retrieval-ready. On an unhealthy vault the warning now means something specific and actionable.

### Parity Contract

- Legacy behavior preserved: `chunks_synced`, `last_chunk_at_ms`, `freshness`, the `source_id LIKE` prefix dispatch, the `SourceStatus` shape, and the `status_list` per-source error fallback are all untouched. Pre-sidecar vaults keep resolving via the legacy `embedding` column (term 4 above), so they see no regression.
- Guard/fallback/dispatch parity checks: existing `freshness_thresholds` and `source_id_prefix_dispatch` unit tests are retained unmodified (the latter now builds its entry through a shared helper). The three existing e2e assertions on `chunks_pending` were audited against the new predicate and all still hold — `memory_source_status_counts_reader_and_composio_prefixes` (legacy column → 1 pending), `memory_raw_coverage_e2e` (no embeddings → 2 pending), and `worker_c_modules_e2e` (already sidecar-shaped → 1 pending).

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none. #5243 touches the same query but is a performance refactor that explicitly preserves this bug in its Parity Contract; it is not a fix for #5329.
- Canonical PR: this one, for the correctness fix.
- Resolution: no duplicates to close. See Impact for how the two interact if #5243 lands first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source pipeline status reporting for chunks awaiting embeddings.
  * Correctly identifies stale, missing, legacy, and re-embedding states.
  * Excludes completed or dropped chunks from pending counts.
  * Improved warnings when embeddings are unavailable or missing for the active model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->