### PR TITLE
fix(agent): preserve chat context across a Quick/Reasoning switch

### DIFF
--- a/src/openhuman/agent/harness/session/runtime.rs
+++ b/src/openhuman/agent/harness/session/runtime.rs
@@ -436,13 +436,30 @@ impl Agent {
             return false;
         }
 
-        let session_raw_dir = self.workspace_dir.join(&self.session_raw_subdir);
+        // The thread's conversation belongs to the THREAD, not the active
+        // profile. Resolve via the cross-dir finder, which scans the shared
+        // `session_raw/` AND every profile-scoped `session_raw-<id>/` for this
+        // exact `thread_id` and returns the NEWEST match. So switching the active
+        // profile mid-thread (e.g. the Quick↔Reasoning toggle) continues the same
+        // conversation even when earlier turns were written under a different
+        // profile's subtree — a dedicated-memory personality, or a profile an
+        // earlier build wrongly scoped (#5351).
+        //
+        // Deliberately NOT own-dir-first (`in_dir(session_raw_subdir).or_else(…)`):
+        // that would let an *older* transcript in the agent's own dir shadow a
+        // *newer* one a sibling scoped dir holds for the same thread — dropping
+        // the most recent turns, and diverging from the transcript view + turn
+        // mirror, which both use this same newest-across-dirs resolver. The own
+        // dir is already included in the scan, so newest-wins is a superset.
+        // Keyed on `thread_id`, so it never bleeds an unrelated session across
+        // profiles; a blank id short-circuits to `None`.
         let Some(path) =
-            super::transcript::find_root_transcript_for_thread_in_dir(&session_raw_dir, thread_id)
+            super::transcript::find_root_transcript_for_thread(&self.workspace_dir, thread_id)
         else {
             log::debug!(
-                "[web-channel] no root session_raw transcript for thread={thread_id} — \
-                 falling back to conversation-log prose seeding"
+                "[web-channel] no root session_raw transcript for thread={thread_id} in any \
+                 (shared or profile-scoped) session_raw dir — falling back to \
+                 conversation-log prose seeding"
             );
             return false;
         };

--- a/src/openhuman/agent/harness/session/tests.rs
+++ b/src/openhuman/agent/harness/session/tests.rs
@@ -1612,6 +1612,153 @@ fn seed_resume_replays_compaction_to_reduced_context() {
     );
 }
 
+/// #5351: a profile-scoped session (running in its own `session_raw-<id>/`
+/// subtree) must still resume a thread whose earlier turns were written under a
+/// DIFFERENT profile's subtree — here the shared `session_raw/`. Without the
+/// cross-dir fallback the Reasoning profile could not see the plan the Quick
+/// profile wrote, dropping all prior context on a mid-thread Quick↔Reasoning
+/// switch.
+#[test]
+fn seed_resume_from_thread_transcript_crosses_profile_scoped_dirs() {
+    use super::transcript::{self, TranscriptMeta};
+    use crate::openhuman::agent::messages::ChatMessage;
+
+    let ws = tempfile::TempDir::new().expect("temp workspace");
+    let wsp = ws.path().to_path_buf();
+    let thread_id = "thr_cross_profile";
+
+    // Prior turns written by the QUICK (default) profile into the SHARED
+    // `session_raw/` subtree.
+    let messages = vec![
+        ChatMessage::system("system prompt"),
+        ChatMessage::user("set up Minimax for image generation"),
+        ChatMessage::assistant("Minimax is configured as the image generator."),
+    ];
+    let meta = TranscriptMeta {
+        agent_name: "orchestrator_thr_cross_pr".to_string(),
+        agent_id: Some("orchestrator".to_string()),
+        agent_type: Some("root".to_string()),
+        dispatcher: "native".to_string(),
+        provider: None,
+        model: None,
+        created: "2026-01-01T00:00:00Z".to_string(),
+        updated: "2026-01-01T00:00:00Z".to_string(),
+        turn_count: 1,
+        input_tokens: 0,
+        output_tokens: 0,
+        cached_input_tokens: 0,
+        charged_amount_usd: 0.0,
+        thread_id: Some(thread_id.to_string()),
+        task_id: None,
+    };
+    // The shared `session_raw/` (default resolve path) — the Quick profile's dir.
+    let path = transcript::resolve_keyed_transcript_path(&wsp, "1700000000_orchestrator")
+        .expect("resolve transcript path");
+    transcript::write_transcript(&path, &messages, &meta, None).expect("write transcript");
+
+    // The REASONING profile runs in a scoped `session_raw-1/` subtree — its own
+    // dir holds no transcript for this thread, so the in-dir lookup misses and
+    // only the cross-dir fallback can recover the conversation.
+    let mut agent = build_minimal_agent_with_definition_name(Some("orchestrator"));
+    agent.workspace_dir = wsp.clone();
+    agent.session_raw_subdir = "session_raw-1".to_string();
+
+    let loaded = agent.seed_resume_from_thread_transcript(thread_id);
+    assert!(
+        loaded,
+        "a profile-scoped session must resume the thread's transcript from the shared \
+         session_raw dir via the cross-dir fallback (#5351)"
+    );
+    let cached = agent
+        .cached_transcript_messages
+        .as_ref()
+        .expect("cached transcript populated");
+    assert!(
+        cached.iter().any(|m| m.content.contains("image generator")),
+        "the prior plan context must be recovered across the profile-scoped dir boundary"
+    );
+}
+
+/// #5351 regression guard: resume must pick the NEWEST transcript across profile
+/// dirs, never the one in the agent's own dir. After the Reasoning profile is
+/// healed back to the shared `session_raw/`, an OLDER transcript there must not
+/// shadow the NEWER turns the profile wrote into its (pre-heal) scoped
+/// `session_raw-1/` — otherwise the switch drops the most recent context and the
+/// seeded history diverges from what the transcript view shows.
+#[test]
+fn seed_resume_from_thread_transcript_picks_newest_across_profile_dirs() {
+    use super::transcript::{self, TranscriptMeta};
+    use crate::openhuman::agent::messages::ChatMessage;
+
+    let ws = tempfile::TempDir::new().expect("temp workspace");
+    let wsp = ws.path().to_path_buf();
+    let thread_id = "thr_newest_wins";
+
+    let meta = |stamp: &str| TranscriptMeta {
+        agent_name: "orchestrator_thr_newest".to_string(),
+        agent_id: Some("orchestrator".to_string()),
+        agent_type: Some("root".to_string()),
+        dispatcher: "native".to_string(),
+        provider: None,
+        model: None,
+        created: stamp.to_string(),
+        updated: stamp.to_string(),
+        turn_count: 1,
+        input_tokens: 0,
+        output_tokens: 0,
+        cached_input_tokens: 0,
+        charged_amount_usd: 0.0,
+        thread_id: Some(thread_id.to_string()),
+        task_id: None,
+    };
+
+    // OLDER transcript in the agent's OWN (shared) dir.
+    let older = vec![
+        ChatMessage::system("system prompt"),
+        ChatMessage::user("draft plan"),
+        ChatMessage::assistant("early draft, details TBD"),
+    ];
+    let old_path = wsp
+        .join("session_raw")
+        .join("1700000000_orchestrator.jsonl");
+    std::fs::create_dir_all(old_path.parent().unwrap()).unwrap();
+    transcript::write_transcript(&old_path, &older, &meta("2026-01-01T00:00:00Z"), None)
+        .expect("write older");
+
+    // NEWER transcript in a sibling scoped dir (written pre-heal, higher stem).
+    let newer = vec![
+        ChatMessage::system("system prompt"),
+        ChatMessage::user("finalize plan"),
+        ChatMessage::assistant("FINAL: Minimax is the image generator"),
+    ];
+    let new_path = wsp
+        .join("session_raw-1")
+        .join("1700009999_orchestrator.jsonl");
+    std::fs::create_dir_all(new_path.parent().unwrap()).unwrap();
+    transcript::write_transcript(&new_path, &newer, &meta("2026-02-02T00:00:00Z"), None)
+        .expect("write newer");
+
+    // Agent runs in the shared dir (healed). Own-dir-first would wrongly pick the
+    // older draft; newest-across-dirs must pick the finalized plan.
+    let mut agent = build_minimal_agent_with_definition_name(Some("orchestrator"));
+    agent.workspace_dir = wsp.clone();
+    agent.session_raw_subdir = "session_raw".to_string();
+
+    assert!(agent.seed_resume_from_thread_transcript(thread_id));
+    let cached = agent
+        .cached_transcript_messages
+        .as_ref()
+        .expect("cached transcript populated");
+    assert!(
+        cached.iter().any(|m| m.content.contains("FINAL")),
+        "resume must load the NEWEST transcript across profile dirs, not the older own-dir copy"
+    );
+    assert!(
+        !cached.iter().any(|m| m.content.contains("early draft")),
+        "the older own-dir transcript must not shadow the newer sibling"
+    );
+}
+
 /// When no root transcript exists for the thread, the transcript resume is a
 /// no-op returning `false` so the caller falls back to prose-pair seeding.
 #[test]

--- a/src/openhuman/agent/profiles/store.rs
+++ b/src/openhuman/agent/profiles/store.rs
@@ -476,6 +476,11 @@ fn normalise_state(state: AgentProfilesState) -> AgentProfilesState {
             profile.is_master = true;
             profile.memory_dir_suffix = Some(String::new());
         } else if built_in_ids.contains(&profile.id) && !profile.dedicated_memory {
+            tracing::debug!(
+                profile_id = %profile.id,
+                had_suffix = profile.memory_dir_suffix.is_some(),
+                "[profiles] normalise pinning built-in profile to shared memory/session_raw subtree"
+            );
             // #5351: the built-in helper profiles (reasoning/research/planner/
             // review) ship `dedicated_memory: false` and are meant to SHARE the
             // default memory + `session_raw` subtree. An earlier `upsert` path

--- a/src/openhuman/agent/profiles/store.rs
+++ b/src/openhuman/agent/profiles/store.rs
@@ -463,6 +463,9 @@ fn normalise_state(state: AgentProfilesState) -> AgentProfilesState {
         .into_iter()
         .map(|profile| (profile.id.clone(), profile))
         .collect();
+    // `by_id` currently holds exactly the built-in profile ids — capture them so
+    // the overlay loop below can recognise a persisted override of a built-in.
+    let built_in_ids: std::collections::HashSet<String> = by_id.keys().cloned().collect();
 
     for profile in state.profiles {
         let mut profile = normalise_profile(profile);
@@ -472,6 +475,22 @@ fn normalise_state(state: AgentProfilesState) -> AgentProfilesState {
         if profile.id == DEFAULT_PROFILE_ID {
             profile.is_master = true;
             profile.memory_dir_suffix = Some(String::new());
+        } else if built_in_ids.contains(&profile.id) && !profile.dedicated_memory {
+            // #5351: the built-in helper profiles (reasoning/research/planner/
+            // review) ship `dedicated_memory: false` and are meant to SHARE the
+            // default memory + `session_raw` subtree. An earlier `upsert` path
+            // (store.rs `upsert`) wrongly stamped them with a numeric
+            // `memory_dir_suffix` ("-1") — isolating their transcripts + memory
+            // recall into `session_raw-1/` / `memory-1/`, which dropped all prior
+            // context when the user flipped the Quick/Reasoning toggle mid-thread.
+            // Pin them back to the shared subtree here (mirroring how `default` is
+            // pinned above, the canonical normalization point that runs on every
+            // load AND save), so both a fresh mis-assignment and an
+            // already-persisted stale suffix are healed. A user who genuinely
+            // wants isolated memory sets `dedicated_memory` (honoured by the guard
+            // above) or creates a custom (non-built-in) profile — neither is
+            // touched here.
+            profile.memory_dir_suffix = None;
         }
         by_id.insert(profile.id.clone(), profile);
     }
@@ -685,6 +704,72 @@ mod tests {
 
         let resolved = store.resolve(Some("custom-profile")).expect("resolve").1;
         assert_eq!(resolved.id, "custom-profile");
+    }
+
+    #[test]
+    fn normalise_state_heals_stale_numeric_suffix_on_built_in_profiles() {
+        // An earlier `upsert` bug stamped the built-in `reasoning` profile with a
+        // scoped `memory_dir_suffix`, isolating its transcripts + memory into
+        // `session_raw-1/` / `memory-1/` and dropping context on a mid-thread
+        // Quick↔Reasoning switch (#5351). Loading must heal it back to the shared
+        // subtree; a genuine custom profile's suffix must be left alone.
+        let mut reasoning = custom("reasoning", "Reasoning", "orchestrator");
+        reasoning.built_in = true;
+        reasoning.memory_dir_suffix = Some("-1".into());
+        let mut sidekick = custom("sidekick", "Sidekick", "orchestrator");
+        sidekick.memory_dir_suffix = Some("-2".into());
+
+        let state = normalise_state(AgentProfilesState {
+            active_profile_id: DEFAULT_PROFILE_ID.into(),
+            profiles: vec![reasoning, sidekick],
+        });
+
+        let reasoning = state
+            .profiles
+            .iter()
+            .find(|p| p.id == "reasoning")
+            .expect("reasoning present");
+        assert_eq!(
+            reasoning.memory_dir_suffix, None,
+            "built-in reasoning must be pinned to the shared memory/session_raw subtree"
+        );
+        let sidekick = state
+            .profiles
+            .iter()
+            .find(|p| p.id == "sidekick")
+            .expect("custom sidekick present");
+        assert_eq!(
+            sidekick.memory_dir_suffix.as_deref(),
+            Some("-2"),
+            "a genuine custom profile's isolated-memory suffix must be preserved"
+        );
+    }
+
+    #[test]
+    fn upsert_of_built_in_reasoning_stays_on_shared_subtree() {
+        // Editing + saving the built-in Reasoning profile must NOT scope its
+        // memory: it ships `dedicated_memory:false` and shares the default
+        // subtree, so a mid-thread switch keeps context (#5351).
+        let dir = tempdir().expect("tempdir");
+        let store = AgentProfileStore::new(dir.path().to_path_buf());
+        let mut reasoning = custom("reasoning", "Reasoning", "orchestrator");
+        reasoning.built_in = true;
+        reasoning.model_override = Some("hint:reasoning".into());
+        // ProfileEditorPage submits without a `memory_dir_suffix`.
+        reasoning.memory_dir_suffix = None;
+
+        store.upsert(reasoning).expect("upsert reasoning");
+
+        let loaded = store.load().expect("load");
+        let reasoning = loaded
+            .profiles
+            .iter()
+            .find(|p| p.id == "reasoning")
+            .expect("reasoning present");
+        assert_eq!(
+            reasoning.memory_dir_suffix, None,
+            "upsert must never stamp a built-in profile with a scoped memory suffix"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- The Quick/Reasoning composer toggle switches the **active agent profile** (`default`/`reasoning`), not a model dropdown. Switching it mid-thread no longer drops the in-progress conversation and plan.
- `normalise_state` now pins built-in non-default, non-`dedicated_memory` profiles (reasoning/research/planner/review) to the **shared** memory + `session_raw` subtree — preventing and healing the mis-scoping on every load/save.
- `seed_resume_from_thread_transcript` now resolves the thread's transcript across **all** profile dirs (newest-wins), so a thread's conversation follows the thread across any profile switch, including already-scoped installs.

## Problem

Reported in #5351: switching quick↔reasoning mid-session drops the earlier plan and all prior context; the new tier behaves like a fresh session.

Root cause: `store.rs::upsert` auto-assigns a numeric `memory_dir_suffix` to any non-`default` profile with `memory_dir_suffix.is_none()` — it excludes only `default`, not the other built-ins. So **editing + saving the built-in Reasoning profile once** stamps it with `"-1"`, routing it to a scoped `session_raw-1/` + `memory-1/` subtree. A mid-thread switch is a session-cache miss that rebuilds the agent from that scoped dir, which cannot see the conversation the previous profile wrote to the shared subtree. It is **conditional** (needs a prior profile edit) and **partial** (the plain-text prose fallback survived; tool-call/reasoning transcript fidelity and semantic recall did not).

## Solution

- **`normalise_state` pin (`store.rs`).** In the canonical normalization point (runs on every `load` and `save`, where `default` is already pinned), built-in non-default, non-`dedicated_memory` profiles are forced to `memory_dir_suffix = None` → shared subtree. This both prevents a fresh mis-assignment and heals an already-persisted stale suffix. Custom profiles and a user-set `dedicated_memory` are untouched. Non-destructive — no filesystem move/delete; orphaned `memory-<n>/` dirs are left in place.
- **Cross-dir transcript resume (`runtime.rs`).** `seed_resume_from_thread_transcript` now uses the cross-dir, newest-wins `find_root_transcript_for_thread` (scans the shared `session_raw/` plus every `session_raw-<id>/`) instead of an own-dir-first lookup. A thread's conversation follows the thread across any profile switch and stays aligned with the transcript view + turn mirror, which already use this same resolver. Matching is keyed on `thread_id`, so it never bleeds an unrelated session across profiles.
- **Design decision.** The pin routes the profile to the right dir for new threads; the cross-dir resume additionally rescues transcripts a profile wrote while scoped (pre-heal) and genuine dedicated-memory personalities. Together they restore both context vectors — the raw transcript (first turn after the switch) and shared-memory recall (later turns) — with no migration and no wire/API change.
- The agent-name warm-resume path (`try_load_session_transcript` / `find_latest_transcript_in_subdir`) is **deliberately left untouched**; it keeps enforcing profile isolation for its (non-thread-keyed) use.

## Submission Checklist

- [x] Tests added or updated (happy path + failure/edge): profile-scoped session resumes the shared-dir transcript; newest-wins across profile dirs (guards the own-dir-shadow regression); `normalise_state` heals a stale suffix while preserving a custom profile's suffix; upsert of the built-in Reasoning profile stays on the shared subtree.
- [x] **Diff coverage ≥ 80%** — not run locally (`pnpm test:coverage`/`cargo-llvm-cov` need a full build the local disk could not fit); the 4 tests exercise both changed code paths. Deferred to the CI coverage gate.
- [x] Coverage matrix updated — `N/A: behaviour-only bugfix`, no feature row added/removed/renamed.
- [x] All affected feature IDs listed under `## Related` — `N/A: behaviour-only change`.
- [x] No new external network dependencies introduced — none added; changes are pure in-process logic.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: internal profile-normalization + transcript-resume logic, no release-cut surface`.
- [x] Linked issue closed via `Closes #NNN` in `## Related`.

## Impact

- **Platform:** desktop + managed/cloud. The profile store and web-chat resume are kernel/always-compiled (no feature gate), so the fix ships in every build. No frontend change, no config schema change, no migration file.
- **Behavior change:** the built-in reasoning/research/planner/review profiles now share the default memory + `session_raw` subtree — their shipped intent (`dedicated_memory: false`). This heals bug-created scoping; any bug-era `memory-<n>/` data is orphaned non-destructively (files remain). A dedicated-memory personality active on a thread may now resume that thread's transcript written under another profile (read-only, same conversation; its writes still go to its scoped dir).
- **Known limitation:** the heal recovers the conversation transcript but not semantic captures written into a bug-era `memory-<n>/` during the scoped window. This does **not** affect the issue's scenario — a plan built under Quick (`default`) lives in shared memory and is recalled. A proper fix (embeddings/SQLite merge) is invasive and out of scope.
- **Performance:** the cross-dir resolve parses root transcripts across profile dirs, but only on a session-cache miss (cold-boot / profile switch) — the same unit cost the transcript view already pays — and is a no-op superset for the common single-profile workspace.
- **Security:** the scan is bounded to the per-user `workspace_dir` (`users/<id>/workspace`), so there is no cross-tenant transcript access.

## Related

- Closes: #5351
- Follow-up PR(s)/TODOs: (optional) cross-scope memory recall / `memory-<n>` merge for bug-era captures — out of scope here.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A (GitHub issue #5351, not Linear)
- URL: N/A

### Commit & Branch

- Branch: `fix/5351-session-context-model-switch`
- Commit SHA: `a37feb743`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no app/src (TypeScript) changes`.
- [x] `pnpm typecheck` — `N/A: no TypeScript changes`.
- [x] Focused tests: `cargo test --lib` — 4 new tests plus 51 in `agent::profiles::store` + `agent::harness::session` pass, 0 failed.
- [x] Rust fmt/check: `cargo check --manifest-path Cargo.toml` clean; `cargo fmt --check` clean on all 3 changed files.
- [x] Tauri fmt/check: `N/A: app/src-tauri untouched; change is core-internal, public API unchanged`.

### Validation Blocked

- `command:` `pnpm test:coverage` / `pnpm rust:check` (Tauri shell) / full `cargo test` link
- `error:` local APFS container saturation during large Rust builds
- `impact:` diff-coverage gate + Tauri shell check deferred to CI; core crate verified via `cargo check` + targeted tests

### Behavior Changes

- Intended behavior change: a mid-thread profile switch retains conversation context; built-in helper profiles share the default memory/`session_raw` subtree.
- User-visible effect: the Quick↔Reasoning toggle no longer resets the conversation/plan.

### Parity Contract

- Legacy behavior preserved: custom-profile numeric-suffix assignment unchanged (`memory_dir_suffix_auto_assigned_on_upsert` passes); default-profile pinning unchanged; the agent-name warm-resume isolation path is untouched.
- Guard/fallback/dispatch parity checks: cross-dir resume is keyed on `thread_id` (no cross-session bleed); `dedicated_memory` is honored; blank `thread_id` short-circuits to `None`.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session resume by finding the newest matching transcript across shared and profile-specific locations.
  * Corrected built-in profile state handling by removing stale memory directory suffixes when dedicated memory is not used.
  * Preserved memory suffixes for profiles that require dedicated memory and for custom profiles.

* **Tests**
  * Added coverage for transcript fallback and profile state normalization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->