### PR TITLE
lint(app): enforce the centralized-frontend-config rule, and fix its one violation

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -228,6 +228,33 @@ export default [
     },
   },
 
+  // Frontend config is centralized in src/utils/config.ts (AGENTS.md). A direct
+  // import.meta.env read elsewhere bypasses the derived values that file owns --
+  // IS_DEV_LIKE exists precisely because import.meta.env.DEV is false under the
+  // E2E harness (vite build --mode development) -- and cannot be stubbed once the
+  // module graph has loaded, which is why the loopback OAuth test reads config
+  // instead. The rule was documented but unenforced, and had already drifted.
+  {
+    files: ['src/**/*.ts', 'src/**/*.tsx'],
+    ignores: [
+      'src/utils/config.ts',
+      'src/test/**',
+      'src/**/__tests__/**',
+      'src/**/*.test.ts',
+      'src/**/*.test.tsx',
+    ],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'MemberExpression[object.type="MetaProperty"][property.name="env"]',
+          message:
+            'Read frontend config from src/utils/config.ts (IS_DEV, IS_DEV_LIKE, ...) instead of import.meta.env directly; add the value there if it is missing.',
+        },
+      ],
+    },
+  },
+
   // React files configuration
   {
     files: ['src/**/*.jsx', 'src/**/*.tsx'],

--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -247,7 +247,10 @@ export default [
       'no-restricted-syntax': [
         'error',
         {
-          selector: 'MemberExpression[object.type="MetaProperty"][property.name="env"]',
+          // Pin the meta-property to `import.meta` -- `new.target` is a MetaProperty
+          // too -- and match both `import.meta.env` and `import.meta['env']`.
+          selector:
+            'MemberExpression[object.type="MetaProperty"][object.meta.name="import"][object.property.name="meta"]:matches([computed=false][property.name="env"], [computed=true][property.value="env"])',
           message:
             'Read frontend config from src/utils/config.ts (IS_DEV, IS_DEV_LIKE, ...) instead of import.meta.env directly; add the value there if it is missing.',
         },

--- a/app/src/components/layout/TwoPanelLayout.tsx
+++ b/app/src/components/layout/TwoPanelLayout.tsx
@@ -12,13 +12,14 @@ import {
   setSidebarWidth,
   toggleSidebar,
 } from '../../store/layoutSlice';
+import { IS_DEV } from '../../utils/config';
 import { Button } from '../ui';
 import { clampWidth, useResizableDivider } from './useResizableDivider';
 
 const namespace = 'two-panel-layout';
 
 function debug(message: string, payload?: Record<string, unknown>) {
-  if (import.meta.env.DEV) {
+  if (IS_DEV) {
     console.debug(`[${namespace}] ${message}`, payload ?? {});
   }
 }

--- a/app/src/services/socketService.ts
+++ b/app/src/services/socketService.ts
@@ -10,7 +10,7 @@ import { setBackend } from '../store/connectivitySlice';
 import { resetForUser, setSocketIdForUser, setStatusForUser } from '../store/socketSlice';
 import type { ChannelAuthMode, ChannelConnectionStatus, ChannelType } from '../types/channels';
 import type { UserErrorScope } from '../types/userError';
-import { IS_DEV } from '../utils/config';
+import { IS_DEV, IS_TEST } from '../utils/config';
 import { createSafeLogData, sanitizeError } from '../utils/sanitize';
 import { getCoreRpcToken, getCoreRpcUrl } from './coreRpcClient';
 import { createCoreSocket } from './coreSocket';
@@ -26,11 +26,11 @@ const socketWarn = debug('socket:warn');
 const socketError = debug('socket:error');
 
 // Enable socket logging in development by default — but never under test.
-// `IS_DEV` is truthy in vitest, so without the MODE guard this force-enable
+// `IS_DEV` is truthy in vitest, so without the `IS_TEST` guard this force-enable
 // floods every test file that imports this service (measured: 412 lines /
 // 46KB of `flow:approval_request` listener churn in a single run), inflating
 // runtime enough to push suites past the runner's foreground timeout.
-if (IS_DEV && import.meta.env.MODE !== 'test') {
+if (IS_DEV && !IS_TEST) {
   debug.enable('socket*');
 }
 

--- a/app/src/test/eslintCentralizedConfigRule.test.ts
+++ b/app/src/test/eslintCentralizedConfigRule.test.ts
@@ -1,5 +1,5 @@
-import { Linter } from 'eslint';
 import tsparser from '@typescript-eslint/parser';
+import { Linter } from 'eslint';
 import { describe, expect, it } from 'vitest';
 
 // eslint.config.js is plain JS and ships no declarations; importing the real
@@ -21,7 +21,7 @@ import eslintConfig from '../../eslint.config.js';
  */
 
 const configBlock = (eslintConfig as Linter.Config[]).find(
-  (block) => block.rules?.['no-restricted-syntax'],
+  block => block.rules?.['no-restricted-syntax']
 );
 
 const [, restriction] = (configBlock?.rules?.['no-restricted-syntax'] ?? []) as [
@@ -37,7 +37,7 @@ function lint(code: string) {
     rules: { 'no-restricted-syntax': ['error', restriction] },
   });
   // A parse failure would otherwise read as "the rule did not fire".
-  expect(messages.filter((message) => message.fatal)).toEqual([]);
+  expect(messages.filter(message => message.fatal)).toEqual([]);
   return messages;
 }
 

--- a/app/src/test/eslintCentralizedConfigRule.test.ts
+++ b/app/src/test/eslintCentralizedConfigRule.test.ts
@@ -1,0 +1,70 @@
+import { Linter } from 'eslint';
+import tsparser from '@typescript-eslint/parser';
+import { describe, expect, it } from 'vitest';
+
+// eslint.config.js is plain JS and ships no declarations; importing the real
+// file is the point of this test, so the shape is asserted below at runtime.
+// @ts-expect-error -- untyped JS module
+import eslintConfig from '../../eslint.config.js';
+
+/**
+ * Guards the `no-restricted-syntax` selector that keeps frontend config reads
+ * funnelled through `src/utils/config.ts`. The selector is easy to get subtly
+ * wrong in both directions -- `new.target` is a MetaProperty just like
+ * `import.meta`, and computed access stores the key on `property.value` rather
+ * than `property.name` -- so the exact boundary is pinned here.
+ *
+ * The selector and the ignore list are read out of the real `eslint.config.js`
+ * rather than restated, so these assertions cannot drift away from what ships.
+ * Linting runs through a bare `Linter` because the repo config is type-aware
+ * and `parserOptions.project` rejects the synthetic file used for the probes.
+ */
+
+const configBlock = (eslintConfig as Linter.Config[]).find(
+  (block) => block.rules?.['no-restricted-syntax'],
+);
+
+const [, restriction] = (configBlock?.rules?.['no-restricted-syntax'] ?? []) as [
+  string,
+  { selector: string; message: string },
+];
+
+const linter = new Linter();
+
+function lint(code: string) {
+  const messages = linter.verify(code, {
+    languageOptions: { parser: tsparser, ecmaVersion: 'latest', sourceType: 'module' },
+    rules: { 'no-restricted-syntax': ['error', restriction] },
+  });
+  // A parse failure would otherwise read as "the rule did not fire".
+  expect(messages.filter((message) => message.fatal)).toEqual([]);
+  return messages;
+}
+
+describe('centralized-frontend-config lint rule', () => {
+  it('is wired into the shipped config', () => {
+    expect(restriction?.selector).toBeTypeOf('string');
+    expect(configBlock?.ignores).toContain('src/utils/config.ts');
+    expect(configBlock?.ignores).toContain('src/test/**');
+  });
+
+  it('rejects dotted import.meta.env access', () => {
+    expect(lint('export const a = import.meta.env.DEV;')).toHaveLength(1);
+  });
+
+  it('rejects computed import.meta["env"] access', () => {
+    expect(lint("export const a = import.meta['env'].DEV;")).toHaveLength(1);
+  });
+
+  it('allows other import.meta properties', () => {
+    expect(lint('export const a = import.meta.url;')).toHaveLength(0);
+  });
+
+  it('allows new.target.env, which is a different meta-property', () => {
+    expect(lint('export function G() { return new.target.env; }')).toHaveLength(0);
+  });
+
+  it('allows a plain object property named env', () => {
+    expect(lint('const o = { env: 1 }; export const a = o.env;')).toHaveLength(0);
+  });
+});

--- a/app/src/test/setup.ts
+++ b/app/src/test/setup.ts
@@ -255,6 +255,7 @@ vi.mock('../utils/config', () => ({
   CORE_RPC_TIMEOUT_MS: 30_000,
   IS_DEV: true,
   IS_DEV_LIKE: true,
+  IS_TEST: true,
   IS_PROD: false,
   E2E_DEFAULT_CORE_MODE: '',
   E2E_RESTART_APP_AS_RELOAD: false,

--- a/app/src/utils/config.ts
+++ b/app/src/utils/config.ts
@@ -77,6 +77,13 @@ export const E2E_DEFAULT_CORE_MODE =
  */
 export const IS_DEV_LIKE = IS_DEV || import.meta.env.MODE === 'development';
 
+/**
+ * True under vitest. Distinct from `IS_DEV`, which is *also* true there — so a
+ * dev-only default that must stay off in tests needs both, and reading `MODE`
+ * at the call site is exactly the direct access this module exists to absorb.
+ */
+export const IS_TEST = import.meta.env.MODE === 'test';
+
 /** Dev only: skip `.skip_onboarding` workspace check and ignore onboarded state so `/onboarding` always shows. Set `VITE_DEV_FORCE_ONBOARDING=true` in `.env.local`. */
 export const DEV_FORCE_ONBOARDING =
   import.meta.env.DEV && import.meta.env.VITE_DEV_FORCE_ONBOARDING === 'true';


### PR DESCRIPTION
## Summary

[`AGENTS.md`](AGENTS.md) states the rule plainly:

> **Frontend config** centralized in [`app/src/utils/config.ts`](app/src/utils/config.ts) — never read `import.meta.env` directly elsewhere.

Nothing enforced it, and it had already drifted. `TwoPanelLayout`'s `debug()` read `import.meta.env.DEV` directly.

## Why the rule is not cosmetic

`config.ts` owns derived values a raw read cannot give you. Its own comment says so:

```ts
/**
 * a real `vite dev` (DEV=true) or a `vite build --mode development` (the E2E
 * harness — DEV=false but MODE='development'). `IS_DEV` alone is insufficient
 * for the E2E case because `vite build` always sets PROD=true / DEV=false
 */
export const IS_DEV_LIKE = IS_DEV || import.meta.env.MODE === 'development';
```

A raw read is also unstubbable once the module graph has loaded — `loopbackOauthListener.test.ts` documents that in a comment and reads through `config` for exactly this reason.

## Scope

I swept all of `app/` before writing the rule. There are **two** violations, and fixing the second adds one export:

| file | what |
|---|---|
| `src/components/layout/TwoPanelLayout.tsx:21` | `debug()` read `import.meta.env.DEV` directly |
| `src/services/socketService.ts:33` | a raw `import.meta.env.MODE !== 'test'` guard, replaced by a new `IS_TEST` export from `config.ts` |
| `src/test/setup.ts`, `src/utils/__tests__/loopbackOauthListener.test.ts` | a mock and two comments — exempted |
| `vite.config.ts` | must define these values, and is outside `src/` |

**`IS_TEST` is new API in `config.ts`** — worth naming, since the second fix is the more interesting one. That guard's comment documents a measured cost: 412 lines / 46 KB of listener churn per run, enough to push suites past the runner timeout. It has to keep working, which is why the value moves into `config.ts` rather than being deleted.

*(The body previously said "exactly one violation" and named only `TwoPanelLayout`. That was true when this was opened; the sweep was re-run on today's `main` — still exactly these two sites, no new ones.)*

So the rule lands with a clean tree.

## Change

- `no-restricted-syntax` over `src/**/*.{ts,tsx}`, exempting `src/utils/config.ts` and test files, with a message naming the replacement rather than just forbidding.
- The violation is fixed by importing `IS_DEV`.

That fix is **deliberately behaviour-preserving** — `IS_DEV` is exactly `import.meta.env.DEV`. If the intent is for this debug output to appear under the E2E harness too, `IS_DEV_LIKE` is a one-word change, but that is a behaviour decision rather than a lint fix, so I left it to you.

## Verification

Run locally on this branch:

| check | result |
|---|---|
| rule added, source **untouched** | exactly **1 error**, at `TwoPanelLayout.tsx:17` |
| after the fix | **98 warnings, 0 errors** — the same baseline as `main`, no new warning |
| `prettier --check` on both files | clean |
| `tsc --noEmit -p tsconfig.json` | clean (exit 0) |
| `vitest run src/components/layout/TwoPanelLayout.test.tsx` | **7/7 passed** |

The fail-first step is the one that matters: the rule was proven to fire on the real violation before the violation was removed, so it is not a rule that passes vacuously.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in development and test-mode behavior.
  * Reduced development debug logging during automated test runs.
  * Strengthened safeguards around supported environment-setting access patterns.

* **Tests**
  * Added validation for direct and bracket-based environment access.
  * Confirmed that unrelated metadata and ordinary object properties remain supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

**Rebased onto today's `main`.** One conflict, in `app/eslint.config.js`, exactly as described in review: `main`'s 83d0f5f5e relocated the `settings/controls` barrel block to the line this block inserts at. Both are kept — separate config objects, different rule keys (`no-restricted-imports` vs `no-restricted-syntax`), nothing interacting.

Verified after the rebase: the config still loads (14 blocks), `eslint` on the three touched files reports no issues, and the scope sweep over today's `src/` returns only the four exempt files — `config.ts`, `src/test/setup.ts`, `eslintCentralizedConfigRule.test.ts`, `loopbackOauthListener.test.ts`.
