### PR TITLE
feat(agent): attribute OpenHuman git commits

### DIFF
--- a/src/openhuman/agent/git_attribution/hook.rs
+++ b/src/openhuman/agent/git_attribution/hook.rs
@@ -1,0 +1,99 @@
+use std::collections::HashMap;
+#[cfg(unix)]
+use std::path::PathBuf;
+#[cfg(unix)]
+use std::sync::OnceLock;
+
+/// OpenHuman's commit trailer.
+pub const TRAILER: &str = "Co-authored-by: OpenHuman <openhuman@tinyhumans.ai>";
+
+#[cfg(unix)]
+const HOOKS: &[&str] = &[
+    "applypatch-msg",
+    "pre-applypatch",
+    "post-applypatch",
+    "pre-commit",
+    "pre-merge-commit",
+    "prepare-commit-msg",
+    "commit-msg",
+    "post-commit",
+    "pre-rebase",
+    "post-checkout",
+    "post-merge",
+    "pre-push",
+    "post-rewrite",
+    "pre-auto-gc",
+    "push-to-checkout",
+    "reference-transaction",
+    "sendemail-validate",
+    "post-index-change",
+];
+
+#[cfg(unix)]
+const SHIM: &str = r#"#!/bin/sh
+# OpenHuman hook shim. Delegate to the repository hook before attributing.
+hook_name=$(basename "$0")
+self_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# Suppress only our injected config while resolving the repository's configured
+# hook path. A project may intentionally set core.hooksPath away from .git/hooks.
+orig_dir=$(GIT_CONFIG_COUNT=0 GIT_CONFIG_PARAMETERS= git config --path --get core.hooksPath 2>/dev/null)
+if [ -z "$orig_dir" ]; then
+    orig_dir=$(GIT_CONFIG_COUNT=0 GIT_CONFIG_PARAMETERS= git rev-parse --git-path hooks 2>/dev/null)
+fi
+if [ -n "$orig_dir" ] && [ "$orig_dir" != "$self_dir" ] && [ -x "$orig_dir/$hook_name" ]; then
+    "$orig_dir/$hook_name" "$@" || exit $?
+fi
+
+[ "$hook_name" = "prepare-commit-msg" ] || exit 0
+case "$2" in merge|squash) exit 0 ;; esac
+git interpret-trailers --in-place --if-exists addIfDifferent \
+    --trailer "$OPENHUMAN_GIT_ATTRIBUTION" "$1" 2>/dev/null || true
+"#;
+
+#[cfg(unix)]
+static HOOK_DIR: OnceLock<Option<PathBuf>> = OnceLock::new();
+
+/// Environment values that activate OpenHuman's commit-attribution hook.
+///
+/// The result is intended for an agent-owned child process. It does not change
+/// repository configuration or the parent application's environment.
+#[cfg(unix)]
+pub fn hook_env() -> HashMap<String, String> {
+    let Some(dir) = HOOK_DIR.get_or_init(|| build_hook_dir().ok()).as_ref() else {
+        return HashMap::new();
+    };
+    HashMap::from([
+        ("OPENHUMAN_GIT_ATTRIBUTION".into(), TRAILER.into()),
+        ("GIT_CONFIG_COUNT".into(), "1".into()),
+        ("GIT_CONFIG_KEY_0".into(), "core.hooksPath".into()),
+        (
+            "GIT_CONFIG_VALUE_0".into(),
+            dir.to_string_lossy().into_owned(),
+        ),
+    ])
+}
+
+#[cfg(not(unix))]
+pub fn hook_env() -> HashMap<String, String> {
+    HashMap::new()
+}
+
+#[cfg(unix)]
+fn build_hook_dir() -> std::io::Result<PathBuf> {
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir()?.keep();
+    for name in HOOKS {
+        let path = dir.join(name);
+        let mut file = std::fs::File::create(&path)?;
+        file.write_all(SHIM.as_bytes())?;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))?;
+    }
+    Ok(dir)
+}
+
+#[cfg(all(unix, test))]
+pub(super) fn test_hook_dir() -> PathBuf {
+    build_hook_dir().expect("create OpenHuman hook directory")
+}

--- a/src/openhuman/agent/git_attribution/mod.rs
+++ b/src/openhuman/agent/git_attribution/mod.rs
@@ -1,0 +1,12 @@
+//! Git commit attribution for changes made by the OpenHuman agent.
+//!
+//! Agent shell commands inherit a temporary `prepare-commit-msg` hook which
+//! appends OpenHuman's co-author trailer. The hook directory contains shims for
+//! every client-side hook, so a repository's validation hooks continue to run.
+
+mod hook;
+
+pub use hook::hook_env;
+
+#[cfg(test)]
+mod tests;

--- a/src/openhuman/agent/git_attribution/tests.rs
+++ b/src/openhuman/agent/git_attribution/tests.rs
@@ -1,0 +1,58 @@
+#[cfg(unix)]
+#[test]
+fn hook_adds_openhuman_trailer_without_disabling_repository_hook() {
+    use std::os::unix::fs::PermissionsExt;
+    use std::process::Command;
+
+    let temp = tempfile::tempdir().unwrap();
+    let repo = temp.path().join("repo");
+    std::fs::create_dir(&repo).unwrap();
+    let git = |args: &[&str]| {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(&repo)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    git(&["init", "-q"]);
+    git(&["config", "user.name", "Test"]);
+    git(&["config", "user.email", "test@example.com"]);
+    let own_hook = repo.join(".git/hooks/prepare-commit-msg");
+    std::fs::write(
+        &own_hook,
+        "#!/bin/sh\nprintf 'repo-hook-ran\\n' >> \"$1\"\n",
+    )
+    .unwrap();
+    std::fs::set_permissions(&own_hook, std::fs::Permissions::from_mode(0o755)).unwrap();
+    std::fs::write(repo.join("a"), "a").unwrap();
+    git(&["add", "a"]);
+
+    let hook_dir = super::hook::test_hook_dir();
+    let output = Command::new("git")
+        .args(["commit", "-q", "-m", "subject"])
+        .current_dir(&repo)
+        .env("OPENHUMAN_GIT_ATTRIBUTION", super::hook::TRAILER)
+        .env("GIT_CONFIG_COUNT", "1")
+        .env("GIT_CONFIG_KEY_0", "core.hooksPath")
+        .env("GIT_CONFIG_VALUE_0", &hook_dir)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let output = Command::new("git")
+        .args(["log", "-1", "--format=%B"])
+        .current_dir(&repo)
+        .output()
+        .unwrap();
+    let message = String::from_utf8(output.stdout).unwrap();
+    assert!(message.contains("repo-hook-ran"), "{message:?}");
+    assert!(message.contains(super::hook::TRAILER), "{message:?}");
+}

--- a/src/openhuman/agent/mod.rs
+++ b/src/openhuman/agent/mod.rs
@@ -28,6 +28,7 @@ pub mod dispatcher;
 pub mod error;
 pub mod experience;
 pub mod file_state;
+pub(crate) mod git_attribution;
 pub mod harness;
 pub mod harness_init;
 pub mod hooks;

--- a/src/openhuman/tools/impl/system/shell.rs
+++ b/src/openhuman/tools/impl/system/shell.rs
@@ -411,6 +411,12 @@ impl ShellTool {
             }
         }
 
+        // Attribute commits made by this agent-owned shell, without persisting
+        // anything in the user's repository or global Git configuration.
+        for (key, value) in crate::openhuman::agent::git_attribution::hook_env() {
+            cmd.env(key, value);
+        }
+
         // Point the child's temp dir at the agent's granted scratch dir
         // (`/tmp/openhuman`, a ReadWrite trusted root — see SecurityPolicy
         // `from_config`) so `python3 tempfile` / `mktemp` / `$TMPDIR` writes land
@@ -540,6 +546,12 @@ impl ShellTool {
                 );
             }
         }
+
+        // The local/no-op sandbox inherits this process's temporary hook
+        // directory, so commits made through a sandboxed shell are attributed
+        // just like native-shell commits. Docker backends safely ignore an
+        // unavailable host path rather than changing repository configuration.
+        extra_env.extend(crate::openhuman::agent::git_attribution::hook_env());
 
         // Sandbox backends require a finite deadline. Without an explicit
         // `timeout_secs`, substitute the generous effective-unbounded cap so a


### PR DESCRIPTION
## Summary

- Add a process-scoped Git hook that appends the OpenHuman co-author trailer to agent-made commits.
- Preserve repository client hooks through shims, so validation hooks continue to run.
- Cover trailer insertion and repository-hook delegation with a real Git repository test.

## Problem

Agent-authored commits did not identify OpenHuman, unlike Medulla-launched harness commits.

## Solution

Agent shell processes receive a temporary `core.hooksPath` override. The generated `prepare-commit-msg` hook adds `Co-authored-by: OpenHuman <openhuman@tinyhumans.ai>` idempotently, while shims delegate all client hooks to the repository-configured hook directory. The override is child-process-only and does not persist Git configuration.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — real Git test covers trailer insertion and existing-hook delegation.
- [ ] **Diff coverage ≥ 80%** — blocked: the focused Rust test cannot compile due to pre-existing missing `crate::core::event_bus` imports in memory modules.
- [x] Coverage matrix updated — N/A: internal agent-shell hook behavior has no matrix feature row.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no feature ID applies.
- [x] No new external network dependencies introduced (mock backend used per Testing Strategy)
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: no release-cut surface.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: no linked issue supplied.

## Impact

Desktop agent shell commits gain OpenHuman attribution. Existing Git authors, committers, and repository hooks are preserved; merge and squash commits are excluded.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/openhuman-git-attribution`
- Commit SHA: `96c550e86`

### Validation Run

- [x] `rustfmt --edition 2021 src/openhuman/agent/git_attribution/{mod,hook,tests}.rs`
- [ ] Focused tests: `cargo test --lib git_attribution` (blocked before test execution)
- [x] Rust fmt/check (if changed): formatting verified for changed Rust files
- [x] Tauri fmt/check (if changed): N/A

### Validation Blocked

- `command:` `cargo test --lib git_attribution`
- `error:` unresolved `crate::core::event_bus` imports in `src/openhuman/memory/guard/{audit,provider_tests}.rs` and `src/openhuman/memory/binding.rs`
- `impact:` focused test did not execute; this PR does not touch those modules.

### Behavior Changes

- Intended behavior change: agent shell commits carry the OpenHuman co-author trailer.
- User-visible effect: GitHub commit metadata credits OpenHuman without changing the human author.

### Parity Contract

- Legacy behavior preserved: user Git configuration and repository hooks remain active.
- Guard/fallback/dispatch parity checks: hook generation failure leaves the shell command runnable without attribution.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic attribution to commits created by the agent.
  * Existing repository commit hooks continue to run alongside attribution.
  * Merge and squash commits are excluded from automatic attribution.
  * Attribution works for both native and sandboxed shell command execution.

* **Bug Fixes**
  * Prevents changes to repository or global Git configuration while enabling commit attribution.

* **Tests**
  * Added coverage verifying attribution and existing commit-hook behavior work together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->