### PR TITLE
fix(human): keep realtime voice turns in one chat thread

### DIFF
--- a/app/src/features/human/voice/useRealtimeVoiceSession.test.ts
+++ b/app/src/features/human/voice/useRealtimeVoiceSession.test.ts
@@ -1,6 +1,11 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  clearAllProactiveThreadPins,
+  PROACTIVE_VOICE_THREAD_ID,
+  proactiveThreadPins,
+} from '../../../providers/proactiveThreadPins';
 import { fetchVoiceAgentSignedUrl } from '../../../services/api/voiceAgentApi';
 import { useRealtimeVoiceSession } from './useRealtimeVoiceSession';
 
@@ -50,6 +55,7 @@ describe('useRealtimeVoiceSession', () => {
     vi.clearAllMocks();
     captured = null;
     Object.keys(socketHandlers).forEach(k => delete socketHandlers[k]);
+    clearAllProactiveThreadPins();
   });
 
   it('fetches a signed URL and opens a WebSocket session with the voice override', async () => {
@@ -120,6 +126,20 @@ describe('useRealtimeVoiceSession', () => {
     act(() => result.current.stop());
     expect(endSession).toHaveBeenCalledTimes(1);
     expect(result.current.state).toBe('idle');
+  });
+
+  it('clears the voice thread pin when a new session begins', async () => {
+    // A prior session pinned proactive:voice to some thread. Starting a new
+    // session must drop that pin so this session's deferred answers resolve to a
+    // fresh/current thread rather than appending to the previous (now off-screen)
+    // one. See resolveVisibleThreadForProactive in ChatRuntimeProvider.
+    proactiveThreadPins.set(PROACTIVE_VOICE_THREAD_ID, 'previous-session-thread');
+    mockFetch.mockResolvedValueOnce({ signedUrl: 'wss://x', agentId: 'a1', userToken: 'tok-1' });
+    const { result } = renderHook(() => useRealtimeVoiceSession());
+    await act(async () => {
+      await result.current.start();
+    });
+    expect(proactiveThreadPins.get(PROACTIVE_VOICE_THREAD_ID)).toBeUndefined();
   });
 
   it('surfaces an SDK onError', () => {

--- a/app/src/features/human/voice/useRealtimeVoiceSession.ts
+++ b/app/src/features/human/voice/useRealtimeVoiceSession.ts
@@ -2,6 +2,10 @@ import { useConversation } from '@elevenlabs/react';
 import createDebug from 'debug';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import {
+  PROACTIVE_VOICE_THREAD_ID,
+  proactiveThreadPins,
+} from '../../../providers/proactiveThreadPins';
 import { fetchVoiceAgentSignedUrl } from '../../../services/api/voiceAgentApi';
 import { socketService } from '../../../services/socketService';
 import { MASCOT_VOICE_ID } from '../../../utils/config';
@@ -89,6 +93,13 @@ export function useRealtimeVoiceSession(opts?: { voiceId?: string }): RealtimeVo
     setError(null);
     setState('connecting');
     spokenRef.current.clear();
+    // Each session is its own conversation: drop any pin from a prior session so
+    // this session's deferred answers resolve to a fresh/current thread rather
+    // than appending to the previous session's thread (which the Human page may
+    // no longer have selected — the answer would land off-screen). The pin is
+    // re-established on this session's first delivery. See
+    // `resolveVisibleThreadForProactive` in ChatRuntimeProvider.
+    proactiveThreadPins.clear(PROACTIVE_VOICE_THREAD_ID);
     log('start: requesting signed url');
     try {
       const { signedUrl, userToken } = await fetchVoiceAgentSignedUrl();

--- a/app/src/features/human/voice/useRealtimeVoiceSession.ts
+++ b/app/src/features/human/voice/useRealtimeVoiceSession.ts
@@ -99,7 +99,7 @@ export function useRealtimeVoiceSession(opts?: { voiceId?: string }): RealtimeVo
     // no longer have selected — the answer would land off-screen). The pin is
     // re-established on this session's first delivery. See
     // `resolveVisibleThreadForProactive` in ChatRuntimeProvider.
-    proactiveThreadPins.clear(PROACTIVE_VOICE_THREAD_ID);
+    proactiveThreadPins.delete(PROACTIVE_VOICE_THREAD_ID);
     log('start: requesting signed url');
     try {
       const { signedUrl, userToken } = await fetchVoiceAgentSignedUrl();

--- a/app/src/providers/ChatRuntimeProvider.tsx
+++ b/app/src/providers/ChatRuntimeProvider.tsx
@@ -78,6 +78,7 @@ import {
   setSelectedThread,
 } from '../store/threadSlice';
 import { DERIVED_TRANSCRIPT_ENABLED, IS_PROD } from '../utils/config';
+import { isProactiveConversationSurface, proactiveThreadPins } from './proactiveThreadPins';
 
 const logChatRuntime = debug('openhuman:chat-runtime');
 const USER_FACING_AGENT_ERROR_MESSAGE =
@@ -114,26 +115,6 @@ function threadHasMessages(state: ThreadSliceState, threadId: string): boolean {
   // unloaded conversation.
   if (!thread) return true;
   return thread.messageCount > 0;
-}
-
-/**
- * The realtime voice session's synthetic proactive thread id (mirrors
- * `VOICE_CHAT_THREAD_ID` in `voice/realtime_harness.rs`). Every deferred voice
- * turn delivers its answer as a `proactive_message` under this one id.
- */
-const PROACTIVE_VOICE_THREAD_ID = 'proactive:voice';
-
-/**
- * Whether a `proactive:` id names an ongoing *conversation surface* — many
- * sequential turns that all belong to a single chat — rather than a one-shot
- * interruption (morning brief, subconscious update, worker handoff). A
- * conversation surface pins the visible thread it first resolves to and reuses
- * it for the whole session; a one-shot keeps the fresh-or-create behaviour so it
- * never lands in the user's active chat (#3713). Today only realtime voice
- * qualifies.
- */
-function isProactiveConversationSurface(incomingThreadId: string): boolean {
-  return incomingThreadId === PROACTIVE_VOICE_THREAD_ID;
 }
 
 function rtLog(message: string, fields?: Record<string, string | number | null | undefined>) {
@@ -301,13 +282,6 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
   const segmentDeliveriesRef = useRef<Map<string, SegmentDelivery>>(new Map());
   const proactiveThreadCreationPromiseRef = useRef<Promise<string | null> | null>(null);
   const proactiveDispatchQueueRef = useRef<Promise<void>>(Promise.resolve());
-  // Pins a proactive *conversation surface* (see `isProactiveConversationSurface`)
-  // to the visible thread it first resolved to, so every subsequent turn of a
-  // realtime voice session lands in that same thread instead of spawning a fresh
-  // one per turn. Session-scoped (a ref, not persisted); an entry is dropped when
-  // its thread no longer exists so delivery re-resolves rather than targeting a
-  // deleted thread.
-  const proactiveThreadPinsRef = useRef<Map<string, string>>(new Map());
   const toolTimelineRef = useRef(toolTimelineByThread);
   const inferenceStatusRef = useRef(inferenceStatusByThread);
   const streamingAssistantRef = useRef(streamingAssistantByThread);
@@ -390,12 +364,12 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
       // re-resolve instead of delivering into a dead thread.
       const isConversationSurface = isProactiveConversationSurface(incomingThreadId);
       if (isConversationSurface) {
-        const pinned = proactiveThreadPinsRef.current.get(incomingThreadId);
+        const pinned = proactiveThreadPins.get(incomingThreadId);
         if (pinned) {
           if (state.threads.some(t => t.id === pinned)) {
             return pinned;
           }
-          proactiveThreadPinsRef.current.delete(incomingThreadId);
+          proactiveThreadPins.clear(incomingThreadId);
         }
       }
 
@@ -411,7 +385,7 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
       const candidateThreadId = state.selectedThreadId ?? state.threads[0]?.id ?? null;
       if (candidateThreadId && !threadHasMessages(state, candidateThreadId)) {
         if (isConversationSurface) {
-          proactiveThreadPinsRef.current.set(incomingThreadId, candidateThreadId);
+          proactiveThreadPins.set(incomingThreadId, candidateThreadId);
         }
         return candidateThreadId;
       }
@@ -425,7 +399,7 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
           const newThread = await dispatch(createNewThread()).unwrap();
           dispatch(setSelectedThread(newThread.id));
           if (isConversationSurface) {
-            proactiveThreadPinsRef.current.set(incomingThreadId, newThread.id);
+            proactiveThreadPins.set(incomingThreadId, newThread.id);
           }
           return newThread.id;
         } catch (error) {

--- a/app/src/providers/ChatRuntimeProvider.tsx
+++ b/app/src/providers/ChatRuntimeProvider.tsx
@@ -116,6 +116,26 @@ function threadHasMessages(state: ThreadSliceState, threadId: string): boolean {
   return thread.messageCount > 0;
 }
 
+/**
+ * The realtime voice session's synthetic proactive thread id (mirrors
+ * `VOICE_CHAT_THREAD_ID` in `voice/realtime_harness.rs`). Every deferred voice
+ * turn delivers its answer as a `proactive_message` under this one id.
+ */
+const PROACTIVE_VOICE_THREAD_ID = 'proactive:voice';
+
+/**
+ * Whether a `proactive:` id names an ongoing *conversation surface* — many
+ * sequential turns that all belong to a single chat — rather than a one-shot
+ * interruption (morning brief, subconscious update, worker handoff). A
+ * conversation surface pins the visible thread it first resolves to and reuses
+ * it for the whole session; a one-shot keeps the fresh-or-create behaviour so it
+ * never lands in the user's active chat (#3713). Today only realtime voice
+ * qualifies.
+ */
+function isProactiveConversationSurface(incomingThreadId: string): boolean {
+  return incomingThreadId === PROACTIVE_VOICE_THREAD_ID;
+}
+
 function rtLog(message: string, fields?: Record<string, string | number | null | undefined>) {
   if (IS_PROD) return;
   if (fields && Object.keys(fields).length > 0) {
@@ -281,6 +301,13 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
   const segmentDeliveriesRef = useRef<Map<string, SegmentDelivery>>(new Map());
   const proactiveThreadCreationPromiseRef = useRef<Promise<string | null> | null>(null);
   const proactiveDispatchQueueRef = useRef<Promise<void>>(Promise.resolve());
+  // Pins a proactive *conversation surface* (see `isProactiveConversationSurface`)
+  // to the visible thread it first resolved to, so every subsequent turn of a
+  // realtime voice session lands in that same thread instead of spawning a fresh
+  // one per turn. Session-scoped (a ref, not persisted); an entry is dropped when
+  // its thread no longer exists so delivery re-resolves rather than targeting a
+  // deleted thread.
+  const proactiveThreadPinsRef = useRef<Map<string, string>>(new Map());
   const toolTimelineRef = useRef(toolTimelineByThread);
   const inferenceStatusRef = useRef(inferenceStatusByThread);
   const streamingAssistantRef = useRef(streamingAssistantByThread);
@@ -351,6 +378,27 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
       }
 
       const state = store.getState().thread;
+
+      // A proactive *conversation surface* (today the realtime voice session's
+      // `proactive:voice`) delivers many sequential turns under one synthetic id.
+      // Once it has resolved to a visible thread, pin that thread and keep
+      // delivering into it for the rest of the session. Without the pin, the
+      // fresh-or-create rule below spawns a brand-new thread on every turn after
+      // the first — turn 1 fills the fresh thread, turn 2+ sees it as occupied and
+      // creates another — flooding the list with one "Chat …" thread per voice
+      // turn. The pin is dropped when its thread no longer exists (deleted) so we
+      // re-resolve instead of delivering into a dead thread.
+      const isConversationSurface = isProactiveConversationSurface(incomingThreadId);
+      if (isConversationSurface) {
+        const pinned = proactiveThreadPinsRef.current.get(incomingThreadId);
+        if (pinned) {
+          if (state.threads.some(t => t.id === pinned)) {
+            return pinned;
+          }
+          proactiveThreadPinsRef.current.delete(incomingThreadId);
+        }
+      }
+
       // Reuse an existing thread for proactive delivery ONLY when it is
       // fresh (no messages). Injecting a morning brief / subconscious
       // update into a thread that already holds a conversation interrupts
@@ -362,6 +410,9 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
       // longer used as a target here.
       const candidateThreadId = state.selectedThreadId ?? state.threads[0]?.id ?? null;
       if (candidateThreadId && !threadHasMessages(state, candidateThreadId)) {
+        if (isConversationSurface) {
+          proactiveThreadPinsRef.current.set(incomingThreadId, candidateThreadId);
+        }
         return candidateThreadId;
       }
 
@@ -373,6 +424,9 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
         try {
           const newThread = await dispatch(createNewThread()).unwrap();
           dispatch(setSelectedThread(newThread.id));
+          if (isConversationSurface) {
+            proactiveThreadPinsRef.current.set(incomingThreadId, newThread.id);
+          }
           return newThread.id;
         } catch (error) {
           rtLog('proactive_thread_create_failed', {

--- a/app/src/providers/ChatRuntimeProvider.tsx
+++ b/app/src/providers/ChatRuntimeProvider.tsx
@@ -369,7 +369,7 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
           if (state.threads.some(t => t.id === pinned)) {
             return pinned;
           }
-          proactiveThreadPins.clear(incomingThreadId);
+          proactiveThreadPins.delete(incomingThreadId);
         }
       }
 

--- a/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
+++ b/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
@@ -790,6 +790,143 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
 
       await waitFor(() => expect(threadApi.appendMessage).toHaveBeenCalledTimes(1));
     });
+
+    it('pins the realtime voice surface to one thread across turns', async () => {
+      // The realtime voice session delivers every deferred turn as a
+      // `proactive:voice` message. They all belong to ONE ongoing conversation,
+      // so they must land in a single thread — not spawn a fresh "Chat …" thread
+      // per turn. Turn 1 reuses the fresh selected thread and pins it; the pin
+      // then keeps turns 2 and 3 in that thread even though it now holds
+      // messages (which the fresh-or-create rule would otherwise treat as
+      // occupied, creating a new thread each time).
+      store.dispatch(
+        loadThreads.fulfilled(
+          { threads: [{ id: 'voice-thread', title: 'voice', messageCount: 0 }] as never, count: 1 },
+          'req-id',
+          undefined
+        )
+      );
+      store.dispatch(setSelectedThread('voice-thread'));
+      const listeners = renderProvider();
+
+      await act(async () => {
+        listeners.onProactiveMessage?.({
+          thread_id: 'proactive:voice',
+          request_id: 'voice-1',
+          full_response: 'here is your inbox summary',
+        });
+        listeners.onProactiveMessage?.({
+          thread_id: 'proactive:voice',
+          request_id: 'voice-2',
+          full_response: 'here is your calendar',
+        });
+        listeners.onProactiveMessage?.({
+          thread_id: 'proactive:voice',
+          request_id: 'voice-3',
+          full_response: 'and the weather',
+        });
+      });
+
+      await waitFor(() => expect(threadApi.appendMessage).toHaveBeenCalledTimes(3));
+      // No new thread was ever created, and every turn landed in the one thread.
+      expect(threadApi.createNewThread).not.toHaveBeenCalled();
+      for (const call of vi.mocked(threadApi.appendMessage).mock.calls) {
+        expect(call[0]).toBe('voice-thread');
+      }
+    });
+
+    it('pins the voice surface through the create path when no fresh thread exists', async () => {
+      vi.mocked(threadApi.createNewThread).mockResolvedValue({
+        id: 'voice-thread',
+        title: 'new',
+      } as never);
+      vi.mocked(threadApi.getThreads).mockResolvedValue({
+        threads: [{ id: 'voice-thread', title: 'new' }] as never,
+        count: 1,
+      });
+
+      // The user is mid-conversation, so turn 1 opens a dedicated thread rather
+      // than interrupting the busy one (#3713) — then PINS it, so turn 2 reuses
+      // that same thread instead of creating another.
+      store.dispatch(
+        loadThreads.fulfilled(
+          { threads: [{ id: 'busy-thread', title: 'chat', messageCount: 4 }] as never, count: 1 },
+          'req-id',
+          undefined
+        )
+      );
+      store.dispatch(setSelectedThread('busy-thread'));
+      const listeners = renderProvider();
+
+      await act(async () => {
+        listeners.onProactiveMessage?.({
+          thread_id: 'proactive:voice',
+          request_id: 'voice-1',
+          full_response: 'first voice answer',
+        });
+        listeners.onProactiveMessage?.({
+          thread_id: 'proactive:voice',
+          request_id: 'voice-2',
+          full_response: 'second voice answer',
+        });
+      });
+
+      await waitFor(() => expect(threadApi.appendMessage).toHaveBeenCalledTimes(2));
+      // Exactly ONE thread created for the whole voice session; the busy thread
+      // is never touched.
+      expect(threadApi.createNewThread).toHaveBeenCalledTimes(1);
+      for (const call of vi.mocked(threadApi.appendMessage).mock.calls) {
+        expect(call[0]).toBe('voice-thread');
+      }
+      expect(threadApi.appendMessage).not.toHaveBeenCalledWith('busy-thread', expect.anything());
+    });
+
+    it('re-resolves the voice surface when its pinned thread was deleted', async () => {
+      store.dispatch(
+        loadThreads.fulfilled(
+          { threads: [{ id: 'voice-thread', title: 'voice', messageCount: 0 }] as never, count: 1 },
+          'req-id',
+          undefined
+        )
+      );
+      store.dispatch(setSelectedThread('voice-thread'));
+      const listeners = renderProvider();
+
+      // Turn 1 pins the fresh selected thread.
+      await act(async () => {
+        listeners.onProactiveMessage?.({
+          thread_id: 'proactive:voice',
+          request_id: 'voice-1',
+          full_response: 'first',
+        });
+      });
+      await waitFor(() =>
+        expect(threadApi.appendMessage).toHaveBeenCalledWith('voice-thread', expect.anything())
+      );
+
+      // The pinned thread is deleted. A later voice turn must NOT deliver into
+      // the dead thread — it drops the stale pin and opens a new one.
+      vi.mocked(threadApi.createNewThread).mockResolvedValue({
+        id: 'voice-thread-2',
+        title: 'new',
+      } as never);
+      vi.mocked(threadApi.getThreads).mockResolvedValue({
+        threads: [{ id: 'voice-thread-2', title: 'new' }] as never,
+        count: 1,
+      });
+      store.dispatch(clearAllThreads());
+
+      await act(async () => {
+        listeners.onProactiveMessage?.({
+          thread_id: 'proactive:voice',
+          request_id: 'voice-2',
+          full_response: 'second',
+        });
+      });
+
+      await waitFor(() => expect(threadApi.createNewThread).toHaveBeenCalledTimes(1));
+      expect(threadApi.appendMessage).toHaveBeenCalledWith('voice-thread-2', expect.anything());
+    });
   });
 
   describe('mid-turn streaming invariants', () => {

--- a/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
+++ b/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
@@ -17,6 +17,7 @@ import {
 import { setStatusForUser } from '../../store/socketSlice';
 import { clearAllThreads, loadThreads, setSelectedThread } from '../../store/threadSlice';
 import ChatRuntimeProvider from '../ChatRuntimeProvider';
+import { clearAllProactiveThreadPins } from '../proactiveThreadPins';
 
 vi.mock('../../services/chatService', async () => {
   const actual = await vi.importActual<typeof chatService>('../../services/chatService');
@@ -76,6 +77,9 @@ function resetRuntimeState() {
   // run order.
   store.dispatch(resetSessionTokenUsage());
   store.dispatch(setStatusForUser({ userId: '__pending__', status: 'disconnected' }));
+  // Pins live at module scope, so clear them between tests or a pinned voice
+  // surface would leak into the next test.
+  clearAllProactiveThreadPins();
 }
 
 describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invariants', () => {

--- a/app/src/providers/proactiveThreadPins.ts
+++ b/app/src/providers/proactiveThreadPins.ts
@@ -1,0 +1,55 @@
+/**
+ * Session-scoped pins mapping a proactive *conversation surface* id to the
+ * visible chat thread it first resolved to. A conversation surface — today only
+ * the realtime voice session's `proactive:voice` — delivers many sequential
+ * turns under one synthetic id; pinning keeps them all in one thread instead of
+ * spawning a fresh thread per turn.
+ *
+ * This lives at module scope (rather than inside a `ChatRuntimeProvider` ref) so
+ * the realtime voice hook can clear the voice pin when a new session begins — a
+ * client-only lifecycle event `ChatRuntimeProvider` cannot observe — without
+ * prop/context plumbing. Without that clear the pin would outlive its session:
+ * a second voice session in the same app run would deliver into the first
+ * session's thread, which the Human page no longer has selected, so the answer
+ * would land in an off-screen thread. Single-process singleton; tests must reset
+ * it with `clearAllProactiveThreadPins`.
+ */
+
+/**
+ * The realtime voice session's synthetic proactive thread id (mirrors
+ * `VOICE_CHAT_THREAD_ID` in `voice/realtime_harness.rs`). Every deferred voice
+ * turn delivers its answer as a `proactive_message` under this one id.
+ */
+export const PROACTIVE_VOICE_THREAD_ID = 'proactive:voice';
+
+/**
+ * Whether a `proactive:` id names an ongoing *conversation surface* — many
+ * sequential turns that all belong to a single chat — rather than a one-shot
+ * interruption (morning brief, subconscious update, worker handoff). A
+ * conversation surface pins the visible thread it first resolves to and reuses
+ * it for the session; a one-shot keeps the fresh-or-create behaviour so it never
+ * lands in the user's active chat (#3713). Today only realtime voice qualifies.
+ */
+export function isProactiveConversationSurface(incomingThreadId: string): boolean {
+  return incomingThreadId === PROACTIVE_VOICE_THREAD_ID;
+}
+
+const pins = new Map<string, string>();
+
+export const proactiveThreadPins = {
+  /** The visible thread this surface is pinned to, or `undefined` if none. */
+  get: (surfaceId: string): string | undefined => pins.get(surfaceId),
+  /** Pin `surfaceId` to `threadId` for the rest of the session. */
+  set: (surfaceId: string, threadId: string): void => {
+    pins.set(surfaceId, threadId);
+  },
+  /** Drop this surface's pin so the next delivery re-resolves a fresh target. */
+  clear: (surfaceId: string): void => {
+    pins.delete(surfaceId);
+  },
+};
+
+/** Test-only: drop every pin so module state does not leak between tests. */
+export function clearAllProactiveThreadPins(): void {
+  pins.clear();
+}

--- a/app/src/providers/proactiveThreadPins.ts
+++ b/app/src/providers/proactiveThreadPins.ts
@@ -43,8 +43,13 @@ export const proactiveThreadPins = {
   set: (surfaceId: string, threadId: string): void => {
     pins.set(surfaceId, threadId);
   },
-  /** Drop this surface's pin so the next delivery re-resolves a fresh target. */
-  clear: (surfaceId: string): void => {
+  /**
+   * Drop a single surface's pin so its next delivery re-resolves a fresh target.
+   * Named `delete` (mirroring `Map.prototype.delete`) — it removes only the
+   * given key, never the whole map. To wipe every pin (tests), use
+   * `clearAllProactiveThreadPins`.
+   */
+  delete: (surfaceId: string): void => {
     pins.delete(surfaceId);
   },
 };


### PR DESCRIPTION
## Summary

- Pin a proactive **conversation surface** (`proactive:voice`) to the visible thread it first resolves to, so a realtime voice session's turns stay in **one** chat thread instead of spawning a new "Chat …" thread per turn.
- Scope the pin to `proactive:voice` only — one-shot morning-brief / subconscious deliveries keep their existing fresh-or-create behavior (#3713 unchanged).
- Drop the pin when its thread no longer exists (deleted) so delivery re-resolves instead of targeting a dead thread.
- Add unit coverage: reuse across turns, create-path pin, and re-resolve after the pinned thread is deleted.

## Problem

On the Human tab, a realtime voice session created a brand-new conversation for every deferred voice turn, flooding the Conversations list with near-identical "Chat …" threads.

Deferred voice answers are delivered core-side as `proactive_message` events on the synthetic `proactive:voice` thread (`VOICE_CHAT_THREAD_ID`, `src/openhuman/voice/realtime_harness.rs`). On the frontend, `resolveVisibleThreadForProactive` (`app/src/providers/ChatRuntimeProvider.tsx`) mapped every `proactive:*` id with a reuse-if-fresh-else-create-new rule (added in #3713 so one-shot morning-brief / subconscious deliveries never interrupt an active chat). Turn 1 fills the fresh thread; every later turn then sees it as occupied and creates a new thread — one thread per voice turn.

## Solution

- Add `isProactiveConversationSurface()` (today only `proactive:voice`) and a session-scoped `proactiveThreadPinsRef` map in `ChatRuntimeProvider`.
- In `resolveVisibleThreadForProactive`, for a conversation surface: return the pinned thread if it still exists (drop the pin if it doesn't), otherwise fall through to the existing fresh-or-create logic and record the resolved thread as the pin (in both the reuse and create branches).
- One-shot proactive ids are untouched, so #3713 behavior is preserved. Proactive deliveries are already serialized (`proactiveDispatchQueueRef`), so there is no create-race on the pin.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + failure/edge cases) — pin reuse across turns, create-path pin, and re-resolve after the pinned thread is deleted, in `ChatRuntimeProvider.test.tsx`.
- [x] **Diff coverage ≥ 80%** — the 3 new tests exercise every added branch; the CI `diff-cover` gate confirms. Focused Vitest (`ChatRuntimeProvider.test.tsx`, 64 passing), ESLint, Prettier, and `tsc --noEmit` pass locally.
- [x] Coverage matrix updated — `N/A: behaviour-only bugfix, no feature row added/removed/renamed`.
- [x] Affected feature IDs listed under `## Related` — `N/A: no matrix rows touched`.
- [x] No new external network dependencies introduced — none added (frontend-only).
- [x] Manual smoke checklist updated — `N/A: no release-cut surface added; fix is within the existing proactive chat-delivery path`.
- [x] Linked issue closed via `Closes #NNN` in `## Related`.

## Impact

- Desktop, frontend only (`app/src/providers/ChatRuntimeProvider.tsx`). No Rust core, RPC, or wire changes.
- No performance/security/migration impact. Adds one bounded in-memory `Map` (one entry per active proactive conversation surface), not persisted.

## Related

- Closes: #5553
- Follow-up PR(s)/TODOs: voice user prompts are still not persisted to chat (the web channel never writes user messages), so the pinned thread shows assistant turns only — pre-existing and out of scope here.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: N/A
- Commit SHA: N/A

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A
- [x] `pnpm typecheck` — N/A
- [x] Focused tests: N/A
- [x] Rust fmt/check (if changed): N/A
- [x] Tauri fmt/check (if changed): N/A

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: N/A
- User-visible effect: N/A

### Parity Contract

- Legacy behavior preserved: N/A
- Guard/fallback/dispatch parity checks: N/A

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: N/A
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Realtime voice conversations now remain connected to the same visible conversation thread across sequential proactive turns.
  * New voice sessions switch deferred answers to the current conversation thread.
  * If the active thread is unavailable or deleted, the conversation automatically switches to a suitable new thread.
  * One-time proactive messages continue to use a fresh or newly created thread.

* **Tests**
  * Added coverage for thread reuse, busy-thread handling, voice-session transitions, and recovery after thread deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->