### PR TITLE
fix(voice): raise the background turn ceiling from 90s to 180s

### DIFF
--- a/src/openhuman/voice/realtime_harness.rs
+++ b/src/openhuman/voice/realtime_harness.rs
@@ -26,7 +26,21 @@ use crate::openhuman::agent::progress::AgentProgress;
 use crate::openhuman::agent::turn_origin::{with_origin, AgentTurnOrigin};
 use crate::openhuman::platform::socket::manager::global_socket_manager;
 
-const TURN_TIMEOUT_SECS: u64 = 90;
+/// Hard ceiling on the background turn — not on how long the caller waits, which
+/// the ack deadline below caps at ~8s.
+///
+/// This governs the deferred half: the orchestrator keeps working after the voice
+/// turn closes, and its answer is delivered into chat and read aloud if the call
+/// is still up. At 90s that ceiling was cutting real answers. Observed on staging:
+/// the same "summarize my emails" request finished in ~53s on one call and was
+/// still running past 90s on the next, where it aborted and the caller got a
+/// failure notice instead of their summary — a hard failure caused purely by
+/// Composio round-trip variance, not by anything being wrong.
+///
+/// Kept in step with `DEFAULT_TIMEOUT_MS` in the backend's `relayService.ts`,
+/// which must stay above this so the desktop's own specific error wins the race
+/// rather than the relay's generic timeout.
+const TURN_TIMEOUT_SECS: u64 = 180;
 
 /// How long a voice turn may run before we stop making the caller wait and hand
 /// the result off to chat. The cloud voice session cancels a turn with no spoken


### PR DESCRIPTION
## Summary

- Follow-up to #5489. Raises the voice harness's background turn ceiling, `TURN_TIMEOUT_SECS`, from 90s to 180s.
- Pairs with tinyhumansai/backend#1274, which raises the relay's own timeout to stay above it.

## Problem

90s was aborting real answers. Observed on staging across two consecutive calls asking the same thing ("Can you please summarize my emails?"):

- `conv_6201kzxwc51ye9682qzgh8wa597r` — the deferred turn finished in ~53s, the read-back landed at `t=58`, and the summary was spoken (519 TTS chars).
- `conv_2001kzxw8r84f82tcpkr7pjyrrd5` — the same request was still running past 90s, hit the ceiling, and the caller got `"Sorry — I couldn't finish that request just now."` instead of their summary. No read-back message appears in that transcript at all.

Same code, same path, same question — the difference is how many Composio round-trips the inbox needed. A hard ceiling that a normal request can cross is a failure the user cannot distinguish from a broken feature.

## Solution

`TURN_TIMEOUT_SECS` 90 → 180, with the reasoning recorded on the constant.

This ceiling does not govern how long the caller waits — `VOICE_ACK_DEADLINE_SECS` caps that at ~8s and hands off to chat. It governs the deferred half: the orchestrator keeps working after the voice turn closes, and its answer is delivered into chat and read aloud if the call is still up. So a higher value costs a slow turn nothing and buys it the chance to land at all.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — `N/A: constant change`. The value is a timeout ceiling with no branch of its own; the paths around it (deferred delivery, failure notice, read-back) are covered by the existing `realtime_harness` tests, which pass unchanged.
- [x] **Diff coverage ≥ 80%** — `N/A: no new executable lines` (one constant, the rest doc comment).
- [x] Coverage matrix updated — `N/A: behaviour-only change`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix rows affected`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface change`
- [x] Linked issue closed via `Closes #NNN` — `N/A: follow-up, #5399 stays open for the remaining work`

## Impact

Desktop only. No API, schema, or storage change.

**Merge order matters.** The relay's `DEFAULT_TIMEOUT_MS` must stay above this ceiling — whichever side is lower decides which error the user sees. tinyhumansai/backend#1274 raises it to 185s and should land first or together. Merging this alone against a 95s relay would cut a still-streaming turn at 95s and report a relay failure for a turn that was working.

The remaining latency work is unchanged and still open under #5399: the ~10.6s pre-model path (per-turn orchestrator rebuild, integration catalogue, memory recall) is why turns defer at all. This raises the ceiling; it does not make turns faster.

## Related

Relates to #5399. Pairs with tinyhumansai/backend#1274. Follow-up to #5489.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended the background voice interaction timeout to support deferred processing for up to three minutes.
  * Updated documentation to clarify the longer processing window and backend coordination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->