### PR TITLE
docs: organize Discussions around the runtime

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/brain-and-memory.yml
+++ b/.github/DISCUSSION_TEMPLATE/brain-and-memory.yml
@@ -1,0 +1,43 @@
+title: ""
+labels: ["memory"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Recall, the workspace, the durable journal, and what "remembers
+        everything" does and does not mean.
+
+        Recall problems are almost always about scale and about where the
+        workspace lives, so say both.
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect it to remember?
+      description: The specific thing, and roughly when it was learned.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened instead?
+    validations:
+      required: true
+  - type: input
+    id: size
+    attributes:
+      label: Roughly how much is stored?
+      description: Number of memories, or the size of the workspace directory.
+    validations:
+      required: true
+  - type: input
+    id: workspace
+    attributes:
+      label: Where is the workspace?
+      description: The OPENHUMAN_WORKSPACE path, and whether it is a local disk, an external drive, or a network mount.
+    validations:
+      required: true
+  - type: input
+    id: embed
+    attributes:
+      label: Embedding model
+      description: Which one, and whether it changed since the memories were written.

--- a/.github/DISCUSSION_TEMPLATE/harness-and-plugins.yml
+++ b/.github/DISCUSSION_TEMPLATE/harness-and-plugins.yml
@@ -23,8 +23,8 @@ body:
     id: what
     attributes:
       label: What are you trying to do?
-      validations:
-        required: true
+    validations:
+      required: true
   - type: textarea
     id: behavior
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/harness-and-plugins.yml
+++ b/.github/DISCUSSION_TEMPLATE/harness-and-plugins.yml
@@ -1,0 +1,46 @@
+title: ""
+labels: ["harness"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The harness itself, the plugin surface, MCP servers, and tools.
+
+        Building something on OpenHuman rather than changing it? That is the
+        point — post it in **Show & tell** so people can install it.
+  - type: dropdown
+    id: kind
+    attributes:
+      label: What is this about?
+      options:
+        - A plugin I am building
+        - A plugin someone else published
+        - An MCP server
+        - The harness or tool surface itself
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What are you trying to do?
+      validations:
+        required: true
+  - type: textarea
+    id: behavior
+    attributes:
+      label: What happens instead?
+      description: Include the tool call or plugin manifest if one is involved.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: The harness output around the failure, with anything private removed.
+      render: text
+  - type: input
+    id: version
+    attributes:
+      label: OpenHuman version
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/install-and-platforms.yml
+++ b/.github/DISCUSSION_TEMPLATE/install-and-platforms.yml
@@ -1,0 +1,49 @@
+title: ""
+labels: ["install"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Installing, updating, and the places OpenHuman has to survive: macOS
+        sandboxing and permissions, Linux distributions, Windows, Docker,
+        mobile builds.
+
+        Nearly every thread here is settled by the install method plus the log.
+  - type: textarea
+    id: what
+    attributes:
+      label: What happens?
+      description: Where in the process it fails, and what you see.
+    validations:
+      required: true
+  - type: dropdown
+    id: how
+    attributes:
+      label: How did you install it?
+      options:
+        - Release binary or app bundle
+        - Package manager
+        - Docker
+        - Built from source
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: OS and architecture
+      description: For example "macOS 15.3, Apple silicon" or "Ubuntu 24.04, x86_64".
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Log output
+      description: From launch to the failure.
+      render: text
+    validations:
+      required: true
+  - type: input
+    id: workspace
+    attributes:
+      label: Workspace path
+      description: Where the journal is being written, and whether that path is writable.

--- a/.github/DISCUSSION_TEMPLATE/models-and-providers.yml
+++ b/.github/DISCUSSION_TEMPLATE/models-and-providers.yml
@@ -1,0 +1,48 @@
+title: ""
+labels: ["models"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Which models work, how they behave under this harness, and providers —
+        hosted, self-hosted, and local.
+
+        Say whether the same thing happens on a second model. It is the fastest
+        way to tell a harness bug from a model one.
+  - type: input
+    id: model
+    attributes:
+      label: Model
+      description: Exact model id.
+    validations:
+      required: true
+  - type: input
+    id: provider
+    attributes:
+      label: Provider
+      description: Hosted service, self-hosted server (name and version), or a local runner.
+    validations:
+      required: true
+  - type: textarea
+    id: behavior
+    attributes:
+      label: What goes wrong?
+      description: Include the request or tool call if you have it, with keys removed.
+    validations:
+      required: true
+  - type: dropdown
+    id: others
+    attributes:
+      label: Does it happen on another model?
+      options:
+        - "Yes, on other models too"
+        - "No, only this one"
+        - "Have not tried"
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: OpenHuman version
+    validations:
+      required: true

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,47 @@
+title: ""
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        OpenHuman runs on your machine, so most answers depend on your machine.
+        The four fields below are what a maintainer would ask for first.
+
+        Mark an answer when you get one — it is what the next person finds.
+  - type: textarea
+    id: question
+    attributes:
+      label: What are you trying to do?
+      description: The goal, not only the error.
+    validations:
+      required: true
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you already tried?
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: OpenHuman version
+      description: The release, or the commit if you built from source.
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Docker
+        - Mobile
+    validations:
+      required: true
+  - type: input
+    id: model
+    attributes:
+      label: Model and provider
+      description: Which model you are running, and whether it is hosted or local.

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,44 @@
+title: ""
+labels: ["show and tell"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Plugins, workflows, and setups built on OpenHuman. Posting one here is
+        how it gets found — the plugin index is built from this category.
+  - type: input
+    id: name
+    attributes:
+      label: What is it called?
+    validations:
+      required: true
+  - type: textarea
+    id: what
+    attributes:
+      label: What does it do?
+      description: One paragraph, written for someone deciding whether to install it.
+    validations:
+      required: true
+  - type: input
+    id: link
+    attributes:
+      label: Where can people get it?
+      description: Repository or install command. Leave blank if it is not published yet.
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind
+      options:
+        - Plugin
+        - MCP server
+        - Workflow or skill
+        - A setup or configuration
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Tested against
+      description: The OpenHuman version you have it working on.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,26 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a question
+    url: https://github.com/tinyhumansai/openhuman/discussions/categories/q-a
+    about: "How do I…? Answers get marked, so the thread becomes the documentation."
+  - name: Install and platform trouble
+    url: https://github.com/tinyhumansai/openhuman/discussions/categories/install-and-platforms
+    about: macOS permissions, Linux, Windows, Docker, mobile builds, updates.
+  - name: Brain & memory
+    url: https://github.com/tinyhumansai/openhuman/discussions/categories/brain-and-memory
+    about: Recall, the workspace, the durable journal, memory at scale.
+  - name: Harness & plugins
+    url: https://github.com/tinyhumansai/openhuman/discussions/categories/harness-and-plugins
+    about: The plugin surface, MCP servers, tools. Build alongside OpenHuman rather than inside it.
+  - name: Models & providers
+    url: https://github.com/tinyhumansai/openhuman/discussions/categories/models-and-providers
+    about: Which models behave, hosted and self-hosted providers, local runners.
+  - name: Show & tell
+    url: https://github.com/tinyhumansai/openhuman/discussions/categories/show-and-tell
+    about: Publish a plugin, a workflow, or a setup. The plugin index is built from here.
+  - name: Discord
+    url: https://discord.tinyhumans.ai/
+    about: Live chat. Anything that should outlive the scrollback belongs in Discussions.
+  - name: Report a security issue
+    url: https://github.com/tinyhumansai/openhuman/security/policy
+    about: Never in a public issue or discussion.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,8 @@ This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDU
 
 - Read the [README](README.md) for product context.
 - Use [`gitbooks/developing/architecture.md`](gitbooks/developing/architecture.md) for the current system architecture.
-- Check [open issues](https://github.com/tinyhumansai/openhuman/issues) and discussions before starting work.
+- Check [open issues](https://github.com/tinyhumansai/openhuman/issues) and [Discussions](https://github.com/tinyhumansai/openhuman/discussions) before starting work.
+- Stuck rather than fixing something? [SUPPORT.md](SUPPORT.md) routes questions, install trouble, memory behavior, and model problems to the right category; [`docs/community/discussions.md`](docs/community/discussions.md) explains how those threads are triaged.
 - For security issues, follow [SECURITY.md](SECURITY.md) and do not file public issues.
 
 ## Development Setup

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 </p>
 
 <p align="center">
+ <a href="https://github.com/tinyhumansai/openhuman/discussions">Discussions</a> •
  <a href="https://discord.tinyhumans.ai/">Discord</a> •
  <a href="https://www.reddit.com/r/tinyhumansai/">Reddit</a> •
  <a href="https://x.com/intent/follow?screen_name=tinyhumansai">X/Twitter</a> •

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,44 @@
+# Support
+
+OpenHuman runs on your machine, so nearly every answer depends on your machine.
+Pick the channel by what you have, and bring the evidence the form asks for.
+
+| You have | Go to |
+| --- | --- |
+| A question about how to do something | [Q&A](https://github.com/tinyhumansai/openhuman/discussions/categories/q-a) |
+| It will not install, launch, or update | [Install & platforms](https://github.com/tinyhumansai/openhuman/discussions/categories/install-and-platforms) |
+| Recall or the workspace behaving oddly | [Brain & memory](https://github.com/tinyhumansai/openhuman/discussions/categories/brain-and-memory) |
+| A plugin, an MCP server, or the tool surface | [Harness & plugins](https://github.com/tinyhumansai/openhuman/discussions/categories/harness-and-plugins) |
+| A model or provider misbehaving | [Models & providers](https://github.com/tinyhumansai/openhuman/discussions/categories/models-and-providers) |
+| Something you built and want people to use | [Show & tell](https://github.com/tinyhumansai/openhuman/discussions/categories/show-and-tell) |
+| Reproducible behavior that should change | [An issue](https://github.com/tinyhumansai/openhuman/issues/new/choose) |
+| A vulnerability | [The security policy](SECURITY.md) — never a public thread |
+| A conversation | [Discord](https://discord.tinyhumans.ai/) |
+
+Discord is for talking; Discussions is for anything that should still be
+findable in six months. If a Discord thread solves something, post the answer in
+Discussions so the next person finds it.
+
+## What to bring
+
+Every category has a form asking for the version, the platform, the model, and
+the log. That set settles most threads on the first reply — filling it in is
+faster than the exchange that asks for it.
+
+A workspace path is worth stating even when it seems irrelevant: a journal that
+cannot be written where OpenHuman expects it produces failures that look like
+something else entirely.
+
+Redact secrets before posting. A discussion is public and indexed; editing it
+later does not un-publish a key.
+
+## What to expect
+
+Maintainers work a triage queue rather than the feed. A thread with community
+replies and no maintainer reply gets `awaiting maintainer` and is worked
+oldest-first — see
+[docs/community/discussions.md](docs/community/discussions.md).
+
+Not everything belongs in core. If the answer is "that should be a plugin", the
+thread gets `plugin, not core` and stays open so the plugin can be linked from
+it when it exists.

--- a/docs/community/discussions.md
+++ b/docs/community/discussions.md
@@ -1,0 +1,92 @@
+# Discussions
+
+How this repository's Discussions are organized, and how a thread moves through
+them. Written for maintainers doing triage; contributors only need
+[SUPPORT.md](../../SUPPORT.md).
+
+## Why not the default six
+
+GitHub gives every repository the same categories — Announcements, General,
+Ideas, Polls, Q&A, Show and tell. They sort by what kind of post something is,
+which is the one distinction that does not help here: someone whose app will not
+launch on macOS and someone whose recall degraded at 40k memories are both
+"Q&A", need entirely different evidence, and are answered by different people.
+
+Categories here follow the runtime, because the runtime decides what evidence
+the thread needs and who can answer it.
+
+## Categories
+
+| Category | Slug | Answerable | For |
+| --- | --- | --- | --- |
+| Announcements | `announcements` | no | Releases and anything that changes how an existing install behaves. |
+| Brain & memory | `brain-and-memory` | yes | Recall, the workspace, the durable journal, memory at scale. |
+| Harness & plugins | `harness-and-plugins` | yes | The plugin surface, MCP servers, tools, the harness itself. |
+| Models & providers | `models-and-providers` | yes | Model behavior under this harness; hosted, self-hosted, and local providers. |
+| Install & platforms | `install-and-platforms` | yes | macOS permissions and sandboxing, Linux, Windows, Docker, mobile, updates. |
+| Deep research | `deep-research` | yes | Multi-step research runs and sub-agent behavior. |
+| Q&A | `q-a` | yes | Everything else someone is stuck on. |
+| Show & tell | `show-and-tell` | no | Plugins, workflows, and setups. The plugin index is built from this category. |
+| General | `general` | no | The catch-all. Triage moves posts out of it. |
+
+Six have a form under
+[`.github/DISCUSSION_TEMPLATE/`](../../.github/DISCUSSION_TEMPLATE). **The file
+name must equal the category slug** — a template whose slug matches no category
+is silently ignored, which is the first thing to check if a form disappears.
+
+## Labels
+
+Discussion labels are the repository's issue labels; these are the ones triage
+runs on.
+
+| Label | Meaning | Who sets it |
+| --- | --- | --- |
+| `awaiting maintainer` | Has replies, none from a maintainer. The triage queue. | Triage |
+| `needs logs` | Cannot be acted on without the launch or harness log. | Anyone |
+| `needs repro` | Nobody else has reproduced it yet. | Anyone |
+| `plugin, not core` | The right shape for this is a plugin. | Maintainer |
+| `local-first` | Turns on whether something is allowed to leave the machine. | Anyone |
+| `promoted` | An issue was opened from this thread; the issue is linked. | Maintainer |
+
+## Triage
+
+Work the queue, not the feed:
+
+1. **Wrong category** — move it. A misfiled thread is answered by nobody.
+2. **`awaiting maintainer`, oldest first.** A thread with community replies and
+   no maintainer reply is the failure this queue exists to catch; the built-in
+   "unanswered" filter cannot see it, because those replies count as answers.
+3. **Answerable and answered** — mark the answer, so the thread becomes the
+   documentation for the next person with the same platform.
+4. **A real defect** — open the issue, link both ways, label the thread
+   `promoted`, and leave it open until the fix ships.
+5. **Should be a plugin** — say so, label it `plugin, not core`, and leave it
+   open. When someone builds it, it gets linked from that thread and posted to
+   Show & tell.
+
+Threads are not closed for age. A stale answered thread is documentation.
+
+## Contributions and pull requests
+
+External pull requests are limited today; the paths that are always open are a
+discussion here and a plugin of your own. When triage closes the door on a code
+change, it should point at whichever of those two actually fits — a "no" with no
+route attached is how contributors leave.
+
+## Cross-posting with OpenCompany
+
+OpenHuman is the runtime inside [OpenCompany](https://github.com/tinyhumansai/opencompany),
+so the launcher, the workspace root, and the agent journal produce questions
+that genuinely belong to both repositories.
+
+Post where you hit it and link the counterpart rather than closing it as a
+duplicate — the repositories have different maintainers, and the link keeps both
+able to answer. When the fix lands in the other repository, say so here and mark
+the thread answered.
+
+## Changing this setup
+
+Categories cannot be created from the API — there is no GraphQL mutation for
+them, so they are made in **Settings → Discussions** by someone with admin on
+the repository. Anything added there needs a row in the table above, and a form
+under `.github/DISCUSSION_TEMPLATE/` if the category expects evidence.


### PR DESCRIPTION
Sets this repository's Discussions up for the traffic it already gets (29 threads and climbing, on GitHub's six default categories), and for the traffic a project this visible will keep getting.

The defaults — Announcements / General / Ideas / Polls / Q&A / Show and tell — sort by what kind of post something is. That is the one distinction that does not help here: someone whose app will not launch under macOS sandboxing and someone whose recall degraded at 40k memories are both "Q&A", need entirely different evidence, and are answered by different people.

Categories here follow **the runtime**, because the runtime decides what evidence a thread needs and who can answer it.

## What's in the diff

- **`.github/DISCUSSION_TEMPLATE/`** — forms for `q-a`, `brain-and-memory`, `harness-and-plugins`, `models-and-providers`, `install-and-platforms`, `show-and-tell`. OpenHuman runs on the poster's machine, so every form asks for the machine: version, platform, model and provider, workspace path, log. The memory form asks how much is stored and whether the embedding model changed; the models form asks whether it reproduces on a second model, which is the fastest way to separate a harness bug from a model one.
- **`.github/ISSUE_TEMPLATE/config.yml`** — new. Routes questions to the right category, keeps Discord listed for live chat, and points security reports at the policy.
- **`SUPPORT.md`** — new. A routing table, what to bring, and the Discord/Discussions split: Discord for talking, Discussions for anything that should still be findable in six months.
- **`docs/community/discussions.md`** — the maintainer runbook: category table with slugs, triage labels, and the order to work the queue.
- **`README.md` / `CONTRIBUTING.md`** — a Discussions link in the nav row, and a pointer from the contributor path.

## Manual steps for an admin (this PR cannot do them)

GitHub has no API for discussion categories — no `createDiscussionCategory` mutation — so these are **Settings → Discussions** by hand. Until they exist the matching templates sit inert; the file name must equal the category slug.

| Name | Slug | Answerable |
| --- | --- | --- |
| Brain & memory | `brain-and-memory` | yes |
| Harness & plugins | `harness-and-plugins` | yes |
| Models & providers | `models-and-providers` | yes |
| Install & platforms | `install-and-platforms` | yes |
| Deep research | `deep-research` | yes |

Keep Announcements, Q&A, Show and tell, General.

Labels triage depends on: `awaiting maintainer`, `needs logs`, `needs repro`, `plugin, not core`, `local-first`, `promoted`.

## Two things this is deliberately built around

**`awaiting maintainer`.** GitHub's built-in filter is "unanswered", which cannot see the case that actually loses contributors — a thread with community replies and no maintainer reply, because those replies count as answers. The label makes that queue visible and workable oldest-first.

**A route attached to every "no".** External PRs are limited, so the runbook says a closed code change must point at whichever open path fits — a discussion or a plugin of their own. A "no" with no route attached is how contributors leave. That is also why `plugin, not core` leaves the thread open, so the plugin can be linked from it later.

## Verification

All six YAML files parse, and every non-markdown block was checked for an `id`, a `label`, dropdown `options`, and `validations` at block level rather than nested under `attributes` (one had it nested — GitHub would have silently dropped the required flag). No submodule gitlinks are touched; the diff is docs and templates only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added categorized GitHub Discussion templates for troubleshooting, Q&A, issue reporting, and sharing projects.
  * Added issue-routing guidance directing questions, support requests, feature discussions, and security reports to the appropriate channels.

* **Documentation**
  * Updated the README and contribution guidance with community support links.
  * Added support instructions covering troubleshooting details, secret redaction, and plugin-related requests.
  * Documented Discussion categories, templates, triage, and contribution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->