### PR TITLE
fix(build): drop unused std::fs import that fails clippy on main

### DIFF
--- a/app/src-tauri/src/process_recovery.rs
+++ b/app/src-tauri/src/process_recovery.rs
@@ -11,7 +11,6 @@ pub(crate) struct ProcessInfo {
 #[cfg(target_os = "macos")]
 mod imp {
     use std::collections::{HashMap, HashSet};
-    use std::fs;
     use std::path::{Path, PathBuf};
     use std::time::Duration;
 


### PR DESCRIPTION
## Summary

- `cargo clippy -- -D warnings` fails on a clean `main`, so the pre-push hook (`pnpm rust:clippy`) blocks **every** contributor's push regardless of what they changed.
- One unused import, one line.

## Problem

On `main` at `c7e15ba04`:

```
error: unused import: `std::fs`
  --> src/process_recovery.rs:14:9
   |
14 |     use std::fs;
   |         ^^^^^^^
   = note: `-D unused-imports` implied by `-D warnings`
```

The import is inside the `#[cfg(target_os = "macos")] mod imp` block at `process_recovery.rs:11`. The `std::fs::` calls further down the file (`:484`, `:498`, `:537`) live in the `#[cfg(target_os = "linux")]` block at `:389` and are fully qualified, so nothing in the macOS block ever used it.

It became unused in `1843706c3` — the CEF → Wry swap in #5456 — which removed the macOS reap path that read the filesystem.

`.husky/pre-push` runs `pnpm rust:clippy`, and that step has no auto-fix path, so the hook fails for anyone pushing anything until this is removed.

## Solution

Delete the import.

## Submission Checklist

- [x] Tests added or updated — `N/A: removing an unused import changes no behaviour and has no failure path to cover.`
- [x] **Diff coverage ≥ 80%** — `N/A: one deleted line, no changed executable lines.`
- [x] Coverage matrix updated — `N/A: no feature rows affected.`
- [x] All affected feature IDs listed — `N/A: no feature IDs.`
- [x] No new external network dependencies introduced — deletion only.
- [x] Manual smoke checklist updated — `N/A: no user-facing surface.`
- [x] Linked issue closed via `Closes #NNN` — `N/A: no issue filed; found while working #5478.`

## Impact

Build/CI only. No runtime change on any platform — the import was unused in the only configuration that compiled it.

Unblocks the pre-push hook repo-wide.

## Related

- Cause: #5456 (`1843706c3`)
- Found while working: #5478. Deliberately kept out of that stack (#5482, #5483) so an unrelated one-line build fix is reviewable on its own rather than buried in a large deletion, and so it can land independently of that work.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/clippy-unused-fs`
- Commit SHA: `ef9b9b357d1ef17eab347c415dba747caba455df`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no frontend files touched.`
- [x] `pnpm typecheck` — `N/A: no TypeScript touched.`
- [x] Focused tests: `N/A: no behaviour to test.`
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path app/src-tauri/Cargo.toml --all --check` clean.
- [x] Tauri fmt/check (if changed): **`cargo clippy --manifest-path app/src-tauri/Cargo.toml -- -D warnings` → 0 errors** (fails with 1 error on `upstream/main`, verified by clean checkout before and after).

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: entirely — the removed import had no users.
- Guard/fallback/dispatch parity checks: `grep -n "fs::" app/src-tauri/src/process_recovery.rs` shows only fully-qualified `std::fs::` calls in the Linux block.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused internal code with no changes to application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->