### PR TITLE
fix(ci): run the Rust lanes when any vendored crate moves

### DIFF
--- a/.github/workflows/ci-lite.yml
+++ b/.github/workflows/ci-lite.yml
@@ -154,8 +154,16 @@ jobs:
               - 'scripts/check-linux-tls-dependencies.sh'
               - 'scripts/test-rust-e2e.sh'
               - 'scripts/test-rust-with-mock.sh'
-              - 'vendor/motosan-ai-oauth/**'
-              - 'vendor/tinychannels'
+              # Every vendored crate, not an enumeration. `[patch.crates-io]`
+              # force-resolves all ten submodules by path, so ANY pointer bump
+              # changes what this crate compiles against. The previous list
+              # named two of them, so a bump to the other eight ran no openhuman
+              # Rust lane at all while PR CI Gate still reported success.
+              # Enumerating here failed the same way the release Docker
+              # submodule list did three times before #5596 replaced it with
+              # `--init --recursive`. Do not go back to a list.
+              - '.gitmodules'
+              - 'vendor/**'
             # Changes here invalidate per-module test scoping → full suite.
             rust-core-full:
               - '.github/workflows/ci-lite.yml'
@@ -167,8 +175,11 @@ jobs:
               - 'rust-toolchain.toml'
               - 'scripts/ci-cancel-aware.sh'
               - 'scripts/check-linux-tls-dependencies.sh'
-              - 'vendor/motosan-ai-oauth/**'
-              - 'vendor/tinychannels'
+              # A vendored-crate bump invalidates per-module test scoping for the
+              # same reason a Cargo.lock change does: it moves the dependency
+              # graph under every module. Full suite, not scoped.
+              - '.gitmodules'
+              - 'vendor/**'
             rust-core-src:
               - 'src/**'
               - 'tests/**'
@@ -185,6 +196,11 @@ jobs:
               - 'rust-toolchain.toml'
               - 'app/src-tauri/**'
               - 'scripts/ci-cancel-aware.sh'
+              # The shell is a second Cargo world with its own duplicate
+              # `[patch.crates-io]` table pointing at the same submodules, so it
+              # is affected by a bump exactly as the core is. It named none.
+              - '.gitmodules'
+              - 'vendor/**'
             # Shared mock backend + script self-tests. The mock backend every
             # E2E suite depends on had zero PR-lane coverage before this (its
             # own socket-auth tests never ran in CI) — arm the scripts


### PR DESCRIPTION
## Summary

- Makes any vendored-crate pointer bump run the openhuman Rust lanes. Today it runs none of them while `PR CI Gate` still reports success.
- Replaces an enumeration of vendored paths with `vendor/**`, because the enumeration is what went stale.

## Problem

`92bab8df` ("bump tinycortex") changes exactly one thing — the `vendor/tinycortex` pointer. [CI Lite run 32358998415](https://github.com/tinyhumansai/openhuman/actions/runs/32358998415):

```
success   TinyCortex Memory Tests
success   PR CI Gate                          <- the aggregate gate
skipped   Rust Quality (fmt, clippy)
skipped   Rust Core Coverage (cargo-llvm-cov)
skipped   Rust Feature-Gate Smoke (gates off)
skipped   Rust Tauri Coverage (cargo-llvm-cov)
```

That commit is the current tip of `main`, so **the tip of main has not been compiled by CI**, and `main` is what `promote-main-to-release.yml` moves to `release`.

The `changes` filters enumerate vendored paths and the list is stale: `rust-core` and `rust-core-full` name `vendor/motosan-ai-oauth/**` and `vendor/tinychannels` — 2 of 10 submodules, and `motosan-ai-oauth` is an in-tree directory rather than a submodule. `rust-tauri` names none at all. The `tinycortex` filter that did match feeds only TinyCortex's own test lane, which is why that ran while nothing compiled openhuman against the new pin.

Every vendored crate is force-resolved by path through `[patch.crates-io]` in **both** cargo worlds, so any bump changes what the core and the shell compile against.

## Solution

Match `vendor/**` and `.gitmodules` in `rust-core`, `rust-core-full` and `rust-tauri`.

Deliberately **not** a list of the ten current submodules. The release Docker job had this exact defect: its hand-maintained list went stale three times before `fe5bcb22` (#5596) replaced it with `--init --recursive`, and that commit message says so. A list here fails the same way on the eleventh crate.

`rust-core-full` gets them too — a dependency-graph change invalidates per-module test scoping for the same reason a `Cargo.lock` change does.

**Cost:** a vendored bump now runs the full Rust lanes rather than nothing. That is the intent; eight of the ten crates could previously move with zero verification.

## Submission Checklist

- [x] Tests added or updated — `N/A: CI path-filter configuration.` The behaviour under change is which jobs a given diff triggers, which is only observable in a real CI run; the reproduction is quoted above and the fix is verifiable by pushing a vendor-only diff.
- [x] **Diff coverage ≥ 80%** — `N/A: no executable lines changed.` YAML filter globs and comments.
- [x] Coverage matrix updated — `N/A: no feature added, removed or renamed.`
- [x] All affected feature IDs listed under `## Related` — `N/A: no matrix feature IDs touched.`
- [x] No new external network dependencies introduced — none.
- [x] Manual smoke checklist updated — `N/A: does not touch a release-cut surface.`
- [x] Linked issue closed via `Closes #NNN` — see `## Related`.

## Impact

- **CI cost:** vendored bumps become expensive rather than free. Given #5598 — a pinned artifact diverging from the submodule the host compiles against — a bump is the change most likely to break the build and least likely to be checked.
- **Risk:** low. Widening a path filter can only cause more jobs to run, never fewer.

## Related

- Closes: #5612
- Follow-up PR(s)/TODOs: the sibling fail-open, where the coverage lane reports success after running zero tests, is #5613.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: N/A
- Commit SHA: N/A

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — N/A: no formatted source changed (workflow YAML only).
- [x] `pnpm typecheck` — N/A: no TypeScript changed.
- [x] Focused tests: N/A: no test targets a path filter.
- [x] Rust fmt/check (if changed): N/A: no Rust changed.
- [x] Tauri fmt/check (if changed): N/A: no Tauri source changed.

### Validation Blocked
- `command:` observing the filter fire on a vendored bump
- `error:` not reproducible locally — `dorny/paths-filter` evaluates against the PR's changed-file set on GitHub
- `impact:` verified by reading the filters against the observed skip in run 32358998415; the first vendored bump after merge is the live confirmation.

### Behavior Changes
- Intended behavior change: a diff touching `vendor/**` or `.gitmodules` now triggers the Rust lanes in full-suite mode.
- User-visible effect: none.

### Parity Contract
- Legacy behavior preserved: all existing filter entries are unchanged; this only adds.
- Guard/fallback/dispatch parity checks: `vendor/**` is a superset of the two paths previously named, so nothing that triggered before stops triggering.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CI change detection to recognize all vendored dependency updates.
  * Ensured relevant Rust core, full-suite, and Tauri checks run when vendored code or submodule references change.
  * Prevented changes to unlisted vendored components from incorrectly bypassing validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->