### PR TITLE
Upgrade tinyflows to 0.8: host-owned checkpointer, engine decoupled from tinyagents, five new node kinds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -391,7 +391,6 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -410,7 +409,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -2639,7 +2637,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -3509,7 +3507,7 @@ dependencies = [
  "base64 0.22.1",
  "percent-encoding",
  "rand 0.9.4",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "sha2 0.10.9",
  "thiserror 2.0.18",
@@ -4147,7 +4145,7 @@ dependencies = [
  "ratatui",
  "rdev",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "ripemd",
  "rppal",
  "rusqlite",
@@ -5214,37 +5212,6 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.7",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "http 1.4.0",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -6395,7 +6362,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "reqwest 0.12.28",
+ "reqwest",
  "rhai",
  "rusqlite",
  "serde",
@@ -6454,7 +6421,7 @@ dependencies = [
  "parking_lot",
  "prost",
  "rand 0.10.1",
- "reqwest 0.12.28",
+ "reqwest",
  "rusqlite",
  "rustls",
  "rustls-pki-types",
@@ -6494,7 +6461,7 @@ dependencies = [
  "parking_lot",
  "rand 0.10.1",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "rusqlite",
  "schemars",
  "serde",
@@ -6526,21 +6493,18 @@ dependencies = [
 
 [[package]]
 name = "tinyflows"
-version = "0.6.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
- "axum",
  "futures-timer",
  "futures-util",
  "getrandom 0.4.2",
  "jaq-core",
  "jaq-json",
  "jaq-std",
- "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tinyagents",
  "tokio",
  "tracing",
 ]
@@ -6552,7 +6516,7 @@ dependencies = [
  "base64 0.22.1",
  "futures",
  "percent-encoding",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6603,7 +6567,7 @@ dependencies = [
  "parking_lot",
  "rand 0.8.6",
  "regex",
- "reqwest 0.12.28",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",
@@ -6648,7 +6612,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "rand 0.8.6",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -6923,7 +6887,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -6962,7 +6925,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -7852,7 +7814,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ tinyplace = "2.0"
 #
 # Optional: exclusive to the default-ON `flows` feature (#4797). A slim build
 # without `flows` drops this crate and its `jaq-*` JSON-query stack entirely.
-tinyflows = { version = "0.6", features = ["mock"], optional = true }
+tinyflows = { version = "0.8", features = ["mock"], optional = true }
 # TinyAgents — Rust LLM orchestration framework (LangGraph/LangChain-style):
 # durable state graphs, agent-loop harness, model/tool registries, REPL +
 # `.rag` workflow language. openhuman's agent engine + orchestration run on this

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -484,7 +484,6 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -503,7 +502,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1687,7 +1685,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2029,7 +2027,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3023,7 +3021,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -3311,15 +3309,8 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bdc5a74b0feeb5e6a1dc2dd08c34280a61e37668d10a6a3b27ad69d0fb9ce2e"
 dependencies = [
- "aho-corasick",
- "base64 0.22.1",
  "bstr",
  "jaq-core",
- "jiff",
- "libm",
- "log",
- "regex-bites",
- "urlencoding",
 ]
 
 [[package]]
@@ -3964,7 +3955,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4147,7 +4138,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5368,7 +5359,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5584,12 +5575,6 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
-
-[[package]]
-name = "regex-bites"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a15a2fa0bfda9361941c45550896ae87b15cc6c8c939ea350079670332e211"
 
 [[package]]
 name = "regex-syntax"
@@ -5864,7 +5849,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5922,7 +5907,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6621,7 +6606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7386,10 +7371,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7669,21 +7654,18 @@ dependencies = [
 
 [[package]]
 name = "tinyflows"
-version = "0.6.1"
+version = "0.8.0"
 dependencies = [
  "async-trait",
- "axum",
  "futures-timer",
  "futures-util",
  "getrandom 0.4.3",
  "jaq-core",
  "jaq-json",
  "jaq-std",
- "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
- "tinyagents",
  "tokio",
  "tracing",
 ]
@@ -8066,7 +8048,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -8105,7 +8086,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -8191,7 +8171,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8272,7 +8252,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8923,7 +8903,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/scripts/kernel-floor.limits
+++ b/scripts/kernel-floor.limits
@@ -19,6 +19,26 @@
 #                      crates no longer enter the always-on `flows` graph;
 #                      OpenHuman keeps only its stable wire types and host
 #                      adapter. Measured with `scripts/kernel-floor.sh flows`.
+#   303/281/2  2026-08-14  tinyflows 0.8: the duplicate reqwest major is gone,
+#                      closing #5539. Main had raised this to 308 because
+#                      tinyflows pulled reqwest 0.13 alongside the kernel's
+#                      0.12; tinyflows PR #45 put its HTTP client behind the
+#                      `chrome-extension` and `host-caps` features, and this
+#                      crate enables neither, so 0.13 leaves the graph entirely
+#                      rather than being unified. -1 PACKAGE, and deliberately
+#                      NOT -1 name: `reqwest` is still resolved at 0.12.28, so
+#                      only the duplicate major goes. Verified with `cargo tree
+#                      --no-default-features --features flows -e normal |
+#                      grep '^reqwest '` → one line. Nothing was gated here;
+#                      the vendor bump stopped pulling the second copy in.
+#                      Measured on top of the TinyJuice entry below:
+#                      303 packages / 281 names / 2 native builds.
+#   304/281/2  2026-08-14  TinyJuice moved behind the TinyBus module boundary
+#                      (-3 packages / -3 names). The `tinyjuice`,
+#                      `tinyjuice-tokenizer`, and `tinyjuice-vector`
+#                      crates no longer enter the always-on `flows` graph;
+#                      OpenHuman keeps only its stable wire types and host
+#                      adapter. Measured with `scripts/kernel-floor.sh flows`.
 #   PLACEHOLDER  2026-08-14  tinyflows 0.8: the duplicate reqwest major is gone,
 #                      undoing the 308 below and closing #5539. tinyflows PR #45
 #                      put its HTTP client behind the `chrome-extension` and
@@ -272,4 +292,4 @@
 #                      (libsqlite3-sys, ring) — see docs/plans MIGRATION-PLAN G6.
 # 307/284  2026-08-12  Re-baseline after the upstream lockfile resolution;
 #                      `flows` remains at two native packages.
-flows:304:281:2
+flows:303:281:2

--- a/scripts/kernel-floor.limits
+++ b/scripts/kernel-floor.limits
@@ -19,7 +19,18 @@
 #                      crates no longer enter the always-on `flows` graph;
 #                      OpenHuman keeps only its stable wire types and host
 #                      adapter. Measured with `scripts/kernel-floor.sh flows`.
-#   308/284/2  2026-08-13  tinyflows' host-stack advance (PR #5537) moved its
+#   PLACEHOLDER  2026-08-14  tinyflows 0.8: the duplicate reqwest major is gone,
+#                      undoing the 308 below and closing #5539. tinyflows PR #45
+#                      put its HTTP client behind the `chrome-extension` and
+#                      `host-caps` features, and this crate enables neither — so
+#                      reqwest 0.13 leaves the graph entirely rather than being
+#                      unified with 0.12. Verified with `cargo tree
+#                      --no-default-features --features flows -e normal`:
+#                      `reqwest v0.12.28` is the only major resolved.
+#                      Nothing was unified and nothing was gated here; the
+#                      vendor bump simply stopped pulling the second copy in.
+#                      Measured with `scripts/kernel-floor.sh flows`:
+##   308/284/2  2026-08-13  tinyflows' host-stack advance (PR #5537) moved its
 #                      direct HTTP client from reqwest 0.12 to 0.13 while the
 #                      rest of the kernel still uses 0.12. That creates one
 #                      additional resolved package but no new crate name or

--- a/src/openhuman/flows/builder_tools.rs
+++ b/src/openhuman/flows/builder_tools.rs
@@ -2660,7 +2660,10 @@ impl Tool for GetNodeKindContractTool {
             "properties": {
                 "kind": {
                     "type": "string",
-                    "description": "One of the 16 node kinds, e.g. 'tool_call' (from list_node_kinds).",
+                    "description": format!(
+                        "One of the {} node kinds, e.g. 'tool_call' (from list_node_kinds).",
+                        crate::openhuman::flows::NODE_KINDS.len()
+                    ),
                     "enum": crate::openhuman::flows::NODE_KINDS,
                 }
             },

--- a/src/openhuman/flows/builder_tools_tests.rs
+++ b/src/openhuman/flows/builder_tools_tests.rs
@@ -1880,19 +1880,23 @@ async fn save_workflow_accepts_correctly_schemad_graph() {
 }
 
 #[tokio::test]
-async fn list_node_kinds_tool_returns_all_sixteen() {
+async fn list_node_kinds_tool_returns_every_kind() {
     let tool = ListNodeKindsTool::new();
     let result = tool.execute(json!({})).await.unwrap();
     assert!(!result.is_error, "{}", result.output());
     let parsed: Value = serde_json::from_str(&result.output()).unwrap();
     let kinds = parsed["node_kinds"].as_array().unwrap();
-    assert_eq!(kinds.len(), 16);
+    assert_eq!(kinds.len(), crate::openhuman::flows::NODE_KINDS.len());
+    // The tool must advertise the whole catalog, not a subset that happens to
+    // include the kinds someone remembered to name here — a kind the engine
+    // knows but this tool omits is a kind the builder agent cannot reach.
+    for kind in crate::openhuman::flows::NODE_KINDS {
+        assert!(
+            kinds.iter().any(|k| k["kind"] == kind),
+            "list_node_kinds omits `{kind}`"
+        );
+    }
     // Each entry carries a kind + summary + the config-field name lists.
-    assert!(kinds.iter().any(|k| k["kind"] == "tool_call"));
-    assert!(kinds.iter().any(|k| k["kind"] == "memory"));
-    assert!(kinds.iter().any(|k| k["kind"] == "dedup"));
-    assert!(kinds.iter().any(|k| k["kind"] == "loop"));
-    assert!(kinds.iter().any(|k| k["kind"] == "shell"));
     assert!(kinds.iter().all(|k| k.get("summary").is_some()));
 }
 

--- a/src/openhuman/flows/n8n_import.rs
+++ b/src/openhuman/flows/n8n_import.rs
@@ -160,7 +160,8 @@ pub(crate) fn map_n8n_workflow(value: &Value) -> Result<N8nImportResult, String>
         // none. The author adds them afterwards if the flow needs them.
         inputs: Vec::new(),
         // n8n agent nodes carry their configuration inline; they do not define
-        // reusable TinyFlows agent-registry entries.
+        // reusable TinyFlows agent-registry entries, so every `agent_ref`
+        // resolves against this host's own registry instead.
         agents: Vec::new(),
         nodes,
         edges,

--- a/src/openhuman/flows/node_contracts.rs
+++ b/src/openhuman/flows/node_contracts.rs
@@ -126,7 +126,7 @@ fn apply_host_overlay(contract: NodeKindContract) -> NodeKindContract {
     }
 }
 
-/// All 16 node-kind contracts with this host's overlay applied, in
+/// Every node-kind contract with this host's overlay applied, in
 /// [`NODE_KINDS`] order.
 pub fn all_node_kind_contracts() -> Vec<NodeKindContract> {
     tinyflows::catalog::all_contracts()
@@ -135,8 +135,8 @@ pub fn all_node_kind_contracts() -> Vec<NodeKindContract> {
         .collect()
 }
 
-/// The overlaid contract for one node kind, or `None` if `kind` is not one of
-/// the 16.
+/// The overlaid contract for one node kind, or `None` when `kind` is not one
+/// of [`NODE_KINDS`].
 pub fn node_kind_contract(kind: &str) -> Option<NodeKindContract> {
     tinyflows::catalog::contract_for(kind).map(apply_host_overlay)
 }
@@ -186,8 +186,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn overlay_preserves_all_16_kinds() {
-        assert_eq!(all_node_kind_contracts().len(), 16);
+    fn overlay_preserves_every_kind() {
+        // Counted from NODE_KINDS rather than a literal: the overlay must keep
+        // pace with the engine's catalog, and pinning a number here only ever
+        // reported "tinyflows added a kind", which is not this test's job.
+        assert_eq!(all_node_kind_contracts().len(), NODE_KINDS.len());
         for kind in NODE_KINDS {
             assert!(node_kind_contract(kind).is_some(), "missing {kind}");
         }

--- a/src/openhuman/flows/node_contracts.rs
+++ b/src/openhuman/flows/node_contracts.rs
@@ -122,6 +122,33 @@ fn apply_host_overlay(contract: NodeKindContract) -> NodeKindContract {
                  the ROOT graph's trigger (default 8). Reach for a loop to repeat a section, \
                  and for sub_workflow to reuse a whole flow.",
             ),
+        "spawn" => contract
+            .with_note(
+                "config.slug for target=tool follows the SAME rule as a tool_call: a real \
+                 Composio action slug (with config.connection_ref for the account) or \
+                 oh:<tool_name> for a native OpenHuman tool. Call get_tool_contract first and \
+                 wire every required_arg into config.args.",
+            )
+            .with_note(
+                "THIS host wires a TaskRunner, so spawned work genuinely overlaps. It is \
+                 in-process only: tickets do not survive a core restart, so a spawn whose gate \
+                 would only be reached after one is a spawn whose result is lost — keep the \
+                 spawn and its gate inside the same run.",
+            ),
+        "gate" => contract.with_note(
+            "wait_mode=\"suspend\" interrupts the run, and in THIS host an interrupted flow run \
+             is resumed through flows_resume against the durable checkpointer — so a suspended \
+             gate survives a restart where a polling one does not. Prefer it for anything \
+             waiting longer than seconds.",
+        ),
+        "scatter" => contract.with_note(
+            "Lanes multiply everything inside the region, including COST: a lane body \
+             containing an agent node runs a full harness turn per lane. This host additionally \
+             caps simultaneous harness turns process-wide (8 by default, \
+             OPENHUMAN_FLOWS_MAX_PARALLEL_AGENTS), so a 200-lane scatter over an agent node \
+             queues rather than running 200 wide — correct, but not the throughput the lane \
+             count suggests. Use config.lanes to chunk deliberately.",
+        ),
         _ => contract,
     }
 }

--- a/src/openhuman/flows/ops_tests.rs
+++ b/src/openhuman/flows/ops_tests.rs
@@ -4507,14 +4507,18 @@ async fn inference_gate_probes_every_distinct_agent_node_role() {
     );
 }
 
-// ── dynamic agent_ref is rejected before inference readiness ───────────────
+// ── dynamic agent_ref: refused at authoring, still reachable at run time ──
 
+/// A `=`-expression `agent_ref` is no longer authorable. TinyFlows requires a
+/// literal agent-registry reference so run data — which may include model
+/// output — cannot choose an agent with different privileges, the same
+/// reasoning this host already applies to `tool_call` slugs.
+///
+/// Pinned here rather than left to the vendor's own suite because the
+/// `workflow_builder` agent can propose this shape, and the message a builder
+/// sees on rejection is this host's contract with it.
 #[test]
 fn dynamic_agent_ref_is_rejected_during_structural_validation() {
-    // TinyFlows requires a literal agent registry reference so run data cannot
-    // choose an agent with different privileges. This happens before the
-    // inference-readiness gate, which therefore never needs to reason about a
-    // dynamic agent role.
     let err = validate_and_migrate_graph(json!({
         "nodes": [
             { "id": "t", "kind": "trigger", "name": "Manual" },
@@ -4524,6 +4528,61 @@ fn dynamic_agent_ref_is_rejected_during_structural_validation() {
         "edges": [ { "from_node": "t", "to_node": "a" } ]
     }))
     .expect_err("dynamic agent_ref must fail structural validation");
+    assert!(
+        err.contains("agent_ref") && err.contains("must be a literal"),
+        "the message must say what is wrong, not just that something is: {err}"
+    );
+}
+
+#[tokio::test]
+async fn inference_gate_reports_signed_out_for_dynamic_agent_ref_only_graph() {
+    // Finding C, and it survives the rule above: an `agent` node whose
+    // `agent_ref` is `=`-derived means "this graph runs inference" whatever
+    // its concrete route resolves to, so it must stay in scope for Layer 1
+    // (signed-out/session) even though its per-model role cannot be resolved
+    // statically. The bug this pins is a graph made up only of such nodes
+    // returning `None` — no readiness signal at all — so a signed-out session
+    // went completely unreported.
+    //
+    // This is NOT a dead path just because authoring now refuses the shape.
+    // `store::load` runs `tinyflows::migrate::migrate` and deserializes, but
+    // never `validate`, and `run_flow_body` hands the loaded `flow.graph`
+    // straight to `validate_inference_readiness` — so a flow persisted before
+    // the vendor rule still reaches this gate with a dynamic ref, which is
+    // also what makes `agent_node_role`'s `=`-filter (and its fallback to the
+    // default role) load-bearing rather than vestigial.
+    //
+    // Built as a struct literal for that reason: `graph()` would reject it,
+    // and going through `graph()` would only prove the rule above twice.
+    let _signed_out = crate::openhuman::cron::scheduler_gate::SignedOutTestGuard::set(true);
+
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+    let g = WorkflowGraph {
+        nodes: vec![
+            tinyflows::model::Node {
+                id: "t".to_string(),
+                kind: NodeKind::Trigger,
+                type_version: 1,
+                name: "Manual".to_string(),
+                config: json!({ "trigger_kind": "manual" }),
+                ports: Vec::new(),
+                position: None,
+            },
+            tinyflows::model::Node {
+                id: "a".to_string(),
+                kind: NodeKind::Agent,
+                type_version: 1,
+                name: "Dynamic".to_string(),
+                config: json!({ "agent_ref": "=nodes.t.item.agent_choice", "prompt": "go" }),
+                ports: Vec::new(),
+                position: None,
+            },
+        ],
+        ..Default::default()
+    };
+
+    let errors = validate_inference_readiness(&config, &g).await;
     assert!(
         err.contains("agent_ref") && err.contains("must be a literal"),
         "{err}"

--- a/src/openhuman/flows/ops_tests.rs
+++ b/src/openhuman/flows/ops_tests.rs
@@ -4584,9 +4584,18 @@ async fn inference_gate_reports_signed_out_for_dynamic_agent_ref_only_graph() {
 
     let errors = validate_inference_readiness(&config, &g).await;
     assert!(
-        err.contains("agent_ref") && err.contains("must be a literal"),
-        "{err}"
+        !errors.is_empty(),
+        "a signed-out session must still be reported even though the only agent node's \
+         agent_ref is dynamic: {errors:?}"
     );
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.to_ascii_lowercase().contains("signed out")),
+        "{errors:?}"
+    );
+    // `SignedOutTestGuard` restores the prior flag on drop at the end of this
+    // scope — no other test observes this override.
 }
 
 #[tokio::test]

--- a/src/openhuman/flows/tinyflows/caps/ops.rs
+++ b/src/openhuman/flows/tinyflows/caps/ops.rs
@@ -640,6 +640,15 @@ pub fn build_capabilities(config: Arc<Config>, state_namespace: impl Into<String
         // until that boundary exists rather than inheriting ambient process
         // access from the workflow engine.
         shell: None,
+        // `spawn`/`gate` overlap only when a TaskRunner is injected. With
+        // `None` the engine still produces the right answer — `spawn` runs its
+        // work inline and hands back a settled ticket — so the failure mode is
+        // a silent loss of concurrency rather than an error, which is exactly
+        // the kind that survives a smoke test. Flow runs are already on tokio,
+        // so take the crate's tokio-backed runner. It is in-process only:
+        // tickets do not survive a restart, which is the right bound for work
+        // a single run collects at its own gate.
+        tasks: Some(Arc::new(TokioTaskRunner::new())),
         memory: Some(Arc::new(
             crate::openhuman::flows::tinyflows::memory_adapter::OpenHumanMemory {
                 config: config.clone(),

--- a/src/openhuman/flows/tinyflows/caps/ops.rs
+++ b/src/openhuman/flows/tinyflows/caps/ops.rs
@@ -12,10 +12,10 @@
 
 use std::sync::Arc;
 
+use crate::openhuman::flows::tinyflows::checkpoint_sqlite::SqliteCheckpointer;
 use anyhow::Context;
 use async_trait::async_trait;
 use serde_json::{json, Value};
-use crate::openhuman::flows::tinyflows::checkpoint_sqlite::SqliteCheckpointer;
 use tinyflows::caps::*;
 use tinyflows::error::{EngineError, Result};
 #[cfg(test)]

--- a/src/openhuman/flows/tinyflows/caps/ops.rs
+++ b/src/openhuman/flows/tinyflows/caps/ops.rs
@@ -651,14 +651,14 @@ pub fn build_capabilities(config: Arc<Config>, state_namespace: impl Into<String
 }
 
 /// Opens the durable, cross-process checkpointer a `flows_run` uses via
-/// `tinyflows::engine::run_with_checkpointer` — the crate's own
-/// `tinyagents::graph::SqliteCheckpointer`, stored under
-/// `<workspace_dir>/flows/checkpoints.db`.
+/// `tinyflows::engine::run_with_checkpointer` — this host's
+/// [`SqliteCheckpointer`], stored under `<workspace_dir>/flows/checkpoints.db`.
 ///
-/// Deliberately **not** a bespoke checkpointer: the crate ships its own
-/// SQLite-backed `Checkpointer<State>` impl (feature `sqlite`, already enabled
-/// on the `tinyagents` dependency), so the seam just opens it — mirrors the
-/// construction in `src/openhuman/agent/orchestration/delegation.rs`.
+/// It became host-owned when tinyflows vendored its state-graph runtime and
+/// dropped the SQLite backend with it (tinyflows PR #43). The port keeps the
+/// schema and SQL byte-identical, so an existing `checkpoints.db` — and any
+/// run interrupted before the upgrade — resumes unchanged. See
+/// [`super::super::checkpoint_sqlite`].
 pub fn open_flow_checkpointer(
     config: &Config,
 ) -> anyhow::Result<Arc<dyn tinyflows::engine::Checkpointer<serde_json::Value>>> {

--- a/src/openhuman/flows/tinyflows/caps/ops.rs
+++ b/src/openhuman/flows/tinyflows/caps/ops.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use async_trait::async_trait;
 use serde_json::{json, Value};
-use tinyagents::graph::SqliteCheckpointer;
+use crate::openhuman::flows::tinyflows::checkpoint_sqlite::SqliteCheckpointer;
 use tinyflows::caps::*;
 use tinyflows::error::{EngineError, Result};
 #[cfg(test)]

--- a/src/openhuman/flows/tinyflows/checkpoint_sqlite.rs
+++ b/src/openhuman/flows/tinyflows/checkpoint_sqlite.rs
@@ -168,6 +168,17 @@ CREATE INDEX IF NOT EXISTS idx_checkpoint_writes_thread
     ON checkpoint_writes (thread_id, checkpoint_id);
 ";
 
+/// tinyflows keeps its own copy `pub(crate)`, so the port carries one. Same
+/// message: a caller comparing the two backends' errors sees no difference.
+fn require_checkpoint_id(config: &CheckpointConfig) -> Result<String> {
+    config.checkpoint_id.clone().ok_or_else(|| {
+        GraphError::Checkpoint(format!(
+            "put_writes requires an explicit checkpoint_id (thread `{}`)",
+            config.thread_id
+        ))
+    })
+}
+
 /// The projected listing columns read from one `checkpoints` row.
 struct MetaRow {
     thread_id: String,
@@ -534,7 +545,7 @@ where
     }
 
     async fn put_writes(&self, config: &CheckpointConfig, writes: &[PendingWrite]) -> Result<()> {
-        let checkpoint_id = super::require_checkpoint_id(config)?;
+        let checkpoint_id = require_checkpoint_id(config)?;
         if writes.is_empty() {
             return Ok(());
         }

--- a/src/openhuman/flows/tinyflows/checkpoint_sqlite.rs
+++ b/src/openhuman/flows/tinyflows/checkpoint_sqlite.rs
@@ -1,0 +1,695 @@
+//! SQLite-backed [`Checkpointer`] for flow runs — the host's own port of the
+//! backend tinyflows dropped when it vendored its state-graph runtime in-crate
+//! (tinyflows PR #43).
+//!
+//! Flow runs are durable and cross-process: `flows_run` resumes an interrupted
+//! run from `<workspace_dir>/flows/checkpoints.db`. That database predates the
+//! engine change, so switching to tinyflows' `FileCheckpointer` would have
+//! stranded every in-flight run rather than merely changing a backend. The
+//! trait tinyflows vendored is method-for-method the one `tinyagents` defines,
+//! so this is that crate's `graph::checkpoint::sqlite` retargeted at
+//! `tinyflows::graph` — same SQL, same schema, same on-disk format, so an
+//! existing `checkpoints.db` is read and written exactly as before.
+//!
+//! Keep it that way: this file is a port, not a rewrite. A behavioural change
+//! here is a divergence from the runtime that reads the rows.
+
+use std::marker::PhantomData;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use rusqlite::{Connection, OptionalExtension, params};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use tinyflows::graph::checkpoint::merge_writes;
+use tinyflows::graph::error::{GraphError, Result};
+use tinyflows::graph::ids::{CheckpointId, NodeId};
+use tinyflows::graph::{
+    Checkpoint, CheckpointConfig, CheckpointMetadata, CheckpointSource, CheckpointTuple,
+    Checkpointer, PendingWrite,
+};
+
+/// A [`Checkpointer`] that persists checkpoints in a SQLite database.
+///
+/// Cheap to clone; clones share the same underlying connection (and therefore
+/// the same data, including for in-memory databases). Generic over `State`; the
+/// [`Checkpointer`] impl requires `State: Serialize + DeserializeOwned`.
+pub struct SqliteCheckpointer<State> {
+    conn: Arc<Mutex<Connection>>,
+    _marker: PhantomData<fn() -> State>,
+}
+
+impl<State> Clone for SqliteCheckpointer<State> {
+    fn clone(&self) -> Self {
+        Self {
+            conn: self.conn.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+fn sqlite_err(context: &str, err: impl std::fmt::Display) -> GraphError {
+    GraphError::Checkpoint(format!("sqlite checkpointer: {context}: {err}"))
+}
+
+impl<State> SqliteCheckpointer<State> {
+    /// Opens (creating if needed) a SQLite-backed checkpointer at `path`.
+    ///
+    /// Pass `":memory:"` for an ephemeral in-memory database (see
+    /// [`SqliteCheckpointer::in_memory`]).
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        let conn = Connection::open(path.as_ref()).map_err(|e| sqlite_err("open database", e))?;
+        Self::from_connection(conn)
+    }
+
+    /// Opens an ephemeral in-memory checkpointer (`":memory:"`).
+    ///
+    /// The database lives only as long as this handle and its clones, which share
+    /// the single underlying connection.
+    pub fn in_memory() -> Result<Self> {
+        let conn = Connection::open_in_memory().map_err(|e| sqlite_err("open in-memory", e))?;
+        Self::from_connection(conn)
+    }
+
+    /// Wraps a caller-owned open [`Connection`], ensuring the checkpoint schema
+    /// exists.
+    ///
+    /// Use this to share a connection from your own pool or an existing
+    /// application database instead of letting the checkpointer own its handle.
+    /// The schema is idempotent (`CREATE TABLE IF NOT EXISTS`), so it is safe to
+    /// call on a database that already has the tables.
+    ///
+    /// If your application depends on a *different* `rusqlite`/`libsqlite3-sys`
+    /// version (a native-link conflict that prevents passing a `Connection`
+    /// across the boundary), apply [`SqliteCheckpointer::schema_sql`] to your own
+    /// connection instead and drive the tables directly.
+    pub fn from_connection(conn: Connection) -> Result<Self> {
+        conn.execute_batch(SCHEMA)
+            .map_err(|e| sqlite_err("create schema", e))?;
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+            _marker: PhantomData,
+        })
+    }
+
+    /// Returns the checkpoint table + index DDL as a reusable, dependency-free
+    /// SQL string.
+    ///
+    /// This is the schema-helper escape hatch for applications that own their
+    /// own SQLite connection (possibly at an incompatible native-link version):
+    /// execute this DDL on your connection to create the tables the checkpoint
+    /// projection expects, without linking this crate's `rusqlite`.
+    pub fn schema_sql() -> &'static str {
+        SCHEMA
+    }
+
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, Connection>> {
+        self.conn.lock().map_err(|_| {
+            GraphError::Checkpoint("sqlite checkpointer: connection lock poisoned".to_string())
+        })
+    }
+}
+
+/// Table + indexes. `seq` preserves insertion order; the indexes serve thread
+/// listing, `(thread_id, checkpoint_id)` parent-chain lookups, and — since the
+/// namespace-scoped overrides landed — `(thread_id, namespace, …)` scoped
+/// lookups.
+///
+/// # `namespace` is a first-class, indexed column
+///
+/// It holds the canonical JSON encoding of the namespace vector, which
+/// `serde_json` emits deterministically, so equality on the column is exactly
+/// equality on the namespace. It was already stored this way; what was missing
+/// were the indexes, and therefore the ability to *push the scope down into
+/// SQL* at all. Without them `get_scoped`, `get_tuple` and `state_history` all
+/// fell back to the trait defaults, which scan the whole thread once per
+/// lineage hop — O(H²) per namespaced read on the one backend that had no
+/// business being in that class. Both are `CREATE INDEX IF NOT EXISTS`, so an
+/// existing database picks them up on the next open with no migration step.
+///
+/// `checkpoint_writes` is the partial-failure ledger. Its primary key
+/// `(thread_id, namespace, checkpoint_id, task_id, idx)` mirrors LangGraph's
+/// writes table and is what makes `put_writes` idempotent in SQL rather than in
+/// application code.
+const SCHEMA: &str = "\
+CREATE TABLE IF NOT EXISTS checkpoints (
+    seq                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    thread_id            TEXT    NOT NULL,
+    checkpoint_id        TEXT    NOT NULL,
+    parent_checkpoint_id TEXT,
+    run_id               TEXT,
+    namespace            TEXT    NOT NULL,
+    next_nodes           TEXT    NOT NULL,
+    source               TEXT    NOT NULL,
+    step                 INTEGER NOT NULL,
+    has_interrupts       INTEGER NOT NULL,
+    record               TEXT    NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_checkpoints_thread ON checkpoints (thread_id, seq);
+CREATE INDEX IF NOT EXISTS idx_checkpoints_lookup ON checkpoints (thread_id, checkpoint_id);
+CREATE INDEX IF NOT EXISTS idx_checkpoints_scoped ON checkpoints (thread_id, namespace, seq);
+CREATE INDEX IF NOT EXISTS idx_checkpoints_scoped_lookup
+    ON checkpoints (thread_id, namespace, checkpoint_id, seq);
+
+CREATE TABLE IF NOT EXISTS checkpoint_writes (
+    thread_id     TEXT    NOT NULL,
+    namespace     TEXT    NOT NULL,
+    checkpoint_id TEXT    NOT NULL,
+    task_id       TEXT    NOT NULL,
+    idx           INTEGER NOT NULL,
+    node          TEXT    NOT NULL,
+    channel       TEXT    NOT NULL,
+    payload       TEXT    NOT NULL,
+    PRIMARY KEY (thread_id, namespace, checkpoint_id, task_id, idx)
+);
+CREATE INDEX IF NOT EXISTS idx_checkpoint_writes_thread
+    ON checkpoint_writes (thread_id, checkpoint_id);
+";
+
+/// The projected listing columns read from one `checkpoints` row.
+struct MetaRow {
+    thread_id: String,
+    checkpoint_id: String,
+    run_id: Option<String>,
+    parent_checkpoint_id: Option<String>,
+    namespace_json: String,
+    next_nodes_json: String,
+    source: String,
+    step: i64,
+    has_interrupts: i64,
+}
+
+/// Reconstructs a [`CheckpointMetadata`] from the projected listing columns,
+/// without touching the full serialized record.
+fn row_metadata(row: MetaRow) -> Result<CheckpointMetadata> {
+    let namespace: Vec<String> =
+        serde_json::from_str(&row.namespace_json).map_err(|e| sqlite_err("decode namespace", e))?;
+    let next_nodes: Vec<NodeId> = serde_json::from_str(&row.next_nodes_json)
+        .map_err(|e| sqlite_err("decode next_nodes", e))?;
+    Ok(CheckpointMetadata {
+        thread_id: row.thread_id,
+        checkpoint_id: row.checkpoint_id,
+        run_id: row.run_id,
+        parent_checkpoint_id: row.parent_checkpoint_id,
+        namespace,
+        next_nodes,
+        has_interrupts: row.has_interrupts != 0,
+        source: CheckpointSource::parse(&row.source).unwrap_or(CheckpointSource::Loop),
+        step: row.step as usize,
+    })
+}
+
+#[async_trait]
+impl<State> Checkpointer<State> for SqliteCheckpointer<State>
+where
+    State: Serialize + DeserializeOwned + Send + Sync + 'static,
+{
+    async fn put(&self, checkpoint: Checkpoint<State>) -> Result<CheckpointId> {
+        let id = CheckpointId::new(checkpoint.checkpoint_id.clone());
+        // Serialize + the synchronous rusqlite insert (which also blocks on the
+        // connection mutex) is blocking work; run it on the blocking pool so it
+        // never stalls a tokio worker on the step-critical path.
+        let conn = self.conn.clone();
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let meta = checkpoint.to_metadata();
+            let namespace = serde_json::to_string(&checkpoint.namespace)
+                .map_err(|e| sqlite_err("encode namespace", e))?;
+            let next_nodes = serde_json::to_string(&checkpoint.next_nodes)
+                .map_err(|e| sqlite_err("encode next_nodes", e))?;
+            let record =
+                serde_json::to_string(&checkpoint).map_err(|e| sqlite_err("encode record", e))?;
+
+            let conn = conn.lock().map_err(|_| {
+                GraphError::Checkpoint(
+                    "sqlite checkpointer: connection lock poisoned".to_string(),
+                )
+            })?;
+            conn.execute(
+                "INSERT INTO checkpoints (
+                thread_id, checkpoint_id, parent_checkpoint_id, run_id,
+                namespace, next_nodes, source, step, has_interrupts, record
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                params![
+                    checkpoint.thread_id,
+                    checkpoint.checkpoint_id,
+                    checkpoint.parent_checkpoint_id,
+                    checkpoint.run_id,
+                    namespace,
+                    next_nodes,
+                    meta.source.as_str(),
+                    meta.step as i64,
+                    i64::from(meta.has_interrupts),
+                    record,
+                ],
+            )
+            .map_err(|e| sqlite_err("insert checkpoint", e))?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| sqlite_err("join blocking put task", e))??;
+        Ok(id)
+    }
+
+    async fn get(
+        &self,
+        thread_id: &str,
+        checkpoint_id: Option<&str>,
+    ) -> Result<Option<Checkpoint<State>>> {
+        let conn = self.lock()?;
+        // Latest matching row (highest seq) for either the whole thread or a
+        // specific id, mirroring the append-only history of the other backends.
+        let record: Option<String> = match checkpoint_id {
+            Some(id) => conn
+                .query_row(
+                    "SELECT record FROM checkpoints
+                     WHERE thread_id = ?1 AND checkpoint_id = ?2
+                     ORDER BY seq DESC LIMIT 1",
+                    params![thread_id, id],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(|e| sqlite_err("query checkpoint", e))?,
+            None => conn
+                .query_row(
+                    "SELECT record FROM checkpoints
+                     WHERE thread_id = ?1
+                     ORDER BY seq DESC LIMIT 1",
+                    params![thread_id],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(|e| sqlite_err("query latest checkpoint", e))?,
+        };
+        match record {
+            Some(json) => Ok(Some(
+                serde_json::from_str(&json).map_err(|e| sqlite_err("decode record", e))?,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    async fn get_scoped(
+        &self,
+        thread_id: &str,
+        checkpoint_id: Option<&str>,
+        namespace: &[String],
+    ) -> Result<Option<Checkpoint<State>>> {
+        // Pushed down to one indexed query. The trait default lists the whole
+        // thread and then re-`get`s the winner, which costs a full thread scan
+        // per call — and `state_history` calls it once per lineage hop.
+        let namespace_json =
+            serde_json::to_string(namespace).map_err(|e| sqlite_err("encode namespace", e))?;
+        let conn = self.lock()?;
+        let record: Option<String> = match checkpoint_id {
+            Some(id) => conn
+                .query_row(
+                    "SELECT record FROM checkpoints
+                     WHERE thread_id = ?1 AND namespace = ?2 AND checkpoint_id = ?3
+                     ORDER BY seq DESC LIMIT 1",
+                    params![thread_id, namespace_json, id],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(|e| sqlite_err("query scoped checkpoint", e))?,
+            None => conn
+                .query_row(
+                    "SELECT record FROM checkpoints
+                     WHERE thread_id = ?1 AND namespace = ?2
+                     ORDER BY seq DESC LIMIT 1",
+                    params![thread_id, namespace_json],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(|e| sqlite_err("query latest scoped checkpoint", e))?,
+        };
+        match record {
+            Some(json) => Ok(Some(
+                serde_json::from_str(&json).map_err(|e| sqlite_err("decode record", e))?,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    async fn state_history(
+        &self,
+        thread_id: &str,
+        namespace: &[String],
+        limit: Option<usize>,
+    ) -> Result<Vec<CheckpointTuple<State>>> {
+        // One indexed range read of the namespace's rows, then the lineage walk
+        // in memory — instead of the default's `get_tuple` (and therefore
+        // `get_scoped`) per hop.
+        let namespace_json =
+            serde_json::to_string(namespace).map_err(|e| sqlite_err("encode namespace", e))?;
+        let (records, writes) = {
+            let conn = self.lock()?;
+            let mut stmt = conn
+                .prepare(
+                    "SELECT record FROM checkpoints
+                     WHERE thread_id = ?1 AND namespace = ?2 ORDER BY seq ASC",
+                )
+                .map_err(|e| sqlite_err("prepare state_history", e))?;
+            let rows = stmt
+                .query_map(params![thread_id, namespace_json], |row| {
+                    row.get::<_, String>(0)
+                })
+                .map_err(|e| sqlite_err("query state_history", e))?;
+            let mut records: Vec<Checkpoint<State>> = Vec::new();
+            for row in rows {
+                let json = row.map_err(|e| sqlite_err("read record row", e))?;
+                records
+                    .push(serde_json::from_str(&json).map_err(|e| sqlite_err("decode record", e))?);
+            }
+            let writes = read_writes_by_checkpoint(&conn, thread_id, &namespace_json)?;
+            (records, writes)
+        };
+        if records.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Last write wins for a re-used id, matching `get`.
+        let mut by_id: std::collections::HashMap<String, Checkpoint<State>> =
+            std::collections::HashMap::with_capacity(records.len());
+        let mut cursor: Option<String> = None;
+        for record in records {
+            cursor = Some(record.checkpoint_id.clone());
+            by_id.insert(record.checkpoint_id.clone(), record);
+        }
+
+        let mut out = Vec::new();
+        while let Some(id) = cursor {
+            if let Some(limit) = limit
+                && out.len() >= limit
+            {
+                break;
+            }
+            // `remove` doubles as the cycle guard: each id is visited once.
+            let Some(checkpoint) = by_id.remove(&id) else {
+                break;
+            };
+            cursor = checkpoint.parent_checkpoint_id.clone();
+            let config = CheckpointConfig {
+                thread_id: checkpoint.thread_id.clone(),
+                checkpoint_id: Some(checkpoint.checkpoint_id.clone()),
+                namespace: checkpoint.namespace.clone(),
+            };
+            let parent_config =
+                checkpoint
+                    .parent_checkpoint_id
+                    .as_ref()
+                    .map(|parent| CheckpointConfig {
+                        thread_id: checkpoint.thread_id.clone(),
+                        checkpoint_id: Some(parent.clone()),
+                        namespace: checkpoint.namespace.clone(),
+                    });
+            let pending_writes = writes
+                .get(&checkpoint.checkpoint_id)
+                .cloned()
+                .unwrap_or_else(|| checkpoint.pending_writes.clone());
+            out.push(CheckpointTuple {
+                config,
+                checkpoint,
+                parent_config,
+                pending_writes,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn list(&self, thread_id: &str) -> Result<Vec<CheckpointMetadata>> {
+        let conn = self.lock()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT thread_id, checkpoint_id, run_id, parent_checkpoint_id,
+                        namespace, next_nodes, source, step, has_interrupts
+                 FROM checkpoints WHERE thread_id = ?1 ORDER BY seq ASC",
+            )
+            .map_err(|e| sqlite_err("prepare list", e))?;
+        let rows = stmt
+            .query_map(params![thread_id], |row| {
+                Ok(MetaRow {
+                    thread_id: row.get(0)?,
+                    checkpoint_id: row.get(1)?,
+                    run_id: row.get(2)?,
+                    parent_checkpoint_id: row.get(3)?,
+                    namespace_json: row.get(4)?,
+                    next_nodes_json: row.get(5)?,
+                    source: row.get(6)?,
+                    step: row.get(7)?,
+                    has_interrupts: row.get(8)?,
+                })
+            })
+            .map_err(|e| sqlite_err("query list", e))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row_metadata(
+                row.map_err(|e| sqlite_err("read list row", e))?,
+            )?);
+        }
+        Ok(out)
+    }
+
+    async fn get_thread(&self, thread_id: &str) -> Result<Vec<Checkpoint<State>>> {
+        // Single-pass bulk read: one indexed range query over the thread's
+        // rows in insertion order, instead of the default's one point query
+        // per listed id.
+        let conn = self.lock()?;
+        let mut stmt = conn
+            .prepare("SELECT record FROM checkpoints WHERE thread_id = ?1 ORDER BY seq ASC")
+            .map_err(|e| sqlite_err("prepare get_thread", e))?;
+        let rows = stmt
+            .query_map(params![thread_id], |row| row.get::<_, String>(0))
+            .map_err(|e| sqlite_err("query get_thread", e))?;
+        let mut out = Vec::new();
+        for row in rows {
+            let json = row.map_err(|e| sqlite_err("read record row", e))?;
+            out.push(serde_json::from_str(&json).map_err(|e| sqlite_err("decode record", e))?);
+        }
+        Ok(out)
+    }
+
+    async fn list_threads(&self) -> Result<Vec<String>> {
+        let conn = self.lock()?;
+        let mut stmt = conn
+            .prepare("SELECT DISTINCT thread_id FROM checkpoints")
+            .map_err(|e| sqlite_err("prepare list_threads", e))?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|e| sqlite_err("query list_threads", e))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(|e| sqlite_err("read thread row", e))?);
+        }
+        Ok(out)
+    }
+
+    async fn delete_thread(&self, thread_id: &str) -> Result<()> {
+        let mut conn = self.lock()?;
+        let tx = conn
+            .transaction()
+            .map_err(|e| sqlite_err("begin delete_thread", e))?;
+        tx.execute(
+            "DELETE FROM checkpoints WHERE thread_id = ?1",
+            params![thread_id],
+        )
+        .map_err(|e| sqlite_err("delete thread", e))?;
+        // Writes go with the thread — and across *every* namespace, not just
+        // the root one, or an embedded subgraph's ledger outlives its thread.
+        tx.execute(
+            "DELETE FROM checkpoint_writes WHERE thread_id = ?1",
+            params![thread_id],
+        )
+        .map_err(|e| sqlite_err("delete thread writes", e))?;
+        tx.commit()
+            .map_err(|e| sqlite_err("commit delete_thread", e))?;
+        Ok(())
+    }
+
+    async fn delete_checkpoints(&self, thread_id: &str, ids: &[String]) -> Result<usize> {
+        if ids.is_empty() {
+            return Ok(0);
+        }
+        let mut conn = self.lock()?;
+        let tx = conn
+            .transaction()
+            .map_err(|e| sqlite_err("begin transaction", e))?;
+        let mut removed = 0usize;
+        for id in ids {
+            removed += tx
+                .execute(
+                    "DELETE FROM checkpoints WHERE thread_id = ?1 AND checkpoint_id = ?2",
+                    params![thread_id, id],
+                )
+                .map_err(|e| sqlite_err("delete checkpoint", e))?;
+            tx.execute(
+                "DELETE FROM checkpoint_writes WHERE thread_id = ?1 AND checkpoint_id = ?2",
+                params![thread_id, id],
+            )
+            .map_err(|e| sqlite_err("delete checkpoint writes", e))?;
+        }
+        tx.commit().map_err(|e| sqlite_err("commit delete", e))?;
+        Ok(removed)
+    }
+
+    async fn put_writes(&self, config: &CheckpointConfig, writes: &[PendingWrite]) -> Result<()> {
+        let checkpoint_id = super::require_checkpoint_id(config)?;
+        if writes.is_empty() {
+            return Ok(());
+        }
+        let namespace_json = serde_json::to_string(&config.namespace)
+            .map_err(|e| sqlite_err("encode namespace", e))?;
+        let mut conn = self.lock()?;
+        let tx = conn
+            .transaction()
+            .map_err(|e| sqlite_err("begin put_writes", e))?;
+        let mut stored = 0usize;
+        for write in writes {
+            // The replace-vs-ignore rule pushed into SQL: a control-plane write
+            // (`idx < 0`) legitimately changes on a retry and upserts, while a
+            // data write is append-once so a retried `put_writes` is a no-op.
+            // Doing it with two conflict clauses rather than a read-then-write
+            // keeps it correct under concurrent writers.
+            let sql = if write.is_control_plane() {
+                "INSERT INTO checkpoint_writes
+                    (thread_id, namespace, checkpoint_id, task_id, idx, node, channel, payload)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                 ON CONFLICT(thread_id, namespace, checkpoint_id, task_id, idx) DO UPDATE SET
+                    node = excluded.node,
+                    channel = excluded.channel,
+                    payload = excluded.payload"
+            } else {
+                "INSERT INTO checkpoint_writes
+                    (thread_id, namespace, checkpoint_id, task_id, idx, node, channel, payload)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                 ON CONFLICT(thread_id, namespace, checkpoint_id, task_id, idx) DO NOTHING"
+            };
+            let payload = serde_json::to_string(&write.payload)
+                .map_err(|e| sqlite_err("encode write payload", e))?;
+            stored += tx
+                .execute(
+                    sql,
+                    params![
+                        config.thread_id,
+                        namespace_json,
+                        checkpoint_id,
+                        write.task_id,
+                        write.idx,
+                        write.node.as_str(),
+                        write.channel,
+                        payload,
+                    ],
+                )
+                .map_err(|e| sqlite_err("insert checkpoint write", e))?;
+        }
+        tx.commit()
+            .map_err(|e| sqlite_err("commit put_writes", e))?;
+        tracing::debug!(
+            "[checkpoint:sqlite] put_writes thread={} checkpoint={checkpoint_id} offered={} stored={stored}",
+            config.thread_id,
+            writes.len()
+        );
+        Ok(())
+    }
+
+    async fn get_writes(&self, config: &CheckpointConfig) -> Result<Vec<PendingWrite>> {
+        let Some(checkpoint_id) = self.resolve_write_target(config).await? else {
+            return Ok(Vec::new());
+        };
+        let namespace_json = serde_json::to_string(&config.namespace)
+            .map_err(|e| sqlite_err("encode namespace", e))?;
+        let conn = self.lock()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT node, task_id, idx, channel, payload FROM checkpoint_writes
+                 WHERE thread_id = ?1 AND namespace = ?2 AND checkpoint_id = ?3
+                 ORDER BY rowid ASC",
+            )
+            .map_err(|e| sqlite_err("prepare get_writes", e))?;
+        let rows = stmt
+            .query_map(
+                params![config.thread_id, namespace_json, checkpoint_id],
+                map_write_row,
+            )
+            .map_err(|e| sqlite_err("query get_writes", e))?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(|e| sqlite_err("read write row", e))??);
+        }
+        Ok(out)
+    }
+}
+
+/// Decodes one `checkpoint_writes` row into a [`PendingWrite`].
+///
+/// Returns a nested `Result` because the payload decode can fail with a serde
+/// error that `rusqlite`'s row-mapper signature has no room for.
+#[allow(clippy::type_complexity)]
+fn map_write_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<Result<PendingWrite>> {
+    let node: String = row.get(0)?;
+    let task_id: String = row.get(1)?;
+    let idx: i64 = row.get(2)?;
+    let channel: String = row.get(3)?;
+    let payload_json: String = row.get(4)?;
+    Ok(
+        match serde_json::from_str::<serde_json::Value>(&payload_json) {
+            Ok(payload) => Ok(PendingWrite {
+                node: NodeId::from(node),
+                task_id,
+                idx,
+                channel,
+                payload,
+            }),
+            Err(e) => Err(sqlite_err("decode write payload", e)),
+        },
+    )
+}
+
+/// Reads every write in `thread_id`/`namespace`, grouped by checkpoint id.
+///
+/// One query for the whole lineage, so `state_history` does not issue a
+/// `get_writes` per hop.
+fn read_writes_by_checkpoint(
+    conn: &Connection,
+    thread_id: &str,
+    namespace_json: &str,
+) -> Result<std::collections::HashMap<String, Vec<PendingWrite>>> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT checkpoint_id, node, task_id, idx, channel, payload FROM checkpoint_writes
+             WHERE thread_id = ?1 AND namespace = ?2 ORDER BY rowid ASC",
+        )
+        .map_err(|e| sqlite_err("prepare writes-by-checkpoint", e))?;
+    let rows = stmt
+        .query_map(params![thread_id, namespace_json], |row| {
+            let checkpoint_id: String = row.get(0)?;
+            let node: String = row.get(1)?;
+            let task_id: String = row.get(2)?;
+            let idx: i64 = row.get(3)?;
+            let channel: String = row.get(4)?;
+            let payload_json: String = row.get(5)?;
+            Ok((checkpoint_id, node, task_id, idx, channel, payload_json))
+        })
+        .map_err(|e| sqlite_err("query writes-by-checkpoint", e))?;
+    let mut out: std::collections::HashMap<String, Vec<PendingWrite>> =
+        std::collections::HashMap::new();
+    for row in rows {
+        let (checkpoint_id, node, task_id, idx, channel, payload_json) =
+            row.map_err(|e| sqlite_err("read write row", e))?;
+        let payload = serde_json::from_str(&payload_json)
+            .map_err(|e| sqlite_err("decode write payload", e))?;
+        let write = PendingWrite {
+            node: NodeId::from(node),
+            task_id,
+            idx,
+            channel,
+            payload,
+        };
+        let slot = out.entry(checkpoint_id).or_default();
+        // `merge_writes` keeps the shared dedupe semantics even here, where the
+        // primary key already guarantees uniqueness — one rule, one place.
+        merge_writes(slot, std::slice::from_ref(&write));
+    }
+    Ok(out)
+}

--- a/src/openhuman/flows/tinyflows/checkpoint_sqlite.rs
+++ b/src/openhuman/flows/tinyflows/checkpoint_sqlite.rs
@@ -391,10 +391,12 @@ where
 
         let mut out = Vec::new();
         while let Some(id) = cursor {
-            if let Some(limit) = limit
-                && out.len() >= limit
-            {
-                break;
+            // Written as a nested `if` rather than the source's let-chain:
+            // this crate is edition 2021, where let-chains do not parse.
+            if let Some(limit) = limit {
+                if out.len() >= limit {
+                    break;
+                }
             }
             // `remove` doubles as the cycle guard: each id is visited once.
             let Some(checkpoint) = by_id.remove(&id) else {

--- a/src/openhuman/flows/tinyflows/checkpoint_sqlite.rs
+++ b/src/openhuman/flows/tinyflows/checkpoint_sqlite.rs
@@ -19,9 +19,9 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use rusqlite::{Connection, OptionalExtension, params};
-use serde::Serialize;
+use rusqlite::{params, Connection, OptionalExtension};
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 
 use tinyflows::graph::checkpoint::merge_writes;
 use tinyflows::graph::error::{GraphError, Result};
@@ -233,9 +233,7 @@ where
                 serde_json::to_string(&checkpoint).map_err(|e| sqlite_err("encode record", e))?;
 
             let conn = conn.lock().map_err(|_| {
-                GraphError::Checkpoint(
-                    "sqlite checkpointer: connection lock poisoned".to_string(),
-                )
+                GraphError::Checkpoint("sqlite checkpointer: connection lock poisoned".to_string())
             })?;
             conn.execute(
                 "INSERT INTO checkpoints (

--- a/src/openhuman/flows/tinyflows/checkpoint_sqlite_tests.rs
+++ b/src/openhuman/flows/tinyflows/checkpoint_sqlite_tests.rs
@@ -188,11 +188,19 @@ async fn scoped_reads_see_only_their_own_namespace() {
     assert_eq!(at_root.state, json!("root"));
 }
 
-/// The partial-failure ledger. `put_writes` is keyed rather than appended, so
-/// a retried superstep must overwrite its own writes instead of accumulating
-/// duplicates — otherwise a resumed run folds the same emission twice.
+/// The partial-failure ledger, and its replace-vs-ignore rule — the thing in
+/// this file most likely to be got subtly wrong, because both halves look like
+/// "write it again".
+///
+/// A **data** write (`idx >= 0`) is append-once: a superstep that is retried
+/// after a partial failure re-emits what it already emitted, and taking the
+/// second copy would fold the same emission twice on resume. A
+/// **control-plane** write (`idx < 0`, e.g. a resume value) legitimately
+/// changes on a retry and must upsert. Both are pushed into SQL as two
+/// conflict clauses rather than a read-then-write, so they stay correct under
+/// concurrent writers.
 #[tokio::test]
-async fn pending_writes_are_idempotent_per_task_and_index() {
+async fn data_writes_are_append_once_and_control_plane_writes_upsert() {
     let store = SqliteCheckpointer::<serde_json::Value>::in_memory().unwrap();
     store
         .put(checkpoint("t1", "cp-1", None, 1, json!({})))
@@ -204,6 +212,7 @@ async fn pending_writes_are_idempotent_per_task_and_index() {
         namespace: Vec::new(),
     };
 
+    // Data write, then the same (task_id, idx) again: the first value stands.
     store
         .put_writes(
             &config,
@@ -211,7 +220,6 @@ async fn pending_writes_are_idempotent_per_task_and_index() {
         )
         .await
         .unwrap();
-    // Same (task_id, idx): an overwrite, not a second row.
     store
         .put_writes(
             &config,
@@ -222,7 +230,33 @@ async fn pending_writes_are_idempotent_per_task_and_index() {
 
     let writes = store.get_writes(&config).await.unwrap();
     assert_eq!(writes.len(), 1, "a re-run task must not duplicate its write");
-    assert_eq!(writes[0].payload, json!("second"));
+    assert_eq!(
+        writes[0].payload,
+        json!("first"),
+        "a data write is append-once — a retry must not overwrite what already landed"
+    );
+
+    // Control-plane write at the reserved resume index: the newest value wins.
+    let resume = |payload| {
+        PendingWrite::data(
+            "n1",
+            "task-a",
+            tinyflows::graph::checkpoint::WRITES_IDX_RESUME,
+            "__resume__",
+            payload,
+        )
+    };
+    store.put_writes(&config, &[resume(json!("old"))]).await.unwrap();
+    store.put_writes(&config, &[resume(json!("new"))]).await.unwrap();
+
+    let writes = store.get_writes(&config).await.unwrap();
+    let control: Vec<_> = writes.iter().filter(|w| w.is_control_plane()).collect();
+    assert_eq!(control.len(), 1, "control-plane writes are keyed, not appended");
+    assert_eq!(
+        control[0].payload,
+        json!("new"),
+        "a control-plane write must upsert — a resume value changes on a retry"
+    );
 }
 
 /// Deleting a thread is how a flow's history is dropped when the flow is

--- a/src/openhuman/flows/tinyflows/checkpoint_sqlite_tests.rs
+++ b/src/openhuman/flows/tinyflows/checkpoint_sqlite_tests.rs
@@ -67,6 +67,10 @@ async fn reads_a_database_written_by_the_previous_backend() {
     let tmp = TempDir::new().unwrap();
     let db = tmp.path().join("checkpoints.db");
 
+    // Fully qualified: the two `Checkpointer` traits share a method set, so
+    // importing both here would make every call in this file ambiguous.
+    use tinyagents::Checkpointer as LegacyCheckpointer;
+
     let old = tinyagents::graph::SqliteCheckpointer::<serde_json::Value>::open(&db).unwrap();
     let written = tinyagents::graph::Checkpoint {
         thread_id: "flow:f1:run-a".to_string(),
@@ -83,7 +87,7 @@ async fn reads_a_database_written_by_the_previous_backend() {
         barrier_arrivals: Vec::new(),
         metadata: json!({ "source": "loop", "step": 3 }),
     };
-    old.put(written).await.unwrap();
+    LegacyCheckpointer::put(&old, written).await.unwrap();
     drop(old);
 
     let new = SqliteCheckpointer::<serde_json::Value>::open(&db).unwrap();

--- a/src/openhuman/flows/tinyflows/checkpoint_sqlite_tests.rs
+++ b/src/openhuman/flows/tinyflows/checkpoint_sqlite_tests.rs
@@ -223,13 +223,23 @@ async fn data_writes_are_append_once_and_control_plane_writes_upsert() {
     store
         .put_writes(
             &config,
-            &[PendingWrite::data("n1", "task-a", 0, "out", json!("second"))],
+            &[PendingWrite::data(
+                "n1",
+                "task-a",
+                0,
+                "out",
+                json!("second"),
+            )],
         )
         .await
         .unwrap();
 
     let writes = store.get_writes(&config).await.unwrap();
-    assert_eq!(writes.len(), 1, "a re-run task must not duplicate its write");
+    assert_eq!(
+        writes.len(),
+        1,
+        "a re-run task must not duplicate its write"
+    );
     assert_eq!(
         writes[0].payload,
         json!("first"),
@@ -246,12 +256,22 @@ async fn data_writes_are_append_once_and_control_plane_writes_upsert() {
             payload,
         )
     };
-    store.put_writes(&config, &[resume(json!("old"))]).await.unwrap();
-    store.put_writes(&config, &[resume(json!("new"))]).await.unwrap();
+    store
+        .put_writes(&config, &[resume(json!("old"))])
+        .await
+        .unwrap();
+    store
+        .put_writes(&config, &[resume(json!("new"))])
+        .await
+        .unwrap();
 
     let writes = store.get_writes(&config).await.unwrap();
     let control: Vec<_> = writes.iter().filter(|w| w.is_control_plane()).collect();
-    assert_eq!(control.len(), 1, "control-plane writes are keyed, not appended");
+    assert_eq!(
+        control.len(),
+        1,
+        "control-plane writes are keyed, not appended"
+    );
     assert_eq!(
         control[0].payload,
         json!("new"),
@@ -314,7 +334,13 @@ async fn clones_share_one_in_memory_database() {
     let store = SqliteCheckpointer::<serde_json::Value>::in_memory().unwrap();
     let clone = store.clone();
     store
-        .put(checkpoint("t1", "cp-1", None, 1, json!("written via original")))
+        .put(checkpoint(
+            "t1",
+            "cp-1",
+            None,
+            1,
+            json!("written via original"),
+        ))
         .await
         .unwrap();
 

--- a/src/openhuman/flows/tinyflows/checkpoint_sqlite_tests.rs
+++ b/src/openhuman/flows/tinyflows/checkpoint_sqlite_tests.rs
@@ -1,0 +1,285 @@
+//! Coverage for the host-owned SQLite checkpointer.
+//!
+//! The port's whole value is that it is *not* new code: the durable flow-run
+//! database predates it, and a run interrupted before the upgrade has to
+//! resume after it. So the tests here are about equivalence and durability
+//! rather than about the SQL — `schema_is_identical_to_the_backend_it_replaced`
+//! is the load-bearing one, and the rest exercise the trait surface
+//! `flows_run` / `flows_resume` actually drive.
+
+use serde_json::json;
+use tempfile::TempDir;
+use tinyflows::graph::ids::NodeId;
+use tinyflows::graph::{Checkpoint, CheckpointConfig, Checkpointer, PendingWrite};
+
+use super::checkpoint_sqlite::SqliteCheckpointer;
+
+/// One checkpoint in `thread`, at `step`, chained to `parent`.
+fn checkpoint(
+    thread: &str,
+    id: &str,
+    parent: Option<&str>,
+    step: u64,
+    state: serde_json::Value,
+) -> Checkpoint<serde_json::Value> {
+    Checkpoint {
+        thread_id: thread.to_string(),
+        checkpoint_id: id.to_string(),
+        run_id: Some("run-1".to_string()),
+        parent_checkpoint_id: parent.map(str::to_string),
+        namespace: Vec::new(),
+        state,
+        next_nodes: vec![NodeId::new("next")],
+        completed_tasks: vec![NodeId::new("done")],
+        pending_writes: Vec::new(),
+        interrupts: Vec::new(),
+        pending_activations: None,
+        barrier_arrivals: Vec::new(),
+        metadata: json!({ "source": "loop", "step": step }),
+    }
+}
+
+/// The reason this file exists. The port is a retarget of the backend
+/// `tinyagents` shipped, and the two must agree on the bytes on disk: an
+/// existing `<workspace>/flows/checkpoints.db` is read and written by this
+/// code after the upgrade, and a divergence would surface as an interrupted
+/// flow that cannot resume — at the worst possible moment, on a user's
+/// machine, with the run already half-done.
+///
+/// Comparing the DDL is the cheapest total statement of that: same tables,
+/// same columns, same primary keys, same indexes.
+#[test]
+fn schema_is_identical_to_the_backend_it_replaced() {
+    assert_eq!(
+        SqliteCheckpointer::<serde_json::Value>::schema_sql(),
+        tinyagents::graph::SqliteCheckpointer::<serde_json::Value>::schema_sql(),
+        "the ported schema drifted from the tinyagents backend that wrote every \
+         checkpoints.db in the field — an existing database would stop resuming"
+    );
+}
+
+/// A database written by the backend this replaced must be readable here, and
+/// the schema check above is a statement about DDL rather than about
+/// behaviour. This writes through the old type and reads back through the new
+/// one, against one file.
+#[tokio::test]
+async fn reads_a_database_written_by_the_previous_backend() {
+    let tmp = TempDir::new().unwrap();
+    let db = tmp.path().join("checkpoints.db");
+
+    let old = tinyagents::graph::SqliteCheckpointer::<serde_json::Value>::open(&db).unwrap();
+    let written = tinyagents::graph::Checkpoint {
+        thread_id: "flow:f1:run-a".to_string(),
+        checkpoint_id: "cp-1".to_string(),
+        run_id: Some("run-1".to_string()),
+        parent_checkpoint_id: None,
+        namespace: Vec::new(),
+        state: json!({ "counter": 7 }),
+        next_nodes: vec![tinyagents::harness::ids::NodeId::new("next")],
+        completed_tasks: vec![tinyagents::harness::ids::NodeId::new("done")],
+        pending_writes: Vec::new(),
+        interrupts: Vec::new(),
+        pending_activations: None,
+        barrier_arrivals: Vec::new(),
+        metadata: json!({ "source": "loop", "step": 3 }),
+    };
+    old.put(written).await.unwrap();
+    drop(old);
+
+    let new = SqliteCheckpointer::<serde_json::Value>::open(&db).unwrap();
+    let read = new
+        .get("flow:f1:run-a", None)
+        .await
+        .unwrap()
+        .expect("the pre-upgrade checkpoint must still load");
+    assert_eq!(read.checkpoint_id, "cp-1");
+    assert_eq!(read.state, json!({ "counter": 7 }));
+    assert_eq!(read.next_nodes, vec![NodeId::new("next")]);
+    assert_eq!(read.metadata["step"], 3);
+}
+
+/// `get(None)` is what resume calls, and "latest" has to mean latest by
+/// insertion, not by id — the ids are opaque and nothing orders them.
+#[tokio::test]
+async fn get_without_an_id_returns_the_most_recently_written_checkpoint() {
+    let store = SqliteCheckpointer::<serde_json::Value>::in_memory().unwrap();
+    store
+        .put(checkpoint("t1", "cp-1", None, 1, json!({ "n": 1 })))
+        .await
+        .unwrap();
+    store
+        .put(checkpoint("t1", "cp-2", Some("cp-1"), 2, json!({ "n": 2 })))
+        .await
+        .unwrap();
+
+    let latest = store.get("t1", None).await.unwrap().expect("latest");
+    assert_eq!(latest.checkpoint_id, "cp-2");
+    assert_eq!(latest.state, json!({ "n": 2 }));
+
+    let addressed = store.get("t1", Some("cp-1")).await.unwrap().expect("cp-1");
+    assert_eq!(addressed.state, json!({ "n": 1 }));
+
+    assert!(store.get("t1", Some("nope")).await.unwrap().is_none());
+    assert!(store.get("other-thread", None).await.unwrap().is_none());
+}
+
+/// Threads must not see each other: a flow run addresses its own thread id,
+/// and one flow's checkpoints leaking into another's resume would replay the
+/// wrong graph.
+#[tokio::test]
+async fn threads_are_isolated_and_listed_in_insertion_order() {
+    let store = SqliteCheckpointer::<serde_json::Value>::in_memory().unwrap();
+    store
+        .put(checkpoint("t1", "a", None, 1, json!(1)))
+        .await
+        .unwrap();
+    store
+        .put(checkpoint("t2", "b", None, 1, json!(2)))
+        .await
+        .unwrap();
+    store
+        .put(checkpoint("t1", "c", Some("a"), 2, json!(3)))
+        .await
+        .unwrap();
+
+    let listed: Vec<String> = store
+        .list("t1")
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|m| m.checkpoint_id)
+        .collect();
+    assert_eq!(listed, vec!["a".to_string(), "c".to_string()]);
+
+    let mut threads = store.list_threads().await.unwrap();
+    threads.sort();
+    assert_eq!(threads, vec!["t1".to_string(), "t2".to_string()]);
+}
+
+/// A namespaced read is how a parent run and the sub-workflows it embeds stay
+/// out of each other's checkpoints — they share a thread id and differ only
+/// here.
+#[tokio::test]
+async fn scoped_reads_see_only_their_own_namespace() {
+    let store = SqliteCheckpointer::<serde_json::Value>::in_memory().unwrap();
+    let mut root = checkpoint("t1", "root-1", None, 1, json!("root"));
+    root.namespace = Vec::new();
+    let mut child = checkpoint("t1", "child-1", None, 1, json!("child"));
+    child.namespace = vec!["sub".to_string()];
+    store.put(root).await.unwrap();
+    store.put(child).await.unwrap();
+
+    let scoped = store
+        .get_scoped("t1", None, &["sub".to_string()])
+        .await
+        .unwrap()
+        .expect("child checkpoint");
+    assert_eq!(scoped.state, json!("child"));
+
+    let at_root = store
+        .get_scoped("t1", None, &[])
+        .await
+        .unwrap()
+        .expect("root checkpoint");
+    assert_eq!(at_root.state, json!("root"));
+}
+
+/// The partial-failure ledger. `put_writes` is keyed rather than appended, so
+/// a retried superstep must overwrite its own writes instead of accumulating
+/// duplicates — otherwise a resumed run folds the same emission twice.
+#[tokio::test]
+async fn pending_writes_are_idempotent_per_task_and_index() {
+    let store = SqliteCheckpointer::<serde_json::Value>::in_memory().unwrap();
+    store
+        .put(checkpoint("t1", "cp-1", None, 1, json!({})))
+        .await
+        .unwrap();
+    let config = CheckpointConfig {
+        thread_id: "t1".to_string(),
+        checkpoint_id: Some("cp-1".to_string()),
+        namespace: Vec::new(),
+    };
+
+    store
+        .put_writes(
+            &config,
+            &[PendingWrite::data("n1", "task-a", 0, "out", json!("first"))],
+        )
+        .await
+        .unwrap();
+    // Same (task_id, idx): an overwrite, not a second row.
+    store
+        .put_writes(
+            &config,
+            &[PendingWrite::data("n1", "task-a", 0, "out", json!("second"))],
+        )
+        .await
+        .unwrap();
+
+    let writes = store.get_writes(&config).await.unwrap();
+    assert_eq!(writes.len(), 1, "a re-run task must not duplicate its write");
+    assert_eq!(writes[0].payload, json!("second"));
+}
+
+/// Deleting a thread is how a flow's history is dropped when the flow is
+/// deleted; it must take that thread's writes with it and leave every other
+/// thread alone.
+#[tokio::test]
+async fn deleting_a_thread_removes_its_checkpoints_and_leaves_others() {
+    let store = SqliteCheckpointer::<serde_json::Value>::in_memory().unwrap();
+    store
+        .put(checkpoint("doomed", "a", None, 1, json!(1)))
+        .await
+        .unwrap();
+    store
+        .put(checkpoint("kept", "b", None, 1, json!(2)))
+        .await
+        .unwrap();
+
+    store.delete_thread("doomed").await.unwrap();
+
+    assert!(store.get("doomed", None).await.unwrap().is_none());
+    assert!(store.list("doomed").await.unwrap().is_empty());
+    assert!(store.get("kept", None).await.unwrap().is_some());
+}
+
+/// Pruning bounds a long-running flow's history. It keeps the newest N, which
+/// is the end resume reads from.
+#[tokio::test]
+async fn prune_keeps_the_newest_checkpoints() {
+    let store = SqliteCheckpointer::<serde_json::Value>::in_memory().unwrap();
+    for i in 1..=5 {
+        store
+            .put(checkpoint("t1", &format!("cp-{i}"), None, i, json!(i)))
+            .await
+            .unwrap();
+    }
+
+    let removed = store.prune("t1", 2).await.unwrap();
+    assert_eq!(removed, 3);
+
+    let remaining: Vec<String> = store
+        .list("t1")
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|m| m.checkpoint_id)
+        .collect();
+    assert_eq!(remaining, vec!["cp-4".to_string(), "cp-5".to_string()]);
+}
+
+/// An in-memory database lives on its connection, so clones have to share one
+/// — a clone that silently got its own empty database would be a resume that
+/// finds nothing.
+#[tokio::test]
+async fn clones_share_one_in_memory_database() {
+    let store = SqliteCheckpointer::<serde_json::Value>::in_memory().unwrap();
+    let clone = store.clone();
+    store
+        .put(checkpoint("t1", "cp-1", None, 1, json!("written via original")))
+        .await
+        .unwrap();
+
+    let seen = clone.get("t1", None).await.unwrap().expect("shared data");
+    assert_eq!(seen.state, json!("written via original"));
+}

--- a/src/openhuman/flows/tinyflows/langfuse_export.rs
+++ b/src/openhuman/flows/tinyflows/langfuse_export.rs
@@ -103,6 +103,42 @@ fn build_flow_exporter(client: LangfuseClient, flow_id: &str) -> GraphLangfuseEx
     })
 }
 
+/// Re-types the engine's observations for the exporter.
+///
+/// The engine now emits `tinyflows::engine::GraphObservation` — tinyflows
+/// vendored its state-graph runtime in PR #43 — while the Langfuse batch is
+/// still built by `tinyagents`' exporter, which names its own. The two types
+/// are the same shape (`tinyagents` is where tinyflows' copy came from) down
+/// to the `GraphEvent` payload, so this re-types through their shared serde
+/// representation rather than duplicating a 20-field mapping that would then
+/// have to be kept in step by hand.
+///
+/// An observation that fails to convert is **dropped, not fatal**: exporting
+/// is best-effort throughout this module, and losing one span from a trace is
+/// a better outcome than losing the trace. A drop is logged at `warn` because
+/// the only way it can happen is the two types drifting apart, which is worth
+/// hearing about — `re_typing_preserves_every_field` is the guard that should
+/// catch it first.
+fn to_exporter_observations(observations: &[FlowObservation]) -> Vec<GraphObservation> {
+    observations
+        .iter()
+        .filter_map(|obs| {
+            match serde_json::to_value(obs).and_then(serde_json::from_value::<GraphObservation>) {
+                Ok(converted) => Some(converted),
+                Err(err) => {
+                    tracing::warn!(
+                        target: LOG_TARGET,
+                        error = %err,
+                        "[flows] dropped an observation the exporter could not read — \
+                         tinyflows and tinyagents GraphObservation have drifted"
+                    );
+                    None
+                }
+            }
+        })
+        .collect()
+}
+
 /// Exports one settled flow run to Langfuse as a single trace. Best-effort:
 /// every failure path logs a `[flows]`-prefixed warning and returns — a
 /// Langfuse outage can never fail or delay-fail the run. No-op when

--- a/src/openhuman/flows/tinyflows/langfuse_export.rs
+++ b/src/openhuman/flows/tinyflows/langfuse_export.rs
@@ -271,14 +271,18 @@ pub async fn export_flow_run_trace(
 mod tests {
     use super::*;
     use serde_json::Value;
-    use tinyagents::harness::ids;
-    use tinyagents::GraphEvent;
+    use tinyflows::graph::ids;
+    use tinyflows::graph::GraphEvent;
 
     /// Builds a minimal observation stream for one node under run/thread ids
     /// shaped like a real `flows_run` (`thread_id = flow:{id}:{uuid}`).
-    fn sample_observations(thread_id: &str) -> Vec<GraphObservation> {
+    ///
+    /// Built as the ENGINE's observation type, which is what the `flows::`
+    /// domain actually hands this module — so every test below goes through
+    /// the same re-typing hop production does.
+    fn sample_observations(thread_id: &str) -> Vec<FlowObservation> {
         let node = ids::NodeId::new("fetch");
-        let mk = |offset: u64, step: usize, ts_ms: u64, event: GraphEvent| GraphObservation {
+        let mk = |offset: u64, step: usize, ts_ms: u64, event: GraphEvent| FlowObservation {
             event_id: ids::EventId::new(format!("evt-{offset}")),
             run_id: ids::RunId::new("run-9"),
             root_run_id: ids::RunId::new("run-9"),
@@ -392,7 +396,7 @@ mod tests {
             FlowRunTrigger::Rpc,
         );
         let payload = exporter
-            .build_ingestion_batch(trace, &observations)
+            .build_ingestion_batch(trace, &to_exporter_observations(&observations))
             .expect("batch");
         let batch = payload["batch"].as_array().expect("batch array");
 
@@ -463,5 +467,43 @@ mod tests {
             &[],
         )
         .await;
+    }
+
+    /// The re-typing hop is a serde round-trip between two independently
+    /// declared types, so nothing but a test notices when one of them grows,
+    /// renames, or re-tags a field: `to_exporter_observations` would start
+    /// silently dropping observations and the trace would quietly lose spans.
+    /// This asserts the whole sample survives AND that the fields the exporter
+    /// keys spans on come through with their values intact.
+    #[test]
+    fn re_typing_preserves_every_field() {
+        let thread_id = "flow:flow-1:uuid-1";
+        let engine = sample_observations(thread_id);
+        let converted = to_exporter_observations(&engine);
+
+        assert_eq!(
+            converted.len(),
+            engine.len(),
+            "an observation was dropped — the two GraphObservation types have drifted"
+        );
+        for (before, after) in engine.iter().zip(converted.iter()) {
+            assert_eq!(
+                serde_json::to_value(before).unwrap(),
+                serde_json::to_value(after).unwrap(),
+                "re-typing changed the observation's serialized form"
+            );
+        }
+
+        // Spot-check the fields the exporter reads directly, so a drift that
+        // happened to stay serde-compatible (a renamed field with a matching
+        // `#[serde(rename)]`, say) still fails here rather than producing a
+        // batch full of empty spans.
+        let first = &converted[0];
+        assert_eq!(first.thread_id.as_ref().map(|t| t.as_str()), Some(thread_id));
+        assert_eq!(first.run_id.as_str(), "run-9");
+        assert_eq!(first.graph_id.as_str(), "workflow");
+        assert_eq!(first.offset, 0);
+        assert_eq!(converted[2].step, 1);
+        assert_eq!(converted[2].ts_ms, 1_020);
     }
 }

--- a/src/openhuman/flows/tinyflows/langfuse_export.rs
+++ b/src/openhuman/flows/tinyflows/langfuse_export.rs
@@ -499,7 +499,10 @@ mod tests {
         // `#[serde(rename)]`, say) still fails here rather than producing a
         // batch full of empty spans.
         let first = &converted[0];
-        assert_eq!(first.thread_id.as_ref().map(|t| t.as_str()), Some(thread_id));
+        assert_eq!(
+            first.thread_id.as_ref().map(|t| t.as_str()),
+            Some(thread_id)
+        );
         assert_eq!(first.run_id.as_str(), "run-9");
         assert_eq!(first.graph_id.as_str(), "workflow");
         assert_eq!(first.offset, 0);

--- a/src/openhuman/flows/tinyflows/langfuse_export.rs
+++ b/src/openhuman/flows/tinyflows/langfuse_export.rs
@@ -27,6 +27,7 @@ use serde_json::{json, Map};
 use tinyagents::{
     GraphLangfuseExporter, GraphObservation, LangfuseAuth, LangfuseClient, LangfuseTraceConfig,
 };
+use tinyflows::engine::GraphObservation as FlowObservation;
 
 use crate::api::config::effective_backend_api_url;
 use crate::openhuman::config::Config;

--- a/src/openhuman/flows/tinyflows/langfuse_export.rs
+++ b/src/openhuman/flows/tinyflows/langfuse_export.rs
@@ -150,7 +150,7 @@ pub async fn export_flow_run_trace(
     thread_id: &str,
     status: &str,
     trigger: FlowRunTrigger,
-    journal_observations: &[GraphObservation],
+    journal_observations: &[FlowObservation],
 ) {
     if !config.observability.share_usage_data {
         tracing::debug!(
@@ -204,9 +204,20 @@ pub async fn export_flow_run_trace(
         }
     };
 
+    let observations = to_exporter_observations(journal_observations);
+    if observations.is_empty() {
+        tracing::warn!(
+            target: LOG_TARGET,
+            flow_id = %flow_id,
+            thread_id = %thread_id,
+            "[flows] langfuse export skipped: no observation survived re-typing"
+        );
+        return;
+    }
+
     let exporter = build_flow_exporter(client, flow_id);
     let trace = build_flow_trace_config(flow_name, flow_id, thread_id, status, trigger);
-    let observation_count = journal_observations.len();
+    let observation_count = observations.len();
     tracing::debug!(
         target: LOG_TARGET,
         flow_id = %flow_id,
@@ -222,7 +233,7 @@ pub async fn export_flow_run_trace(
     // timeout caps a hung connection the same way the agent exporter does.
     match tokio::time::timeout(
         PUSH_TIMEOUT,
-        exporter.send_observations(trace, journal_observations),
+        exporter.send_observations(trace, &observations),
     )
     .await
     {

--- a/src/openhuman/flows/tinyflows/mod.rs
+++ b/src/openhuman/flows/tinyflows/mod.rs
@@ -1,13 +1,14 @@
 //! The `tinyflows` capability seam: wires the `tinyflows` workflow engine
-//! (an external, host-agnostic crate — validate → compile → run on
-//! `tinyagents`) to real OpenHuman services.
+//! (an external, host-agnostic crate — validate → compile → run on its own
+//! in-crate state-graph runtime) to real OpenHuman services.
 //!
 //! This module is export-focused. Six of the seven capability adapters plus
 //! the two run entry points — [`build_capabilities`] and
 //! [`open_flow_checkpointer`], re-exported below — live in [`caps`]; the
 //! `memory` node's `MemoryProvider` adapter (`OpenHumanMemory`) lives in its
 //! own [`memory_adapter`] module, per this repo's ~500-line file-size
-//! convention (`caps.rs` is already large); run observability logging lives
+//! convention (`caps.rs` is already large); the durable SQLite checkpoint
+//! backend lives in [`checkpoint_sqlite`]; run observability logging lives
 //! in [`observability`]; post-run Langfuse export of a run's durable graph
 //! observations lives in [`langfuse_export`]. The `flows::` domain
 //! (`src/openhuman/flows/ops.rs`) calls [`build_capabilities`] /
@@ -15,6 +16,7 @@
 //! [`langfuse_export::export_flow_run_trace`] after it settles.
 
 pub mod caps;
+pub mod checkpoint_sqlite;
 pub mod langfuse_export;
 pub mod memory_adapter;
 /// End-to-end coverage for the `memory` node through the REAL engine + real

--- a/src/openhuman/flows/tinyflows/mod.rs
+++ b/src/openhuman/flows/tinyflows/mod.rs
@@ -17,6 +17,8 @@
 
 pub mod caps;
 pub mod checkpoint_sqlite;
+#[cfg(test)]
+mod checkpoint_sqlite_tests;
 pub mod langfuse_export;
 pub mod memory_adapter;
 /// End-to-end coverage for the `memory` node through the REAL engine + real

--- a/src/openhuman/flows/tools.rs
+++ b/src/openhuman/flows/tools.rs
@@ -605,10 +605,12 @@ fn config_hint(node: &Node) -> Option<String> {
                 .get("path")
                 .and_then(Value::as_str)
                 .map_or_else(|| "input items".to_string(), |p| format!("path: {p}"));
-            Some(truncate_hint(&match cfg.get("lanes").and_then(Value::as_u64) {
-                Some(lanes) => format!("{over} · {lanes} lanes"),
-                None => over,
-            }))
+            Some(truncate_hint(
+                &match cfg.get("lanes").and_then(Value::as_u64) {
+                    Some(lanes) => format!("{over} · {lanes} lanes"),
+                    None => over,
+                },
+            ))
         }
         // A void takes no config, and "discards its input" is what the kind
         // already says on the timeline.

--- a/src/openhuman/flows/tools.rs
+++ b/src/openhuman/flows/tools.rs
@@ -547,6 +547,46 @@ fn config_hint(node: &Node) -> Option<String> {
                 None => format!("max {max}"),
             })
         }
+        // What was started is the one thing worth seeing at a glance; which
+        // gate collects it is an edge, and the timeline already shows edges.
+        NodeKind::Spawn => {
+            let target = cfg.get("target").and_then(Value::as_str).unwrap_or("?");
+            let what = cfg
+                .get("slug")
+                .and_then(Value::as_str)
+                .or_else(|| cfg.get("name").and_then(Value::as_str));
+            Some(truncate_hint(&match what {
+                Some(what) => format!("{target}: {what}"),
+                None => target.to_string(),
+            }))
+        }
+        // A gate and a gather both wait, and the release policy is the whole
+        // question — `any` versus `all` is the difference between a run that
+        // proceeds on one result and one that blocks on the slowest.
+        NodeKind::Gate | NodeKind::Gather => {
+            let release = cfg
+                .get("release")
+                .and_then(Value::as_str)
+                .unwrap_or("all")
+                .to_string();
+            Some(match cfg.get("n").and_then(Value::as_u64) {
+                Some(n) => format!("{release} ({n})"),
+                None => release,
+            })
+        }
+        NodeKind::Scatter => {
+            let over = cfg
+                .get("path")
+                .and_then(Value::as_str)
+                .map_or_else(|| "input items".to_string(), |p| format!("path: {p}"));
+            Some(truncate_hint(&match cfg.get("lanes").and_then(Value::as_u64) {
+                Some(lanes) => format!("{over} · {lanes} lanes"),
+                None => over,
+            }))
+        }
+        // A void takes no config, and "discards its input" is what the kind
+        // already says on the timeline.
+        NodeKind::Void => None,
         NodeKind::Merge | NodeKind::OutputParser | NodeKind::Trigger => None,
     }
 }

--- a/src/openhuman/flows/tools.rs
+++ b/src/openhuman/flows/tools.rs
@@ -57,7 +57,7 @@ impl Tool for ProposeWorkflowTool {
          (to_port just stays \"main\"); routing is keyed exclusively on from_port, so a label \
          on to_port instead silently turns the branch into an unconditional fan-out and is a \
          hard reject. Exactly ONE \
-         trigger node is required. The 16 node kinds: trigger (config.trigger_kind: manual | \
+         trigger node is required. The 21 node kinds: trigger (config.trigger_kind: manual | \
          schedule | webhook | app_event | form | chat_message | evaluation | system | \
          execute_by_workflow; schedule needs config.schedule = {kind:\"cron\",expr,tz?} | \
          {kind:\"at\",at} | {kind:\"every\",every_ms}; app_event needs config.toolkit + \

--- a/src/openhuman/flows/tools.rs
+++ b/src/openhuman/flows/tools.rs
@@ -91,7 +91,32 @@ impl Tool for ProposeWorkflowTool {
          node back to the loop node. The pass number is readable as \
          \"=nodes.<loop id>.iteration\". The `body` must ROUTE BACK to the loop node, not merely \
          leave it. A fan-in `merge` must not sit on the cycle, and the loop node must not itself \
-         be a fan-in — join before it instead). If \
+         be a fan-in — join before it instead), \
+         spawn (config.target REQUIRED: workflow | tool | http — starts work WITHOUT waiting \
+         and emits an opaque ticket, so the branch carries on; target=tool needs config.slug + \
+         config.args, target=workflow needs config.workflow, target=http needs config.request. \
+         Pass the ticket to a `gate`; never interpret it. A spawn no gate collects simply runs \
+         — wire it into a `void` to say that on purpose), \
+         gate (the collecting half of spawn: config.from = ids of the spawn nodes to wait on, \
+         or config.tickets \"=expr\"; optional config.release: \"all\" (default) | \"any\" | \
+         \"first_n\" | \"quorum\" | \"timeout_partial\", with config.n REQUIRED and > 0 for \
+         first_n/quorum; optional config.wait_mode: \"poll\" (default) | \"suspend\". EVERY \
+         poll costs a super-step, so a long wait wants \"suspend\", not a big max_polls), \
+         scatter (fans the whole DOWNSTREAM PATH into parallel lanes, not just the immediate \
+         successors: scatter → enrich → score → gather runs that pipeline once per lane. \
+         Optional config.path to an array to fan out over, else the node's own input items are \
+         the lanes; optional config.lanes to chunk into at most N lanes, clamped to 256. MUST \
+         reach a `gather`, and lane nodes are read as \"=nodes.<id>.lanes.<lane>\", NOT \
+         \"=nodes.<id>.item\". A nested scatter, a loop head, or requires_approval inside a \
+         lane are each rejected), \
+         gather (collects the lanes: config.from REQUIRED = ids of the lane-terminal nodes; same \
+         config.release/config.n policies as gate; optional config.on_lane_error: \"collect\" \
+         (default) | \"skip\" | \"fail_fast\". Output is ordered by lane index, not by finish \
+         order), \
+         void (terminal sink, no config: accepts items, discards them, runs nothing downstream. \
+         Says \"this branch is a side effect and nothing waits on it\" where an unwired port \
+         would read like a forgotten one. An outgoing edge is a hard reject, and so is having \
+         no incoming edge; it adds NO concurrency — use spawn for that). If \
          validation fails, fix the graph and call this tool again."
     }
 

--- a/src/openhuman/flows/tools.rs
+++ b/src/openhuman/flows/tools.rs
@@ -144,7 +144,8 @@ impl Tool for ProposeWorkflowTool {
                                             "trigger", "agent", "tool_call", "http_request",
                                             "code", "shell", "condition", "switch", "merge", "split_out",
                                             "transform", "output_parser", "sub_workflow", "memory",
-                                            "dedup", "loop"
+                                            "dedup", "loop", "spawn", "gate", "scatter", "gather",
+                                            "void"
                                         ]
                                     },
                                     "name": { "type": "string", "description": "Human-readable node name." },


### PR DESCRIPTION
## Summary

- Advances `vendor/tinyflows` from `c242184` to `cd39220` — **0.6 → 0.8**, picking up tinyflows PRs #43–#50 on top of the host-stack bump #5537 already landed.
- **Ports the SQLite checkpointer host-side.** tinyflows dropped its SQLite backend when it vendored the state-graph runtime in-crate (its PR #43), and flow runs resume from a durable `checkpoints.db` that predates the change.
- **Re-types graph observations for the Langfuse exporter**, which still comes from `tinyagents` while the engine now emits its own `GraphObservation`.
- **Surfaces the five new node kinds** — `spawn` / `gate` / `scatter` / `gather` / `void` — through `propose_workflow`, the node-kind catalog overlay and the builder tools. The catalog is 16 → 21 kinds.
- **Wires a `TaskRunner`** so `spawn`/`gate` genuinely overlap instead of silently running inline.
- **Ratchets the kernel floor down to 303/281/2**, closing #5539: the duplicate reqwest major is gone rather than unified.

## Problem

`main` sat on the gitlink from #5537, which is the merge of tinyflows PR #42 — after configurable agents (#41) but before the engine work. Everything since then was unavailable, and three of those changes are breaking:

1. **`tinyagents::graph::SqliteCheckpointer` is no longer a `tinyflows::engine::Checkpointer`.** tinyflows PR #43 vendored the state-graph runtime as `crate::graph` and dropped the SQLite backend on the way in, so the two are now distinct traits. `open_flow_checkpointer` stopped compiling.
2. **The Langfuse exporter takes the wrong type.** `langfuse_export` builds its batch with `tinyagents`' `GraphLangfuseExporter`, which names `tinyagents::GraphObservation`; the engine now emits `tinyflows::engine::GraphObservation`.
3. **`Capabilities` gained `tasks`, `WorkflowGraph` gained `agents`, and `NodeKind` gained five variants** — each an exhaustive-construction or exhaustive-match break.

Beyond compiling, the five new kinds were invisible to the `workflow_builder` agent: present in the engine, absent from `propose_workflow`'s schema enum, so a strict schema-constrained caller could never emit one.

## Solution

**Checkpointer (`flows/tinyflows/checkpoint_sqlite.rs`).** Switching to tinyflows' `FileCheckpointer` compiles in one line, but it would strand every in-flight run — the database is durable and cross-process, and `flows_resume` reads it. The trait tinyflows vendored is method-for-method the one `tinyagents` defines, so this is that crate's `graph::checkpoint::sqlite` retargeted at `tinyflows::graph`: same SQL, same schema, same on-disk format. It is a port, not a rewrite, and the module doc says so — a behavioural change here is a divergence from the runtime that reads the rows. Two edits were needed: a let-chain rewritten as a nested `if` (this crate is edition 2021), and `require_checkpoint_id` inlined because tinyflows keeps its copy `pub(crate)`.

**Langfuse.** The two observation types are field-identical down to the `GraphEvent` payload, so `to_exporter_observations` converts through their shared serde representation rather than duplicating a 20-field mapping that would then need keeping in step by hand. A failed conversion **drops that observation rather than failing** — export is best-effort throughout the module, and losing one span beats losing the trace — but logs at `warn`, since the only way it can happen is the two types drifting.

**Node kinds.** Counts are now derived from `NODE_KINDS.len()` rather than the literal `16`, and `list_node_kinds`' test iterates the catalog instead of naming five kinds by hand — so kind #22 needs no edit in either place. Host overlay notes were added where this host has a fact the vendor cannot know: `spawn`'s `slug` follows the same Composio/`oh:` rule as `tool_call`, `gate`'s `wait_mode: "suspend"` survives a restart here because interrupted runs resume through the durable checkpointer, and a `scatter` over an agent node still queues against this host's process-wide harness cap.

**`tasks`.** With `None`, `spawn` runs its work inline and hands back a settled ticket: right answer, no concurrency. That is a silent performance cliff rather than an error — exactly the kind that survives a smoke test — so flow runs take the crate's tokio-backed runner.

### The `agent_ref` decision, which is worth a reviewer's eye

tinyflows PR #41 rejects an `=`-expression `agent_ref` structurally, because an expression resolves from run data that may include model output and would let upstream data choose a differently-privileged agent. `b4723844b` on main aligned our tests with that by **deleting** `inference_gate_reports_signed_out_for_dynamic_agent_ref_only_graph`, reasoning that rejection happens before the readiness gate so the gate never sees a dynamic ref.

That holds for newly authored graphs but **not for stored ones**: `store::load` runs `tinyflows::migrate::migrate` and deserializes, but never `validate`, and `run_flow_body` hands the loaded `flow.graph` straight to `validate_inference_readiness`. A flow persisted before the vendor rule therefore still reaches that gate with a dynamic ref, which is what keeps `agent_node_role`'s `=`-filter load-bearing rather than vestigial.

So this PR keeps main's rejection test and restores the readiness one, built as a struct literal (going through `graph()` would only prove the rejection twice) with that reachability argument in the comment. **If you disagree that pre-rule stored flows are reachable, this is the line to push back on.**

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — 9 new checkpointer tests, a Langfuse re-typing drift guard, a catalog-completeness test, and the two `agent_ref` tests above
- [x] **Diff coverage ≥ 80%** — the two new modules carry dedicated test files; the remaining changed lines are tool descriptions and catalog notes exercised by the existing drift tests
- [ ] Coverage matrix updated — `N/A: no feature row added, removed or renamed; this is a vendor upgrade behind existing rows`
- [x] All affected feature IDs from the matrix are listed under `## Related`
- [x] No new external network dependencies introduced — the dependency graph **shrinks** (see the ratchet below)
- [ ] Manual smoke checklist updated — `N/A: no release-cut surface changed`
- [x] Linked issue closed via `Closes #NNN`

## Impact

**Compatibility — the load-bearing claim.** An existing `<workspace>/flows/checkpoints.db` is read and written exactly as before, so a run interrupted before this upgrade resumes after it. Two tests pin that rather than asserting it in prose: `schema_is_identical_to_the_backend_it_replaced` compares the DDL against the live `tinyagents` backend, and `reads_a_database_written_by_the_previous_backend` writes through the old type and reads back through the new one against one file.

**Dependencies.** The kernel floor goes **down**: 304/281/2 → **303/281/2**, measured on top of the TinyJuice module move now on `main`. Main had raised this to 308 because tinyflows pulled reqwest 0.13 alongside the kernel's 0.12, tracked as #5539; tinyflows PR #45 put its HTTP client behind the `chrome-extension` and `host-caps` features, and this crate enables neither — so 0.13 leaves the graph entirely rather than being unified. That is −1 package and deliberately **not** −1 name: `reqwest` is still resolved at 0.12.28, only the duplicate major goes. Verified with `cargo tree --no-default-features --features flows -e normal | grep '^reqwest '` → one line. Nothing was gated here; the vendor bump simply stopped pulling the second copy in.

**Behaviour.** `spawn`/`gate` now overlap where they previously would have run inline. `agent_ref` as an `=`-expression is refused at authoring (vendor rule, already on main). No RPC namespace, wire shape or persisted format changes.

**Not in this PR — the flow editor.** The frontend keeps its own `NodeKind` union and already omits `shell`, and `nodeKindIcon` / `nodeKindTile` fall back for an unrecognised kind, so a `spawn` node renders with a neutral tile rather than crashing — checked specifically, because `propose_workflow` can now emit one. Adding the five kinds properly means icons, palette entries, per-kind config editors and i18n across 14 locales, which is its own change.

## Related

- Closes: #5539
- Follow-up PR(s)/TODOs:
  - Flow-editor support for `spawn` / `gate` / `scatter` / `gather` / `void` (palette, config editors, i18n × 14 locales).
  - Opt into tinyflows' richer `AgentRunner` seams (`resolve_agent` / `list_agents` / `resolve_context` / `resolve_tools`). All are defaulted, so today's behaviour is byte-identical; wiring our agent registry and memory stack into them is what would let flow-authored agents pick up real OpenHuman agent types and context, and would surface `StopReason::Paused` instead of marching downstream with a partial answer.
  - tinyflows is GPL-3.0-**or-later** while the `tinyagents` code it vendored is GPL-3.0-**only**; upstream flagged this as a deliberate decision to make rather than an omission.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `tinyflows-0.8-upgrade`
- Commit SHA: `27edc3db7ec62b128334810e94df6c163f07e007`

### Validation Run

- [ ] `pnpm --filter openhuman-app format:check` — `N/A: no frontend file changed`
- [ ] `pnpm typecheck` — `N/A: no frontend file changed`
- [x] Focused tests: `cargo test --lib -- openhuman::flows` → **843 passed**; full lib suite → **12562 passed, 0 failed**
- [x] Rust fmt/check: `cargo fmt --all`; `cargo check` clean on `--features flows`, the product feature set (`--all-targets`) and `--no-default-features`; `cargo clippy --all-targets` clean — no warning in any file this PR touches
- [x] Tauri fmt/check: `cargo check --manifest-path app/src-tauri/Cargo.toml` clean

### Validation Blocked

- `command:` `cargo test --lib` (full suite, default stack)
- `error:` two agent-harness tests overflow the stack in debug builds (`run_single_publishes_completed_and_error_events`, `last_turn_usage_is_public_and_non_draining`); the suite completes under `RUST_MIN_STACK=33554432`, where it is fully green
- `impact:` none from this PR — both reproduce identically on unmodified `main`. Separately, `cargo clippy` reports two `approx_constant` errors (`src/core/rpc_log.rs:105`, `src/openhuman/agent/pformat.rs:426`) under a local clippy 1.96; both files are untouched here and both reproduce on `main`.

### Behavior Changes

- Intended behavior change: `spawn`/`gate` overlap via an injected `TaskRunner`; the builder agent can author the five new node kinds.
- User-visible effect: workflows can express fan-out pipelines and fire-and-forget branches. Existing flows are unaffected — no persisted format, RPC namespace or wire shape changes.

### Parity Contract

- Legacy behavior preserved: the checkpoint database's schema, SQL and on-disk format are unchanged, so pre-upgrade runs resume; the Langfuse batch is byte-identical after re-typing.
- Guard/fallback/dispatch parity checks: `schema_is_identical_to_the_backend_it_replaced`, `reads_a_database_written_by_the_previous_backend`, `data_writes_are_append_once_and_control_plane_writes_upsert`, `re_typing_preserves_every_field`.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: builds on #5537 (gitlink bump) and the `main` commits that fixed the resulting red build; no overlap remains beyond the `agent_ref` test discussed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added durable SQLite checkpointing with support for in-memory and existing database connections.
  - Expanded workflow support for spawn, gate, scatter, gather, and void nodes.
  - Added configuration guidance for concurrency, release policies, scatter paths, and task handling.
- **Bug Fixes**
  - Improved checkpoint history, namespace isolation, deletion, and pending-write handling.
  - Preserved compatibility with databases created by the previous checkpoint backend.
  - Improved flow observation export compatibility.
- **Documentation**
  - Clarified imported n8n agents, agent-reference rules, and host-specific node behavior.
  - Updated workflow documentation to reflect the complete node catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->