### PR TITLE
fix(voice): stop leaking the Piper default voice into cloud TTS (#5355)

### DIFF
--- a/src/openhuman/voice/factory/entry.rs
+++ b/src/openhuman/voice/factory/entry.rs
@@ -93,20 +93,31 @@ pub fn create_tts_provider(
     config: &Config,
 ) -> anyhow::Result<Box<dyn TtsProvider>> {
     debug!("{LOG_PREFIX} create_tts_provider provider={provider} voice={voice}");
-    let voice = if voice.trim().is_empty() {
-        DEFAULT_PIPER_VOICE
-    } else {
-        voice
-    };
+    let voice = voice.trim();
     match provider.trim() {
-        "cloud" | "openhuman" => Ok(Box::new(CloudTtsProvider::new(if voice.is_empty() {
-            None
-        } else {
-            Some(voice.to_string())
-        }))),
-        "piper" => Ok(Box::new(PiperTtsProvider::new(voice))),
+        // Cloud/ElevenLabs resolves its own default voice server-side — the
+        // hosted `/audio/speech` proxy omits `voice_id` when it is absent (see
+        // `reply_speech::synthesize_reply`), so an empty voice must stay empty
+        // (`None`). Injecting the Piper default `en_US-lessac-medium` here sent
+        // an invalid voice to the upstream ElevenLabs proxy and 400'd (#5355).
+        "cloud" | "openhuman" => Ok(Box::new(CloudTtsProvider::new(
+            (!voice.is_empty()).then(|| voice.to_string()),
+        ))),
+        // Piper is the only provider whose default voice is the local
+        // `en_US-lessac-medium` model, so the fallback lives in this arm only.
+        "piper" => {
+            let voice = if voice.is_empty() {
+                DEFAULT_PIPER_VOICE
+            } else {
+                voice
+            };
+            Ok(Box::new(PiperTtsProvider::new(voice)))
+        }
         other => {
             let (slug, slug_voice) = split_slug_model(other);
+            // An empty voice lets `create_tts_provider_by_slug` fall back to the
+            // registry entry's `default_tts_voice` (e.g. the ElevenLabs default),
+            // not the Piper voice id.
             let effective_voice = if slug_voice.is_empty() {
                 voice
             } else {

--- a/src/openhuman/voice/factory/tests.rs
+++ b/src/openhuman/voice/factory/tests.rs
@@ -7,7 +7,9 @@ use super::entry::{
 use super::helpers::{effective_stt_provider, effective_tts_provider, split_slug_model};
 use super::stt_providers::WhisperSttProvider;
 use super::traits::SttProvider;
-use crate::openhuman::config::schema::voice_providers::{SttApiStyle, VoiceCapability};
+use crate::openhuman::config::schema::voice_providers::{
+    SttApiStyle, TtsApiStyle, VoiceCapability,
+};
 use crate::openhuman::config::Config;
 
 fn cfg() -> Config {
@@ -132,6 +134,66 @@ fn tts_factory_piper_empty_voice_uses_default() {
 fn tts_factory_openhuman_sentinel() {
     let p = create_tts_provider("openhuman", "alloy", &cfg()).unwrap();
     assert_eq!(p.name(), "cloud");
+}
+
+#[test]
+fn tts_factory_cloud_empty_voice_stays_none() {
+    // #5355 regression: an empty voice on the cloud provider must NOT inherit the
+    // Piper default `en_US-lessac-medium`. That id is invalid for the
+    // ElevenLabs-backed cloud proxy and returns HTTP 400. Empty resolves to
+    // `None` so the backend picks its own default voice.
+    let p = create_tts_provider("cloud", "", &cfg()).unwrap();
+    assert_eq!(p.name(), "cloud");
+    assert_eq!(p.configured_voice(), None);
+}
+
+#[test]
+fn tts_factory_openhuman_empty_voice_stays_none() {
+    // The `openhuman` sentinel resolves to the same cloud path, so it carries
+    // the identical guarantee.
+    let p = create_tts_provider("openhuman", "", &cfg()).unwrap();
+    assert_eq!(p.name(), "cloud");
+    assert_eq!(p.configured_voice(), None);
+}
+
+#[test]
+fn tts_factory_cloud_keeps_explicit_voice() {
+    let p = create_tts_provider("cloud", "Rachel", &cfg()).unwrap();
+    assert_eq!(p.name(), "cloud");
+    assert_eq!(p.configured_voice().as_deref(), Some("Rachel"));
+}
+
+#[test]
+fn tts_factory_piper_empty_voice_resolves_piper_default() {
+    // Piper is the one provider whose default voice legitimately is
+    // `en_US-lessac-medium`, so the fallback still applies here.
+    let p = create_tts_provider("piper", "", &cfg()).unwrap();
+    assert_eq!(p.name(), "piper");
+    assert_eq!(p.configured_voice().as_deref(), Some("en_US-lessac-medium"));
+}
+
+#[test]
+fn tts_factory_external_empty_voice_uses_registry_default_not_piper() {
+    // An external ElevenLabs provider with no explicit voice must fall back to
+    // the registry entry's `default_tts_voice`, never the Piper id (which would
+    // 400 upstream) — the latent form of #5355 on the BYOK path.
+    let mut config = cfg();
+    config.voice_providers.push(
+        crate::openhuman::config::schema::voice_providers::VoiceProviderCreds {
+            slug: "elevenlabs".into(),
+            endpoint: "https://api.elevenlabs.io/v1".into(),
+            capability: VoiceCapability::Both,
+            tts_api_style: TtsApiStyle::ElevenLabs,
+            default_tts_voice: Some("JBFqnCBsd6RMkjVDRZzb".into()),
+            ..Default::default()
+        },
+    );
+    let p = create_tts_provider("elevenlabs", "", &config).unwrap();
+    assert_eq!(p.name(), "external");
+    assert_eq!(
+        p.configured_voice().as_deref(),
+        Some("JBFqnCBsd6RMkjVDRZzb")
+    );
 }
 
 #[test]

--- a/src/openhuman/voice/factory/traits.rs
+++ b/src/openhuman/voice/factory/traits.rs
@@ -64,4 +64,14 @@ pub trait TtsProvider: Send + Sync {
         text: &str,
         voice: Option<&str>,
     ) -> Result<RpcOutcome<ReplySpeechResult>, String>;
+
+    /// Test-only accessor for the voice this provider was constructed with.
+    /// Used to assert the factory's provider-aware voice resolution — an empty
+    /// voice must resolve to the Piper default only for Piper, never leak that
+    /// id into the cloud provider (#5355). Defaults to `None`; concrete
+    /// providers that carry a configured voice override it.
+    #[cfg(test)]
+    fn configured_voice(&self) -> Option<String> {
+        None
+    }
 }

--- a/src/openhuman/voice/factory/tts_providers.rs
+++ b/src/openhuman/voice/factory/tts_providers.rs
@@ -56,6 +56,11 @@ impl TtsProvider for CloudTtsProvider {
         };
         synthesize_reply(config, text, &opts).await
     }
+
+    #[cfg(test)]
+    fn configured_voice(&self) -> Option<String> {
+        self.voice.clone()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -100,6 +105,11 @@ impl TtsProvider for PiperTtsProvider {
             voice: Some(resolved_voice),
         };
         synthesize_piper(config, text, &opts).await
+    }
+
+    #[cfg(test)]
+    fn configured_voice(&self) -> Option<String> {
+        Some(self.voice.clone())
     }
 }
 
@@ -176,6 +186,11 @@ impl TtsProvider for ExternalTtsProvider {
             },
             format!("voice-factory: external TTS completed via {}", self.slug),
         ))
+    }
+
+    #[cfg(test)]
+    fn configured_voice(&self) -> Option<String> {
+        Some(self.default_voice.clone())
     }
 }
 


### PR DESCRIPTION
## Summary

- Fixes the managed/cloud TTS **400 Bad Request** caused by the invalid voice id `en_US-lessac-medium` (the Settings → Voice "Test TTS" button and any empty-voice cloud synth).
- Root cause: `create_tts_provider` applied the **Piper** default voice to an empty voice *before* branching on the provider, so the cloud/ElevenLabs proxy received a Piper voice id.
- The Piper default now lives in the `piper` arm only; cloud resolves to no voice (backend picks its own default), external slugs resolve to their registry default.

## Problem

`src/openhuman/voice/factory/entry.rs::create_tts_provider` did `let voice = if empty { DEFAULT_PIPER_VOICE } else { voice }` ahead of the `match provider`. For the `cloud`/`openhuman` provider an empty voice therefore became `en_US-lessac-medium` — a Piper model id that ElevenLabs (behind the hosted `/openai/v1/audio/speech` proxy) rejects with HTTP 400 (#5355). The same premature default also leaked into external **ElevenLabs** BYOK slugs. The normal Human-tab conversation path was unaffected because it always sends a concrete ElevenLabs voice; the bug surfaced on the empty-voice paths (provider self-test, podcast, dispatch defaults).

## Solution

- Move the `DEFAULT_PIPER_VOICE` fallback into the `"piper"` match arm only.
- `cloud`/`openhuman`: an empty voice stays `None`. `reply_speech::synthesize_reply` omits `voice_id` when absent, so the backend selects its own default — the established behavior already relied on by the meet-bot and in-app `web_chat` speak paths.
- external slug: an empty voice falls back to the registry entry's `default_tts_voice` (via `create_tts_provider_by_slug`), not the Piper id.
- Added a test-only `TtsProvider::configured_voice` accessor and regression tests pinning the resolved voice per provider for the empty-voice case.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy
- [x] **Diff coverage ≥ 80%** — changed lines covered by the new `voice::factory::tests` cases (cloud/openhuman empty→None, cloud explicit voice, piper empty→default, external empty→registry default). `cargo test voice::factory::tests` green (33/33).
- [x] N/A: Coverage matrix updated — behaviour-only bug fix, no feature rows added/removed/renamed.
- [x] N/A: affected feature IDs listed under `## Related` — no matrix rows affected.
- [x] No new external network dependencies introduced
- [x] N/A: manual smoke checklist — no release-cut surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Desktop/CLI Rust core (`voice` domain). No wire/API change; no migration.
- Restores managed TTS end-to-end and the Settings → Voice TTS self-test. The pre-existing handler-level guards in `transcribe_tts.rs` become redundant-but-consistent (left in place; a future cleanup could centralize voice resolution).

## Related

- Closes: #5355
- Follow-up PR(s)/TODOs: optional — centralize provider-aware voice resolution so the shared `local_ai.tts_voice_id` default (a Piper id) can no longer be paired with a cloud provider.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/tts-cloud-voice-id-5355
- Commit SHA: bb20ac73c

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — Rust-only change.
- [x] N/A: `pnpm typecheck` — Rust-only change.
- [x] Focused tests: `cargo test voice::factory::tests` (33/33) and the `voice::` suite (261) green.
- [x] Rust fmt/check: `cargo fmt --check` clean; `cargo clippy` clean on changed files.
- [x] N/A: Tauri fmt/check — Tauri shell not changed.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: empty cloud voice no longer sends the Piper id; it sends no voice so the backend default applies.
- User-visible effect: managed TTS + the Settings TTS self-test stop returning HTTP 400.

### Parity Contract

- Legacy behavior preserved: Piper provider still defaults to `en_US-lessac-medium`; explicit voices pass through unchanged.
- Guard/fallback/dispatch parity checks: verified all `create_tts_provider` callers (dispatch handlers, podcast, self-test) — no regression.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A
