### PR TITLE
fix(voice): send the relay identity token where the backend can read it

### DIFF
--- a/app/src/features/human/voice/useRealtimeVoiceSession.test.ts
+++ b/app/src/features/human/voice/useRealtimeVoiceSession.test.ts
@@ -45,11 +45,26 @@ describe('useRealtimeVoiceSession', () => {
       signedUrl: 'wss://x',
       connectionType: 'websocket',
       userId: 'tok-1',
+      customLlmExtraBody: { user: 'tok-1' },
       overrides: { tts: { voiceId: 'v9' } },
     });
 
     act(() => captured?.onConnect());
     expect(result.current.state).toBe('active');
+  });
+
+  // `userId` alone never reaches the Custom-LLM request the backend relay
+  // serves, so the relay cannot identify the caller and rejects the turn.
+  // `customLlmExtraBody` is the field that carries it there.
+  it('carries the relay token in customLlmExtraBody, not only in userId', async () => {
+    mockFetch.mockResolvedValueOnce({ signedUrl: 'wss://x', agentId: 'a1', userToken: 'tok-9' });
+    const { result } = renderHook(() => useRealtimeVoiceSession());
+    await act(async () => {
+      await result.current.start();
+    });
+    expect(startSession).toHaveBeenCalledWith(
+      expect.objectContaining({ customLlmExtraBody: { user: 'tok-9' } })
+    );
   });
 
   it('falls back to the default mascot voice id', async () => {

--- a/app/src/features/human/voice/useRealtimeVoiceSession.ts
+++ b/app/src/features/human/voice/useRealtimeVoiceSession.ts
@@ -76,12 +76,23 @@ export function useRealtimeVoiceSession(opts?: { voiceId?: string }): RealtimeVo
     try {
       const { signedUrl, userToken } = await fetchVoiceAgentSignedUrl();
       log('start: signed url acquired, opening session');
-      // `userId` is the identity binding the backend relay verifies (#5399);
-      // ElevenLabs forwards it as the Custom-LLM `user` field.
+      // `userId` is the identity binding the backend relay verifies (#5399).
+      //
+      // It rides the conversation-init event as `user_id`, but the provider does
+      // not put it on the Custom-LLM request body: a live capture of
+      // `POST /voice-agent/chat/completions` carried only
+      // [messages, model, max_tokens, stream, stream_options, temperature, tools],
+      // so every relayed turn was rejected for having no identity.
+      //
+      // `customLlmExtraBody` does reach that request — forwarded under an
+      // `elevenlabs_extra_body` key rather than merged into the top level, which
+      // is where the relay looks for it. `userId` stays for provider-side
+      // attribution.
       conversation.startSession({
         signedUrl,
         connectionType: 'websocket',
         userId: userToken,
+        customLlmExtraBody: { user: userToken },
         overrides: { tts: { voiceId: opts?.voiceId ?? MASCOT_VOICE_ID } },
       });
     } catch (err) {


### PR DESCRIPTION
## Summary

- Send the signed voice-relay identity token via `customLlmExtraBody` so it
  actually reaches the backend relay; `userId` alone never did.
- Unit test pinning that the token travels in `customLlmExtraBody`, not only in
  `userId`.

## Problem

A realtime voice session passed the relay token only as `startSession({ userId })`.
The provider puts that on its own conversation-init event, but it does not place
it on the Custom-LLM request it makes to our relay. A capture of a live
`POST /voice-agent/chat/completions` carried only:

```
[messages, model, max_tokens, stream, stream_options, temperature, tools]
```

No `user`, no `user_id`. The relay could not identify the caller, rejected the
turn with `400 request is missing the user token`, and the desktop agent was
never asked to answer — the session connected, listened, and stayed silent.

## Solution

Pass the same token through `customLlmExtraBody`, which does reach the
Custom-LLM request. The provider forwards it nested under an
`elevenlabs_extra_body` key rather than merging it into the top level, and the
relay reads that shape (backend PR below). `userId` is left in place for
provider-side attribution, so nothing about the session binding changes.

Confirmed end to end against a live agent: with this change the relay logs
`AUTH OK` and dispatches to the desktop, where the orchestrator runs the turn.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — the existing session-start test now asserts `customLlmExtraBody`, plus a dedicated case covering the token-delivery contract on its own. Failure paths for this hook (signed-URL rejection, SDK `onError`, disconnect) are already covered in the same suite.
- [x] **Diff coverage ≥ 80%** — both changed lines are inside `startSession`, exercised by every passing case in `useRealtimeVoiceSession.test.ts` (9 passing).
- [x] Coverage matrix updated — `N/A: behaviour-only fix inside an already-listed surface (5.1.x Voice)`; no feature row added, removed, or renamed.
- [x] No new external network dependencies introduced — the ElevenLabs SDK is already a dependency; this only adds a field to an existing call.
- [x] Manual smoke checklist updated — `N/A: realtime voice ships dark behind VITE_VOICE_MODE and is not on a release-cut surface.`
- [x] Linked issue closed via `Closes #NNN` — see `## Related`.

## Impact

Desktop only, and only the realtime voice mode, which is gated behind
`VITE_VOICE_MODE` plus the persisted `mascot.voiceMode` and ships off by
default. No change to the classic turn-based voice path.

Security: the value sent is the same short-lived, purpose-scoped relay token
already passed as `userId` — no new secret leaves the client, and the relay
still verifies the signature rather than trusting any id in the payload.

Ordering: the backend accepts the token from both the top level and
`elevenlabs_extra_body`, so the two changes are independent and this can merge
in either order.

## Related

Depends on tinyhumansai/backend#1230 (relay reads the nested field and keeps the
stream alive while the desktop turn runs).

Follow-up to #5407 / #5399 (ElevenLabs Voice Agents).
