### PR TITLE
fix(build): stop serialising release codegen — macOS desktop 90m timeout to 46m

### DIFF
--- a/.github/workflows/build-desktop.yml
+++ b/.github/workflows/build-desktop.yml
@@ -98,7 +98,11 @@ jobs:
   build:
     name: "Desktop: ${{ matrix.settings.artifact_suffix }}"
     runs-on: ${{ matrix.settings.platform }}
-    timeout-minutes: 90
+    # 120, not 90: the macOS legs were clipped at exactly 90m in every failing
+    # run (#5595), so their true duration was never observed. The codegen-units
+    # fix should bring these back to ~45-50 min; the extra headroom means a slow
+    # runner reports a real result instead of another censored timeout.
+    timeout-minutes: 120
     environment: Production
     strategy:
       fail-fast: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1214,11 +1214,22 @@ split-debuginfo = "packed"
 # `dsymutil` first and keeps the DWARF. Do not "simplify" by dropping the
 # `debug` line: that would empty the dSYM and un-symbolicate production.
 #
-# Cost: release builds are slower (one codegen unit + an LTO pass). The `ci`
-# profile below deliberately overrides all three, so the fast CI lanes are
-# unaffected.
+# Cost: release builds are slower (an LTO pass). The `ci` profile below
+# deliberately overrides all three, so the fast CI lanes are unaffected.
+#
+# `codegen-units` was 1 from #5541 until #5595. That serialised codegen for the
+# entire crate and took the desktop release matrix from ~46 min to ~84 min
+# (+82%) — past the 90-minute job timeout in `build-desktop.yml`, which blocked
+# every production release from 2026-08-14. The `ci` override meant the PR
+# lanes never saw it, so it surfaced only at release time.
+#
+# 16 restores codegen parallelism. `lto = "thin"` still does cross-crate
+# inlining and `strip = "symbols"` is unchanged, so the expectation is that
+# most of #5541's 43% size win survives — but that is an expectation, not a
+# measurement. If the binary grows materially, the tradeoff to revisit is
+# `lto = "fat"` with `codegen-units = 16`, not a return to one codegen unit.
 lto = "thin"
-codegen-units = 1
+codegen-units = 16
 strip = "symbols"
 
 # Fast CI builds: trade runtime perf for compile speed

--- a/app/src-tauri-mobile/Cargo.toml
+++ b/app/src-tauri-mobile/Cargo.toml
@@ -58,5 +58,7 @@ custom-protocol = ["tauri/custom-protocol"]
 debug = "line-tables-only"
 split-debuginfo = "packed"
 lto = "thin"
-codegen-units = 1
+# 16, not 1 — see the root `Cargo.toml` for why (#5595: one codegen unit cost
+# the desktop release matrix +82% build time and blocked every release).
+codegen-units = 16
 strip = "symbols"

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -312,7 +312,9 @@ split-debuginfo = "packed"
 # change here needs the same change in the root `Cargo.toml` and in
 # `app/src-tauri-mobile/Cargo.toml` (the iOS/Android host).
 lto = "thin"
-codegen-units = 1
+# 16, not 1 — see the root `Cargo.toml` for why (#5595: one codegen unit cost
+# the desktop release matrix +82% build time and blocked every release).
+codegen-units = 16
 strip = "symbols"
 
 # Fast CI builds: trade runtime perf for compile speed


### PR DESCRIPTION
## Summary

- Identifies and fixes the cause of the desktop build-time doubling that #5595 records as unexplained: `codegen-units = 1` on `[profile.release]`.
- Cuts the macOS build from **hitting the 90-minute timeout** to **46 minutes**, verified on a real desktop matrix run.
- Raises `timeout-minutes` to 120 as headroom — see the note below, it is now insurance rather than a requirement.

## Problem

#5595 documents the symptom precisely and states the open question plainly: *"Something between 2026-08-13 and 2026-08-19 roughly doubled desktop build time across all three platforms. **I have not identified what**."*

It is `38ec4b0a` — *"perf(build): cut the release binary 43% via LTO, codegen-units and strip"* (#5541, 2026-08-14), which added `lto = "thin"`, `codegen-units = 1` and `strip = "symbols"` to `[profile.release]` in both cargo worlds. It landed ~9 hours after the last passing release run and before every failing one.

The commit anticipated the cost and reasoned it was contained:

> `# Cost: release builds are slower (one codegen unit + an LTO pass). The 'ci'`
> `# profile below deliberately overrides all three, so the fast CI lanes are unaffected.`

That is correct about the PR lanes and wrong about the release lane: the desktop matrix builds `--release`, not `ci` (`release-production.yml:353`), so it absorbs the full cost. The regression was invisible pre-merge **by construction**.

### Two independent measurements

Windows never times out, so its durations are uncensored — step 18 (`Build and package Tauri app`):

| leg | 08-13 | 08-19 |
|---|---|---|
| **windows (control)** | **46m13s** | **84m14s** (+82%) |
| aarch64-apple-darwin | 49m37s ✅ | 1h28m22s ⛔ |
| x86_64-apple-darwin | 39m45s ✅ | 1h28m17s ⛔ |

And staging ran the *same tree the same day* with `build_profile: debug`, 21 minutes before the first failing production run: macOS aarch64 in **15m46s** versus production's **1h28m22s**. Same runners, same commits. The profile is the only variable.

This also explains the log signature — both macOS legs go quiet after `Compiling directories v5.0.1` for ~80 minutes. That is not a hang; a single-codegen-unit LTO link over an 825-crate binary emits nothing while it runs.

## Solution

`codegen-units = 16` restores codegen parallelism while keeping `lto = "thin"` and `strip = "symbols"`, so #5541's size win should largely survive. All three cargo worlds move together, as the profile comments require.

### Verified on a real desktop matrix run

Fork run with no secrets, `build_profile: release`:

| leg | build step now | before | change |
|---|---|---|---|
| **aarch64-apple-darwin** | **45.9m — success** | ≥88.4m, killed at the cap | **−48%** |
| **x86_64-apple-darwin** | **success** | ≥88.3m, killed at the cap | — |
| windows | 45.6m | 84.2m | −46% |

Both macOS legs, which had failed every release run since 2026-08-14, now pass.

### Two honest caveats

1. **The −48% is a lower bound.** Pre-fix macOS was clipped at the 90-minute cap, so its true duration was never observed.
2. **I have not measured the binary size.** The expectation is that thin LTO plus `strip` retains most of #5541's 43% reduction, but that is an expectation. If the binary grows materially, the tradeoff to revisit is `lto = "fat"` with `codegen-units = 16` — **not** a return to one codegen unit. Worth a reviewer checking against #5541's number before this is considered settled.

### On the timeout bump

`timeout-minutes: 120` was written when macOS durations were censored and genuinely unknown. **With the profile fixed at ~46 minutes, 90 would now be comfortable.** I have kept 120 as protection against a slow runner, but it is insurance, not a requirement — strike it if you would rather keep the ceiling tight as a regression tripwire. I would not object.

## Submission Checklist

- [x] Tests added or updated — `N/A: build-profile configuration change.` There is no unit test for "the release build is fast enough"; the evidence is the matrix run above, with Windows and a same-day debug build as controls.
- [x] **Diff coverage ≥ 80%** — `N/A: no executable lines changed.` The diff is Cargo profile keys, a workflow timeout value and comments.
- [x] Coverage matrix updated — `N/A: no feature added, removed or renamed.`
- [x] All affected feature IDs listed under `## Related` — `N/A: no matrix feature IDs touched.`
- [x] No new external network dependencies introduced — none.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: build timing only; no packaging, signing or artifact surface changes.`
- [x] Linked issue closed via `Closes #NNN` — deliberately **not** closing. See `## Related`.

## Impact

- **Platform:** all five desktop targets; unblocks the two macOS legs.
- **Performance:** release builds roughly halve. Runtime performance is unchanged by `codegen-units` in any way I can measure here; `lto = "thin"` still does cross-crate inlining.
- **Risk:** binary size. Unmeasured, stated plainly above.
- Mobile (`app/src-tauri-mobile`) moves in lockstep as its own comment requires, so the iOS/Android lanes get the same change.

## Related

- Closes: *(none — deliberately)*
- Refs #5595. I have **not** used a closing keyword: #5595's remaining scope after this is whether to keep the 120-minute ceiling and whether the size tradeoff is acceptable, both of which are maintainer calls. Close it when those are settled.
- Follow-up PR(s)/TODOs: measure the binary against #5541's 43% target; the Linux release blockers are in a separate PR so a dispute here cannot block them.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: N/A
- Commit SHA: N/A

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — ran, clean (pre-commit hook; prettier + `cargo fmt` both pass).
- [x] `pnpm typecheck` — N/A: no TypeScript changed.
- [x] Focused tests: N/A: no test targets this change. Validated by the desktop matrix run quoted above.
- [x] Rust fmt/check (if changed): `cargo fmt --check` ran clean via the pre-commit hook on both manifests. A full `cargo check` was **not** run locally — a release-profile build is precisely the 45-minute operation under discussion; CI is the right place for it.
- [x] Tauri fmt/check (if changed): `cargo fmt --check` on `app/src-tauri` clean via the same hook.

### Validation Blocked
- `command:` local `cargo build --release` to measure binary size
- `error:` not blocked by tooling — declined on cost/disk grounds (~25-35GB of `target/` and ~45 minutes per world)
- `impact:` the size claim is stated as an expectation, not a measurement. Flagged for a reviewer.

### Behavior Changes
- Intended behavior change: release builds compile with 16 codegen units instead of 1.
- User-visible effect: none at runtime. Release artifacts may be marginally larger.

### Parity Contract
- Legacy behavior preserved: `lto` and `strip` unchanged, so the debug-symbol/dSYM and Sentry symbolication path (#1403) is untouched.
- Guard/fallback/dispatch parity checks: `[profile.ci]` still overrides all three keys, so PR-lane timings are unchanged.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Improvements**
  * Increased the maximum time allowed for desktop release builds.
  * Optimized release build settings to reduce build times while preserving compact binaries and performance optimizations.
  * Applied faster release compilation settings across desktop and mobile builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->