### PR TITLE
fix(share): scrub credentials that carry no upper-case character

### DIFF
--- a/app/src/features/share/shareContent.test.ts
+++ b/app/src/features/share/shareContent.test.ts
@@ -50,18 +50,23 @@ describe('redactSensitive', () => {
 
   // The last-resort rule requires an upper-case character so it does not fire on
   // prose. Everything below is lower-case + digits, so it reached the card intact
-  // until these patterns were added. Each string is a shape-accurate dummy.
+  // until these patterns were added. Each value is a shape-accurate dummy, not a
+  // real credential.
   //
-  // The Slack ones are assembled from parts on purpose: written as one literal they
-  // match GitHub's Slack-token detector well enough that push protection rejects the
-  // commit, which would block this file for anyone pushing it.
-  const slackToken = (prefix: string, ...rest: string[]) => [prefix, ...rest].join('-');
+  // Every vendor-prefixed value is assembled from parts on purpose: written as a
+  // single literal it carries the vendor's exact token shape, which is what a
+  // secret scanner keys on. GitHub push protection already rejects the Slack form
+  // outright, and that would block this file for anyone pushing it.
+  const assembled = (separator: string, ...parts: string[]) => parts.join(separator);
 
   test.each([
-    ['slack bot token', slackToken('xoxb', '123456789012', '987654321098', 'abcdefghijklmnop')],
-    ['slack user token', slackToken('xoxp', '987654321098', '123456789012', 'zyxwvutsrqponmlk')],
-    ['gitlab personal access token', 'glpat-abcdefghij1234567890'],
-    ['huggingface token', 'hf_abcdefghijklmnopqrstuvwxyz1234'],
+    ['slack bot token', assembled('-', 'xoxb', '123456789012', '987654321098', 'abcdefghijklmnop')],
+    [
+      'slack user token',
+      assembled('-', 'xoxp', '987654321098', '123456789012', 'zyxwvutsrqponmlk'),
+    ],
+    ['gitlab personal access token', assembled('-', 'glpat', 'abcdefghij1234567890')],
+    ['huggingface token', assembled('_', 'hf', 'abcdefghijklmnopqrstuvwxyz1234')],
   ])('scrubs an all-lower-case %s', (_label, secret) => {
     const out = redactSensitive(`saved ${secret} for you`);
     expect(out).toContain('[redacted]');
@@ -80,7 +85,8 @@ describe('redactSensitive', () => {
 
   test('survives stripMarkdown running first, as buildFallbackHeadline runs it', () => {
     // stripMarkdown removes `_`, so a pattern that insisted on it would never match.
-    const head = buildFallbackHeadline('Done. Saved hf_abcdefghijklmnopqrstuvwxyz1234 for you.');
+    const hfToken = assembled('_', 'hf', 'abcdefghijklmnopqrstuvwxyz1234');
+    const head = buildFallbackHeadline(`Done. Saved ${hfToken} for you.`);
     expect(head).not.toContain('abcdefghijklmnopqrstuvwxyz');
     expect(head).toContain('[redacted]');
   });

--- a/app/src/features/share/shareContent.test.ts
+++ b/app/src/features/share/shareContent.test.ts
@@ -48,6 +48,48 @@ describe('redactSensitive', () => {
     expect(redactSensitive('mail jane.doe@example.com now')).toContain('[email]');
   });
 
+  // The last-resort rule requires an upper-case character so it does not fire on
+  // prose. Everything below is lower-case + digits, so it reached the card intact
+  // until these patterns were added. Each string is a shape-accurate dummy.
+  //
+  // The Slack ones are assembled from parts on purpose: written as one literal they
+  // match GitHub's Slack-token detector well enough that push protection rejects the
+  // commit, which would block this file for anyone pushing it.
+  const slackToken = (prefix: string, ...rest: string[]) => [prefix, ...rest].join('-');
+
+  test.each([
+    ['slack bot token', slackToken('xoxb', '123456789012', '987654321098', 'abcdefghijklmnop')],
+    ['slack user token', slackToken('xoxp', '987654321098', '123456789012', 'zyxwvutsrqponmlk')],
+    ['gitlab personal access token', 'glpat-abcdefghij1234567890'],
+    ['huggingface token', 'hf_abcdefghijklmnopqrstuvwxyz1234'],
+  ])('scrubs an all-lower-case %s', (_label, secret) => {
+    const out = redactSensitive(`saved ${secret} for you`);
+    expect(out).toContain('[redacted]');
+    expect(out).not.toContain(secret);
+  });
+
+  test.each([
+    ['slack', 'https://hooks.slack.com/services/T00000000/B00000000/abcdefghijklmnopqrst'],
+    [
+      'discord',
+      'https://discord.com/api/webhooks/123456789012345678/abcdefghijklmnopqrstuvwxyz012345',
+    ],
+  ])('scrubs a %s webhook URL, which carries its secret in the path', (_label, url) => {
+    expect(redactSensitive(`posting to ${url} now`)).not.toContain(url);
+  });
+
+  test('survives stripMarkdown running first, as buildFallbackHeadline runs it', () => {
+    // stripMarkdown removes `_`, so a pattern that insisted on it would never match.
+    const head = buildFallbackHeadline('Done. Saved hf_abcdefghijklmnopqrstuvwxyz1234 for you.');
+    expect(head).not.toContain('abcdefghijklmnopqrstuvwxyz');
+    expect(head).toContain('[redacted]');
+  });
+
+  test('does not fire on ordinary lower-case prose', () => {
+    const clean = 'renamed the folder to archive and moved twelve files into it';
+    expect(redactSensitive(clean)).toBe(clean);
+  });
+
   test('is idempotent and leaves clean prose untouched', () => {
     const clean = 'Summarised three months of emails in twelve seconds';
     expect(redactSensitive(clean)).toBe(clean);

--- a/app/src/features/share/shareContent.ts
+++ b/app/src/features/share/shareContent.ts
@@ -36,6 +36,19 @@ const REDACTIONS: ReadonlyArray<{ re: RegExp; with: string }> = [
   { re: /\bBearer\s+[A-Za-z0-9._-]{12,}\b/gi, with: '[redacted]' },
   // AWS access key ids.
   { re: /\bAKIA[0-9A-Z]{16}\b/g, with: '[redacted]' },
+  // Vendor-prefixed credentials whose body is lower-case and digits only. The
+  // last-resort rule below cannot reach these: it requires an upper-case letter so
+  // it does not fire on prose, and an all-lower-case token slips straight past it.
+  // The `_` is optional because `stripMarkdown` strips emphasis characters before
+  // this runs, so `hf_abc…` arrives here as `hfabc…`.
+  { re: /\b(?:xox[abeprs]|xapp)-[A-Za-z0-9-]{10,}/g, with: '[redacted]' },
+  { re: /\bglpat-[A-Za-z0-9_-]{16,}/g, with: '[redacted]' },
+  { re: /\bhf_?[a-z0-9]{20,}\b/g, with: '[redacted]' },
+  // Webhook URLs carry the secret in the path, so the whole URL has to go.
+  {
+    re: /\bhttps?:\/\/(?:hooks\.slack\.com|discord(?:app)?\.com\/api\/webhooks)\/[^\s"'`)]+/gi,
+    with: '[redacted]',
+  },
   // Long opaque hex runs (>= 32 chars) that look like secrets, not prose.
   { re: /\b[A-Fa-f0-9]{32,}\b/g, with: '[redacted]' },
   // Long opaque base64/base64url runs (>= 24 chars) that mix upper/lower/digit,


### PR DESCRIPTION
## Summary

`shareContent.ts` opens with its own bar:

> **PRIVACY** (issue #5006 acceptance criterion): nothing private must leak into a shared card.

The last-resort secret pattern requires an upper-case character so it does not fire on prose:

```
(?=[A-Za-z0-9+/_-]*[A-Z])(?=[A-Za-z0-9+/_-]*[a-z])(?=[A-Za-z0-9+/_-]*[0-9])
```

That makes it blind to any credential whose body is lower-case and digits only. Those reached the card text intact — the text that gets posted publicly.

## Measured on `main`

Each value below passed through `buildFallbackHeadline` verbatim (shape-accurate dummies, not real keys):

| shape | on `main` |
|---|---|
| Slack bot token `xoxb-…` | **verbatim** |
| Slack user token `xoxp-…` | **verbatim** |
| GitLab PAT `glpat-…` | **verbatim** |
| HuggingFace `hf_…` | **verbatim** |
| Discord webhook URL | **verbatim** (the token is in the path) |

For contrast, these were already handled and still are: `sk-…`, `AKIA…`, `npm_…` (mixed case), long hex, and a JWT's payload/signature segments.

## The fix, and what I deliberately did not do

Added explicit patterns for those shapes, in the same style as the existing specific rules that precede the last-resort one.

I did **not** relax the last-resort rule to drop its upper-case requirement. That would catch this whole class in one line, but it trades it for over-redacting ordinary lower-case identifiers, and the file already states it is "intentionally last-resort and biased toward over-redaction". Where that line sits is your call, not mine to assume — say the word and I'll switch the approach.

One detail worth keeping in view: the `_` is optional in the HuggingFace pattern because `stripMarkdown` removes emphasis characters **before** redaction runs, so `hf_abc…` arrives here as `hfabc…`. A pattern insisting on the underscore would silently never match. There is a test pinning that.

I also checked whether swapping the order (`stripMarkdown(redactSensitive(x))`) would be the better fix — it makes no difference to any of these cases, so I left the order alone rather than churn it.

## Verification

Eight tests added to `shareContent.test.ts`. Reverting only `shareContent.ts`:

```
Tests  6 failed | 25 passed (31)
```

The six failures are the bug proofs. The other two pass either way, and I would rather name them than let them pad the count:

- the **Slack webhook URL** case — that particular URL's path contains `T00000000`/`B00000000`, so the upper-case requirement happened to be satisfied already;
- the **prose guard** — there to show the new patterns do not start eating ordinary lower-case sentences.

With the fix: `31 passed`, and `62 passed` across all of `src/features/share`.

`prettier --check .`, `eslint src` and `tsc --noEmit` each exit 0.

### One note on the test fixtures

The two Slack tokens are assembled from parts rather than written as literals. As single literals they match GitHub's Slack-token detector closely enough that **push protection rejects the commit** — I hit exactly that pushing this branch. Assembling them keeps the regex under test identical while letting the file be pushed. I did not use the "allow this secret" bypass; that seemed like the wrong habit to bake into a repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection of sensitive information when sharing content.
  * Redacts additional credentials, including Slack, GitLab, and Hugging Face tokens.
  * Removes Slack and Discord webhook URLs from shared content.
  * Preserves ordinary lowercase text while maintaining redaction after Markdown formatting is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->