### PR TITLE
fix(tauri): make macOS dev launcher work without dotenv

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "vite",
     "dev:web": "vite",
-    "dev:app": "source ../scripts/load-dotenv.sh && APPLE_SIGNING_IDENTITY='OpenHuman Dev Signer' cargo tauri dev --config '{\"build\":{\"devUrl\":\"http://localhost:'\"${OPENHUMAN_DEV_PORT:-1420}\"'\"}}' ",
+    "dev:app": "bash ../scripts/run-dev-macos.sh",
     "dev:app:win": "\"C:/Program Files/Git/bin/bash.exe\" ../scripts/run-dev-win.sh",
     "core:stage": "echo '[core:stage] no-op — core is linked in-process; sidecar removed (PR #1061)'",
     "tauri:ios:init": "bash ../scripts/ios-init.sh",

--- a/app/src-tauri/src/native_notifications/mod.rs
+++ b/app/src-tauri/src/native_notifications/mod.rs
@@ -98,6 +98,7 @@ pub fn show_native_notification(
 
 #[cfg(target_os = "macos")]
 mod macos {
+    use std::path::Path;
     use std::ptr::NonNull;
     use std::sync::mpsc;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -114,6 +115,7 @@ mod macos {
     /// Read authorization status synchronously by blocking on
     /// `getNotificationSettingsWithCompletionHandler:`.
     pub(super) fn permission_state() -> Result<String, String> {
+        ensure_bundled_app()?;
         let center = UNUserNotificationCenter::currentNotificationCenter();
         let (tx, rx) = mpsc::channel::<String>();
         let completion = RcBlock::new(move |settings: NonNull<UNNotificationSettings>| {
@@ -129,6 +131,7 @@ mod macos {
     /// `granted` if the user accepted (or had previously accepted),
     /// `denied` otherwise.
     pub(super) fn request_permission() -> Result<String, String> {
+        ensure_bundled_app()?;
         let center = UNUserNotificationCenter::currentNotificationCenter();
         let (tx, rx) = mpsc::channel::<bool>();
         let options = UNAuthorizationOptions::Alert
@@ -150,6 +153,7 @@ mod macos {
     /// call but the OS would drop the banner, which is exactly the
     /// "reports success but nothing appears" failure mode of #1152.
     pub(super) fn show(title: String, body: String, tag: Option<String>) -> Result<(), String> {
+        ensure_bundled_app()?;
         let state = permission_state()?;
         if !is_granted(&state) {
             log::warn!("[notify] show aborted: permission state={state}");
@@ -221,6 +225,38 @@ mod macos {
         matches!(state, "granted" | "provisional" | "ephemeral")
     }
 
+    /// `UNUserNotificationCenter` aborts an unbundled macOS process rather
+    /// than returning an error. `cargo tauri dev` runs exactly that shape, so
+    /// reject it before touching the Objective-C API.
+    fn ensure_bundled_app() -> Result<(), String> {
+        let executable = std::env::current_exe()
+            .map_err(|error| format!("could not determine macOS executable path: {error}"))?;
+        if is_bundled_app_executable(&executable) {
+            Ok(())
+        } else {
+            Err(
+                "native notifications are unavailable in an unbundled macOS dev process"
+                    .to_string(),
+            )
+        }
+    }
+
+    fn is_bundled_app_executable(executable: &Path) -> bool {
+        executable.parent().is_some_and(|macos_dir| {
+            macos_dir.file_name().is_some_and(|name| name == "MacOS")
+                && macos_dir.parent().is_some_and(|contents_dir| {
+                    contents_dir
+                        .file_name()
+                        .is_some_and(|name| name == "Contents")
+                        && contents_dir.parent().is_some_and(|bundle_dir| {
+                            bundle_dir
+                                .extension()
+                                .is_some_and(|extension| extension == "app")
+                        })
+                })
+        })
+    }
+
     fn status_to_str(status: UNAuthorizationStatus) -> &'static str {
         if status == UNAuthorizationStatus::Authorized {
             "granted"
@@ -269,6 +305,20 @@ mod macos {
                 "provisional"
             );
             assert_eq!(status_to_str(UNAuthorizationStatus::Ephemeral), "ephemeral");
+        }
+
+        #[test]
+        fn bundled_app_layout_is_accepted() {
+            assert!(is_bundled_app_executable(Path::new(
+                "/Applications/OpenHuman.app/Contents/MacOS/OpenHuman"
+            )));
+        }
+
+        #[test]
+        fn unbundled_executable_is_rejected() {
+            assert!(!is_bundled_app_executable(Path::new(
+                "/tmp/openhuman/target/debug/OpenHuman"
+            )));
         }
     }
 }

--- a/scripts/__tests__/run-dev-macos.test.mjs
+++ b/scripts/__tests__/run-dev-macos.test.mjs
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const script = path.join(repoRoot, "scripts", "run-dev-macos.sh");
+
+function runLauncher(env = {}) {
+  const bin = fs.mkdtempSync(path.join(os.tmpdir(), "openhuman-fake-cargo-"));
+  const cargo = path.join(bin, "cargo");
+  fs.writeFileSync(cargo, "#!/usr/bin/env bash\nprintf 'identity=%s\\nargs=%s\\n' \"$APPLE_SIGNING_IDENTITY\" \"$*\"\n");
+  fs.chmodSync(cargo, 0o755);
+  return execFileSync("bash", [script], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, ...env, PATH: `${bin}:${process.env.PATH}` },
+  });
+}
+
+test("starts without an untracked .env using the default port", () => {
+  const output = runLauncher({ OPENHUMAN_DEV_PORT: "" });
+
+  assert.match(output, /identity=OpenHuman Dev Signer/);
+  assert.match(output, /devUrl.*localhost:1420/);
+});
+
+test("falls back to the default port when OPENHUMAN_DEV_PORT is invalid", () => {
+  const output = runLauncher({ OPENHUMAN_DEV_PORT: "not-a-port" });
+
+  assert.match(output, /devUrl.*localhost:1420/);
+});

--- a/scripts/__tests__/run-dev-macos.test.mjs
+++ b/scripts/__tests__/run-dev-macos.test.mjs
@@ -12,7 +12,7 @@ const script = path.join(repoRoot, "scripts", "run-dev-macos.sh");
 function runLauncher(env = {}) {
   const bin = fs.mkdtempSync(path.join(os.tmpdir(), "openhuman-fake-cargo-"));
   const cargo = path.join(bin, "cargo");
-  fs.writeFileSync(cargo, "#!/usr/bin/env bash\nprintf 'identity=%s\\nargs=%s\\n' \"$APPLE_SIGNING_IDENTITY\" \"$*\"\n");
+  fs.writeFileSync(cargo, "#!/usr/bin/env bash\nprintf 'identity=%s\\nport=%s\\nargs=%s\\n' \"$APPLE_SIGNING_IDENTITY\" \"$OPENHUMAN_DEV_PORT\" \"$*\"\n");
   fs.chmodSync(cargo, 0o755);
   return execFileSync("bash", [script], {
     cwd: repoRoot,
@@ -22,14 +22,33 @@ function runLauncher(env = {}) {
 }
 
 test("starts without an untracked .env using the default port", () => {
-  const output = runLauncher({ OPENHUMAN_DEV_PORT: "" });
+  const output = runLauncher({
+    APPLE_SIGNING_IDENTITY: "",
+    OPENHUMAN_DEV_PORT: "",
+  });
 
   assert.match(output, /identity=OpenHuman Dev Signer/);
+  assert.match(output, /port=1420/);
   assert.match(output, /devUrl.*localhost:1420/);
 });
 
 test("falls back to the default port when OPENHUMAN_DEV_PORT is invalid", () => {
   const output = runLauncher({ OPENHUMAN_DEV_PORT: "not-a-port" });
 
+  assert.match(output, /port=1420/);
+  assert.match(output, /devUrl.*localhost:1420/);
+});
+
+test("passes a validated custom port to Tauri and Vite", () => {
+  const output = runLauncher({ OPENHUMAN_DEV_PORT: " 15321 " });
+
+  assert.match(output, /port=15321/);
+  assert.match(output, /devUrl.*localhost:15321/);
+});
+
+test("normalizes invalid numeric ports before starting Tauri and Vite", () => {
+  const output = runLauncher({ OPENHUMAN_DEV_PORT: "65536" });
+
+  assert.match(output, /port=1420/);
   assert.match(output, /devUrl.*localhost:1420/);
 });

--- a/scripts/run-dev-macos.sh
+++ b/scripts/run-dev-macos.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Start the macOS Tauri development app from a clean checkout or a configured
+# local environment. A `.env` is optional: local defaults and inherited values
+# are sufficient for the desktop dev path.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [[ -f "$REPO_ROOT/.env" ]]; then
+  # shellcheck source=load-dotenv.sh
+  source "$SCRIPT_DIR/load-dotenv.sh" "$REPO_ROOT/.env"
+fi
+
+raw_dev_port="${OPENHUMAN_DEV_PORT:-1420}"
+if [[ "$raw_dev_port" =~ ^[0-9]+$ ]] && (( raw_dev_port >= 1 && raw_dev_port <= 65535 )); then
+  dev_port="$raw_dev_port"
+else
+  echo "[run-dev-macos] WARNING: invalid OPENHUMAN_DEV_PORT='$raw_dev_port'; falling back to 1420" >&2
+  dev_port=1420
+fi
+
+export APPLE_SIGNING_IDENTITY="${APPLE_SIGNING_IDENTITY:-OpenHuman Dev Signer}"
+config_override="{\"build\":{\"devUrl\":\"http://localhost:${dev_port}\"}}"
+
+cd "$REPO_ROOT/app"
+exec cargo tauri dev --config "$config_override"

--- a/scripts/run-dev-macos.sh
+++ b/scripts/run-dev-macos.sh
@@ -13,13 +13,15 @@ if [[ -f "$REPO_ROOT/.env" ]]; then
 fi
 
 raw_dev_port="${OPENHUMAN_DEV_PORT:-1420}"
-if [[ "$raw_dev_port" =~ ^[0-9]+$ ]] && (( raw_dev_port >= 1 && raw_dev_port <= 65535 )); then
+raw_dev_port="${raw_dev_port//[[:space:]]/}"
+if [[ "$raw_dev_port" =~ ^[0-9]+$ ]] && (( 10#$raw_dev_port >= 1 && 10#$raw_dev_port <= 65535 )); then
   dev_port="$raw_dev_port"
 else
   echo "[run-dev-macos] WARNING: invalid OPENHUMAN_DEV_PORT='$raw_dev_port'; falling back to 1420" >&2
   dev_port=1420
 fi
 
+export OPENHUMAN_DEV_PORT="$dev_port"
 export APPLE_SIGNING_IDENTITY="${APPLE_SIGNING_IDENTITY:-OpenHuman Dev Signer}"
 config_override="{\"build\":{\"devUrl\":\"http://localhost:${dev_port}\"}}"
 


### PR DESCRIPTION
## Summary

- Make `pnpm dev:app` work from a clean checkout without an untracked `.env`.
- Validate custom dev ports and preserve the local macOS signing identity.
- Prevent unbundled `cargo tauri dev` processes from aborting on macOS notification APIs.
- Add launcher and macOS bundle-layout regression tests.

## Problem

- The macOS desktop launcher exited before Tauri started whenever `.env` was absent.
- After that was fixed, the unbundled debug executable could abort when it accessed `UNUserNotificationCenter`.

## Solution

- Route the app script through a dedicated macOS launcher that loads `.env` only when present and passes a validated Tauri dev URL.
- Gate macOS notification access on the packaged `.app/Contents/MacOS` executable layout, returning a descriptive dev-process error otherwise.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — CI coverage gate will measure this PR; launcher and native guard paths have focused regression tests.
- [x] Coverage matrix updated — N/A: launcher and platform safety behavior are not feature-matrix rows.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no affected feature IDs.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: development launcher only.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: no issue exists for this local startup regression.

## Impact

- Desktop/macOS development startup only. Packaged app notifications keep their existing behavior; unbundled dev calls now return an actionable error instead of aborting.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix-tauri-startup`
- Commit SHA: `712d98ae147b1e514dd6acd8e0c8152643f3aeca`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck` — N/A: no TypeScript source changes; required pre-push ESLint passed.
- [x] Focused tests: `pnpm test:scripts` (119 passed); `cargo test --manifest-path app/src-tauri/Cargo.toml native_notifications::macos::tests --lib` (5 passed); live Tauri smoke (Vite HTTP 200 and `OpenHuman` stayed alive).
- [x] Rust fmt/check (if changed): `cargo fmt --check` passed; root Clippy pre-push check passed.
- [x] Tauri fmt/check (if changed): `cargo fmt --check` passed; Tauri Clippy pre-push check passed.

### Validation Blocked

- command: N/A
- error: N/A
- impact: N/A

### Behavior Changes

- Intended behavior change: absent `.env` no longer blocks the macOS dev launcher; unbundled notification calls fail safely.
- User-visible effect: `pnpm dev:app` reaches Tauri in a clean checkout instead of exiting or aborting.

### Parity Contract

- Legacy behavior preserved: packaged `.app` notification behavior is unchanged.
- Guard/fallback/dispatch parity checks: bundle-layout tests cover packaged and unbundled paths.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None found.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): N/A.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a streamlined macOS development launch process with automatic environment loading, configurable port support, and default signing configuration.
  * Development launches now use a consistent local application URL.

* **Bug Fixes**
  * Improved macOS notification reliability by preventing notification actions when the app is not running from a valid application bundle.
  * Added clearer failure handling for unsupported notification environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->