### PR TITLE
Say why triage acknowledge writes nothing, instead of promising it will

### DIFF
--- a/src/openhuman/agent/triage/escalation.rs
+++ b/src/openhuman/agent/triage/escalation.rs
@@ -50,8 +50,10 @@ pub async fn apply_decision(run: TriageRun, envelope: &TriggerEnvelope) -> anyho
     match run.decision.action {
         TriageAction::Drop => {
             tracing::debug!(
+                source = %envelope.source.slug(),
                 label = %envelope.display_label,
                 external_id = %envelope.external_id,
+                card_linked = envelope.card_link.is_some(),
                 reason = %run.decision.reason,
                 "[triage::escalation] DROP — no downstream work"
             );
@@ -64,11 +66,26 @@ pub async fn apply_decision(run: TriageRun, envelope: &TriggerEnvelope) -> anyho
             gate_linked_card_terminal(envelope, "drop").await;
         }
         TriageAction::Acknowledge => {
+            // Acknowledge is a classification, not a write. What the trigger
+            // *was* is already durable in the composio trigger-history JSONL,
+            // and what it was *judged to be* went out as `TriggerEvaluated`
+            // above. Copying a summary into the memory store on top of that
+            // would duplicate a document the connector sync already ingested —
+            // same mail, second copy, competing for the same recall slots — so
+            // this arm deliberately writes nothing.
+            //
+            // What is genuinely missing is not a copy of the input but a record
+            // of what happened *after* the verdict, for every action, not just
+            // this one. That belongs in a progress surface of its own rather
+            // than bolted onto the acknowledge branch (#5408).
             tracing::info!(
+                source = %envelope.source.slug(),
                 label = %envelope.display_label,
                 external_id = %envelope.external_id,
+                card_linked = envelope.card_link.is_some(),
                 reason = %run.decision.reason,
-                "[triage::escalation] ACKNOWLEDGE — logged (memory-write is a future addition)"
+                "[triage::escalation] ACKNOWLEDGE — no autonomous action; \
+                 recorded as TriggerEvaluated, input retained in trigger history"
             );
             // Acknowledge means "seen, no autonomous action needed" — same as
             // drop, the linked card must not be picked up by the board poller.

--- a/src/openhuman/agent/triage/escalation.rs
+++ b/src/openhuman/agent/triage/escalation.rs
@@ -25,7 +25,7 @@ use crate::openhuman::agent::orchestration::parent_context::build_root_parent;
 use crate::openhuman::config::Config;
 
 use super::decision::TriageAction;
-use super::envelope::{TaskCardLink, TriggerEnvelope};
+use super::envelope::{TaskCardLink, TriggerEnvelope, TriggerSource};
 use super::evaluator::TriageRun;
 use super::events;
 
@@ -74,18 +74,23 @@ pub async fn apply_decision(run: TriageRun, envelope: &TriggerEnvelope) -> anyho
             // same mail, second copy, competing for the same recall slots — so
             // this arm deliberately writes nothing.
             //
+            // What survives differs by source, so the log says which — only the
+            // composio path archives its input, and claiming otherwise sends an
+            // operator looking for a record that was never written.
+            //
             // What is genuinely missing is not a copy of the input but a record
-            // of what happened *after* the verdict, for every action, not just
-            // this one. That belongs in a progress surface of its own rather
-            // than bolted onto the acknowledge branch (#5408).
+            // of what happened *after* the verdict, for every action and every
+            // source, not just this one. That belongs in a progress surface of
+            // its own rather than bolted onto the acknowledge branch (#5408).
             tracing::info!(
                 source = %envelope.source.slug(),
                 label = %envelope.display_label,
                 external_id = %envelope.external_id,
                 card_linked = envelope.card_link.is_some(),
+                retained = %retained_input_note(&envelope.source),
                 reason = %run.decision.reason,
                 "[triage::escalation] ACKNOWLEDGE — no autonomous action; \
-                 recorded as TriggerEvaluated, input retained in trigger history"
+                 recorded as TriggerEvaluated"
             );
             // Acknowledge means "seen, no autonomous action needed" — same as
             // drop, the linked card must not be picked up by the board poller.
@@ -340,6 +345,21 @@ async fn dispatch_linked_card(
         .find(|c| c.id == link.card_id)
         .ok_or_else(|| format!("card `{}` not found on board", link.card_id))?;
     crate::openhuman::agent::task_dispatcher::dispatch_card(link.location.clone(), card).await
+}
+
+/// What survives an acknowledged trigger, for the source it actually came from.
+///
+/// The composio webhook path archives every event to a daily JSONL before the
+/// triage gates, so its input is durable whatever the verdict. No other source
+/// has an equivalent: a webhook, cron, webview, or external trigger leaves only
+/// the `TriggerEvaluated` event. Saying "retained in trigger history" for all
+/// of them would tell an operator to go looking for a record that was never
+/// written.
+fn retained_input_note(source: &TriggerSource) -> &'static str {
+    match source {
+        TriggerSource::Composio { .. } => "trigger-history archive",
+        _ => "none — verdict only",
+    }
 }
 
 /// Terminally gate a card-linked trigger that triage decided to `drop` /

--- a/src/openhuman/agent/triage/escalation_tests.rs
+++ b/src/openhuman/agent/triage/escalation_tests.rs
@@ -360,3 +360,40 @@ async fn apply_decision_escalate_failure_publishes_failed_event() {
             if external_id == "esc-escalate-fail"
     )));
 }
+
+/// Only the composio path archives its input before triage. Naming a
+/// trigger-history record for a webhook or cron acknowledge would send an
+/// operator looking for a file that was never written.
+#[test]
+fn only_composio_claims_a_retained_input() {
+    assert_eq!(
+        retained_input_note(&TriggerSource::Composio {
+            toolkit: "gmail".into(),
+            trigger: "GMAIL_NEW_GMAIL_MESSAGE".into(),
+        }),
+        "trigger-history archive"
+    );
+
+    for source in [
+        TriggerSource::Webhook {
+            tunnel_id: "t".into(),
+            method: "POST".into(),
+            path: "/x".into(),
+        },
+        TriggerSource::Cron {
+            job_id: "j".into(),
+            job_name: "nightly".into(),
+        },
+        TriggerSource::WebviewIntegration {
+            provider: "gmail".into(),
+            account_id: "a".into(),
+        },
+    ] {
+        assert_eq!(
+            retained_input_note(&source),
+            "none — verdict only",
+            "{} has no archive to point at",
+            source.slug()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

The `Acknowledge` arm of `triage::escalation::apply_decision` logged `memory-write is a future addition`. That described an unimplemented plan rather than the behaviour — and the plan was wrong. Replaces it with the reason the arm writes nothing, improves the log line, and files the work that note was actually pointing at.

## Problem

Three things, in order of how much they matter.

**The planned write would have been a bug.** Copying an acknowledged trigger's summary into the memory store duplicates a document the connector sync has already ingested — the same mail, a second copy, competing with extracted memories for the same recall slots. That is #5312; #5315 is the fix for the copies that already exist. A note inviting the next contributor to add another one is worse than no note.

**The arm's real behaviour was undocumented.** Acknowledge is a classification, and the two things worth keeping are already kept elsewhere:

| | where | when |
|---|---|---|
| what the trigger *was* | `trigger_history` daily JSONL | written **before** the triage gates, so it survives even with triage disabled |
| what it was *judged to be* | `DomainEvent::TriggerEvaluated` | published for every action, a few lines above this arm |

Neither is obvious from the arm, so "writes nothing" read as an omission rather than a decision.

**The log said what was missing instead of what happened.** A reader tailing logs for an acknowledged trigger got a parenthetical about future work and no statement of the outcome.

## Solution

- The comment now states why the arm writes nothing, and names the two records that already exist.
- The log line states what happened and where to look, and carries `source` and `card_linked` alongside the existing fields.
- The sibling `DROP` arm gets the same two fields. Both are "no downstream work" verdicts; a dashboard filtering on `source=` would otherwise silently see only half of them.
- The genuinely-missing piece — a record of what happened *after* the verdict, for every action rather than this one — is filed as #5408 and referenced from the comment, so the next reader finds the work instead of re-deriving the note.

No behaviour change: the arm wrote nothing before and writes nothing now.

## Acceptance criteria

- [x] **The misleading note is gone** — replaced by the reason, not by silence.
- [x] **The reason is checkable** — the comment names `trigger_history` and `TriggerEvaluated`, both verifiable in the same file's call path.
- [x] **The follow-up is findable** — #5408 is linked from the code, not only from this PR.
- [x] **Sibling arms stay greppable together** — `DROP` and `ACKNOWLEDGE` carry the same field set.
- [x] **Tests pass** — `agent::triage` 70 tests; `cargo check --lib --all-features` clean.

## Related

- #5408 — record what a trigger's verdict actually led to (what the removed note was reaching for).
- #5409 — surface background work in the app; renders #5408.
- #5312 / #5315 — why writing the input to memory a second time is the wrong move.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved drop and acknowledgment activity logs with trigger source and task-card details.
  * Clarified acknowledgment records to show whether trigger history is retained or only the evaluation result is preserved.
  * Indicated when no memory entry is created, including distinct retention behavior for Composio, Webhook, Cron, and Webview Integration triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->