### PR TITLE
perf(skills): discover installed skills once per workflow lookup

### DIFF
--- a/src/openhuman/skills/registry.rs
+++ b/src/openhuman/skills/registry.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use crate::openhuman::agent::harness::definition::{AgentDefinition, PromptSource};
-use crate::openhuman::skills::WorkflowScope;
+use crate::openhuman::skills::{Workflow, WorkflowScope};
 
 /// One declared input — a parameter the skill needs, with a human description.
 /// `required` inputs must be supplied at run time; `kind` is an optional type
@@ -172,10 +172,35 @@ pub fn load_workflows_with_profile(
     workspace_dir: &Path,
     profile_skills_root: Option<&Path>,
 ) -> Vec<WorkflowDefinition> {
-    // Prune any legacy bundled skills an older build left behind so discover's
-    // legacy scan no longer surfaces them (idempotent).
-    prune_legacy_default_workflows(workspace_dir);
+    definitions_from_discovered(&discover_all(workspace_dir, profile_skills_root))
+}
 
+/// Prune legacy bundled skills, then enumerate every installed skill across all
+/// roots (deduped + scope-prioritised) via the same discovery the create/list
+/// path uses. Returns the lightweight discovered entries **without** parsing
+/// each one's definition — callers that need only a slug/name/scope (e.g. the
+/// display-name fallback in [`get_workflow_with_profile`]) can reuse this list
+/// instead of walking the roots again.
+///
+/// The prune runs **before** discovery so its legacy scan no longer surfaces
+/// the pruned skills (idempotent).
+fn discover_all(workspace_dir: &Path, profile_skills_root: Option<&Path>) -> Vec<Workflow> {
+    prune_legacy_default_workflows(workspace_dir);
+    let home = dirs::home_dir();
+    let trusted = super::ops_discover::is_workspace_trusted(workspace_dir);
+    super::ops_discover::discover_workflows_with_profile(
+        home.as_deref(),
+        Some(workspace_dir),
+        profile_skills_root,
+        trusted,
+    )
+}
+
+/// Parse a [`WorkflowDefinition`] for each already-discovered skill, prepended
+/// by the built-in agents. Split out from [`load_workflows_with_profile`] so a
+/// single [`discover_all`] walk can feed both the parsed list and a slug/name
+/// lookup without re-discovering.
+fn definitions_from_discovered(discovered: &[Workflow]) -> Vec<WorkflowDefinition> {
     let mut workflows: Vec<WorkflowDefinition> = Vec::new();
 
     if let Ok(builtins) = crate::openhuman::agent::registry::agents::load_builtins() {
@@ -188,16 +213,7 @@ pub fn load_workflows_with_profile(
         }
     }
 
-    // Enumerate across all roots (deduped + scope-prioritised) via the same
-    // discovery the create/list path uses, then load each one's definition.
-    let home = dirs::home_dir();
-    let trusted = super::ops_discover::is_workspace_trusted(workspace_dir);
-    for wf in super::ops_discover::discover_workflows_with_profile(
-        home.as_deref(),
-        Some(workspace_dir),
-        profile_skills_root,
-        trusted,
-    ) {
+    for wf in discovered {
         let Some(skill_md) = wf.location.as_ref() else {
             continue;
         };
@@ -287,7 +303,13 @@ pub fn get_workflow_with_profile(
     id: &str,
     profile_skills_root: Option<&Path>,
 ) -> Option<WorkflowDefinition> {
-    let workflows = load_workflows_with_profile(workspace_dir, profile_skills_root);
+    // Discover once; both the parsed-definition lookup and the display-name
+    // fallback below derive from this single walk. Previously each call
+    // discovered the roots twice — once inside `load_workflows_with_profile`
+    // and again for the name fallback.
+    let discovered = discover_all(workspace_dir, profile_skills_root);
+    let workflows = definitions_from_discovered(&discovered);
+
     // Built-ins are prepended and discovered workflows follow them. Search in
     // reverse so the scope-resolved discovered entry (profile wins over global)
     // also wins over a built-in with the same runnable id.
@@ -300,23 +322,17 @@ pub fn get_workflow_with_profile(
     // a private workflow admitted by the profile-local allow set can actually
     // be described and run. Keep the legacy profile-less lookup id-only: global
     // display names have never been runnable ids and may collide with builtins.
-    let home = dirs::home_dir();
-    let trusted = super::ops_discover::is_workspace_trusted(workspace_dir);
-    let slug = super::ops_discover::discover_workflows_with_profile(
-        home.as_deref(),
-        Some(workspace_dir),
-        profile_skills_root,
-        trusted,
-    )
-    .into_iter()
-    .find(|workflow| workflow.scope == WorkflowScope::Profile && workflow.name == id)
-    .map(|workflow| {
-        if workflow.dir_name.is_empty() {
-            workflow.name
-        } else {
-            workflow.dir_name
-        }
-    })?;
+    // Reuse the discovery above rather than walking the roots a second time.
+    let slug = discovered
+        .iter()
+        .find(|workflow| workflow.scope == WorkflowScope::Profile && workflow.name == id)
+        .map(|workflow| {
+            if workflow.dir_name.is_empty() {
+                workflow.name.clone()
+            } else {
+                workflow.dir_name.clone()
+            }
+        })?;
 
     workflows
         .into_iter()


### PR DESCRIPTION
## Summary

- `get_workflow_with_profile` — the resolution seam behind `run_workflow` / `describe_workflow` — walked the installed-skill roots **twice** per call: once inside `load_workflows_with_profile`, and again to resolve a display-name in the fallback branch.
- Extract `discover_all` (prune + one discovery walk) and `definitions_from_discovered` (builtins + parse each discovered skill); discover once and feed both the id lookup and the name fallback from that single list.
- Behavior-preserving refactor — the parsed list and resolution order are unchanged.

## Problem

Resolving one skill by id parses the whole catalogue and, on the fallback path, re-walks the roots:

```rust
let workflows = load_workflows_with_profile(workspace_dir, profile_skills_root); // discover walk #1 + parse all
if let Some(exact) = workflows.iter().rev().find(|s| s.definition.id == id) { return Some(exact.clone()); }
// display-name fallback:
let slug = discover_workflows_with_profile(/* … */)   // discover walk #2 — from scratch
    .into_iter().find(|w| w.scope == WorkflowScope::Profile && w.name == id)…;
```

`discover_workflows_with_profile` already reads every skill's `WORKFLOW.md`/`SKILL.md` frontmatter; `load_workflows_with_profile` then reads each one again to parse its definition; and the name-fallback discovers a **second** full time. So a single `run_workflow` pays O(N_installed_skills) filesystem reads, with the fallback path re-walking the roots it just walked.

## Solution

Split the work so discovery happens once and is reused:

- `discover_all(workspace_dir, profile_skills_root)` — prune (before discovery, unchanged ordering) + one `discover_workflows_with_profile` walk, returning the lightweight `Workflow` entries.
- `definitions_from_discovered(&[Workflow])` — builtins prepended + parse each discovered skill's definition.
- `load_workflows_with_profile` now delegates to both (behavior identical).
- `get_workflow_with_profile` calls `discover_all` **once**, derives the parsed list from it, and — on the name-fallback — reuses that same discovery instead of walking the roots again.

This is a pure refactor: the parsed workflow list is byte-identical (same builtins, same discovery, same per-skill parse), the exact-id then display-name resolution order is unchanged, and the fallback reads the same discovery it did before — computed once rather than twice. It removes one full root walk per lookup (a third markdown read of every installed skill on the fallback path).

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — behavior-preserving refactor; covered by the existing resolution suite, which now exercises both extracted helpers: `get_workflow_with_profile_resolution_matrix` (id resolution + precedence), `get_profile_workflow_resolves_distinct_display_name` (the reused name fallback), `profile_workflow_exact_id_overrides_builtin` (builtin vs discovered), `skill_md_only_install_resolves_by_dir_slug_not_frontmatter_name` (slug vs frontmatter name), and `prune_removes_legacy_bundled_only` (prune-before-discover ordering). All 15 `skills::registry` tests pass.
- [x] **Diff coverage ≥ 80%** — the two extracted helpers and the rewritten lookup are exercised by the resolution suite above (both are on the call path of every `get_workflow*` / `load_workflows*` test).
- [x] Coverage matrix updated — `N/A: behaviour-preserving performance refactor, no matrix row added/removed/renamed`.
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A`.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: internal resolution path, identical behavior`.
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue (self-identified hot-path redundancy)`.

## Impact

- **Runtime:** desktop/core — every `run_workflow` / `describe_workflow` (and any `get_workflow` caller). Removes a redundant full discovery walk per lookup; the win scales with the number of installed skills.
- **Compatibility:** none — resolution results and precedence are unchanged.

## Related

- Closes: N/A
- Follow-up PR(s)/TODOs: the primary lookup still parses every discovered skill's definition to match one id; resolving a single skill lazily (parse only the matched directory) is a larger change with a subtler correctness argument (`workflow.toml` ids can differ from the dir slug) and is intentionally out of scope here.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `perf/skills-registry-single-discover`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow discovery to consistently identify applicable workflows.
  * Removed outdated workflows from loading results.
  * Improved profile display-name resolution when viewing workflow details.

* **Performance**
  * Streamlined workflow loading to avoid repeated discovery, providing more efficient results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->