### PR TITLE
fix(memory): advertise what the pinned module serves, not the whole contract

### DIFF
--- a/src/openhuman/modules/memory.rs
+++ b/src/openhuman/modules/memory.rs
@@ -41,7 +41,75 @@
 
 use std::sync::Arc;
 
-use crate::openhuman::memory::api::capabilities::Capabilities;
+use crate::openhuman::memory::api::capabilities::{Capabilities, Capability};
+
+/// The release whose capability set [`ARTIFACT_CAPABILITIES`] was read from.
+///
+/// Checked against the registry pin by `the_capability_list_matches_the_pinned_release`,
+/// so bumping the pin without re-reading the list is a red test rather than a
+/// silent over-claim.
+const ARTIFACT_CAPABILITIES_PIN: &str = "1.0.1";
+
+/// The capability families the **pinned artifact** actually serves.
+///
+/// Deliberately not `Capabilities::all()`. `Capability::ALL` is what the
+/// *contract crate this host compiles against* declares; the loaded `cdylib` is
+/// an older release and serves fewer families. Read from `Capability::ALL` in
+/// `api/src/capabilities.rs` at tag `v1.0.1` — thirteen entries. The five the
+/// contract has since added (`People`, `Chunks`, `Retrieval`, `Profile`,
+/// `Episodic`) have no bus member in that artifact, so calling them returns
+/// `tinybus::Error::UnknownMethod` (#5598).
+///
+/// **Widen this only together with the `version` bump in
+/// [`super::registry`].**
+const ARTIFACT_CAPABILITIES: &[Capability] = &[
+    Capability::Core,
+    Capability::Recall,
+    Capability::Ingest,
+    Capability::Documents,
+    Capability::Tree,
+    Capability::Entities,
+    Capability::Graph,
+    Capability::Diff,
+    Capability::Goals,
+    Capability::ToolMemory,
+    Capability::Sources,
+    Capability::Maintenance,
+    Capability::Portability,
+];
+
+/// Escape hatch for a locally-built module.
+///
+/// Set `OPENHUMAN_MEMORY_MODULE_ASSUME_FULL_CAPABILITIES=1` when the loaded
+/// library was built from `vendor/tinymemory/crates/tinymemory-module` rather
+/// than downloaded from the pinned release — that build serves the whole
+/// contract, and pinning it to the older list would hide families it does have.
+/// Deliberately **not** keyed off `TINYMEMORY_TEST_MODULE`: CI sets that to the
+/// downloaded `v1.0.1` artifact, so keying off it would switch the guard off in
+/// exactly the lane that must exercise it.
+fn assume_full_capabilities() -> bool {
+    matches!(
+        std::env::var("OPENHUMAN_MEMORY_MODULE_ASSUME_FULL_CAPABILITIES")
+            .ok()
+            .as_deref()
+            .map(str::trim),
+        Some("1") | Some("true") | Some("yes") | Some("on")
+    )
+}
+
+/// The set this build will advertise for the module driver.
+fn artifact_capabilities() -> Capabilities {
+    if assume_full_capabilities() {
+        return Capabilities::all();
+    }
+    ARTIFACT_CAPABILITIES.iter().copied().collect()
+}
+
+/// Whether the pinned artifact serves `capability`. Drives the optional
+/// `as_*()` accessors so they agree with [`artifact_capabilities`].
+fn artifact_serves(capability: Capability) -> bool {
+    assume_full_capabilities() || ARTIFACT_CAPABILITIES.contains(&capability)
+}
 use crate::openhuman::memory::api::chunks::Chunk;
 use crate::openhuman::memory::api::error::MemoryError;
 use crate::openhuman::memory::api::goals::GoalsDoc;
@@ -309,29 +377,30 @@ impl MemoryProvider for ModuleMemoryProvider {
         &self.driver_id
     }
 
-    /// Every family is implemented by the pinned compiled module.
+    /// The families the **pinned artifact** serves — not the whole contract.
     ///
-    /// # This couples to the registry pin, and the coupling is not enforced
+    /// # This couples to the registry pin, and the coupling IS enforced
     ///
     /// `Capabilities::all()` grows whenever a family is added to the contract,
     /// but the *artifact* only grows when a release is cut and
-    /// [`registry`](super::registry) is re-pinned to it. Between those two
-    /// moments this over-claims: the host says it can do something the loaded
-    /// binary cannot.
+    /// [`registry`](super::registry) is re-pinned to it. Returning `all()`
+    /// between those two moments over-claimed: the host said it could do
+    /// something the loaded binary could not, and [`Self::verify`] noticed and
+    /// logged it without narrowing the advertised set. The failure mode was a
+    /// call that reached the module and came back `UnknownMethod` (#5598)
+    /// rather than a family that cleanly reported itself absent.
     ///
-    /// [`Self::verify`] notices and logs, but it does **not** narrow the
-    /// advertised set — so the failure mode is a call that reaches the module
-    /// and comes back as an unknown method, not a family that quietly turns
-    /// itself off.
+    /// [`ARTIFACT_CAPABILITIES`] is now the source of truth, and
+    /// `the_capability_list_matches_the_pinned_release` fails if it is widened
+    /// without moving [`ARTIFACT_CAPABILITIES_PIN`] and the registry pin
+    /// together.
     ///
-    /// Today `people` is exactly that case: family fourteen is served by the
-    /// module source in this tree but not by the pinned `1.0.1` artifact. It is
-    /// currently inert, because nothing in the host reaches `as_people()` yet.
-    /// **It stops being inert the moment the people RPC handlers are routed
-    /// through this driver**, so that change and the module release must land
-    /// together — see `docs/specs/2026-08-13-memory-module-port.md` stage 2.
+    /// The kernel filters its RPC surface and agent-tool assembly from this set,
+    /// and the guard builds one family decorator per `provides()`, so an
+    /// over-claim here is precisely what turns an absent family into a live
+    /// method that answers `UnknownMethod`.
     fn capabilities(&self) -> Capabilities {
-        Capabilities::all()
+        artifact_capabilities()
     }
 
     async fn health(&self) -> MemoryHealth {
@@ -392,17 +461,23 @@ impl MemoryProvider for ModuleMemoryProvider {
     fn as_maintenance(&self) -> Option<&dyn MemoryMaintenance> {
         Some(self)
     }
+    // The four families below are gated on the pinned artifact rather than
+    // returning `Some(self)` unconditionally. `provides()` derives from these
+    // accessors, the guard builds its decorators from `provides()`, and every
+    // caller already writes a clean "driver does not support the X family"
+    // error on `None` — so gating here converts a deep `UnknownMethod` into an
+    // early, accurate refusal at every call site at once (#5598).
     fn as_people(&self) -> Option<&dyn MemoryPeople> {
-        Some(self)
+        artifact_serves(Capability::People).then_some(self as &dyn MemoryPeople)
     }
     fn as_chunks(&self) -> Option<&dyn MemoryChunks> {
-        Some(self)
+        artifact_serves(Capability::Chunks).then_some(self as &dyn MemoryChunks)
     }
     fn as_retrieval(&self) -> Option<&dyn MemoryRetrieval> {
-        Some(self)
+        artifact_serves(Capability::Retrieval).then_some(self as &dyn MemoryRetrieval)
     }
     fn as_profile(&self) -> Option<&dyn MemoryProfile> {
-        Some(self)
+        artifact_serves(Capability::Profile).then_some(self as &dyn MemoryProfile)
     }
 }
 

--- a/src/openhuman/modules/memory.rs
+++ b/src/openhuman/modules/memory.rs
@@ -99,7 +99,19 @@ fn assume_full_capabilities() -> bool {
 
 /// The set this build will advertise for the module driver.
 fn artifact_capabilities() -> Capabilities {
-    if assume_full_capabilities() {
+    capabilities_for(assume_full_capabilities())
+}
+
+/// The advertised set for a given override state.
+///
+/// Split out from [`artifact_capabilities`] so the pinned-artifact invariants
+/// can be asserted on the `false` branch directly. Reading the environment
+/// inside the assertion would make those tests fail for anyone who has
+/// `OPENHUMAN_MEMORY_MODULE_ASSUME_FULL_CAPABILITIES=1` exported — a documented,
+/// supported configuration — and mutating the variable from a test would race
+/// the rest of the binary.
+fn capabilities_for(assume_full: bool) -> Capabilities {
+    if assume_full {
         return Capabilities::all();
     }
     ARTIFACT_CAPABILITIES.iter().copied().collect()
@@ -338,16 +350,25 @@ impl ModuleMemoryProvider {
     /// Cross-check the module's advertised capabilities against what this build
     /// assumes, once per process.
     ///
-    /// Logged rather than fatal. Any mismatch means the registry pin and the
-    /// artifact have diverged; advertising less is the dangerous direction,
-    /// because the host assembled its full memory surface from this static set.
+    /// Compared against [`artifact_capabilities`] rather than
+    /// `Capabilities::all()`: the pinned `v1.0.1` artifact answers thirteen
+    /// families, so comparing with the eighteen the contract declares would warn
+    /// on the *expected* state at every first module use and leave the warning
+    /// permanently crying wolf. Against the configured set it fires only when
+    /// the loaded artifact genuinely disagrees with the pin — including when the
+    /// full-capability override is on but an older artifact was loaded.
+    ///
+    /// Logged rather than fatal. A mismatch means the registry pin and the
+    /// artifact have diverged; the module advertising *less* than this build
+    /// assumes is the dangerous direction, because the host assembles its memory
+    /// RPC surface and tool families from the assumed set before any call.
     async fn verify(&self, proxy: &tinybus::Proxy) {
         if self.verified.get().is_some() {
             return;
         }
         match proxy.call::<Capabilities>("Capabilities", ()).await {
             Ok(actual) => {
-                let assumed = Capabilities::all();
+                let assumed = artifact_capabilities();
                 if actual != assumed {
                     log::warn!(
                         "[modules:memory] the module advertises {actual:?} but this build \

--- a/src/openhuman/modules/memory_tests.rs
+++ b/src/openhuman/modules/memory_tests.rs
@@ -43,16 +43,35 @@ fn construction_touches_no_io_and_needs_no_runtime() {
 }
 
 #[test]
-fn the_advertised_capabilities_cover_the_complete_memory_api() {
-    // The compiled module owns the complete TinyMemory API, so the host can
-    // assemble every memory RPC and tool family before the async bus starts.
+fn the_advertised_capabilities_match_the_pinned_artifact() {
+    // Renamed from `..._cover_the_complete_memory_api`, which asserted
+    // `capabilities == Capabilities::all()`. That encoded #5598 as the expected
+    // behaviour: the host advertised all eighteen families the contract crate
+    // declares while the pinned v1.0.1 artifact serves thirteen, so the other
+    // five answered UnknownMethod instead of reporting themselves absent.
+    //
+    // The part that was always true is still pinned below: the host assembles
+    // the memory RPC surface and its tool families from this set before the
+    // async bus starts, so a missing mandatory family is a boot-time defect.
     let capabilities = provider().capabilities();
-    assert_eq!(capabilities, Capabilities::all());
 
     for mandatory in Capability::MANDATORY {
         assert!(capabilities.contains(mandatory), "{mandatory:?} is missing");
     }
     assert!(capabilities.contains(Capability::Tree));
+
+    // A strict subset of the contract: the artifact is a released binary and the
+    // contract is the crate this host compiles against, so the contract may be
+    // ahead but can never be behind.
+    assert!(
+        Capabilities::all().contains_all(capabilities),
+        "the artifact advertises a family the contract does not declare",
+    );
+    assert_ne!(
+        capabilities,
+        Capabilities::all(),
+        "advertising the whole contract is the #5598 over-claim",
+    );
 }
 
 #[test]
@@ -189,4 +208,55 @@ async fn shutdown_on_an_unused_driver_is_a_no_op() {
 
     let provider = ModuleMemoryProvider::new(Arc::new(config));
     assert!(provider.shutdown().await.is_ok());
+}
+
+#[test]
+fn the_capability_list_matches_the_pinned_release() {
+    // ARTIFACT_CAPABILITIES describes what ONE specific release of the module
+    // serves. Re-pinning the registry to a newer release without re-reading that
+    // list would silently re-introduce #5598 in the other direction — the host
+    // would under-claim and hide families the new artifact does have.
+    //
+    // Tying the two together here means the pin bump is a red test, not a
+    // silent drift.
+    let record = crate::openhuman::modules::registry::find(super::MODULE_ID)
+        .expect("the tinymemory module must be in the registry");
+    assert_eq!(
+        record.version,
+        super::ARTIFACT_CAPABILITIES_PIN,
+        "the registry pin moved to {} but ARTIFACT_CAPABILITIES is still the list read from {}. \
+         Re-read Capability::ALL at the new tag, update both, and re-run.",
+        record.version,
+        super::ARTIFACT_CAPABILITIES_PIN,
+    );
+}
+
+#[test]
+fn the_advertised_set_does_not_over_claim_the_artifact() {
+    // The regression guard for #5598 proper: the driver must not advertise a
+    // family the pinned artifact cannot serve. Capabilities::all() is what the
+    // CONTRACT declares; the artifact is older and smaller.
+    use crate::openhuman::memory::api::capabilities::{Capabilities, Capability};
+
+    let advertised = super::artifact_capabilities();
+    for capability in [
+        Capability::People,
+        Capability::Chunks,
+        Capability::Retrieval,
+        Capability::Profile,
+    ] {
+        assert!(
+            !advertised.contains(capability),
+            "{capability:?} is advertised but the pinned {} artifact does not serve it — \
+             this is exactly the over-claim that made memory_tree, memory_store_raw_chunks \
+             and memory_diff answer UnknownMethod (#5598)",
+            super::ARTIFACT_CAPABILITIES_PIN,
+        );
+    }
+
+    assert_ne!(
+        advertised,
+        Capabilities::all(),
+        "advertising the whole contract is the bug this test exists to prevent",
+    );
 }

--- a/src/openhuman/modules/memory_tests.rs
+++ b/src/openhuman/modules/memory_tests.rs
@@ -67,10 +67,27 @@ fn the_advertised_capabilities_match_the_pinned_artifact() {
         Capabilities::all().contains_all(capabilities),
         "the artifact advertises a family the contract does not declare",
     );
+    // Stated on the pinned branch, not on `capabilities`, so the documented
+    // `OPENHUMAN_MEMORY_MODULE_ASSUME_FULL_CAPABILITIES=1` override cannot turn
+    // this red. Every assertion above holds under both configurations; this one
+    // is about the pin itself.
     assert_ne!(
-        capabilities,
+        super::capabilities_for(false),
         Capabilities::all(),
         "advertising the whole contract is the #5598 over-claim",
+    );
+}
+
+#[test]
+fn the_full_capability_override_restores_the_whole_contract() {
+    // The escape hatch for a locally-built module, which does serve the whole
+    // contract. Asserted through `capabilities_for` rather than by setting
+    // `OPENHUMAN_MEMORY_MODULE_ASSUME_FULL_CAPABILITIES` — mutating a
+    // process-global env var would race every other test in this binary.
+    assert_eq!(super::capabilities_for(true), Capabilities::all());
+    assert_ne!(
+        super::capabilities_for(true),
+        super::capabilities_for(false)
     );
 }
 
@@ -238,12 +255,19 @@ fn the_advertised_set_does_not_over_claim_the_artifact() {
     // CONTRACT declares; the artifact is older and smaller.
     use crate::openhuman::memory::api::capabilities::{Capabilities, Capability};
 
-    let advertised = super::artifact_capabilities();
+    // `capabilities_for(false)` rather than `artifact_capabilities()`: the
+    // invariant is a property of the pinned list, and reading the environment
+    // here would make this test fail for anyone running with the documented
+    // `OPENHUMAN_MEMORY_MODULE_ASSUME_FULL_CAPABILITIES=1` override.
+    let advertised = super::capabilities_for(false);
     for capability in [
         Capability::People,
         Capability::Chunks,
         Capability::Retrieval,
         Capability::Profile,
+        // The fifth family the contract added after v1.0.1. Without it the
+        // explicit check below passes if only `Episodic` is added by mistake.
+        Capability::Episodic,
     ] {
         assert!(
             !advertised.contains(capability),


### PR DESCRIPTION
## Summary

- Stops the module memory driver advertising capability families the pinned artifact cannot serve — the direct cause of #5598.
- Converts a deep `UnknownMethod` from inside the module into a clean, early "driver does not support this family" refusal.
- Adds a test that fails if the registry pin moves without the capability list being re-read.

## Problem

`ModuleMemoryProvider::capabilities()` returned `Capabilities::all()` — all eighteen families the contract crate this host compiles against declares. The artifact it loads is the pinned `tinymemory` **v1.0.1**, which serves **thirteen**. The five it does not serve are `People`, `Chunks`, `Retrieval`, `Profile`, `Episodic`.

tinymemory's contract makes a minor skew like this safe on purpose: capability negotiation hides families the bound driver does not advertise. Returning `all()` defeats that mechanism at the one point where it matters. `verify()` already *detects* the divergence — it logs it and leaves the advertised set untouched.

So the kernel builds an RPC surface and an agent-tool list for families that cannot answer, and #5598's `memory_tree`, `memory_store_raw_chunks` and `memory_diff` return `UnknownMethod` from deep inside the call.

The existing doc comment on `capabilities()` described this defect precisely and called it inert. It is not inert — the kernel filters its RPC surface and tool assembly from this set, and the guard builds one family decorator per `provides()`.

## Solution

`ARTIFACT_CAPABILITIES` becomes the source of truth, read from `Capability::ALL` at tag v1.0.1. The four optional accessors (`as_people`, `as_chunks`, `as_retrieval`, `as_profile`) derive from the same list, so the advertised claim and the reachable surface cannot drift apart.

### This is a correction, not a regression

No `push_cap` site and no `tool_capability()` arm names any of the five families, so **no RPC namespace and no agent tool disappears** — `memory_families_registered_when_capabilities_advertised` passes unchanged. What changes is the shape of an existing failure: callers that were reaching the module and getting `UnknownMethod` now get the clean refusal each of them already writes for `None`.

### Escape hatch

`OPENHUMAN_MEMORY_MODULE_ASSUME_FULL_CAPABILITIES=1` restores the old behaviour for a locally-built module from `vendor/tinymemory`, which does serve the whole contract. Deliberately **not** keyed off `TINYMEMORY_TEST_MODULE`: CI sets that to the downloaded v1.0.1 artifact, so keying off it would switch the guard off in exactly the lane that must exercise it.

### A test asserted the bug

`the_advertised_capabilities_cover_the_complete_memory_api` asserted `capabilities == Capabilities::all()`, on the stated premise that *"the compiled module owns the complete TinyMemory API"*. It encoded the over-claim as expected behaviour. Rewritten as `the_advertised_capabilities_match_the_pinned_artifact`, keeping the mandatory-family and `Tree` assertions — which were always true — and replacing the equality with a strict-subset check.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — three: `the_capability_list_matches_the_pinned_release` (fails if the registry pin moves without the list being re-read — the same bug in the other direction, the host under-claiming and hiding families a newer artifact does have), `the_advertised_set_does_not_over_claim_the_artifact` (the #5598 guard proper), and the rewritten subset test. Verified non-vacuous: the rewritten test **failed** against the pre-fix code, which is how the bug-asserting test was found.
- [x] **Diff coverage ≥ 80%** — could not measure locally (a coverage build needs a second instrumented `target/`). Every changed line is either the new constants, the two-line `capabilities()` body, or four one-line accessors, and all are exercised by the tests above. Flagging for the lane rather than claiming a number I did not compute.
- [x] Coverage matrix updated — `N/A: behaviour-only change`; no feature row added, removed or renamed.
- [x] All affected feature IDs listed under `## Related` — `N/A: no matrix feature IDs touched.`
- [x] No new external network dependencies introduced — none.
- [x] Manual smoke checklist updated — `N/A: no release-cut surface touched.`
- [x] Linked issue closed via `Closes #NNN` — deliberately **not** closing #5598. See `## Related`.

## Impact

- **Runtime:** the four accessors return `None` for families the pinned artifact does not serve. Every caller already handles `None` with an explicit error.
- **Risk:** low, and bounded by the fact that the affected families already fail today — just later and less legibly.
- **Not fixed here:** the underlying pin skew. The artifact is 169 commits behind `vendor/tinymemory`; closing that needs a tinymemory release plus a registry re-pin, and is outside this PR.

## Related

- Refs #5598. **Not** using a closing keyword: this makes the failure honest, it does not restore the five families. #5598 asks for `memory_tree` to work, which needs the pin bump. Close it when the artifact catches up.
- Refs #5612 — no CI job guards the artifact/submodule pairing, which is why this skew went unnoticed.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue
- Key: N/A
- URL: N/A

### Commit & Branch
- Branch: N/A
- Commit SHA: N/A

### Validation Run
- [x] `pnpm --filter openhuman-app format:check` — N/A: no formatted JS/TS changed.
- [x] `pnpm typecheck` — N/A: no TypeScript changed.
- [x] Focused tests: `cargo test --lib openhuman::modules::memory` → **16 passed, 0 failed**.
- [x] Rust fmt/check (if changed): `cargo check --tests` → clean, exit 0, no diagnostics in the changed files.
- [x] Tauri fmt/check (if changed): N/A: no Tauri source changed.

### Validation Blocked
- `command:` `cargo llvm-cov` for a diff-coverage number
- `error:` not blocked by tooling — declined on disk cost (a separate instrumented target tree)
- `impact:` the coverage checkbox above is annotated rather than claimed.

### Behavior Changes
- Intended behavior change: the driver advertises thirteen families instead of eighteen, and four optional accessors return `None` accordingly.
- User-visible effect: calls into the five unserved families fail with a clear "driver does not support the X family" error instead of `UnknownMethod` from inside the module.

### Parity Contract
- Legacy behavior preserved: the thirteen served families are untouched; the ten already-served optional accessors keep returning `Some(self)`.
- Guard/fallback/dispatch parity checks: `push_cap` and `tool_capability()` name none of the five families, so registration is unchanged and the existing registration test passes as-is.

### Duplicate / Superseded PR Handling
- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Memory modules now advertise only the capabilities they actually support.
  - Unsupported People, Chunks, Retrieval, and Profile operations are prevented from being invoked.
  - Capability reporting now stays aligned with the loaded module version.
  - Full-capability locally built modules can be enabled through an environment setting.

- **Tests**
  - Added coverage to verify required capabilities are advertised without claiming unsupported functionality.
  - Verified capability reporting remains aligned with the registered module version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->