### PR TITLE
fix(policy_denial): forbid fabricating results in denial messages

### DIFF
--- a/src/openhuman/agent/tinyagents/policy_denial.rs
+++ b/src/openhuman/agent/tinyagents/policy_denial.rs
@@ -8,6 +8,16 @@
 //! silently. The rendered string is returned as the (failed) tool result, so it
 //! flows back into the turn the same way the unknown-tool corrective error is
 //! surfaced to the model (see PR #4360).
+//!
+//! The relay instruction also states, at the point of denial, that the tool did
+//! not run and that no result for it may be reported. Pressure to produce a
+//! substantive answer, next to a tool result that carries no output, is an
+//! invitation for a weak model to fill the gap: an observed turn had every
+//! shell call denied and the agent then reported a fabricated directory listing
+//! and `git log` as if they had run. The system prompt's grounding rule did not
+//! bite; a contradiction sitting in the tool result itself has a better chance.
+//! It is a mitigation, not a guarantee — detecting fabrication needs the
+//! tool-call record carried out to the caller.
 
 use crate::openhuman::security::POLICY_BLOCKED_MARKER;
 use crate::openhuman::tools::PermissionLevel;
@@ -65,10 +75,14 @@ pub(super) enum PolicyDenial<'a> {
 }
 
 /// Suffix appended to every denial so the agent relays the block instead of
-/// silently stopping.
-const RELAY_INSTRUCTION: &str = "Relay this to the user: explain what was \
-    blocked and why, then offer the workaround as the next step. Do not stop \
-    silently.";
+/// silently stopping — *and* does not paper over the absent output by inventing
+/// it. The no-output sentence comes first deliberately: the relay directive on
+/// its own is pressure to produce a substantive answer, and the prohibition has
+/// to bound it before the model reads that pressure.
+const RELAY_INSTRUCTION: &str = "The tool did not run and produced no output — \
+    do NOT invent or report any result for it. Relay this to the user: explain \
+    what was blocked and why, then offer the workaround as the next step. Do \
+    not stop silently.";
 
 impl PolicyDenial<'_> {
     /// Render the denial as a structured `Blocked / Reason / Workaround / relay`
@@ -231,6 +245,8 @@ mod tests {
         assert!(msg.contains("agent-access tier"));
         // The relay instruction is what keeps the agent from halting silently.
         assert!(msg.contains("Relay this to the user"));
+        // ...and the prohibition is what keeps it from inventing a result.
+        assert!(msg.contains("did not run and produced no output"));
     }
 
     #[test]
@@ -320,6 +336,81 @@ mod tests {
 
         // A plain non-policy error is untouched.
         assert!(maybe_enrich_policy_block("read_file", "Error: file not found").is_none());
+    }
+
+    /// Every denial — whatever the boundary — must say the tool did not run and
+    /// forbid reporting a result for it. A denial that only pressed the model to
+    /// "not stop silently" was observed being answered with a fabricated
+    /// directory listing and `git log` for commands that never executed.
+    #[test]
+    fn every_denial_forbids_fabricating_a_result() {
+        let denials = [
+            PolicyDenial::SecurityPolicyBlocked {
+                tool: "run_command",
+                raw_reason: "[policy-blocked] Security policy: read-only mode",
+            },
+            PolicyDenial::SessionForbidden {
+                tool: "run_script",
+                required: Some(PermissionLevel::Execute),
+                allowed: PermissionLevel::ReadOnly,
+                channel: "web",
+            },
+            PolicyDenial::SessionForbidden {
+                tool: "run_script",
+                required: None,
+                allowed: PermissionLevel::ReadOnly,
+                channel: "cron",
+            },
+            PolicyDenial::PermissionTooLow {
+                tool: "shell",
+                required: PermissionLevel::Write,
+                allowed: PermissionLevel::ReadOnly,
+                channel: "web",
+            },
+            PolicyDenial::PolicyDenied {
+                tool: "run_script",
+                policy: "sandbox",
+                reason: "sandbox restriction",
+            },
+            PolicyDenial::ApprovalRequired {
+                tool: "send_email",
+                policy: "approval_gate",
+                reason: "outbound message needs sign-off",
+            },
+        ];
+
+        for denial in &denials {
+            let msg = denial.render();
+            assert!(
+                msg.contains("The tool did not run and produced no output"),
+                "denial must state the tool never ran: {msg}"
+            );
+            assert!(
+                msg.contains("do NOT invent or report any result for it"),
+                "denial must forbid inventing a result: {msg}"
+            );
+            // The prohibition precedes the relay directive so it bounds it.
+            let no_output = msg
+                .find("The tool did not run")
+                .expect("no-output sentence present");
+            let relay = msg.find("Relay this to the user").expect("relay present");
+            assert!(no_output < relay, "prohibition must come first: {msg}");
+        }
+    }
+
+    /// The enrichment path for raw `[policy-blocked]` results carries the
+    /// prohibition too — those are the shell/command denials that triggered the
+    /// fabrication in the first place.
+    #[test]
+    fn enriched_raw_policy_block_forbids_fabricating_a_result() {
+        let enriched = maybe_enrich_policy_block(
+            "run_command",
+            "[policy-blocked] Command not allowed by security policy: ls -la",
+        )
+        .expect("a raw policy block should be enriched");
+
+        assert!(enriched.contains("The tool did not run and produced no output"));
+        assert!(enriched.contains("do NOT invent or report any result for it"));
     }
 
     #[test]


### PR DESCRIPTION
## What happened

An agent turn was told to run several shell commands in a checkout and report their
output verbatim. Every external-effect tool was refused by the policy gate. The agent
then answered with confident, plausible, entirely fabricated output for commands that
never ran — it invented a directory listing and a `git log` — while accurately quoting
the real denial text for the write attempts. Same invented listing on all three runs,
so it reproduces.

The system prompt already carries an explicit anti-fabrication rule
(`prompts/sections.rs`, `GROUNDING_BODY`). The model ignored it three times out of
three. This PR does not touch it.

## The contributor in the denial text

Every policy denial is rendered as
`Blocked: {blocked}. Reason: {reason}. Workaround: {workaround} {RELAY_INSTRUCTION}`,
and `RELAY_INSTRUCTION` said:

> Relay this to the user: explain what was blocked and why, then offer the workaround
> as the next step. Do not stop silently.

That applies general pressure to produce a substantive answer and never says what the
model must *not* claim. Sitting next to a tool result that carries no output, "do not
stop silently" reads to a weak model as an invitation to fill the gap. For contrast,
Codex CLI returns roughly `exec command rejected by user` — six words, no directive —
and does not show this failure.

New text:

> The tool did not run and produced no output — do NOT invent or report any result for
> it. Relay this to the user: explain what was blocked and why, then offer the
> workaround as the next step. Do not stop silently.

The prohibition deliberately comes **first**, so it bounds the relay directive rather
than trailing behind it. The useful behaviour is unchanged: the agent still explains
the blocker, still offers the workaround, still does not dead-end.

## Why a per-call prohibition rather than a stronger system-prompt rule

The system-prompt rule is a general statement read once, hundreds of tokens away from
the moment it applies, and it competes with the whole rest of the prompt. The denial
text is in the tool result itself — same position in context as the missing output,
read at exactly the decision point, and it directly contradicts the specific thing the
model is about to do. That is a better place for it to bite. Strengthening
`GROUNDING_BODY` further is known not to work, so it is left alone.

## Scope

`RELAY_INSTRUCTION` has one definition and every denial variant renders through
`PolicyDenial::render`, so all six boundaries (`SecurityPolicyBlocked`,
`SessionForbidden` with and without a required level, `PermissionTooLow`,
`PolicyDenied`, `ApprovalRequired`) plus the `maybe_enrich_policy_block` enrichment
path pick the new wording up together. I grepped for paraphrases elsewhere; the only
sibling is `spawn_subagent.rs`'s `[SUBAGENT_INCOMPLETE]` envelope, which already says
"Do NOT report this as done or fabricate a result" — consistent, so untouched.

## Honest limits

This is a mitigation, not a fix. It makes fabrication less inviting; it cannot make it
impossible, and nothing here detects it when it happens anyway. The structural fix is
carrying tool-call records out to the caller so a claimed result can be checked against
whether the call actually ran. That is separate work.

## Validation

Run from the repo root:

- `cargo fmt -- --check` — clean
- `cargo test --manifest-path Cargo.toml --lib policy_denial` — 9 passed, 0 failed
- `cargo test --manifest-path Cargo.toml --lib tinyagents::` — 327 passed, 0 failed
- `cargo clippy --manifest-path Cargo.toml --all-targets` — no errors, no new warnings
  (nothing reported against `policy_denial.rs`)

Tests: existing assertions updated, plus `every_denial_forbids_fabricating_a_result`
(all six variants carry the prohibition and it precedes the relay directive) and
`enriched_raw_policy_block_forbids_fabricating_a_result` (the raw `[policy-blocked]`
enrichment path — the one the shell denials take).
