### PR TITLE
fix(agent): rename spawn_parallel graph topology to resolve dual kind collision (#5601)

### DIFF
--- a/src/openhuman/agent/tinyagents/topology.rs
+++ b/src/openhuman/agent/tinyagents/topology.rs
@@ -66,7 +66,7 @@ pub(crate) fn all_graph_topologies() -> Vec<GraphTopologyReport> {
         crate::openhuman::agent::orchestration::spawn_parallel_graph::spawn_parallel_graph_topology(
         )
     {
-        out.push(describe("spawn_parallel_agents", &t));
+        out.push(describe("spawn_parallel_graph", &t));
     }
 
     // Not exported: generic item-count-driven `map_reduce` fan-outs whose node

--- a/src/openhuman/agent/tinyagents/topology_tests.rs
+++ b/src/openhuman/agent/tinyagents/topology_tests.rs
@@ -20,7 +20,11 @@ fn all_topologies_includes_the_member_graph() {
 #[test]
 fn all_topologies_includes_delegation_and_workflow_scheduler() {
     let reports = all_graph_topologies();
-    for name in ["delegation", "workflow_runs:scheduler"] {
+    for name in [
+        "delegation",
+        "workflow_runs:scheduler",
+        "spawn_parallel_graph",
+    ] {
         let report = reports
             .iter()
             .find(|r| r.name == name)
@@ -34,6 +38,54 @@ fn all_topologies_includes_delegation_and_workflow_scheduler() {
             report.mermaid.contains("flowchart"),
             "{name} mermaid should render: {}",
             report.mermaid
+        );
+    }
+}
+
+#[test]
+fn all_topologies_names_do_not_collide_with_production_tools() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let config = std::sync::Arc::new(crate::openhuman::config::Config::default());
+    let security = std::sync::Arc::new(crate::openhuman::security::SecurityPolicy::default());
+    let audit = std::sync::Arc::new(
+        crate::openhuman::security::AuditLogger::new(
+            crate::openhuman::config::AuditConfig {
+                enabled: false,
+                log_path: "audit.log".into(),
+                max_size_mb: 10,
+            },
+            tmp.path().to_path_buf(),
+        )
+        .expect("create audit logger"),
+    );
+    let browser = crate::openhuman::config::BrowserConfig::default();
+    let http = crate::openhuman::config::HttpRequestConfig::default();
+    let agents = std::collections::HashMap::new();
+
+    let tools = crate::openhuman::tools::all_tools(
+        config.clone(),
+        &security,
+        audit,
+        &browser,
+        &http,
+        tmp.path(),
+        &agents,
+        &config,
+    );
+    let tool_names: std::collections::HashSet<_> = tools.iter().map(|t| t.name()).collect();
+
+    // Verify runtime tool `spawn_parallel_agents` is present in the checked tool set
+    assert!(
+        tool_names.contains("spawn_parallel_agents"),
+        "expected spawn_parallel_agents in production all_tools registration"
+    );
+
+    let reports = all_graph_topologies();
+    for report in &reports {
+        assert!(
+            !tool_names.contains(report.name),
+            "graph name '{}' collides with registered tool of the same name",
+            report.name
         );
     }
 }


### PR DESCRIPTION
Closes #5601

### Summary of Changes
- Renamed exported structural graph topology from `spawn_parallel_agents` to `spawn_parallel_graph` in `src/openhuman/agent/tinyagents/topology.rs`.
- Resolves ambiguous dispatch warnings in `CapabilityRegistry` caused by tool/graph name collision on `spawn_parallel_agents`.
- Added collision-prevention regression test `all_topologies_names_do_not_collide_with_production_tools` in `topology_tests.rs` ensuring no graph topology name clashes with registered production tools.

### Verification
- `cargo test --manifest-path Cargo.toml --lib openhuman::agent::tinyagents::topology` (passed)
- `cargo check --manifest-path Cargo.toml` (passed)

### Checklist
- [x] Code formatting (`cargo fmt`) and clippy linter pass locally.
- [x] Unit tests covering topology name collision added to `topology_tests.rs`.
- [x] N/A - Documentation updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the reported name of the spawn-parallel graph topology to `spawn_parallel_graph`, improving consistency when viewing or consuming topology reports.
  * Prevented graph topology names from conflicting with registered tool names.

* **Tests**
  * Added coverage confirming the topology is exported, structurally valid, renderable as Mermaid, and uniquely named.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->