### PR TITLE
Fix three capture regressions from the TinyVoice port

### DIFF
--- a/src/openhuman/voice/always_on.rs
+++ b/src/openhuman/voice/always_on.rs
@@ -655,7 +655,7 @@ async fn osa(script: &str) -> Result<(), String> {
 /// Spawn the dedicated cpal capture thread. Blocks until the stream is set up
 /// (or fails), mirroring `audio_capture::start_recording`'s readiness handshake.
 fn spawn_capture_thread(
-    tx: tokio::sync::mpsc::UnboundedSender<RawChunk>,
+    tx: tokio::sync::mpsc::Sender<RawChunk>,
 ) -> Result<CaptureFormat, String> {
     let (setup_tx, setup_rx) = std::sync::mpsc::sync_channel::<Result<CaptureFormat, String>>(1);
     std::thread::Builder::new()
@@ -681,7 +681,7 @@ fn spawn_capture_thread(
 /// they now happen in the async processor, because this runs on a realtime
 /// audio thread where the right amount of work is the least possible.
 fn capture_on_thread(
-    tx: tokio::sync::mpsc::UnboundedSender<RawChunk>,
+    tx: tokio::sync::mpsc::Sender<RawChunk>,
     setup_tx: &std::sync::mpsc::SyncSender<Result<CaptureFormat, String>>,
 ) -> Result<(), String> {
     use crate::openhuman::desktop::accessibility::{detect_microphone_permission, PermissionState};

--- a/src/openhuman/voice/always_on.rs
+++ b/src/openhuman/voice/always_on.rs
@@ -39,6 +39,19 @@ const LOG_PREFIX: &str = "[voice::always_on]";
 /// mid-session starts segmenting without the user restarting anything.
 const SESSION_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
 
+/// How many raw capture chunks may queue for the processor.
+///
+/// The channel was unbounded, which was survivable when the callback did the
+/// downmix and resample itself: the processor's work was pure arithmetic and it
+/// always outran the microphone. It no longer does — each chunk now costs three
+/// module round trips — so a stalled or slow processor could let the queue grow
+/// without limit behind a producer that never blocks.
+///
+/// A few seconds of chunks at typical `cpal` buffer sizes. Deliberately a
+/// *count* rather than a byte budget: the callback must not do arithmetic to
+/// decide whether to send.
+const CAPTURE_QUEUE_CHUNKS: usize = 256;
+
 /// One chunk of raw capture, exactly as the device delivered it.
 ///
 /// Interleaved and at the device's own rate: the callback converts the sample
@@ -119,7 +132,7 @@ pub async fn start_if_enabled(app_config: &Config) {
     // while — so run it on the blocking pool. This function is polled
     // concurrently with the other login-gated services (#3490), and blocking an
     // async worker here would stall them.
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<RawChunk>();
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<RawChunk>(CAPTURE_QUEUE_CHUNKS);
     log::debug!(
         "{LOG_PREFIX} starting microphone capture (blocking readiness handshake on the blocking pool)"
     );
@@ -706,9 +719,26 @@ fn capture_on_thread(
     );
 
     // Forward one raw interleaved chunk per callback.
+    //
+    // `try_send`, never `send`: this runs on a realtime audio thread where
+    // blocking is a dropout, so a full queue drops the chunk rather than
+    // waiting for the processor to catch up. Dropping the newest chunk is the
+    // right end to lose — the queue ahead of it is older speech that is closer
+    // to being transcribed.
+    //
+    // A send error also covers the processor being gone (shutdown), which is
+    // why neither case is fatal here.
+    let mut dropped: u64 = 0;
     let forward = move |samples: Vec<f32>| {
-        // Ignore send errors — they mean the processor task is gone (shutdown).
-        let _ = tx.send(RawChunk { samples });
+        if tx.try_send(RawChunk { samples }).is_err() {
+            dropped = dropped.saturating_add(1);
+            // Log on a power-of-two schedule: a persistently overloaded
+            // processor should be visible without logging inside every
+            // callback once it starts.
+            if dropped.is_power_of_two() {
+                log::warn!("{LOG_PREFIX} capture queue full; dropped {dropped} chunk(s) so far");
+            }
+        }
     };
 
     let err_fn = |e| log::warn!("{LOG_PREFIX} cpal stream error: {e}");

--- a/src/openhuman/voice/always_on.rs
+++ b/src/openhuman/voice/always_on.rs
@@ -278,22 +278,19 @@ pub async fn start_if_enabled(app_config: &Config) {
             // Measure BEFORE draining. Draining first and then failing would
             // discard the frames outright — a module hiccup would eat the
             // user's audio rather than delay it.
-            let energies = match tinyvoice::frame_energies(
-                &config,
-                &pending[..whole],
-                FRAME_SAMPLES as u32,
-            )
-            .await
-            {
-                Ok(energies) => energies,
-                Err(error) => {
-                    log::warn!(
-                        "{LOG_PREFIX} could not measure frame energies ({error}); \
+            let energies =
+                match tinyvoice::frame_energies(&config, &pending[..whole], FRAME_SAMPLES as u32)
+                    .await
+                {
+                    Ok(energies) => energies,
+                    Err(error) => {
+                        log::warn!(
+                            "{LOG_PREFIX} could not measure frame energies ({error}); \
                          retrying these frames on the next chunk"
-                    );
-                    continue;
-                }
-            };
+                        );
+                        continue;
+                    }
+                };
             let frames: Vec<f32> = pending.drain(..whole).collect();
 
             for rms in &energies {
@@ -662,9 +659,7 @@ async fn osa(script: &str) -> Result<(), String> {
 
 /// Spawn the dedicated cpal capture thread. Blocks until the stream is set up
 /// (or fails), mirroring `audio_capture::start_recording`'s readiness handshake.
-fn spawn_capture_thread(
-    tx: tokio::sync::mpsc::Sender<RawChunk>,
-) -> Result<CaptureFormat, String> {
+fn spawn_capture_thread(tx: tokio::sync::mpsc::Sender<RawChunk>) -> Result<CaptureFormat, String> {
     let (setup_tx, setup_rx) = std::sync::mpsc::sync_channel::<Result<CaptureFormat, String>>(1);
     std::thread::Builder::new()
         .name("voice-always-on".into())

--- a/src/openhuman/voice/always_on.rs
+++ b/src/openhuman/voice/always_on.rs
@@ -52,6 +52,14 @@ const SESSION_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_se
 /// decide whether to send.
 const CAPTURE_QUEUE_CHUNKS: usize = 256;
 
+/// Chunks the capture callback had to drop because the queue was full.
+///
+/// A process-wide counter rather than closure state: the callback is built once
+/// per sample format and each closure must stay `Fn`, so the count cannot live
+/// in a captured local. One always-on stream exists per process, so a single
+/// counter is not an aggregation of unrelated streams.
+static DROPPED_CHUNKS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// One chunk of raw capture, exactly as the device delivered it.
 ///
 /// Interleaved and at the device's own rate: the callback converts the sample
@@ -728,10 +736,9 @@ fn capture_on_thread(
     //
     // A send error also covers the processor being gone (shutdown), which is
     // why neither case is fatal here.
-    let mut dropped: u64 = 0;
     let forward = move |samples: Vec<f32>| {
         if tx.try_send(RawChunk { samples }).is_err() {
-            dropped = dropped.saturating_add(1);
+            let dropped = DROPPED_CHUNKS.fetch_add(1, Ordering::Relaxed) + 1;
             // Log on a power-of-two schedule: a persistently overloaded
             // processor should be visible without logging inside every
             // callback once it starts.

--- a/src/openhuman/voice/always_on.rs
+++ b/src/openhuman/voice/always_on.rs
@@ -254,16 +254,26 @@ pub async fn start_if_enabled(app_config: &Config) {
             if whole == 0 {
                 continue;
             }
+            // Measure BEFORE draining. Draining first and then failing would
+            // discard the frames outright — a module hiccup would eat the
+            // user's audio rather than delay it.
+            let energies = match tinyvoice::frame_energies(
+                &config,
+                &pending[..whole],
+                FRAME_SAMPLES as u32,
+            )
+            .await
+            {
+                Ok(energies) => energies,
+                Err(error) => {
+                    log::warn!(
+                        "{LOG_PREFIX} could not measure frame energies ({error}); \
+                         retrying these frames on the next chunk"
+                    );
+                    continue;
+                }
+            };
             let frames: Vec<f32> = pending.drain(..whole).collect();
-
-            let energies =
-                match tinyvoice::frame_energies(&config, &frames, FRAME_SAMPLES as u32).await {
-                    Ok(energies) => energies,
-                    Err(error) => {
-                        log::warn!("{LOG_PREFIX} could not measure frame energies: {error}");
-                        continue;
-                    }
-                };
 
             for rms in &energies {
                 level_peak = level_peak.max(*rms);

--- a/src/openhuman/voice/audio_capture.rs
+++ b/src/openhuman/voice/audio_capture.rs
@@ -165,7 +165,18 @@ async fn finalize(config: &Config, raw: &RawRecording) -> Result<RecordingResult
     .await
     .map_err(|e| format!("could not encode captured audio: {e}"))?;
 
-    let sample_count = mono.len();
+    // Derived from the WAV that is actually returned, not from `mono`.
+    //
+    // `mono` is the UNGATED buffer — it exists to measure peak energy, which
+    // has to see the silence. `wav_bytes` is the gated one. Reporting `mono`'s
+    // length here would describe audio the caller does not have: `server.rs`
+    // gates on `duration_secs` against `min_duration_secs`, so a recording that
+    // is mostly silence would claim a long duration and pass a check it should
+    // fail. Before the gate moved to the module it ran in the capture callback,
+    // so the buffer this was derived from was already gated and the two agreed.
+    //
+    // 16-bit mono PCM after a 44-byte header, so two bytes per sample.
+    let sample_count = wav_bytes.len().saturating_sub(44) / 2;
     let duration_secs = sample_count as f32 / TARGET_SAMPLE_RATE as f32;
     info!(
         "{LOG_PREFIX} recording finalized: {duration_secs:.1}s, {} bytes WAV, peak_rms={peak_rms:.6}",


### PR DESCRIPTION
Follow-up to #5547. Three defects that landed with that PR — all consequences of moving the capture DSP off the audio callback, all found by review after it merged.

## 1. The always-on capture channel was unbounded

`always_on` fed raw chunks over `mpsc::unbounded_channel`. That was survivable while the callback did the downmix and resample itself: the processor's work was pure arithmetic and always outran the microphone. It no longer does — each chunk now costs three module round trips — so a slow or stalled processor lets the queue grow without limit behind a producer that never blocks.

Now `mpsc::channel(CAPTURE_QUEUE_CHUNKS)` with **`try_send`, never `send`**: this runs on a realtime audio thread where blocking is a dropout, so a full queue drops the newest chunk rather than waiting. Newest is the right end to lose — everything queued ahead of it is older speech, closer to being transcribed. Drops are counted and logged on a power-of-two schedule, so a persistently overloaded processor is visible without logging inside every callback.

## 2. `duration_secs` and `sample_count` described audio the caller does not have

`finalize` derived both from `mono`, which is the **ungated** buffer — it exists only so the peak-energy measurement can see the silence. The returned `wav_bytes` is the **gated** one.

This is not cosmetic: `server.rs` gates on `duration_secs` against `min_duration_secs`, so a recording that is mostly silence claimed a long duration and passed a check it should have failed. Before the gate moved to the module it ran inside the capture callback, so the buffer this was derived from was already gated and the two agreed.

Now derived from the returned WAV: `(len - 44) / 2`, 16-bit mono after the header.

## 3. A module hiccup ate captured audio

The processor did `pending.drain(..whole)` and *then* called `frame_energies`. On failure it `continue`d — with the frames already drained and gone.

`frame_energies` now measures `&pending[..whole]` and the `drain` only runs once it succeeds, so a transient module error delays those frames to the next chunk instead of discarding them.

## Verification

`cargo fmt --all -- --check` clean; both clippy sets (`contributor default` and product) clean under `-D warnings`; **12521 lib tests pass, 0 failed**.

## Why this is a separate PR

#5547 merged at 14:10 UTC while these fixes were still in review on the branch, so they never reached `main`. Raising them separately rather than reopening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved always-on audio capture reliability by preventing callback slowdowns and safely handling full audio queues.
  - Preserved audio frames for later processing when module processing temporarily fails.
  - Corrected recording duration and sample counts to reflect the audio retained after silence removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->