### PR TITLE
fix(hosting): compile the hosting family into the product

### DIFF
--- a/.github/workflows/ci-lite.yml
+++ b/.github/workflows/ci-lite.yml
@@ -143,6 +143,14 @@ jobs:
               # The changed-files runner itself must trigger the lane that
               # runs it (it is also in rust-core-full → full-suite mode).
               - 'scripts/ci/rust-coverage-changed.sh'
+              # The product feature set decides what the Rust lanes below
+              # actually compile (clippy's `--features`, the test suite's, and
+              # rust-coverage-changed.sh's). Changing it changes the code under
+              # test as surely as editing `Cargo.toml` does, so it has to arm
+              # this lane too — #5619 turned `hosting` on and, without this
+              # entry, resolved to `["rust-tauri"]` alone, skipping every lane
+              # that would have compiled the family it enabled.
+              - 'scripts/ci/product-features.*'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'build.rs'
@@ -160,6 +168,10 @@ jobs:
             rust-core-full:
               - '.github/workflows/ci-lite.yml'
               - 'scripts/ci/rust-coverage-changed.sh'
+              # Same reason as in `rust-core` above: a feature-set change
+              # changes what compiles, which invalidates per-module scoping
+              # exactly as a `Cargo.toml` change does.
+              - 'scripts/ci/product-features.*'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'build.rs'

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4424,6 +4424,7 @@ dependencies = [
  "tinycortex",
  "tinycortex-api",
  "tinyflows",
+ "tinyhosts",
  "tinyhumans-sdk",
  "tinymemory",
  "tinymemory-api",
@@ -7154,6 +7155,21 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "tinyhosts"
+version = "0.1.5"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "hex",
+ "percent-encoding",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha1",
+ "thiserror 2.0.20",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -182,6 +182,12 @@ openhuman_core = { path = "../..", package = "openhuman", default-features = fal
     # shipped app, the memory_diff agent tool is absent, and the embedded
     # driver stops advertising Capability::Diff — the product keeps all three.
     "memory-git",
+    # Declared "Default-OFF, product-ON" by its own gate comment in the root
+    # Cargo.toml, but it reached neither the product set nor this list, so the
+    # family was compiled in no configuration at all. Registration stays
+    # credential-gated in tools/ops.rs, so a host with no hosting credential
+    # sees no new tools.
+    "hosting",
 ] }
 
 [target.'cfg(unix)'.dependencies]

--- a/scripts/ci/product-features.txt
+++ b/scripts/ci/product-features.txt
@@ -96,3 +96,12 @@ runtime-node
 # Git-backed memory diff (snapshots/checkpoints/read markers) and the git wiki
 # mirror of summary nodes. Carries git2 + vendored libgit2.
 memory-git
+
+# The `hosting_*` agent tools: put a workspace on a real hosting provider and
+# manage its sites, databases, environment, domains and deployments over the
+# tinyhosts unified model. Its gate in the root Cargo.toml declares
+# "Default-OFF, product-ON" but it reached neither this file nor the shell's
+# forwarding list, so the family compiled in no configuration. Tool
+# registration stays credential-gated (`tools/ops.rs`), so enabling this adds
+# nothing for a host without a hosting credential.
+hosting


### PR DESCRIPTION
## Summary

- Compiles the `hosting` family into the product. It is currently built in **no** configuration — 1,643 lines including a 511-line test file and nine `hosting_*` agent tools, shipped in nothing.
- Restores the gate's own declared intent ("Default-OFF, product-ON"); this is not a new product decision.

## Problem

The gate exists in the root `Cargo.toml` and states what should happen:

> `# ... Default-OFF, product-ON: a host with no hosting credential has no use for the tools, and an agent that can deploy to the internet is authority a headless embedding should have to ask for.`

But `hosting` is in `[features] default` — no; in `scripts/ci/product-features.txt` — no; in the shell's forwarding list — no. "product-ON" never happened.

**Why the guard did not catch it.** `check-feature-forwarding.mjs` asserts set equality between the core's default gates and the shell's forwarding list. `hosting` is absent from both, the sets agree, the gate passes. A gate cannot catch a feature nobody told it about.

This is the shape of #4901, where `voice` shipped missing to 56 users — the incident that guard was built to prevent.

It is also the concrete case behind #5613: because `hosting` is in no CI command, `Rust Core Coverage` on #5593 ran `0 tests; 12202 filtered out` and reported success.

## Solution

Add `hosting` to `scripts/ci/product-features.txt` and to the shell's forwarding list together — the forwarding gate requires both to move at once.

Everything else was already wired: `src/openhuman/mod.rs:29` declares the module behind the gate and `src/openhuman/tools/ops.rs:1031` registers the tools.

### This does not expose anything to users who have not asked for it

Tool registration is credential-gated on `Account::from_config`, matching the gate's own comment that *"a tool that cannot work is worse than a tool that is not there"*. A host without `[hosting].api_key` or the provider's environment variable sees **no new tools**. What changes is that the code is compiled, linted and tested.

`app/src-tauri/Cargo.lock` gains `tinyhosts 0.1.5` — a required consequence, and CI builds `--locked`, so it ships with the change. Verified the lockfile diff is that one package and nothing else.

## Submission Checklist

- [x] Tests added or updated — `N/A: build-configuration change.` The family already carries a 511-line `test.rs` which this PR causes to be **compiled and run for the first time**. That is the substance of the change: no new test is needed, an existing suite starts executing.
- [x] **Diff coverage ≥ 80%** — `N/A: no executable lines changed.` The diff is a feature-list entry, a forwarding-list entry and a lockfile.
- [x] Coverage matrix updated — `hosting` newly reaches the product set. If the matrix tracks it as a feature row, it wants adding; I could not find an existing `hosting` row to update, so flagging for a reviewer rather than inventing one.
- [x] All affected feature IDs listed under `## Related` — `N/A: no matrix feature IDs identified for hosting.`
- [x] No new external network dependencies introduced — none at build time. At runtime the tools call a hosting provider, but only once a credential resolves, which is pre-existing behaviour now actually reachable.
- [x] Manual smoke checklist updated — flagged: this is the first build in which `hosting_*` tools can appear, so a smoke entry for "configure a hosting credential, confirm the tools register" is worth adding. Not added here — I would rather a maintainer own that wording.
- [x] Linked issue closed via `Closes #NNN` — see `## Related`.

## Impact

- **Build:** the core and shell now compile `openhuman::hosting` and link `tinyhosts`. Expect a small build-time and binary-size increase.
- **Runtime:** none for users without a hosting credential.
- **Risk:** the family has never been compiled by CI, so this PR is the first time its 1,643 lines face the compiler and its tests run. That is the point, but it means this PR's own CI result is the first real signal about that code. If it goes red, the failure is pre-existing rather than introduced here.

## Related

- Closes: #5614
- Refs #5613 (the coverage gate that let it through), tinyhumansai/openhuman#5578 (added the domain), #5593 (added rollback/history/logs).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: N/A
- Commit SHA: N/A

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — N/A: no formatted source changed.
- [x] `pnpm typecheck` — N/A: no TypeScript changed.
- [x] Focused tests: `node scripts/ci/check-feature-forwarding.mjs` → OK, 19 shell forwards, both lists moved together.
- [x] Rust fmt/check (if changed): N/A: no Rust source changed — this enables existing Rust.
- [x] Tauri fmt/check (if changed): N/A: `app/src-tauri/Cargo.toml` feature list + lockfile only.

### Validation Blocked
- `command:` `cargo check --features "$(bash scripts/ci/product-features.sh)"` including hosting
- `error:` not blocked by tooling — declined on cost (a second ~25-35GB `target/` for the product feature set)
- `impact:` the family's first compile happens in this PR's CI. Called out under Impact.

### Behavior Changes
- Intended behavior change: `openhuman::hosting` is compiled into the product and the shell.
- User-visible effect: none without a hosting credential; with one, the nine `hosting_*` tools become available as originally intended.

### Parity Contract
- Legacy behavior preserved: the gate remains default-OFF, so headless embedders opt in explicitly.
- Guard/fallback/dispatch parity checks: `check-feature-forwarding.mjs` passes with both lists updated.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled hosting capabilities in the desktop application.
  * Added tools for managing hosted sites, databases, environments, domains, and deployments.
  * Hosting tools remain available only when the required credentials are configured.
  * Added support for managing hosting workflows from the application, including deployment-related operations and workspace hosting setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->