### PR TITLE
build: CI toolchain fix, mold, aws-lc-sys shed, tokio-tungstenite 0.29

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -39,12 +39,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpangocairo-1.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
-# Rust 1.93.0 with minimal profile + fmt/clippy
+# Rust 1.96.1 with minimal profile + fmt/clippy
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH="/usr/local/cargo/bin:$PATH"
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
-    -y --default-toolchain 1.93.0 --profile minimal \
+    -y --default-toolchain 1.96.1 --profile minimal \
     -c rustfmt -c clippy \
     -t x86_64-unknown-linux-gnu
 

--- a/.github/workflows/android-compile.yml
+++ b/.github/workflows/android-compile.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.96.1"
           targets: aarch64-linux-android,armv7-linux-androideabi
 
       - name: Cache Rust build artifacts

--- a/.github/workflows/build-ci-image.yml
+++ b/.github/workflows/build-ci-image.yml
@@ -32,4 +32,4 @@ jobs:
           provenance: false
           tags: |-
             ghcr.io/tinyhumansai/openhuman_ci:latest
-            ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+            ghcr.io/tinyhumansai/openhuman_ci:rust-1.96.1

--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -157,17 +157,19 @@ jobs:
         with:
           node-version: 24.x
       - name: Install Rust (rust-toolchain.toml)
-        uses: dtolnay/rust-toolchain@1.93.0
+        uses: dtolnay/rust-toolchain@1.96.1
         with:
           targets: ${{ matrix.settings.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
       - name: Ensure macOS cross target on the toolchain-file toolchain
         if: matrix.settings.platform == 'macos-latest'
         run: |
-          # rust-toolchain.toml pins 1.96.1, which overrides the dtolnay-installed
-          # 1.93.0. The action's `targets:` input added the darwin targets to
-          # 1.93.0, not the override toolchain the vendored tauri-cli's CEF
-          # universal-helper build actually uses, so add them to the active
-          # (override) toolchain here to avoid E0463 "can't find crate for `core`".
+          # The action pin and rust-toolchain.toml agree today
+          # (scripts/ci/check-toolchain-image.mjs enforces that), so the action's
+          # `targets:` input lands on the toolchain the vendored tauri-cli's CEF
+          # universal-helper build actually uses. Re-adding the targets against
+          # the *active* (override) toolchain keeps this step correct if the two
+          # ever diverge again, which used to fail with E0463
+          # "can't find crate for `core`".
           cargo --version
           rustup target add aarch64-apple-darwin x86_64-apple-darwin
       - name: Install Tauri dependencies (ubuntu only)

--- a/.github/workflows/ci-lite.yml
+++ b/.github/workflows/ci-lite.yml
@@ -73,6 +73,9 @@ jobs:
       # Test wiring surface (workflows, package.json, all.rs, tests/, script
       # tests) → run the test-inventory orphan + controller-domain guard.
       inventory: ${{ steps.filter.outputs.inventory }}
+      # CI image and toolchain pin inputs → check that every workflow, the
+      # image Dockerfile, and rust-toolchain.toml stay in lockstep.
+      toolchain-image: ${{ steps.filter.outputs['toolchain-image'] }}
       # Windows installer or its unit test → run the Pester install lane.
       install-ps1: ${{ steps.filter.outputs.install_ps1 }}
       coverage: ${{ steps.filter.outputs.frontend == 'true' || steps.filter.outputs['rust-core'] == 'true' || steps.filter.outputs['rust-tauri'] == 'true' }}
@@ -201,6 +204,13 @@ jobs:
               - 'scripts/**/*.test.mjs'
               - 'scripts/tests/**'
               - 'scripts/generate-test-inventory.mjs'
+            # The drift guard scans every workflow plus these two direct
+            # inputs, so changes to any of them must run it.
+            toolchain-image:
+              - '.github/workflows/**'
+              - '.github/Dockerfile'
+              - 'rust-toolchain.toml'
+              - 'scripts/ci/check-toolchain-image.mjs'
             # Windows installer + its Pester unit test.
             install_ps1:
               - '.github/workflows/ci-lite.yml'
@@ -360,9 +370,6 @@ jobs:
 
       - name: Check Rust formatting
         run: cargo fmt --all -- --check
-
-      - name: Guard — CI image tag matches rust-toolchain.toml
-        run: node scripts/ci/check-toolchain-image.mjs
 
       - name: Enforce Linux TLS dependency policy
         if: needs.changes.outputs['rust-core'] == 'true' || needs.changes.outputs['rust-tauri'] == 'true'
@@ -829,6 +836,22 @@ jobs:
       - name: Run test-inventory guard
         run: pnpm test:inventory
 
+  toolchain-image-drift:
+    name: Toolchain Image Drift Guard
+    needs: [changes]
+    if: needs.changes.outputs['toolchain-image'] == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify CI image and Rust toolchain pins
+        run: node scripts/ci/check-toolchain-image.mjs
+
   orch-ip-gate:
     name: Orchestration IP Gate (no local brain re-entry)
     runs-on: ubuntu-22.04
@@ -933,6 +956,7 @@ jobs:
       - rust-tauri-coverage
       - scripts-tests
       - test-inventory
+      - toolchain-image-drift
       - pester-install
       - tinycortex-tests
       - orch-ip-gate
@@ -952,6 +976,7 @@ jobs:
             ["Rust Tauri Coverage"]="${{ needs['rust-tauri-coverage'].result }}"
             ["Scripts Self-Tests"]="${{ needs['scripts-tests'].result }}"
             ["Test Inventory"]="${{ needs['test-inventory'].result }}"
+            ["Toolchain Image Drift Guard"]="${{ needs['toolchain-image-drift'].result }}"
             ["PowerShell Install Test"]="${{ needs['pester-install'].result }}"
             ["TinyCortex Memory Tests"]="${{ needs['tinycortex-tests'].result }}"
             ["Orchestration IP Gate"]="${{ needs['orch-ip-gate'].result }}"

--- a/.github/workflows/ci-lite.yml
+++ b/.github/workflows/ci-lite.yml
@@ -214,7 +214,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     container:
-      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.96.1
     steps:
       - name: Checkout code
         # Pinned to the v7 commit SHA for supply-chain hardening (CodeRabbit
@@ -333,9 +333,10 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     container:
-      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.96.1
     env:
       CARGO_INCREMENTAL: "0"
+      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -359,6 +360,9 @@ jobs:
 
       - name: Check Rust formatting
         run: cargo fmt --all -- --check
+
+      - name: Guard — CI image tag matches rust-toolchain.toml
+        run: node scripts/ci/check-toolchain-image.mjs
 
       - name: Enforce Linux TLS dependency policy
         if: needs.changes.outputs['rust-core'] == 'true' || needs.changes.outputs['rust-tauri'] == 'true'
@@ -399,9 +403,10 @@ jobs:
     # binary, not just `cargo check`.
     timeout-minutes: 40
     container:
-      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.96.1
     env:
       CARGO_INCREMENTAL: "0"
+      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       # Deep-async-stack belt (same as the coverage lanes) — virtual reservation,
       # zero cost. Keeps a gate-contract test with a deep stack from tripping.
       RUST_MIN_STACK: "67108864"
@@ -533,9 +538,10 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 40
     container:
-      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.96.1
     env:
       CARGO_INCREMENTAL: "0"
+      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -580,9 +586,10 @@ jobs:
     # needs more wall-time.
     timeout-minutes: 50
     container:
-      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.96.1
     env:
       CARGO_INCREMENTAL: "0"
+      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       # Coverage-instrumented test binaries are dominated by DWARF debug info,
       # which exhausts the runner disk and SIGBUSes the linker. Drop debug info
       # entirely for this job — llvm-cov line/region coverage is read from the
@@ -677,9 +684,10 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     container:
-      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.96.1
     env:
       CARGO_INCREMENTAL: "0"
+      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       # The instrumented Tauri shell binary (whole tauri/zbus/CEF graph) is
       # dominated by DWARF debug info, which exhausts the runner disk and
       # SIGBUSes the linker (collect2: ld terminated with signal 7) during the
@@ -768,7 +776,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     container:
-      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.96.1
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -807,7 +815,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     container:
-      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.96.1
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -889,9 +897,10 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     container:
-      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.96.1
     env:
       CARGO_INCREMENTAL: "0"
+      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/e2e-agent-review.yml
+++ b/.github/workflows/e2e-agent-review.yml
@@ -56,7 +56,7 @@ jobs:
           node-version: 24.x
       - name: Install Rust (rust-toolchain.toml)
         if: steps.gate.outputs.present == 'true'
-        uses: dtolnay/rust-toolchain@1.93.0
+        uses: dtolnay/rust-toolchain@1.96.1
       - name: Install system dependencies (CEF + Xvfb)
         if: steps.gate.outputs.present == 'true'
         run: |

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -465,7 +465,7 @@ jobs:
           cache: pnpm
 
       - name: Install Rust (rust-toolchain.toml)
-        uses: dtolnay/rust-toolchain@1.93.0
+        uses: dtolnay/rust-toolchain@1.96.1
         with:
           # macos-latest is arm64, but the vendored tauri-cli's build.rs
           # compiles a CEF helper for x86_64-apple-darwin (universal binary),
@@ -474,14 +474,15 @@ jobs:
 
       - name: Verify cargo resolves to real toolchain
         run: |
-          rustup default 1.93.0 || true
+          rustup default 1.96.1 || true
           which cargo
           # `cargo --version` in the repo root materializes the
-          # rust-toolchain.toml override toolchain (1.96.1), which supersedes the
-          # dtolnay-installed 1.93.0. The action's `targets:` input added
-          # x86_64-apple-darwin to 1.93.0, NOT the override toolchain the CEF
-          # universal-helper build actually uses — so add it to the active
-          # (override) toolchain here or the cross-compile fails with E0463
+          # rust-toolchain.toml override toolchain. The action pin and
+          # rust-toolchain.toml agree today (scripts/ci/check-toolchain-image.mjs
+          # enforces that), so the action's `targets:` input lands on the same
+          # toolchain — but re-adding the target against the *active* toolchain
+          # keeps this step correct if the two ever diverge again, which used to
+          # fail the CEF universal-helper cross-compile with E0463
           # "can't find crate for `core`".
           cargo --version
           rustup target add x86_64-apple-darwin
@@ -580,7 +581,7 @@ jobs:
           cache: pnpm
 
       - name: Install Rust (rust-toolchain.toml)
-        uses: dtolnay/rust-toolchain@1.93.0
+        uses: dtolnay/rust-toolchain@1.96.1
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
@@ -677,7 +678,7 @@ jobs:
           cache: pnpm
 
       - name: Install Rust (rust-toolchain.toml)
-        uses: dtolnay/rust-toolchain@1.93.0
+        uses: dtolnay/rust-toolchain@1.96.1
         with:
           # macos-latest is arm64, but the vendored tauri-cli's build.rs
           # compiles a CEF helper for x86_64-apple-darwin (universal binary),
@@ -687,14 +688,15 @@ jobs:
 
       - name: Verify cargo resolves to real toolchain
         run: |
-          rustup default 1.93.0 || true
+          rustup default 1.96.1 || true
           which cargo
           # `cargo --version` in the repo root materializes the
-          # rust-toolchain.toml override toolchain (1.96.1), which supersedes the
-          # dtolnay-installed 1.93.0. The action's `targets:` input added
-          # x86_64-apple-darwin to 1.93.0, NOT the override toolchain the CEF
-          # universal-helper build actually uses — so add it to the active
-          # (override) toolchain here or the cross-compile fails with E0463
+          # rust-toolchain.toml override toolchain. The action pin and
+          # rust-toolchain.toml agree today (scripts/ci/check-toolchain-image.mjs
+          # enforces that), so the action's `targets:` input lands on the same
+          # toolchain — but re-adding the target against the *active* toolchain
+          # keeps this step correct if the two ever diverge again, which used to
+          # fail the CEF universal-helper cross-compile with E0463
           # "can't find crate for `core`".
           cargo --version
           rustup target add x86_64-apple-darwin
@@ -905,7 +907,7 @@ jobs:
           cache: pnpm
 
       - name: Install Rust (rust-toolchain.toml)
-        uses: dtolnay/rust-toolchain@1.93.0
+        uses: dtolnay/rust-toolchain@1.96.1
 
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ios-appstore.yml
+++ b/.github/workflows/ios-appstore.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.96.1"
           targets: aarch64-apple-ios,aarch64-apple-ios-sim
 
       - name: Cache Rust build artifacts

--- a/.github/workflows/ios-compile.yml
+++ b/.github/workflows/ios-compile.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.93.0"
+          toolchain: "1.96.1"
           targets: aarch64-apple-ios
 
       - name: Cache Rust build artifacts

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     container:
-      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.96.1
     continue-on-error: true
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'docs') && !contains(github.event.pull_request.labels.*.name, 'chore') }}
     steps:
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     container:
-      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.96.1
     continue-on-error: true
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'docs') && !contains(github.event.pull_request.labels.*.name, 'chore') }}
     steps:

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 1
           submodules: recursive
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.93.0
+        uses: dtolnay/rust-toolchain@1.96.1
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -484,7 +484,7 @@ jobs:
           fetch-depth: 1
           submodules: recursive
       - name: Install Rust (rust-toolchain.toml)
-        uses: dtolnay/rust-toolchain@1.93.0
+        uses: dtolnay/rust-toolchain@1.96.1
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/test-reusable.yml
+++ b/.github/workflows/test-reusable.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
     container:
-      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.96.1
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     container:
-      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.96.1
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -120,9 +120,10 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     container:
-      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.96.1
     env:
       CARGO_INCREMENTAL: "0"
+      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
       # Keep the full core test binary link under hosted-runner memory/disk
       # pressure. Tests do not need full DWARF; file/line backtraces remain.
       CARGO_PROFILE_DEV_DEBUG: line-tables-only
@@ -202,9 +203,10 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     container:
-      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.96.1
     env:
       CARGO_INCREMENTAL: "0"
+      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -268,9 +270,10 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     container:
-      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.93.0
+      image: ghcr.io/tinyhumansai/openhuman_ci:rust-1.96.1
     env:
       CARGO_INCREMENTAL: "0"
+      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4730,7 +4730,7 @@ dependencies = [
  "tinyplace",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "tower",
@@ -7377,7 +7377,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite 0.29.0",
  "url",
  "x25519-dalek",
 ]
@@ -7484,14 +7484,8 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
- "rustls",
- "rustls-pki-types",
  "tokio",
- "tokio-native-tls",
- "tokio-rustls",
  "tungstenite 0.24.0",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -7502,9 +7496,11 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "rustls",
  "rustls-pki-types",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tungstenite 0.29.0",
  "webpki-roots 0.26.11",
@@ -7830,10 +7826,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "native-tls",
  "rand 0.8.6",
- "rustls",
- "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -7850,6 +7843,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,7 +319,7 @@ docx-rs = { version = "0.4.20", optional = true }
 # Windows: tokio-tungstenite uses native-tls (schannel) so wss://
 # connections honor the Windows cert store, including corporate CAs
 # installed by AV / TLS-inspection proxies. See run-dev-win.sh notes.
-tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "handshake", "native-tls"] }
+tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "handshake", "native-tls"] }
 # Windows re-adds reqwest's native-tls backend (dropped from the base decl in
 # `[dependencies]`) so `tls::tls_client_builder()` can call `.use_native_tls()`
 # and reach the SChannel/OS cert store — same rationale as tokio-tungstenite
@@ -343,7 +343,7 @@ windows-sys = { version = "0.61", features = [
 [target.'cfg(not(windows))'.dependencies]
 # macOS / Linux: keep rustls + Mozilla webpki-roots — the historical
 # default. Avoids pulling OpenSSL as a runtime dep on Linux.
-tokio-tungstenite = { version = "0.24", default-features = false, features = ["connect", "handshake", "rustls-tls-webpki-roots"] }
+tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "handshake", "rustls-tls-webpki-roots"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 whisper-rs = { version = "0.16", features = ["metal"], optional = true }

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -526,28 +526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5606,7 +5584,7 @@ dependencies = [
  "tinyplace",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
@@ -7128,7 +7106,6 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -7193,7 +7170,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -9091,7 +9067,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite 0.29.0",
  "url",
  "x25519-dalek",
 ]
@@ -9190,14 +9166,8 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
- "rustls",
- "rustls-pki-types",
  "tokio",
- "tokio-native-tls",
- "tokio-rustls",
  "tungstenite 0.24.0",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -9208,9 +9178,11 @@ checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "rustls",
  "rustls-pki-types",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tungstenite 0.29.0",
  "webpki-roots 0.26.11",
@@ -9568,10 +9540,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "native-tls",
  "rand 0.8.6",
- "rustls",
- "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -9588,6 +9557,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",

--- a/gitbooks/developing/building-rust-core.md
+++ b/gitbooks/developing/building-rust-core.md
@@ -71,6 +71,30 @@ Notes:
 - If you prefer package-oriented cargo commands for packager scripts, use `-p openhuman`.
 - The built binary lands at `target/debug/openhuman-core` or `target/release/openhuman-core`.
 
+### Faster local linking (optional)
+
+The `openhuman` core crate links a large single rlib, so the edit → `cargo
+check`/`cargo test` inner loop is frequently link-bound. A faster linker (mold
+on Linux, lld on macOS) can cut a large slice off every incremental relink.
+[`.cargo/config.toml`](../../.cargo/config.toml) documents the manual
+opt-in, but the easiest path is:
+
+```bash
+# installs mold/lld detection into $CARGO_HOME/config.toml — never the
+# repo's tracked .cargo/config.toml, so it's a per-machine opt-in
+scripts/dev-setup-linker.sh
+
+# preview the change first
+scripts/dev-setup-linker.sh --dry-run
+```
+
+Install the linker first (`apt install mold` / `brew install llvm`) — the
+script detects it and exits with instructions if it's missing. It's
+idempotent: re-running it after the linker is already configured is a no-op.
+CI enables the same flag directly via `RUSTFLAGS` in the Linux Rust jobs; this
+script exists so local `cargo` invocations get the same speedup without
+depending on a container.
+
 ## 4. macOS prerequisites
 
 Install:

--- a/scripts/check-linux-tls-dependencies.sh
+++ b/scripts/check-linux-tls-dependencies.sh
@@ -2,15 +2,24 @@
 set -euo pipefail
 
 target="${1:-x86_64-unknown-linux-gnu}"
-forbidden='^(native-tls|openssl|openssl-sys|aws-lc-sys|aws-lc-rs) v'
+forbidden='^(aws-lc-sys|aws-lc-rs) v'
 
 check_world() {
   local label="$1"
   local manifest="$2"
   local tree
   tree="$(cargo tree --locked --manifest-path "$manifest" --target "$target" --prefix none)"
+  if matches="$(printf '%s\n' "$tree" | grep -E "$forbidden")"; then
+    printf 'error: aws-lc dependencies found in %s for %s:\n%s\n' \
+      "$label" "$target" "$matches" >&2
+    exit 1
+  fi
+
+  # The core must use rustls only. Tauri has a deliberate native-TLS/OpenSSL
+  # exception for its updater/dev proxy dependencies, checked by ownership
+  # below so that only those known paths retain the exemption.
   if [[ "$label" == core ]] &&
-    matches="$(printf '%s\n' "$tree" | grep -E "$forbidden")"; then
+    matches="$(printf '%s\n' "$tree" | grep -E '^(native-tls|openssl|openssl-sys) v')"; then
     printf 'error: native TLS/OpenSSL dependencies found in %s for %s:\n%s\n' \
       "$label" "$target" "$matches" >&2
     exit 1

--- a/scripts/check-linux-tls-dependencies.sh
+++ b/scripts/check-linux-tls-dependencies.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 target="${1:-x86_64-unknown-linux-gnu}"
-forbidden='^(native-tls|openssl|openssl-sys) v'
+forbidden='^(native-tls|openssl|openssl-sys|aws-lc-sys|aws-lc-rs) v'
 
 check_world() {
   local label="$1"

--- a/scripts/ci/check-toolchain-image.mjs
+++ b/scripts/ci/check-toolchain-image.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+// Drift guard: the openhuman_ci image tag (rust-<version>) baked into every
+// workflow that runs in the container, the version-pinned
+// `dtolnay/rust-toolchain@<version>` steps used by the workflows that run on
+// bare runners instead of the container, and the toolchain version installed
+// by .github/Dockerfile must all match rust-toolchain.toml's pinned channel.
+//
+// Nothing enforces that agreement automatically — bumping rust-toolchain.toml
+// without rebuilding/retagging the CI image (or vice versa) leaves jobs
+// silently running a different compiler than local `cargo` invocations use,
+// which is exactly the kind of drift that is easy to introduce in one PR and
+// hard to notice until a toolchain-specific feature fails only in CI (or only
+// locally). This script fails loudly instead.
+//
+// Usage: node scripts/ci/check-toolchain-image.mjs
+
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+function fail(message) {
+  console.error(`[check-toolchain-image] ${message}`);
+  process.exitCode = 1;
+}
+
+function readToolchainChannel() {
+  const tomlPath = path.join(repoRoot, "rust-toolchain.toml");
+  const text = readFileSync(tomlPath, "utf8");
+  const match = text.match(/^channel\s*=\s*"([^"]+)"/m);
+  if (!match) {
+    fail(
+      `could not find a "channel" line in ${path.relative(repoRoot, tomlPath)}`,
+    );
+    return null;
+  }
+  return match[1];
+}
+
+const IMAGE_TAG_RE =
+  /ghcr\.io\/tinyhumansai\/openhuman_ci:rust-([0-9][0-9A-Za-z.\-]*)/g;
+// Only version-pinned uses drift. `@stable` / `@master` track upstream on
+// purpose and are none of this guard's business.
+const ACTION_PIN_RE = /dtolnay\/rust-toolchain@([0-9][0-9A-Za-z.\-]*)/g;
+// The other spelling: `uses: dtolnay/rust-toolchain@stable` with an explicit
+// `toolchain: "1.2.3"` input (the mobile workflows use this form).
+const TOOLCHAIN_INPUT_RE =
+  /^\s*toolchain:\s*"?([0-9]+\.[0-9]+(?:\.[0-9]+)?)"?\s*$/gm;
+
+// Scan the whole workflows directory rather than a hand-maintained file list:
+// a new workflow that pins the image or the action is exactly the case this
+// guard exists to catch, and it would slip through a fixed list unnoticed.
+function workflowFiles() {
+  const dir = path.join(repoRoot, ".github", "workflows");
+  return readdirSync(dir)
+    .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
+    .sort()
+    .map((name) => path.join(dir, name));
+}
+
+function findPinnedVersions(regex, kind) {
+  const found = [];
+  for (const filePath of workflowFiles()) {
+    const text = readFileSync(filePath, "utf8");
+    let match;
+    regex.lastIndex = 0;
+    while ((match = regex.exec(text)) !== null) {
+      found.push({
+        kind,
+        file: path.relative(repoRoot, filePath),
+        version: match[1],
+        line: text.slice(0, match.index).split("\n").length,
+      });
+    }
+  }
+  return found;
+}
+
+function readDockerfileToolchainVersion() {
+  const dockerfilePath = path.join(repoRoot, ".github", "Dockerfile");
+  const text = readFileSync(dockerfilePath, "utf8");
+  const match = text.match(/--default-toolchain\s+([0-9][0-9A-Za-z.\-]*)/);
+  if (!match) {
+    fail(
+      `could not find "--default-toolchain <version>" in ${path.relative(repoRoot, dockerfilePath)}`,
+    );
+    return null;
+  }
+  return match[1];
+}
+
+function main() {
+  const channel = readToolchainChannel();
+  if (!channel) return;
+
+  const imageTags = findPinnedVersions(IMAGE_TAG_RE, "image tag");
+  if (imageTags.length === 0) {
+    fail(
+      "found no 'ghcr.io/tinyhumansai/openhuman_ci:rust-*' image references to check",
+    );
+    return;
+  }
+  const actionPins = [
+    ...findPinnedVersions(ACTION_PIN_RE, "dtolnay/rust-toolchain pin"),
+    ...findPinnedVersions(
+      TOOLCHAIN_INPUT_RE,
+      'version-pinned "toolchain:" input',
+    ),
+  ];
+
+  const dockerfileVersion = readDockerfileToolchainVersion();
+
+  const pins = [...imageTags, ...actionPins];
+  const mismatches = pins.filter((pin) => pin.version !== channel);
+  for (const pin of mismatches) {
+    fail(
+      `${pin.file}:${pin.line} pins ${pin.kind} "${pin.version}", but rust-toolchain.toml channel is "${channel}"`,
+    );
+  }
+
+  if (dockerfileVersion && dockerfileVersion !== channel) {
+    fail(
+      `.github/Dockerfile installs toolchain "${dockerfileVersion}", but rust-toolchain.toml channel is "${channel}"`,
+    );
+  }
+
+  if (process.exitCode) {
+    fail(
+      "fix by bumping the drifted reference(s) to match rust-toolchain.toml, or bump rust-toolchain.toml and rebuild/retag the CI image (see build-ci-image.yml).",
+    );
+    return;
+  }
+
+  console.log(
+    `[check-toolchain-image] OK — ${imageTags.length} image reference(s), ` +
+      `${actionPins.length} version-pinned dtolnay/rust-toolchain step(s) and the Dockerfile ` +
+      `toolchain all match rust-toolchain.toml channel "${channel}"`,
+  );
+}
+
+main();

--- a/scripts/dev-setup-linker.sh
+++ b/scripts/dev-setup-linker.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# scripts/dev-setup-linker.sh
+#
+# Opt in to a faster local linker (mold on Linux, lld on macOS) WITHOUT
+# touching the repo's tracked .cargo/config.toml. That file intentionally
+# ships the linker block commented out (see the comment header there) — an
+# unconditional `linker=`/`-fuse-ld=` would hard-fail every build on a
+# machine that doesn't have the linker installed, including the
+# `pnpm rust:check` pre-push hook.
+#
+# This script instead writes (or merges into) $CARGO_HOME/config.toml
+# (defaulting to ~/.cargo/config.toml), which Cargo layers on top of any
+# repo-level config. That keeps the opt-in per-machine and out of git.
+#
+# Usage:
+#   scripts/dev-setup-linker.sh            # detect + install the config
+#   scripts/dev-setup-linker.sh --dry-run  # print what would change, no writes
+#   scripts/dev-setup-linker.sh -n         # same as --dry-run
+#
+# Idempotent: running it twice leaves the config file unchanged the second
+# time (it detects its own previously-written block and skips it).
+
+set -euo pipefail
+
+DRY_RUN=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run | -n)
+      DRY_RUN=1
+      ;;
+    -h | --help)
+      sed -n '2,25p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "dev-setup-linker.sh: unknown argument: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+log() {
+  echo "[dev-setup-linker] $*"
+}
+
+CARGO_HOME_DIR="${CARGO_HOME:-$HOME/.cargo}"
+CONFIG_PATH="$CARGO_HOME_DIR/config.toml"
+
+# Marker so re-runs can detect (and skip) a block this script already wrote.
+MARKER_BEGIN="# BEGIN openhuman dev-setup-linker (scripts/dev-setup-linker.sh)"
+MARKER_END="# END openhuman dev-setup-linker"
+
+uname_s="$(uname -s)"
+uname_m="$(uname -m)"
+
+target=""
+rustflags_value=""
+tool_name=""
+
+case "$uname_s" in
+  Linux)
+    if ! command -v mold >/dev/null 2>&1; then
+      log "mold not found on PATH. Install it first:"
+      log "  apt: sudo apt-get install mold"
+      log "  dnf: sudo dnf install mold"
+      log "  pacman: sudo pacman -S mold"
+      exit 1
+    fi
+    tool_name="mold"
+    case "$uname_m" in
+      x86_64 | amd64)
+        target="x86_64-unknown-linux-gnu"
+        ;;
+      aarch64 | arm64)
+        target="aarch64-unknown-linux-gnu"
+        ;;
+      *)
+        log "unsupported Linux architecture: $uname_m"
+        exit 1
+        ;;
+    esac
+    rustflags_value='["-C", "link-arg=-fuse-ld=mold"]'
+    ;;
+  Darwin)
+    # Prefer lld from a Homebrew LLVM install (ld64.lld). Recent Xcode ships
+    # Apple's ld-prime, which is already fast, so this is often only a
+    # marginal win on Apple Silicon — measure before relying on it (see
+    # .cargo/config.toml's comment header).
+    lld_path=""
+    for candidate in \
+      /opt/homebrew/opt/llvm/bin/ld64.lld \
+      /usr/local/opt/llvm/bin/ld64.lld; do
+      if [ -x "$candidate" ]; then
+        lld_path="$candidate"
+        break
+      fi
+    done
+    if [ -z "$lld_path" ]; then
+      log "ld64.lld not found. Install LLVM first: brew install llvm"
+      exit 1
+    fi
+    tool_name="lld ($lld_path)"
+    case "$uname_m" in
+      arm64)
+        target="aarch64-apple-darwin"
+        ;;
+      x86_64)
+        target="x86_64-apple-darwin"
+        ;;
+      *)
+        log "unsupported macOS architecture: $uname_m"
+        exit 1
+        ;;
+    esac
+    rustflags_value="[\"-C\", \"link-arg=-fuse-ld=$lld_path\"]"
+    ;;
+  *)
+    log "unsupported OS: $uname_s (only Linux and macOS are supported)"
+    exit 1
+    ;;
+esac
+
+log "detected $tool_name for target $target"
+
+block=$(
+  cat <<EOF
+$MARKER_BEGIN
+[target.$target]
+rustflags = $rustflags_value
+$MARKER_END
+EOF
+)
+
+if [ -f "$CONFIG_PATH" ] && grep -Fq "$MARKER_BEGIN" "$CONFIG_PATH"; then
+  log "$CONFIG_PATH already has an openhuman dev-setup-linker block — nothing to do"
+  log "(delete the block between the BEGIN/END markers and re-run to refresh it)"
+  exit 0
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  log "--dry-run: would write to $CONFIG_PATH:"
+  echo ""
+  echo "$block"
+  exit 0
+fi
+
+mkdir -p "$CARGO_HOME_DIR"
+
+if [ -f "$CONFIG_PATH" ]; then
+  log "appending linker block to existing $CONFIG_PATH"
+  {
+    echo ""
+    echo "$block"
+  } >>"$CONFIG_PATH"
+else
+  log "creating $CONFIG_PATH"
+  echo "$block" >"$CONFIG_PATH"
+fi
+
+log "done. New cargo invocations will use $tool_name for target $target."

--- a/scripts/dev-setup-linker.sh
+++ b/scripts/dev-setup-linker.sh
@@ -137,6 +137,22 @@ if [ -f "$CONFIG_PATH" ] && grep -Fq "$MARKER_BEGIN" "$CONFIG_PATH"; then
   exit 0
 fi
 
+# A TOML table cannot be declared twice. Do not append a second target table
+# to a developer's global Cargo config: merging their existing rustflags could
+# silently discard linker options they deliberately configured.
+if [ -f "$CONFIG_PATH" ] && awk -v table="[target.$target]" '
+  {
+    sub(/[[:space:]]*#.*/, "")
+    gsub(/^[[:space:]]+|[[:space:]]+$/, "")
+    if ($0 == table) found = 1
+  }
+  END { exit !found }
+' "$CONFIG_PATH"; then
+  log "$CONFIG_PATH already declares [target.$target]; refusing to modify it"
+  log "add the linker rustflags manually or remove that table and re-run"
+  exit 1
+fi
+
 if [ "$DRY_RUN" -eq 1 ]; then
   log "--dry-run: would write to $CONFIG_PATH:"
   echo ""

--- a/scripts/kernel-floor.limits
+++ b/scripts/kernel-floor.limits
@@ -13,6 +13,41 @@
 # Simulate with: scripts/dep-sim.py --cut <crates>
 #
 # History
+#   304/281/5  2026-08-08  tokio-tungstenite unified on 0.29 (-6 packages/-2
+#                      names). Root Cargo.toml's two per-target
+#                      tokio-tungstenite entries and
+#                      vendor/tinyplace/sdk/rust/Cargo.toml were pinned at
+#                      "0.24"; bumped all three to "0.29" (same feature names:
+#                      connect/handshake/native-tls/rustls-tls-webpki-roots).
+#                      Sheds the duplicate tungstenite 0.24 + thiserror 1.x +
+#                      thiserror-impl 1.x majors from the `flows` profile
+#                      (confirmed: `cargo tree --no-default-features --features
+#                      flows -e normal --prefix none | grep '^thiserror 1'` is
+#                      empty, and tungstenite/tokio-tungstenite both resolve
+#                      to a single 0.29 there). Call-site fix: tungstenite
+#                      0.29's `Message::Text` now wraps `Utf8Bytes` instead of
+#                      `String` — `.into()` at each send call site in
+#                      src/openhuman/platform/socket/ws_loop.rs (+ its test
+#                      double server in ws_loop_tests.rs) and
+#                      vendor/tinyplace/sdk/rust/src/websocket.rs.
+#                      NOTE: the DEFAULT (full-feature) profile still shows
+#                      both tungstenite 0.24 and 0.29 — socketioxide 0.15.2 /
+#                      engineioxide 0.15.2 (pulled in by the default-ON
+#                      `http-server` feature, unrelated to the three
+#                      activators above) pin `tokio-tungstenite = "0.24"`
+#                      themselves and were out of scope here. Unifying the
+#                      default profile too would mean bumping socketioxide,
+#                      a separate, broader change.
+#   310/283/5  2026-08-08  aws-lc-sys shed (-2 packages/names, -1 native). The
+#                      sole activator was vendor/tinychannels: `rustls = {
+#                      features = ["ring"] }` without `default-features =
+#                      false` unions in rustls's default aws_lc_rs provider,
+#                      and bare `tokio-rustls = "0.26.4"` defaults to
+#                      aws_lc_rs too. Pinned both to default-features = false
+#                      with an explicit ring/std/logging/tls12 feature set.
+#                      Default profile moved 577/533/10 -> 575/531/9 the same
+#                      way. Verified with scripts/assert-shed.sh flows
+#                      aws-lc-sys aws-lc-rs.
 #   312/285/6  2026-08-02  merge origin/main (+5 names) — INHERITED, not introduced here.
 #                      A rise in this number is the one thing this file exists
 #                      to make someone justify, so: main grew the graph on its
@@ -62,4 +97,4 @@
 #                      Native: aws-lc-sys libgit2-sys libsqlite3-sys libz-sys
 #                      lzma-sys ring. Target after gating is 222 names / 2 native
 #                      (libsqlite3-sys, ring) — see docs/plans MIGRATION-PLAN G6.
-flows:312:285:6
+flows:304:281:5

--- a/src/openhuman/platform/socket/ws_loop.rs
+++ b/src/openhuman/platform/socket/ws_loop.rs
@@ -460,7 +460,7 @@ async fn run_connection(
     // 4. Send Socket.IO CONNECT with auth token
     let connect_payload = json!({"token": token});
     let connect_msg = format!("40{}", serde_json::to_string(&connect_payload).unwrap());
-    if let Err(e) = ws_write.send(WsMessage::Text(connect_msg)).await {
+    if let Err(e) = ws_write.send(WsMessage::Text(connect_msg.into())).await {
         return ConnectionOutcome::Failed(format!("Send SIO CONNECT: {e}"));
     }
 
@@ -521,7 +521,7 @@ async fn run_connection(
             outgoing = emit_rx.recv() => {
                 match outgoing {
                     Some(msg) => {
-                        if let Err(e) = ws_write.send(WsMessage::Text(msg)).await {
+                        if let Err(e) = ws_write.send(WsMessage::Text(msg.into())).await {
                             return ConnectionOutcome::Lost(format!("Send failed: {e}"));
                         }
                     }

--- a/src/openhuman/platform/socket/ws_loop_tests.rs
+++ b/src/openhuman/platform/socket/ws_loop_tests.rs
@@ -446,12 +446,12 @@ async fn spawn_mock_eio_server(
         // 1. Send EIO OPEN (type 0) — short intervals so tests stay snappy.
         let open =
             r#"0{"sid":"mock-eio-sid","upgrades":[],"pingInterval":1000,"pingTimeout":2000}"#;
-        let _ = write.send(WsMessage::Text(open.to_string())).await;
+        let _ = write.send(WsMessage::Text(open.into())).await;
 
         // 2. Read client SIO CONNECT (`40{...}`) and forward it so tests
         //    can assert the token round-trip before the ack.
         if let Some(Ok(WsMessage::Text(t))) = read.next().await {
-            let _ = forward_tx.send(t);
+            let _ = forward_tx.send(t.to_string());
         }
 
         match connect_behavior {
@@ -512,7 +512,7 @@ async fn pump_client_to_forward(
     while tokio::time::Instant::now() < end {
         match timeout(Duration::from_millis(100), read.next()).await {
             Ok(Some(Ok(WsMessage::Text(t)))) => {
-                let _ = forward_tx.send(t);
+                let _ = forward_tx.send(t.to_string());
             }
             Ok(Some(Ok(WsMessage::Close(_)))) | Ok(None) => break,
             Ok(Some(Err(_))) => break,
@@ -910,14 +910,12 @@ async fn spawn_mock_invalid_token_server() -> std::net::SocketAddr {
                 // 1. Send EIO OPEN.
                 let open =
                     r#"0{"sid":"mock-eio","upgrades":[],"pingInterval":1000,"pingTimeout":2000}"#;
-                let _ = write.send(WsMessage::Text(open.to_string())).await;
+                let _ = write.send(WsMessage::Text(open.into())).await;
                 // 2. Drain the SIO CONNECT frame (don't care about its content).
                 let _ = read.next().await;
                 // 3. Reply with CONNECT_ERROR "Invalid token".
                 let _ = write
-                    .send(WsMessage::Text(
-                        r#"44{"message":"Invalid token"}"#.to_string(),
-                    ))
+                    .send(WsMessage::Text(r#"44{"message":"Invalid token"}"#.into()))
                     .await;
                 let _ = write.close().await;
             });

--- a/tests/raw_coverage/inference_voice_http_round23_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/inference_voice_http_round23_raw_coverage_e2e.rs
@@ -214,7 +214,7 @@ async fn dictation_ws_empty_stop_and_audio_cap_do_not_load_whisper() {
     let (mut ws, _) = tokio_tungstenite::connect_async(&ws_url)
         .await
         .expect("connect empty dictation ws");
-    ws.send(WsMessage::Text(r#"{"type":"stop"}"#.to_string()))
+    ws.send(WsMessage::Text(r#"{"type":"stop"}"#.into()))
         .await
         .expect("send stop");
     let final_msg = ws.next().await.expect("final frame").expect("final ok");
@@ -227,7 +227,7 @@ async fn dictation_ws_empty_stop_and_audio_cap_do_not_load_whisper() {
     let (mut ws, _) = tokio_tungstenite::connect_async(&ws_url)
         .await
         .expect("connect capped dictation ws");
-    ws.send(WsMessage::Binary(vec![0u8; 9_600_002]))
+    ws.send(WsMessage::Binary(vec![0u8; 9_600_002].into()))
         .await
         .expect("send oversized pcm");
     let error_msg = ws.next().await.expect("error frame").expect("error ok");


### PR DESCRIPTION
Phase 1 of the build-time reduction program: three infrastructure quick wins with no product-surface change.

## Changes

1. **CI toolchain unification** — the CI image installed Rust 1.93.0 while `rust-toolchain.toml` pins 1.96.1, so every Rust job downloaded and installed a full toolchain before its first cargo call. All 17 `openhuman_ci` image references and 11 version-pinned `dtolnay/rust-toolchain` steps now match, guarded by a new `scripts/ci/check-toolchain-image.mjs` drift check wired into the Rust Quality lane. Also enables the already-installed-but-unused **mold** linker on the 9 Linux container jobs that run cargo, and adds `scripts/dev-setup-linker.sh` for opt-in local mold/lld setup (writes to `$CARGO_HOME`, never the repo config).
2. **`aws-lc-sys` shed** — its sole activator was two dependency lines in `vendor/tinychannels` missing `default-features = false`, unioning rustls's default aws-lc provider into every consumer graph despite the ring provider being installed explicitly at all call sites. Gone from both Cargo worlds; now forbidden by `scripts/check-linux-tls-dependencies.sh`. Kernel profile: 312/285/**6 native** → 304/281/**5 native**. Depends on tinyhumansai/tinychannels#14 (gitlink bumped here).
3. **tokio-tungstenite 0.24 → 0.29** — unifies the kernel profile on one tungstenite major and sheds the duplicate `thiserror` 1.x + `thiserror-impl` 1.x proc-macro compile. The default profile still carries 0.24 transitively via `socketioxide` 0.15 (documented in `kernel-floor.limits`; a socketioxide bump is a separate follow-up). Depends on tinyhumansai/tiny.place#273 (gitlink bumped here).

## Measured

`scripts/kernel-floor.sh flows`: 312 pkgs / 285 names / 6 native → **304 / 281 / 5** (ratchet written back).

## Ordering note

The workflow changes reference the image tag `openhuman_ci:rust-1.96.1`, which does not exist yet — `build-ci-image.yml` must run and publish it before this PR's container jobs can go green.

Part of the build-time reduction program; the Phase 2 deletions PR is stacked on this branch.