### PR TITLE
fix(harness): stop moving the turn generator through task-local scopes

### DIFF
--- a/src/openhuman/agent/harness/fork_context.rs
+++ b/src/openhuman/agent/harness/fork_context.rs
@@ -187,7 +187,10 @@ pub async fn with_parent_context<F, R>(ctx: ParentExecutionContext, future: F) -
 where
     F: std::future::Future<Output = R>,
 {
-    PARENT_CONTEXT.scope(ctx, future).await
+    // Box before `scope` so only a pointer moves into the task-local frame
+    // rather than the whole nested turn generator — see the measurements on
+    // `with_turn_collector` in `turn_subagent_usage.rs`.
+    PARENT_CONTEXT.scope(ctx, Box::pin(future)).await
 }
 
 /// Returns the one-shot context-preparation sources that have already run for
@@ -222,7 +225,10 @@ pub async fn with_agent_context_prepared_sources<F, R>(
 where
     F: std::future::Future<Output = R>,
 {
+    // Box before `scope` so only a pointer moves into the task-local frame
+    // rather than the whole nested turn generator — see the measurements on
+    // `with_turn_collector` in `turn_subagent_usage.rs`.
     AGENT_CONTEXT_PREPARED_SOURCES
-        .scope(Arc::new(std::sync::Mutex::new(sources)), future)
+        .scope(Arc::new(std::sync::Mutex::new(sources)), Box::pin(future))
         .await
 }

--- a/src/openhuman/agent/harness/sandbox_context.rs
+++ b/src/openhuman/agent/harness/sandbox_context.rs
@@ -50,7 +50,12 @@ pub async fn with_current_sandbox_mode<F, R>(mode: SandboxMode, future: F) -> R
 where
     F: std::future::Future<Output = R>,
 {
-    CURRENT_AGENT_SANDBOX_MODE.scope(mode, future).await
+    // Box before `scope` so only a pointer moves into the task-local frame
+    // rather than the whole nested turn generator — see the measurements on
+    // `with_turn_collector` in `turn_subagent_usage.rs`.
+    CURRENT_AGENT_SANDBOX_MODE
+        .scope(mode, Box::pin(future))
+        .await
 }
 
 #[cfg(test)]

--- a/src/openhuman/agent/harness/turn_attachments_context.rs
+++ b/src/openhuman/agent/harness/turn_attachments_context.rs
@@ -36,8 +36,11 @@ pub async fn with_current_turn_image_placeholders<F, R>(placeholders: Vec<String
 where
     F: std::future::Future<Output = R>,
 {
+    // Box before `scope` so only a pointer moves into the task-local frame
+    // rather than the whole nested turn generator — see the measurements on
+    // `with_turn_collector` in `turn_subagent_usage.rs`.
     CURRENT_TURN_IMAGE_PLACEHOLDERS
-        .scope(placeholders, future)
+        .scope(placeholders, Box::pin(future))
         .await
 }
 

--- a/src/openhuman/agent/harness/turn_subagent_usage.rs
+++ b/src/openhuman/agent/harness/turn_subagent_usage.rs
@@ -123,7 +123,18 @@ where
     F: std::future::Future<Output = R>,
 {
     let collector: TurnSubagentUsage = Arc::new(Mutex::new(Vec::new()));
-    let out = TURN_SUBAGENT_USAGE.scope(collector.clone(), future).await;
+    // `scope` takes the inner future **by value**, so a debug build moves the
+    // whole nested turn generator through this frame on its way in. On the agent
+    // turn path that nesting is hundreds of KiB, and this wrapper was the most
+    // expensive of them: measured under gdb, its own frame was 239,184 bytes of
+    // a 2,090,360-byte stack, against the 2 MiB thread `libtest` hands a test.
+    // Pinning to the heap first means only a pointer moves. Boxing here and at
+    // the four sibling `scope` wrappers took the same stack to 731,928 bytes and
+    // fixed 131 tests that aborted on a stack overflow; the cost is one
+    // allocation per scope, against a turn that is about to call a model.
+    let out = TURN_SUBAGENT_USAGE
+        .scope(collector.clone(), Box::pin(future))
+        .await;
     let entries = collector
         .lock()
         .map(|g| g.clone())


### PR DESCRIPTION
## Summary

Five task-local `scope` wrappers on the agent turn path took the inner future
**by value**, so a debug build moved the entire nested turn generator through
each wrapper's stack frame on its way in. `Box::pin` first, and only a pointer
moves.

This is not a leak or a recursion — the path is genuinely that wide. The frames
are the `poll` functions' stack temporaries, which a debug build does not shrink.

## How it was found

`cargo test` in [opencompany](https://github.com/tinyhumansai/opencompany) (which
vendors this crate) aborted with `has overflowed its stack` on **131 tests**.
Under gdb at the point of overflow, the stack was **126 frames deep — no
recursion** — and spanned **2,090,360 bytes**, just over the 2 MiB thread
`libtest` hands each test. Five frames accounted for ~1.5 MiB of it:

| frame | bytes |
|---|---|
| `session::turn::core::…::turn` | 326,256 |
| `turn_subagent_usage::with_turn_collector` | 239,184 |
| `session::turn::graph::run_chat_turn_graph` | 145,056 |
| `agent::tinyagents::run_turn_via_tinyagents_shared` | 133,504 |
| `session_import::live::session_kv_store` | 79,968 |

## Result

Measured at the same breakpoint, with the same graph, on the same build:

| | stack span | 100 KiB+ harness frames | overflowing tests |
|---|---|---|---|
| before | 2,090,360 B | 5 | 131 |
| after | **731,928 B** (−65%) | 0 (largest 106 KiB) | **0** |

Verified by cherry-picking this change onto the commit opencompany pins and
running its suite under the affected feature set: `cargo test --lib --features
openhuman,tinycortex` → **3876 passed, 0 failed, 3 ignored**, no overflow, and
*without* `RUST_MIN_STACK` set. All 131 previously-aborting tests were re-run
individually and all pass.

## Behaviour

None. Same futures, same polling semantics, same task-local propagation — the
existing tests on these wrappers cover that. The cost is one heap allocation per
scope, against a turn that is about to make a model call.

## Commands run locally

- `cargo fmt --all -- --check` — clean
- In the vendoring repo, against this change: `cargo test --lib --features openhuman,tinycortex` — 3876 passed, 0 failed
- Per-test re-probe of all 131 previously-overflowing tests — 0 still overflow

## Note

Not verified against this crate's own test suite locally — openhuman `main`
requires a newer `tinyagents` than the vendoring repo pins, so measurement was
done on the pinned commit (the change cherry-picks cleanly to both). Relying on
CI here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when processing nested agent tasks and contextual operations.
  * Reduced stack usage to help prevent stack overflows during complex or deeply nested workflows.
* **Performance**
  * Optimized asynchronous context handling without changing externally visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->