### PR TITLE
feat(threads): name a thread in three words

### DIFF
--- a/src/openhuman/threads/ops_tests.rs
+++ b/src/openhuman/threads/ops_tests.rs
@@ -75,15 +75,15 @@ fn build_title_prompt_renders_user_and_assistant_sections_in_order() {
     let prompt = build_title_prompt("hi there", "hello back");
     assert_eq!(
         prompt,
-        "First user message:\nhi there\n\nAssistant reply:\nhello back\n\nReturn the best thread title."
+        "First user message:\nhi there\n\nAssistant reply:\nhello back\n\nReturn the best thread slug."
     );
 }
 
 // NOTE: the sanitize_generated_title / title_from_user_message copies were
 // removed here (plan.md §2.1) — threads/title.rs (the owning module) already
-// covers these functions with equivalent cases (quotes/punct trimming, first
-// non-empty line, empty→None, internal-whitespace collapse, char-safe 80-char
-// truncation incl. multibyte, and the fallback-title cases).
+// covers these functions with equivalent cases (slug shaping, filler removal,
+// first non-empty line, empty→None, and the char-safe length ceiling incl.
+// multibyte input).
 
 // ── is_auto_generated_thread_title ────────────────────────────
 
@@ -281,11 +281,11 @@ fn record_to_message_preserves_null_extra_metadata() {
 
 #[test]
 fn title_system_prompt_constrains_model_output_shape() {
-    // The system prompt is shipped verbatim to the provider. Locking
-    // in the trailing "no trailing punctuation" clause catches
-    // accidental edits that would let the model emit trailing periods
-    // that `sanitize_generated_title` would then silently strip.
-    assert!(THREAD_TITLE_SYSTEM_PROMPT.contains("under 8 words"));
+    // The system prompt is shipped verbatim to the provider. Locking in the
+    // slug clauses catches accidental edits that would let the model emit a
+    // sentence-shaped title that `sanitize_generated_title` would then have to
+    // rewrite silently.
+    assert!(THREAD_TITLE_SYSTEM_PROMPT.contains("at most 3 lowercase words joined by hyphens"));
     assert!(THREAD_TITLE_SYSTEM_PROMPT.contains("No quotes"));
     assert!(THREAD_TITLE_SYSTEM_PROMPT.contains("No markdown"));
 }

--- a/src/openhuman/threads/ops_tests.rs
+++ b/src/openhuman/threads/ops_tests.rs
@@ -75,13 +75,13 @@ fn build_title_prompt_renders_user_and_assistant_sections_in_order() {
     let prompt = build_title_prompt("hi there", "hello back");
     assert_eq!(
         prompt,
-        "First user message:\nhi there\n\nAssistant reply:\nhello back\n\nReturn the best thread slug."
+        "First user message:\nhi there\n\nAssistant reply:\nhello back\n\nReturn the best thread name."
     );
 }
 
 // NOTE: the sanitize_generated_title / title_from_user_message copies were
 // removed here (plan.md §2.1) — threads/title.rs (the owning module) already
-// covers these functions with equivalent cases (slug shaping, filler removal,
+// covers these functions with equivalent cases (title shaping, filler removal,
 // first non-empty line, empty→None, and the char-safe length ceiling incl.
 // multibyte input).
 
@@ -282,10 +282,10 @@ fn record_to_message_preserves_null_extra_metadata() {
 #[test]
 fn title_system_prompt_constrains_model_output_shape() {
     // The system prompt is shipped verbatim to the provider. Locking in the
-    // slug clauses catches accidental edits that would let the model emit a
+    // length clause catches accidental edits that would let the model emit a
     // sentence-shaped title that `sanitize_generated_title` would then have to
     // rewrite silently.
-    assert!(THREAD_TITLE_SYSTEM_PROMPT.contains("at most 3 lowercase words joined by hyphens"));
+    assert!(THREAD_TITLE_SYSTEM_PROMPT.contains("at most 3 words"));
     assert!(THREAD_TITLE_SYSTEM_PROMPT.contains("No quotes"));
     assert!(THREAD_TITLE_SYSTEM_PROMPT.contains("No markdown"));
 }

--- a/src/openhuman/threads/title.rs
+++ b/src/openhuman/threads/title.rs
@@ -7,21 +7,21 @@ use std::hash::{Hash, Hasher};
 
 pub const THREAD_TITLE_LOG_PREFIX: &str = "[threads:title]";
 pub const THREAD_TITLE_MODEL_HINT: &str = "hint:summarize";
-pub const THREAD_TITLE_SYSTEM_PROMPT: &str = "You name chat threads with a short slug taken from the first user message and the assistant reply. Return only the slug: at most 3 lowercase words joined by hyphens, like fix-session-handoff or gmail-oauth-retry. Lead with the verb or the subject and drop filler words. No quotes. No markdown. No punctuation other than the hyphens.";
+pub const THREAD_TITLE_SYSTEM_PROMPT: &str = "You name chat threads from the first user message and the assistant reply. Return only the name: at most 3 words, like Fix session handoff or Gmail OAuth retry. Lead with the verb or the subject and drop filler words. No quotes. No markdown. No punctuation.";
 
-/// Words a slug carries at most. Three is the whole point of the shape: a
+/// Words a title carries at most. Three is the whole point of the shape: a
 /// thread list is scanned, not read, and a fourth word is always the one that
 /// pushes the specific words off the end of a narrow row.
 pub const THREAD_TITLE_MAX_WORDS: usize = 3;
-/// Hard character ceiling on a slug, so one very long word cannot widen a row.
+/// Hard character ceiling on a title, so one very long word cannot widen a row.
 pub const THREAD_TITLE_MAX_CHARS: usize = 48;
 
-/// Filler a slug is better off without.
+/// Filler a title is better off without.
 ///
 /// Prompts open with conversational scaffolding ("okay so can you please…"),
-/// and taking the first three words verbatim would spend the whole slug on it.
+/// and taking the first three words verbatim would spend the whole title on it.
 /// Only words that never identify a thread on their own are listed; a filtered
-/// slug that comes out empty falls back to the unfiltered words, so a message
+/// title that comes out empty falls back to the unfiltered words, so a message
 /// made entirely of these still gets a name.
 const FILLER_WORDS: &[&str] = &[
     "a", "about", "an", "and", "are", "as", "at", "be", "but", "by", "can", "could", "do", "does",
@@ -102,67 +102,68 @@ pub fn collapse_whitespace(input: &str) -> String {
     input.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-/// Reduces any text to the thread-title slug shape: at most
-/// [`THREAD_TITLE_MAX_WORDS`] lowercase words joined by hyphens, e.g.
-/// `fix-session-handoff`.
+/// Reduces any text to the thread-title shape: at most
+/// [`THREAD_TITLE_MAX_WORDS`] words, e.g. `Fix session handoff`.
 ///
-/// This is the shape enforcer, not a request: the model is asked for a slug in
-/// [`THREAD_TITLE_SYSTEM_PROMPT`], but a title that reaches storage as a
-/// sentence because one completion ignored the instruction is exactly the bug
-/// the slug is meant to remove, so every path runs through here.
+/// This is the shape enforcer, not a request: the model is asked for a short
+/// name in [`THREAD_TITLE_SYSTEM_PROMPT`], but a title that reaches storage as
+/// a whole sentence because one completion ignored the instruction is exactly
+/// the bug the shape is meant to remove, so every path runs through here.
 ///
 /// Rules applied (in order):
 /// - split on anything that is not alphanumeric (punctuation, quotes, markdown,
-///   whitespace, existing hyphens all become word breaks)
-/// - lowercase every word
+///   and whitespace all become word breaks)
 /// - drop [`FILLER_WORDS`], unless that would leave nothing
 /// - keep the first [`THREAD_TITLE_MAX_WORDS`] words, and stop early rather
 ///   than exceed [`THREAD_TITLE_MAX_CHARS`]
 ///
+/// A word's own spelling is left alone — `OAuth` and `Gmail` read wrong
+/// lowercased, and the model is the only thing here that knows which is which.
+///
 /// Returns `None` when no word survives.
-pub fn slugify_title(text: &str) -> Option<String> {
-    let words: Vec<String> = text
+pub fn shorten_title(text: &str) -> Option<String> {
+    let words: Vec<&str> = text
         .split(|c: char| !c.is_alphanumeric())
         .filter(|word| !word.is_empty())
-        .map(|word| word.to_lowercase())
         .collect();
     if words.is_empty() {
         return None;
     }
-    let meaningful: Vec<&String> = words
+    let meaningful: Vec<&str> = words
         .iter()
-        .filter(|word| !FILLER_WORDS.contains(&word.as_str()))
+        .copied()
+        .filter(|word| !FILLER_WORDS.contains(&word.to_lowercase().as_str()))
         .collect();
     // All-filler input ("can you please") still names its thread, badly-but-
     // stably, rather than leaving the placeholder title in place.
-    let source: Vec<&String> = if meaningful.is_empty() {
-        words.iter().collect()
+    let source = if meaningful.is_empty() {
+        words
     } else {
         meaningful
     };
 
-    let mut slug = String::new();
+    let mut title = String::new();
     for word in source.into_iter().take(THREAD_TITLE_MAX_WORDS) {
-        let separator = usize::from(!slug.is_empty());
-        let room = THREAD_TITLE_MAX_CHARS.saturating_sub(slug.chars().count() + separator);
+        let separator = usize::from(!title.is_empty());
+        let room = THREAD_TITLE_MAX_CHARS.saturating_sub(title.chars().count() + separator);
         if room == 0 {
             break;
         }
-        if !slug.is_empty() {
-            slug.push('-');
+        if !title.is_empty() {
+            title.push(' ');
         }
         // A single word longer than the ceiling is truncated rather than
-        // dropped: dropping it can empty an otherwise usable slug.
-        slug.extend(word.chars().take(room));
+        // dropped: dropping it can empty an otherwise usable title.
+        title.extend(word.chars().take(room));
     }
-    (!slug.is_empty()).then_some(slug)
+    (!title.is_empty()).then_some(title)
 }
 
 /// Sanitises a raw LLM title completion into a stored thread title.
 ///
 /// Takes the first non-empty line — a chatty model that adds a second line of
-/// commentary should not have it folded into the name — and slugifies it with
-/// [`slugify_title`], which absorbs the quote/markdown/punctuation stripping
+/// commentary should not have it folded into the name — and shortens it with
+/// [`shorten_title`], which absorbs the quote/markdown/punctuation stripping
 /// the older sentence-shaped title needed done by hand.
 ///
 /// Returns `None` if the result is empty.
@@ -171,7 +172,7 @@ pub fn sanitize_generated_title(raw: &str) -> Option<String> {
         .lines()
         .find(|line| !line.trim().is_empty())
         .unwrap_or(raw);
-    slugify_title(line)
+    shorten_title(line)
 }
 
 /// Derives a stable display title directly from the first useful user message.
@@ -186,18 +187,18 @@ pub fn title_from_user_message(message: &str) -> Option<String> {
     }
 
     // Only the first sentence describes the ask; what follows is context the
-    // slug has no room for anyway.
+    // title has no room for anyway.
     let first_sentence = collapsed
         .split(['.', '!', '?', '\n'])
         .find(|part| !part.trim().is_empty())
         .unwrap_or(&collapsed);
-    slugify_title(first_sentence)
+    shorten_title(first_sentence)
 }
 
 /// Builds the user-visible prompt passed to the title-generation model.
 pub fn build_title_prompt(user_message: &str, assistant_message: &str) -> String {
     format!(
-        "First user message:\n{user_message}\n\nAssistant reply:\n{assistant_message}\n\nReturn the best thread slug."
+        "First user message:\n{user_message}\n\nAssistant reply:\n{assistant_message}\n\nReturn the best thread name."
     )
 }
 
@@ -316,91 +317,100 @@ mod tests {
         assert_eq!(collapse_whitespace("   "), "");
     }
 
-    // ── slugify_title ─────────────────────────────────────────────
+    // ── shorten_title ─────────────────────────────────────────────
 
     #[test]
-    fn slugify_keeps_at_most_three_lowercase_words() {
+    fn shorten_keeps_at_most_three_words() {
         assert_eq!(
-            slugify_title("Fix session handoff flow and pointer").unwrap(),
-            "fix-session-handoff"
+            shorten_title("Fix session handoff flow and pointer").unwrap(),
+            "Fix session handoff"
         );
-        assert_eq!(slugify_title("Launch Plan").unwrap(), "launch-plan");
+        assert_eq!(shorten_title("Launch Plan").unwrap(), "Launch Plan");
     }
 
     #[test]
-    fn slugify_drops_leading_filler() {
+    fn shorten_leaves_a_words_own_spelling_alone() {
+        // Lowercasing would turn these into something nobody would type.
         assert_eq!(
-            slugify_title("okay so can you please fix the session handoff").unwrap(),
-            "fix-session-handoff"
-        );
-    }
-
-    #[test]
-    fn slugify_falls_back_to_filler_when_that_is_all_there_is() {
-        assert_eq!(slugify_title("can you please").unwrap(), "can-you-please");
-    }
-
-    #[test]
-    fn slugify_treats_punctuation_and_markdown_as_word_breaks() {
-        assert_eq!(
-            slugify_title("**Debugging deploys:** retry").unwrap(),
-            "debugging-deploys-retry"
-        );
-        assert_eq!(
-            slugify_title("\"gmail/oauth retry\"").unwrap(),
-            "gmail-oauth-retry"
+            shorten_title("Gmail OAuth retry loop").unwrap(),
+            "Gmail OAuth retry"
         );
     }
 
     #[test]
-    fn slugify_bounds_total_length() {
+    fn shorten_drops_leading_filler() {
+        assert_eq!(
+            shorten_title("okay so can you please fix the session handoff").unwrap(),
+            "fix session handoff"
+        );
+    }
+
+    #[test]
+    fn shorten_falls_back_to_filler_when_that_is_all_there_is() {
+        assert_eq!(shorten_title("can you please").unwrap(), "can you please");
+    }
+
+    #[test]
+    fn shorten_treats_punctuation_and_markdown_as_word_breaks() {
+        assert_eq!(
+            shorten_title("**Debugging deploys:** retry").unwrap(),
+            "Debugging deploys retry"
+        );
+        assert_eq!(
+            shorten_title("\"gmail/oauth retry\"").unwrap(),
+            "gmail oauth retry"
+        );
+    }
+
+    #[test]
+    fn shorten_bounds_total_length() {
         let long = format!("{} {} {}", "a".repeat(30), "b".repeat(30), "c".repeat(30));
-        let out = slugify_title(&long).unwrap();
+        let out = shorten_title(&long).unwrap();
         assert!(out.chars().count() <= THREAD_TITLE_MAX_CHARS);
         // A word that does not fit whole is truncated, never dropped.
         assert!(out.starts_with(&"a".repeat(30)));
     }
 
     #[test]
-    fn slugify_counts_chars_not_bytes() {
+    fn shorten_counts_chars_not_bytes() {
         // Each ✨ is 3 bytes in UTF-8, and is not alphanumeric — a title made
         // only of them has no word to keep.
-        assert!(slugify_title(&"✨".repeat(90)).is_none());
-        let out = slugify_title(&"é".repeat(90)).unwrap();
+        assert!(shorten_title(&"✨".repeat(90)).is_none());
+        let out = shorten_title(&"é".repeat(90)).unwrap();
         assert_eq!(out.chars().count(), THREAD_TITLE_MAX_CHARS);
     }
 
     #[test]
-    fn slugify_returns_none_without_a_word() {
-        assert!(slugify_title("").is_none());
-        assert!(slugify_title("   \n\t  ").is_none());
-        assert!(slugify_title("///").is_none());
+    fn shorten_returns_none_without_a_word() {
+        assert!(shorten_title("").is_none());
+        assert!(shorten_title("   \n\t  ").is_none());
+        assert!(shorten_title("///").is_none());
     }
 
     // ── sanitize_generated_title ──────────────────────────────────
 
     #[test]
-    fn sanitize_slugifies_a_sentence_shaped_completion() {
+    fn sanitize_shortens_a_sentence_shaped_completion() {
         assert_eq!(
             sanitize_generated_title("\"Planning the launch party\"").unwrap(),
-            "planning-launch-party"
+            "Planning launch party"
         );
         // "are"/"we" are filler, so a question collapses to its one real word.
-        assert_eq!(sanitize_generated_title("Where are we?").unwrap(), "where");
+        assert_eq!(sanitize_generated_title("Where are we?").unwrap(), "Where");
     }
 
     #[test]
-    fn sanitize_passes_an_already_slugged_completion_through() {
+    fn sanitize_passes_an_already_short_completion_through() {
         assert_eq!(
-            sanitize_generated_title("fix-session-handoff").unwrap(),
-            "fix-session-handoff"
+            sanitize_generated_title("Fix session handoff").unwrap(),
+            "Fix session handoff"
         );
     }
 
     #[test]
     fn sanitize_picks_first_nonempty_line() {
         let raw = "\n\n  First real line  \nsecond line\n";
-        assert_eq!(sanitize_generated_title(raw).unwrap(), "first-real-line");
+        assert_eq!(sanitize_generated_title(raw).unwrap(), "First real line");
     }
 
     #[test]
@@ -424,7 +434,7 @@ mod tests {
         assert_eq!(
             title_from_user_message("Can you retrieve my latest 5 emails and summarize them?")
                 .unwrap(),
-            "retrieve-latest-5"
+            "retrieve latest 5"
         );
     }
 
@@ -432,7 +442,7 @@ mod tests {
     fn title_from_user_message_removes_command_prefix_and_punctuation() {
         assert_eq!(
             title_from_user_message("/briefing Morning update, please. Then check email").unwrap(),
-            "briefing-morning-update"
+            "briefing Morning update"
         );
     }
 
@@ -449,6 +459,6 @@ mod tests {
         let prompt = build_title_prompt("hello", "hi there");
         assert!(prompt.contains("First user message:\nhello"));
         assert!(prompt.contains("Assistant reply:\nhi there"));
-        assert!(prompt.contains("Return the best thread slug"));
+        assert!(prompt.contains("Return the best thread name"));
     }
 }

--- a/src/openhuman/threads/title.rs
+++ b/src/openhuman/threads/title.rs
@@ -7,7 +7,29 @@ use std::hash::{Hash, Hasher};
 
 pub const THREAD_TITLE_LOG_PREFIX: &str = "[threads:title]";
 pub const THREAD_TITLE_MODEL_HINT: &str = "hint:summarize";
-pub const THREAD_TITLE_SYSTEM_PROMPT: &str = "You generate short, specific chat thread titles from the first user message and the assistant reply. Return only the title text. Keep it under 8 words. No quotes. No markdown. No trailing punctuation unless it is part of a proper noun.";
+pub const THREAD_TITLE_SYSTEM_PROMPT: &str = "You name chat threads with a short slug taken from the first user message and the assistant reply. Return only the slug: at most 3 lowercase words joined by hyphens, like fix-session-handoff or gmail-oauth-retry. Lead with the verb or the subject and drop filler words. No quotes. No markdown. No punctuation other than the hyphens.";
+
+/// Words a slug carries at most. Three is the whole point of the shape: a
+/// thread list is scanned, not read, and a fourth word is always the one that
+/// pushes the specific words off the end of a narrow row.
+pub const THREAD_TITLE_MAX_WORDS: usize = 3;
+/// Hard character ceiling on a slug, so one very long word cannot widen a row.
+pub const THREAD_TITLE_MAX_CHARS: usize = 48;
+
+/// Filler a slug is better off without.
+///
+/// Prompts open with conversational scaffolding ("okay so can you please…"),
+/// and taking the first three words verbatim would spend the whole slug on it.
+/// Only words that never identify a thread on their own are listed; a filtered
+/// slug that comes out empty falls back to the unfiltered words, so a message
+/// made entirely of these still gets a name.
+const FILLER_WORDS: &[&str] = &[
+    "a", "about", "an", "and", "are", "as", "at", "be", "but", "by", "can", "could", "do", "does",
+    "for", "from", "hey", "hi", "how", "i", "if", "in", "into", "is", "it", "its", "just", "let",
+    "lets", "like", "me", "my", "of", "ok", "okay", "on", "or", "our", "please", "so", "thanks",
+    "that", "the", "their", "then", "there", "these", "they", "this", "to", "uh", "um", "us",
+    "was", "we", "well", "what", "when", "which", "will", "with", "would", "you", "your",
+];
 
 /// Stable 16-hex-char fingerprint of a title — safe for structured logs
 /// where we want to correlate events without leaking the raw title text.
@@ -80,32 +102,76 @@ pub fn collapse_whitespace(input: &str) -> String {
     input.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-/// Sanitises a raw LLM title completion into a single display-ready line.
+/// Reduces any text to the thread-title slug shape: at most
+/// [`THREAD_TITLE_MAX_WORDS`] lowercase words joined by hyphens, e.g.
+/// `fix-session-handoff`.
+///
+/// This is the shape enforcer, not a request: the model is asked for a slug in
+/// [`THREAD_TITLE_SYSTEM_PROMPT`], but a title that reaches storage as a
+/// sentence because one completion ignored the instruction is exactly the bug
+/// the slug is meant to remove, so every path runs through here.
 ///
 /// Rules applied (in order):
-/// - take the first non-empty line
-/// - strip wrapping quotes / backticks
-/// - drop trailing `. ! ? : ;`
-/// - collapse internal whitespace
-/// - truncate to 80 characters
+/// - split on anything that is not alphanumeric (punctuation, quotes, markdown,
+///   whitespace, existing hyphens all become word breaks)
+/// - lowercase every word
+/// - drop [`FILLER_WORDS`], unless that would leave nothing
+/// - keep the first [`THREAD_TITLE_MAX_WORDS`] words, and stop early rather
+///   than exceed [`THREAD_TITLE_MAX_CHARS`]
+///
+/// Returns `None` when no word survives.
+pub fn slugify_title(text: &str) -> Option<String> {
+    let words: Vec<String> = text
+        .split(|c: char| !c.is_alphanumeric())
+        .filter(|word| !word.is_empty())
+        .map(|word| word.to_lowercase())
+        .collect();
+    if words.is_empty() {
+        return None;
+    }
+    let meaningful: Vec<&String> = words
+        .iter()
+        .filter(|word| !FILLER_WORDS.contains(&word.as_str()))
+        .collect();
+    // All-filler input ("can you please") still names its thread, badly-but-
+    // stably, rather than leaving the placeholder title in place.
+    let source: Vec<&String> = if meaningful.is_empty() {
+        words.iter().collect()
+    } else {
+        meaningful
+    };
+
+    let mut slug = String::new();
+    for word in source.into_iter().take(THREAD_TITLE_MAX_WORDS) {
+        let separator = usize::from(!slug.is_empty());
+        let room = THREAD_TITLE_MAX_CHARS.saturating_sub(slug.chars().count() + separator);
+        if room == 0 {
+            break;
+        }
+        if !slug.is_empty() {
+            slug.push('-');
+        }
+        // A single word longer than the ceiling is truncated rather than
+        // dropped: dropping it can empty an otherwise usable slug.
+        slug.extend(word.chars().take(room));
+    }
+    (!slug.is_empty()).then_some(slug)
+}
+
+/// Sanitises a raw LLM title completion into a stored thread title.
+///
+/// Takes the first non-empty line — a chatty model that adds a second line of
+/// commentary should not have it folded into the name — and slugifies it with
+/// [`slugify_title`], which absorbs the quote/markdown/punctuation stripping
+/// the older sentence-shaped title needed done by hand.
 ///
 /// Returns `None` if the result is empty.
 pub fn sanitize_generated_title(raw: &str) -> Option<String> {
     let line = raw
         .lines()
         .find(|line| !line.trim().is_empty())
-        .unwrap_or(raw)
-        .trim();
-    let trimmed = line
-        .trim_matches(|c: char| matches!(c, '"' | '\'' | '`'))
-        .trim()
-        .trim_end_matches(['.', '!', '?', ':', ';'])
-        .trim();
-    let collapsed = collapse_whitespace(trimmed);
-    if collapsed.is_empty() {
-        return None;
-    }
-    Some(collapsed.chars().take(80).collect())
+        .unwrap_or(raw);
+    slugify_title(line)
 }
 
 /// Derives a stable display title directly from the first useful user message.
@@ -115,32 +181,23 @@ pub fn sanitize_generated_title(raw: &str) -> Option<String> {
 /// title meaningful without repeatedly renaming the thread later.
 pub fn title_from_user_message(message: &str) -> Option<String> {
     let collapsed = collapse_whitespace(message);
-    let stripped = collapsed
-        .trim_matches(|c: char| matches!(c, '"' | '\'' | '`'))
-        .trim()
-        .trim_start_matches(['/', '@', '#'])
-        .trim();
-    if stripped.is_empty() {
+    if collapsed.is_empty() {
         return None;
     }
 
-    let first_sentence = stripped
+    // Only the first sentence describes the ask; what follows is context the
+    // slug has no room for anyway.
+    let first_sentence = collapsed
         .split(['.', '!', '?', '\n'])
         .find(|part| !part.trim().is_empty())
-        .unwrap_or(stripped)
-        .trim();
-    let words = first_sentence
-        .split_whitespace()
-        .take(8)
-        .collect::<Vec<_>>()
-        .join(" ");
-    sanitize_generated_title(&words)
+        .unwrap_or(&collapsed);
+    slugify_title(first_sentence)
 }
 
 /// Builds the user-visible prompt passed to the title-generation model.
 pub fn build_title_prompt(user_message: &str, assistant_message: &str) -> String {
     format!(
-        "First user message:\n{user_message}\n\nAssistant reply:\n{assistant_message}\n\nReturn the best thread title."
+        "First user message:\n{user_message}\n\nAssistant reply:\n{assistant_message}\n\nReturn the best thread slug."
     )
 }
 
@@ -259,48 +316,91 @@ mod tests {
         assert_eq!(collapse_whitespace("   "), "");
     }
 
-    // ── sanitize_generated_title ──────────────────────────────────
+    // ── slugify_title ─────────────────────────────────────────────
 
     #[test]
-    fn sanitize_strips_wrapping_quotes() {
+    fn slugify_keeps_at_most_three_lowercase_words() {
         assert_eq!(
-            sanitize_generated_title("\"Launch plan\"").unwrap(),
-            "Launch plan"
+            slugify_title("Fix session handoff flow and pointer").unwrap(),
+            "fix-session-handoff"
         );
+        assert_eq!(slugify_title("Launch Plan").unwrap(), "launch-plan");
+    }
+
+    #[test]
+    fn slugify_drops_leading_filler() {
         assert_eq!(
-            sanitize_generated_title("'Debugging deploys'").unwrap(),
-            "Debugging deploys"
-        );
-        assert_eq!(
-            sanitize_generated_title("`retro notes`").unwrap(),
-            "retro notes"
+            slugify_title("okay so can you please fix the session handoff").unwrap(),
+            "fix-session-handoff"
         );
     }
 
     #[test]
-    fn sanitize_strips_trailing_punctuation() {
+    fn slugify_falls_back_to_filler_when_that_is_all_there_is() {
+        assert_eq!(slugify_title("can you please").unwrap(), "can-you-please");
+    }
+
+    #[test]
+    fn slugify_treats_punctuation_and_markdown_as_word_breaks() {
         assert_eq!(
-            sanitize_generated_title("Planning session.").unwrap(),
-            "Planning session"
+            slugify_title("**Debugging deploys:** retry").unwrap(),
+            "debugging-deploys-retry"
         );
         assert_eq!(
-            sanitize_generated_title("Where are we?").unwrap(),
-            "Where are we"
+            slugify_title("\"gmail/oauth retry\"").unwrap(),
+            "gmail-oauth-retry"
+        );
+    }
+
+    #[test]
+    fn slugify_bounds_total_length() {
+        let long = format!("{} {} {}", "a".repeat(30), "b".repeat(30), "c".repeat(30));
+        let out = slugify_title(&long).unwrap();
+        assert!(out.chars().count() <= THREAD_TITLE_MAX_CHARS);
+        // A word that does not fit whole is truncated, never dropped.
+        assert!(out.starts_with(&"a".repeat(30)));
+    }
+
+    #[test]
+    fn slugify_counts_chars_not_bytes() {
+        // Each ✨ is 3 bytes in UTF-8, and is not alphanumeric — a title made
+        // only of them has no word to keep.
+        assert!(slugify_title(&"✨".repeat(90)).is_none());
+        let out = slugify_title(&"é".repeat(90)).unwrap();
+        assert_eq!(out.chars().count(), THREAD_TITLE_MAX_CHARS);
+    }
+
+    #[test]
+    fn slugify_returns_none_without_a_word() {
+        assert!(slugify_title("").is_none());
+        assert!(slugify_title("   \n\t  ").is_none());
+        assert!(slugify_title("///").is_none());
+    }
+
+    // ── sanitize_generated_title ──────────────────────────────────
+
+    #[test]
+    fn sanitize_slugifies_a_sentence_shaped_completion() {
+        assert_eq!(
+            sanitize_generated_title("\"Planning the launch party\"").unwrap(),
+            "planning-launch-party"
+        );
+        // "are"/"we" are filler, so a question collapses to its one real word.
+        assert_eq!(sanitize_generated_title("Where are we?").unwrap(), "where");
+    }
+
+    #[test]
+    fn sanitize_passes_an_already_slugged_completion_through() {
+        assert_eq!(
+            sanitize_generated_title("fix-session-handoff").unwrap(),
+            "fix-session-handoff"
         );
     }
 
     #[test]
     fn sanitize_picks_first_nonempty_line() {
         let raw = "\n\n  First real line  \nsecond line\n";
-        assert_eq!(sanitize_generated_title(raw).unwrap(), "First real line");
-    }
-
-    #[test]
-    fn sanitize_collapses_internal_whitespace() {
-        assert_eq!(
-            sanitize_generated_title("hello    world").unwrap(),
-            "hello world"
-        );
+        assert_eq!(sanitize_generated_title(raw).unwrap(), "first-real-line");
     }
 
     #[test]
@@ -311,18 +411,10 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_truncates_to_eighty_chars() {
+    fn sanitize_bounds_length() {
         let long = "a".repeat(200);
         let out = sanitize_generated_title(&long).unwrap();
-        assert_eq!(out.chars().count(), 80);
-    }
-
-    #[test]
-    fn sanitize_truncates_by_char_count_not_byte_count() {
-        // Each ✨ is 3 bytes in UTF-8; ensure truncation counts chars, not bytes.
-        let long: String = std::iter::repeat('✨').take(90).collect();
-        let out = sanitize_generated_title(&long).unwrap();
-        assert_eq!(out.chars().count(), 80);
+        assert_eq!(out.chars().count(), THREAD_TITLE_MAX_CHARS);
     }
 
     // ── title_from_user_message ──────────────────────────────────
@@ -332,7 +424,7 @@ mod tests {
         assert_eq!(
             title_from_user_message("Can you retrieve my latest 5 emails and summarize them?")
                 .unwrap(),
-            "Can you retrieve my latest 5 emails and"
+            "retrieve-latest-5"
         );
     }
 
@@ -340,7 +432,7 @@ mod tests {
     fn title_from_user_message_removes_command_prefix_and_punctuation() {
         assert_eq!(
             title_from_user_message("/briefing Morning update, please. Then check email").unwrap(),
-            "briefing Morning update, please"
+            "briefing-morning-update"
         );
     }
 
@@ -357,6 +449,6 @@ mod tests {
         let prompt = build_title_prompt("hello", "hi there");
         assert!(prompt.contains("First user message:\nhello"));
         assert!(prompt.contains("Assistant reply:\nhi there"));
-        assert!(prompt.contains("Return the best thread title"));
+        assert!(prompt.contains("Return the best thread slug"));
     }
 }


### PR DESCRIPTION
## Summary

- Thread titles are now at most three words ("Fix session handoff") instead of sentences under eight words.
- `THREAD_TITLE_SYSTEM_PROMPT` asks the model for that shape; a new `shorten_title` enforces it, so a completion that ignores the instruction still lands short.
- Both no-provider fallbacks (`title_from_user_message`, `sanitize_generated_title`) go through the same shaper, so a thread named without the model reads the same as one named with it.

## Problem

A generated title was a whole clause — "Fix session handoff flow and pointer" — sized for a wide chat header. Everywhere a thread is *scanned* rather than read (sidebar rows, agent rails, session lists) the fourth word onwards is what pushes the identifying words off the end of the row, and the leading words are usually the prompt's conversational scaffolding ("okay so can you please…"), not its subject.

The prompt alone could not fix it: it is an instruction, not a constraint, and a single off-instruction completion put a sentence into durable storage where nothing downstream reshaped it.

## Solution

- `shorten_title(text)` — split on every non-alphanumeric character (so quotes, markdown, and punctuation are word breaks), drop `FILLER_WORDS`, keep the first `THREAD_TITLE_MAX_WORDS` (3), stop before `THREAD_TITLE_MAX_CHARS` (48). Returns `None` when no word survives, so the existing fallback chain is unchanged.
- **A word's own spelling is left alone.** `Gmail` and `OAuth` read wrong lowercased, and the model is the only thing here that knows which is which — so the title stays a title, not a slug.
- All-filler input ("can you please") falls back to the unfiltered words rather than leaving the thread unnamed — a bad-but-stable name beats a placeholder that never gets replaced.
- A word longer than the ceiling is truncated rather than dropped, because dropping it can empty an otherwise usable title.
- `sanitize_generated_title` keeps taking the first non-empty line (a chatty model's second line is commentary, not the name) and then shortens; the old quote/trailing-punctuation trimming is subsumed by the split rule.
- `title_from_user_message` still takes the first sentence, then shortens.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `threads::title::tests` covers title shaping, filler removal, the all-filler fallback, punctuation/markdown breaks, the length ceiling, multibyte input, and the no-word `None` case.
- [x] **Diff coverage ≥ 80%** — the change is one pure module plus its tests; every new branch (filler-empty fallback, `room == 0` break, word truncation, empty result) has a case. `cargo test --lib openhuman::threads::` — 183 passed.
- [x] N/A: behaviour-only change, no feature rows added/removed/renamed.
- [x] N/A: no matrix feature IDs affected.
- [x] No new external network dependencies introduced.
- [x] N/A: no release-cut surface touched.
- [x] N/A: no linked issue.

## Impact

- User-visible: thread names in the sidebar and anywhere else a thread is listed become short names (at most three ordinary words, e.g. "Fix session handoff") instead of full sentences. Existing titles are untouched — only newly generated ones take the new shape, and user-renamed threads are still never overwritten (`is_auto_generated_thread_title` is unchanged).
- No migration, no schema change, no performance or security implication. The shortened title is strictly narrower than what it replaced, so no layout can get wider.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: tinyhumansai/medulla#197 is the consumer-side change. It applies the same three-word rule but renders a kebab slug, which is the shape its terminal rails want; this repo keeps ordinary words for the chat UI.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `session-title-slug`
- Commit SHA: 7659127e2

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no `app/` change.
- [x] `pnpm typecheck` — N/A: no TypeScript change.
- [x] Focused tests: `cargo test --lib openhuman::threads::` — 183 passed, 0 failed.
- [x] Rust fmt/check (if changed): `cargo fmt`.
- [x] Tauri fmt/check (if changed) — N/A: no `app/src-tauri` change.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: generated thread titles change shape from a sentence to at most three words.
- User-visible effect: a thread that would have been "Fix session handoff flow and pointer" is now "Fix session handoff".

### Parity Contract

- Legacy behavior preserved: the generate → sanitize → fallback chain, the placeholder-only replacement rule, and the `None`-means-keep-current-title contract are all unchanged; only the shape of the produced string differs.
- Guard/fallback/dispatch parity checks: `sanitize_generated_title` and `title_from_user_message` keep their signatures and their `None` conditions, so `threads::ops` needed no change.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A



