### PR TITLE
fix(mcp): add uvx PATH preflight check and actionable guidance (#5600)

### DIFF
--- a/src/openhuman/mcp/config_servers/spawn_env.rs
+++ b/src/openhuman/mcp/config_servers/spawn_env.rs
@@ -151,7 +151,10 @@ fn version_manager_dirs() -> Vec<PathBuf> {
     #[cfg(windows)]
     {
         if let Some(local_app_data) = dirs::data_local_dir() {
-            push_if_dir(&mut dirs, local_app_data.join("Programs").join("uv").join("bin"));
+            push_if_dir(
+                &mut dirs,
+                local_app_data.join("Programs").join("uv").join("bin"),
+            );
             push_if_dir(&mut dirs, local_app_data.join("Programs").join("uv"));
             push_if_dir(&mut dirs, local_app_data.join("bin"));
         }

--- a/src/openhuman/mcp/config_servers/spawn_env.rs
+++ b/src/openhuman/mcp/config_servers/spawn_env.rs
@@ -148,6 +148,14 @@ fn version_manager_dirs() -> Vec<PathBuf> {
         push_if_dir(&mut dirs, home.join(".cargo").join("bin"));
         dirs.extend(nvm_latest_bin_dir(&home));
     }
+    #[cfg(windows)]
+    {
+        if let Some(local_app_data) = dirs::data_local_dir() {
+            push_if_dir(&mut dirs, local_app_data.join("Programs").join("uv").join("bin"));
+            push_if_dir(&mut dirs, local_app_data.join("Programs").join("uv"));
+            push_if_dir(&mut dirs, local_app_data.join("bin"));
+        }
+    }
     for fixed in ["/opt/homebrew/bin", "/usr/local/bin", "/usr/local/sbin"] {
         push_if_dir(&mut dirs, PathBuf::from(fixed));
     }

--- a/src/openhuman/mcp/config_servers/stdio.rs
+++ b/src/openhuman/mcp/config_servers/stdio.rs
@@ -311,4 +311,28 @@ mod tests {
             "expected Node.js guidance, got: {err}"
         );
     }
+
+    #[tokio::test]
+    async fn initialize_missing_uvx_mentions_uv_and_docs_link() {
+        let client = McpStdioClient::new(
+            "uvx".to_string(),
+            Vec::new(),
+            vec![("PATH".to_string(), "/openhuman/does-not-exist".to_string())],
+            None,
+            McpClientIdentityConfig::default(),
+        );
+        let err = client
+            .initialize()
+            .await
+            .expect_err("missing uvx must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("uv (Python)"),
+            "expected uv guidance, got: {msg}"
+        );
+        assert!(
+            msg.contains("https://docs.astral.sh/uv/"),
+            "expected uv docs link, got: {msg}"
+        );
+    }
 }


### PR DESCRIPTION
Closes #5600

### Summary of Changes
- Added Windows \%LOCALAPPDATA%\Programs\uv\bin\ and standard \uv\ installation fallback directories to \ersion_manager_dirs()\ in \spawn_env.rs\.
- Added unit test \initialize_missing_uvx_mentions_uv_and_docs_link\ in \stdio.rs\ verifying that missing \uvx\ produces actionable installation guidance pointing to \https://docs.astral.sh/uv/\.

### Verification
- \cargo test --manifest-path Cargo.toml --lib openhuman::mcp::config_servers::stdio\ (passed)
- \cargo check --manifest-path Cargo.toml\ (passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows command resolution by recognizing commonly used local application directories.
  * Enhanced error messages when an `uvx`-based connection cannot start, including guidance for installing `uv (Python)` and a link to official documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->