### PR TITLE
fix(agent): send user image attachments as image blocks, not text (#5359)

### DIFF
--- a/src/openhuman/agent/message_convert.rs
+++ b/src/openhuman/agent/message_convert.rs
@@ -15,7 +15,7 @@
 //! agent-loop while callers keep speaking openhuman's `ChatMessage` vocabulary.
 
 use tinyagents::harness::message::{
-    AssistantMessage, ContentBlock, Message, SystemMessage, ToolMessage, UserMessage,
+    AssistantMessage, ContentBlock, ImageRef, Message, SystemMessage, ToolMessage, UserMessage,
 };
 use tinyagents::harness::tool::ToolCall as TaToolCall;
 
@@ -120,9 +120,56 @@ pub(crate) fn chat_message_to_message(msg: &ChatMessage) -> Message {
         // "user" and any unrecognized role default to a user turn — the safest
         // mapping for a free-form inbound message.
         _ => Message::User(UserMessage {
-            content: vec![ContentBlock::Text(text)],
+            content: user_content_blocks(text),
         }),
     }
+}
+
+/// Build the content blocks for a user turn, lifting any `[IMAGE:…]` markers out
+/// of the text into typed [`ContentBlock::Image`] blocks.
+///
+/// By the time a user message reaches this bridge the multimodal pipeline has
+/// already rehydrated and normalized every attachment into an inline
+/// `[IMAGE:data:<mime>;base64,…]` marker (see
+/// [`crate::openhuman::agent::multimodal::prepare_messages_for_provider`]).
+/// Leaving those buried in a single [`ContentBlock::Text`] ships the base64 to
+/// the model as literal text, so vision models never actually see the image —
+/// PNG screenshots fail outright and JPEGs get guessed at (#5359). Splitting the
+/// markers into [`ContentBlock::Image`] lets the provider layer serialize them
+/// as real `image_url` parts. The crate forwards [`ImageRef::url`] verbatim, so
+/// the marker payload (already a `data:` URI here) is exactly what it needs.
+fn user_content_blocks(text: String) -> Vec<ContentBlock> {
+    let (cleaned, image_refs) = crate::openhuman::agent::multimodal::parse_image_markers(&text);
+    if image_refs.is_empty() {
+        // No attachments: keep the exact prior mapping (the original, untrimmed
+        // text) so plain messages are byte-for-byte unchanged.
+        return vec![ContentBlock::Text(text)];
+    }
+    let mut content = Vec::with_capacity(image_refs.len() + 1);
+    // Lead with the marker-free prose when there is any; an image-only turn
+    // emits no empty text block (some providers reject one).
+    if !cleaned.is_empty() {
+        content.push(ContentBlock::Text(cleaned));
+    }
+    for reference in image_refs {
+        let mime_type = data_uri_mime(&reference);
+        content.push(ContentBlock::Image(ImageRef {
+            url: reference,
+            mime_type,
+        }));
+    }
+    content
+}
+
+/// Extract the MIME type from a `data:<mime>;base64,…` URI, if present.
+///
+/// Best-effort: the provider layer also reads the type straight from the `data:`
+/// URI, so a non-`data:` reference (e.g. an `http(s)` URL) simply carries
+/// `None` and is forwarded as-is.
+fn data_uri_mime(reference: &str) -> Option<String> {
+    let rest = reference.strip_prefix("data:")?;
+    let mime = rest.split([';', ',']).next()?.trim();
+    (!mime.is_empty()).then(|| mime.to_string())
 }
 
 /// Parse a native assistant tool-call envelope (`{ "content", "tool_calls" }`, as
@@ -409,6 +456,75 @@ pub(crate) fn ta_call_to_oh_call(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // #5359: a user turn whose text carries an inline `[IMAGE:data:…]` marker
+    // (what the multimodal pipeline hands this bridge) must emit a typed
+    // `ContentBlock::Image` so the provider serializes it as `image_url` — not
+    // bury the base64 in a `ContentBlock::Text` the model reads as literal text.
+    #[test]
+    fn user_image_marker_becomes_an_image_content_block() {
+        let png = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==";
+        let msg = ChatMessage::user(format!("what is in this screenshot? [IMAGE:{png}]"));
+
+        let Message::User(user) = chat_message_to_message(&msg) else {
+            panic!("user role must map to a user message");
+        };
+        assert_eq!(user.content.len(), 2, "prose text + one image block");
+        match &user.content[0] {
+            ContentBlock::Text(text) => assert_eq!(text, "what is in this screenshot?"),
+            other => panic!("expected the marker-free prose first, got {other:?}"),
+        }
+        match &user.content[1] {
+            ContentBlock::Image(image) => {
+                assert_eq!(image.url, png, "the data URI is forwarded verbatim");
+                assert_eq!(image.mime_type.as_deref(), Some("image/png"));
+            }
+            other => panic!("expected an image block, got {other:?}"),
+        }
+    }
+
+    // An image-only turn must not emit an empty text block (some providers 400
+    // on one), and multiple attachments each become their own image block.
+    #[test]
+    fn image_only_and_multi_image_user_turns_map_to_image_blocks_only() {
+        let jpeg = "data:image/jpeg;base64,/9j/4AAQSkZJRg==";
+        let gif = "data:image/gif;base64,R0lGODlhAQABAAAAACw=";
+
+        let Message::User(only) =
+            chat_message_to_message(&ChatMessage::user(format!("[IMAGE:{jpeg}]")))
+        else {
+            panic!("user role must map to a user message");
+        };
+        assert_eq!(only.content.len(), 1);
+        assert!(matches!(&only.content[0], ContentBlock::Image(image) if image.url == jpeg));
+
+        let Message::User(multi) = chat_message_to_message(&ChatMessage::user(format!(
+            "compare [IMAGE:{jpeg}] and [IMAGE:{gif}]"
+        ))) else {
+            panic!("user role must map to a user message");
+        };
+        let images: Vec<&str> = multi
+            .content
+            .iter()
+            .filter_map(|block| match block {
+                ContentBlock::Image(image) => Some(image.url.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(images, vec![jpeg, gif]);
+    }
+
+    // No marker → byte-for-byte the previous behavior: a single text block that
+    // preserves the original (untrimmed) content.
+    #[test]
+    fn plain_user_text_stays_a_single_text_block() {
+        let Message::User(user) = chat_message_to_message(&ChatMessage::user("  hi there  "))
+        else {
+            panic!("user role must map to a user message");
+        };
+        assert_eq!(user.content.len(), 1);
+        assert!(matches!(&user.content[0], ContentBlock::Text(text) if text == "  hi there  "));
+    }
 
     #[test]
     fn seeded_native_tool_round_recovers_structure_and_round_trips() {

--- a/src/openhuman/agent/message_convert.rs
+++ b/src/openhuman/agent/message_convert.rs
@@ -138,27 +138,79 @@ pub(crate) fn chat_message_to_message(msg: &ChatMessage) -> Message {
 /// markers into [`ContentBlock::Image`] lets the provider layer serialize them
 /// as real `image_url` parts. The crate forwards [`ImageRef::url`] verbatim, so
 /// the marker payload (already a `data:` URI here) is exactly what it needs.
+///
+/// Blocks are emitted in **source order** — prose and images interleave as the
+/// user wrote them, so a caption stays next to its image. A marker whose payload
+/// is not a provider-ready reference (a `data:` URI or an `http(s)` URL) is kept
+/// verbatim as text rather than sent as an image the provider would reject.
 fn user_content_blocks(text: String) -> Vec<ContentBlock> {
-    let (cleaned, image_refs) = crate::openhuman::agent::multimodal::parse_image_markers(&text);
-    if image_refs.is_empty() {
-        // No attachments: keep the exact prior mapping (the original, untrimmed
-        // text) so plain messages are byte-for-byte unchanged.
+    const PREFIX: &str = "[IMAGE:";
+    // Fast path: no markers → unchanged single text block (byte-for-byte).
+    if !text.contains(PREFIX) {
         return vec![ContentBlock::Text(text)];
     }
-    let mut content = Vec::with_capacity(image_refs.len() + 1);
-    // Lead with the marker-free prose when there is any; an image-only turn
-    // emits no empty text block (some providers reject one).
-    if !cleaned.is_empty() {
-        content.push(ContentBlock::Text(cleaned));
+
+    fn flush_text(pending: &mut String, blocks: &mut Vec<ContentBlock>) {
+        let trimmed = pending.trim();
+        if !trimmed.is_empty() {
+            blocks.push(ContentBlock::Text(trimmed.to_string()));
+        }
+        pending.clear();
     }
-    for reference in image_refs {
-        let mime_type = data_uri_mime(&reference);
-        content.push(ContentBlock::Image(ImageRef {
-            url: reference,
-            mime_type,
-        }));
+
+    let mut blocks: Vec<ContentBlock> = Vec::new();
+    let mut pending = String::new();
+    let mut images = 0usize;
+    let mut rest = text.as_str();
+
+    while let Some(start) = rest.find(PREFIX) {
+        pending.push_str(&rest[..start]);
+        let after = &rest[start + PREFIX.len()..];
+        let Some(end) = after.find(']') else {
+            // Unterminated marker — keep the remainder verbatim as text.
+            pending.push_str(&rest[start..]);
+            rest = "";
+            break;
+        };
+        let payload = after[..end].trim();
+        if is_provider_ready_image_reference(payload) {
+            // Preserve source order: flush the prose seen so far, then the image.
+            flush_text(&mut pending, &mut blocks);
+            blocks.push(ContentBlock::Image(ImageRef {
+                url: payload.to_string(),
+                mime_type: data_uri_mime(payload),
+            }));
+            images += 1;
+        } else {
+            // Not provider-ready (bare path / un-normalized marker) — keep the
+            // whole `[IMAGE:…]` marker verbatim as text.
+            pending.push_str(&rest[start..start + PREFIX.len() + end + 1]);
+        }
+        rest = &after[end + 1..];
     }
-    content
+    pending.push_str(rest);
+    flush_text(&mut pending, &mut blocks);
+
+    if images > 0 {
+        log::debug!(
+            "[agent][message_convert] lifted {images} image attachment(s) from user text into content blocks"
+        );
+    }
+    // A whitespace-only, image-less remainder still needs a block to stay a
+    // valid user turn.
+    if blocks.is_empty() {
+        blocks.push(ContentBlock::Text(text));
+    }
+    blocks
+}
+
+/// Whether an `[IMAGE:…]` payload is a reference the provider can serialize as an
+/// image: an inline `data:` URI or an `http(s)` URL. Anything else (a bare
+/// filesystem path, an un-normalized marker) is left as text.
+fn is_provider_ready_image_reference(reference: &str) -> bool {
+    reference.starts_with("data:")
+        || reference.starts_with("http://")
+        || reference.starts_with("https://")
 }
 
 /// Extract the MIME type from a `data:<mime>;base64,…` URI, if present.
@@ -498,20 +550,37 @@ mod tests {
         assert_eq!(only.content.len(), 1);
         assert!(matches!(&only.content[0], ContentBlock::Image(image) if image.url == jpeg));
 
+        // Interleaved prose + images preserve source order: text, image, text,
+        // image — so each caption stays next to its image.
         let Message::User(multi) = chat_message_to_message(&ChatMessage::user(format!(
             "compare [IMAGE:{jpeg}] and [IMAGE:{gif}]"
         ))) else {
             panic!("user role must map to a user message");
         };
-        let images: Vec<&str> = multi
-            .content
-            .iter()
-            .filter_map(|block| match block {
-                ContentBlock::Image(image) => Some(image.url.as_str()),
-                _ => None,
-            })
-            .collect();
-        assert_eq!(images, vec![jpeg, gif]);
+        assert_eq!(multi.content.len(), 4, "text, image, text, image in order");
+        assert!(matches!(&multi.content[0], ContentBlock::Text(t) if t == "compare"));
+        assert!(matches!(&multi.content[1], ContentBlock::Image(i) if i.url == jpeg));
+        assert!(matches!(&multi.content[2], ContentBlock::Text(t) if t == "and"));
+        assert!(matches!(&multi.content[3], ContentBlock::Image(i) if i.url == gif));
+    }
+
+    // A marker whose payload is not a provider-ready reference (a bare path, an
+    // un-normalized marker) must stay verbatim as text — never sent as an image
+    // the provider would reject.
+    #[test]
+    fn non_data_image_marker_is_kept_as_text() {
+        let Message::User(user) = chat_message_to_message(&ChatMessage::user(
+            "see [IMAGE:/tmp/local/path.png] here".to_string(),
+        )) else {
+            panic!("user role must map to a user message");
+        };
+        assert_eq!(user.content.len(), 1);
+        assert!(
+            matches!(&user.content[0], ContentBlock::Text(t)
+                if t == "see [IMAGE:/tmp/local/path.png] here"),
+            "a non-data/http marker stays literal text, got {:?}",
+            user.content
+        );
     }
 
     // No marker → byte-for-byte the previous behavior: a single text block that


### PR DESCRIPTION
## Summary

- Fixes the agent being unable to read attached images: PNG failed entirely and JPEG was described inaccurately.
- Lifts inline `[IMAGE:data:<mime>;base64,…]` markers out of the user text into typed `ContentBlock::Image` blocks so the provider serializes them as real `image_url` parts.

## Problem

By the time a user turn reaches the tinyagents bridge, the multimodal pipeline has already rehydrated and normalized each attachment into an inline `[IMAGE:data:<mime>;base64,…]` marker — but `chat_message_to_message` dropped the whole message into a single `ContentBlock::Text`. That shipped the base64 to the model as literal text, so vision models never received a real image: PNG (lossless, large) is unrecoverable as text, while JPEG occasionally let the model guess — matching the reported symptom exactly.

## Solution

Parse the `[IMAGE:…]` markers out of the user text and emit a typed `ContentBlock::Image` per attachment, with the marker-free prose as a leading text block (image-only turns emit no empty text block, which some providers reject). The provider layer already serializes `ContentBlock::Image` as an `image_url` part and forwards `ImageRef.url` verbatim — the marker payload is already a canonical `data:` URI — so no downstream change is needed. Non-vision models are unaffected: the pipeline never rehydrates a marker for them.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — mixed text+image turn, image-only turn (no empty text block), multi-image turn, and an unchanged plain-text turn.
- [x] **Diff coverage ≥ 80%** — the added tests exercise the changed lines; CI `diff-cover` (`cargo-llvm-cov`) enforces the gate.
- [x] Coverage matrix updated — `N/A: bug fix, no added/removed/renamed feature row.`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: bug fix.`
- [x] No new external network dependencies introduced — pure in-process message conversion.
- [x] Manual smoke checklist updated — `N/A: fixes existing image-attachment behaviour; no new release-cut surface.`
- [x] Linked issue closed via `Closes #NNN`.

## Impact

- Rust core; all platforms. Vision-capable models now receive attached images as structured `image_url` parts. `cargo fmt` + `cargo clippy -p openhuman -- -D warnings` clean; unit tests green.

## Related

- Closes: #5359
- Follow-up PR(s)/TODOs: none.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/agent-image-content-blocks-5359`
