### PR TITLE
fix(core): retry domain subscriber registration after bus startup

### DIFF
--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -1941,12 +1941,42 @@ impl DomainSubscriberPlan {
     }
 }
 
+/// Consume a domain's registration token only when the global event bus is
+/// ready. An early bus-unavailable attempt therefore remains retryable.
+fn group_first_time_when_bus_ready(
+    completed: &std::sync::Mutex<std::collections::HashSet<crate::core::all::DomainGroup>>,
+    group: crate::core::all::DomainGroup,
+    bus_ready: bool,
+) -> bool {
+    if !bus_ready {
+        log::warn!("[event_bus] deferred {group:?} subscriber registration - bus not initialized");
+        return false;
+    }
+
+    completed
+        .lock()
+        .expect("domain-subscriber registry lock poisoned")
+        .insert(group)
+}
+
+fn group_first_time(group: crate::core::all::DomainGroup) -> bool {
+    use std::collections::HashSet;
+    use std::sync::{Mutex, OnceLock};
+
+    static DONE: OnceLock<Mutex<HashSet<crate::core::all::DomainGroup>>> = OnceLock::new();
+    group_first_time_when_bus_ready(
+        DONE.get_or_init(|| Mutex::new(HashSet::new())),
+        group,
+        crate::core::event_bus::global().is_some(),
+    )
+}
+
 /// Registers all long-lived domain event-bus subscribers, each group at most
 /// once per process.
 ///
 /// Ungated core/platform infra runs exactly once behind `INFRA: Once`; each
 /// gated [`DomainGroup`](crate::core::all::DomainGroup) installs the first time
-/// it is enabled (tracked by `group_first_time`), so widening the ambient
+/// it is enabled after the event bus is ready, so widening the ambient
 /// `DomainSet` on a later call (`harness()` → `full()`) still installs the
 /// newly-enabled groups without double-subscribing the ones already registered.
 fn register_domain_subscribers(
@@ -1956,43 +1986,16 @@ fn register_domain_subscribers(
     domains: crate::core::runtime::DomainSet,
 ) {
     use crate::core::all::DomainGroup;
-    use std::collections::HashSet;
     use std::sync::{Arc, Mutex, Once, OnceLock};
 
     let plan = DomainSubscriberPlan::for_domains(domains);
     log::debug!("[event_bus] register_domain_subscribers: domains={domains:?} plan={plan:?}");
 
-    // Per-group idempotency (#4808 review): the previous single process-wide
-    // `Once` fixed the subscriber set to the FIRST caller's DomainSet — an
-    // embedder or test that built `harness()`/`none()` first and later widened
-    // to `full()` would never install the subscribers skipped on that first
-    // call, even though those domains' controllers are now exposed. Tracking the
-    // set of already-registered groups lets a later, wider DomainSet install
-    // exactly the newly-enabled groups (and no group twice). `insert` returns
-    // `true` only the first time a group is seen.
-    //
-    // **Known limitation (issue #5265, CodeRabbit "Major" on the dedup engine
-    // PR):** this marks a group "done" the moment its `if group_first_time(…)`
-    // block is entered, not once every `subscribe_global` call inside it
-    // actually returns `Some`. A transient `subscribe_global` failure (the
-    // global bus not yet initialized) inside one of those blocks — e.g. the
-    // Flows block's `FlowTriggerSubscriber` / `FlowRunDigestSubscriber` /
-    // `DedupCommitSubscriber` registrations — only logs a warning; the group
-    // is still marked done, so no later call ever retries it, leaving that
-    // subscriber permanently absent for the process's lifetime. This is a
-    // pre-existing pattern shared by every `group_first_time(DomainGroup::…)`
-    // call site in this function, not something introduced by (or specific
-    // to) the dedup subscriber — reworking it (e.g. marking the group done
-    // only after every registration in its block succeeds, or making
-    // individual registrations retryable) is out of scope for the dedup PR
-    // and is reported as a separate follow-up issue instead of fixed here.
-    fn group_first_time(group: DomainGroup) -> bool {
-        static DONE: OnceLock<Mutex<HashSet<DomainGroup>>> = OnceLock::new();
-        DONE.get_or_init(|| Mutex::new(HashSet::new()))
-            .lock()
-            .expect("domain-subscriber registry lock poisoned")
-            .insert(group)
-    }
+    // `subscribe_global` returns `None` only before the process-global bus is
+    // initialized. Because that bus is a monotonic `OnceLock`, checking it here
+    // guarantees the registrations in the guarded block cannot later lose bus
+    // availability. A premature call leaves the group absent from `DONE`, so a
+    // later bootstrap retries it instead of permanently skipping subscribers.
 
     /// Learning subscribers need their own idempotency token rather than
     /// `group_first_time(DomainGroup::Agent)`: the Agent block below already

--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -1971,6 +1971,36 @@ fn group_first_time(group: crate::core::all::DomainGroup) -> bool {
     )
 }
 
+/// Consume the learning-subscriber token only when the global event bus is
+/// ready. Learning has a separate token from the Agent group because both
+/// registration blocks must run exactly once.
+fn learning_first_time_when_bus_ready(completed: &std::sync::Mutex<bool>, bus_ready: bool) -> bool {
+    if !bus_ready {
+        log::warn!(
+            "[event_bus] deferred Agent learning subscriber registration - bus not initialized"
+        );
+        return false;
+    }
+
+    let mut completed = completed
+        .lock()
+        .expect("learning-subscriber registry lock poisoned");
+    if *completed {
+        false
+    } else {
+        *completed = true;
+        true
+    }
+}
+
+fn learning_first_time() -> bool {
+    static DONE: std::sync::OnceLock<std::sync::Mutex<bool>> = std::sync::OnceLock::new();
+    learning_first_time_when_bus_ready(
+        DONE.get_or_init(|| std::sync::Mutex::new(false)),
+        crate::core::event_bus::global().is_some(),
+    )
+}
+
 /// Registers all long-lived domain event-bus subscribers, each group at most
 /// once per process.
 ///
@@ -1986,7 +2016,7 @@ fn register_domain_subscribers(
     domains: crate::core::runtime::DomainSet,
 ) {
     use crate::core::all::DomainGroup;
-    use std::sync::{Arc, Mutex, Once, OnceLock};
+    use std::sync::{Arc, Once};
 
     let plan = DomainSubscriberPlan::for_domains(domains);
     log::debug!("[event_bus] register_domain_subscribers: domains={domains:?} plan={plan:?}");
@@ -1996,23 +2026,6 @@ fn register_domain_subscribers(
     // guarantees the registrations in the guarded block cannot later lose bus
     // availability. A premature call leaves the group absent from `DONE`, so a
     // later bootstrap retries it instead of permanently skipping subscribers.
-
-    /// Learning subscribers need their own idempotency token rather than
-    /// `group_first_time(DomainGroup::Agent)`: the Agent block below already
-    /// consumes that token, and whichever ran second would silently skip.
-    fn learning_first_time() -> bool {
-        static DONE: OnceLock<Mutex<bool>> = OnceLock::new();
-        let mut done = DONE
-            .get_or_init(|| Mutex::new(false))
-            .lock()
-            .expect("learning-subscriber registry lock poisoned");
-        if *done {
-            false
-        } else {
-            *done = true;
-            true
-        }
-    }
 
     // Seed the live tool-execution timeout from the persisted `[agent]` config
     // so a user-configured value (Settings → Agent OS access → Action timeout)

--- a/src/core/jsonrpc_tests.rs
+++ b/src/core/jsonrpc_tests.rs
@@ -7,8 +7,9 @@ use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
 use super::{
-    default_state, invoke_method, is_session_expired_error, is_unconfirmed_unauthorized_error,
-    params_to_object, parse_json_params, type_name, DomainSubscriberPlan,
+    default_state, group_first_time, group_first_time_when_bus_ready, invoke_method,
+    is_session_expired_error, is_unconfirmed_unauthorized_error, params_to_object,
+    parse_json_params, type_name, DomainSubscriberPlan,
 };
 // These are the `http-server`-gated RPC-surface symbols (#5048); the tests that
 // name them below carry the same `#[cfg]` so the disabled-build test compile
@@ -95,6 +96,72 @@ fn domain_subscriber_plan_harness_gates_by_owning_group() {
         "harness must skip hosted orchestration ingest"
     );
     assert!(!plan.mcp, "harness must skip mcp_registry bus init");
+}
+
+#[test]
+fn domain_subscriber_registration_retries_after_bus_becomes_ready() {
+    use crate::core::all::DomainGroup;
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+
+    let completed = Mutex::new(HashSet::new());
+
+    assert!(!group_first_time_when_bus_ready(
+        &completed,
+        DomainGroup::Flows,
+        false,
+    ));
+    assert!(
+        completed.lock().expect("registry lock").is_empty(),
+        "a deferred attempt must not mark the group complete"
+    );
+
+    assert!(group_first_time_when_bus_ready(
+        &completed,
+        DomainGroup::Flows,
+        true,
+    ));
+    assert!(
+        completed
+            .lock()
+            .expect("registry lock")
+            .contains(&DomainGroup::Flows),
+        "the ready retry must mark the group complete"
+    );
+}
+
+#[test]
+fn domain_subscriber_registration_is_idempotent_after_success() {
+    use crate::core::all::DomainGroup;
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+
+    let completed = Mutex::new(HashSet::new());
+
+    assert!(group_first_time_when_bus_ready(
+        &completed,
+        DomainGroup::Channels,
+        true,
+    ));
+    assert!(!group_first_time_when_bus_ready(
+        &completed,
+        DomainGroup::Channels,
+        true,
+    ));
+    assert_eq!(
+        completed.lock().expect("registry lock").len(),
+        1,
+        "a completed group must be recorded exactly once"
+    );
+}
+
+#[test]
+fn domain_subscriber_registration_wrapper_uses_the_global_bus() {
+    use crate::core::all::DomainGroup;
+
+    crate::core::event_bus::init_global(crate::core::event_bus::DEFAULT_CAPACITY);
+    assert!(group_first_time(DomainGroup::Media));
+    assert!(!group_first_time(DomainGroup::Media));
 }
 
 /// #5027 — the tool-execution timeout must be seeded on the always-on core boot

--- a/src/core/jsonrpc_tests.rs
+++ b/src/core/jsonrpc_tests.rs
@@ -8,8 +8,9 @@ use tokio_util::sync::CancellationToken;
 
 use super::{
     default_state, group_first_time, group_first_time_when_bus_ready, invoke_method,
-    is_session_expired_error, is_unconfirmed_unauthorized_error, params_to_object,
-    parse_json_params, type_name, DomainSubscriberPlan,
+    is_session_expired_error, is_unconfirmed_unauthorized_error,
+    learning_first_time_when_bus_ready, params_to_object, parse_json_params, type_name,
+    DomainSubscriberPlan,
 };
 // These are the `http-server`-gated RPC-surface symbols (#5048); the tests that
 // name them below carry the same `#[cfg]` so the disabled-build test compile
@@ -153,6 +154,31 @@ fn domain_subscriber_registration_is_idempotent_after_success() {
         1,
         "a completed group must be recorded exactly once"
     );
+}
+
+#[test]
+fn learning_subscriber_registration_retries_after_bus_becomes_ready() {
+    let completed = std::sync::Mutex::new(false);
+
+    assert!(!learning_first_time_when_bus_ready(&completed, false));
+    assert!(
+        !*completed.lock().expect("registry lock"),
+        "a deferred learning attempt must not consume its token"
+    );
+
+    assert!(learning_first_time_when_bus_ready(&completed, true));
+    assert!(
+        *completed.lock().expect("registry lock"),
+        "the ready retry must consume the learning token"
+    );
+}
+
+#[test]
+fn learning_subscriber_registration_is_idempotent_after_success() {
+    let completed = std::sync::Mutex::new(false);
+
+    assert!(learning_first_time_when_bus_ready(&completed, true));
+    assert!(!learning_first_time_when_bus_ready(&completed, true));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Keep a domain's subscriber-registration token unconsumed while the global event bus is unavailable.
- Preserve existing once-per-process registration after the bus is initialized.
- Cover deferred registration, successful retry, production global-bus wiring, and post-success idempotency.

## Problem

`group_first_time` inserted a `DomainGroup` into the process-wide completed set before its registration block ran. If the block ran before the global event bus was initialized, every `subscribe_global` call returned `None`, but the group stayed marked complete and could never retry during the process lifetime.

## Solution

Gate insertion into the completed set on global event-bus readiness. `subscribe_global` has only one failure condition: the monotonic global bus `OnceLock` has not been initialized. Once the bus exists it cannot disappear, so the existing registration blocks can run unchanged and remain idempotent.

The state transition is extracted behind an injectable readiness flag for deterministic failure-path coverage. A separate wrapper test exercises the real global-bus lookup with a domain token that has no subscriber block.

On current main, `bootstrap_core_runtime` initializes the bus before it registers domain subscribers, which narrows the normal-startup window. `start_channels` can still reach registration before that path; retaining the readiness gate keeps a premature attempt retryable rather than permanently consuming its token.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage >= 80%** - changed lines reached 100% with the repository's scoped Rust coverage lane and `diff-cover` on the current branch head.
- [x] Coverage matrix updated - N/A: behavior-only correction to existing core bootstrap registration.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` - N/A: no matrix feature ID applies.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated - N/A: no release-cut or user-facing workflow changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

Core runtime only. A premature registration attempt now defers cleanly and can succeed on a later bootstrap call. Current bootstrap ordering narrows the normal-startup window, but `start_channels` can still arrive before it; normal startup, domain widening, and once-per-process behavior are otherwise unchanged. No persistence, migration, API, or user-interface impact.

## Related

- Closes #5269
- Follow-up PR(s)/TODOs: None.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `agent/retry-domain-subscriber-registration`
- Commit SHA: `8e4eed191ff069843f40fdb938d4a095d03fbb3d`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` - N/A: no frontend files changed.
- [x] `pnpm typecheck` - N/A: no TypeScript files changed.
- [x] Focused tests: `cargo test --lib domain_subscriber -- --nocapture` (6 passed); repository scoped coverage lane (97 passed, 1 pre-existing ignored); `diff-cover` (100%).
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path Cargo.toml --check`; `git diff --check`; default and slim-feature focused test builds passed.
- [x] Tauri fmt/check (if changed): N/A: no Tauri files changed.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: bus-unavailable domain registration attempts remain retryable.
- User-visible effect: none during normal startup; prevents silently missing domain subscribers after premature registration.

### Parity Contract

- Legacy behavior preserved: domain selection, later DomainSet widening, registration order, and once-per-process idempotency after successful bus initialization.
- Guard/fallback/dispatch parity checks: default-feature and `--no-default-features --features tokenjuice-treesitter` registrar tests both pass.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None found in the final live search.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved domain event subscriber registration reliability when the event bus is temporarily unavailable.
  * Registrations now remain retryable until the event bus is ready, preventing missed subscriptions.
  * Successful registrations are safely handled as idempotent, avoiding duplicate setup.
  * Added coverage for deferred retries, repeated registrations, and event-bus readiness behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
