### PR TITLE
docs(composio): name the OpenCompany twin of mapComposioCategory

### DIFF
--- a/app/src/components/composio/toolkitMeta.tsx
+++ b/app/src/components/composio/toolkitMeta.tsx
@@ -302,6 +302,25 @@ function guessCategory(slug: string, name: string): SkillCategory {
  * `"crm"`, `"developer-tools"`), so we match on substrings and return the
  * first hit. Returns `undefined` when nothing matches so the caller can
  * fall back to the slug/name keyword heuristic.
+ *
+ * ## This function has a twin. Edit both.
+ *
+ * The other copy is `mapComposioCategory` in
+ * `frontend/src/lib/composio-catalog.ts` in **tinyhumansai/opencompany**,
+ * where the operator console buckets the same Composio catalog off the same
+ * free-form strings (opencompany#600). Nothing mechanical detects a
+ * divergence: edit one and both consoles keep looking correct in isolation
+ * while bucketing the same provider differently.
+ *
+ * The branch **order** is as load-bearing as the substrings — both copies
+ * return on the first hit, so an entry carrying several categories depends on
+ * Chat → Social → Productivity → Platform. Reordering here alone is the
+ * subtlest way the two can drift.
+ *
+ * There is no shared package to hoist this into, so the guard is social and
+ * deliberately cheap: this notice, the matching one on the OpenCompany side,
+ * and that repository's `mapComposioCategory keeps the buckets its OpenHuman
+ * twin produces` test, which pins the table case-by-case.
  */
 function mapComposioCategory(categories?: string[]): SkillCategory | undefined {
   if (!categories || categories.length === 0) return undefined;


### PR DESCRIPTION
## Summary

- Adds a doc comment to `mapComposioCategory` (`app/src/components/composio/toolkitMeta.tsx`) naming its second copy in **tinyhumansai/opencompany**, at `frontend/src/lib/composio-catalog.ts`.
- Records that the branch **order** is as load-bearing as the substring list, which was previously unstated on both sides.
- Comment-only: no code, no behaviour, no new dependency, 19 added lines and nothing removed.

## Problem

`mapComposioCategory` here and `mapComposioCategory` in OpenCompany's operator console bucket **the same Composio catalog** off **the same free-form category strings** — opencompany#600 ported this function to fix a flat 123-provider list there.

Nothing mechanical detects a divergence between the two. They live in different repositories with no shared package, so edit one and both consoles keep looking correct in isolation while bucketing the same provider differently. The failure is silent on both sides and only visible to someone comparing two products.

Raised in review on tinyhumansai/opencompany#639, which asks for a notice on each side. This is the OpenHuman half; the OpenCompany half ships in that PR.

## Solution

The cheap, honest guard rather than machinery that does not exist yet:

- **This notice**, naming the twin by repository and path so a future edit at least knows a sibling exists.
- **The matching notice** on the OpenCompany copy, pointing back here.
- **A pinned table** on the OpenCompany side (`mapComposioCategory keeps the buckets its OpenHuman twin produces`) asserting the substring mapping case-by-case, plus one asserting the first-hit branch order. Editing the table without editing the list fails that suite — which is the moment the editor is told a twin exists.

One thing the comment adds beyond the review's ask: both copies `return` on the first match, so an entry carrying several categories depends on Chat → Social → Productivity → Platform. Reordering the branches on one side only is the subtlest way these can drift, and neither copy said so.

Hoisting the function into a shared package would be the real fix. That is a cross-repository dependency decision well beyond a review nit, so it is not attempted here.

## Submission Checklist

- [x] Tests added or updated — `N/A: comment-only change, no executable line added or altered.` The behavioural pinning this review item asked for lands with the OpenCompany copy (three tests in tinyhumansai/opencompany#639), where the function's tests already live.
- [x] **Diff coverage ≥ 80%** — `N/A: every changed line is a comment, so no changed line is instrumentable.`
- [x] Coverage matrix updated — `N/A: behaviour-only change` (in fact not even that — documentation only).
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no feature row is affected.`
- [x] No new external network dependencies introduced — none; nothing executable changed.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: does not alter any runtime surface.`
- [x] Linked issue closed via `Closes #NNN` — `N/A: no OpenHuman issue exists.` This originates from review feedback on a PR in another repository, linked below.

## Impact

None at runtime. The bundle is unchanged apart from a comment stripped at build time; no desktop, mobile, web, or CLI behaviour is touched, and there are no performance, security, migration, or compatibility implications.

## Related

- Closes: `N/A` — no OpenHuman issue.
- Cross-repo origin: tinyhumansai/opencompany#639 (review by @oxoxDev asking for a twin notice on each side) and tinyhumansai/opencompany#600.
- Follow-up PR(s)/TODOs: hoisting `mapComposioCategory` into a package both repositories consume would remove the need for this notice entirely. Not attempted here — it is a cross-repository dependency decision, not a review nit.

---

## AI Authored PR Metadata

### Linear Issue

- Key: `N/A` — originates from a GitHub review comment on tinyhumansai/opencompany#639, not Linear.
- URL: `N/A`

### Commit & Branch

- Branch: `docs/composio-category-twin`
- Commit SHA: `4a96a86f8`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — passes: "All matched files use Prettier code style!", plus the `cargo fmt` half. Prettier parsing the file is also proof it remains syntactically valid TSX.
- [x] `pnpm typecheck` — passes clean (`tsc --noEmit`, no output). Run at this branch's own base in a dedicated worktree with its own `pnpm install --frozen-lockfile`; an earlier attempt to reuse a checkout 53 commits behind was discarded because its baseline already failed on an unrelated file, which would have been a meaningless signal.
- [x] Focused tests: `N/A` — no executable line changed; there is no test that can distinguish this commit from its parent.
- [x] Rust fmt/check (if changed): `N/A` — no Rust touched.
- [x] Tauri fmt/check (if changed): `N/A` — no Tauri shell code touched.

### Validation Blocked

- `command:` `N/A`
- `error:` `N/A`
- `impact:` `N/A` — nothing blocked. The checklist item above was initially left unticked because the command had not been run, which failed the **PR Submission Checklist** gate. The fix was to run it rather than to tick it: deps were installed in a worktree at this branch's base and both `pnpm typecheck` and `pnpm --filter openhuman-app format:check` now pass.

### Behavior Changes

- Intended behavior change: none.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: entirely — `mapComposioCategory`'s body, signature and branch order are byte-identical.
- Guard/fallback/dispatch parity checks: `N/A` — no guard, fallback, or dispatch path is touched. The comment *documents* the existing first-hit branch order; it does not change it.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none.
- Canonical PR: this one.
- Resolution: `N/A`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added developer documentation explaining category assignment behavior and branch ordering.
  * Documented the relationship to the corresponding implementation and parity test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
