### PR TITLE
feat(inference): let one agent_chat call name its own endpoint

### DIFF
--- a/src/openhuman/agent/schemas.rs
+++ b/src/openhuman/agent/schemas.rs
@@ -9,9 +9,12 @@ use crate::rpc::RpcOutcome;
 
 /// Params for `agent.chat` and `agent.chat_simple`.
 ///
-/// Kept byte-identical to the copy in
+/// A near-copy of the params in
 /// [`crate::openhuman::inference::local::schemas`], which backs the
-/// `inference.agent_chat*` namespace over the same ops.
+/// `inference.agent_chat*` namespace over the same ops. That surface carries
+/// two fields this one does not — a per-call `inference_url` + `api_key` —
+/// because `agent.chat` describes a turn on the account's own configured
+/// inference.
 #[derive(Debug, Deserialize)]
 struct AgentChatParams {
     message: String,
@@ -237,6 +240,11 @@ fn handle_chat(params: Map<String, Value>) -> ControllerFuture {
                 p.temperature,
                 p.thread_id,
                 p.cwd,
+                // `openhuman.agent_chat` describes a turn on the account's own
+                // configured inference. A caller that wants this one turn
+                // somewhere else says so through `inference_agent_chat`, which
+                // takes the endpoint and bearer as parameters.
+                None,
             )
             .await?,
         )

--- a/src/openhuman/config/schema/ephemeral_route.rs
+++ b/src/openhuman/config/schema/ephemeral_route.rs
@@ -1,0 +1,142 @@
+//! A per-call inference route that lives only in memory.
+//!
+//! # Why a config field rather than a parameter
+//!
+//! An embedding host — the desktop app, or another process driving the core
+//! through the embed facade — sometimes knows where a *single* turn should run
+//! before the core does: it holds an OpenAI-compatible endpoint and a bearer for
+//! it, and wants this turn on that endpoint without changing where the account's
+//! other work runs.
+//!
+//! The obvious spelling, writing `inference_url`/`api_key`/`cloud_providers`
+//! through `config_update_model_settings`, is wrong for that: those are
+//! persisted, so a caller borrowing the account's inference route for one turn
+//! would repoint the operator's whole install and have to remember to put it
+//! back. A crash between the two writes leaves the install repointed for good.
+//!
+//! So the route rides on [`Config`](crate::openhuman::config::Config) — which
+//! every resolution step already reads — in a field that is `#[serde(skip)]`.
+//! It cannot reach `config.toml` even if a caller does save the config, because
+//! there is no field on the wire to save it into. Controllers that accept a
+//! route apply it to their own per-call `Config` copy, which is dropped when the
+//! call returns.
+//!
+//! # What it does and does not capture
+//!
+//! [`apply`] pins the four roles an agent turn actually runs on — chat,
+//! reasoning, agentic, coding. It deliberately leaves the background roles
+//! (memory, embeddings, heartbeat, learning, subconscious) and `vision` alone:
+//! those run tier-specific models a coding endpoint generally cannot serve, and
+//! silently sending an embeddings request to a chat model is worse than ignoring
+//! the route for that workload.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::cloud_providers::{AuthStyle, CloudProviderCreds};
+
+/// The `cloud_providers` slug [`apply`] registers the route under.
+///
+/// Hyphenated and prefixed so it cannot collide with a provider slug a user
+/// would choose, and deliberately *not* in
+/// [`is_slug_reserved`](super::cloud_providers::is_slug_reserved): reserved
+/// slugs are re-injected from the stored config on save, which is the opposite
+/// of what an in-memory-only entry wants.
+pub const EPHEMERAL_ROUTE_SLUG: &str = "ephemeral-route";
+
+/// Where one call's inference should go, and what authenticates it.
+///
+/// Never serialized — see the module docs. `JsonSchema` is derived only because
+/// [`Config`](crate::openhuman::config::Config) derives it for the whole struct.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct EphemeralRoute {
+    /// OpenAI-compatible base URL, as a `cloud_providers` endpoint would be
+    /// spelled (`/chat/completions` is appended to it).
+    pub endpoint: String,
+    /// The bearer presented to `endpoint`.
+    ///
+    /// Read back only by
+    /// [`lookup_key_for_slug`](crate::openhuman::inference::provider::factory::lookup_key_for_slug)
+    /// and only for [`EPHEMERAL_ROUTE_SLUG`], so it cannot be handed to a
+    /// provider the caller did not name.
+    pub api_key: String,
+}
+
+impl EphemeralRoute {
+    /// Build a route from a controller's two optional parameters.
+    ///
+    /// `None` unless both arrive non-blank: an endpoint with no credential and a
+    /// credential with no endpoint are both partial statements, and guessing the
+    /// missing half is how a turn ends up somewhere the caller did not ask for.
+    pub fn from_params(endpoint: Option<String>, api_key: Option<String>) -> Option<Self> {
+        let endpoint = endpoint?.trim().to_string();
+        let api_key = api_key?.trim().to_string();
+        (!endpoint.is_empty() && !api_key.is_empty()).then_some(Self { endpoint, api_key })
+    }
+}
+
+/// Point `config`'s agent-turn roles at `route`, in memory.
+///
+/// Registers the route as a `cloud_providers` entry and pins the four roles a
+/// turn runs on to `"<slug>:<model>"`, taking the model from `config`'s
+/// resolved `default_model` — which a caller passing `model_override` has
+/// already set. Any explicit pin on those roles is replaced, because the route
+/// *is* the caller's statement about where this turn runs and
+/// [`provider_for_role`](crate::openhuman::inference::provider::factory::provider_for_role)
+/// consults the pins first.
+///
+/// A blank `default_model` leaves the roles alone and registers nothing: the
+/// slug grammar has no model to carry, and pinning a role to `"<slug>:"` would
+/// trade a working default for a "resolved to an empty model id" bail.
+pub fn apply(config: &mut crate::openhuman::config::Config, route: EphemeralRoute) {
+    let model = config
+        .default_model
+        .as_deref()
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .map(str::to_string);
+    let Some(model) = model else {
+        log::warn!(
+            "[config][ephemeral-route] ignoring route to {} — no model resolved for this call",
+            crate::openhuman::inference::provider::factory::redact_endpoint(&route.endpoint)
+        );
+        return;
+    };
+
+    // Replace rather than append: a second call on the same `Config` copy is not
+    // expected, but two entries sharing a slug would make which one resolves an
+    // ordering accident.
+    config
+        .cloud_providers
+        .retain(|entry| entry.slug != EPHEMERAL_ROUTE_SLUG);
+    config.cloud_providers.push(CloudProviderCreds {
+        // A fixed id, not a generated one: nothing persists this entry and
+        // nothing selects it by id (`primary_cloud` is left untouched), so a
+        // fresh random id per call would only make the value unpredictable.
+        id: EPHEMERAL_ROUTE_SLUG.to_string(),
+        slug: EPHEMERAL_ROUTE_SLUG.to_string(),
+        label: "Per-call route".to_string(),
+        endpoint: route.endpoint.clone(),
+        auth_style: AuthStyle::Bearer,
+        legacy_type: None,
+        default_model: Some(model.clone()),
+    });
+
+    let provider_string = format!("{EPHEMERAL_ROUTE_SLUG}:{model}");
+    config.chat_provider = Some(provider_string.clone());
+    config.reasoning_provider = Some(provider_string.clone());
+    config.agentic_provider = Some(provider_string.clone());
+    config.coding_provider = Some(provider_string);
+
+    log::info!(
+        "[config][ephemeral-route] this call routed to {} model={}",
+        crate::openhuman::inference::provider::factory::redact_endpoint(&route.endpoint),
+        model
+    );
+
+    config.ephemeral_route = Some(route);
+}
+
+#[cfg(test)]
+#[path = "ephemeral_route_tests.rs"]
+mod tests;

--- a/src/openhuman/config/schema/ephemeral_route_tests.rs
+++ b/src/openhuman/config/schema/ephemeral_route_tests.rs
@@ -1,0 +1,179 @@
+use super::*;
+
+use crate::openhuman::config::Config;
+
+/// A config with a model resolved for the call, as `agent_chat` leaves it after
+/// applying `model_override`.
+fn config_with_model(model: &str) -> Config {
+    Config {
+        default_model: Some(model.to_string()),
+        ..Config::default()
+    }
+}
+
+fn route() -> EphemeralRoute {
+    EphemeralRoute {
+        endpoint: "http://127.0.0.1:41234/openai".to_string(),
+        api_key: "mdl-token".to_string(),
+    }
+}
+
+// ── from_params ──────────────────────────────────────────────────────────────
+
+#[test]
+fn from_params_needs_both_halves() {
+    assert_eq!(
+        EphemeralRoute::from_params(Some("http://x/openai".into()), Some("k".into())),
+        Some(EphemeralRoute {
+            endpoint: "http://x/openai".into(),
+            api_key: "k".into(),
+        })
+    );
+    // An endpoint with no credential and a credential with no endpoint are both
+    // partial statements; guessing the other half would run the turn somewhere
+    // the caller never named.
+    assert_eq!(
+        EphemeralRoute::from_params(Some("http://x/openai".into()), None),
+        None
+    );
+    assert_eq!(EphemeralRoute::from_params(None, Some("k".into())), None);
+    assert_eq!(EphemeralRoute::from_params(None, None), None);
+}
+
+#[test]
+fn from_params_treats_blank_as_absent_and_trims() {
+    assert_eq!(
+        EphemeralRoute::from_params(Some("  ".into()), Some("k".into())),
+        None
+    );
+    assert_eq!(
+        EphemeralRoute::from_params(Some("http://x/openai".into()), Some("\t".into())),
+        None
+    );
+    assert_eq!(
+        EphemeralRoute::from_params(Some(" http://x/openai ".into()), Some(" k ".into())),
+        Some(EphemeralRoute {
+            endpoint: "http://x/openai".into(),
+            api_key: "k".into(),
+        })
+    );
+}
+
+// ── apply ────────────────────────────────────────────────────────────────────
+
+#[test]
+fn apply_registers_the_entry_and_pins_the_turn_roles() {
+    let mut config = config_with_model("anthropic/claude-sonnet-4");
+    apply(&mut config, route());
+
+    let entry = config
+        .cloud_providers
+        .iter()
+        .find(|entry| entry.slug == EPHEMERAL_ROUTE_SLUG)
+        .expect("the route registers a cloud_providers entry");
+    assert_eq!(entry.endpoint, "http://127.0.0.1:41234/openai");
+    assert_eq!(entry.auth_style, AuthStyle::Bearer);
+
+    let expected = format!("{EPHEMERAL_ROUTE_SLUG}:anthropic/claude-sonnet-4");
+    assert_eq!(config.chat_provider.as_deref(), Some(expected.as_str()));
+    assert_eq!(
+        config.reasoning_provider.as_deref(),
+        Some(expected.as_str())
+    );
+    assert_eq!(config.agentic_provider.as_deref(), Some(expected.as_str()));
+    assert_eq!(config.coding_provider.as_deref(), Some(expected.as_str()));
+}
+
+#[test]
+fn apply_replaces_an_explicit_role_pin() {
+    // The route is the caller's whole statement about where this turn runs, and
+    // `provider_for_role` reads the pins first — leaving one in place would send
+    // the turn to the account's provider and make the route look ignored.
+    let mut config = config_with_model("x/y");
+    config.coding_provider = Some("anthropic:claude-3-5-sonnet".into());
+    apply(&mut config, route());
+    assert_eq!(
+        config.coding_provider.as_deref(),
+        Some(format!("{EPHEMERAL_ROUTE_SLUG}:x/y").as_str())
+    );
+}
+
+#[test]
+fn apply_leaves_background_roles_alone() {
+    // Embeddings and memory run tier-specific models a chat endpoint generally
+    // cannot serve. Ignoring the route for those workloads beats sending them
+    // somewhere that will 404 or answer with prose.
+    let mut config = config_with_model("x/y");
+    config.embeddings_provider = Some("openhuman".into());
+    config.memory_provider = Some("openhuman".into());
+    config.vision_provider = Some("openhuman".into());
+    apply(&mut config, route());
+    assert_eq!(config.embeddings_provider.as_deref(), Some("openhuman"));
+    assert_eq!(config.memory_provider.as_deref(), Some("openhuman"));
+    assert_eq!(config.vision_provider.as_deref(), Some("openhuman"));
+}
+
+#[test]
+fn apply_leaves_the_persisted_inference_route_untouched() {
+    // `inference_url`/`api_key`/`primary_cloud` are the account's own BYOK
+    // route. A per-call route that rewrote them would be indistinguishable from
+    // the operator changing their settings.
+    let mut config = config_with_model("x/y");
+    config.inference_url = Some("https://api.example.test/v1".into());
+    config.api_key = Some("account-key".into());
+    config.primary_cloud = Some("some-id".into());
+    apply(&mut config, route());
+    assert_eq!(
+        config.inference_url.as_deref(),
+        Some("https://api.example.test/v1")
+    );
+    assert_eq!(config.api_key.as_deref(), Some("account-key"));
+    assert_eq!(config.primary_cloud.as_deref(), Some("some-id"));
+}
+
+#[test]
+fn apply_without_a_model_changes_nothing() {
+    // `"<slug>:"` would trade a working default for a "resolved to an empty
+    // model id" bail, which is strictly worse than ignoring the route.
+    let mut config = Config::default();
+    config.default_model = Some("   ".into());
+    apply(&mut config, route());
+    assert!(config.ephemeral_route.is_none());
+    assert!(config.chat_provider.is_none());
+    assert!(config
+        .cloud_providers
+        .iter()
+        .all(|entry| entry.slug != EPHEMERAL_ROUTE_SLUG));
+}
+
+#[test]
+fn apply_twice_leaves_one_entry() {
+    let mut config = config_with_model("x/y");
+    apply(&mut config, route());
+    apply(
+        &mut config,
+        EphemeralRoute {
+            endpoint: "http://127.0.0.1:9999/openai".into(),
+            api_key: "mdl-other".into(),
+        },
+    );
+    let entries: Vec<_> = config
+        .cloud_providers
+        .iter()
+        .filter(|entry| entry.slug == EPHEMERAL_ROUTE_SLUG)
+        .collect();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].endpoint, "http://127.0.0.1:9999/openai");
+}
+
+#[test]
+fn the_route_cannot_be_serialized_into_a_config_file() {
+    // The containment the whole design rests on: there is no field on the wire
+    // to write it into, so a caller that saves this config cannot repoint the
+    // operator's install.
+    let mut config = config_with_model("x/y");
+    apply(&mut config, route());
+    let encoded = toml::to_string(&config).expect("config serializes");
+    assert!(!encoded.contains("mdl-token"));
+    assert!(!encoded.contains("ephemeral_route"));
+}

--- a/src/openhuman/config/schema/mod.rs
+++ b/src/openhuman/config/schema/mod.rs
@@ -9,6 +9,8 @@ pub use cloud_providers::{
     generate_provider_id, is_slug_reserved, migrate_legacy_fields, AuthStyle, CloudProviderCreds,
     CloudProviderType,
 };
+pub mod ephemeral_route;
+pub use ephemeral_route::{EphemeralRoute, EPHEMERAL_ROUTE_SLUG};
 pub mod subconscious;
 pub use subconscious::{MedullaLocalConfig, SubconsciousConfig, SubconsciousEngine};
 mod agent;

--- a/src/openhuman/config/schema/types.rs
+++ b/src/openhuman/config/schema/types.rs
@@ -364,6 +364,17 @@ pub struct Config {
     #[serde(default)]
     pub primary_cloud: Option<String>,
 
+    /// Runtime only — where this one call's inference goes, when the caller
+    /// named an endpoint and bearer for it.
+    ///
+    /// `#[serde(skip)]` is the whole point: a per-call route must not be able to
+    /// reach `config.toml` and repoint the account's inference for good. See
+    /// [`ephemeral_route`](crate::openhuman::config::schema::ephemeral_route)
+    /// for how it is installed and which roles it governs.
+    #[serde(skip)]
+    #[schemars(skip)]
+    pub ephemeral_route: Option<crate::openhuman::config::schema::ephemeral_route::EphemeralRoute>,
+
     /// Provider string for direct conversational chat (simple back-and-forth).
     #[serde(default)]
     pub chat_provider: Option<String>,
@@ -749,6 +760,7 @@ impl Default for Config {
             api_url: None,
             api_key: None,
             inference_url: None,
+            ephemeral_route: None,
             default_model: Some(DEFAULT_MODEL.to_string()),
             default_temperature: DEFAULT_TEMPERATURE,
             output_language: None,

--- a/src/openhuman/inference/local/ops.rs
+++ b/src/openhuman/inference/local/ops.rs
@@ -152,6 +152,14 @@ fn grant_turn_cwd(config: &mut Config, root: &std::path::Path) {
 /// the awaited future (see [`crate::agent_progress`]), it is attached to the
 /// agent built here, so an in-process embedder observes the turn's tool calls
 /// and deltas live instead of only its final string.
+///
+/// # Per-call inference route
+///
+/// `route` names an endpoint and bearer for this call alone. It is applied to
+/// `config` in memory before the agent is built — including before the `cwd`
+/// clone below, so a turn that is both rooted and routed gets both — and is
+/// never persisted. See
+/// [`ephemeral_route`](crate::openhuman::config::schema::ephemeral_route).
 pub async fn agent_chat(
     config: &mut Config,
     message: &str,
@@ -159,6 +167,7 @@ pub async fn agent_chat(
     temperature: Option<f64>,
     thread_id: Option<String>,
     cwd: Option<String>,
+    route: Option<crate::openhuman::config::schema::EphemeralRoute>,
 ) -> Result<RpcOutcome<String>, String> {
     enforce_user_prompt_or_reject(message, "local_ai.ops.agent_chat")?;
 
@@ -170,6 +179,12 @@ pub async fn agent_chat(
     }
     if let Some(temp) = temperature {
         config.default_temperature = temp;
+    }
+    // After the model override, because the route pins its roles to
+    // `"<slug>:<model>"` and the model it uses is the one this call resolved.
+    // Before the `cwd` clone below, so a rooted turn is routed too.
+    if let Some(route) = route {
+        crate::openhuman::config::schema::ephemeral_route::apply(config, route);
     }
     let turn_cwd = resolve_turn_cwd(cwd)?;
     let mut agent = match turn_cwd.as_ref() {

--- a/src/openhuman/inference/local/schemas.rs
+++ b/src/openhuman/inference/local/schemas.rs
@@ -14,9 +14,11 @@ use crate::rpc::RpcOutcome;
 
 /// Params for `inference.agent_chat` and `inference.agent_chat_simple`.
 ///
-/// Kept byte-identical to the copy in
-/// [`crate::openhuman::agent::schemas`], which backs the `agent.chat` /
-/// `agent.chat_simple` namespace over the same ops.
+/// A near-copy of the params in [`crate::openhuman::agent::schemas`], which
+/// backs the `agent.chat` / `agent.chat_simple` namespace over the same ops.
+/// The two diverge in one field: only this surface accepts a per-call
+/// `inference_url` + `api_key`, because `agent.chat` describes a turn on the
+/// account's own configured inference.
 #[derive(Debug, Deserialize)]
 struct AgentChatParams {
     message: String,
@@ -27,6 +29,15 @@ struct AgentChatParams {
     /// tools. Absent or empty keeps the configured `action_dir`. Ignored by the
     /// `*_simple` variant, which runs a bare provider call with no tools.
     cwd: Option<String>,
+    /// OpenAI-compatible endpoint this one call should run against. Paired with
+    /// `api_key`; either alone is ignored. See
+    /// [`ephemeral_route`](crate::openhuman::config::schema::ephemeral_route).
+    #[serde(default)]
+    inference_url: Option<String>,
+    /// Bearer for `inference_url`. Never persisted and never handed to any
+    /// other provider.
+    #[serde(default)]
+    api_key: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -167,6 +178,16 @@ pub fn schemas(function: &str) -> ControllerSchema {
                     "Optional working directory for this turn: the agent's file and shell \
                      tools are rooted here, so relative paths resolve inside it. Must be an \
                      existing directory. Omit (or pass empty) to use the configured action_dir.",
+                ),
+                optional_string(
+                    "inference_url",
+                    "Optional OpenAI-compatible endpoint for this call only. \
+                     Requires api_key; never persisted.",
+                ),
+                optional_string(
+                    "api_key",
+                    "Bearer for inference_url. Scoped to this call and to that \
+                     endpoint alone.",
                 ),
             ],
             outputs: vec![json_output("response", "Agent response payload.")],
@@ -319,6 +340,10 @@ fn handle_agent_chat(params: Map<String, Value>) -> ControllerFuture {
                 p.temperature,
                 p.thread_id,
                 p.cwd,
+                crate::openhuman::config::schema::EphemeralRoute::from_params(
+                    p.inference_url,
+                    p.api_key,
+                ),
             )
             .await?,
         )

--- a/src/openhuman/inference/provider/factory.rs
+++ b/src/openhuman/inference/provider/factory.rs
@@ -2543,6 +2543,24 @@ pub(crate) fn openai_bearer_is_oauth(config: &Config) -> bool {
 /// "no auth", which surfaces an authentication error at first call rather than
 /// at factory build time.
 pub fn lookup_key_for_slug(slug: &str, config: &Config) -> anyhow::Result<String> {
+    // Ahead of the stored profiles, and scoped to the one slug the per-call
+    // route registers. A caller that named an endpoint and a bearer for this
+    // turn has said where the credential comes from, and there is nothing on
+    // disk to find for a slug that exists only in this `Config` copy. Scoping it
+    // by slug is what keeps the bearer from reaching a provider the caller never
+    // named — the same containment the legacy `config.api_key` fallback below
+    // gets from `legacy_inference_slug`.
+    if slug == crate::openhuman::config::schema::EPHEMERAL_ROUTE_SLUG {
+        if let Some(route) = config.ephemeral_route.as_ref() {
+            log::debug!(
+                "[providers][chat-factory] auth lookup slug={} key_present={} (per-call route)",
+                slug,
+                !route.api_key.trim().is_empty()
+            );
+            return Ok(route.api_key.trim().to_string());
+        }
+    }
+
     let auth = AuthService::from_config(config);
     // Try new-style key first.
     let new_key = auth_key_for_slug(slug);
@@ -2625,7 +2643,7 @@ pub fn lookup_key_for_slug(slug: &str, config: &Config) -> anyhow::Result<String
 }
 
 /// Return a safe-to-log representation of a URL endpoint: `scheme://host` only.
-pub(super) fn redact_endpoint(url: &str) -> String {
+pub fn redact_endpoint(url: &str) -> String {
     let trimmed = url.trim();
     if let Some(rest) = trimmed.split_once("://") {
         let scheme = rest.0;

--- a/src/openhuman/inference/provider/factory_tests.rs
+++ b/src/openhuman/inference/provider/factory_tests.rs
@@ -1628,3 +1628,86 @@ fn cloud_fallback_roles_match_the_roles_provider_for_role_actually_falls_back() 
         );
     }
 }
+
+// ── Per-call inference route ────────────────────────────────────────────────
+//
+// These close the loop between `ephemeral_route::apply` and the two resolution
+// steps that have to honour it for a routed turn to reach the caller's
+// endpoint. Both are read from `Config`, so they are exercised without a
+// network or a booted core.
+
+/// A config carrying a resolved model, as `agent_chat` leaves it after applying
+/// `model_override` and before building the agent.
+fn routed_config(endpoint: &str, api_key: &str, model: &str) -> Config {
+    use crate::openhuman::config::schema::ephemeral_route::{apply, EphemeralRoute};
+    let mut config = Config {
+        default_model: Some(model.to_string()),
+        ..Config::default()
+    };
+    apply(
+        &mut config,
+        EphemeralRoute {
+            endpoint: endpoint.to_string(),
+            api_key: api_key.to_string(),
+        },
+    );
+    config
+}
+
+#[test]
+fn a_routed_turn_resolves_its_roles_to_the_callers_endpoint() {
+    use crate::openhuman::config::schema::EPHEMERAL_ROUTE_SLUG;
+    let config = routed_config(
+        "http://127.0.0.1:41234/openai",
+        "mdl-token",
+        "anthropic/claude-sonnet-4",
+    );
+    let expected = format!("{EPHEMERAL_ROUTE_SLUG}:anthropic/claude-sonnet-4");
+    for role in ["chat", "reasoning", "coding", "agentic"] {
+        assert_eq!(
+            provider_for_role(role, &config),
+            expected,
+            "role '{role}' must resolve to the per-call route"
+        );
+    }
+}
+
+#[test]
+fn a_routed_turn_authenticates_with_the_callers_bearer() {
+    use crate::openhuman::config::schema::EPHEMERAL_ROUTE_SLUG;
+    let config = routed_config("http://127.0.0.1:41234/openai", "mdl-token", "x/y");
+    // Read straight off the config: there is no auth profile on disk for a slug
+    // that exists only in this in-memory copy, so the stored-profile lookup
+    // would come back empty and the turn would 401 several layers later.
+    assert_eq!(
+        lookup_key_for_slug(EPHEMERAL_ROUTE_SLUG, &config).expect("resolves"),
+        "mdl-token"
+    );
+}
+
+#[test]
+fn the_routes_bearer_is_not_offered_to_any_other_slug() {
+    // The containment that makes reusing one config field safe: a background
+    // role that fell through to some other cloud slug must not be handed the
+    // caller's credential.
+    let config = routed_config("http://127.0.0.1:41234/openai", "mdl-token", "x/y");
+    for slug in ["openrouter", "anthropic", "openai"] {
+        let key = lookup_key_for_slug(slug, &config).expect("resolves");
+        assert_ne!(key, "mdl-token", "slug '{slug}' must not see the route key");
+    }
+}
+
+#[test]
+fn the_route_resolves_to_a_provider_the_factory_can_build() {
+    // `resolve_cloud_slug` is where a missing `cloud_providers` entry or an
+    // empty model turns into an error. Building the model proves the entry
+    // `apply` registered is complete enough to be used, not merely present.
+    let config = routed_config("http://127.0.0.1:41234/openai", "mdl-token", "x/y");
+    let (_, model_id) = create_test_chat_model_from_string(
+        "coding",
+        &provider_for_role("coding", &config),
+        &config,
+    )
+    .expect("the per-call route builds a chat model");
+    assert_eq!(model_id, "x/y");
+}


### PR DESCRIPTION
## Why

An embedding host sometimes knows where a *single* turn should run before the core does: it holds an OpenAI-compatible endpoint and a bearer for it, and wants that turn there without moving where the account's other work runs.

The existing spelling cannot express that. `config_update_model_settings` writes `inference_url` / `api_key` / `cloud_providers` to disk, so a caller borrowing an endpoint for one turn repoints the operator's whole install and has to remember to put it back — and a crash between the two writes leaves it repointed for good.

## What

A per-call route that lives only in memory.

It rides on `Config` — which every resolution step already reads — in a field that is `#[serde(skip)]`. It cannot reach `config.toml` even if a caller saves the config, because there is no field on the wire to save it into. Controllers apply it to their own per-call `Config` copy, which is dropped when the call returns.

- **`config::schema::ephemeral_route`** — the `EphemeralRoute` type and `apply`, which registers the route as a `cloud_providers` entry and pins the four roles an agent turn runs on (chat, reasoning, agentic, coding).
- **`provider::factory::lookup_key_for_slug`** — resolves the route's bearer ahead of the stored profiles and *only* for the route's own slug. There is nothing on disk to find for a slug that exists only in memory, and scoping it by slug is what keeps the bearer from reaching a provider the caller never named (the same containment the legacy `config.api_key` fallback gets from `legacy_inference_slug`).
- **`inference.agent_chat`** — optional `inference_url` + `api_key`, applied after the model override and before the `cwd` clone, so a turn that is both rooted and routed gets both.

### Deliberate limits

Background roles (memory, embeddings, heartbeat, learning, subconscious) and `vision` are **left alone**. They run tier-specific models a chat endpoint generally cannot serve, and silently sending an embeddings request to a chat model is worse than ignoring the route for that workload.

`agent.chat` is unchanged and keeps describing a turn on the account's own configured inference — a caller that wants a turn elsewhere says so through `inference_agent_chat`. The two params structs are no longer byte-identical and the doc comments on both now say so.

The route is ignored when no model resolved: pinning a role to `"<slug>:"` would trade a working default for a "resolved to an empty model id" bail.

## Testing

`cargo fmt --check` clean. 13 new tests, all passing:

- **Containment** — not serializable into a config file, not offered to any other slug, persisted `inference_url`/`api_key`/`primary_cloud` untouched, background roles untouched.
- **Resolution** — the two steps that must honour the route for a routed turn to reach the caller's endpoint: `provider_for_role` returns the route for all four roles, and `lookup_key_for_slug` returns its bearer. `the_route_resolves_to_a_provider_the_factory_can_build` goes one further and builds the `ChatModel`, proving the registered entry is complete enough to use rather than merely present.

Two `--lib` failures on this branch are **pre-existing** — both reproduce identically at the base commit `9ef37ba` with these changes stashed:

- `cron::scheduler::tests::cron_agent_job_short_loopback_send_error_stays_retryable` — stack overflow (SIGABRT). Checked specifically, since adding a `Config` field could plausibly tip a near-limit stack. It does not.
- `agent::schemas::tests::schemas_expose_expected_inputs_and_unknown_fallback` — asserts 4 inputs, gets 5; the `cwd` commit added the fifth and did not update the test. Left alone to keep this diff scoped, but it is a one-line fix if you want it here.

## Consumer

`tinyhumansai/medulla` uses this to run an embedded OpenHuman turn on a `[[customHarnesses]]` preset's OpenRouter model, with the endpoint being Medulla's loopback attribution proxy and the bearer a machine-local token rather than the real OpenRouter key. That PR moves its gitlink onto this branch and needs this to land first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a per-call inference endpoint and API key when using `inference.agent_chat`.
  * Per-call settings apply across chat, reasoning, agentic, and coding tasks using the selected model.
  * Temporary inference credentials are used only for the current runtime session and are not saved to configuration files.
  * Existing temporary settings are safely replaced when new per-call values are provided.

* **Documentation**
  * Clarified the difference between account-configured agent chat and per-call inference chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->