### PR TITLE
feat: show in-app web apps only to already-connected users

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -10,6 +10,7 @@ import {
 import { PersistGate } from 'redux-persist/integration/react';
 
 import AppRoutes from './AppRoutes';
+import WebAppsSunsetNotice from './components/accounts/WebAppsSunsetNotice';
 import WebviewHost from './components/accounts/WebviewHost';
 import { AnalyticsPageTracker } from './components/analytics';
 import AnnouncementGate from './components/Announcement/AnnouncementGate';
@@ -299,6 +300,9 @@ export function AppShellDesktop() {
           Only renders for users whose embeddings actually bill against the
           managed budget. */}
       <MemoryEmbeddingBudgetBanner />
+      {/* #5423: in-app web apps are being removed after 31 August 2026. The
+          notice shows only to users who already connected at least one app. */}
+      <WebAppsSunsetNotice />
       <AppRoutes location={baseLocation} />
       {activeProviderAccount && !accountsOverlayOpen && (
         <div className="absolute inset-0 z-30">

--- a/app/src/components/OpenhumanLinkModal.tsx
+++ b/app/src/components/OpenhumanLinkModal.tsx
@@ -448,8 +448,7 @@ const AccountsSetupBody = ({ close }: { close: () => void }) => {
 
   // #5423 — the in-app web-apps feature is being removed after 31 August 2026.
   // Only apps the user already connected are listed here; connecting a new one
-  // is no longer offered. A user with none connected sees just the removal
-  // notice below.
+  // is no longer offered.
   const connectedDescriptors = useMemo(
     () =>
       ACCOUNTS_SETUP_PROVIDERS.map(id => PROVIDERS.find(p => p.id === id)).filter(
@@ -457,6 +456,15 @@ const AccountsSetupBody = ({ close }: { close: () => void }) => {
       ),
     [accountByProvider]
   );
+
+  // A user with no web apps connected must see no trace of the feature. The
+  // `accounts/setup` deep link stays reachable (old chat/onboarding pills can
+  // still dispatch it), so for a never-connected user this step is a no-op that
+  // simply closes rather than surfacing the removal notice.
+  const hasConnectedApps = order.length > 0;
+  useEffect(() => {
+    if (!hasConnectedApps) close();
+  }, [hasConnectedApps, close]);
 
   const handleDisconnect = (providerId: AccountProvider) => {
     const existing = accountByProvider.get(providerId);
@@ -466,6 +474,8 @@ const AccountsSetupBody = ({ close }: { close: () => void }) => {
   };
 
   const doneLabel = t('app.openhumanLink.accounts.done');
+
+  if (!hasConnectedApps) return null;
 
   return (
     <div className="space-y-4 text-sm text-content-secondary">

--- a/app/src/components/OpenhumanLinkModal.tsx
+++ b/app/src/components/OpenhumanLinkModal.tsx
@@ -21,7 +21,7 @@ import {
   showNativeNotification,
 } from '../lib/nativeNotifications/tauriBridge';
 import { isTauri, purgeWebviewAccount } from '../services/webviewAccountService';
-import { addAccount, removeAccount, setActiveAccount } from '../store/accountsSlice';
+import { removeAccount } from '../store/accountsSlice';
 import { useAppDispatch, useAppSelector } from '../store/hooks';
 import {
   type Account,
@@ -408,18 +408,6 @@ const ACCOUNTS_SETUP_PROVIDERS: readonly AccountProvider[] = [
   'linkedin',
 ];
 
-function makeAccountId(): string {
-  const c = globalThis.crypto;
-  if (c && typeof c.randomUUID === 'function') return c.randomUUID();
-  if (c && typeof c.getRandomValues === 'function') {
-    const bytes = new Uint8Array(4);
-    c.getRandomValues(bytes);
-    const suffix = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
-    return `acct-${Date.now().toString(36)}-${suffix}`;
-  }
-  return `acct-${Date.now().toString(36)}`;
-}
-
 /**
  * Translation key + color for a given account lifecycle status. Returns a
  * `labelKey` (not a literal) so the caller can localize it via `useT()` —
@@ -448,10 +436,6 @@ const AccountsSetupBody = ({ close }: { close: () => void }) => {
   const accountsById = useAppSelector(s => s.accounts.accounts);
   const order = useAppSelector(s => s.accounts.order);
 
-  // Track accounts added during this modal session so "Done" can navigate.
-  // Uses state (not ref) so the CTA label re-renders when toggles change.
-  const [newlyAdded, setNewlyAdded] = useState<Map<string, string>>(new Map());
-
   // Map provider → first existing account (one provider, one row).
   const accountByProvider = useMemo(() => {
     const map = new Map<AccountProvider, Account>();
@@ -462,103 +446,79 @@ const AccountsSetupBody = ({ close }: { close: () => void }) => {
     return map;
   }, [accountsById, order]);
 
-  const providerDescriptors = useMemo(
+  // #5423 — the in-app web-apps feature is being removed after 31 August 2026.
+  // Only apps the user already connected are listed here; connecting a new one
+  // is no longer offered. A user with none connected sees just the removal
+  // notice below.
+  const connectedDescriptors = useMemo(
     () =>
       ACCOUNTS_SETUP_PROVIDERS.map(id => PROVIDERS.find(p => p.id === id)).filter(
-        Boolean
-      ) as typeof PROVIDERS,
-    []
+        (p): p is (typeof PROVIDERS)[number] => p !== undefined && accountByProvider.has(p.id)
+      ),
+    [accountByProvider]
   );
 
-  const handleToggle = (providerId: AccountProvider, label: string, currentlyOn: boolean) => {
-    if (currentlyOn) {
-      const existing = accountByProvider.get(providerId);
-      if (!existing) return;
-      void purgeWebviewAccount(existing.id).catch(() => {});
-      setNewlyAdded(prev => {
-        const next = new Map(prev);
-        next.delete(existing.id);
-        return next;
-      });
-      dispatch(removeAccount({ accountId: existing.id }));
-      return;
-    }
-    const acct: Account = {
-      id: makeAccountId(),
-      provider: providerId,
-      label,
-      createdAt: new Date().toISOString(),
-      status: 'pending',
-    };
-    setNewlyAdded(prev => new Map(prev).set(acct.id, label));
-    dispatch(addAccount(acct));
+  const handleDisconnect = (providerId: AccountProvider) => {
+    const existing = accountByProvider.get(providerId);
+    if (!existing) return;
+    void purgeWebviewAccount(existing.id).catch(() => {});
+    dispatch(removeAccount({ accountId: existing.id }));
   };
 
-  const handleDone = () => {
-    close();
-    // Activate the first newly-added account so the shell-level WebviewHost
-    // opens the auth flow immediately without mutating the current route.
-    const firstNew = [...newlyAdded.keys()][0];
-    if (firstNew) {
-      dispatch(setActiveAccount(firstNew));
-    }
-  };
-
-  // Dynamic CTA based on what's been toggled on
-  const firstNewLabel = [...newlyAdded.values()][0];
-  const doneLabel = firstNewLabel
-    ? t('app.openhumanLink.accounts.continueWith').replace('{label}', firstNewLabel)
-    : t('app.openhumanLink.accounts.done');
+  const doneLabel = t('app.openhumanLink.accounts.done');
 
   return (
     <div className="space-y-4 text-sm text-content-secondary">
-      <p>{t('app.openhumanLink.accounts.intro')}</p>
-      <div className="space-y-2">
-        {providerDescriptors.map(p => {
-          const acct = accountByProvider.get(p.id);
-          const on = !!acct;
-          const status = acct?.status;
-          return (
-            <div
-              key={p.id}
-              className="flex items-center gap-3 rounded-xl border border-line-subtle bg-surface p-3">
-              <ProviderIcon provider={p.id} className="h-5 w-5 flex-none" />
-              <div className="min-w-0 flex-1">
-                <div className="text-sm font-medium text-content">{p.label}</div>
-                {on && status ? (
-                  <div className="flex items-center gap-1.5">
-                    <span
-                      className={`inline-block h-1.5 w-1.5 rounded-full ${statusDisplay(status).dotClass}`}
-                    />
-                    <span className="text-xs text-content-muted">
-                      {t(statusDisplay(status).labelKey)}
-                    </span>
-                  </div>
-                ) : (
-                  <p className="line-clamp-1 text-xs text-content-muted">{p.description}</p>
-                )}
-              </div>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={on}
-                aria-label={`${on ? t('skills.disconnect') : t('skills.connect')} ${p.label}`}
-                onClick={() => handleToggle(p.id, p.label, on)}
-                className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors ${
-                  on ? 'bg-primary-500' : 'bg-surface-strong'
-                }`}>
-                <span
-                  className={`inline-block h-5 w-5 transform rounded-full bg-surface shadow transition-transform ${
-                    on ? 'translate-x-5' : 'translate-x-0.5'
-                  }`}
-                />
-              </button>
-            </div>
-          );
-        })}
+      <div
+        data-testid="openhuman-link-webapps-sunset"
+        className="rounded-xl border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-500/15">
+        <p className="text-xs font-medium text-blue-700 dark:text-blue-300">
+          {t('webAppsSunset.title')}
+        </p>
+        <p className="text-xs text-blue-600 dark:text-blue-300">{t('webAppsSunset.message')}</p>
       </div>
+      {connectedDescriptors.length > 0 && (
+        <div className="space-y-2">
+          {connectedDescriptors.map(p => {
+            const status = accountByProvider.get(p.id)?.status;
+            return (
+              <div
+                key={p.id}
+                className="flex items-center gap-3 rounded-xl border border-line-subtle bg-surface p-3">
+                <ProviderIcon provider={p.id} className="h-5 w-5 flex-none" />
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-medium text-content">{p.label}</div>
+                  {status ? (
+                    <div className="flex items-center gap-1.5">
+                      <span
+                        className={`inline-block h-1.5 w-1.5 rounded-full ${statusDisplay(status).dotClass}`}
+                      />
+                      <span className="text-xs text-content-muted">
+                        {t(statusDisplay(status).labelKey)}
+                      </span>
+                    </div>
+                  ) : (
+                    <p className="line-clamp-1 text-xs text-content-muted">{p.description}</p>
+                  )}
+                </div>
+                {/* Only disconnect is offered — the feature is being removed, so
+                    re-adding a service is intentionally not possible here. */}
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={true}
+                  aria-label={`${t('skills.disconnect')} ${p.label}`}
+                  onClick={() => handleDisconnect(p.id)}
+                  className="relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full bg-primary-500 transition-colors">
+                  <span className="inline-block h-5 w-5 translate-x-5 transform rounded-full bg-surface shadow transition-transform" />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
       <p className="text-xs text-content-faint">{t('app.openhumanLink.accounts.webviewNote')}</p>
-      <DoneFooter close={close} onDone={handleDone} doneLabel={doneLabel} />
+      <DoneFooter close={close} onDone={close} doneLabel={doneLabel} />
     </div>
   );
 };

--- a/app/src/components/__tests__/OpenhumanLinkModal.accounts.test.tsx
+++ b/app/src/components/__tests__/OpenhumanLinkModal.accounts.test.tsx
@@ -35,6 +35,18 @@ function createStore() {
   });
 }
 
+function seedAccount(
+  store: ReturnType<typeof createStore>,
+  provider: string,
+  status: string,
+  id = `test-${provider}`
+) {
+  store.dispatch({
+    type: 'accounts/addAccount',
+    payload: { id, provider, label: provider, createdAt: new Date().toISOString(), status },
+  });
+}
+
 function renderModal(store = createStore()) {
   return {
     store,
@@ -56,77 +68,68 @@ function openAccountsModal() {
   });
 }
 
-describe('OpenhumanLinkModal accounts setup', () => {
+describe('OpenhumanLinkModal accounts setup (sunset, #5423)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('renders provider toggles when accounts/setup path is opened', () => {
+  it('shows the removal notice when the accounts step opens', () => {
     renderModal();
     openAccountsModal();
 
-    expect(screen.getByLabelText('Connect WhatsApp Web')).toBeInTheDocument();
-    expect(screen.getByLabelText('Connect WeChat Web')).toBeInTheDocument();
-    expect(screen.getByLabelText('Connect Telegram Web')).toBeInTheDocument();
-    expect(screen.getByLabelText('Connect Slack')).toBeInTheDocument();
-    expect(screen.getByLabelText('Connect Discord')).toBeInTheDocument();
-    expect(screen.getByLabelText('Connect LinkedIn')).toBeInTheDocument();
+    expect(screen.getByTestId('openhuman-link-webapps-sunset')).toBeInTheDocument();
   });
 
-  it('toggle ON adds account to Redux store', () => {
-    const { store } = renderModal();
+  it('does not offer to connect a provider the user has not already connected', () => {
+    renderModal();
     openAccountsModal();
 
-    fireEvent.click(screen.getByLabelText('Connect Telegram Web'));
-
-    const state = store.getState().accounts;
-    const telegramAccount = Object.values(state.accounts).find(a => a.provider === 'telegram');
-    expect(telegramAccount).toBeDefined();
-    expect(telegramAccount!.status).toBe('pending');
+    // The add path is gone: no "Connect X" toggles for un-connected providers,
+    // so a user cannot pick up a service they were not already using.
+    expect(screen.queryByLabelText('Connect WhatsApp Web')).toBeNull();
+    expect(screen.queryByLabelText('Connect Telegram Web')).toBeNull();
+    expect(screen.queryByLabelText('Connect Discord')).toBeNull();
   });
 
-  it('toggle OFF removes account from Redux store', () => {
-    const { store } = renderModal();
+  it('lists an already-connected app with a disconnect control', () => {
+    const store = createStore();
+    seedAccount(store, 'telegram', 'open');
+    renderModal(store);
     openAccountsModal();
 
-    // Toggle ON
-    fireEvent.click(screen.getByLabelText('Connect Telegram Web'));
-    expect(Object.values(store.getState().accounts.accounts)).toHaveLength(1);
+    // The connected app is shown (by its catalog label) and can be disconnected.
+    expect(screen.getByLabelText('Disconnect Telegram Web')).toBeInTheDocument();
+  });
 
-    // Toggle OFF
+  it('disconnect removes the connected account from the store', () => {
+    const store = createStore();
+    seedAccount(store, 'telegram', 'open');
+    renderModal(store);
+    openAccountsModal();
+
     fireEvent.click(screen.getByLabelText('Disconnect Telegram Web'));
     expect(Object.values(store.getState().accounts.accounts)).toHaveLength(0);
   });
 
-  it('Done button sets first new account as active without navigating', () => {
-    const { store } = renderModal();
+  it('shows a status indicator for a connected account', () => {
+    const store = createStore();
+    seedAccount(store, 'telegram', 'open');
+    renderModal(store);
     openAccountsModal();
 
-    // Toggle two providers ON
-    fireEvent.click(screen.getByLabelText('Connect Telegram Web'));
-    fireEvent.click(screen.getByLabelText('Connect Slack'));
-
-    const accountIds = store.getState().accounts.order;
-    expect(accountIds).toHaveLength(2);
-
-    // Click the CTA (dynamic label: "Continue with Telegram Web sign-in")
-    fireEvent.click(screen.getByRole('button', { name: /Continue with Telegram Web sign-in/ }));
-
-    expect(store.getState().accounts.activeAccountId).toBe(accountIds[0]);
-    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(screen.getByText('Connected')).toBeInTheDocument();
   });
 
-  it('Skip button closes modal without navigating', () => {
-    renderModal();
+  it('shows "Needs sign-in" for an account with pending status', () => {
+    const store = createStore();
+    seedAccount(store, 'slack', 'pending');
+    renderModal(store);
     openAccountsModal();
 
-    fireEvent.click(screen.getByLabelText('Connect Telegram Web'));
-    fireEvent.click(screen.getByRole('button', { name: 'Skip for now' }));
-
-    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(screen.getByText('Needs sign-in')).toBeInTheDocument();
   });
 
-  it('Done without any new toggles does not navigate', () => {
+  it('Done closes the modal without navigating', () => {
     renderModal();
     openAccountsModal();
 
@@ -134,70 +137,11 @@ describe('OpenhumanLinkModal accounts setup', () => {
     expect(mockNavigate).not.toHaveBeenCalled();
   });
 
-  it('shows dynamic CTA label when a provider is toggled on', () => {
+  it('Skip closes the modal without navigating', () => {
     renderModal();
     openAccountsModal();
 
-    // Before toggling, button says "Done"
-    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument();
-
-    // Toggle Discord on
-    fireEvent.click(screen.getByLabelText('Connect Discord'));
-
-    // CTA should now reference Discord
-    expect(
-      screen.getByRole('button', { name: /Continue with Discord sign-in/ })
-    ).toBeInTheDocument();
-  });
-
-  it('shows status indicator for existing accounts with a status', () => {
-    const store = createStore();
-    // Pre-populate an account with 'open' status
-    store.dispatch({
-      type: 'accounts/addAccount',
-      payload: {
-        id: 'test-acct-1',
-        provider: 'telegram',
-        label: 'Telegram',
-        createdAt: new Date().toISOString(),
-        status: 'open',
-      },
-    });
-
-    render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <OpenhumanLinkModal />
-        </MemoryRouter>
-      </Provider>
-    );
-    openAccountsModal();
-
-    expect(screen.getByText('Connected')).toBeInTheDocument();
-  });
-
-  it('shows "Needs sign-in" for accounts with pending status', () => {
-    const store = createStore();
-    store.dispatch({
-      type: 'accounts/addAccount',
-      payload: {
-        id: 'test-acct-2',
-        provider: 'slack',
-        label: 'Slack',
-        createdAt: new Date().toISOString(),
-        status: 'pending',
-      },
-    });
-
-    render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <OpenhumanLinkModal />
-        </MemoryRouter>
-      </Provider>
-    );
-    openAccountsModal();
-
-    expect(screen.getByText('Needs sign-in')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Skip for now' }));
+    expect(mockNavigate).not.toHaveBeenCalled();
   });
 });

--- a/app/src/components/__tests__/OpenhumanLinkModal.accounts.test.tsx
+++ b/app/src/components/__tests__/OpenhumanLinkModal.accounts.test.tsx
@@ -73,21 +73,35 @@ describe('OpenhumanLinkModal accounts setup (sunset, #5423)', () => {
     vi.clearAllMocks();
   });
 
-  it('shows the removal notice when the accounts step opens', () => {
-    renderModal();
+  it('shows the removal notice for a user with connected web apps', () => {
+    const store = createStore();
+    seedAccount(store, 'telegram', 'open');
+    renderModal(store);
     openAccountsModal();
 
     expect(screen.getByTestId('openhuman-link-webapps-sunset')).toBeInTheDocument();
   });
 
-  it('does not offer to connect a provider the user has not already connected', () => {
+  it('renders no trace of the feature for a user with no connected apps (#5423)', () => {
     renderModal();
+    openAccountsModal();
+
+    // The accounts/setup deep link stays reachable (old pills can dispatch it),
+    // but a never-connected user must see nothing of the retired feature — the
+    // step is a no-op with no notice and no controls.
+    expect(screen.queryByTestId('openhuman-link-webapps-sunset')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Done' })).toBeNull();
+  });
+
+  it('does not offer to connect a provider the user has not already connected', () => {
+    const store = createStore();
+    seedAccount(store, 'telegram', 'open');
+    renderModal(store);
     openAccountsModal();
 
     // The add path is gone: no "Connect X" toggles for un-connected providers,
     // so a user cannot pick up a service they were not already using.
     expect(screen.queryByLabelText('Connect WhatsApp Web')).toBeNull();
-    expect(screen.queryByLabelText('Connect Telegram Web')).toBeNull();
     expect(screen.queryByLabelText('Connect Discord')).toBeNull();
   });
 
@@ -130,7 +144,9 @@ describe('OpenhumanLinkModal accounts setup (sunset, #5423)', () => {
   });
 
   it('Done closes the modal without navigating', () => {
-    renderModal();
+    const store = createStore();
+    seedAccount(store, 'telegram', 'open');
+    renderModal(store);
     openAccountsModal();
 
     fireEvent.click(screen.getByRole('button', { name: 'Done' }));
@@ -138,7 +154,9 @@ describe('OpenhumanLinkModal accounts setup (sunset, #5423)', () => {
   });
 
   it('Skip closes the modal without navigating', () => {
-    renderModal();
+    const store = createStore();
+    seedAccount(store, 'telegram', 'open');
+    renderModal(store);
     openAccountsModal();
 
     fireEvent.click(screen.getByRole('button', { name: 'Skip for now' }));

--- a/app/src/components/accounts/WebAppsSunsetNotice.test.tsx
+++ b/app/src/components/accounts/WebAppsSunsetNotice.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import WebAppsSunsetNotice from './WebAppsSunsetNotice';
+
+let mockState = { accounts: { order: [] as string[] } };
+
+vi.mock('../../lib/i18n/I18nContext', () => ({ useT: () => ({ t: (k: string) => k }) }));
+vi.mock('../../store/hooks', () => ({
+  useAppSelector: (sel: (state: typeof mockState) => unknown) => sel(mockState),
+}));
+
+describe('WebAppsSunsetNotice', () => {
+  beforeEach(() => {
+    mockState = { accounts: { order: [] } };
+  });
+
+  it('renders nothing when the user has no connected web apps (#5423)', () => {
+    mockState = { accounts: { order: [] } };
+    render(<WebAppsSunsetNotice />);
+
+    // A user who never connected an app must see no trace of the feature.
+    expect(screen.queryByTestId('web-apps-sunset-notice')).toBeNull();
+  });
+
+  it('shows the removal notice when the user has connected web apps (#5423)', () => {
+    mockState = { accounts: { order: ['acct-whatsapp'] } };
+    render(<WebAppsSunsetNotice />);
+
+    expect(screen.getByTestId('web-apps-sunset-notice')).toBeInTheDocument();
+    expect(screen.getByText('webAppsSunset.title')).toBeInTheDocument();
+    expect(screen.getByText('webAppsSunset.message')).toBeInTheDocument();
+  });
+
+  it('is not dismissible — no dismiss control is rendered (#5423)', () => {
+    mockState = { accounts: { order: ['acct-whatsapp'] } };
+    render(<WebAppsSunsetNotice />);
+
+    // The deadline is fixed, so the notice must stay put rather than be silenced.
+    expect(screen.queryByRole('button', { name: 'common.dismiss' })).toBeNull();
+  });
+});

--- a/app/src/components/accounts/WebAppsSunsetNotice.tsx
+++ b/app/src/components/accounts/WebAppsSunsetNotice.tsx
@@ -1,0 +1,38 @@
+/**
+ * In-app web-apps removal notice (#5423).
+ *
+ * Shell-mounted beside the other content-top banners so it reaches users on
+ * whatever screen they are on. Shown only to users who already have at least
+ * one web app connected — a user with none connected sees no trace of the
+ * feature at all (the "Add apps" affordance is gone from {@link
+ * SidebarAppRail}), so a notice for them would advertise a feature they never
+ * had.
+ *
+ * Non-dismissible on purpose: the feature is going away on a fixed date, so the
+ * notice must stay visible until then rather than being silenced once.
+ */
+import { useT } from '../../lib/i18n/I18nContext';
+import { useAppSelector } from '../../store/hooks';
+import UpsellBanner from '../upsell/UpsellBanner';
+
+export default function WebAppsSunsetNotice() {
+  const { t } = useT();
+  // `order` holds only real provider accounts (the agent tile is virtual and
+  // never enters the store), so a non-empty order means the user has connected
+  // at least one web app.
+  const hasConnectedApps = useAppSelector(state => state.accounts.order.length > 0);
+
+  if (!hasConnectedApps) return null;
+
+  return (
+    <div className="relative z-20" data-testid="web-apps-sunset-notice">
+      <UpsellBanner
+        variant="info"
+        title={t('webAppsSunset.title')}
+        message={t('webAppsSunset.message')}
+        rounded={false}
+        dismissible={false}
+      />
+    </div>
+  );
+}

--- a/app/src/components/layout/shell/SidebarAppRail.test.tsx
+++ b/app/src/components/layout/shell/SidebarAppRail.test.tsx
@@ -81,21 +81,38 @@ describe('SidebarAppRail', () => {
     });
   });
 
-  it('shows the "Add apps" label when no provider apps are connected', () => {
-    setAccounts([]);
-    renderRail('/chat');
-
-    const addButton = screen.getByTestId('accounts-add-button');
-    expect(addButton).toHaveTextContent('accounts.addApps');
-  });
-
-  it('collapses the add button to an icon once an app is connected', () => {
+  it('offers no way to add a new app — the feature is being removed (#5423)', () => {
     setAccounts(['acct-whatsapp']);
     renderRail('/chat');
 
-    const addButton = screen.getByTestId('accounts-add-button');
-    expect(addButton).not.toHaveTextContent('accounts.addApps');
-    expect(addButton).toHaveAttribute('aria-label', 'accounts.addApps');
+    // The "Add apps" button and its label are gone: a user can no longer pick
+    // up a service they were not already using.
+    expect(screen.queryByTestId('accounts-add-button')).toBeNull();
+    expect(screen.queryByText('accounts.addApps')).toBeNull();
+  });
+
+  it('shows only the agent tile when no apps are connected — no trace of the feature (#5423)', () => {
+    setAccounts([]);
+    renderRail('/chat');
+
+    // The agent tile is core chat and stays; there are no provider tiles and no
+    // add affordance, so a user who never connected an app sees nothing of it.
+    expect(screen.getByRole('button', { name: 'accounts.agent' })).toBeInTheDocument();
+    expect(screen.queryByTestId('accounts-add-button')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'WhatsApp' })).toBeNull();
+  });
+
+  it('still lets a connected app be reconnected by selecting its tile (#5423)', () => {
+    setAccounts(['acct-whatsapp']);
+    renderRail('/chat');
+
+    // Selecting an already-connected app re-activates it (reconnect path), which
+    // must keep working after the add path is removed.
+    fireEvent.click(screen.getByRole('button', { name: 'WhatsApp' }));
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: 'accounts/setActiveAccount',
+      payload: 'acct-whatsapp',
+    });
   });
 
   it('drops the account from state synchronously on disconnect, before the async purge (#4695)', () => {

--- a/app/src/components/layout/shell/SidebarAppRail.tsx
+++ b/app/src/components/layout/shell/SidebarAppRail.tsx
@@ -6,31 +6,17 @@ import { useT } from '../../../lib/i18n/I18nContext';
 import { trackEvent } from '../../../services/analytics';
 import { purgeWebviewAccount } from '../../../services/webviewAccountService';
 import {
-  addAccount,
   removeAccount,
   setAccountsOverlayOpen,
   setActiveAccount,
   setLastActiveAccount,
 } from '../../../store/accountsSlice';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
-import type { Account, AccountProvider, ProviderDescriptor } from '../../../types/accounts';
+import type { Account } from '../../../types/accounts';
 import { AGENT_ACCOUNT_ID as AGENT_ID } from '../../../utils/accountsFullscreen';
-import AddAccountModal from '../../accounts/AddAccountModal';
 import { AgentIcon, ProviderIcon } from '../../accounts/providerIcons';
 
 const debug = debugFactory('layout:sidebar-app-rail');
-
-function makeAccountId(): string {
-  const c = globalThis.crypto;
-  if (c && typeof c.randomUUID === 'function') return c.randomUUID();
-  if (c && typeof c.getRandomValues === 'function') {
-    const bytes = new Uint8Array(4);
-    c.getRandomValues(bytes);
-    const suffix = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
-    return `acct-${Date.now().toString(36)}-${suffix}`;
-  }
-  return `acct-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
-}
 
 interface RailButtonProps {
   active: boolean;
@@ -82,11 +68,19 @@ interface ContextMenuState {
 }
 
 /**
- * The persistent app rail (agent + connected provider apps + add button),
- * rendered directly in {@link AppSidebar} so it sticks regardless of the active
- * route. Selecting an app sets the active account in Redux and navigates to the
- * chat surface, where the provider webview is composited; the rail itself never
- * unmounts as the user moves between pages.
+ * The persistent app rail (agent + connected provider apps), rendered directly
+ * in {@link AppSidebar} so it sticks regardless of the active route. Selecting
+ * an app sets the active account in Redux and navigates to the chat surface,
+ * where the provider webview is composited; the rail itself never unmounts as
+ * the user moves between pages.
+ *
+ * Issue #5423 — the in-app web-apps feature is being removed from the app after
+ * 31 August 2026. New connections are no longer offered (the "Add apps" button
+ * is gone), so the rail only ever shows apps a user already connected. A user
+ * with none connected sees just the agent tile — no trace of the feature. Apps
+ * already connected keep working and can be reconnected (select the tile) or
+ * disconnected (right-click). The removal notice lives in {@link
+ * WebAppsSunsetNotice}, mounted in the shell.
  */
 export default function SidebarAppRail() {
   const { t } = useT();
@@ -97,7 +91,6 @@ export default function SidebarAppRail() {
   const order = useAppSelector(state => state.accounts.order);
   const activeAccountId = useAppSelector(state => state.accounts.activeAccountId);
   const unreadByAccount = useAppSelector(state => state.accounts.unread);
-  const [addOpen, setAddOpen] = useState(false);
   const [ctxMenu, setCtxMenu] = useState<ContextMenuState | null>(null);
 
   const accounts: Account[] = useMemo(
@@ -105,25 +98,14 @@ export default function SidebarAppRail() {
     [order, accountsById]
   );
 
-  const connectedProviders = useMemo(
-    () => new Set<AccountProvider>(accounts.map(a => a.provider)),
-    [accounts]
-  );
-
   const selectedId = activeAccountId ?? AGENT_ID;
   const isAgentSelected = selectedId === AGENT_ID;
 
-  // New-user affordance: when no provider apps are connected yet, the lone
-  // dashed "+" tile reads as ambiguous. Expand it into a labelled "Add apps"
-  // pill so first-run users understand they can connect more apps; once at
-  // least one app is connected, collapse back to the compact icon to reclaim
-  // horizontal space in the rail.
-  const showAddLabel = accounts.length === 0;
-
-  // The chat page hides its active provider webview while a rail overlay is
-  // open (the native CEF view composites above HTML, so React overlays would be
-  // painted over). Mirror local overlay state into Redux for it to read.
-  const overlayOpen = addOpen || ctxMenu !== null;
+  // The chat page hides its active provider webview while a rail overlay (the
+  // right-click context menu) is open — the native CEF view composites above
+  // HTML, so React overlays would be painted over. Mirror overlay state into
+  // Redux for it to read.
+  const overlayOpen = ctxMenu !== null;
   useEffect(() => {
     dispatch(setAccountsOverlayOpen(overlayOpen));
   }, [overlayOpen, dispatch]);
@@ -136,24 +118,6 @@ export default function SidebarAppRail() {
     if (!onChat) {
       navigate('/chat');
     }
-  };
-
-  const handlePickProvider = (p: ProviderDescriptor) => {
-    setAddOpen(false);
-    trackEvent('account_connect_start', { provider: p.id });
-    const id = makeAccountId();
-    const acct: Account = {
-      id,
-      provider: p.id,
-      label: p.label,
-      createdAt: new Date().toISOString(),
-      status: 'pending',
-    };
-    dispatch(addAccount(acct));
-    dispatch(setActiveAccount(id));
-    // Issue #1233 — record this real-account selection in the persisted MRU
-    // pointer so the next session can prewarm it.
-    dispatch(setLastActiveAccount(id));
   };
 
   const selectAgent = () => {
@@ -256,39 +220,7 @@ export default function SidebarAppRail() {
             <ProviderIcon provider={acct.provider} className="h-5 w-5 rounded" />
           </RailButton>
         ))}
-
-        <button
-          type="button"
-          onClick={() => {
-            trackEvent('tauri_browser_click', {
-              surface: 'sidebar_app_rail',
-              action: 'open_add_account',
-              provider: 'none',
-            });
-            setAddOpen(true);
-          }}
-          data-analytics-id="sidebar-app-rail-add-account"
-          data-testid="accounts-add-button"
-          className={`group relative flex h-9 flex-none items-center justify-center gap-1.5 rounded-xl border border-dashed border-line-strong text-content-faint transition-colors hover:bg-surface-hover hover:text-content-secondary ${
-            showAddLabel ? 'w-auto px-2.5' : 'w-9'
-          }`}
-          aria-label={t('accounts.addApps')}
-          title={t('accounts.addApps')}>
-          <svg className="h-4 w-4 flex-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
-          {showAddLabel && (
-            <span className="whitespace-nowrap text-xs font-medium">{t('accounts.addApps')}</span>
-          )}
-        </button>
       </div>
-
-      <AddAccountModal
-        open={addOpen}
-        onClose={() => setAddOpen(false)}
-        onPick={handlePickProvider}
-        connectedProviders={connectedProviders}
-      />
 
       {ctxMenu && (
         <div

--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -7039,6 +7039,9 @@ const messages: TranslationMap = {
   'memoryBudget.exhaustedMessage':
     'انتهت ميزانية التضمينات لديك، لذلك لم يعد المحتوى الجديد يُضاف إلى الذاكرة. أعدّ تضمينات محلية أو أضف مفتاح API الخاص بك للمتابعة.',
   'memoryBudget.cta': 'إعداد التضمينات',
+  'webAppsSunset.title': 'يتم إيقاف تطبيقات الويب داخل التطبيق',
+  'webAppsSunset.message':
+    'ستتم إزالة تطبيقات الويب المتصلة من التطبيق بعد 31 أغسطس 2026. نعتذر عن الإزعاج.',
   'userErrors.scope.memory': 'الذاكرة',
   // Agent World: Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'المبلغ',

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -7198,6 +7198,9 @@ const messages: TranslationMap = {
   'memoryBudget.exhaustedMessage':
     'আপনার এমবেডিং বাজেট শেষ, তাই নতুন কনটেন্ট আর মেমরিতে যুক্ত হচ্ছে না। আবার শুরু করতে লোকাল এমবেডিং সেট আপ করুন বা নিজের API কী যোগ করুন।',
   'memoryBudget.cta': 'এমবেডিং সেট আপ করুন',
+  'webAppsSunset.title': 'অ্যাপের ভেতরের ওয়েব অ্যাপগুলো সরিয়ে নেওয়া হচ্ছে',
+  'webAppsSunset.message':
+    'আপনার সংযুক্ত ওয়েব অ্যাপগুলো ৩১ আগস্ট ২০২৬-এর পর অ্যাপ থেকে সরিয়ে ফেলা হবে। অসুবিধার জন্য দুঃখিত।',
   'userErrors.scope.memory': 'মেমরি',
   // Agent World: Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'পরিমাণ',

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -7401,6 +7401,9 @@ const messages: TranslationMap = {
   'memoryBudget.exhaustedMessage':
     'Dein Embedding-Budget ist aufgebraucht, daher werden keine neuen Inhalte mehr ins Gedächtnis aufgenommen. Richte lokale Embeddings ein oder hinterlege deinen eigenen API-Schlüssel, um fortzufahren.',
   'memoryBudget.cta': 'Embeddings einrichten',
+  'webAppsSunset.title': 'In-App-Web-Apps werden eingestellt',
+  'webAppsSunset.message':
+    'Deine verbundenen Web-Apps werden nach dem 31. August 2026 aus der App entfernt. Entschuldige die Unannehmlichkeiten.',
   'userErrors.scope.memory': 'Speicher',
   // Agent World: Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'Betrag',

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -7600,6 +7600,9 @@ const en: TranslationMap = {
   'memoryBudget.exhaustedMessage':
     'Your embedding budget is used up, so new content is no longer being added to memory. Set up local embeddings or add your own API key to resume.',
   'memoryBudget.cta': 'Set up embeddings',
+  'webAppsSunset.title': 'In-app web apps are being retired',
+  'webAppsSunset.message':
+    'Your connected web apps will be removed from the app after 31 August 2026. Sorry for the inconvenience.',
   'memorySources.codingSessions.title': 'Coding-agent sessions',
   'memorySources.codingSessions.description':
     'Turn your Codex and Claude Code decisions and corrections into private persona memory.',

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -7348,6 +7348,9 @@ const messages: TranslationMap = {
   'memoryBudget.exhaustedMessage':
     'Tu presupuesto de embeddings se agotó, así que el contenido nuevo ya no se añade a la memoria. Configura embeddings locales o añade tu propia clave de API para reanudar.',
   'memoryBudget.cta': 'Configurar embeddings',
+  'webAppsSunset.title': 'Las aplicaciones web integradas se van a retirar',
+  'webAppsSunset.message':
+    'Tus aplicaciones web conectadas se eliminarán de la app después del 31 de agosto de 2026. Lamentamos las molestias.',
   'userErrors.scope.memory': 'Memoria',
   // Agent World: Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'Importe',

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -7379,6 +7379,9 @@ const messages: TranslationMap = {
   'memoryBudget.exhaustedMessage':
     "Votre budget d'embeddings est épuisé, les nouveaux contenus ne sont donc plus ajoutés à la mémoire. Configurez des embeddings locaux ou ajoutez votre propre clé API pour reprendre.",
   'memoryBudget.cta': 'Configurer les embeddings',
+  'webAppsSunset.title': 'Les applications web intégrées vont être retirées',
+  'webAppsSunset.message':
+    'Vos applications web connectées seront supprimées de l’application après le 31 août 2026. Désolés pour la gêne occasionnée.',
   'userErrors.scope.memory': 'Mémoire',
   // Agent World: Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'Montant',

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -7196,6 +7196,9 @@ const messages: TranslationMap = {
   'memoryBudget.exhaustedMessage':
     'आपका एम्बेडिंग बजट खत्म हो गया है, इसलिए नई सामग्री अब मेमोरी में नहीं जुड़ रही। दोबारा शुरू करने के लिए लोकल एम्बेडिंग सेट करें या अपनी API कुंजी जोड़ें।',
   'memoryBudget.cta': 'एम्बेडिंग सेट करें',
+  'webAppsSunset.title': 'ऐप के अंदर की वेब ऐप्स हटाई जा रही हैं',
+  'webAppsSunset.message':
+    'आपकी कनेक्ट की गई वेब ऐप्स 31 अगस्त 2026 के बाद ऐप से हटा दी जाएंगी। असुविधा के लिए क्षमा करें।',
   'userErrors.scope.memory': 'मेमोरी',
   // Agent World: Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'राशि',

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -7234,6 +7234,9 @@ const messages: TranslationMap = {
   'memoryBudget.exhaustedMessage':
     'Anggaran embedding Anda sudah habis, sehingga konten baru tidak lagi ditambahkan ke memori. Siapkan embedding lokal atau tambahkan kunci API Anda sendiri untuk melanjutkan.',
   'memoryBudget.cta': 'Siapkan embedding',
+  'webAppsSunset.title': 'Aplikasi web dalam aplikasi akan dihentikan',
+  'webAppsSunset.message':
+    'Aplikasi web yang terhubung akan dihapus dari aplikasi setelah 31 Agustus 2026. Mohon maaf atas ketidaknyamanannya.',
   'userErrors.scope.memory': 'Memori',
   // Agent World: Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'Jumlah',

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -7331,6 +7331,9 @@ const messages: TranslationMap = {
   'memoryBudget.exhaustedMessage':
     'Il tuo budget di embedding è esaurito, quindi i nuovi contenuti non vengono più aggiunti alla memoria. Configura embedding locali o aggiungi la tua chiave API per riprendere.',
   'memoryBudget.cta': 'Configura gli embedding',
+  'webAppsSunset.title': 'Le web app integrate verranno rimosse',
+  'webAppsSunset.message':
+    'Le tue web app collegate verranno rimosse dall’app dopo il 31 agosto 2026. Ci scusiamo per il disagio.',
   'userErrors.scope.memory': 'Memoria',
   // Agent World: Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'Importo',

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -7117,6 +7117,9 @@ const messages: TranslationMap = {
   'memoryBudget.exhaustedMessage':
     '임베딩 예산을 모두 사용해 새 콘텐츠가 메모리에 추가되지 않습니다. 로컬 임베딩을 설정하거나 본인의 API 키를 추가하면 다시 시작됩니다.',
   'memoryBudget.cta': '임베딩 설정',
+  'webAppsSunset.title': '앱 내 웹 앱 기능이 종료됩니다',
+  'webAppsSunset.message':
+    '연결된 웹 앱은 2026년 8월 31일 이후 앱에서 제거됩니다. 불편을 드려 죄송합니다.',
   'userErrors.scope.memory': '메모리',
   // Agent World: Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': '금액',

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -7303,6 +7303,9 @@ const messages: TranslationMap = {
   'memoryBudget.exhaustedMessage':
     'Twój budżet osadzeń został wyczerpany, więc nowe treści nie są już dodawane do pamięci. Skonfiguruj lokalne osadzenia lub dodaj własny klucz API, aby wznowić.',
   'memoryBudget.cta': 'Skonfiguruj osadzenia',
+  'webAppsSunset.title': 'Aplikacje internetowe w aplikacji zostaną wycofane',
+  'webAppsSunset.message':
+    'Twoje połączone aplikacje internetowe zostaną usunięte z aplikacji po 31 sierpnia 2026 r. Przepraszamy za niedogodności.',
   'userErrors.scope.memory': 'Pamięć',
   // Agent World: Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'Kwota',

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -7314,6 +7314,9 @@ const messages: TranslationMap = {
   'memoryBudget.exhaustedMessage':
     'Seu orçamento de embeddings acabou, então novos conteúdos não estão mais sendo adicionados à memória. Configure embeddings locais ou adicione sua própria chave de API para retomar.',
   'memoryBudget.cta': 'Configurar embeddings',
+  'webAppsSunset.title': 'Os aplicativos web integrados serão removidos',
+  'webAppsSunset.message':
+    'Seus aplicativos web conectados serão removidos do app depois de 31 de agosto de 2026. Pedimos desculpas pelo transtorno.',
   'userErrors.scope.memory': 'Memória',
   // Agent World: Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'Valor',

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -7276,6 +7276,9 @@ const messages: TranslationMap = {
   'memoryBudget.exhaustedMessage':
     'Бюджет эмбеддингов израсходован, поэтому новые данные больше не добавляются в память. Настройте локальные эмбеддинги или добавьте свой ключ API, чтобы продолжить.',
   'memoryBudget.cta': 'Настроить эмбеддинги',
+  'webAppsSunset.title': 'Встроенные веб-приложения отключаются',
+  'webAppsSunset.message':
+    'Подключённые веб-приложения будут удалены из приложения после 31 августа 2026 года. Приносим извинения за неудобства.',
   'userErrors.scope.memory': 'Память',
   // Agent World: Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': 'Сумма',

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -6812,6 +6812,9 @@ const messages: TranslationMap = {
   'memoryBudget.exhaustedMessage':
     '你的嵌入额度已用尽，新内容不会再加入记忆。设置本地嵌入或添加你自己的 API 密钥即可恢复。',
   'memoryBudget.cta': '设置嵌入',
+  'webAppsSunset.title': '应用内网页应用即将下线',
+  'webAppsSunset.message':
+    '你已连接的网页应用将在 2026 年 8 月 31 日后从应用中移除。给你带来不便，敬请谅解。',
   'userErrors.scope.memory': '记忆',
   // Agent World：Identity trading (confirm-before-spend + balance gate)
   'agentWorld.trading.amountLabel': '金额',


### PR DESCRIPTION
## Summary

- The in-app web apps (Accounts webview rail) are being removed from the app after 31 August 2026. This hides the feature from users who never connected one and shows a persistent removal notice to those who have. **No code is removed** — visibility + notice only.
- Sidebar rail: dropped the "Add apps" button + AddAccountModal; already-connected apps still show and can be reconnected (select tile) or disconnected (right-click). Zero connected → only the agent tile.
- Deep-link accounts step (OpenhumanLinkModal): now connected-only and disconnect-only — no way to add a service you weren't already using.
- New non-dismissable `WebAppsSunsetNotice`, shown only when ≥1 app is connected, mounted beside the other shell banners.
- `webAppsSunset.*` copy added to every supported locale.

## Problem

New users shouldn't pick up a feature that's about to disappear, and existing users need a clear heads-up. The app had no way to gate the web-apps entry points by "has this user connected one?".

## Solution

The durable "already connected" signal is the persisted Redux `accounts` slice (survives session drops), so a channel that dropped its session still shows for reconnect while a never-connected one shows nothing. All add-new entry points are removed; a non-dismissable banner names the 31 August 2026 date.

## Submission Checklist

- [x] Tests added or updated (happy path + failure/edge) — rail, notice, and deep-link step; 23 tests pass
- [x] **Diff coverage ≥ 80%** — new component/rail/modal changes are covered by Vitest (frontend-only diff)
- [x] Coverage matrix updated — N/A: visibility-gating change, no new feature IDs
- [x] All affected feature IDs listed under Related — N/A: no matrix rows affected
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated — N/A: no release-cut surface touched
- [x] Linked issue closed via `Closes #NNN`

## Impact

- Frontend-only (desktop app UI). No Rust/backend changes.
- **CI note:** the local pre-push hook runs full Rust clippy over the core + Tauri shell, which can't run in a fresh worktree without the vendored submodules (incl. the large CEF submodule) initialized. This diff touches **zero Rust**, so that check is not applicable here; frontend format/lint/typecheck/i18n and the changed-file tests all pass locally, and CI's Rust lanes correctly skip for this frontend-only diff.

## Related

- Closes: #5423
- Sibling (ship together): #5424 (tiny.place) — #5439
- Follow-up PR(s)/TODOs: eventual code removal after 31 August 2026

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

N/A — not a Codex/Linear-authored PR.

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: SidebarAppRail, WebAppsSunsetNotice, OpenhumanLinkModal.accounts (23 pass)
- [x] Rust fmt/check (if changed) — N/A: no Rust changed
- [x] Tauri fmt/check (if changed) — N/A: no Rust changed
