### PR TITLE
fix(security): carry turn origin and a per-turn workspace across the subagent spawn boundary

### DIFF
--- a/src/openhuman/agent/harness/session/builder/factory.rs
+++ b/src/openhuman/agent/harness/session/builder/factory.rs
@@ -231,8 +231,16 @@ impl Agent {
         // The expression is extracted into [`derive_profile_workspace_descriptor`]
         // so the unit tests exercise the *same* code path rather than a
         // hand-copied mirror.
+        //
+        // When no profile binds one, an embedder may still have scoped a
+        // per-turn root (`agent::turn_workspace`) — a workflow node running
+        // this turn against the checkout it names. The profile's dedicated
+        // workspace wins where both exist: it is the stronger, persisted
+        // isolation boundary, and a profile that asked for its own home must
+        // not be relocated by an ambient host hint.
         let profile_workspace_descriptor =
-            derive_profile_workspace_descriptor(&config.action_dir, profile);
+            derive_profile_workspace_descriptor(&config.action_dir, profile)
+                .or_else(derive_turn_workspace_descriptor);
 
         let runtime: Arc<dyn host_runtime::RuntimeAdapter> = Arc::from(
             host_runtime::create_runtime(&config.runtime, config.shell.hide_window)?,

--- a/src/openhuman/agent/harness/session/builder/factory.rs
+++ b/src/openhuman/agent/harness/session/builder/factory.rs
@@ -1627,6 +1627,45 @@ pub(crate) fn derive_profile_workspace_descriptor(
     )
 }
 
+/// Section D, embedder variant — the turn's workspace descriptor from the
+/// per-turn root an embedder scoped via
+/// [`turn_workspace::with_workspace`](crate::openhuman::agent::turn_workspace::with_workspace).
+///
+/// Returns a [`WorkspaceDescriptor`](tinyagents::harness::workspace::WorkspaceDescriptor)
+/// rooted at the scoped directory so this turn's acting tools (shell, file,
+/// git) resolve their default cwd there instead of the shared `action_dir`.
+/// `None` — every caller that scoped nothing — leaves the shared-`action_dir`
+/// behaviour byte-identical.
+///
+/// The root is only honoured when it is an existing directory: binding every
+/// acting tool to a cwd that does not exist would turn a host's stale path into
+/// an unexplained failure in each individual tool, and the shared `action_dir`
+/// is the better fallback (same reasoning as the profile variant's
+/// create-failure path).
+///
+/// The policy id is a fixed label rather than the path: it is surfaced in tool
+/// logs, and a host's checkout path is not something to spread through them.
+fn derive_turn_workspace_descriptor() -> Option<tinyagents::harness::workspace::WorkspaceDescriptor>
+{
+    let root = crate::openhuman::agent::turn_workspace::current()?;
+    if !root.is_dir() {
+        tracing::warn!(
+            root = %root.display(),
+            "[turn_workspace] scoped root is not an existing directory — \
+             falling back to the shared action_dir cwd for this turn"
+        );
+        return None;
+    }
+    tracing::debug!(
+        root = %root.display(),
+        "[turn_workspace] turn bound to the embedder's per-turn root as default cwd"
+    );
+    Some(
+        tinyagents::harness::workspace::WorkspaceDescriptor::new(root)
+            .with_policy_id("turn-workspace"),
+    )
+}
+
 fn build_profile_security(
     config: &crate::openhuman::config::Config,
     profile: Option<&crate::openhuman::agent::profiles::AgentProfile>,

--- a/src/openhuman/agent/mod.rs
+++ b/src/openhuman/agent/mod.rs
@@ -76,6 +76,12 @@ pub mod triage;
 /// origin-aware decisions rather than inferring trust from the absence of
 /// `APPROVAL_CHAT_CONTEXT`.
 pub mod turn_origin;
+/// Turn-workspace task-local — the per-turn filesystem root an embedder binds
+/// a single agent turn to. Read by the session builder (as the turn's default
+/// cwd) and by the path policy (as a read/write trusted root), so a host that
+/// runs one turn against a checkout it names does not have to mutate
+/// process-global state to do it.
+pub mod turn_workspace;
 pub use schemas::{
     all_controller_schemas as all_agent_controller_schemas,
     all_registered_controllers as all_agent_registered_controllers,

--- a/src/openhuman/agent/orchestration/ops.rs
+++ b/src/openhuman/agent/orchestration/ops.rs
@@ -486,14 +486,21 @@ impl AgentOrchestrationSession {
 
         let task_session = self.clone();
         let task_id = orchestration_id.clone();
-        let task = tokio::spawn(async move {
-            task_session.mark_running(&task_id).await;
-            let result = with_parent_context(parent, async move {
-                run_subagent(&definition, &prompt, options).await
-            })
-            .await;
-            task_session.finish_agent(&task_id, result).await;
-        });
+        // Captured on *this* task: a `tokio::task_local` does not cross
+        // `tokio::spawn`, so the turn's origin label and workspace root are
+        // carried across the same boundary the parent execution context
+        // already is. Without the origin the spawned agent's external-effect
+        // tools reach the approval gate unlabelled and are refused.
+        let task = tokio::spawn(crate::openhuman::agent::turn_origin::propagate(
+            crate::openhuman::agent::turn_workspace::propagate(async move {
+                task_session.mark_running(&task_id).await;
+                let result = with_parent_context(parent, async move {
+                    run_subagent(&definition, &prompt, options).await
+                })
+                .await;
+                task_session.finish_agent(&task_id, result).await;
+            }),
+        ));
 
         {
             let mut state = self.state.lock().await;

--- a/src/openhuman/agent/orchestration/tools/spawn_async_subagent.rs
+++ b/src/openhuman/agent/orchestration/tools/spawn_async_subagent.rs
@@ -534,7 +534,18 @@ impl Tool for SpawnAsyncSubagentTool {
         );
         let background_prompt = add_background_contract(&prompt);
 
-        let join = tokio::spawn(async move {
+        // The detached child starts on a fresh task, and a `tokio::task_local`
+        // does not cross `tokio::spawn`. The parent's execution context and
+        // chat thread are already re-installed inside the task for exactly that
+        // reason; the turn's origin label and its workspace root are the other
+        // two that have to travel, and they are captured **here**, on the
+        // spawning task, rather than inside the closure where they would
+        // already be gone. Without the origin every external-effect tool the
+        // child calls reaches the approval gate unlabelled and is refused,
+        // which is the whole of why a delegated coding task could not run a
+        // shell.
+        let join = tokio::spawn(crate::openhuman::agent::turn_origin::propagate(
+            crate::openhuman::agent::turn_workspace::propagate(async move {
             let options = SubagentRunOptions {
                 skill_filter_override: None,
                 toolkit_override,
@@ -799,7 +810,8 @@ impl Tool for SpawnAsyncSubagentTool {
                     }
                 }
             }
-        });
+        }),
+        ));
 
         // Register *after* spawn so the AbortHandle is available. The task owns
         // `status_tx`; this side holds `status_rx` for `wait_subagent`.

--- a/src/openhuman/agent/orchestration/tools/spawn_async_subagent.rs
+++ b/src/openhuman/agent/orchestration/tools/spawn_async_subagent.rs
@@ -546,78 +546,78 @@ impl Tool for SpawnAsyncSubagentTool {
         // shell.
         let join = tokio::spawn(crate::openhuman::agent::turn_origin::propagate(
             crate::openhuman::agent::turn_workspace::propagate(async move {
-            let options = SubagentRunOptions {
-                skill_filter_override: None,
-                toolkit_override,
-                context,
-                model_override,
-                task_id: Some(background_task_id.clone()),
-                worker_thread_id: background_worker_thread_id.clone(),
-                initial_history: background_initial_history,
-                checkpoint_dir: None,
-                worktree_action_dir: background_worktree_action_dir,
-                workspace_descriptor: background_workspace_descriptor,
-                run_queue: Some(task_queue),
-            };
+                let options = SubagentRunOptions {
+                    skill_filter_override: None,
+                    toolkit_override,
+                    context,
+                    model_override,
+                    task_id: Some(background_task_id.clone()),
+                    worker_thread_id: background_worker_thread_id.clone(),
+                    initial_history: background_initial_history,
+                    checkpoint_dir: None,
+                    worktree_action_dir: background_worktree_action_dir,
+                    workspace_descriptor: background_workspace_descriptor,
+                    run_queue: Some(task_queue),
+                };
 
-            let result = with_parent_context(background_parent, async move {
-                crate::openhuman::agent::tinyagents::thread_context::with_thread_id(
-                    background_thread_affinity_id,
-                    async move {
-                        run_subagent(&background_definition, &background_prompt, options).await
-                    },
-                )
-                .await
-            })
-            .await;
+                let result = with_parent_context(background_parent, async move {
+                    crate::openhuman::agent::tinyagents::thread_context::with_thread_id(
+                        background_thread_affinity_id,
+                        async move {
+                            run_subagent(&background_definition, &background_prompt, options).await
+                        },
+                    )
+                    .await
+                })
+                .await;
 
-            match result {
-                Ok(outcome) => match outcome.status {
-                    SubagentRunStatus::Completed => {
-                        if let Err(err) = subagent_sessions::mark_finished(
-                            &background_store,
-                            &background_subagent_session_id,
-                            &outcome.task_id,
-                            &outcome.status,
-                            outcome.final_history.clone(),
-                        ) {
-                            log::warn!(
+                match result {
+                    Ok(outcome) => match outcome.status {
+                        SubagentRunStatus::Completed => {
+                            if let Err(err) = subagent_sessions::mark_finished(
+                                &background_store,
+                                &background_subagent_session_id,
+                                &outcome.task_id,
+                                &outcome.status,
+                                outcome.final_history.clone(),
+                            ) {
+                                log::warn!(
                                 "[subagent_reuse] mark_completed failed subagent_session_id={} task_id={} agent_id={} error={}",
                                 background_subagent_session_id,
                                 outcome.task_id,
                                 outcome.agent_id,
                                 err
                             );
-                        }
-                        let _ = status_tx.send(SubagentStatus::Completed {
-                            output: outcome.output.clone(),
-                            iterations: outcome.iterations,
-                        });
-                        // A workflow proposal produced inside the child's tool
-                        // history is durable state, not prose: persist it into
-                        // the parent chat thread (survives reload / reconnect —
-                        // the old socket-only delivery could silently drop it)
-                        // and carry the full payload in the delivery notice so
-                        // the follow-up turn can present it faithfully.
-                        let delivery_summary = attach_workflow_proposal(
-                            &background_workspace_dir,
-                            background_parent_thread_id.as_deref(),
-                            &outcome.task_id,
-                            &outcome.agent_id,
-                            &outcome.final_history,
-                            outcome.output.clone(),
-                        );
-                        // Queue the finished result for idle-gated, batched
-                        // delivery back into the parent chat (the session
-                        // runtime drains this when the session is next idle).
-                        crate::openhuman::agent::orchestration::background_completions::record_completion(
+                            }
+                            let _ = status_tx.send(SubagentStatus::Completed {
+                                output: outcome.output.clone(),
+                                iterations: outcome.iterations,
+                            });
+                            // A workflow proposal produced inside the child's tool
+                            // history is durable state, not prose: persist it into
+                            // the parent chat thread (survives reload / reconnect —
+                            // the old socket-only delivery could silently drop it)
+                            // and carry the full payload in the delivery notice so
+                            // the follow-up turn can present it faithfully.
+                            let delivery_summary = attach_workflow_proposal(
+                                &background_workspace_dir,
+                                background_parent_thread_id.as_deref(),
+                                &outcome.task_id,
+                                &outcome.agent_id,
+                                &outcome.final_history,
+                                outcome.output.clone(),
+                            );
+                            // Queue the finished result for idle-gated, batched
+                            // delivery back into the parent chat (the session
+                            // runtime drains this when the session is next idle).
+                            crate::openhuman::agent::orchestration::background_completions::record_completion(
                             background_parent_session.clone(),
                             outcome.task_id.clone(),
                             outcome.agent_id.clone(),
                             delivery_summary,
                             background_parent_thread_id.clone(),
                         );
-                        crate::openhuman::agent::orchestration::subagent_events::publish_subagent_completed(
+                            crate::openhuman::agent::orchestration::subagent_events::publish_subagent_completed(
                             background_parent_session,
                             outcome.task_id.clone(),
                             outcome.agent_id.clone(),
@@ -625,69 +625,69 @@ impl Tool for SpawnAsyncSubagentTool {
                             outcome.output.chars().count(),
                             outcome.iterations,
                         );
-                        if let Some(ref tx) = background_progress {
-                            let _ = tx
-                                .send(AgentProgress::SubagentCompleted {
-                                    agent_id: outcome.agent_id,
-                                    task_id: outcome.task_id,
-                                    elapsed_ms: outcome.elapsed.as_millis() as u64,
-                                    iterations: outcome.iterations as u32,
-                                    output_chars: outcome.output.chars().count(),
-                                    output: outcome.output.clone(),
-                                    worktree_path: None,
-                                    changed_files: Vec::new(),
-                                    dirty_status: None,
-                                })
-                                .await;
+                            if let Some(ref tx) = background_progress {
+                                let _ = tx
+                                    .send(AgentProgress::SubagentCompleted {
+                                        agent_id: outcome.agent_id,
+                                        task_id: outcome.task_id,
+                                        elapsed_ms: outcome.elapsed.as_millis() as u64,
+                                        iterations: outcome.iterations as u32,
+                                        output_chars: outcome.output.chars().count(),
+                                        output: outcome.output.clone(),
+                                        worktree_path: None,
+                                        changed_files: Vec::new(),
+                                        dirty_status: None,
+                                    })
+                                    .await;
+                            }
                         }
-                    }
-                    SubagentRunStatus::Incomplete { ref reason } => {
-                        // Async sub-agent stopped short (stuck halt / iteration
-                        // cap). Mark the session finished and deliver the PARTIAL
-                        // progress back to the parent, framed so it is not
-                        // mistaken for a completed result (#4096).
-                        if let Err(err) = subagent_sessions::mark_finished(
-                            &background_store,
-                            &background_subagent_session_id,
-                            &outcome.task_id,
-                            &outcome.status,
-                            outcome.final_history.clone(),
-                        ) {
-                            log::warn!(
+                        SubagentRunStatus::Incomplete { ref reason } => {
+                            // Async sub-agent stopped short (stuck halt / iteration
+                            // cap). Mark the session finished and deliver the PARTIAL
+                            // progress back to the parent, framed so it is not
+                            // mistaken for a completed result (#4096).
+                            if let Err(err) = subagent_sessions::mark_finished(
+                                &background_store,
+                                &background_subagent_session_id,
+                                &outcome.task_id,
+                                &outcome.status,
+                                outcome.final_history.clone(),
+                            ) {
+                                log::warn!(
                                 "[subagent_reuse] mark_incomplete failed subagent_session_id={} task_id={} agent_id={} error={}",
                                 background_subagent_session_id,
                                 outcome.task_id,
                                 outcome.agent_id,
                                 err
                             );
-                        }
-                        let framed = format!(
-                            "[SUBAGENT_INCOMPLETE] the sub-agent {reason} and did not finish. \
+                            }
+                            let framed = format!(
+                                "[SUBAGENT_INCOMPLETE] the sub-agent {reason} and did not finish. \
                              Partial progress:\n{}",
-                            outcome.output
-                        );
-                        let _ = status_tx.send(SubagentStatus::Completed {
-                            output: framed.clone(),
-                            iterations: outcome.iterations,
-                        });
-                        // An incomplete run may still have produced a full
-                        // proposal before stalling — preserve it durably too.
-                        let framed = attach_workflow_proposal(
-                            &background_workspace_dir,
-                            background_parent_thread_id.as_deref(),
-                            &outcome.task_id,
-                            &outcome.agent_id,
-                            &outcome.final_history,
-                            framed,
-                        );
-                        crate::openhuman::agent::orchestration::background_completions::record_completion(
+                                outcome.output
+                            );
+                            let _ = status_tx.send(SubagentStatus::Completed {
+                                output: framed.clone(),
+                                iterations: outcome.iterations,
+                            });
+                            // An incomplete run may still have produced a full
+                            // proposal before stalling — preserve it durably too.
+                            let framed = attach_workflow_proposal(
+                                &background_workspace_dir,
+                                background_parent_thread_id.as_deref(),
+                                &outcome.task_id,
+                                &outcome.agent_id,
+                                &outcome.final_history,
+                                framed,
+                            );
+                            crate::openhuman::agent::orchestration::background_completions::record_completion(
                             background_parent_session.clone(),
                             outcome.task_id.clone(),
                             outcome.agent_id.clone(),
                             framed,
                             background_parent_thread_id.clone(),
                         );
-                        crate::openhuman::agent::orchestration::subagent_events::publish_subagent_completed(
+                            crate::openhuman::agent::orchestration::subagent_events::publish_subagent_completed(
                             background_parent_session,
                             outcome.task_id.clone(),
                             outcome.agent_id.clone(),
@@ -695,122 +695,122 @@ impl Tool for SpawnAsyncSubagentTool {
                             outcome.output.chars().count(),
                             outcome.iterations,
                         );
-                        if let Some(ref tx) = background_progress {
-                            let _ = tx
-                                .send(AgentProgress::SubagentCompleted {
-                                    agent_id: outcome.agent_id,
-                                    task_id: outcome.task_id,
-                                    elapsed_ms: outcome.elapsed.as_millis() as u64,
-                                    iterations: outcome.iterations as u32,
-                                    output_chars: outcome.output.chars().count(),
-                                    output: outcome.output.clone(),
-                                    worktree_path: None,
-                                    changed_files: Vec::new(),
-                                    dirty_status: None,
-                                })
-                                .await;
+                            if let Some(ref tx) = background_progress {
+                                let _ = tx
+                                    .send(AgentProgress::SubagentCompleted {
+                                        agent_id: outcome.agent_id,
+                                        task_id: outcome.task_id,
+                                        elapsed_ms: outcome.elapsed.as_millis() as u64,
+                                        iterations: outcome.iterations as u32,
+                                        output_chars: outcome.output.chars().count(),
+                                        output: outcome.output.clone(),
+                                        worktree_path: None,
+                                        changed_files: Vec::new(),
+                                        dirty_status: None,
+                                    })
+                                    .await;
+                            }
                         }
-                    }
-                    SubagentRunStatus::AwaitingUser { ref question, .. } => {
-                        if let Err(err) = subagent_sessions::mark_finished(
-                            &background_store,
-                            &background_subagent_session_id,
-                            &outcome.task_id,
-                            &outcome.status,
-                            outcome.final_history.clone(),
-                        ) {
-                            log::warn!(
+                        SubagentRunStatus::AwaitingUser { ref question, .. } => {
+                            if let Err(err) = subagent_sessions::mark_finished(
+                                &background_store,
+                                &background_subagent_session_id,
+                                &outcome.task_id,
+                                &outcome.status,
+                                outcome.final_history.clone(),
+                            ) {
+                                log::warn!(
                                 "[subagent_reuse] mark_awaiting_user failed subagent_session_id={} task_id={} agent_id={} error={}",
                                 background_subagent_session_id,
                                 outcome.task_id,
                                 outcome.agent_id,
                                 err
                             );
-                        }
-                        let _ = status_tx.send(SubagentStatus::AwaitingUser {
-                            question: question.clone(),
-                        });
-                        let error = format!(
+                            }
+                            let _ = status_tx.send(SubagentStatus::AwaitingUser {
+                                question: question.clone(),
+                            });
+                            let error = format!(
                             "async sub-agent requested user clarification and was not continued: {question}"
                         );
-                        // #4896: a detached child that pauses for input won't
-                        // continue on its own — queue a framed notice so the
-                        // parent chat learns the delegated task needs input,
-                        // instead of finalizing silently on "Accepted". Rides the
-                        // same idle-gated background_delivery path as a success.
-                        crate::openhuman::agent::orchestration::background_completions::record_awaiting_input(
+                            // #4896: a detached child that pauses for input won't
+                            // continue on its own — queue a framed notice so the
+                            // parent chat learns the delegated task needs input,
+                            // instead of finalizing silently on "Accepted". Rides the
+                            // same idle-gated background_delivery path as a success.
+                            crate::openhuman::agent::orchestration::background_completions::record_awaiting_input(
                             background_parent_session.clone(),
                             outcome.task_id.clone(),
                             outcome.agent_id.clone(),
                             question,
                             background_parent_thread_id.clone(),
                         );
-                        crate::openhuman::agent::orchestration::subagent_events::publish_subagent_failed(
+                            crate::openhuman::agent::orchestration::subagent_events::publish_subagent_failed(
                             background_parent_session,
                             outcome.task_id.clone(),
                             outcome.agent_id.clone(),
                             error.clone(),
                         );
-                        if let Some(ref tx) = background_progress {
-                            let _ = tx
-                                .send(AgentProgress::SubagentFailed {
-                                    agent_id: outcome.agent_id,
-                                    task_id: outcome.task_id,
-                                    error,
-                                })
-                                .await;
+                            if let Some(ref tx) = background_progress {
+                                let _ = tx
+                                    .send(AgentProgress::SubagentFailed {
+                                        agent_id: outcome.agent_id,
+                                        task_id: outcome.task_id,
+                                        error,
+                                    })
+                                    .await;
+                            }
                         }
-                    }
-                },
-                Err(err) => {
-                    let error = err.to_string();
-                    if let Err(store_err) = subagent_sessions::mark_failed(
-                        &background_store,
-                        &background_subagent_session_id,
-                        &background_task_id,
-                        error.clone(),
-                    ) {
-                        log::warn!(
+                    },
+                    Err(err) => {
+                        let error = err.to_string();
+                        if let Err(store_err) = subagent_sessions::mark_failed(
+                            &background_store,
+                            &background_subagent_session_id,
+                            &background_task_id,
+                            error.clone(),
+                        ) {
+                            log::warn!(
                             "[subagent_reuse] mark_failed failed subagent_session_id={} task_id={} agent_id={} error={}",
                             background_subagent_session_id,
                             background_task_id,
                             background_agent_id,
                             store_err
                         );
-                    }
-                    let _ = status_tx.send(SubagentStatus::Failed {
-                        error: error.clone(),
-                    });
-                    // #4896: a detached child that errors previously only
-                    // published an event — nothing reached chat, so the parent
-                    // turn finalized on "Accepted" and the failure was lost.
-                    // Queue a framed failure notice so background_delivery
-                    // surfaces it as a follow-up chat turn.
-                    crate::openhuman::agent::orchestration::background_completions::record_failure(
+                        }
+                        let _ = status_tx.send(SubagentStatus::Failed {
+                            error: error.clone(),
+                        });
+                        // #4896: a detached child that errors previously only
+                        // published an event — nothing reached chat, so the parent
+                        // turn finalized on "Accepted" and the failure was lost.
+                        // Queue a framed failure notice so background_delivery
+                        // surfaces it as a follow-up chat turn.
+                        crate::openhuman::agent::orchestration::background_completions::record_failure(
                         background_parent_session.clone(),
                         background_task_id.clone(),
                         background_agent_id.clone(),
                         &error,
                         background_parent_thread_id.clone(),
                     );
-                    crate::openhuman::agent::orchestration::subagent_events::publish_subagent_failed(
+                        crate::openhuman::agent::orchestration::subagent_events::publish_subagent_failed(
                         background_parent_session,
                         background_task_id.clone(),
                         background_agent_id.clone(),
                         error.clone(),
                     );
-                    if let Some(ref tx) = background_progress {
-                        let _ = tx
-                            .send(AgentProgress::SubagentFailed {
-                                agent_id: background_agent_id,
-                                task_id: background_task_id,
-                                error,
-                            })
-                            .await;
+                        if let Some(ref tx) = background_progress {
+                            let _ = tx
+                                .send(AgentProgress::SubagentFailed {
+                                    agent_id: background_agent_id,
+                                    task_id: background_task_id,
+                                    error,
+                                })
+                                .await;
+                        }
                     }
                 }
-            }
-        }),
+            }),
         ));
 
         // Register *after* spawn so the AbortHandle is available. The task owns

--- a/src/openhuman/agent/turn_origin.rs
+++ b/src/openhuman/agent/turn_origin.rs
@@ -157,6 +157,42 @@ pub fn current() -> Option<AgentTurnOrigin> {
     AGENT_TURN_ORIGIN.try_with(|o| o.clone()).ok()
 }
 
+/// Carry the origin scoped **right now** into a future that will run on
+/// another task.
+///
+/// A `tokio::task_local` does not cross `tokio::spawn`: a detached sub-agent
+/// (`spawn_async_subagent`, the orchestration `spawn_agent` task) starts on a
+/// fresh task where [`current`] is `None`, so every external-effect tool it
+/// calls reaches the approval gate as [`AgentTurnOrigin::Unknown`] and is
+/// refused — even though the parent turn that delegated the work was properly
+/// labelled. That is the same failure mode
+/// [`fork_context::with_parent_context`](crate::openhuman::agent::harness::fork_context)
+/// and [`thread_context::with_thread_id`](crate::openhuman::agent::tinyagents::thread_context)
+/// already re-install explicitly at those spawn sites; the origin is the third
+/// thing that has to travel with them.
+///
+/// **Call this on the parent task**, i.e. build the future *before* handing it
+/// to `tokio::spawn` — the origin is read when this function is called, not
+/// when the returned future is first polled:
+///
+/// ```ignore
+/// tokio::spawn(turn_origin::propagate(async move { run_subagent(..).await }));
+/// ```
+///
+/// Fail-closed is preserved: with no ambient origin nothing is scoped, so the
+/// child still lands on `Unknown` rather than inheriting a label nobody set.
+/// This only ever *carries* a decision the parent entry point already made — it
+/// cannot manufacture trust that did not exist on the spawning task.
+pub fn propagate<F: std::future::Future>(fut: F) -> impl std::future::Future<Output = F::Output> {
+    let captured = current();
+    async move {
+        match captured {
+            Some(origin) => with_origin(origin, fut).await,
+            None => fut.await,
+        }
+    }
+}
+
 /// Read the ambient web-chat `request_id` for the current turn, when one was
 /// scoped by an [`AgentTurnOrigin::WebChat`] entry point. `None` for every
 /// other origin (channel / cron / CLI / sub-agent) and outside any scope —

--- a/src/openhuman/agent/turn_origin.rs
+++ b/src/openhuman/agent/turn_origin.rs
@@ -225,6 +225,62 @@ mod tests {
         assert!(current().is_none());
     }
 
+    /// Regression: a detached sub-agent (`spawn_async_subagent`, the
+    /// orchestration spawn task) starts on a fresh task, and without explicit
+    /// propagation its tools reach the approval gate as `Unknown` and every
+    /// external-effect call is refused — the parent's label silently lost at
+    /// the `tokio::spawn` boundary.
+    #[tokio::test]
+    async fn propagate_carries_the_origin_across_a_spawn() {
+        let observed = with_origin(
+            AgentTurnOrigin::TrustedAutomation {
+                job_id: "run-1".to_string(),
+                source: TrustedAutomationSource::Workflow {
+                    require_approval: false,
+                },
+            },
+            async {
+                tokio::spawn(propagate(async { current() }))
+                    .await
+                    .expect("spawned task panicked")
+            },
+        )
+        .await;
+        assert!(matches!(
+            observed,
+            Some(AgentTurnOrigin::TrustedAutomation {
+                source: TrustedAutomationSource::Workflow {
+                    require_approval: false
+                },
+                ..
+            })
+        ));
+    }
+
+    /// Without propagation the same spawn loses the label — the behaviour the
+    /// helper above exists to fix, pinned so a future refactor cannot quietly
+    /// reintroduce it by dropping the wrapper.
+    #[tokio::test]
+    async fn a_bare_spawn_loses_the_origin() {
+        let observed = with_origin(AgentTurnOrigin::Cli, async {
+            tokio::spawn(async { current() })
+                .await
+                .expect("spawned task panicked")
+        })
+        .await;
+        assert!(observed.is_none());
+    }
+
+    /// Fail-closed is preserved: propagation carries a decision, it does not
+    /// invent one. An unlabelled parent still yields an unlabelled child.
+    #[tokio::test]
+    async fn propagate_does_not_manufacture_an_origin() {
+        let observed = tokio::spawn(propagate(async { current() }))
+            .await
+            .expect("spawned task panicked");
+        assert!(observed.is_none());
+    }
+
     #[tokio::test]
     async fn current_returns_none_outside_scope() {
         assert!(current().is_none());

--- a/src/openhuman/agent/turn_workspace.rs
+++ b/src/openhuman/agent/turn_workspace.rs
@@ -108,6 +108,33 @@ mod tests {
         assert!(current().is_none(), "root must not leak past the scope");
     }
 
+    /// A detached sub-agent must keep working in the tree its parent turn was
+    /// bound to; a bare `tokio::spawn` drops the root, which is what put its
+    /// writes back outside the sandbox.
+    #[tokio::test]
+    async fn propagate_carries_the_root_across_a_spawn() {
+        let observed = with_workspace(PathBuf::from("/work/checkout"), async {
+            tokio::spawn(propagate(async { current() }))
+                .await
+                .expect("spawned task panicked")
+        })
+        .await;
+        assert_eq!(observed, Some(PathBuf::from("/work/checkout")));
+    }
+
+    /// Without the wrapper the same spawn loses the root — pinned so the fix
+    /// cannot be silently undone.
+    #[tokio::test]
+    async fn a_bare_spawn_loses_the_root() {
+        let observed = with_workspace(PathBuf::from("/work/checkout"), async {
+            tokio::spawn(async { current() })
+                .await
+                .expect("spawned task panicked")
+        })
+        .await;
+        assert!(observed.is_none());
+    }
+
     #[tokio::test]
     async fn nested_scope_overrides_the_outer_root() {
         with_workspace(PathBuf::from("/outer"), async {

--- a/src/openhuman/agent/turn_workspace.rs
+++ b/src/openhuman/agent/turn_workspace.rs
@@ -74,6 +74,28 @@ pub fn current() -> Option<PathBuf> {
     AGENT_TURN_WORKSPACE.try_with(|root| root.clone()).ok()
 }
 
+/// Carry the workspace scoped **right now** into a future that will run on
+/// another task.
+///
+/// Same contract, and same reason, as
+/// [`turn_origin::propagate`](super::turn_origin::propagate): a detached
+/// sub-agent starts on a fresh task where [`current`] is `None`, so it would
+/// lose the root its parent turn was bound to and have its writes into that
+/// checkout refused. Build the future on the parent task, before `tokio::spawn`
+/// — the root is read when this is called, not when the future is polled.
+///
+/// With no scoped root this is a no-op, which is every caller that never opted
+/// in.
+pub fn propagate<F: std::future::Future>(fut: F) -> impl std::future::Future<Output = F::Output> {
+    let captured = current();
+    async move {
+        match captured {
+            Some(root) => with_workspace(root, fut).await,
+            None => fut.await,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/openhuman/agent/turn_workspace.rs
+++ b/src/openhuman/agent/turn_workspace.rs
@@ -1,0 +1,101 @@
+//! Agent turn workspace — the per-turn filesystem root an embedder binds a
+//! single agent turn to.
+//!
+//! A host that drives the core in-process (the Medulla TUI's embedded core, a
+//! workflow node dispatched to the `openhuman` harness) runs one turn *against
+//! a checkout it names*, not against the operator's ambient
+//! [`Config::action_dir`](crate::openhuman::config::Config). Everything the
+//! core already had for this was **process-global**: `action_dir` comes from
+//! config, and [`SecurityPolicy`](crate::openhuman::security::SecurityPolicy)
+//! is installed once per process, so two concurrent turns could not disagree
+//! about where they are allowed to write.
+//!
+//! This module is the per-turn answer, deliberately shaped like
+//! [`super::turn_origin`]: a [`tokio::task_local`] the entry point scopes
+//! around its `run_turn` invocation, read by the two places that decide where
+//! a turn may work:
+//!
+//! * the session builder
+//!   ([`Agent::from_config`](crate::openhuman::agent::Agent::from_config)),
+//!   which turns it into the turn's
+//!   [`WorkspaceDescriptor`](tinyagents::harness::workspace::WorkspaceDescriptor)
+//!   so acting tools (shell, file, git) resolve their default cwd there; and
+//! * [`SecurityPolicy::is_within_trusted_root`](crate::openhuman::security::SecurityPolicy::is_within_trusted_root),
+//!   which treats the scoped root as a read/write trusted root for the
+//!   duration of the turn, so a write into that checkout is not refused as an
+//!   escape from `workspace_dir`.
+//!
+//! # Trust
+//!
+//! Scoping a root here is a **grant**, exactly as strong as a user-configured
+//! [`TrustedRoot`](crate::openhuman::security::TrustedRoot) with
+//! `access = ReadWrite`, and it is scoped to one turn rather than persisted.
+//! It therefore never weakens the two invariants a trusted root has never been
+//! able to weaken: credential stores
+//! ([`SecurityPolicy::is_always_forbidden`](crate::openhuman::security::SecurityPolicy::is_always_forbidden))
+//! and workspace-internal application state stay unreachable. An embedder
+//! scopes it only for a root it already decided the turn owns — a workflow
+//! run's checkout — which is why the API takes an owned [`PathBuf`] the caller
+//! resolved rather than a string the model could have supplied.
+//!
+//! Nothing is scoped by default: `current()` returning `None` is every
+//! existing caller, and leaves path policy byte-identical.
+
+use std::path::PathBuf;
+
+tokio::task_local! {
+    /// Per-turn filesystem root. Scoped by an embedder around the agent turn it
+    /// drives; read by the session builder and the path policy. Unset for every
+    /// caller that has not opted in.
+    pub static AGENT_TURN_WORKSPACE: PathBuf;
+}
+
+/// Scope `root` as the workspace for the duration of `fut`.
+///
+/// `root` should be an existing, absolute directory the caller has already
+/// resolved — a relative or missing path still scopes, but the tools rooted at
+/// it will fail on their own terms rather than being caught here, and the
+/// policy grant only ever covers paths that actually resolve under it.
+///
+/// The inner future is `Box::pin`-ed before entering the task-local scope for
+/// the same reason [`super::turn_origin::with_origin`] does it: the agent loop
+/// downstream is deep, and stacking task-local scopes plus the loop on a 2 MiB
+/// worker stack blows the test runtime.
+pub async fn with_workspace<F: std::future::Future>(root: PathBuf, fut: F) -> F::Output {
+    AGENT_TURN_WORKSPACE.scope(root, Box::pin(fut)).await
+}
+
+/// The workspace root scoped for the current turn, when an embedder set one.
+///
+/// `None` — the default everywhere — means "no per-turn root": the session
+/// binds no [`WorkspaceDescriptor`](tinyagents::harness::workspace::WorkspaceDescriptor)
+/// of its own and the path policy grants nothing beyond its configured roots.
+pub fn current() -> Option<PathBuf> {
+    AGENT_TURN_WORKSPACE.try_with(|root| root.clone()).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn scope_sets_and_clears_the_root() {
+        assert!(current().is_none(), "baseline outside any scope");
+        let observed = with_workspace(PathBuf::from("/work/checkout"), async { current() }).await;
+        assert_eq!(observed, Some(PathBuf::from("/work/checkout")));
+        assert!(current().is_none(), "root must not leak past the scope");
+    }
+
+    #[tokio::test]
+    async fn nested_scope_overrides_the_outer_root() {
+        with_workspace(PathBuf::from("/outer"), async {
+            assert_eq!(current(), Some(PathBuf::from("/outer")));
+            with_workspace(PathBuf::from("/inner"), async {
+                assert_eq!(current(), Some(PathBuf::from("/inner")));
+            })
+            .await;
+            assert_eq!(current(), Some(PathBuf::from("/outer")));
+        })
+        .await;
+    }
+}

--- a/src/openhuman/inference/local/ops.rs
+++ b/src/openhuman/inference/local/ops.rs
@@ -104,9 +104,14 @@ pub async fn agent_chat(
     let mut agent = Agent::from_config(config).map_err(|e| e.to_string())?;
     // Direct `agent_chat` RPC — invoked by trusted clients (desktop UI,
     // operator CLI). Label as CLI so the approval gate doesn't fail
-    // closed on an unlabelled call site.
+    // closed on an unlabelled call site — *unless* the caller already scoped a
+    // more specific origin around this dispatch, which an in-process embedder
+    // can do (a workflow node labels its turn `TrustedAutomation::Workflow`).
+    // Overwriting that with `Cli` would silently discard the caller's own
+    // trust statement and hand every such turn the blanket CLI allowance
+    // instead of the narrower one it asked for.
     let run = crate::openhuman::agent::turn_origin::with_origin(
-        crate::openhuman::agent::turn_origin::AgentTurnOrigin::Cli,
+        effective_agent_chat_origin(),
         agent.run_single(message),
     );
     let response = match thread_id.as_deref() {

--- a/src/openhuman/inference/local/ops.rs
+++ b/src/openhuman/inference/local/ops.rs
@@ -72,6 +72,19 @@ fn enforce_user_prompt_or_reject(prompt: &str, source: &'static str) -> Result<(
     }
 }
 
+/// The origin label [`agent_chat`] scopes around its turn.
+///
+/// An ambient origin — scoped by an in-process embedder around its
+/// `invoke("openhuman.inference_agent_chat", …)` — is the caller's own,
+/// deliberate trust statement about the turn and is kept. Absent one, the
+/// historical [`AgentTurnOrigin::Cli`] label applies: this RPC is reached by
+/// trusted clients (desktop UI, operator CLI), and leaving it unlabelled would
+/// fail the approval gate closed on every external-effect tool.
+fn effective_agent_chat_origin() -> crate::openhuman::agent::turn_origin::AgentTurnOrigin {
+    crate::openhuman::agent::turn_origin::current()
+        .unwrap_or(crate::openhuman::agent::turn_origin::AgentTurnOrigin::Cli)
+}
+
 /// Executes a single chat turn with an AI agent.
 ///
 /// This function initializes an agent from the provided configuration and

--- a/src/openhuman/inference/local/ops_tests.rs
+++ b/src/openhuman/inference/local/ops_tests.rs
@@ -180,3 +180,41 @@ fn normalize_model_override_passes_non_empty_verbatim() {
         Some("hint:reasoning".to_string())
     );
 }
+
+/// No embedder scoped an origin: this RPC is the trusted desktop / operator
+/// entry point, so the turn keeps its historical `Cli` label rather than
+/// falling through to the gate's fail-closed `Unknown` arm.
+#[tokio::test]
+async fn effective_origin_defaults_to_cli_outside_any_scope() {
+    use crate::openhuman::agent::turn_origin::AgentTurnOrigin;
+    assert!(matches!(effective_agent_chat_origin(), AgentTurnOrigin::Cli));
+}
+
+/// An in-process embedder that labelled the turn keeps its label: a workflow
+/// node's `TrustedAutomation::Workflow` origin is what the approval gate must
+/// see, not the blanket `Cli` allowance this RPC would otherwise impose.
+#[tokio::test]
+async fn effective_origin_keeps_an_embedder_scoped_label() {
+    use crate::openhuman::agent::turn_origin::{
+        with_origin, AgentTurnOrigin, TrustedAutomationSource,
+    };
+    let observed = with_origin(
+        AgentTurnOrigin::TrustedAutomation {
+            job_id: "run-7".to_string(),
+            source: TrustedAutomationSource::Workflow {
+                require_approval: false,
+            },
+        },
+        async { effective_agent_chat_origin() },
+    )
+    .await;
+    assert!(matches!(
+        observed,
+        AgentTurnOrigin::TrustedAutomation {
+            source: TrustedAutomationSource::Workflow {
+                require_approval: false
+            },
+            ..
+        }
+    ));
+}

--- a/src/openhuman/inference/local/ops_tests.rs
+++ b/src/openhuman/inference/local/ops_tests.rs
@@ -187,7 +187,10 @@ fn normalize_model_override_passes_non_empty_verbatim() {
 #[tokio::test]
 async fn effective_origin_defaults_to_cli_outside_any_scope() {
     use crate::openhuman::agent::turn_origin::AgentTurnOrigin;
-    assert!(matches!(effective_agent_chat_origin(), AgentTurnOrigin::Cli));
+    assert!(matches!(
+        effective_agent_chat_origin(),
+        AgentTurnOrigin::Cli
+    ));
 }
 
 /// An in-process embedder that labelled the turn keeps its label: a workflow

--- a/src/openhuman/security/policy/path_checks.rs
+++ b/src/openhuman/security/policy/path_checks.rs
@@ -477,6 +477,21 @@ impl SecurityPolicy {
         if Self::is_always_forbidden(path) {
             return false;
         }
+        // Per-turn grant (see `agent::turn_workspace`): an embedder that scoped
+        // a workspace root for this turn — a workflow run's checkout — trusts
+        // it read/write for the turn's duration. Checked alongside the
+        // configured roots rather than instead of them, and *after*
+        // `is_always_forbidden` above, so a per-turn grant is exactly as strong
+        // as a user-configured `TrustedRoot` and no stronger: credential stores
+        // and workspace-internal state stay unreachable through it.
+        if let Some(turn_root) = crate::openhuman::agent::turn_workspace::current() {
+            let canonical_turn_root = turn_root
+                .canonicalize()
+                .unwrap_or_else(|_| turn_root.clone());
+            if path.starts_with(&turn_root) || path.starts_with(&canonical_turn_root) {
+                return true;
+            }
+        }
         self.trusted_roots.iter().any(|root| {
             if require_write && root.access != TrustedAccess::ReadWrite {
                 return false;

--- a/src/openhuman/security/policy/policy_tests.rs
+++ b/src/openhuman/security/policy/policy_tests.rs
@@ -2808,7 +2808,10 @@ async fn write_outside_the_workspace_is_refused_without_a_turn_root() {
         .validate_parent_path(target.to_str().unwrap())
         .await
         .expect_err("a path outside the workspace must not validate");
-    assert!(err.contains("escapes workspace"), "unexpected error: {err}");
+    assert!(
+        err.contains(POLICY_BLOCKED_MARKER),
+        "unexpected error: {err}"
+    );
 }
 
 /// With the checkout scoped as this turn's workspace, the same write validates:
@@ -2850,7 +2853,10 @@ async fn the_turn_root_grant_does_not_reach_a_sibling_directory() {
     })
     .await
     .expect_err("a sibling of the scoped root must stay outside it");
-    assert!(err.contains("escapes workspace"), "unexpected error: {err}");
+    assert!(
+        err.contains(POLICY_BLOCKED_MARKER),
+        "unexpected error: {err}"
+    );
 }
 
 /// The grant is exactly as strong as a configured trusted root and no stronger:

--- a/src/openhuman/security/policy/policy_tests.rs
+++ b/src/openhuman/security/policy/policy_tests.rs
@@ -2823,11 +2823,7 @@ async fn write_into_the_scoped_turn_root_is_allowed() {
     let resolved = crate::openhuman::agent::turn_workspace::with_workspace(checkout.clone(), {
         let policy = &policy;
         let target = target.clone();
-        async move {
-            policy
-                .validate_parent_path(target.to_str().unwrap())
-                .await
-        }
+        async move { policy.validate_parent_path(target.to_str().unwrap()).await }
     })
     .await
     .expect("the scoped turn root must be writable");
@@ -2845,11 +2841,7 @@ async fn the_turn_root_grant_does_not_reach_a_sibling_directory() {
     let err = crate::openhuman::agent::turn_workspace::with_workspace(checkout, {
         let policy = &policy;
         let target = target.clone();
-        async move {
-            policy
-                .validate_parent_path(target.to_str().unwrap())
-                .await
-        }
+        async move { policy.validate_parent_path(target.to_str().unwrap()).await }
     })
     .await
     .expect_err("a sibling of the scoped root must stay outside it");
@@ -2870,11 +2862,7 @@ async fn the_turn_root_grant_never_reaches_a_credential_store() {
     let err = crate::openhuman::agent::turn_workspace::with_workspace(checkout, {
         let policy = &policy;
         let target = target.clone();
-        async move {
-            policy
-                .validate_parent_path(target.to_str().unwrap())
-                .await
-        }
+        async move { policy.validate_parent_path(target.to_str().unwrap()).await }
     })
     .await
     .expect_err("credential stores stay forbidden inside a granted root");

--- a/src/openhuman/security/policy/policy_tests.rs
+++ b/src/openhuman/security/policy/policy_tests.rs
@@ -2769,3 +2769,111 @@ fn action_dir_in_default_policy() {
     let policy = SecurityPolicy::default();
     assert_eq!(policy.action_dir, std::path::PathBuf::from("."));
 }
+
+// -- Per-turn workspace grant (agent::turn_workspace) ------------------------
+//
+// These drive the grant through the real `validate_parent_path` gate every file
+// write funnels through, so they prove the tightening/loosening lands at the
+// shared call site rather than only in the standalone predicate.
+
+/// A `workspace_only` policy whose workspace is `<root>/home`, plus a separate
+/// `<root>/checkout` directory standing in for the run's own tree.
+fn turn_workspace_policy() -> (tempfile::TempDir, PathBuf, SecurityPolicy) {
+    let root = tempfile::tempdir().expect("root tempdir");
+    let workspace = root.path().join("home");
+    let checkout = root.path().join("checkout");
+    std::fs::create_dir_all(&workspace).unwrap();
+    std::fs::create_dir_all(&checkout).unwrap();
+    let policy = SecurityPolicy {
+        autonomy: AutonomyLevel::Full,
+        workspace_dir: workspace.clone(),
+        action_dir: workspace,
+        workspace_only: true,
+        // The OS tempdir lives under /tmp or /var, both on the default
+        // forbidden list; clear it so the workspace boundary is what decides.
+        forbidden_paths: Vec::new(),
+        trusted_roots: Vec::new(),
+        ..SecurityPolicy::default()
+    };
+    (root, checkout, policy)
+}
+
+/// Without a scoped root the checkout is simply outside the workspace, and a
+/// write into it is refused — the behaviour every existing caller keeps.
+#[tokio::test]
+async fn write_outside_the_workspace_is_refused_without_a_turn_root() {
+    let (_root, checkout, policy) = turn_workspace_policy();
+    let target = checkout.join("notes.md");
+    let err = policy
+        .validate_parent_path(target.to_str().unwrap())
+        .await
+        .expect_err("a path outside the workspace must not validate");
+    assert!(err.contains("escapes workspace"), "unexpected error: {err}");
+}
+
+/// With the checkout scoped as this turn's workspace, the same write validates:
+/// the grant is what lets an embedded turn work in the tree its host named.
+#[tokio::test]
+async fn write_into_the_scoped_turn_root_is_allowed() {
+    let (_root, checkout, policy) = turn_workspace_policy();
+    let target = checkout.join("notes.md");
+    let resolved = crate::openhuman::agent::turn_workspace::with_workspace(checkout.clone(), {
+        let policy = &policy;
+        let target = target.clone();
+        async move {
+            policy
+                .validate_parent_path(target.to_str().unwrap())
+                .await
+        }
+    })
+    .await
+    .expect("the scoped turn root must be writable");
+    assert!(resolved.ends_with("notes.md"), "resolved: {resolved:?}");
+}
+
+/// The grant covers its own subtree and nothing beside it: a sibling directory
+/// stays outside, so scoping one checkout does not open the whole parent.
+#[tokio::test]
+async fn the_turn_root_grant_does_not_reach_a_sibling_directory() {
+    let (root, checkout, policy) = turn_workspace_policy();
+    let sibling = root.path().join("other");
+    std::fs::create_dir_all(&sibling).unwrap();
+    let target = sibling.join("notes.md");
+    let err = crate::openhuman::agent::turn_workspace::with_workspace(checkout, {
+        let policy = &policy;
+        let target = target.clone();
+        async move {
+            policy
+                .validate_parent_path(target.to_str().unwrap())
+                .await
+        }
+    })
+    .await
+    .expect_err("a sibling of the scoped root must stay outside it");
+    assert!(err.contains("escapes workspace"), "unexpected error: {err}");
+}
+
+/// The grant is exactly as strong as a configured trusted root and no stronger:
+/// a credential store under the scoped tree is still unreachable.
+#[tokio::test]
+async fn the_turn_root_grant_never_reaches_a_credential_store() {
+    let (_root, checkout, policy) = turn_workspace_policy();
+    let ssh = checkout.join(".ssh");
+    std::fs::create_dir_all(&ssh).unwrap();
+    let target = ssh.join("id_rsa");
+    let err = crate::openhuman::agent::turn_workspace::with_workspace(checkout, {
+        let policy = &policy;
+        let target = target.clone();
+        async move {
+            policy
+                .validate_parent_path(target.to_str().unwrap())
+                .await
+        }
+    })
+    .await
+    .expect_err("credential stores stay forbidden inside a granted root");
+    assert!(
+        err.contains(POLICY_BLOCKED_MARKER),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
## What this fixes

A delegated coding task could not run a shell, edit a file, or execute code — every
external-effect tool it called was refused with:

```
[policy-denied] Tool '...' rejected: agent turn has no origin label.
Refusing external_effect tool from unlabelled call site.
```

### Root cause

`AGENT_TURN_ORIGIN` is a `tokio::task_local`, and a task-local does **not** cross
`tokio::spawn`. `spawn_async_subagent` (which every `PreferAsync` archetype delegation
tool routes through — `run_code`, `research`, `plan`, `delegate_*`) and the
orchestration `spawn_agent` task both detach onto a fresh task. Both already re-install
the parent execution context and the chat thread id inside that task for exactly this
reason; the **origin was the third thing that had to travel with them, and did not**.

So the parent turn was labelled correctly (`agent_chat` scopes `Cli`, the web/channel/cron
entry points scope their own), the delegated child ran unlabelled, and the approval gate
fail-closed on every acting tool it tried. `bus.rs` already documents this failure mode for
native-bus dispatch; this is the same hazard at two other spawn sites.

## Changes

**`agent::turn_origin::propagate`** — captures the origin scoped *now* and re-scopes it
inside a future destined for another task. Applied at
`orchestration/tools/spawn_async_subagent.rs` and `orchestration/ops.rs`, on the spawning
task. Fail-closed is preserved: with no ambient origin nothing is scoped and the child
still lands on `Unknown`. It only ever carries a decision the parent entry point already
made — it cannot manufacture trust.

**`agent::turn_workspace`** (new) — a per-turn filesystem root an in-process embedder can
bind one agent turn to, shaped deliberately like `turn_origin`. `action_dir` comes from
config and `SecurityPolicy` is installed process-globally, so before this there was no way
for one turn to work in a checkout of its own. It is read in exactly two places:

* the session builder, which turns it into the turn's `WorkspaceDescriptor` so acting tools
  resolve their default cwd there (falls back to the shared `action_dir` when the root is
  not an existing directory; a profile's `dedicated_workspace` still wins where both exist);
* `SecurityPolicy::is_within_trusted_root`, which treats it as a read/write trusted root for
  the turn's duration.

It has a `propagate` for the same spawn boundary.

**`inference::local::ops::agent_chat`** — keeps an already-scoped origin instead of
overwriting it with `Cli`. An in-process embedder that labelled its turn
(`TrustedAutomation { source: Workflow { .. } }`) had that label silently replaced with the
blanket CLI allowance. Absent an ambient origin the historical `Cli` label is unchanged.

## Security implications

The per-turn workspace grant is **exactly as strong as a user-configured
`TrustedRoot { access: ReadWrite }`, and no stronger** — it is checked alongside the
configured roots and after `is_always_forbidden`, so credential stores and
workspace-internal application state stay unreachable through it, the cross-profile write
guard still applies, and the grant covers only its own subtree. It is scoped to one turn
rather than persisted, and the API takes an owned `PathBuf` the host resolved rather than a
string a model could supply. Nothing is scoped by default: `current() == None` is every
existing caller and leaves path policy byte-identical.

Origin propagation does not widen the gate's decision table. It restores the parent's own
label on a child that today runs unlabelled, which is what the two sibling task-locals at
those spawn sites already do.

## Validation

Run from `vendor/openhuman` in the consuming Medulla checkout:

- `cargo fmt --check` — clean
- `cargo clippy --lib -- -D warnings` — clean
- `cargo test --lib turn_origin` — 6 passed
- `cargo test --lib turn_workspace` — 4 passed
- `cargo test --lib turn_root` — 4 passed (the policy grant, driven through the real
  `validate_parent_path` gate)
- `cargo test --lib effective_origin` — 2 passed
- `cargo test --lib security::policy` — 171 passed
- `cargo test --lib agent::harness::session::builder` — 36 passed
- `cargo test --lib orchestration` — 422 passed
- `cargo test --lib spawn_async_subagent` — 17 passed

New tests pin both directions: a bare `tokio::spawn` loses the origin/root (the bug), the
wrapped one keeps it (the fix), and an unlabelled parent still yields an unlabelled child
(fail-closed).

Branched from `475c9be4` — the commit `tinyhumansai/medulla` pins as its `vendor/openhuman`
gitlink — rather than current `main`, so the consuming Medulla PR moves the gitlink by this
change alone.
