### PR TITLE
fix(kernel): resolve team/delegate model pins through the config accessor

### DIFF
--- a/docs/specs/kernel.md
+++ b/docs/specs/kernel.md
@@ -129,7 +129,7 @@ retained `mcp` and `tui` CLI arms.
 Every subsystem call from product code goes through a kernel-owned **guard decorator**, never to
 the driver directly:
 
-```
+```text
 agent tool / RPC handler
         │
         ▼

--- a/docs/specs/plan-agents.md
+++ b/docs/specs/plan-agents.md
@@ -347,8 +347,8 @@ Two loads remain in moving files, both host-boundary code that gets extracted
 rather than moved:
 
 - `session/turn/tools.rs:123` — Composio integration fetch. Config is *already*
-  threaded via the session's `integration_runtime_config` (set in
-  `factory.rs:1280`); this is only the fallback when a session is built through
+  threaded via the session's `runtime_config` (set in
+  `factory.rs`); this is only the fallback when a session is built through
   the raw setter path. Composio is host product logic and becomes a `Tool` impl
   in Phase 4, so the fallback was left rather than risk silently disabling
   integration fetching for setter-built sessions.
@@ -494,28 +494,37 @@ work as Phase 5, not a repoint. `ToolOutcomeClassifier`'s only host consumer is
 | `ToolOutcomeClassifier` | nothing | yes |
 | `ProgressSink` | `Sender<AgentProgress>` | yes |
 | `LearningSink` | `Vec<Arc<dyn PostTurnHook>>` | yes |
-| **`BudgetGate`, `ContextComposer`, `ModelResolver`** | **`Arc<Config>`** | **no — holds `AgentConfig`; full `Config` only as the optional `integration_runtime_config`** |
+| **`BudgetGate`, `ContextComposer`, `ModelResolver`** | **`Arc<Config>`** | **yes — the session carries `runtime_config: Option<Arc<Config>>`** |
 | **`SecurityGate`** | **`Arc<SecurityPolicy>`** + tool sets | tool sets yes, **policy no** |
 
-That `Arc<Config>` gap is precisely the Phase 3 blocker, which means:
+The `Arc<Config>` gap that used to head this chain is **closed**: the session
+field was promoted from `integration_runtime_config: Option<Config>` to
+`runtime_config: Option<Arc<Config>>` in #5396, and the same pass collapsed the
+subagent spawn path from seven ambient `Config::load_or_init()` calls to one.
+`BudgetGate`, `ContextComposer` and `ModelResolver` are therefore constructible
+today.
 
-> **The program is now a dependency chain, and its head is elapsed time.**
-> Phase 4's repointing needs the session to carry a full `Config` → that is
-> Phase 3's session-config swap → which is blocked on Phase 2 rehoming
-> `session_dual_write` / `session_shadow_reads` → which is blocked on the
-> parity soak, and the soak needs a *shipped release* to produce data.
+What remains blocked is narrower than it was:
+
+> Phase 4's **repointing** still needs Phase 2 to rehome
+> `session_dual_write` / `session_shadow_reads`, which needs the parity soak,
+> and the soak needs a *shipped release* to produce data.
 >
 > So §5's claim that Phase 4 "delivers most of the architectural value with
-> none of the relocation risk" and is a legitimate stopping point holds only
-> for the **adapters**, which are done. The repointing half is not independently
-> executable, and no amount of effort unblocks it before the soak lands.
+> none of the relocation risk" holds for the **adapters**, which are done. The
+> repointing half is gated on elapsed time, not on effort.
 
-**What is unblocked meanwhile:** promoting the session's optional
-`integration_runtime_config: Option<Config>` to a first-class `Arc<Config>`
-(the factory already sets it at `factory.rs:1307`) would make four of the six
-blocked adapters constructible without waiting on Phase 2. That is the one
-piece of Phase 4 repointing that can proceed now, and it is worth doing before
-the soak completes so the rest is a short step rather than a long one.
+**Two further blockers surfaced in #5396's review, both crate-side** and both
+filed upstream — repointing should not proceed past them:
+
+- [`tinyagents#88`](https://github.com/tinyhumansai/tinyagents/issues/88) —
+  `ProgressEvent` has no tool-completion milestone, so a host cannot report a
+  tool's outcome. Tool rows would stay `running` forever; synthesising
+  `success: true` would put wrong data in the timeline and the trace exporter.
+- [`tinyagents#89`](https://github.com/tinyhumansai/tinyagents/issues/89) —
+  `ModelResolveRequest` carries no model pin, so a definition's exact model id
+  has no route to the resolver. Per-agent pins would silently resolve to the
+  workload default.
 
 **21 `TODO(phase4)` markers** remain across the adapters, each naming a domain
 surface that was not reachable. They are honest gaps, not stubs pretending to

--- a/docs/specs/plan-agents.md
+++ b/docs/specs/plan-agents.md
@@ -297,7 +297,7 @@ value maps to `Auto` with a warning rather than failing: the host's own schema
 lets a typo through validation, so refusing to build the session would turn a
 cosmetic config error into an agent that cannot run.
 
-#### Repointing: what the "37 files" actually decomposes into
+### Repointing: what the "37 files" actually decomposes into
 
 The 37-file figure counts every `agent/` production file with a qualified
 `config::` path. **Only ~19 are in the moving set** — the rest (`host_runtime`,
@@ -374,7 +374,7 @@ the field most read. One source of truth or none.
 `factory.rs` reaches 21 domains and is going to be *split* into host trait impls,
 not moved verbatim. Repointing its `Config` usage now is rework.
 
-#### Done in this pass
+### Done in this pass
 
 `RequiredOutputContract` → crate `RequiredOutput`, the one clean type swap
 available: `harness/required_output.rs` (pure logic, no host domains) and
@@ -392,7 +392,7 @@ session builder takes a **per-agent `AgentConfig` override** — mapping only fr
 the global `Config` would have discarded it and run every agent on the global
 limits.
 
-#### Revised remaining work
+### Revised remaining work
 
 1. ~~Thread config through the ambient-load sites.~~ **Done 2026-08-02.**
 2. After Phase 2: replace `Agent.config` with crate config; migrate the two real

--- a/src/openhuman/agent/tinyagents/config.rs
+++ b/src/openhuman/agent/tinyagents/config.rs
@@ -148,11 +148,18 @@ pub fn apply_team_models(session: &mut SessionConfig, config: &Config, team: &st
         );
         return;
     };
-    if let Some(lead) = pins.lead_model.as_ref() {
-        session.lead_model = Some(lead.clone());
+    // Resolve through `model_for_role` rather than copying the raw options.
+    // That helper owns three behaviours this mapper must not re-derive: it
+    // trims, it drops empty strings (so a blank pin cannot displace a valid
+    // default), and it falls back across the pair — a team that sets only
+    // `lead_model` means that model for *both* tiers. Copying the fields
+    // directly left the unset tier on the global default, which is a different
+    // model from the one the user configured.
+    if let Some(lead) = pins.model_for_role(true) {
+        session.lead_model = Some(lead.to_string());
     }
-    if let Some(agent) = pins.agent_model.as_ref() {
-        session.subagent_model = Some(agent.clone());
+    if let Some(agent) = pins.model_for_role(false) {
+        session.subagent_model = Some(agent.to_string());
     }
 }
 

--- a/src/openhuman/agent/tinyagents/config.rs
+++ b/src/openhuman/agent/tinyagents/config.rs
@@ -397,8 +397,13 @@ mod tests {
         assert_eq!(untouched, before);
     }
 
+    /// `TeamModelConfig`'s own doc: "Callers fall back across the pair so
+    /// configs can specify only one tier without breaking routing." A team that
+    /// pins one model means that model for both tiers — leaving the other on the
+    /// **global** default would silently run half the team on a model the user
+    /// did not choose for this team.
     #[test]
-    fn a_team_pinning_only_one_tier_leaves_the_other_on_the_default() {
+    fn a_team_pinning_only_one_tier_applies_it_to_both() {
         let mut c = base();
         c.default_model = Some("sonnet".into());
         c.teams.insert(
@@ -412,7 +417,46 @@ mod tests {
         let mut s = session_config_from(&c);
         apply_team_models(&mut s, &c, "solo");
         assert_eq!(s.effective_lead_model(), "opus");
+        assert_eq!(
+            s.effective_subagent_model(),
+            "opus",
+            "a single pin covers both tiers"
+        );
+    }
+
+    /// A blank pin is not a pin. Without the trim-and-drop it would replace a
+    /// working default with the empty string and fail at dispatch instead.
+    #[test]
+    fn a_blank_team_pin_does_not_displace_the_default() {
+        let mut c = base();
+        c.default_model = Some("sonnet".into());
+        c.teams.insert(
+            "blank".into(),
+            crate::openhuman::config::TeamModelConfig {
+                lead_model: Some("   ".into()),
+                agent_model: None,
+            },
+        );
+
+        let mut s = session_config_from(&c);
+        apply_team_models(&mut s, &c, "blank");
+        assert_eq!(s.effective_lead_model(), "sonnet");
         assert_eq!(s.effective_subagent_model(), "sonnet");
+    }
+
+    #[test]
+    fn a_blank_delegate_model_keeps_the_session_default() {
+        let mut c = base();
+        c.default_model = Some("sonnet".into());
+        let mut s = session_config_from(&c);
+        apply_delegate(
+            &mut s,
+            &DelegateAgentConfig {
+                model: "  ".into(),
+                ..Default::default()
+            },
+        );
+        assert_eq!(s.model, "sonnet");
     }
 
     #[test]

--- a/src/openhuman/agent/tinyagents/config.rs
+++ b/src/openhuman/agent/tinyagents/config.rs
@@ -453,7 +453,9 @@ mod tests {
             &mut s,
             &DelegateAgentConfig {
                 model: "  ".into(),
-                ..Default::default()
+                system_prompt: None,
+                temperature: None,
+                max_depth: 1,
             },
         );
         assert_eq!(s.model, "sonnet");

--- a/src/openhuman/agent/tinyagents/config.rs
+++ b/src/openhuman/agent/tinyagents/config.rs
@@ -204,6 +204,14 @@ mod tests {
         c.agent.parallel_tools = true;
         c.agent.max_parallel_tools = 3;
         c.agent.agent_timeout_secs = 45;
+        // Set away from the default so a dropped assignment fails here. A
+        // default-valued field is invisible to `default_config_maps_to_the_
+        // crate_defaults` (it compares against `TurnConfig::default()`) and to
+        // `per_section_mappers_agree_with_the_composed_one` (which compares
+        // `turn_config_from` against itself), so this is the only test that can
+        // catch it.
+        c.agent.compact_context = !AgentConfig::default().compact_context;
+        c.agent.tool_result_budget_bytes = 4242;
 
         let t = session_config_from(&c).turn;
         assert_eq!(t.max_tool_iterations, 7);
@@ -211,6 +219,8 @@ mod tests {
         assert!(t.parallel_tools);
         assert_eq!(t.max_parallel_tools, 3);
         assert_eq!(t.timeout_secs, 45);
+        assert_eq!(t.compact_context, !AgentConfig::default().compact_context);
+        assert_eq!(t.tool_result_budget_bytes, 4242);
     }
 
     #[test]

--- a/src/openhuman/agent/tinyagents/config.rs
+++ b/src/openhuman/agent/tinyagents/config.rs
@@ -170,7 +170,20 @@ pub fn apply_team_models(session: &mut SessionConfig, config: &Config, team: &st
 /// `lead_model`: a delegate *is* the agent running this session, so it is the
 /// base model, not an override layered over some other base.
 pub fn apply_delegate(session: &mut SessionConfig, delegate: &DelegateAgentConfig) {
-    session.model = delegate.model.clone();
+    // `DelegateAgentConfig::model` is a bare `String`, and TOML happily accepts
+    // `model = ""`. Assigning that unchecked would replace a working session
+    // model with the empty string and fail at dispatch rather than here, so a
+    // blank pin leaves the session default alone — the same trim-and-drop rule
+    // `TeamModelConfig::model_for_role` applies to team pins.
+    let model = delegate.model.trim();
+    if model.is_empty() {
+        tracing::warn!(
+            target: "tinyagents",
+            "[tinyagents] delegate model pin is blank; keeping the session default model"
+        );
+    } else {
+        session.model = model.to_string();
+    }
     if let Some(t) = delegate.temperature {
         session.temperature = Some(t);
     }

--- a/src/openhuman/config/schema/agent.rs
+++ b/src/openhuman/config/schema/agent.rs
@@ -353,7 +353,8 @@ pub struct AgentConfig {
     /// store existed have no stream and report `Unavailable`, not divergence,
     /// so an upgrading user's old transcripts do not generate warnings. The
     /// `OPENHUMAN_SESSION_SHADOW_READS` env var is a pure **kill switch**: a
-    /// falsy value (`0`/`false`/`no`/`off`/`disable`) forces the shadow read
+    /// falsy value (`0`/`false`/`no`/`off`/`disable`/`disabled`, case-
+    /// insensitive) forces the shadow read
     /// OFF regardless of config; it can never force it ON. See
     /// [`crate::openhuman::agent::session_import::live::shadow_reads_enabled`].
     #[serde(default = "default_session_shadow_reads")]


### PR DESCRIPTION
## Summary

- Resolves the remaining review threads from #5396 that were still open when it merged.
- **Team model pins now resolve through `TeamModelConfig::model_for_role`** — a team pinning only one tier applied it to that tier only, leaving the other on the *global* default instead of the team's model.
- **A blank model pin no longer displaces a working default** — TOML accepts `model = ""`, and both the team and delegate paths assigned it unchecked.
- Extends turn-config test coverage to the two fields no test could have caught being dropped.
- Doc fixes: the kill-switch value list, the MD040/MD001 markdownlint violations, and the Phase 4 plan section that described a seam #5396 actually landed.

## Problem

#5396 merged with 18 unresolved threads. Four were real defects in the config seam; the rest were documentation drift and lint.

The two model-pin bugs share a shape: the mapper copied raw `Option<String>` fields instead of going through the accessor that owns the semantics.

- `TeamModelConfig::model_for_role` trims, drops empty strings, **and falls back across the `lead_model`/`agent_model` pair** — its own doc says "callers fall back across the pair so configs can specify only one tier without breaking routing". `apply_team_models` did none of that, so a team pinning only `lead_model` ran its subagents on the global default rather than the model the user chose for that team.
- `DelegateAgentConfig::model` is a bare `String`. `apply_delegate` assigned it unchecked, so `model = ""` replaced a working session model with the empty string and failed at dispatch rather than at config load.

The coverage gap was pointed out with unusual precision and is worth restating: `compact_context` and `tool_result_budget_bytes` were mapped but **unfalsifiable**. `default_config_maps_to_the_crate_defaults` compares against `TurnConfig::default()`, so a field left at the crate default still passes; `per_section_mappers_agree_with_the_composed_one` asserts `s.turn == turn_config_from(&c.agent)`, which compares the mapper against itself. A dropped assignment for either field would have stayed green.

## Solution

- `apply_team_models` resolves both roles through `model_for_role(true/false)`.
- `apply_delegate` trims and ignores a blank pin, warning rather than silently substituting.
- `turn_limits_come_from_the_agent_section` sets both previously-uncovered fields away from their defaults, with a comment naming why the other two tests cannot catch them.
- `AgentConfig::session_shadow_reads`' doc now lists `disabled` and notes case-insensitivity, matching `env_kill_switch_engaged`, which accepts `0|false|no|off|disable|disabled`. **The implementation was right and the config doc was incomplete** — the reviewer offered "or remove an unsupported value", but the value is supported.
- `plan-agents.md` §Phase 4: `integration_runtime_config: Option<Config>` → `runtime_config: Option<Arc<Config>>` landed in #5396, so the plan was describing completed work as a future blocker. Rewritten, and the two crate-side blockers found during that review are now linked.

**Behaviour change worth flagging:** `a_team_pinning_only_one_tier_leaves_the_other_on_the_default` asserted the buggy behaviour and has been replaced by `a_team_pinning_only_one_tier_applies_it_to_both`. If the old semantics were intentional, this is the test to argue about — but `TeamModelConfig`'s own doc says otherwise.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `a_team_pinning_only_one_tier_applies_it_to_both`, `a_blank_team_pin_does_not_displace_the_default`, `a_blank_delegate_model_keeps_the_session_default`, plus the extended turn-limits assertions.
- [x] **Diff coverage ≥ 80%** — deferring to the CI gate; the change is small and test-heavy.
- [x] Coverage matrix updated — `N/A: no feature rows added, removed, or renamed`.
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix rows touched`.
- [x] No new external network dependencies introduced — `N/A: no network code`.
- [x] Manual smoke checklist updated — `N/A: no release-cut surface touched`.
- [x] Linked issue closed via `Closes #NNN` — `N/A: follow-up to a merged PR, no tracking issue`.

## Impact

Config mapping only, and the adapters remain unwired (Phase 4 repointing is still blocked), so nothing changes at runtime today. The team-pin fix changes which model a team's subagents would resolve to once the seam goes live.

`cargo fmt --check`, `cargo clippy --lib -D warnings`, and the full lib suite (12820 / 0) are clean.

**One caveat I would rather state than omit:** the *first* full-suite run in this fresh worktree reported 3 failures whose names I did not capture, and four subsequent runs were clean. It looks like first-run state initialisation rather than these changes — they touch only config mapping and docs — but I could not reproduce it to confirm, so I am not claiming it away.

## Related

Follow-up to #5396. Two crate-side blockers surfaced by that review are filed upstream:

- tinyhumansai/tinyagents#88 — `ProgressEvent` has no tool-completion milestone
- tinyhumansai/tinyagents#89 — `ModelResolveRequest` carries no model pin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved team model selection with trimming, empty-value filtering, and fallback between configured tiers.
  * Blank delegate model settings no longer override the session’s selected model.
  * Added coverage for model selection and context/tool-result budget scenarios.

* **Documentation**
  * Clarified configuration planning and model-resolution prerequisites.
  * Documented that setting shadow reads to `disabled`, as well as other falsy values, disables them.
  * Improved Markdown syntax highlighting for the policy flow diagram.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->