### PR TITLE
fix(media): error instead of false success on the generation poll timeout

### DIFF
--- a/src/openhuman/media/generation/tools.rs
+++ b/src/openhuman/media/generation/tools.rs
@@ -83,20 +83,25 @@ async fn generate_and_persist(
             // The generation never reached a terminal state within the budget, so
             // no artifact was downloaded. Surface an error rather than a false
             // success — a caller told "success" would report a file that was never
-            // produced. It was accepted and billed, so it may still finish
-            // server-side.
-            let mut msg = format!(
-                "Media generation did not complete within {max_wait_secs}s \
-                 (request_id: {request_id}, last status: {}). It was accepted and \
-                 billed and may still finish — try again shortly.",
+            // produced. Keep the message stable and free of upstream error text
+            // (that stays in the log line above): the request was accepted and
+            // billed and may still be running server-side, and there is no
+            // resume-by-id path, so retrying submits and bills a brand-new
+            // generation.
+            return ToolResult::error(format!(
+                "Media generation did not complete within {max_wait_secs}s (request_id: \
+                 {request_id}, last status: {}). The request was accepted and billed and may \
+                 still be running on the server. Calling this tool again starts and bills a \
+                 separate generation (there is no resume-by-id), so do not retry automatically — \
+                 report this to the user and let them decide.",
                 latest.status
-            );
-            if let Some(err) = &last_poll_error {
-                msg.push_str(&format!(" Last polling error: {err}"));
-            }
-            return ToolResult::error(msg);
+            ));
         }
-        tokio::time::sleep(POLL_INTERVAL).await;
+        // Don't sleep past the deadline: cap the poll interval to the time left so
+        // the wait budget is enforced before each poll. The poll request itself is
+        // bounded by the integration client's request timeout.
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        tokio::time::sleep(POLL_INTERVAL.min(remaining)).await;
         match client.get::<MediaResponse>(&status_path).await {
             Ok(resp) => {
                 tracing::debug!(

--- a/src/openhuman/media/generation/tools.rs
+++ b/src/openhuman/media/generation/tools.rs
@@ -11,7 +11,9 @@
 //! (`wait:false`, so the backend charges + returns a request id immediately),
 //! then poll the request until it reaches a terminal state, download each
 //! resulting artifact into the agent's `generated-media/` root, and return the
-//! local file paths. The backend owns GMI keys, billing, and rate limiting.
+//! local file paths. If the request does not reach a terminal state within the
+//! wait budget, the tool returns an error (never a success with no file). The
+//! backend owns GMI keys, billing, and rate limiting.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -36,7 +38,7 @@ const MODELS_PATH: &str = "/agent-integrations/media-generation/models";
 
 /// Poll cadence + caps. Images are fast; video can take minutes.
 const POLL_INTERVAL: Duration = Duration::from_secs(4);
-const IMAGE_MAX_WAIT_SECS: u64 = 180;
+const IMAGE_MAX_WAIT_SECS: u64 = 300;
 const VIDEO_MAX_WAIT_SECS: u64 = 420;
 
 /// Shared submit-then-poll-then-persist flow for both modalities.
@@ -68,19 +70,31 @@ async fn generate_and_persist(
     );
 
     let mut latest = submitted;
+    let mut last_poll_error: Option<String> = None;
     let deadline = Instant::now() + Duration::from_secs(max_wait_secs);
     while !latest.is_terminal() {
         if Instant::now() >= deadline {
             tracing::warn!(
-                "[media_generation] wait budget elapsed for request={} (status={})",
+                "[media_generation] wait budget elapsed for request={} (status={}, last_poll_error={:?})",
                 request_id,
+                latest.status,
+                last_poll_error
+            );
+            // The generation never reached a terminal state within the budget, so
+            // no artifact was downloaded. Surface an error rather than a false
+            // success — a caller told "success" would report a file that was never
+            // produced. It was accepted and billed, so it may still finish
+            // server-side.
+            let mut msg = format!(
+                "Media generation did not complete within {max_wait_secs}s \
+                 (request_id: {request_id}, last status: {}). It was accepted and \
+                 billed and may still finish — try again shortly.",
                 latest.status
             );
-            return ToolResult::success(format!(
-                "Media generation is still {} after {}s. It was accepted (request_id: {}) and \
-                 billed; it may finish shortly — check again later.",
-                latest.status, max_wait_secs, request_id
-            ));
+            if let Some(err) = &last_poll_error {
+                msg.push_str(&format!(" Last polling error: {err}"));
+            }
+            return ToolResult::error(msg);
         }
         tokio::time::sleep(POLL_INTERVAL).await;
         match client.get::<MediaResponse>(&status_path).await {
@@ -97,8 +111,10 @@ async fn generate_and_persist(
                     "[media_generation] poll error for request={}: {e}",
                     request_id
                 );
-                // Transient poll failures shouldn't abort a paid generation —
-                // keep polling until the deadline.
+                // Transient poll failures shouldn't abort a paid generation — keep
+                // polling until the deadline, but remember the last error so a
+                // timeout can explain why it never observed a terminal status.
+                last_poll_error = Some(e.to_string());
             }
         }
     }

--- a/src/openhuman/media/generation/tools_tests.rs
+++ b/src/openhuman/media/generation/tools_tests.rs
@@ -295,8 +295,9 @@ async fn deadline_after_poll_errors_still_errors() {
     // Submit is accepted but stays non-terminal, and every status poll fails.
     // Transient poll errors must not abort the paid generation, but once the wait
     // budget elapses the tool must surface an error (never a false success),
-    // remembering the last poll failure. A 1s budget against the 4s poll interval
-    // yields exactly one erroring poll before the deadline.
+    // remembering the last poll failure. The 1s budget caps the first sleep to the
+    // remaining time (not the full 4s interval), so exactly one failing poll runs
+    // before the deadline fires.
     Mock::given(method("POST"))
         .and(path("/agent-integrations/media-generation/images"))
         .respond_with(ResponseTemplate::new(200).set_body_json(

--- a/src/openhuman/media/generation/tools_tests.rs
+++ b/src/openhuman/media/generation/tools_tests.rs
@@ -247,3 +247,89 @@ async fn list_models_tool_returns_backend_catalog() {
     let res = tool.execute(json!({})).await.unwrap();
     assert!(!res.is_error, "expected success, got {res:?}");
 }
+
+#[tokio::test]
+async fn deadline_without_terminal_status_errors_without_persisting() {
+    let server = MockServer::start().await;
+    // Submit is accepted but the request never reaches a terminal state. With a
+    // zero-second wait budget the poll deadline is hit immediately, so nothing is
+    // ever downloaded — the tool must surface an error, not a false success.
+    Mock::given(method("POST"))
+        .and(path("/agent-integrations/media-generation/images"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            serde_json::json!({ "success": true, "data": {
+            "requestId": "req-timeout",
+            "status": "queued",
+            "model": "seedream-4-0-250828",
+            "media": []
+        } }),
+        ))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let client = client_for(&server);
+    let res = super::generate_and_persist(
+        &client,
+        tmp.path(),
+        super::IMAGES_PATH,
+        json!({ "prompt": "a fox", "wait": false }),
+        0,
+    )
+    .await;
+
+    assert!(
+        res.is_error,
+        "deadline with no terminal status must error, got {res:?}"
+    );
+    let dir = tmp.path().join("generated-media");
+    assert!(
+        !dir.exists() || std::fs::read_dir(&dir).unwrap().count() == 0,
+        "no artifact should be persisted on a timeout"
+    );
+}
+
+#[tokio::test]
+async fn deadline_after_poll_errors_still_errors() {
+    let server = MockServer::start().await;
+    // Submit is accepted but stays non-terminal, and every status poll fails.
+    // Transient poll errors must not abort the paid generation, but once the wait
+    // budget elapses the tool must surface an error (never a false success),
+    // remembering the last poll failure. A 1s budget against the 4s poll interval
+    // yields exactly one erroring poll before the deadline.
+    Mock::given(method("POST"))
+        .and(path("/agent-integrations/media-generation/images"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            serde_json::json!({ "success": true, "data": {
+            "requestId": "req-pollerr",
+            "status": "queued",
+            "model": "seedream-4-0-250828",
+            "media": []
+        } }),
+        ))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path_regex(
+            r"^/agent-integrations/media-generation/requests/.+",
+        ))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let client = client_for(&server);
+    let res = super::generate_and_persist(
+        &client,
+        tmp.path(),
+        super::IMAGES_PATH,
+        json!({ "prompt": "a fox", "wait": false }),
+        1,
+    )
+    .await;
+
+    assert!(
+        res.is_error,
+        "deadline after failing polls must error, got {res:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Fix `create_image` / `create_video` returning "success" with **no file** when a generation does not finish within the tool's poll budget.
- The tool submits (`wait=false`) then polls the backend until terminal; on the poll deadline it now returns an **error** instead of a success message with no artifact.
- Capture the last polling error so a timeout explains *why* it never observed a terminal status.
- Raise the image poll budget 180s → 300s (video is already 420s) so more slow/queued generations finish in-window.

## Problem

`media_generate_image` (`create_image`) is asynchronous: the tool submits, then polls `GET /agent-integrations/media-generation/requests/{id}` until the request is terminal, downloads the media, and returns the local file path. If the request never reached a terminal state within the wait budget — a slow/queued upstream, or repeated (tolerated) poll errors — the deadline branch returned `ToolResult::success(...)` with **no file downloaded**. The agent reported success and produced nothing (tinyhumansai/backend#1199).

## Solution

- `generate_and_persist`: the wait-budget-elapsed branch now returns `ToolResult::error(...)`, not `success`. The message states the request was accepted and billed and may still finish, and includes the last polling error when one occurred.
- Poll failures are still tolerated mid-flight (a transient error must not abort a paid generation), but the last one is remembered and surfaced if the deadline is hit — no more silent draining into a false success.
- `IMAGE_MAX_WAIT_SECS` 180 → 300.
- The happy path (terminal success → download → local path) and the existing terminal-`failed` / empty-`media` guards are unchanged.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — new: `deadline_without_terminal_status_errors_without_persisting`, `deadline_after_poll_errors_still_errors`. Existing submit/poll/terminal-`failed`/empty-`media` tests unchanged and green.
- [x] **Diff coverage ≥ 80%** — the new branches (deadline error + last-poll-error capture/formatting) are covered by the two new tests. `cargo test --lib media::generation` green.
- [x] Coverage matrix updated — `N/A: behaviour-only change` (no feature rows added/removed/renamed).
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: behaviour-only change`.
- [x] No new external network dependencies introduced — the mock backend (`wiremock`) is used.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: changes an agent-tool error message only, not a release-cut surface`.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

- Desktop/CLI agent-tool behaviour only. `create_image` / `create_video` now return an **error** (instead of a misleading success) when a generation does not finish within the budget; on success, behaviour is unchanged.
- No performance/security/migration impact. The maximum in-tool image wait rises 180s → 300s (bounded; the tool already blocked with progress).

## Related

- Closes: tinyhumansai/backend#1199
- Follow-up PR(s)/TODOs: companion backend PR (honest `wait=true` contract + `mediaCount` telemetry): https://github.com/tinyhumansai/backend/pull/1218

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Human-authored PR — AI-specific fields marked `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/1199-media-poll-deadline-error`
- Commit SHA: 23b15dffa

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no `app/` (frontend) files changed
- [x] `pnpm typecheck` — N/A: no TypeScript files changed
- [x] Focused tests: `cargo test --lib media::generation` — 14 passing
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo test` compiles the core crate clean
- [x] Tauri fmt/check (if changed): N/A: no `app/src-tauri/` files changed

### Validation Blocked

- `command:` local pre-push hook (`pnpm format:check` / `lint` / `compile` / `rust:clippy`)
- `error:` this change was prepared in a git worktree that is not provisioned with the frontend `node_modules`, so the `pnpm`-based front-end steps that run first cannot execute; the change is Rust-core-only (`src/openhuman/media/generation/`)
- `impact:` none — Rust validated locally (`cargo test --lib media::generation` green, `cargo fmt --check` clean); the full gated checks (Rust core coverage + clippy, diff coverage ≥ 80%) run in CI (`ci-lite.yml`) on this PR

### Behavior Changes

- Intended behavior change: on a poll-budget timeout the tool returns an error rather than a success with no file; image wait budget 180s → 300s.
- User-visible effect: a timed-out generation now reports a clear error (with request id) instead of silently claiming success.

### Parity Contract

- Legacy behavior preserved: submit, poll cadence, download/persist, terminal-`failed` and empty-`media` handling are unchanged; only the timeout branch and the wait cap change.
- Guard/fallback/dispatch parity checks: terminal-`success` → download → local path unchanged; terminal-`failed` → error unchanged; empty-`media` → error unchanged.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image generation now returns an error when requests time out instead of reporting success without a file.
  * Timeout errors include the request ID, elapsed wait duration, latest status, and relevant polling failure details.
  * Polling now respects the configured deadline, preventing unnecessary waits after a request has timed out.
  * Image generation can wait up to 300 seconds for completion, improving support for longer-running requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->