### PR TITLE
fix(voice): show realtime voice mode toggle by default in all builds

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -85,6 +85,12 @@ VITE_DEV_FORCE_ONBOARDING=false
 # tier at runtime. Set to false to hard-disable the attach button for a build.
 # VITE_CHAT_ATTACHMENTS=false
 
+# [optional] Realtime ElevenLabs voice mode (#5399) — exposes the Settings
+# toggle in Voice. Enabled by default in every build; the feature still ships
+# dark until the user flips the toggle (persisted mascot.voiceMode='realtime').
+# Set to false to hide the toggle for a build (kill-switch).
+# VITE_VOICE_MODE=false
+
 # [optional] Client-side timeout for skill callTool/triggerSync (seconds; default 120, max 3600).
 # Should match OPENHUMAN_TOOL_TIMEOUT_SECS on the core when set.
 # VITE_TOOL_TIMEOUT_SECS=

--- a/app/src/utils/config.ts
+++ b/app/src/utils/config.ts
@@ -280,16 +280,15 @@ export const MASCOT_VOICE_MODEL_ID =
   'eleven_multilingual_v2';
 
 /**
- * Gates the realtime ElevenLabs Agents voice mode (#5399). Off by default so
- * the classic turn-based voice pipeline stays the only path until the realtime
- * session is ready; set `VITE_VOICE_MODE` to any non-empty value to expose the
- * Settings toggle. This gates only the UI switch — the realtime code paths
- * additionally check the persisted `mascot.voiceMode`, so the feature ships
- * dark even where the flag is on.
+ * Gates the realtime ElevenLabs Agents voice mode (#5399). On by default in
+ * every build (local, staging, production) so the Settings toggle is exposed
+ * without any build-time env wiring; set `VITE_VOICE_MODE=false` to hide it
+ * (kill switch). This gates only the UI switch — the realtime code paths
+ * additionally check the persisted `mascot.voiceMode`, so the feature still
+ * ships dark until the user opts in via the toggle.
  */
-export const VOICE_MODE_FLAG_ENABLED = Boolean(
-  (import.meta.env.VITE_VOICE_MODE as string | undefined)?.trim()
-);
+export const VOICE_MODE_FLAG_ENABLED =
+  (import.meta.env.VITE_VOICE_MODE as string | undefined)?.trim() !== 'false';
 
 /**
  * URL of the published mascot manifest (`dist/mascots.json` from the


### PR DESCRIPTION
## Summary

- Show the realtime ElevenLabs voice-mode toggle (Settings → Voice) by default in every build — local, staging, and production.
- Flip `VOICE_MODE_FLAG_ENABLED` from opt-in (`Boolean(VITE_VOICE_MODE)`) to default-on with a kill switch (`VITE_VOICE_MODE=false`), matching the `CHAT_ATTACHMENTS_ENABLED` / `DERIVED_TRANSCRIPT_ENABLED` idiom in the same file.
- Document the `VITE_VOICE_MODE` kill switch in `app/.env.example`.

## Problem

The realtime voice mode section (#5399) was gated on `VOICE_MODE_FLAG_ENABLED`, which resolves to `Boolean(import.meta.env.VITE_VOICE_MODE)` — a **build-time** Vite env var. `VITE_VOICE_MODE` is not injected anywhere in the build pipeline: it is absent from the `VITE_*` env block in `.github/workflows/build-desktop.yml` (the single injection point both `release-staging.yml` and `release-production.yml` reuse), and from every `.env` file. It therefore baked in as `false` in every shipped bundle, so the toggle never rendered in local, staging, or production — only in unit tests that mock the flag on. Wiring the backend relay flags (the ElevenLabs Voice Agent identity-token / keepalive fixes) has no effect on this UI gate, since it is a compile-time `import.meta.env` constant.

## Solution

- `app/src/utils/config.ts`: `VOICE_MODE_FLAG_ENABLED = (…VITE_VOICE_MODE…)?.trim() !== 'false'`. Undefined (the shipped case) → on; explicit `VITE_VOICE_MODE=false` → off. No CI/env wiring required, so the toggle appears in all three build environments by default.
- The realtime code paths still additionally gate on the persisted `mascot.voiceMode` (`HumanPage.tsx`), so the feature ships dark until the user flips the now-visible toggle — no behaviour change for users who do not opt in.
- `app/.env.example`: documented the kill switch next to the sibling `VITE_CHAT_ATTACHMENTS` entry.
- Validation: `pnpm typecheck` clean; focused suites `HumanPage.realtimeMode.test.tsx` + `RealtimeVoiceControls.test.tsx` pass (9/9).

## Submission Checklist

- [x] N/A — behaviour-only default flip of an existing, already-tested flag; the visible/hidden gate is covered by `HumanPage.realtimeMode.test.tsx` and `RealtimeVoiceControls.test.tsx`. No new branch to cover. The global test mock (`app/src/test/setup.ts`) intentionally keeps the flag off for determinism.
- [x] Diff coverage ≥ 80% — the only executable changed line is the module-level flag assignment; `.env.example` and comment lines are non-executable. Ran focused tests + typecheck locally, not the full `test:coverage` merge.
- [x] N/A — no feature row added/removed/renamed in the coverage matrix (behaviour-only change).
- [x] All affected feature IDs listed under `## Related`.
- [x] No new external network dependencies introduced.
- [x] N/A — does not change a release-cut smoke surface beyond exposing an already-documented-dark toggle.
- [x] N/A — no tracking issue; follow-up to #5399.

## Impact

- Desktop (all OSes). Frontend-only; no Rust core, no migration.
- Exposes an existing, backend-ready feature's Settings toggle. Off-by-persisted-state until opted in, so no runtime behaviour change unless the user enables realtime voice mode. Reversible per-build via `VITE_VOICE_MODE=false`.

## Related

- Closes: N/A — no tracking issue (follow-up to #5399 realtime ElevenLabs voice mode; complements the relay-side fixes in tinyhumansai/backend#1230).
- Follow-up PR(s)/TODOs: none.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: N/A
- Commit SHA: N/A

### Validation Run

- [x] N/A
- [x] N/A
- [x] N/A
- [x] N/A
- [x] N/A

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: N/A
- User-visible effect: N/A

### Parity Contract

- Legacy behavior preserved: N/A
- Guard/fallback/dispatch parity checks: N/A

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A
