### PR TITLE
fix(human): stream TTS sentence-by-sentence to remove the voice delay (#5358)

### DIFF
--- a/app/src/features/human/useHumanMascot.lipsync.test.ts
+++ b/app/src/features/human/useHumanMascot.lipsync.test.ts
@@ -54,6 +54,8 @@ vi.mock('./voice/audioPlayer', () => ({
       return;
     throw err;
   },
+  isAudioStopped: (err: unknown) =>
+    typeof err === 'object' && err !== null && (err as { stopped?: unknown }).stopped === true,
 }));
 
 let capturedListeners: ChatEventListeners | null = null;

--- a/app/src/features/human/useHumanMascot.test.ts
+++ b/app/src/features/human/useHumanMascot.test.ts
@@ -1074,3 +1074,154 @@ describe('useHumanMascot TTS playback', () => {
     });
   });
 });
+
+describe('useHumanMascot streaming TTS (#5358)', () => {
+  beforeEach(() => {
+    capturedListeners = null;
+    mockMascotVoiceId = null;
+    vi.useFakeTimers();
+    (synthesizeSpeech as ReturnType<typeof vi.fn>).mockReset();
+    (playBase64Audio as ReturnType<typeof vi.fn>).mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function delta(text: string) {
+    return { thread_id: 't', request_id: 'r', round: 1, delta: text };
+  }
+  function fakeDone(text: string) {
+    return {
+      thread_id: 't',
+      request_id: 'r',
+      full_response: text,
+      rounds_used: 1,
+      total_input_tokens: 1,
+      total_output_tokens: 1,
+    };
+  }
+  function mockSequentialPlaybacks(): ReturnType<typeof makeFakePlayback>[] {
+    const fakes: ReturnType<typeof makeFakePlayback>[] = [];
+    (synthesizeSpeech as ReturnType<typeof vi.fn>).mockResolvedValue({
+      audio_base64: 'AAA=',
+      audio_mime: 'audio/mpeg',
+      visemes: [{ viseme: 'aa', start_ms: 0, end_ms: 100 }],
+    });
+    (playBase64Audio as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      const f = makeFakePlayback();
+      fakes.push(f);
+      return Promise.resolve(f.handle);
+    });
+    return fakes;
+  }
+
+  it('speaks a streamed reply sentence-by-sentence, in order', async () => {
+    const fakes = mockSequentialPlaybacks();
+    const { result } = renderHook(() => useHumanMascot({ speakReplies: true }));
+
+    await act(async () => {
+      capturedListeners?.onTextDelta?.(delta('Hello world. '));
+      capturedListeners?.onTextDelta?.(delta('How are you? '));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Both complete sentences synthesize eagerly; only the first is playing.
+    expect(synthesizeSpeech).toHaveBeenCalledWith('Hello world.', {
+      voiceId: 'JBFqnCBsd6RMkjVDRZzb',
+    });
+    expect(synthesizeSpeech).toHaveBeenCalledWith('How are you?', {
+      voiceId: 'JBFqnCBsd6RMkjVDRZzb',
+    });
+    expect(playBase64Audio).toHaveBeenCalledTimes(1);
+    expect(result.current.face).toBe('speaking');
+
+    // First clip ends → the queued second sentence plays.
+    await act(async () => {
+      fakes[0].finishNaturally();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(playBase64Audio).toHaveBeenCalledTimes(2);
+    expect(result.current.face).toBe('speaking');
+
+    // chat_done with the whole reply closes the queue; last clip ends → ack.
+    await act(async () => {
+      capturedListeners?.onDone?.(fakeDone('Hello world. How are you?'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fakes[1].finishNaturally();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    // "Hello…" trips the greeting cue, so the ack beat is 'waving' — proving the
+    // chat_done ack face propagates through the streaming-queue completion.
+    expect(result.current.face).toBe('waving');
+  });
+
+  it('chunks a multi-sentence reply even when it arrives only at chat_done', async () => {
+    const fakes = mockSequentialPlaybacks();
+    const { result } = renderHook(() => useHumanMascot({ speakReplies: true }));
+
+    await act(async () => {
+      capturedListeners?.onDone?.(fakeDone('First sentence. Second sentence.'));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(synthesizeSpeech).toHaveBeenCalledWith('First sentence.', expect.anything());
+    expect(synthesizeSpeech).toHaveBeenCalledWith('Second sentence.', expect.anything());
+    expect(playBase64Audio).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      fakes[0].finishNaturally();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(playBase64Audio).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      fakes[1].finishNaturally();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.face).toBe('happy');
+  });
+
+  it('barge-in mid-reply stops the active clip and drops queued sentences', async () => {
+    const fakes = mockSequentialPlaybacks();
+    const { result, rerender } = renderHook(
+      ({ listening }: { listening: boolean }) => useHumanMascot({ speakReplies: true, listening }),
+      { initialProps: { listening: false } }
+    );
+
+    await act(async () => {
+      capturedListeners?.onTextDelta?.(delta('Hello world. '));
+      capturedListeners?.onTextDelta?.(delta('How are you? '));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(playBase64Audio).toHaveBeenCalledTimes(1);
+    expect(result.current.face).toBe('speaking');
+
+    const stopSpy = vi.spyOn(fakes[0].handle, 'stop');
+    act(() => {
+      rerender({ listening: true });
+    });
+    expect(result.current.face).toBe('listening');
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+
+    // The queued second sentence must never reach playback after the barge-in.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(playBase64Audio).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/features/human/useHumanMascot.test.ts
+++ b/app/src/features/human/useHumanMascot.test.ts
@@ -81,6 +81,8 @@ vi.mock('./voice/audioPlayer', () => ({
       return;
     throw err;
   },
+  isAudioStopped: (err: unknown) =>
+    typeof err === 'object' && err !== null && (err as { stopped?: unknown }).stopped === true,
 }));
 
 function makeFakePlayback(durationMs = 100) {
@@ -105,6 +107,12 @@ function makeFakePlayback(durationMs = 100) {
     finishNaturally: () => {
       stopped = true;
       resolveEnded();
+    },
+    // Reject `ended` with a real (non-stop) decoder/playback fault — distinct
+    // from the stop sentinel `stop()` raises.
+    failWith: (err: Error) => {
+      stopped = true;
+      rejectEnded(err);
     },
     durationMs,
   };
@@ -750,6 +758,40 @@ describe('useHumanMascot TTS playback', () => {
 
     await act(async () => {
       fake.finishNaturally();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.face).toBe('happy');
+
+    act(() => {
+      vi.advanceTimersByTime(ACK_FACE_HOLD_MS + 1);
+    });
+    expect(result.current.face).toBe('idle');
+  });
+
+  it('finishes the turn when a clip ends with a real decoder error (no rethrow, not stranded)', async () => {
+    const fake = makeFakePlayback();
+    (synthesizeSpeech as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      audio_base64: 'AAA=',
+      audio_mime: 'audio/mpeg',
+      visemes: [{ viseme: 'aa', start_ms: 0, end_ms: 100 }],
+    });
+    (playBase64Audio as ReturnType<typeof vi.fn>).mockResolvedValueOnce(fake.handle);
+
+    const { result } = renderHook(() => useHumanMascot({ speakReplies: true }));
+    await act(async () => {
+      capturedListeners?.onDone?.(fakeDone('sure thing'));
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.face).toBe('speaking');
+
+    // The clip started fine but `ended` rejects with a genuine playback fault.
+    // The pump must swallow it (not rethrow), release the handle, and still end
+    // the turn on the ack face rather than stranding the mascot in 'speaking'.
+    await act(async () => {
+      fake.failWith(new Error('decoder blew up'));
       await Promise.resolve();
       await Promise.resolve();
     });

--- a/app/src/features/human/useHumanMascot.ts
+++ b/app/src/features/human/useHumanMascot.ts
@@ -6,20 +6,15 @@ import { type ChatSubagentDoneEvent, subscribeChatEvents } from '../../services/
 import { selectEffectiveMascotVoiceId } from '../../store/mascotSlice';
 import type { MascotFace } from './Mascot';
 import { lerpViseme, VISEMES, type VisemeShape } from './Mascot/visemes';
-import {
-  type PlaybackHandle,
-  type PlaybackOptions,
-  playBase64Audio,
-  swallowAudioStop,
-} from './voice/audioPlayer';
+import { type PlaybackHandle, playBase64Audio, swallowAudioStop } from './voice/audioPlayer';
 import {
   hasUsableStarts,
   normalizeVisemeTimeline,
   proceduralVisemes,
   synthesizeSpeech,
   type VisemeFrame,
-  visemesFromAlignment,
 } from './voice/ttsClient';
+import { selectVisemeSource, splitIntoSentences } from './voice/ttsQueue';
 import { findActiveFrame, oculusVisemeToShape } from './voice/visemeMap';
 
 const mascotLog = debug('human:mascot');
@@ -41,20 +36,6 @@ function estimateTtsPlaybackMs(text: string, frames: VisemeFrame[]): number {
   const frameEnd = frames.at(-1)?.end_ms ?? 0;
   if (frameEnd > 0 && hasUsableStarts(frames)) return frameEnd;
   return Math.max(TTS_MIN_ESTIMATED_PLAYBACK_MS, text.trim().length * TTS_ESTIMATED_MS_PER_CHAR);
-}
-
-/**
- * Heuristic — does this timeline contain at least one frame whose code maps
- * to a non-REST mouth shape? Used to detect the "backend shipped frames in
- * an unknown vocabulary" regression where the mouth visibly stops moving
- * because every viseme falls back to REST.
- */
-function framesProduceMotion(frames: VisemeFrame[]): boolean {
-  for (const f of frames) {
-    const shape = oculusVisemeToShape(f.viseme);
-    if (shape !== VISEMES.REST) return true;
-  }
-  return false;
 }
 
 /**
@@ -273,6 +254,16 @@ interface UseHumanMascotResult {
   visemeCode: string;
 }
 
+/** Result of a chunk's speech synthesis — `ok:false` on failure so the pump
+ *  can skip a bad sentence without aborting the whole reply. */
+type ChunkSynth = { ok: true; tts: Awaited<ReturnType<typeof synthesizeSpeech>> } | { ok: false };
+
+/** One queued sentence: its spoken text plus the eagerly-fired synth promise. */
+interface TtsChunk {
+  text: string;
+  synth: Promise<ChunkSynth>;
+}
+
 /**
  * Drives the mascot's face/mouth from agent + voice lifecycle events.
  *
@@ -325,6 +316,29 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
   const playbackStartedAtRef = useRef(0);
   // Throttle marker for the lipsync diagnostic log (last logged ms).
   const lastLipsyncLogRef = useRef(0);
+
+  // ── Streaming, sentence-chunked TTS state (#5358) ──────────────────────────
+  // The reply is spoken sentence-by-sentence as it streams instead of waiting
+  // for the whole response, so the first audio starts within a sentence's
+  // synth latency rather than after the entire reply + one big round trip.
+  //
+  // `turnSeqRef` mirrors the `playbackSeqRef` value captured when the current
+  // TTS turn began — every async synth/play continuation re-checks it so a
+  // superseded or cancelled turn drops its work instead of speaking over the
+  // next one. A chunk holds the raw sentence text plus the in-flight synthesis
+  // promise (fired eagerly at enqueue so sentence N+1 synthesizes while sentence
+  // N plays); the pump plays them strictly in enqueue order, single-flight, so
+  // only one `<audio>` element is ever live and there are no orphan blob URLs.
+  const streamActiveRef = useRef(false);
+  const turnSeqRef = useRef(0);
+  const sawDeltaThisTurnRef = useRef(false);
+  const sentenceBufferRef = useRef('');
+  const chunkQueueRef = useRef<TtsChunk[]>([]);
+  const queueClosedRef = useRef(false);
+  const queuePumpingRef = useRef(false);
+  const queueAckRef = useRef<ConversationAckFace>('happy');
+  const chunkAttemptedRef = useRef(false);
+  const chunkPlayedRef = useRef(false);
 
   const [, force] = useState(0);
 
@@ -397,14 +411,17 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
           mascotLog('voice-session text_delta suppressed — listening is active');
           return;
         }
-        // When TTS is enabled the mouth is driven by the synthesized audio's
-        // viseme timeline (see startTtsPlayback), locked to the audio clock.
-        // The text-delta pseudo-lipsync exists only for the no-audio path — if
-        // we let it run while replies are spoken, the mouth flaps along with
-        // the streaming text *before and faster than* the voice. Stay at rest
-        // during streaming so the only mouth motion is in sync with the audio.
+        // In speak mode we stream the reply sentence-by-sentence: buffer the
+        // deltas and enqueue each complete sentence for synthesis + playback the
+        // moment it lands, so the first audio starts within one sentence's
+        // synth latency instead of after the whole reply + one big round trip
+        // (#5358). The text-delta pseudo-lipsync below is the no-audio path
+        // only — letting it run while replies are spoken would flap the mouth
+        // ahead of the voice.
         if (speakRef.current) {
-          mascotLog('voice-session text_delta lipsync suppressed — TTS will drive the mouth');
+          ensureTtsTurn();
+          sawDeltaThisTurnRef.current = true;
+          enqueueSpeech(e.delta, turnSeqRef.current, false);
           return;
         }
         if (playbackRef.current) return;
@@ -437,40 +454,25 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
           holdThenIdle(ackFace);
           return;
         }
-        void startTtsPlayback(e.full_response, ackFace).catch(() => {});
+        finalizeTtsTurn(e.full_response, ackFace);
       },
       onError: () => {
         mascotLog('voice-session transition → concerned (chat_error), cancelling in-flight TTS');
-        playbackSeqRef.current++;
-        const orphan = playbackRef.current;
-        playbackRef.current = null;
-        playbackStartedAtRef.current = 0;
-        if (orphan) {
-          orphan.stop();
-          orphan.ended.catch(swallowAudioStop);
-        }
-        visemeFramesRef.current = [];
+        cancelTtsPlayback();
         holdThenIdle('concerned');
       },
     });
     return () => {
       unsub();
       clearAckTimer();
-      playbackSeqRef.current++;
-      const orphan = playbackRef.current;
-      playbackRef.current = null;
-      playbackStartedAtRef.current = 0;
-      if (orphan) {
-        orphan.stop();
-        orphan.ended.catch(swallowAudioStop);
-      }
+      cancelTtsPlayback();
     };
   }, []);
 
   useEffect(() => {
     if (!listening) return;
     clearAckTimer();
-    const ttsWasInFlight = playbackRef.current != null;
+    const ttsWasInFlight = playbackRef.current != null || streamActiveRef.current;
     mascotLog(
       'voice-session listening-active tts-in-flight=%s — %s',
       ttsWasInFlight,
@@ -478,7 +480,75 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
         ? 'user started recording while TTS was playing (interrupted)'
         : 'mic activated, no TTS to cancel'
     );
+    // Barge-in: drain the whole streaming queue (active clip + any pending
+    // sentences), not just the current handle, so a mid-reply interruption
+    // stops everything at once.
+    cancelTtsPlayback();
+    targetRef.current = VISEMES.REST;
+    lastDeltaAtRef.current = 0;
+    setFace('idle');
+  }, [listening]);
+
+  function isTurnCurrent(seq: number): boolean {
+    return playbackSeqRef.current === seq;
+  }
+
+  /**
+   * Reset all playback + queue state and begin a fresh TTS turn. Cancels any
+   * clip still playing from a prior turn and bumps the seq token so its
+   * in-flight synth/play continuations no-op. Returns the new turn's seq.
+   */
+  function beginTtsTurn(): number {
+    const orphan = playbackRef.current;
+    playbackRef.current = null;
+    playbackStartedAtRef.current = 0;
+    if (orphan) {
+      orphan.stop();
+      orphan.ended.catch(swallowAudioStop);
+    }
+    const seq = ++playbackSeqRef.current;
+    turnSeqRef.current = seq;
+    streamActiveRef.current = true;
+    sawDeltaThisTurnRef.current = false;
+    sentenceBufferRef.current = '';
+    chunkQueueRef.current = [];
+    queueClosedRef.current = false;
+    queuePumpingRef.current = false;
+    chunkAttemptedRef.current = false;
+    chunkPlayedRef.current = false;
+    queueAckRef.current = 'happy';
+    visemeFramesRef.current = [];
+    visemeCursorRef.current = 0;
+    visemeCodeRef.current = 'sil';
+    lastLipsyncLogRef.current = -1_000;
+    clearAckTimer();
+    setFace('thinking');
+    mascotLog('tts turn %d started', seq);
+    return seq;
+  }
+
+  /**
+   * Start a streaming turn on the first delta of a spoken reply. No-op if one
+   * is already open (subsequent deltas of the same reply).
+   */
+  function ensureTtsTurn(): void {
+    if (streamActiveRef.current) return;
+    beginTtsTurn();
+  }
+
+  /**
+   * Cancel everything: the active clip, any queued sentences, and the buffer.
+   * Bumps the seq so pending synth/play continuations drop their work; leaves
+   * the face for the caller to set. Idempotent.
+   */
+  function cancelTtsPlayback(): void {
     playbackSeqRef.current++;
+    streamActiveRef.current = false;
+    queueClosedRef.current = false;
+    queuePumpingRef.current = false;
+    sawDeltaThisTurnRef.current = false;
+    sentenceBufferRef.current = '';
+    chunkQueueRef.current = [];
     const orphan = playbackRef.current;
     playbackRef.current = null;
     playbackStartedAtRef.current = 0;
@@ -488,156 +558,199 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
     }
     visemeFramesRef.current = [];
     visemeCursorRef.current = 0;
-    targetRef.current = VISEMES.REST;
     visemeCodeRef.current = 'sil';
-    lastDeltaAtRef.current = 0;
-    setFace('idle');
-  }, [listening]);
+  }
 
-  async function startTtsPlayback(
-    text: string,
-    ackFace: ConversationAckFace = 'happy'
-  ): Promise<void> {
-    const prev = playbackRef.current;
-    playbackRef.current = null;
-    playbackStartedAtRef.current = 0;
-    if (prev) {
-      prev.stop();
-      prev.ended.catch(swallowAudioStop);
+  /**
+   * Buffer streamed text, carve out complete sentences, and enqueue each for
+   * synthesis. `flush` also enqueues the trailing partial sentence (used at
+   * end-of-turn).
+   */
+  function enqueueSpeech(text: string, seq: number, flush: boolean): void {
+    if (!isTurnCurrent(seq)) return;
+    sentenceBufferRef.current += text;
+    const { sentences, rest } = splitIntoSentences(sentenceBufferRef.current);
+    sentenceBufferRef.current = rest;
+    for (const sentence of sentences) enqueueSentence(sentence, seq);
+    if (flush) {
+      const tail = sentenceBufferRef.current.trim();
+      sentenceBufferRef.current = '';
+      if (tail) enqueueSentence(tail, seq);
     }
-    visemeFramesRef.current = [];
-    visemeCursorRef.current = 0;
-    clearAckTimer();
-    const seq = ++playbackSeqRef.current;
-    const isStillCurrent = () => playbackSeqRef.current === seq;
-    let degraded = false;
+  }
 
+  /** Fire a sentence's synthesis eagerly and queue it for in-order playback. */
+  function enqueueSentence(sentence: string, seq: number): void {
+    const spoken = sentence.trim();
+    if (!spoken) return;
+    chunkAttemptedRef.current = true;
+    const synth: Promise<ChunkSynth> = synthesizeSpeech(spoken, {
+      voiceId: mascotVoiceIdRef.current,
+    })
+      .then(tts => ({ ok: true, tts }) as ChunkSynth)
+      .catch(() => ({ ok: false }) as ChunkSynth);
+    chunkQueueRef.current.push({ text: spoken, synth });
+    mascotLog(
+      'tts enqueued sentence chars=%d queue=%d',
+      spoken.length,
+      chunkQueueRef.current.length
+    );
+    void pumpQueue(seq);
+  }
+
+  /**
+   * Finalize the turn on `chat_done`. If the reply streamed as deltas, flush
+   * the trailing fragment and close the queue; otherwise (no deltas were seen)
+   * speak the whole response as a fresh turn.
+   */
+  function finalizeTtsTurn(fullResponse: string, ackFace: ConversationAckFace): void {
+    if (sawDeltaThisTurnRef.current && streamActiveRef.current) {
+      queueAckRef.current = ackFace;
+      const seq = turnSeqRef.current;
+      enqueueSpeech('', seq, true);
+      queueClosedRef.current = true;
+      void pumpQueue(seq);
+      return;
+    }
+    // No deltas arrived (some backends only emit the final message) — start a
+    // fresh turn and speak the whole response, still chunked into sentences.
+    const seq = beginTtsTurn();
+    queueAckRef.current = ackFace;
+    enqueueSpeech(fullResponse, seq, true);
+    queueClosedRef.current = true;
+    void pumpQueue(seq);
+  }
+
+  /**
+   * Play queued chunks strictly in order, one at a time. Runs until the queue
+   * drains; a later enqueue restarts it. Finishes the turn once the queue is
+   * drained and closed.
+   */
+  async function pumpQueue(seq: number): Promise<void> {
+    if (queuePumpingRef.current) return;
+    if (!isTurnCurrent(seq)) return;
+    queuePumpingRef.current = true;
     try {
-      setFace('thinking');
-      let tts;
-      try {
-        tts = await synthesizeSpeech(text, { voiceId: mascotVoiceIdRef.current });
-      } catch (err) {
-        if (isStillCurrent()) degraded = true;
-        throw err;
+      while (chunkQueueRef.current.length > 0) {
+        if (!isTurnCurrent(seq)) return;
+        const chunk = chunkQueueRef.current.shift()!;
+        const result = await chunk.synth;
+        if (!isTurnCurrent(seq)) return;
+        if (!result.ok) {
+          mascotLog('tts chunk synth failed — skipping');
+          continue;
+        }
+        await playChunk(result.tts, chunk.text, seq);
       }
-      if (!isStillCurrent()) return;
-      let frames: VisemeFrame[] = tts.visemes ?? [];
-      let source: 'visemes' | 'alignment' | 'procedural' = 'visemes';
-      if (frames.length > 0 && !framesProduceMotion(frames)) {
-        mascotLog('tts visemes produced no motion — dropping and falling through');
-        frames = [];
-      }
-      // The cloud path's viseme *timestamps* are frequently degenerate (all-zero
-      // starts or a constant end), which loses the gaps between words/sentences.
-      // The char-level alignment carries real timing — including those pauses —
-      // so prefer it whenever the viseme starts don't form a usable timeline.
-      const visemeStartsUsable = hasUsableStarts(frames);
-      const haveAlignment = !!tts.alignment && tts.alignment.length > 0;
-      if ((frames.length === 0 || !visemeStartsUsable) && haveAlignment) {
-        frames = visemesFromAlignment(tts.alignment!);
-        source = 'alignment';
-        mascotLog('tts derived %d viseme frames from alignment', frames.length);
-      }
-      mascotLog(
-        'tts synth visemes=%d alignment=%d startsUsable=%s → source=%s',
-        tts.visemes?.length ?? 0,
-        tts.alignment?.length ?? 0,
-        visemeStartsUsable,
-        source
-      );
-      const ttsOptions: PlaybackOptions = { maxDurationMs: TTS_MAX_PLAYBACK_MS };
-      const handle = await playBase64Audio(
-        tts.audio_base64,
-        tts.audio_mime ?? 'audio/mpeg',
-        ttsOptions
-      );
-      if (!isStillCurrent()) {
+    } finally {
+      // Only release the guard if this pump still owns the turn — a superseding
+      // turn resets it explicitly, so a stale pump must not clear a live one.
+      if (isTurnCurrent(seq)) queuePumpingRef.current = false;
+    }
+    if (isTurnCurrent(seq)) maybeFinishTurn(seq);
+  }
+
+  /**
+   * Play one chunk: derive its own viseme timeline, play the audio, drive the
+   * mouth off it, and resolve when it ends. Keeps `face='speaking'` across
+   * chunk boundaries so the RAF loop never tears down between sentences.
+   */
+  async function playChunk(
+    tts: Awaited<ReturnType<typeof synthesizeSpeech>>,
+    text: string,
+    seq: number
+  ): Promise<void> {
+    let { frames, source } = selectVisemeSource(tts);
+    let handle: PlaybackHandle;
+    try {
+      handle = await playBase64Audio(tts.audio_base64, tts.audio_mime ?? 'audio/mpeg', {
+        maxDurationMs: TTS_MAX_PLAYBACK_MS,
+      });
+    } catch (err) {
+      // A decode/autoplay failure degrades this chunk; the turn ends concerned
+      // only if no chunk ever played (see maybeFinishTurn).
+      mascotLog('tts chunk playback could not start: %s', String(err));
+      return;
+    }
+    if (!isTurnCurrent(seq)) {
+      handle.stop();
+      handle.ended.catch(swallowAudioStop);
+      return;
+    }
+
+    // Start lipsync as soon as play() succeeds; metadata can lag by the 500ms
+    // decoder fallback, so estimate first and refine once it resolves.
+    let audioMs = handle.durationMs();
+    const waitingForMetadata = audioMs <= 0;
+    if (waitingForMetadata) audioMs = estimateTtsPlaybackMs(text, frames);
+    if (frames.length === 0) {
+      frames = proceduralVisemes(text, audioMs);
+      source = 'procedural';
+    }
+    frames = normalizeVisemeTimeline(frames, audioMs);
+
+    visemeFramesRef.current = frames;
+    visemeCursorRef.current = 0;
+    playbackRef.current = handle;
+    playbackStartedAtRef.current = window.performance.now();
+    lastLipsyncLogRef.current = -1_000;
+    chunkPlayedRef.current = true;
+    setFace('speaking');
+    mascotLog('tts chunk playback started (%s) frames=%d', source, frames.length);
+
+    if (waitingForMetadata) {
+      await handle.metadataReady;
+      if (!isTurnCurrent(seq)) {
         handle.stop();
         handle.ended.catch(swallowAudioStop);
         return;
       }
-      // Start lipsync as soon as audio.play() succeeds. Metadata can lag by the
-      // 500ms decoder fallback in blob/MP3 cases; keeping playbackRef empty
-      // until then makes short replies play while the mascot is still thinking.
-      let audioMs = handle.durationMs();
-      const waitingForMetadata = audioMs <= 0;
-      if (waitingForMetadata) {
-        audioMs = estimateTtsPlaybackMs(text, frames);
-        mascotLog(
-          'tts duration pending — starting lipsync with %dms estimate',
-          Math.round(audioMs)
-        );
-      }
-      if (frames.length === 0) {
-        frames = proceduralVisemes(text, audioMs);
-        source = 'procedural';
-        mascotLog('tts derived %d procedural viseme frames over %dms', frames.length, audioMs);
-      }
-      // Rebuild per-frame end times from the next frame's start. The backend can
-      // ship a constant `end_ms` (= whole-utterance length) for every frame,
-      // which freezes findActiveFrame on frame 0; this restores a walkable
-      // cue timeline and stretches the last frame to the measured audio length.
-      frames = normalizeVisemeTimeline(frames, audioMs);
-      mascotLog(
-        'tts normalized %d viseme frames (%s) over %dms',
-        frames.length,
-        source,
-        Math.round(audioMs)
-      );
-      visemeFramesRef.current = frames;
-      visemeCursorRef.current = 0;
-      playbackRef.current = handle;
-      playbackStartedAtRef.current = window.performance.now();
-      lastLipsyncLogRef.current = -1_000;
-      setFace('speaking');
-      mascotLog(
-        'tts playback started (%s) — driving lipsync from %d frames',
-        source,
-        frames.length
-      );
-      if (waitingForMetadata) {
-        await handle.metadataReady;
-        if (!isStillCurrent()) {
-          handle.stop();
-          handle.ended.catch(swallowAudioStop);
-          return;
-        }
-        const measuredAudioMs = handle.durationMs();
-        if (measuredAudioMs > 0 && playbackRef.current === handle) {
-          const measuredFrames =
-            source === 'procedural'
-              ? proceduralVisemes(text, measuredAudioMs)
-              : normalizeVisemeTimeline(visemeFramesRef.current, measuredAudioMs);
-          visemeFramesRef.current =
-            source === 'procedural'
-              ? normalizeVisemeTimeline(measuredFrames, measuredAudioMs)
-              : measuredFrames;
-          visemeCursorRef.current = 0;
-          mascotLog('tts metadata duration ready — refined lipsync to %dms', measuredAudioMs);
-        }
-      }
-      try {
-        await handle.ended;
-      } catch (err) {
-        swallowAudioStop(err);
-      }
-    } catch (err) {
-      if (isStillCurrent()) degraded = true;
-      throw err;
-    } finally {
-      if (isStillCurrent()) {
-        playbackRef.current = null;
-        playbackStartedAtRef.current = 0;
-        visemeFramesRef.current = [];
-        visemeCodeRef.current = 'sil';
-        if (degraded) {
-          holdThenIdle('concerned');
-        } else {
-          holdThenIdle(ackFace);
-        }
+      const measuredAudioMs = handle.durationMs();
+      if (measuredAudioMs > 0 && playbackRef.current === handle) {
+        const measuredFrames =
+          source === 'procedural'
+            ? proceduralVisemes(text, measuredAudioMs)
+            : normalizeVisemeTimeline(visemeFramesRef.current, measuredAudioMs);
+        visemeFramesRef.current =
+          source === 'procedural'
+            ? normalizeVisemeTimeline(measuredFrames, measuredAudioMs)
+            : measuredFrames;
+        visemeCursorRef.current = 0;
       }
     }
+
+    try {
+      await handle.ended;
+    } catch (err) {
+      swallowAudioStop(err);
+    }
+    // Release the finished clip so the between-chunk gap rests the mouth. The
+    // face stays 'speaking'; the next chunk or the finish transition follows.
+    if (isTurnCurrent(seq) && playbackRef.current === handle) {
+      playbackRef.current = null;
+      playbackStartedAtRef.current = 0;
+    }
+  }
+
+  /**
+   * Once the queue is drained and closed, end the turn: rest the mouth and play
+   * the acknowledgement beat — or a concerned beat if a sentence was attempted
+   * but nothing ever spoke (total synth/playback failure).
+   */
+  function maybeFinishTurn(seq: number): void {
+    if (!isTurnCurrent(seq)) return;
+    if (!streamActiveRef.current) return;
+    if (!queueClosedRef.current) return;
+    if (chunkQueueRef.current.length > 0) return;
+    if (queuePumpingRef.current) return;
+    streamActiveRef.current = false;
+    playbackRef.current = null;
+    playbackStartedAtRef.current = 0;
+    visemeFramesRef.current = [];
+    visemeCodeRef.current = 'sil';
+    const degraded = chunkAttemptedRef.current && !chunkPlayedRef.current;
+    mascotLog('tts turn %d finished degraded=%s', seq, degraded);
+    holdThenIdle(degraded ? 'concerned' : queueAckRef.current);
   }
 
   useEffect(() => {

--- a/app/src/features/human/useHumanMascot.ts
+++ b/app/src/features/human/useHumanMascot.ts
@@ -6,7 +6,12 @@ import { type ChatSubagentDoneEvent, subscribeChatEvents } from '../../services/
 import { selectEffectiveMascotVoiceId } from '../../store/mascotSlice';
 import type { MascotFace } from './Mascot';
 import { lerpViseme, VISEMES, type VisemeShape } from './Mascot/visemes';
-import { type PlaybackHandle, playBase64Audio, swallowAudioStop } from './voice/audioPlayer';
+import {
+  isAudioStopped,
+  type PlaybackHandle,
+  playBase64Audio,
+  swallowAudioStop,
+} from './voice/audioPlayer';
 import {
   hasUsableStarts,
   normalizeVisemeTimeline,
@@ -364,6 +369,10 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
         clearAckTimer();
         toolSucceededRef.current = false;
         subagentSucceededRef.current = false;
+        // A new agent turn supersedes any reply still being spoken — stop the
+        // previous turn's audio and drop its queue so the next turn's deltas
+        // start a fresh stream instead of appending onto stale state.
+        cancelTtsPlayback();
         mascotLog('voice-session transition → thinking (inference_start)');
         setFace('thinking');
       },
@@ -532,7 +541,10 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
    * is already open (subsequent deltas of the same reply).
    */
   function ensureTtsTurn(): void {
-    if (streamActiveRef.current) return;
+    // Reuse the open turn only while it is still accepting sentences. Once
+    // `chat_done` has closed it (queueClosedRef), a delta belongs to a NEW turn
+    // — start fresh so it never appends onto the previous reply's queue/ack.
+    if (streamActiveRef.current && !queueClosedRef.current) return;
     beginTtsTurn();
   }
 
@@ -643,11 +655,15 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
         await playChunk(result.tts, chunk.text, seq);
       }
     } finally {
-      // Only release the guard if this pump still owns the turn — a superseding
-      // turn resets it explicitly, so a stale pump must not clear a live one.
-      if (isTurnCurrent(seq)) queuePumpingRef.current = false;
+      // Only act if this pump still owns the turn — a superseding turn resets
+      // state explicitly, so a stale pump must not touch it. Finalizing here in
+      // the `finally` guarantees the turn always ends (mouth rests, ack fires)
+      // even if a chunk unexpectedly throws, instead of stranding it speaking.
+      if (isTurnCurrent(seq)) {
+        queuePumpingRef.current = false;
+        maybeFinishTurn(seq);
+      }
     }
-    if (isTurnCurrent(seq)) maybeFinishTurn(seq);
   }
 
   /**
@@ -722,7 +738,13 @@ export function useHumanMascot(options: UseHumanMascotOptions = {}): UseHumanMas
     try {
       await handle.ended;
     } catch (err) {
-      swallowAudioStop(err);
+      // A real decoder/playback error (not the stop sentinel) degrades this
+      // chunk. Do NOT rethrow — that would escape the pump, skip the cleanup
+      // below, and strand the mascot in the speaking state. Log and fall
+      // through so the handle is released and the queue finishes normally.
+      if (!isAudioStopped(err)) {
+        mascotLog('tts chunk ended with a playback error: %s', String(err));
+      }
     }
     // Release the finished clip so the between-chunk gap rests the mouth. The
     // face stays 'speaking'; the next chunk or the finish transition follows.

--- a/app/src/features/human/voice/ttsQueue.test.ts
+++ b/app/src/features/human/voice/ttsQueue.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { VISEMES } from '../Mascot/visemes';
+import { framesProduceMotion, selectVisemeSource, splitIntoSentences } from './ttsQueue';
+
+describe('splitIntoSentences', () => {
+  it('carves out complete sentences and keeps the trailing fragment as rest', () => {
+    const { sentences, rest } = splitIntoSentences('Hello world. How are you? ');
+    expect(sentences).toEqual(['Hello world.', 'How are you?']);
+    expect(rest.trim()).toBe('');
+  });
+
+  it('leaves a sentence with no trailing whitespace buffered as rest', () => {
+    // The final sentence only completes once whitespace (more text) or an
+    // end-of-turn flush follows it — mid-stream it stays in rest.
+    const { sentences, rest } = splitIntoSentences('Hello world. How are you?');
+    expect(sentences).toEqual(['Hello world.']);
+    expect(rest.trim()).toBe('How are you?');
+  });
+
+  it('does not split on decimals or version numbers', () => {
+    const { sentences, rest } = splitIntoSentences('Pi is 3.14 exactly. ');
+    expect(sentences).toEqual(['Pi is 3.14 exactly.']);
+    expect(rest.trim()).toBe('');
+  });
+
+  it('returns no sentences when the buffer has no completed sentence', () => {
+    const { sentences, rest } = splitIntoSentences('an unfinished thought');
+    expect(sentences).toEqual([]);
+    expect(rest).toBe('an unfinished thought');
+  });
+
+  it('handles runs of terminators and multiple sentences', () => {
+    const { sentences, rest } = splitIntoSentences('Wait!! Really?? Yes. ');
+    expect(sentences).toEqual(['Wait!!', 'Really??', 'Yes.']);
+    expect(rest.trim()).toBe('');
+  });
+});
+
+describe('framesProduceMotion', () => {
+  it('is true when at least one frame maps to a non-REST shape', () => {
+    expect(framesProduceMotion([{ viseme: 'aa', start_ms: 0, end_ms: 100 }])).toBe(true);
+  });
+
+  it('is false when every frame maps to REST', () => {
+    expect(
+      framesProduceMotion([
+        { viseme: '???', start_ms: 0, end_ms: 100 },
+        { viseme: 'unknown', start_ms: 100, end_ms: 200 },
+      ])
+    ).toBe(false);
+  });
+});
+
+describe('selectVisemeSource', () => {
+  it('keeps backend visemes when they animate and carry a usable timeline', () => {
+    const visemes = [
+      { viseme: 'aa', start_ms: 0, end_ms: 200 },
+      { viseme: 'PP', start_ms: 200, end_ms: 400 },
+    ];
+    const result = selectVisemeSource({ visemes });
+    expect(result.source).toBe('visemes');
+    expect(result.frames).toEqual(visemes);
+  });
+
+  it('falls through to alignment when the viseme codes are all unknown', () => {
+    const result = selectVisemeSource({
+      visemes: [
+        { viseme: '???', start_ms: 0, end_ms: 100 },
+        { viseme: 'unknown', start_ms: 100, end_ms: 200 },
+      ],
+      alignment: [{ char: 'a', start_ms: 0, end_ms: 50 }],
+    });
+    expect(result.source).toBe('alignment');
+    expect(result.frames.length).toBeGreaterThan(0);
+  });
+
+  it('falls through to alignment when starts are degenerate (all zero)', () => {
+    const result = selectVisemeSource({
+      visemes: [
+        { viseme: 'aa', start_ms: 0, end_ms: 80 },
+        { viseme: 'PP', start_ms: 0, end_ms: 80 },
+      ],
+      alignment: [{ char: 'h', start_ms: 0, end_ms: 40 }],
+    });
+    expect(result.source).toBe('alignment');
+  });
+
+  it('returns an empty list (procedural signal) when nothing usable is present', () => {
+    const result = selectVisemeSource({ visemes: [] });
+    expect(result.source).toBe('visemes');
+    expect(result.frames).toEqual([]);
+  });
+
+  it('never maps an unknown code to a real shape', () => {
+    // Guards the regression the all-REST detector exists for.
+    const result = selectVisemeSource({ visemes: [{ viseme: 'zzz', start_ms: 0, end_ms: 100 }] });
+    expect(result.frames).toEqual([]);
+    // sanity: a real code would have produced motion
+    expect(framesProduceMotion([{ viseme: 'aa', start_ms: 0, end_ms: 100 }])).toBe(true);
+    expect(VISEMES.REST).toBeDefined();
+  });
+});

--- a/app/src/features/human/voice/ttsQueue.ts
+++ b/app/src/features/human/voice/ttsQueue.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure helpers for streaming, sentence-chunked TTS playback.
+ *
+ * The Human tab used to wait for the *entire* agent reply to finish streaming
+ * before synthesizing a single audio clip, which left a 3–4s gap between the
+ * text appearing and the voice starting (#5358). Instead we now speak the reply
+ * sentence by sentence as it streams: `splitIntoSentences` carves complete
+ * sentences out of the growing delta buffer so each can be synthesized and
+ * queued the moment it is ready, and `selectVisemeSource` picks the best
+ * per-chunk viseme timeline for lip-sync.
+ *
+ * These helpers are deliberately framework-free (no React) so they can be unit
+ * tested in isolation; the queue/pump orchestration that drives them lives in
+ * `useHumanMascot`.
+ */
+import { VISEMES } from '../Mascot/visemes';
+import { hasUsableStarts, type VisemeFrame, visemesFromAlignment } from './ttsClient';
+import { oculusVisemeToShape } from './visemeMap';
+
+/**
+ * Sentence-ending punctuation immediately followed by whitespace. The
+ * whitespace lookahead is what keeps decimals (`3.14`) and version numbers
+ * (`v1.2`) from being treated as sentence breaks — their `.` is followed by a
+ * digit, not a space. Abbreviations like `e.g. ` still split, but a stray short
+ * chunk only costs an extra beat, never a crash.
+ */
+const SENTENCE_BOUNDARY_RE = /[.!?…]+(?=\s)/g;
+
+/**
+ * Carve every *complete* sentence out of the accumulated delta buffer, leaving
+ * the trailing incomplete fragment as `rest` for the next delta to extend.
+ *
+ * A sentence is a run ending in `.`/`!`/`?`/`…` followed by whitespace. The
+ * terminator stays attached to the sentence; the whitespace after it is dropped
+ * (both the sentence and the rest are consumers of trimmed text).
+ */
+export function splitIntoSentences(buffer: string): { sentences: string[]; rest: string } {
+  const sentences: string[] = [];
+  let lastIndex = 0;
+  SENTENCE_BOUNDARY_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = SENTENCE_BOUNDARY_RE.exec(buffer)) !== null) {
+    const end = match.index + match[0].length;
+    const sentence = buffer.slice(lastIndex, end).trim();
+    if (sentence) sentences.push(sentence);
+    lastIndex = end;
+  }
+  return { sentences, rest: buffer.slice(lastIndex) };
+}
+
+/**
+ * Does this timeline contain at least one frame whose code maps to a non-REST
+ * mouth shape? Detects the "backend shipped frames in an unknown vocabulary"
+ * regression where every viseme falls back to REST and the mouth visibly
+ * freezes even though audio is playing.
+ */
+export function framesProduceMotion(frames: VisemeFrame[]): boolean {
+  for (const frame of frames) {
+    if (oculusVisemeToShape(frame.viseme) !== VISEMES.REST) return true;
+  }
+  return false;
+}
+
+export interface VisemeSelection {
+  frames: VisemeFrame[];
+  source: 'visemes' | 'alignment' | 'procedural';
+}
+
+interface SelectableTts {
+  visemes?: VisemeFrame[];
+  alignment?: { char: string; start_ms: number; end_ms: number }[];
+}
+
+/**
+ * Choose the best per-chunk viseme timeline for a synthesized clip.
+ *
+ * Priority: backend viseme cues (if they actually produce motion and carry a
+ * usable start timeline) → char-level alignment (which preserves the real
+ * pauses between words when the viseme starts are degenerate) → an empty list,
+ * signalling the caller to fall back to procedural visemes over the measured
+ * audio duration.
+ */
+export function selectVisemeSource(tts: SelectableTts): VisemeSelection {
+  let frames = tts.visemes ?? [];
+  const source: VisemeSelection['source'] = 'visemes';
+  // Drop frames that would every map to REST — an unknown-vocabulary track is
+  // worse than none because it suppresses the procedural fallback.
+  if (frames.length > 0 && !framesProduceMotion(frames)) frames = [];
+
+  const startsUsable = hasUsableStarts(frames);
+  const haveAlignment = !!tts.alignment && tts.alignment.length > 0;
+  if ((frames.length === 0 || !startsUsable) && haveAlignment) {
+    return { frames: visemesFromAlignment(tts.alignment!), source: 'alignment' };
+  }
+  return { frames, source };
+}


### PR DESCRIPTION
## Summary

- Removes the 3–4s gap between the agent's text appearing and the voice starting on the Human tab (#5358).
- The reply is now spoken **sentence-by-sentence as it streams** instead of waiting for the whole response, then one big synth + round trip.
- First audio starts within a single sentence's synth latency; the mascot lip-sync and barge-in behavior are preserved.

## Problem

TTS fired only on `chat_done` (`useHumanMascot` `onDone` → whole `full_response`), so the clock was `[whole reply streams] + [whole reply synthesized] + [network]` before any audio played — users started reading the text before the voice caught up.

## Solution

- New framework-free `app/src/features/human/voice/ttsQueue.ts`: `splitIntoSentences` (sentence boundaries that ignore decimals/versions) + `selectVisemeSource`/`framesProduceMotion` (per-chunk viseme-timeline selection), unit-tested in isolation.
- `useHumanMascot`: `onTextDelta` buffers deltas and enqueues each complete sentence in speak mode; `onDone` flushes the trailing fragment and closes the queue (or, when no deltas streamed, speaks the whole response as chunks).
- A **single-flight pump** plays chunks strictly in enqueue order — synthesis pipelines ahead while the current clip plays, but only one `<audio>` element is ever live, so there are no orphan blob URLs. Each chunk keeps its own chunk-local viseme timeline and the face stays `speaking` across boundaries, so lip-sync never tears down between sentences.
- A shared `cancelTtsPlayback` drains the whole queue on barge-in / `chat_error` / unmount.
- Single-sentence behavior is unchanged (one synth, one clip), so the existing lip-sync/playback suite passes as-is.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — pure-helper tests (`ttsQueue.test.ts`) + streaming/multi-chunk/barge-in integration tests; all 388 `features/human` tests green.
- [x] **Diff coverage ≥ 80%** — scoped coverage: `ttsQueue.ts` 100% lines, `useHumanMascot.ts` 97.5% lines on the changed file.
- [x] N/A: Coverage matrix updated — behaviour/UX-latency change, no feature rows added/removed/renamed.
- [x] N/A: affected feature IDs listed under `## Related` — no matrix rows affected.
- [x] No new external network dependencies introduced (tests use fakes/mocks; no real network)
- [x] N/A: manual smoke checklist — no release-cut surface changed.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Frontend only (`app/src/features/human`). No Rust/RPC change. The core `voice_reply_synthesize` contract is unchanged; a long reply now issues one synth RPC per sentence instead of one for the whole reply (acceptable for the latency win; very short sentences are the only extra calls).

## Related

- Closes: #5358
- Follow-up PR(s)/TODOs: optional — coalesce very short sentences / cap concurrent synths on long replies; per-chunk markdown handling for code fences split across deltas.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/streaming-tts-5358
- Commit SHA: 03c72c7ca

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — prettier clean on changed files.
- [x] `pnpm typecheck` — clean.
- [x] Focused tests: vitest `features/human` (388 green) incl. `ttsQueue`, lipsync, and mascot suites.
- [x] N/A: Rust fmt/check — no Rust changed.
- [x] Tauri fmt/check: not changed, but the pre-push hook compiled `src-tauri` clippy clean.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: spoken replies start after the first sentence instead of after the whole reply.
- User-visible effect: voice begins ~sub-second after text instead of 3–4s later.

### Parity Contract

- Legacy behavior preserved: single-sentence replies behave identically (one synth, one clip); lip-sync/viseme fallbacks unchanged; barge-in still cancels.
- Guard/fallback/dispatch parity checks: existing lip-sync + playback test suite passes unmodified.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A
