### PR TITLE
fix(memory_tree): diagnose embeddings from the real resolver ladder

### DIFF
--- a/src/openhuman/memory/tree/health/doctor.rs
+++ b/src/openhuman/memory/tree/health/doctor.rs
@@ -97,6 +97,9 @@ pub fn run_doctor(config: &Config) -> DoctorReport {
     use crate::openhuman::memory::queue::store as queue;
     use crate::openhuman::memory::queue::types::JobStatus;
     use crate::openhuman::memory::store::chunks::store as chunks;
+    use crate::openhuman::memory::tree::score::embed::factory::{
+        resolved_embedder, ResolvedEmbedder,
+    };
 
     let degraded = current_degraded_state();
     let counters = DoctorCounters {
@@ -134,29 +137,34 @@ pub fn run_doctor(config: &Config) -> DoctorReport {
         ));
     }
 
-    // 1. Routing/config sanity — is *any* embeddings provider configured?
-    //    (`build_write_embedder` skips embedding when none is, so this is the
-    //    most common "empty wiki" root cause.)
-    let embeddings_provider = config
-        .memory_tree
-        .embedding_endpoint
-        .as_deref()
-        .filter(|s| !s.trim().is_empty())
-        .map(|_| "ollama-override".to_string())
-        .or_else(|| config.embeddings_provider.clone())
-        .filter(|s| !s.trim().is_empty());
-    stages.push(match embeddings_provider.as_deref() {
+    // 1. Routing/config sanity — will the embedder factory actually resolve a
+    //    provider? (`build_write_embedder` skips embedding when it can't, so
+    //    this is the most common "empty wiki" root cause.)
+    //
+    //    Ask the factory's own resolution ladder rather than re-deriving it
+    //    here. This stage used to check `memory_tree.embedding_endpoint` and
+    //    then fall back to the top-level `embeddings_provider` workload field —
+    //    a one-step approximation of a six-step ladder, and `embeddings_provider`
+    //    is `None` by default. Every install resolving further down the ladder
+    //    (unified local model, user OpenAI-compatible endpoint, or the
+    //    logged-in managed cloud that most installs land on) was therefore
+    //    reported as `embeddings_unconfigured` while embedding demonstrably
+    //    worked — masking the real blocking cause and sending users off to
+    //    "fix" a setting that was already correct.
+    stages.push(match resolved_embedder(config) {
         // Explicit `none` opt-out: semantic recall is off by the user's choice,
         // not a fault. Reported `ok` (consistent with a `scheduler_gate=off`
         // pause and the write-path opt-out treatment) but with an honest note,
         // so the prior "provider configured: none" can't read as a working
         // embeddings provider. (CodeRabbit on doctor.rs)
-        Some("none") => StageHealth::ok(
+        ResolvedEmbedder::OptOut => StageHealth::ok(
             "embeddings",
             "embeddings disabled by you (provider = none) — semantic recall is intentionally off",
         ),
-        Some(p) => StageHealth::ok("embeddings", format!("provider configured: {p}")),
-        None => StageHealth::bad(
+        ResolvedEmbedder::Provider(p) => {
+            StageHealth::ok("embeddings", format!("provider configured: {p}"))
+        }
+        ResolvedEmbedder::Unconfigured => StageHealth::bad(
             "embeddings",
             PipelineFailure::new(FailureCode::EmbeddingsUnconfigured),
             "no embeddings provider configured — semantic recall is off",
@@ -286,7 +294,24 @@ mod tests {
         cfg.workspace_dir = tmp.path().to_path_buf();
         cfg.memory_tree.embedding_endpoint = None;
         cfg.memory_tree.embedding_model = None;
+        // Plant config_path in the tempdir. The embeddings stage now walks the
+        // factory's ladder, whose last rung probes for `auth-profiles.json`
+        // next to the config file — without this the tests would read the
+        // developer's real session and pass or fail depending on whether the
+        // machine happens to be logged in. (Mirrors the factory's own harness.)
+        cfg.config_path = tmp.path().join("config.toml");
         (tmp, cfg)
+    }
+
+    /// Simulate a logged-in install: the ladder's cloud rung only checks that
+    /// `auth-profiles.json` exists next to the config file.
+    fn touch_auth_profile(cfg: &Config) {
+        let path = cfg
+            .config_path
+            .parent()
+            .map(|p| p.join("auth-profiles.json"))
+            .expect("config_path has a parent");
+        std::fs::write(&path, "{}").expect("write stub auth-profiles.json");
     }
 
     #[test]
@@ -452,6 +477,84 @@ mod tests {
             .expect("storage stage present");
         assert!(!storage.ok);
         assert!(report.degraded.storage);
+    }
+
+    /// The embeddings stage must be diagnosed from the factory's resolution
+    /// ladder, not from a local approximation of it.
+    ///
+    /// Regression: a logged-in install with no explicit embeddings config
+    /// resolves to the managed cloud and embeds fine, but this stage used to
+    /// read the top-level `embeddings_provider` workload field — which is
+    /// `None` by default — and reported `embeddings_unconfigured`. Because
+    /// embeddings sit near the front of the stage list that became
+    /// `first_blocking_cause`, hiding the genuine failure further down and
+    /// pointing the user at a setting that was already correct.
+    #[test]
+    fn working_cloud_provider_is_not_reported_unconfigured() {
+        use crate::openhuman::memory::tree::score::embed::factory::{
+            resolved_embedder, ResolvedEmbedder,
+        };
+        let _g = super::super::test_guard();
+        let (_tmp, mut cfg) = test_config();
+        // A default install: no override, no workload model, no OpenAI-compatible
+        // backend — just a session, which is all the cloud rung needs.
+        cfg.embeddings_provider = None;
+        touch_auth_profile(&cfg);
+
+        // Precondition: the ladder really does resolve a usable provider here,
+        // so a non-ok embeddings stage below can only be the doctor's own fault.
+        assert_eq!(
+            resolved_embedder(&cfg),
+            ResolvedEmbedder::Provider("cloud"),
+            "test setup: the factory must resolve to the managed cloud"
+        );
+
+        let report = run_doctor(&cfg);
+        let embed = report
+            .stages
+            .iter()
+            .find(|s| s.stage == "embeddings")
+            .expect("embeddings stage present");
+        assert!(
+            embed.ok,
+            "a provider the factory would really use must not be a fault, got: {}",
+            embed.note
+        );
+        assert!(
+            embed.note.contains("cloud"),
+            "the note should name the resolved provider, got: {}",
+            embed.note
+        );
+        assert_ne!(
+            report.first_blocking_cause.clone().map(|c| c.code),
+            Some(FailureCode::EmbeddingsUnconfigured),
+            "embeddings must not mask the real blocking cause"
+        );
+    }
+
+    /// The stage must also see a provider that resolves at the *middle* of the
+    /// ladder (unified workload model), not just the terminal cloud rung.
+    #[test]
+    fn workload_local_model_is_reported_as_configured() {
+        let _g = super::super::test_guard();
+        let (_tmp, mut cfg) = test_config();
+        cfg.embeddings_provider = Some("ollama:all-minilm:latest".into());
+        cfg.local_ai.runtime_enabled = true;
+        cfg.local_ai.embedding_model_id = "all-minilm:latest".to_string();
+        // Deliberately NOT logged in: the local model alone must be enough.
+
+        let report = run_doctor(&cfg);
+        let embed = report
+            .stages
+            .iter()
+            .find(|s| s.stage == "embeddings")
+            .expect("embeddings stage present");
+        assert!(embed.ok, "local Ollama embeddings are a real provider");
+        assert!(
+            embed.note.contains("ollama"),
+            "the note should name the resolved provider, got: {}",
+            embed.note
+        );
     }
 
     #[test]

--- a/src/openhuman/memory/tree/score/embed/factory.rs
+++ b/src/openhuman/memory/tree/score/embed/factory.rs
@@ -649,7 +649,7 @@ mod tests {
         assert_eq!(e.name(), "ollama");
     }
 
-    // ── resolved_embedder (health-doctor diagnostic view) ────────────────────
+    // resolved_embedder (health-doctor diagnostic view)
     //
     // `resolved_embedder` is the ladder's answer *without* building anything.
     // Its whole value is that it cannot drift from the factories, so the tests

--- a/src/openhuman/memory/tree/score/embed/factory.rs
+++ b/src/openhuman/memory/tree/score/embed/factory.rs
@@ -185,6 +185,48 @@ fn resolve_embedder_choice(config: &Config) -> Result<EmbedderChoice> {
     Ok(EmbedderChoice::NoProvider)
 }
 
+/// Which provider the resolution ladder selects, as a *diagnostic* — no
+/// embedder is constructed and no network call is made. See
+/// [`resolved_embedder`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResolvedEmbedder {
+    /// A usable provider resolved. Carries the same stable short label the
+    /// built embedder reports from [`Embedder::name`] (`ollama`, `openai`,
+    /// `custom`, `cloud`).
+    Provider(&'static str),
+    /// `embeddings_provider = "none"` — vector search off by deliberate user
+    /// choice, not a fault.
+    OptOut,
+    /// No usable provider resolved, or the configured one could not be built.
+    Unconfigured,
+}
+
+/// Report which embedder [`build_embedder_from_config`] / [`build_write_embedder`]
+/// *would* select for `config`, without building it.
+///
+/// Exists so the health doctor can diagnose the embeddings stage from the real
+/// ladder instead of re-deriving it. The doctor used to approximate step 1 plus
+/// the top-level `embeddings_provider` workload field — which is `None` by
+/// default — so every install that resolves further down (unified local model,
+/// user OpenAI-compatible endpoint, or the logged-in managed cloud that most
+/// installs land on) was reported as `embeddings_unconfigured` even though
+/// embedding demonstrably worked, masking the real blocking cause. Routing both
+/// through [`resolve_embedder_choice`] makes the diagnosis correct by
+/// construction and keeps it correct as the ladder evolves.
+pub fn resolved_embedder(config: &Config) -> ResolvedEmbedder {
+    match resolve_embedder_choice(config) {
+        Ok(EmbedderChoice::Ollama { .. }) => ResolvedEmbedder::Provider("ollama"),
+        Ok(EmbedderChoice::OptOut) => ResolvedEmbedder::OptOut,
+        Ok(EmbedderChoice::OpenAiCompat(openai)) => ResolvedEmbedder::Provider(openai.name()),
+        Ok(EmbedderChoice::Cloud) => ResolvedEmbedder::Provider("cloud"),
+        // A ladder error means the configured OpenAI-compatible provider could
+        // not be constructed. From the user's point of view embeddings are not
+        // usable, which is exactly what `Unconfigured` reports — and the write
+        // path already fails loudly with the same underlying error.
+        Ok(EmbedderChoice::NoProvider) | Err(_) => ResolvedEmbedder::Unconfigured,
+    }
+}
+
 /// Build the embedder used by **write** paths (ingest extract + seal), with an
 /// explicit "no usable embedder" signal (#002 FR-002).
 ///
@@ -318,7 +360,7 @@ mod tests {
         assert_eq!(e.name(), "ollama");
     }
 
-    // ── build_write_embedder (T010, #002 FR-002) ─────────────────────────
+    // ── build_write_embedder (T010, #002 FR-002) ─────────────────────────────
     //
     // These assert the write-path factory's "skip vs embed" contract. The
     // degraded flag is a process-global atomic, so the flag-sensitive tests
@@ -605,5 +647,101 @@ mod tests {
         cfg.local_ai.usage.embeddings = true;
         let e = build_embedder_from_config(&cfg).expect("override path should build");
         assert_eq!(e.name(), "ollama");
+    }
+
+    // ── resolved_embedder (health-doctor diagnostic view) ────────────────────
+    //
+    // `resolved_embedder` is the ladder's answer *without* building anything.
+    // Its whole value is that it cannot drift from the factories, so the tests
+    // below assert agreement with the built embedder rather than restating the
+    // ladder a third time.
+
+    #[test]
+    fn resolved_embedder_reports_the_logged_in_cloud_default() {
+        // The regression that motivated this API: a default, logged-in install
+        // resolves to the managed cloud and embeds fine, but the doctor read a
+        // config field that is `None` by default and cried "unconfigured".
+        let (_tmp, mut cfg) = test_config();
+        cfg.memory_tree.embedding_endpoint = None;
+        cfg.memory_tree.embedding_model = None;
+        touch_auth_profile(&cfg);
+        assert_eq!(
+            resolved_embedder(&cfg),
+            ResolvedEmbedder::Provider("cloud"),
+            "a logged-in default install has a working provider"
+        );
+    }
+
+    #[test]
+    fn resolved_embedder_reports_opt_out_not_unconfigured() {
+        // `none` is a deliberate choice; it must stay distinguishable from
+        // "nothing is set up" so surfaces don't nag a user who opted out.
+        let (_tmp, mut cfg) = test_config();
+        cfg.embeddings_provider = Some("none".into());
+        touch_auth_profile(&cfg);
+        assert_eq!(resolved_embedder(&cfg), ResolvedEmbedder::OptOut);
+    }
+
+    #[test]
+    fn resolved_embedder_reports_unconfigured_when_nothing_resolves() {
+        // No override, no workload model, no OpenAI-compatible backend and no
+        // session — the one case that genuinely is unconfigured.
+        let (_tmp, mut cfg) = test_config();
+        cfg.memory_tree.embedding_endpoint = None;
+        cfg.memory_tree.embedding_model = None;
+        cfg.embeddings_provider = None;
+        assert_eq!(resolved_embedder(&cfg), ResolvedEmbedder::Unconfigured);
+    }
+
+    #[test]
+    fn resolved_embedder_reports_the_openai_compatible_backend() {
+        let (_tmp, mut cfg) = test_config();
+        cfg.memory_tree.embedding_endpoint = None;
+        cfg.memory_tree.embedding_model = None;
+        cfg.embeddings_provider = None; // top-level workload routing: unset
+        cfg.memory.embedding_provider = "openai".to_string();
+        cfg.memory.embedding_model = "text-embedding-3-large".to_string();
+        assert_eq!(
+            resolved_embedder(&cfg),
+            ResolvedEmbedder::Provider("openai"),
+            "must see the user's OpenAI embeddings, not report unconfigured"
+        );
+    }
+
+    #[test]
+    fn resolved_embedder_label_agrees_with_the_built_embedder() {
+        // Parity guard: for every provider the ladder can select, the label the
+        // diagnostic reports must equal the name the read factory's embedder
+        // reports. If a future branch is added to the ladder and only one of
+        // the two match arms is updated, this fails.
+        let cases: Vec<(&str, Box<dyn Fn(&mut Config)>)> = vec![
+            (
+                "ollama",
+                Box::new(|c: &mut Config| {
+                    c.memory_tree.embedding_endpoint = Some("http://localhost:11434".into());
+                    c.memory_tree.embedding_model = Some("bge-m3".into());
+                }),
+            ),
+            (
+                "openai",
+                Box::new(|c: &mut Config| {
+                    c.memory.embedding_provider = "openai".to_string();
+                    c.memory.embedding_model = "text-embedding-3-large".to_string();
+                }),
+            ),
+        ];
+        for (expected, setup) in cases {
+            let (_tmp, mut cfg) = test_config();
+            cfg.memory_tree.embedding_endpoint = None;
+            cfg.memory_tree.embedding_model = None;
+            setup(&mut cfg);
+            let built = build_embedder_from_config(&cfg).expect("factory should build");
+            assert_eq!(
+                resolved_embedder(&cfg),
+                ResolvedEmbedder::Provider(expected),
+                "diagnostic label drifted from the factory for {expected}"
+            );
+            assert_eq!(built.name(), expected);
+        }
     }
 }

--- a/src/openhuman/memory/tree/score/embed/factory.rs
+++ b/src/openhuman/memory/tree/score/embed/factory.rs
@@ -186,7 +186,7 @@ fn resolve_embedder_choice(config: &Config) -> Result<EmbedderChoice> {
 }
 
 /// Which provider the resolution ladder selects, as a *diagnostic* — no
-/// embedder is constructed and no network call is made. See
+/// embedder is returned to the caller and no network call is made. See
 /// [`resolved_embedder`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ResolvedEmbedder {
@@ -202,7 +202,12 @@ pub enum ResolvedEmbedder {
 }
 
 /// Report which embedder [`build_embedder_from_config`] / [`build_write_embedder`]
-/// *would* select for `config`, without building it.
+/// *would* select for `config`, without handing one back.
+///
+/// Cheap and side-effect-free: it allocates, probes one path, and (only on the
+/// OpenAI-compatible rung) constructs an `OpenAiCompatEmbedder` that is dropped
+/// immediately after its label is read. No network request is issued on any
+/// rung, and no embedder escapes.
 ///
 /// Exists so the health doctor can diagnose the embeddings stage from the real
 /// ladder instead of re-deriving it. The doctor used to approximate step 1 plus
@@ -727,6 +732,15 @@ mod tests {
                 Box::new(|c: &mut Config| {
                     c.memory.embedding_provider = "openai".to_string();
                     c.memory.embedding_model = "text-embedding-3-large".to_string();
+                }),
+            ),
+            (
+                // The terminal rung, and the one most installs actually land
+                // on — so a rename of the `cloud` label must break this guard
+                // too. (greptile on the parity guard)
+                "cloud",
+                Box::new(|c: &mut Config| {
+                    touch_auth_profile(c);
                 }),
             ),
         ];

--- a/src/openhuman/memory/tree/score/embed/factory.rs
+++ b/src/openhuman/memory/tree/score/embed/factory.rs
@@ -360,7 +360,7 @@ mod tests {
         assert_eq!(e.name(), "ollama");
     }
 
-    // ── build_write_embedder (T010, #002 FR-002) ─────────────────────────────
+    // ── build_write_embedder (T010, #002 FR-002) ─────────────────────
     //
     // These assert the write-path factory's "skip vs embed" contract. The
     // degraded flag is a process-global atomic, so the flag-sensitive tests

--- a/src/openhuman/memory/tree/score/embed/factory.rs
+++ b/src/openhuman/memory/tree/score/embed/factory.rs
@@ -551,109 +551,6 @@ mod tests {
         assert_eq!(e.name(), "inert");
     }
 
-    #[test]
-    fn write_embedder_routes_to_openai_when_memory_provider_is_openai() {
-        // #002 FR-015 regression: the headline bug was that a user-configured
-        // OpenAI embeddings provider (`config.memory.embedding_provider =
-        // "openai"`) matched no factory branch and silently fell through to the
-        // managed-budget backend. Lock the routing in at the FACTORY level —
-        // `openai_compat`'s own tests only cover `try_from_config` in isolation,
-        // so a factory refactor could re-break this with those tests still green.
-        //
-        // Note the two distinct config fields the factory reads: the top-level
-        // `embeddings_provider` (here unset, so the "none"/`ollama:` branches do
-        // not match) vs `memory.embedding_provider` (the unified Embeddings-
-        // settings field that drives the OpenAI/custom detection).
-        let _guard = degraded_flag_lock();
-        use crate::openhuman::memory::tree::health::{
-            current_degraded_state, mark_semantic_recall_degraded, FailureCode,
-        };
-        mark_semantic_recall_degraded(FailureCode::EmbeddingsUnconfigured);
-        let (_tmp, mut cfg) = test_config();
-        cfg.memory_tree.embedding_endpoint = None;
-        cfg.memory_tree.embedding_model = None;
-        cfg.embeddings_provider = None; // top-level workload routing: unset
-        cfg.memory.embedding_provider = "openai".to_string();
-        cfg.memory.embedding_model = "text-embedding-3-large".to_string();
-        let e = build_write_embedder(&cfg)
-            .expect("factory must not error")
-            .expect("openai provider → Some(embedder), must NOT fall through to skip/cloud");
-        assert_eq!(
-            e.name(),
-            "openai",
-            "must route to the user's OpenAI embeddings, not the managed backend"
-        );
-        assert!(
-            !current_degraded_state().semantic_recall,
-            "a usable OpenAI provider must clear the degraded flag"
-        );
-    }
-
-    #[test]
-    fn write_embedder_routes_to_lmstudio_local_endpoint() {
-        // #3781 regression at the factory/seal level: a configured local
-        // OpenAI-compatible embeddings backend (LM Studio at localhost:1234,
-        // registered as a `cloud_providers` slug) must drive bucket sealing —
-        // the same way the LLM extractor already resolves the `lmstudio` slug —
-        // and NOT fall through to the managed cloud budget (which 400s with
-        // "Insufficient budget" and fails the seal job unrecoverably).
-        use crate::openhuman::config::schema::cloud_providers::CloudProviderCreds;
-        use crate::openhuman::memory::tree::health::{
-            current_degraded_state, mark_semantic_recall_degraded, FailureCode,
-        };
-        let _guard = degraded_flag_lock();
-        mark_semantic_recall_degraded(FailureCode::EmbeddingsUnconfigured);
-        let (_tmp, mut cfg) = test_config();
-        cfg.memory_tree.embedding_endpoint = None;
-        cfg.memory_tree.embedding_model = None;
-        cfg.embeddings_provider = None; // top-level workload routing: unset
-        cfg.memory.embedding_provider = "lmstudio".to_string();
-        cfg.memory.embedding_model = "bge-m3".to_string();
-        cfg.cloud_providers = vec![CloudProviderCreds {
-            id: "p_lmstudio".to_string(),
-            slug: "lmstudio".to_string(),
-            endpoint: "http://localhost:1234/v1".to_string(),
-            ..Default::default()
-        }];
-        let e = build_write_embedder(&cfg)
-            .expect("factory must not error")
-            .expect("lmstudio backend → Some(embedder), must NOT fall through to cloud");
-        assert_eq!(
-            e.name(),
-            "custom",
-            "must route to the local OpenAI-compatible endpoint, not the managed backend"
-        );
-        assert!(
-            !current_degraded_state().semantic_recall,
-            "a usable local provider must clear the degraded flag"
-        );
-    }
-
-    #[test]
-    fn read_embedder_routes_to_openai_when_memory_provider_is_openai() {
-        // Same FR-015 routing, read path (`build_embedder_from_config`).
-        let (_tmp, mut cfg) = test_config();
-        cfg.memory_tree.embedding_endpoint = None;
-        cfg.memory_tree.embedding_model = None;
-        cfg.embeddings_provider = None;
-        cfg.memory.embedding_provider = "openai".to_string();
-        cfg.memory.embedding_model = "text-embedding-3-large".to_string();
-        let e = build_embedder_from_config(&cfg).expect("openai path should build");
-        assert_eq!(e.name(), "openai");
-    }
-
-    #[test]
-    fn explicit_endpoint_override_wins_over_local_ai_flag() {
-        // Power-user override beats the checkbox.
-        let (_tmp, mut cfg) = test_config();
-        cfg.memory_tree.embedding_endpoint = Some("http://staging-embed:11434".into());
-        cfg.memory_tree.embedding_model = Some("bge-m3".into());
-        cfg.local_ai.runtime_enabled = true;
-        cfg.local_ai.usage.embeddings = true;
-        let e = build_embedder_from_config(&cfg).expect("override path should build");
-        assert_eq!(e.name(), "ollama");
-    }
-
     // resolved_embedder (health-doctor diagnostic view)
     //
     // `resolved_embedder` is the ladder's answer *without* building anything.
@@ -757,5 +654,108 @@ mod tests {
             );
             assert_eq!(built.name(), expected);
         }
+    }
+
+    #[test]
+    fn write_embedder_routes_to_openai_when_memory_provider_is_openai() {
+        // #002 FR-015 regression: the headline bug was that a user-configured
+        // OpenAI embeddings provider (`config.memory.embedding_provider =
+        // "openai"`) matched no factory branch and silently fell through to the
+        // managed-budget backend. Lock the routing in at the FACTORY level —
+        // `openai_compat`'s own tests only cover `try_from_config` in isolation,
+        // so a factory refactor could re-break this with those tests still green.
+        //
+        // Note the two distinct config fields the factory reads: the top-level
+        // `embeddings_provider` (here unset, so the "none"/`ollama:` branches do
+        // not match) vs `memory.embedding_provider` (the unified Embeddings-
+        // settings field that drives the OpenAI/custom detection).
+        let _guard = degraded_flag_lock();
+        use crate::openhuman::memory::tree::health::{
+            current_degraded_state, mark_semantic_recall_degraded, FailureCode,
+        };
+        mark_semantic_recall_degraded(FailureCode::EmbeddingsUnconfigured);
+        let (_tmp, mut cfg) = test_config();
+        cfg.memory_tree.embedding_endpoint = None;
+        cfg.memory_tree.embedding_model = None;
+        cfg.embeddings_provider = None; // top-level workload routing: unset
+        cfg.memory.embedding_provider = "openai".to_string();
+        cfg.memory.embedding_model = "text-embedding-3-large".to_string();
+        let e = build_write_embedder(&cfg)
+            .expect("factory must not error")
+            .expect("openai provider → Some(embedder), must NOT fall through to skip/cloud");
+        assert_eq!(
+            e.name(),
+            "openai",
+            "must route to the user's OpenAI embeddings, not the managed backend"
+        );
+        assert!(
+            !current_degraded_state().semantic_recall,
+            "a usable OpenAI provider must clear the degraded flag"
+        );
+    }
+
+    #[test]
+    fn write_embedder_routes_to_lmstudio_local_endpoint() {
+        // #3781 regression at the factory/seal level: a configured local
+        // OpenAI-compatible embeddings backend (LM Studio at localhost:1234,
+        // registered as a `cloud_providers` slug) must drive bucket sealing —
+        // the same way the LLM extractor already resolves the `lmstudio` slug —
+        // and NOT fall through to the managed cloud budget (which 400s with
+        // "Insufficient budget" and fails the seal job unrecoverably).
+        use crate::openhuman::config::schema::cloud_providers::CloudProviderCreds;
+        use crate::openhuman::memory::tree::health::{
+            current_degraded_state, mark_semantic_recall_degraded, FailureCode,
+        };
+        let _guard = degraded_flag_lock();
+        mark_semantic_recall_degraded(FailureCode::EmbeddingsUnconfigured);
+        let (_tmp, mut cfg) = test_config();
+        cfg.memory_tree.embedding_endpoint = None;
+        cfg.memory_tree.embedding_model = None;
+        cfg.embeddings_provider = None; // top-level workload routing: unset
+        cfg.memory.embedding_provider = "lmstudio".to_string();
+        cfg.memory.embedding_model = "bge-m3".to_string();
+        cfg.cloud_providers = vec![CloudProviderCreds {
+            id: "p_lmstudio".to_string(),
+            slug: "lmstudio".to_string(),
+            endpoint: "http://localhost:1234/v1".to_string(),
+            ..Default::default()
+        }];
+        let e = build_write_embedder(&cfg)
+            .expect("factory must not error")
+            .expect("lmstudio backend → Some(embedder), must NOT fall through to cloud");
+        assert_eq!(
+            e.name(),
+            "custom",
+            "must route to the local OpenAI-compatible endpoint, not the managed backend"
+        );
+        assert!(
+            !current_degraded_state().semantic_recall,
+            "a usable local provider must clear the degraded flag"
+        );
+    }
+
+    #[test]
+    fn read_embedder_routes_to_openai_when_memory_provider_is_openai() {
+        // Same FR-015 routing, read path (`build_embedder_from_config`).
+        let (_tmp, mut cfg) = test_config();
+        cfg.memory_tree.embedding_endpoint = None;
+        cfg.memory_tree.embedding_model = None;
+        cfg.embeddings_provider = None;
+        cfg.memory.embedding_provider = "openai".to_string();
+        cfg.memory.embedding_model = "text-embedding-3-large".to_string();
+        let e = build_embedder_from_config(&cfg).expect("openai path should build");
+        assert_eq!(e.name(), "openai");
+    }
+
+    #[test]
+    fn explicit_endpoint_override_wins_over_local_ai_flag() {
+        // Power-user override beats the checkbox.
+        let (_tmp, mut cfg) = test_config();
+        cfg.memory_tree.embedding_endpoint = Some("http://staging-embed:11434".into());
+        cfg.memory_tree.embedding_model = Some("bge-m3".into());
+        cfg.local_ai.runtime_enabled = true;
+        cfg.local_ai.usage.embeddings = true;
+        let e = build_embedder_from_config(&cfg).expect("override path should build");
+        assert_eq!(e.name(), "ollama");
     }
 }

--- a/src/openhuman/memory/tree/score/embed/factory.rs
+++ b/src/openhuman/memory/tree/score/embed/factory.rs
@@ -360,7 +360,7 @@ mod tests {
         assert_eq!(e.name(), "ollama");
     }
 
-    // ── build_write_embedder (T010, #002 FR-002) ─────────────────────
+    // ── build_write_embedder (T010, #002 FR-002) ─────────────────────────
     //
     // These assert the write-path factory's "skip vs embed" contract. The
     // degraded flag is a process-global atomic, so the flag-sensitive tests


### PR DESCRIPTION
## Summary

- The memory-tree health doctor's `embeddings` stage re-derived provider resolution instead of asking the embedder factory, so it reported `embeddings_unconfigured` on installs where embedding demonstrably works.
- Add `resolved_embedder()` + `ResolvedEmbedder` to `score/embed/factory.rs`: a diagnostic view of the factory's existing resolution ladder that reports *which provider would be selected* without handing back an embedder or touching the network.
- Route the doctor's `embeddings` stage through it, so the diagnosis is the factory's own answer rather than a parallel approximation.
- Because the embeddings stage sits near the front of the ordered stage list, the bogus failure became `first_blocking_cause` and **masked the genuine one** — this restores the doctor's core promise of "one actionable answer".
- Adds 7 tests (5 factory, 2 doctor) and makes the doctor's `test_config()` hermetic.

> **Note on the issue's file paths:** #5330 cites `src/openhuman/memory_tree/health/doctor.rs` and `src/openhuman/memory_tree/score/embed/factory.rs`. Those paths don't exist; the real ones are under `memory/tree/`. The described behaviour is otherwise exactly as reported.

## Problem

`run_doctor` computed the embeddings stage like this:

```rust
let embeddings_provider = config
    .memory_tree
    .embedding_endpoint
    .as_deref()
    .filter(|s| !s.trim().is_empty())
    .map(|_| "ollama-override".to_string())
    .or_else(|| config.embeddings_provider.clone())
    .filter(|s| !s.trim().is_empty());
```

That is a **one-step approximation of a six-step ladder**. `resolve_embedder_choice` in `score/embed/factory.rs` — the single source of truth walked by *both* `build_embedder_from_config` (read) and `build_write_embedder` (write) — resolves in this order:

1. explicit Ollama override (`memory_tree.embedding_endpoint` **and** `embedding_model`, both non-empty)
2. `embeddings_provider == "none"` → deliberate opt-out
3. `config.workload_local_model("embeddings")` → local Ollama
4. `OpenAiCompatEmbedder::try_from_config` → user OpenAI / custom endpoint
5. `cloud_session_available` → managed cloud
6. nothing usable

Three concrete defects:

1. Step 1 requires endpoint **and** model; the doctor checked only the endpoint (so it could also report a provider the factory would reject).
2. It fell back to the top-level `config.embeddings_provider`, which is workload routing and **defaults to `None`**.
3. It never saw rungs 3–5 at all — including rung 5, the path a **default logged-in install** lands on.

So the common case (logged in, no explicit embeddings config) embeds fine but is reported `embeddings_unconfigured`. In the reporter's case that masked `summarizer_unavailable`, and sent them to "fix" a setting that was already correct.

## Solution

Rather than teach the doctor to read one more config field — which would re-break the moment the ladder changes — expose the ladder's answer:

```rust
pub enum ResolvedEmbedder {
    Provider(&'static str), // same label Embedder::name() reports
    OptOut,                 // `none` — off by choice, not a fault
    Unconfigured,
}

pub fn resolved_embedder(config: &Config) -> ResolvedEmbedder;
```

The doctor then just matches on it. Design notes:

- **New public API instead of making `resolve_embedder_choice` / `EmbedderChoice` public.** `EmbedderChoice::OpenAiCompat` owns a constructed `OpenAiCompatEmbedder`; publishing it would leak embedder internals and hand callers a built embedder they didn't ask for. `ResolvedEmbedder` is `Copy` and carries only a label.
- **No network, nothing escapes.** The ladder allocates and does one `Path::exists()`; on the OpenAI-compatible rung it constructs an `OpenAiCompatEmbedder` that is dropped immediately after its label is read (thanks @greptile-apps for catching that my first doc comment overclaimed here). It does not set the process-global degraded flags — only the factories' terminals do. The doctor already performs synchronous SQLite reads, so this is comfortably the cheapest thing it does.
- **`Err(_)` is folded into `Unconfigured`.** A ladder error means the configured OpenAI-compatible provider could not be constructed — from the user's perspective embeddings are unusable, which is what `Unconfigured` says. The write path still fails loudly with the underlying error.
- **The `none` opt-out stays `ok`.** It's a deliberate choice (like `scheduler_gate = off`), reported with an honest note that can't read as a working provider — preserving the behaviour a previous CodeRabbit review asked for.

### Tests

`factory.rs` (5): the logged-in cloud default, the `none` opt-out staying distinct from unconfigured, the genuinely-unconfigured case, the OpenAI-compatible backend, and a **parity guard** asserting the diagnostic's label equals `build_embedder_from_config(...).name()` for `ollama`, `openai` **and** `cloud` — so adding a ladder rung, or renaming a label, and updating only one match arm fails CI.

`doctor.rs` (2): `working_cloud_provider_is_not_reported_unconfigured` (the #5330 regression, with a precondition assert that the ladder really resolves to cloud, so a failure can only be the doctor's fault) and `workload_local_model_is_reported_as_configured` (a mid-ladder rung).

`doctor.rs`'s `test_config()` now plants `config_path` inside the `TempDir`. The ladder's last rung probes the filesystem for `auth-profiles.json` next to the config file, so without this the doctor suite would read the developer's real session and pass or fail depending on whether the machine happens to be logged in. This mirrors the harness `factory.rs` already uses.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — 7 new tests; failure/edge cases covered by `resolved_embedder_reports_unconfigured_when_nothing_resolves`, the `Err(_) → Unconfigured` arm, and the preserved `misconfigured_workspace_reports_embeddings_as_first_blocking_cause`.
- [x] **Diff coverage ≥ 80%** — verified by CI, not locally: **Rust Core Coverage (cargo-llvm-cov)** and the **PR CI Gate** both passed on this branch. I have no Rust toolchain locally (see *Validation Blocked*), so CI is the evidence here.
- [x] Coverage matrix updated — `N/A: behaviour-only fix`; no feature rows added, removed or renamed. The **Coverage Matrix Sync** check passed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix rows are affected by this change.`
- [x] No new external network dependencies introduced — `resolved_embedder` issues no network request on any rung; the new tests use a `TempDir` and a stub file only. No new crates.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface changes.` The doctor report's *shape* is unchanged; only the value of one stage is corrected.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- **Runtime/platform:** all platforms, diagnostic-only. Affects the `memory_tree doctor` agent tool / CLI / RPC output and the status panel's `first_blocking_cause`.
- **Behaviour:** installs previously mislabelled `embeddings_unconfigured` will now show the resolved provider, and `first_blocking_cause` will surface the *real* problem (or `healthy`). Installs with genuinely no provider are unchanged.
- **Performance:** one extra ladder walk per `run_doctor` call — allocations plus a single `Path::exists()`, alongside the several SQLite queries the doctor already runs.
- **Security / migration / compatibility:** none. No serialized shape changed, no config migration, no new deps. `resolved_embedder` is additive; no existing signature changed.

## Related

- Closes: #5330
- Follow-up PR(s)/TODOs: the `status`/`pipeline_status` surface derives its own embeddings view; worth auditing whether it shares this bug, but it's out of scope here and I didn't want to widen the diff.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: `N/A` — external contributor, no Linear access.
- URL: `N/A`

### Commit & Branch

- Branch: `Mustaqeem66:fix/5330-doctor-embeddings-ladder`
- Commit SHA: see the branch head (latest commit addresses the Greptile review)

### Validation Run

> I have no Rust/pnpm toolchain and no network in the environment this was authored in, so **nothing below was run locally.** Each box is ticked against the equivalent **CI job on this branch**, which is stronger evidence than a local run anyway. Full detail in *Validation Blocked*.

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no frontend files changed.` CI's **Frontend Checks** correctly skipped for this diff.
- [x] `pnpm typecheck` — `N/A: no TypeScript changed.` This PR touches two `.rs` files only.
- [x] Focused tests: **NOT RUN locally** — covered by CI's **Rust Core Coverage (cargo-llvm-cov)** ✅, which builds and runs the crate's test suite including the 7 new tests. Intended local commands were `cargo test -p openhuman memory::tree::health::doctor` and `... memory::tree::score::embed::factory`.
- [x] Rust fmt/check (if changed): **NOT RUN locally** — covered by CI's **Rust Quality (fmt, clippy)** ✅ and **Rust Feature-Gate Smoke (gates off)** ✅.
- [x] Tauri fmt/check (if changed): `N/A: no Tauri code touched.`

### Validation Blocked

- `command:` `cargo test` / `cargo fmt --check` / `cargo clippy` / `pnpm typecheck`
- `error:` no Rust toolchain (`cargo`/`rustc` absent) and no network access to install one or reach the crate registry in the environment this change was authored in.
- `impact:` **I could not compile or execute anything before pushing.** I compensated by hand-verification: both files were reconstructed byte-for-byte against their upstream blobs before editing (confirmed by git blob SHA) so the diff contains only intended changes; I traced all six ladder rungs against every pre-existing doctor test to confirm none flip (`"none"` → `OptOut` → still `ok`; `"ollama:bge-m3"` → rung 3 → `Provider("ollama")` → still `ok`; the misconfigured-workspace test → rung 6 → still `Unconfigured`, which the hermetic `config_path` change guarantees). **CI has since confirmed this**: fmt, clippy, the feature-gate smoke build and the coverage gate all pass on the branch. I'll keep treating CI as the authority and fix anything it flags promptly.

Disclosing plainly per the repo's AI-authorship requirement: **this PR was written with AI assistance.** The analysis, the design decision, and every claim above are ones I stand behind and can defend in review, and the validation I could not perform is stated rather than checked off silently.

### Behavior Changes

- Intended behavior change: the doctor's `embeddings` stage reports the provider the embedder factory would actually select, instead of a locally re-derived approximation.
- User-visible effect: `openhuman doctor` / the memory-tree status panel stop claiming "no embeddings provider configured" on working installs, and `first_blocking_cause` now names the real blocker instead of being masked by the false embeddings failure.

### Parity Contract

- Legacy behavior preserved: the stage id (`embeddings`), the `FailureCode::EmbeddingsUnconfigured` code, and all three note strings are unchanged verbatim. A genuinely unconfigured install produces a byte-identical stage to before. The `none` opt-out keeps its `ok`-with-honest-note treatment.
- Guard/fallback/dispatch parity checks: `resolved_embedder` and the two factories share one `resolve_embedder_choice` call, so they cannot diverge; `resolved_embedder_label_agrees_with_the_built_embedder` asserts the diagnostic's label equals `Embedder::name()` for `ollama`, `openai` and `cloud`; and the doctor test asserts a precondition on the ladder before asserting on the stage.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none — I searched open PRs for `doctor`, `embeddings`, `resolved_embedder` and #5330 references before starting.
- Canonical PR: this one.
- Resolution: `N/A`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved embedding health checks to accurately reflect the configured provider and resolution settings.
  * Added clearer status reporting for enabled providers, intentional opt-out, and unavailable configurations.
  * Improved support for managed cloud, local-model, and OpenAI-compatible embedding setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->