### PR TITLE
fix(voice): stop the Piper voice id leaking into non-Piper TTS providers

### DIFF
--- a/src/openhuman/voice/factory/entry.rs
+++ b/src/openhuman/voice/factory/entry.rs
@@ -137,13 +137,15 @@ pub fn create_tts_provider(
 /// omits `voice_id` from the backend request body, and the slug branch falls
 /// through to the registry entry's `default_tts_voice`.
 ///
-/// `provider` is matched pre-trimmed; `voice` is trimmed here. For the slug
-/// form (`"openai:shimmer"`), a voice in the suffix wins over the `voice`
-/// argument, matching the STT model-resolution order in
-/// [`create_stt_provider`].
+/// Both arguments are trimmed here, so the function is safe to call with raw
+/// caller input: an untrimmed `"  cloud  "` would otherwise match neither
+/// literal arm and fall through to the slug branch, silently treating a known
+/// provider as an unknown one. For the slug form (`"openai:shimmer"`), a voice
+/// in the suffix wins over the `voice` argument, matching the STT
+/// model-resolution order in [`create_stt_provider`].
 pub(super) fn resolve_tts_voice<'a>(provider: &'a str, voice: &'a str) -> Option<&'a str> {
     let voice = voice.trim();
-    match provider {
+    match provider.trim() {
         "cloud" | "openhuman" => {
             if voice.is_empty() {
                 None

--- a/src/openhuman/voice/factory/entry.rs
+++ b/src/openhuman/voice/factory/entry.rs
@@ -87,32 +87,86 @@ pub fn create_stt_provider(
 /// runtime contract (subprocess + `.onnx` model) is simpler. Adding Kokoro
 /// later is straightforward: add a new branch here and a `local_speech_kokoro`
 /// sibling module.
+///
+/// **The empty-voice fallback is per-provider and must stay that way.**
+/// [`DEFAULT_PIPER_VOICE`] is a Piper model id and is meaningful *only* to the
+/// Piper branch. This function previously coerced an empty `voice` to that
+/// constant before the match, which handed `en_US-lessac-medium` to every
+/// provider: the cloud branch forwarded it as `voice_id` to the backend
+/// ElevenLabs proxy (`POST /openai/v1/audio/speech`), which rejects it with
+/// **400 Bad Request** — breaking the Settings → Voice "Test" button and every
+/// cloud TTS reply (#5355). It also pre-empted each external provider's
+/// configured `default_tts_voice`, since the Piper id was never empty by the
+/// time [`create_tts_provider_by_slug`] looked at it.
+///
+/// Callers deliberately pass an empty `voice` to mean "this provider picks its
+/// own default" (`handle_voice_test_provider`, `handle_voice_reply_synthesize`,
+/// `handle_voice_tts_dispatch`, `audio_toolkit::ops`) — each of those already
+/// guards the Piper default at its own level, and that guard is only effective
+/// if this function honours the empty string.
 pub fn create_tts_provider(
     provider: &str,
     voice: &str,
     config: &Config,
 ) -> anyhow::Result<Box<dyn TtsProvider>> {
     debug!("{LOG_PREFIX} create_tts_provider provider={provider} voice={voice}");
-    let voice = if voice.trim().is_empty() {
-        DEFAULT_PIPER_VOICE
-    } else {
-        voice
-    };
-    match provider.trim() {
-        "cloud" | "openhuman" => Ok(Box::new(CloudTtsProvider::new(if voice.is_empty() {
-            None
-        } else {
-            Some(voice.to_string())
-        }))),
-        "piper" => Ok(Box::new(PiperTtsProvider::new(voice))),
+    let provider = provider.trim();
+    let resolved = resolve_tts_voice(provider, voice);
+    debug!(
+        "{LOG_PREFIX} create_tts_provider resolved provider={provider} voice={}",
+        resolved.unwrap_or("<provider default>")
+    );
+    match provider {
+        "cloud" | "openhuman" => Ok(Box::new(CloudTtsProvider::new(
+            resolved.map(str::to_string),
+        ))),
+        "piper" => Ok(Box::new(PiperTtsProvider::new(
+            // `resolve_tts_voice` guarantees `Some` for piper.
+            resolved.unwrap_or(DEFAULT_PIPER_VOICE),
+        ))),
         other => {
-            let (slug, slug_voice) = split_slug_model(other);
-            let effective_voice = if slug_voice.is_empty() {
-                voice
+            let (slug, _) = split_slug_model(other);
+            create_tts_provider_by_slug(slug, resolved.unwrap_or(""), config)
+        }
+    }
+}
+
+/// Resolve the voice a TTS provider should be constructed with.
+///
+/// `None` means "let the provider pick its own default": the cloud branch
+/// omits `voice_id` from the backend request body, and the slug branch falls
+/// through to the registry entry's `default_tts_voice`.
+///
+/// `provider` is matched pre-trimmed; `voice` is trimmed here. For the slug
+/// form (`"openai:shimmer"`), a voice in the suffix wins over the `voice`
+/// argument, matching the STT model-resolution order in
+/// [`create_stt_provider`].
+pub(super) fn resolve_tts_voice<'a>(provider: &'a str, voice: &'a str) -> Option<&'a str> {
+    let voice = voice.trim();
+    match provider {
+        "cloud" | "openhuman" => {
+            if voice.is_empty() {
+                None
             } else {
-                slug_voice
-            };
-            create_tts_provider_by_slug(slug, effective_voice, config)
+                Some(voice)
+            }
+        }
+        // `DEFAULT_PIPER_VOICE` is a Piper model id and is meaningful to this
+        // branch only — never let it escape to another provider.
+        "piper" => Some(if voice.is_empty() {
+            DEFAULT_PIPER_VOICE
+        } else {
+            voice
+        }),
+        other => {
+            let (_, slug_voice) = split_slug_model(other);
+            if !slug_voice.is_empty() {
+                Some(slug_voice)
+            } else if !voice.is_empty() {
+                Some(voice)
+            } else {
+                None
+            }
         }
     }
 }

--- a/src/openhuman/voice/factory/tests.rs
+++ b/src/openhuman/voice/factory/tests.rs
@@ -6,7 +6,7 @@ use super::entry::{
 };
 use super::helpers::{effective_stt_provider, effective_tts_provider, split_slug_model};
 use super::stt_providers::WhisperSttProvider;
-use super::traits::SttProvider;
+use super::traits::{SttProvider, TtsProvider};
 use crate::openhuman::config::schema::voice_providers::{SttApiStyle, VoiceCapability};
 use crate::openhuman::config::Config;
 
@@ -204,10 +204,23 @@ fn tts_voice_slug_suffix_beats_voice_argument() {
 }
 
 #[test]
+fn tts_voice_resolution_tolerates_untrimmed_provider() {
+    // A padded provider name must not fall through to the slug branch and be
+    // treated as an unknown external provider.
+    assert_eq!(resolve_tts_voice("  cloud  ", ""), None);
+    assert_eq!(
+        resolve_tts_voice("  piper  ", ""),
+        Some(DEFAULT_PIPER_VOICE)
+    );
+}
+
+#[test]
 fn tts_factory_slug_empty_voice_uses_registry_default() {
     // End-to-end through the factory: with no voice anywhere, the registry
     // entry's `default_tts_voice` must be what the provider is built with —
-    // previously pre-empted by the Piper id.
+    // previously pre-empted by the Piper id. Asserting the voice (not just
+    // `name()`) is the point: a factory that passed a hardcoded value instead
+    // of `resolved.unwrap_or("")` would still produce an "external" provider.
     let mut config = cfg();
     config.voice_providers.push(
         crate::openhuman::config::schema::voice_providers::VoiceProviderCreds {
@@ -220,6 +233,59 @@ fn tts_factory_slug_empty_voice_uses_registry_default() {
     );
     let p = create_tts_provider("openai", "", &config).unwrap();
     assert_eq!(p.name(), "external");
+    assert_eq!(
+        p.configured_voice(),
+        Some("alloy"),
+        "registry default_tts_voice must reach the provider, not the Piper id"
+    );
+}
+
+#[test]
+fn tts_factory_cloud_empty_voice_carries_no_voice() {
+    // The #5355 regression, asserted end-to-end through the boxed provider:
+    // nothing but `None` may reach `CloudTtsProvider`, or `synthesize_reply`
+    // puts a Piper id in `voice_id` and the backend answers 400.
+    for provider in ["cloud", "openhuman"] {
+        let p = create_tts_provider(provider, "", &cfg()).unwrap();
+        assert_eq!(p.name(), "cloud");
+        assert_eq!(
+            p.configured_voice(),
+            None,
+            "{provider} must carry no voice so the backend default applies"
+        );
+    }
+}
+
+#[test]
+fn tts_factory_cloud_preserves_explicit_voice() {
+    let p = create_tts_provider("cloud", "JBFqnCBsd6RMkjVDRZzb", &cfg()).unwrap();
+    assert_eq!(p.configured_voice(), Some("JBFqnCBsd6RMkjVDRZzb"));
+}
+
+#[test]
+fn tts_factory_piper_empty_voice_carries_bundled_voice() {
+    // The other half of the guarantee: Piper — and only Piper — still gets the
+    // bundled voice id when the caller supplies none.
+    let p = create_tts_provider("piper", "", &cfg()).unwrap();
+    assert_eq!(p.name(), "piper");
+    assert_eq!(p.configured_voice(), Some(DEFAULT_PIPER_VOICE));
+}
+
+#[test]
+fn tts_factory_slug_colon_voice_reaches_provider() {
+    // `slug:voice` must beat the registry default end-to-end.
+    let mut config = cfg();
+    config.voice_providers.push(
+        crate::openhuman::config::schema::voice_providers::VoiceProviderCreds {
+            slug: "openai".into(),
+            endpoint: "https://api.openai.com/v1".into(),
+            capability: VoiceCapability::Both,
+            default_tts_voice: Some("alloy".into()),
+            ..Default::default()
+        },
+    );
+    let p = create_tts_provider("openai:shimmer", "", &config).unwrap();
+    assert_eq!(p.configured_voice(), Some("shimmer"));
 }
 
 #[test]

--- a/src/openhuman/voice/factory/tests.rs
+++ b/src/openhuman/voice/factory/tests.rs
@@ -2,7 +2,7 @@
 
 use super::entry::{
     create_stt_provider, create_tts_provider, default_stt_provider, default_tts_provider,
-    WHISPER_MODEL_PRESETS,
+    resolve_tts_voice, DEFAULT_PIPER_VOICE, WHISPER_MODEL_PRESETS,
 };
 use super::helpers::{effective_stt_provider, effective_tts_provider, split_slug_model};
 use super::stt_providers::WhisperSttProvider;
@@ -126,6 +126,100 @@ fn tts_factory_piper_branch() {
 fn tts_factory_piper_empty_voice_uses_default() {
     let p = create_tts_provider("piper", "", &cfg()).unwrap();
     assert_eq!(p.name(), "piper");
+}
+
+// ---------------------------------------------------------------------------
+// Voice resolution (#5355)
+//
+// The regression: `create_tts_provider` coerced an empty voice to
+// `DEFAULT_PIPER_VOICE` *before* the provider match, so every provider got a
+// Piper model id. The cloud branch forwarded it as `voice_id` to the backend
+// ElevenLabs proxy, which answers 400 Bad Request. The three RPC handlers that
+// deliberately pass "" for non-Piper providers were silently overridden.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tts_voice_empty_never_yields_piper_default_for_cloud() {
+    // The #5355 regression, stated directly: no Piper voice id may escape to
+    // the cloud provider. `None` makes `synthesize_reply` omit `voice_id` so
+    // the backend applies its own default.
+    for provider in ["cloud", "openhuman"] {
+        assert_eq!(
+            resolve_tts_voice(provider, ""),
+            None,
+            "{provider} with an empty voice must defer to the backend default"
+        );
+        assert_eq!(
+            resolve_tts_voice(provider, "   "),
+            None,
+            "{provider} must treat a whitespace-only voice as empty"
+        );
+    }
+}
+
+#[test]
+fn tts_voice_explicit_is_preserved_for_cloud() {
+    // An explicit cloud voice (e.g. an ElevenLabs id) must still pass through
+    // untouched — the fix must not swallow caller-supplied voices.
+    assert_eq!(
+        resolve_tts_voice("cloud", "JBFqnCBsd6RMkjVDRZzb"),
+        Some("JBFqnCBsd6RMkjVDRZzb")
+    );
+    assert_eq!(resolve_tts_voice("cloud", "  Rachel  "), Some("Rachel"));
+}
+
+#[test]
+fn tts_voice_piper_still_defaults_to_bundled_voice() {
+    // Piper is the one provider the constant is valid for; this behaviour is
+    // unchanged by the fix.
+    assert_eq!(
+        resolve_tts_voice("piper", ""),
+        Some(DEFAULT_PIPER_VOICE),
+        "piper must keep its bundled-voice fallback"
+    );
+    assert_eq!(
+        resolve_tts_voice("piper", "en_GB-alba-medium"),
+        Some("en_GB-alba-medium")
+    );
+}
+
+#[test]
+fn tts_voice_slug_empty_defers_to_registry_default() {
+    // Second defect on the same line: the Piper id was never empty by the time
+    // `create_tts_provider_by_slug` looked at it, so an external provider's
+    // configured `default_tts_voice` could never win.
+    assert_eq!(resolve_tts_voice("openai", ""), None);
+    assert_eq!(resolve_tts_voice("elevenlabs", "   "), None);
+}
+
+#[test]
+fn tts_voice_slug_suffix_beats_voice_argument() {
+    // `slug:voice` is the more specific request, so it outranks the ambient
+    // `voice` argument — same precedence the STT model resolution uses.
+    assert_eq!(
+        resolve_tts_voice("openai:shimmer", "alloy"),
+        Some("shimmer")
+    );
+    assert_eq!(resolve_tts_voice("openai", "alloy"), Some("alloy"));
+}
+
+#[test]
+fn tts_factory_slug_empty_voice_uses_registry_default() {
+    // End-to-end through the factory: with no voice anywhere, the registry
+    // entry's `default_tts_voice` must be what the provider is built with —
+    // previously pre-empted by the Piper id.
+    let mut config = cfg();
+    config.voice_providers.push(
+        crate::openhuman::config::schema::voice_providers::VoiceProviderCreds {
+            slug: "openai".into(),
+            endpoint: "https://api.openai.com/v1".into(),
+            capability: VoiceCapability::Both,
+            default_tts_voice: Some("alloy".into()),
+            ..Default::default()
+        },
+    );
+    let p = create_tts_provider("openai", "", &config).unwrap();
+    assert_eq!(p.name(), "external");
 }
 
 #[test]

--- a/src/openhuman/voice/factory/traits.rs
+++ b/src/openhuman/voice/factory/traits.rs
@@ -64,4 +64,18 @@ pub trait TtsProvider: Send + Sync {
         text: &str,
         voice: Option<&str>,
     ) -> Result<RpcOutcome<ReplySpeechResult>, String>;
+
+    /// The voice this provider was constructed with, or `None` when it defers
+    /// to a downstream default (cloud omits `voice_id` so the backend picks).
+    ///
+    /// Test-only, and deliberately so: the factory hands back a
+    /// `Box<dyn TtsProvider>`, so the voice a provider actually carries is
+    /// otherwise unobservable without a live synthesis call. That blind spot is
+    /// how a Piper voice id reached the cloud proxy unnoticed (#5355) — the
+    /// pre-existing factory tests asserted only [`TtsProvider::name`], which
+    /// stayed green throughout.
+    #[cfg(test)]
+    fn configured_voice(&self) -> Option<&str> {
+        None
+    }
 }

--- a/src/openhuman/voice/factory/tts_providers.rs
+++ b/src/openhuman/voice/factory/tts_providers.rs
@@ -56,6 +56,11 @@ impl TtsProvider for CloudTtsProvider {
         };
         synthesize_reply(config, text, &opts).await
     }
+
+    #[cfg(test)]
+    fn configured_voice(&self) -> Option<&str> {
+        self.voice.as_deref()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -100,6 +105,11 @@ impl TtsProvider for PiperTtsProvider {
             voice: Some(resolved_voice),
         };
         synthesize_piper(config, text, &opts).await
+    }
+
+    #[cfg(test)]
+    fn configured_voice(&self) -> Option<&str> {
+        Some(&self.voice)
     }
 }
 
@@ -176,6 +186,11 @@ impl TtsProvider for ExternalTtsProvider {
             },
             format!("voice-factory: external TTS completed via {}", self.slug),
         ))
+    }
+
+    #[cfg(test)]
+    fn configured_voice(&self) -> Option<&str> {
+        Some(&self.default_voice)
     }
 }
 


### PR DESCRIPTION
## Summary

- Managed ("cloud") TTS always sent the **Piper** voice id `en_US-lessac-medium` to the backend ElevenLabs proxy, which rejects it with **400 Bad Request**. The Settings → Voice "Test" button therefore never passed.
- The empty-voice fallback in `create_tts_provider` is now **per-provider** instead of applied before the provider match, so a Piper model id can no longer escape the Piper branch.
- Fixes a second defect on the same line: external (slug-keyed) providers could never reach their configured `default_tts_voice`.
- Core-only change. No RPC surface, config schema, or frontend change.

## Problem

`src/openhuman/voice/factory/entry.rs` coerced an empty `voice` to `DEFAULT_PIPER_VOICE` **before** the provider match:

```rust
let voice = if voice.trim().is_empty() { DEFAULT_PIPER_VOICE } else { voice };
match provider.trim() {
    "cloud" | "openhuman" => Ok(Box::new(CloudTtsProvider::new(if voice.is_empty() { None } else { ... }))),
```

Every provider was then constructed with `en_US-lessac-medium`. The inner `voice.is_empty()` was dead — it can never be true after the coercion — so the cloud branch always received `Some("en_US-lessac-medium")`, which `synthesize_reply` forwards as `voice_id` to `POST /openai/v1/audio/speech` → 400.

Three call sites already guarded against exactly this and were silently defeated. Two in `voice/schemas/handlers/transcribe_tts.rs` carry the comment *"Only default to the Piper voice id when the active provider is actually Piper"*; the Test handler is `voice/schemas/handlers/provider_server.rs:362`. All three pass `""` to mean "this provider picks its own default", and the factory overrode them.

Second defect, same line: because the Piper id was never empty by the time `create_tts_provider_by_slug` inspected it, an external provider's configured `default_tts_voice` was unreachable.

**Not affected:** the mascot reply path. `app/src/features/human/voice/ttsClient.ts` always sends an explicit ElevenLabs voice id, so it took the non-empty branch. The broken paths were the Test button, `voice_tts_dispatch` without an explicit voice, and cloud podcast generation in `voice/audio_toolkit/ops.rs`.

**Not the cause:** `local_ai.tts_voice_id`. Its default is also `en_US-lessac-medium`, but the cloud path never reads it — the constant was the whole story. That key is left untouched; all 12 of its readers are Piper-install/status paths where the Piper id is correct.

## Solution

Extracted `resolve_tts_voice(provider, voice) -> Option<&str>`, where `None` means "let the provider pick its own default":

| Provider | Empty voice resolves to | Effect |
| --- | --- | --- |
| `cloud` / `openhuman` | `None` | `synthesize_reply` omits `voice_id`; backend applies its own default |
| `piper` | `DEFAULT_PIPER_VOICE` | unchanged |
| slug (`openai`, `openai:shimmer`) | `None` → `""` | registry entry's `default_tts_voice` applies |

Slug-suffix precedence (`openai:shimmer` beats the `voice` argument) is preserved, matching the model-resolution order in `create_stt_provider`.

**Design note — why `None` rather than an explicit id.** Omitting `voice_id` lets the backend choose. `default_tts_provider()` already constructs `CloudTtsProvider::new(None)` in production, so this path is proven. Hardcoding a specific ElevenLabs id (e.g. the mascot default `JBFqnCBsd6RMkjVDRZzb`) would couple the core to one voice and drift when the backend's default changes. Tradeoff: if the backend ever makes `voice_id` required, this regresses — worth a reviewer's opinion.

Pulling the decision into a pure function is what makes it testable: the factory returns `Box<dyn TtsProvider>`, so the resolved voice is otherwise unobservable without a live backend call — which is precisely how this shipped unnoticed. Existing tests asserted only `provider.name()`.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — 6 new tests in `src/openhuman/voice/factory/tests.rs`. The failure-path test is `tts_voice_empty_never_yields_piper_default_for_cloud`, which pins the regression directly; also covers whitespace-only voices, explicit-voice preservation, the unchanged Piper fallback, slug precedence, and an end-to-end factory assertion for the registry default.
- [x] **Diff coverage ≥ 80%** — every changed line in `entry.rs` is a branch of `resolve_tts_voice` or the match arms that consume it; all are exercised. `cargo test --lib openhuman::voice` → 216 passed, 0 failed.
- [x] Coverage matrix updated — `N/A: behaviour-only bug fix`; no feature row added, removed, or renamed.
- [x] All affected feature IDs from the matrix are listed under `## Related`
- [x] No new external network dependencies introduced — the fix removes a field from an existing request body; no new call sites.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no new surface`. Existing "voice" smoke steps cover this and need no wording change.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Platform:** desktop (all OSes). Core-only; the Tauri shell and React app are untouched.
- **Compatibility:** no breaking changes. `create_tts_provider`'s signature, `DEFAULT_PIPER_VOICE`, and the `TtsProvider` trait are unchanged. `resolve_tts_voice` is `pub(super)`, not public API.
- **Feature gates:** no `stub.rs` or forwarding change needed — the voice public surface is unchanged. The voice-disabled build (`--no-default-features --features tokenjuice-treesitter`) was verified to compile.
- **Migration:** none. No config schema or persisted-field change.
- **Behavioral deltas** — all confined to the empty-voice path:
  - `cloud`: was `en_US-lessac-medium` (→ 400), now omitted. Pure fix.
  - `piper`: unchanged.
  - external slug: was `en_US-lessac-medium`, now the registry `default_tts_voice` (or `"default"` when unconfigured). Called out for transparency: for an unconfigured external provider this swaps one invalid id for another on a path that was already broken — not a regression, but it is a changed outgoing string.
- **Security/performance:** none.

## Related

- Closes: #5355
- Affected coverage-matrix feature IDs: 5.1.4 (Mascot Voice Selection — nearest existing row; this PR is core-side provider voice resolution beneath it, no row change)
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5355-managed-tts-voice-id`
- Commit SHA: a129fb66a28f58f47f99c3348feedd266b3c3b32

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no frontend files changed`
- [x] `pnpm typecheck` — `N/A: no TypeScript changed`
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --lib openhuman::voice` → **216 passed, 0 failed**
- [x] Rust fmt/check: `cargo fmt --check` clean; `cargo clippy --lib --all-targets` reports no diagnostics on the changed files; voice-disabled build `cargo check --no-default-features --features tokenjuice-treesitter` compiles
- [x] Tauri fmt/check: `N/A: app/src-tauri untouched`

### Validation Blocked

- `command:` end-to-end managed TTS against the live backend (acceptance criterion 3, "TTS works end-to-end on v0.63.9+")
- `error:` not run — requires a signed-in desktop build hitting the real `api.tinyhumans.ai`
- `impact:` the 400 is proven fixed at the unit level (no `voice_id` is emitted for cloud), but a reviewer should click Settings → Voice → Test on a signed-in build to confirm the round trip

Pre-existing and unrelated: `cargo clippy` reports 2 errors (`clippy::approx_constant` on `3.14` in `src/core/rpc_log.rs:105` and `src/openhuman/agent/pformat.rs:426`). Both reproduce on a clean `upstream/main` checkout with this branch's changes stashed.

### Behavior Changes

- Intended behavior change: an empty voice no longer resolves to the Piper voice id for non-Piper TTS providers.
- User-visible effect: Settings → Voice → "Test" now succeeds for the managed/cloud provider instead of failing with a 400. Cloud podcast generation and `voice_tts_dispatch` without an explicit voice are fixed by the same change.

### Parity Contract

- Legacy behavior preserved: Piper keeps its `DEFAULT_PIPER_VOICE` fallback (`tts_factory_piper_empty_voice_uses_default` and `tts_voice_piper_still_defaults_to_bundled_voice`); an explicitly supplied voice still passes through untouched for every provider; slug-suffix precedence (`openai:shimmer`) is unchanged.
- Guard/fallback/dispatch parity checks: the three handler-level guards in `transcribe_tts.rs` and `provider_server.rs` are now actually effective rather than overridden — no handler code changed, so their dispatch logic is untouched. `default_tts_provider()` already passed `None` for cloud and is unaffected.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-to-speech voice selection across providers.
  * Cloud providers now preserve intentionally empty voice settings.
  * Piper automatically uses its bundled default voice when no voice is specified.
  * Slug-specific voices now take precedence over explicit and registry defaults.
  * Provider and voice settings are now trimmed before resolution.

* **Tests**
  * Added coverage for empty, whitespace-only, explicit, and provider-specific voice configurations.
  * Added regression coverage for resolved voices passed to providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->