### PR TITLE
Add lowercase openHuman launcher symlink to the .deb package

### DIFF
--- a/app/src-tauri/postinst
+++ b/app/src-tauri/postinst
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Debian postinst maintainer script for OpenHuman (openhuman#5497).
+#
+# dpkg installs the bundled binary as /usr/bin/OpenHuman — capital O, from the
+# Cargo `[[bin]]` name. Users on non-bash shells (fish, zsh) and anyone typing
+# the lowercase form hit "command not found", because no lowercase launcher is
+# on PATH. Create a /usr/local/bin/openHuman symlink so the app resolves from
+# any POSIX shell without manual PATH setup; the capitalised name keeps working
+# through /usr/bin/OpenHuman.
+set -e
+
+# Paths are overridable only so the maintainer-script test can exercise this
+# logic in a sandbox (scripts/test-deb-maintainer-scripts.sh). dpkg invokes the
+# script with neither variable set, so production always uses the defaults.
+TARGET="${OPENHUMAN_DEB_BINARY:-/usr/bin/OpenHuman}"
+LINK="${OPENHUMAN_DEB_SYMLINK:-/usr/local/bin/openHuman}"
+
+case "$1" in
+  configure)
+    if [ -e "$TARGET" ]; then
+      mkdir -p "$(dirname "$LINK")"
+      # Manage only our own symlink; never clobber a real file a user placed here.
+      if [ -L "$LINK" ] || [ ! -e "$LINK" ]; then
+        ln -sf "$TARGET" "$LINK"
+      fi
+    fi
+    ;;
+esac
+
+exit 0

--- a/app/src-tauri/postinst
+++ b/app/src-tauri/postinst
@@ -21,7 +21,12 @@ case "$1" in
       mkdir -p "$(dirname "$LINK")"
       # Manage only our own symlink; never clobber a real file a user placed here.
       if [ -L "$LINK" ] || [ ! -e "$LINK" ]; then
-        ln -sf "$TARGET" "$LINK"
+        # Remove our own symlink first, then recreate it. `ln -sf` would FOLLOW a
+        # symlink that already points at a directory and create the launcher
+        # *inside* that directory (CWE-59) rather than replacing the link; `rm -f`
+        # deletes the symlink itself, so the fresh `ln -s` always lands at $LINK.
+        rm -f "$LINK"
+        ln -s "$TARGET" "$LINK"
       fi
     fi
     ;;

--- a/app/src-tauri/postrm
+++ b/app/src-tauri/postrm
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Debian postrm maintainer script for OpenHuman (openhuman#5497).
+#
+# Remove the /usr/local/bin/openHuman compatibility symlink created by postinst,
+# but only while it still points at our binary — never delete a file a user
+# later put in its place. Not touched on upgrade: dpkg calls this with "upgrade"
+# for the outgoing version and the new postinst recreates the link.
+set -e
+
+# Overridable for the maintainer-script test only; dpkg sets neither variable,
+# so production uses the defaults. See scripts/test-deb-maintainer-scripts.sh.
+LINK="${OPENHUMAN_DEB_SYMLINK:-/usr/local/bin/openHuman}"
+TARGET="${OPENHUMAN_DEB_BINARY:-/usr/bin/OpenHuman}"
+
+case "$1" in
+  remove|purge)
+    if [ -L "$LINK" ] && [ "$(readlink "$LINK")" = "$TARGET" ]; then
+      rm -f "$LINK"
+    fi
+    ;;
+esac
+
+exit 0

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -66,7 +66,9 @@
           "libxkbcommon0",
           "libxshmfence1"
         ],
-        "desktopTemplate": "main.desktop"
+        "desktopTemplate": "main.desktop",
+        "postInstallScript": "postinst",
+        "postRemoveScript": "postrm"
       }
     },
     "windows": {

--- a/scripts/test-deb-maintainer-scripts.sh
+++ b/scripts/test-deb-maintainer-scripts.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# scripts/test-deb-maintainer-scripts.sh — regression guard for the Debian
+# maintainer scripts that make the OpenHuman binary reachable from any shell
+# (openhuman#5497). No CI lane executes shell packaging tests today, so run this
+# locally / in review after touching app/src-tauri/{postinst,postrm} or the deb
+# bundle config: bash scripts/test-deb-maintainer-scripts.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC_TAURI="$REPO_ROOT/app/src-tauri"
+POSTINST="$SRC_TAURI/postinst"
+POSTRM="$SRC_TAURI/postrm"
+CONF="$SRC_TAURI/tauri.conf.json"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+# --- 1. The scripts exist and are valid POSIX sh -----------------------------
+[ -f "$POSTINST" ] || fail "missing $POSTINST"
+[ -f "$POSTRM" ] || fail "missing $POSTRM"
+sh -n "$POSTINST" || fail "postinst is not valid POSIX sh"
+sh -n "$POSTRM" || fail "postrm is not valid POSIX sh"
+
+# --- 2. tauri.conf.json wires both scripts into the deb bundle ---------------
+grep -q '"postInstallScript": "postinst"' "$CONF" \
+  || fail "tauri.conf.json does not reference postinst via postInstallScript"
+grep -q '"postRemoveScript": "postrm"' "$CONF" \
+  || fail "tauri.conf.json does not reference postrm via postRemoveScript"
+# The lowercase symlink only helps if the binary really installs as OpenHuman.
+grep -q '"productName": "OpenHuman"' "$CONF" \
+  || fail "productName changed — the postinst symlink target is now stale"
+
+# --- 3. Behavioural test in a throwaway sandbox ------------------------------
+# Point the scripts' hardcoded /usr paths at a temp root via the documented
+# override env vars, so we exercise the real logic without touching the system.
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+export OPENHUMAN_DEB_BINARY="$SANDBOX/usr/bin/OpenHuman"
+export OPENHUMAN_DEB_SYMLINK="$SANDBOX/usr/local/bin/openHuman"
+
+mkdir -p "$(dirname "$OPENHUMAN_DEB_BINARY")"
+printf '#!/bin/sh\nexit 0\n' >"$OPENHUMAN_DEB_BINARY"
+chmod +x "$OPENHUMAN_DEB_BINARY"
+
+# 3a. Fresh install creates the lowercase symlink pointing at the binary.
+sh "$POSTINST" configure
+[ -L "$OPENHUMAN_DEB_SYMLINK" ] || fail "postinst did not create the symlink"
+[ "$(readlink "$OPENHUMAN_DEB_SYMLINK")" = "$OPENHUMAN_DEB_BINARY" ] \
+  || fail "symlink points at the wrong target"
+
+# 3b. Re-running (upgrade reconfigure) is idempotent.
+sh "$POSTINST" configure
+[ -L "$OPENHUMAN_DEB_SYMLINK" ] || fail "postinst not idempotent"
+
+# 3c. Removal deletes our symlink.
+sh "$POSTRM" remove
+[ -e "$OPENHUMAN_DEB_SYMLINK" ] && fail "postrm did not remove the symlink"
+
+# 3d. postrm on 'upgrade' must NOT remove the link (postinst recreates it).
+sh "$POSTINST" configure
+sh "$POSTRM" upgrade
+[ -L "$OPENHUMAN_DEB_SYMLINK" ] || fail "postrm removed the symlink on upgrade"
+
+# 3e. A user's own file at the link path is never clobbered or deleted.
+rm -f "$OPENHUMAN_DEB_SYMLINK"
+printf 'user data\n' >"$OPENHUMAN_DEB_SYMLINK"
+sh "$POSTINST" configure
+[ -L "$OPENHUMAN_DEB_SYMLINK" ] && fail "postinst clobbered a user's real file"
+sh "$POSTRM" purge
+[ -f "$OPENHUMAN_DEB_SYMLINK" ] || fail "postrm deleted a user's real file"
+
+echo "PASS: deb maintainer scripts create/remove the openHuman symlink safely"

--- a/scripts/test-deb-maintainer-scripts.sh
+++ b/scripts/test-deb-maintainer-scripts.sh
@@ -71,4 +71,16 @@ sh "$POSTINST" configure
 sh "$POSTRM" purge
 [ -f "$OPENHUMAN_DEB_SYMLINK" ] || fail "postrm deleted a user's real file"
 
+# 3f. A pre-existing symlink at the link path that points to a DIRECTORY must be
+# replaced in place — never followed. `ln -sf` would create the launcher inside
+# that directory (CWE-59); postinst must land the link at $LINK and write
+# nothing into the target directory.
+rm -f "$OPENHUMAN_DEB_SYMLINK"
+DECOY_DIR="$SANDBOX/decoy-dir"
+mkdir -p "$DECOY_DIR"
+ln -s "$DECOY_DIR" "$OPENHUMAN_DEB_SYMLINK"
+sh "$POSTINST" configure
+[ -e "$DECOY_DIR/$(basename "$OPENHUMAN_DEB_BINARY")" ] && fail "postinst followed a symlink and wrote inside the target directory (CWE-59)"
+[ "$(readlink "$OPENHUMAN_DEB_SYMLINK")" = "$OPENHUMAN_DEB_BINARY" ] || fail "postinst did not replace the directory symlink with the launcher link"
+
 echo "PASS: deb maintainer scripts create/remove the openHuman symlink safely"


### PR DESCRIPTION
## Summary

- The Debian bundle installs the binary as `/usr/bin/OpenHuman` (capital `O`, from the Cargo `[[bin]]` name), so on non-bash shells (fish, zsh) and for anyone typing the lowercase form the app is unreachable — `command not found`.
- Adds `postinst`/`postrm` Debian maintainer scripts to the `deb` bundle. `postinst` creates a `/usr/local/bin/openHuman` symlink on the standard `PATH`; `postrm` removes it on uninstall.
- `OpenHuman` (capital) keeps working unchanged via `/usr/bin/OpenHuman`.
- Adds `scripts/test-deb-maintainer-scripts.sh` covering install, idempotent reconfigure, upgrade-preserves, removal, and the user-file clobber guard.

## Problem

Addresses Bug 3 of #5497. On a fresh pikaOS/Debian `.deb` install the launcher is only reachable as `OpenHuman`:

```
geko@pikaOS ~> openHuman   # fish
fish: Unknown command: openHuman
geko@pikaOS:~$ openHuman    # bash
bash: openHuman: command not found
```

dpkg places the binary at `/usr/bin/OpenHuman` and the bundle ships no lowercase launcher, so the capitalisation mismatch breaks fish, zsh, and lowercase-typing bash users alike.

## Solution

- Wire `postInstallScript`/`postRemoveScript` into `bundle.linux.deb` in `app/src-tauri/tauri.conf.json` (keys map to the bundler's `post_install_script`/`post_remove_script`, written to the Debian `postinst`/`postrm` control scripts at mode `0755`).
- `postinst` (on `configure`): `mkdir -p /usr/local/bin` then `ln -sf /usr/bin/OpenHuman /usr/local/bin/openHuman`. `/usr/local/bin` precedes `/usr/bin` on the standard `PATH`, so the lowercase name resolves from any POSIX shell with no manual configuration. Guarded so it never clobbers a real file a user placed at that path.
- `postrm` (on `remove`/`purge` only): removes the symlink, and only while it still points at our binary — never a file the user substituted. Left intact on `upgrade` (the new `postinst` recreates it).
- The two path constants are overridable via `OPENHUMAN_DEB_BINARY`/`OPENHUMAN_DEB_SYMLINK` **for the maintainer-script test only**; dpkg sets neither, so production always uses the defaults.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `scripts/test-deb-maintainer-scripts.sh`: fresh install, idempotent reconfigure, `postrm upgrade` preserves the link, removal deletes it, and the clobber guard (a user's real file is neither replaced nor deleted).
- [x] **Diff coverage ≥ 80%** — N/A: the change is Debian packaging config (JSON) + POSIX shell + a Bash test. It contains no Rust or `app/src` TypeScript lines, so the `diff-cover` gate (Vitest + `cargo-llvm-cov`) has nothing to measure.
- [x] Coverage matrix updated — N/A: packaging change, no feature row.
- [x] All affected feature IDs from the matrix are listed — N/A.
- [x] No new external network dependencies introduced — none added.
- [x] Manual smoke checklist updated — N/A this PR; recommended follow-up smoke step for `docs/RELEASE-MANUAL-SMOKE.md`: on a Debian `.deb` install, `which openHuman` and `which OpenHuman` both resolve.
- [x] Linked issue closed via `Closes #NNN` — N/A: this fixes only Bug 3 of #5497. Bug 2 (`/orchestration/v1/steering` 404) is already fixed on `main` by #5306; Bug 1 (`stream=true` 400) needs a separate change. Using a non-closing reference so #5497 stays open for the remaining bugs.

## Impact

- Linux `.deb` packaging only. No effect on the AppImage (self-contained), macOS, or Windows bundles, and no runtime/code-path change in the app itself.
- Release-cut surface: the maintainer scripts run under dpkg on install/upgrade/removal.

## Related

- #5497 (Bug 3 only — see checklist for Bugs 1 & 2 status)
- Follow-up PR(s)/TODOs: Bug 1 (`stream=true`) — request-layer / provider-config fix tracked separately.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/deb-path-lowercase-symlink-5497`
- Commit SHA: 3f919bfb6

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — verified clean on the changed `tauri.conf.json` (`prettier --write` is a no-op on it)
- [x] `pnpm typecheck` — N/A (no TypeScript changed)
- [x] Focused tests: `bash scripts/test-deb-maintainer-scripts.sh` → PASS; `sh -n` clean on `postinst`/`postrm`
- [x] Rust fmt/check (if changed): N/A (no Rust changed)
- [x] Tauri fmt/check (if changed): N/A (no Rust changed)

### Validation Blocked

- `command:` pre-push hook (`format:check` + `lint` + `compile` + `rust:clippy` on both Rust codebases)
- `error:` the diff has no Rust/TS, and the vendored-CEF Tauri-shell clippy is not built in this local environment; running the full gate is disproportionate and provides no signal for a packaging-only change
- `impact:` none on this diff — the changed JSON is prettier-clean and the shell scripts pass `sh -n` + the added Bash test; CI-Lite runs the applicable lanes on this PR

### Behavior Changes

- Intended behavior change: a lowercase `openHuman` launcher resolves after a `.deb` install
- User-visible effect: `openHuman` works in bash/fish/zsh; `OpenHuman` continues to work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Debian package lifecycle handling to create the `/usr/local/bin/openHuman` command shortcut when installing the application.
  * Added safe cleanup of the shortcut when the application is removed or purged.
  * Existing user-owned files and links are preserved.
  * Integrated the shortcut setup and cleanup into Linux package installation and removal.

* **Tests**
  * Added regression coverage for installation, upgrades, removal, and file-preservation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->