### PR TITLE
fix(ci): init every vendored submodule in the release Docker builds

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -397,11 +397,26 @@ jobs:
         with:
           ref: ${{ needs.prepare-build.outputs.build_ref }}
           fetch-depth: 1
-      # Targeted init (not `submodules: true`) so we skip the large tauri-cef
-      # fork the core image doesn't need. The Dockerfile COPYs vendor/ because
-      # [patch.crates-io] resolves Rust SDK crates from vendor/.
+      # Every submodule, not an enumerated subset. The Dockerfile COPYs vendor/
+      # because [patch.crates-io] resolves Rust SDK crates from vendor/, and an
+      # uninitialised submodule is copied in as an EMPTY directory — cargo then
+      # fails on the missing manifest before it compiles anything.
+      #
+      # This used to name eight paths, to skip "the large tauri-cef fork the
+      # core image doesn't need". That fork stopped being a submodule in
+      # `1843706c3 refactor(tauri): replace CEF runtime with upstream Wry`, so
+      # there is nothing left for the list to exclude: all ten entries in
+      # `.gitmodules` are `path` dependencies of the root crate, and cargo reads
+      # every one of their manifests to resolve, `optional` or not. A subset is
+      # therefore always a bug, which is what the list kept producing — it went
+      # stale three times (tinymemory in `54f8710f`, then tinywallet and
+      # tinyhosts together, issue #5594), and each time the breakage surfaced at
+      # RELEASE time rather than in PR CI.
+      #
+      # Enumerating buys nothing once nothing can legitimately be excluded, so
+      # the enumeration is gone rather than corrected a third time.
       - name: Init vendored Rust submodules
-        run: git submodule update --init --recursive vendor/tinyagents vendor/tinyflows vendor/tinycortex vendor/tinychannels vendor/tinyplace vendor/tinyhumans-sdk vendor/tinybus vendor/tinymemory
+        run: git submodule update --init --recursive
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Log in to GHCR

--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -293,11 +293,26 @@ jobs:
         with:
           ref: ${{ needs.prepare-build.outputs.build_ref }}
           fetch-depth: 1
-      # Targeted init (not `submodules: true`) so we skip the large tauri-cef
-      # fork the core image doesn't need. The Dockerfile COPYs vendor/ because
-      # [patch.crates-io] resolves Rust SDK crates from vendor/.
+      # Every submodule, not an enumerated subset. The Dockerfile COPYs vendor/
+      # because [patch.crates-io] resolves Rust SDK crates from vendor/, and an
+      # uninitialised submodule is copied in as an EMPTY directory — cargo then
+      # fails on the missing manifest before it compiles anything.
+      #
+      # This used to name eight paths, to skip "the large tauri-cef fork the
+      # core image doesn't need". That fork stopped being a submodule in
+      # `1843706c3 refactor(tauri): replace CEF runtime with upstream Wry`, so
+      # there is nothing left for the list to exclude: all ten entries in
+      # `.gitmodules` are `path` dependencies of the root crate, and cargo reads
+      # every one of their manifests to resolve, `optional` or not. A subset is
+      # therefore always a bug, which is what the list kept producing — it went
+      # stale three times (tinymemory in `54f8710f`, then tinywallet and
+      # tinyhosts together, issue #5594), and each time the breakage surfaced at
+      # RELEASE time rather than in PR CI.
+      #
+      # Enumerating buys nothing once nothing can legitimately be excluded, so
+      # the enumeration is gone rather than corrected a third time.
       - name: Init vendored Rust submodules
-        run: git submodule update --init --recursive vendor/tinyagents vendor/tinyflows vendor/tinycortex vendor/tinychannels vendor/tinyplace vendor/tinyhumans-sdk vendor/tinybus vendor/tinymemory
+        run: git submodule update --init --recursive
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Build image (no push)


### PR DESCRIPTION
## Summary

- The release Docker jobs initialised submodules from a **hand-maintained 8-entry list** while `.gitmodules` declares **10**, so `vendor/tinyhosts` and `vendor/tinywallet` were never checked out and cargo could not resolve two path dependencies.
- **Production releases have been blocked since 2026-08-07**; staging carries a byte-identical list and is broken the same way. Both are fixed here.
- The enumeration is **removed**, not corrected: nothing remains that it could legitimately exclude, so a subset is always a bug.
- ⚠️ **Release-blocking — this needs to reach `release`.** It targets `main` per the fleet default; a maintainer will need to promote or cherry-pick it, since `release` is where the blocked pipeline actually runs.

## Problem

The Dockerfile does `COPY vendor/ vendor/`, so an uninitialised submodule arrives in the image as an **empty directory**. Cargo then fails on the missing manifest before compiling anything:

```
error: failed to get `tinyhosts` as a dependency of package `openhuman v0.63.12 (/build)`
Caused by: failed to read `/build/vendor/tinyhosts/Cargo.toml`
Caused by: No such file or directory (os error 2)
```

`optional = true` does not exempt these: cargo reads every `path` dependency's manifest to build the lockfile whether or not the feature is enabled. The failing build proves it — `tinyhosts` is declared `optional = true` and still broke resolution.

**Fixing only `tinyhosts` would not have worked.** Cargo stops at the first unresolvable dependency, and `tinywallet` (`Cargo.toml:524`) sits behind `tinyhosts` (`:493`). Both were missing; both are added.

## Solution

I removed the list rather than adding two names to it, and the deciding evidence is that **nothing is left for it to exclude**:

1. **The stated rationale is gone.** The comment justified the subset as skipping *"the large tauri-cef fork the core image doesn't need"*. `tauri-cef` stopped being a submodule in `1843706c3 refactor(tauri): replace CEF runtime with upstream Wry`. It is not in `.gitmodules` today, so a recursive init cannot pull it — the ~28 remaining `tauri-cef` references in the tree are docs, scripts and TS, plus exactly one `Cargo.toml` line that is a *comment*, not a dependency.
2. **All ten declared submodules are required.** Every entry in `.gitmodules` is a `path` dependency of the root crate. The only other `vendor/` path dep, `motosan-ai-oauth`, is a committed directory rather than a submodule (`git ls-files` lists its sources), so it is unaffected either way. A correct list is therefore *always* all ten — the enumeration had no legitimate degrees of freedom left, only the ability to be wrong.
3. **Nothing heavy gets dragged in.** The two missing crates are **508K** and **836K**, and their only nested submodule is `tinybus`, which the old list already named.
4. **It had already drifted three times**, each surfacing at *release* time rather than in PR CI — `tinymemory` (fixed in `54f8710f`), then `tinywallet` and `tinyhosts` together (this issue). Correcting it a third time would schedule a fourth.

This also makes the proposed "add a CI guard that asserts the list matches `Cargo.toml`" follow-up unnecessary for this class: there is no list left to drift.

Both files get the identical change, so staging and production cannot diverge again.

## Verification — the pipeline is the only real test

**Stated plainly: a `.github/workflows` change cannot be proven locally.** It only executes on a `workflow_dispatch` of the release pipelines, which I am not authorised to run, and this repo's rule is to verify Rust through CI rather than building locally.

What I could check, I did:

- Both files **parse as YAML**, and the changed step resolves to exactly `git submodule update --init --recursive` in the `build-docker` job of each (11 jobs parsed in production, 5 in staging).
- `.gitmodules` declares 10 paths; the old list named 8; the two missing names are exactly `vendor/tinyhosts` and `vendor/tinywallet`.
- `git submodule update --init vendor/tinyhosts vendor/tinywallet` succeeds and both contain a `Cargo.toml` — so the checkout the workflow will now perform does produce the manifests cargo was looking for.
- `tauri-cef` absent from `.gitmodules`, and the commit that removed it identified.

The honest confirmation is the next `Release Staging` dispatch reaching the Docker build step. **Nothing in this PR is exercised by PR CI**, so a green run here is not evidence the fix works.

## Submission Checklist

- [x] N/A: this is a `.github/workflows` change with no application code; there is no unit-testable surface, and the only execution path is a release dispatch. — Tests added or updated (happy path + at least one failure / edge case)
- [x] N/A: no changed lines are Rust or TS, so `diff-cover` has nothing to measure on this diff. — **Diff coverage ≥ 80%**
- [x] N/A: behaviour-only CI change; no feature rows added, removed or renamed. — Coverage matrix updated
- [x] N/A: no feature IDs are touched by a workflow submodule-init change. — All affected feature IDs listed under `## Related`
- [x] No new external network dependencies introduced — the two submodules are already declared in `.gitmodules` and already fetched by every other job that uses `submodules: recursive`; this adds no new remote.
- [x] N/A: no release-cut *surface* changes — the smoke checklist covers what a release produces, and this changes only how the builder checks out its sources. (It does unblock the release from running at all.) — Manual smoke checklist updated
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

**Platform:** Linux/Docker (`openhuman-core` image) on the production and staging release pipelines. No runtime, application or user-visible change — nothing ships differently, the builder simply checks out the sources it already required.

**Performance:** two additional submodules and their nested `tinybus` (already fetched). 508K + 836K, negligible against the image build.

**Security / compatibility / migration:** none. No new remotes, no dependency version changes, no lockfile change.

**Risk if wrong:** contained to the release pipeline, which is already failing — this cannot regress a passing state.

## Related

- Closes: #5594
- Follow-up PR(s)/TODOs: #5595 — the desktop matrix hits `timeout-minutes: 90` on macOS and Linux while Windows passes with **9 seconds** of margin, so a release still cannot go green on this fix alone. Filed separately with the measurement that the researcher's write-up did not have: desktop build time roughly **doubled** between 08-13 and 08-19 (Windows, the uncensored control leg: 51m58s → 89m01s → 89m51s), so the ceiling is the symptom rather than the cause.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A — filed from GitHub issue #5594, no Linear ticket.
- URL: N/A — see https://github.com/tinyhumansai/openhuman/issues/5594

### Commit & Branch

- Branch: `fix/5594-release-submodule-list`
- Commit SHA: `fe5bcb224`

### Validation Run

- [x] N/A: no files under `app/` are touched. — `pnpm --filter openhuman-app format:check`
- [x] N/A: no TypeScript is touched; the diff is two workflow YAML files. — `pnpm typecheck`
- [x] N/A: there is no test that exercises a workflow file. Focused checks run instead: both YAMLs parse and the changed step resolves to the intended command in each `build-docker` job. — Focused tests
- [x] N/A: no Rust changed. Building openhuman locally is also disallowed in this repo; Rust is verified through CI. — Rust fmt/check (if changed)
- [x] N/A: no Tauri/`src-tauri` files changed. — Tauri fmt/check (if changed)

### Validation Blocked

- `command:` the release pipelines (`Release Staging` / `Release Production`, `workflow_dispatch`)
- `error:` not run — dispatching a release is a maintainer action, and PR CI does not execute these workflows
- `impact:` the fix is unverified end-to-end until a release dispatch reaches the Docker build step. The failure mode if it is still wrong is identical and immediate (cargo cannot read a `vendor/*/Cargo.toml`), so it fails loudly rather than shipping a bad image.

### Behavior Changes

- Intended behavior change: the release Docker jobs initialise every declared submodule instead of eight named ones.
- User-visible effect: none directly. Indirectly, production and staging releases can build again.

### Parity Contract

- Legacy behavior preserved: yes for the eight previously-named submodules — they are still initialised recursively, by the same command in the same step. The change is purely additive in effect (8 → 10).
- Guard/fallback/dispatch parity checks: production and staging receive byte-identical edits, which is what stops the two pipelines drifting apart again — they were byte-identical before and are byte-identical after.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A — no duplicates found for #5594.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production and staging release builds by ensuring all required Rust components are initialized automatically.
  * Removed outdated exclusions that could cause release builds to fail when new components were added.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->