### PR TITLE
fix(integrations): include required OAuth scopes for Reddit authorization (#5507)

### DIFF
--- a/src/openhuman/integrations/composio/client_part_01.rs
+++ b/src/openhuman/integrations/composio/client_part_01.rs
@@ -21,6 +21,9 @@ const POST_OAUTH_ACTION_RETRY_DELAY: Duration = Duration::from_secs(10);
 const POST_OAUTH_AUTH_ERROR_STRINGS: &[&str] = &["connection error, try to authenticate"];
 const AUTHORIZE_OAUTH_SCOPES_FIELD: &str = "oauth_scopes";
 const GMAIL_REQUIRED_OAUTH_SCOPES: &[&str] = &["https://www.googleapis.com/auth/gmail.readonly"];
+/// Required OAuth scopes for Reddit integration covering user verification,
+/// post/comment reading, and subscribed subreddit listing (#5507).
+const REDDIT_REQUIRED_OAUTH_SCOPES: &[&str] = &["identity", "read", "mysubreddits"];
 
 /// High-level client for all backend-proxied Composio operations.
 #[derive(Clone)]
@@ -603,6 +606,11 @@ fn required_oauth_scopes_for_toolkit(toolkit: &str) -> &'static [&'static str] {
         // profile-only Google token and trigger enable fails with 403 insufficient
         // authentication scopes (#2186).
         "gmail" => GMAIL_REQUIRED_OAUTH_SCOPES,
+        // Reddit actions require `identity` for user verification, `read` for
+        // retrieving posts and comments, and `mysubreddits` for listing subscribed
+        // communities. Without these explicit scopes, Reddit OAuth handoffs fail
+        // with HTTP 400 Bad Request or omit necessary token permissions (#5507).
+        "reddit" => REDDIT_REQUIRED_OAUTH_SCOPES,
         _ => &[],
     }
 }

--- a/src/openhuman/integrations/composio/client_tests_part_01_tests.rs
+++ b/src/openhuman/integrations/composio/client_tests_part_01_tests.rs
@@ -278,6 +278,65 @@ async fn authorize_merges_gmail_required_oauth_scopes_with_extra_params() {
     assert_eq!(resp.connection_id, "conn-gmail");
 }
 
+/// Verifies that `authorize()` for Reddit automatically attaches mandatory non-sensitive OAuth scopes (#5507)
+/// ensuring permissions for identity, reading, and subscribed subreddits.
+#[tokio::test]
+async fn authorize_merges_reddit_required_oauth_scopes() {
+    let app = Router::new().route(
+        "/agent-integrations/composio/authorize",
+        post(|Json(body): Json<Value>| async move {
+            assert_eq!(body["toolkit"].as_str(), Some("reddit"));
+            let scopes: Vec<&str> = body["oauth_scopes"]
+                .as_array()
+                .expect("reddit authorize should include oauth_scopes")
+                .iter()
+                .map(|item| item.as_str().expect("scope should be a string"))
+                .collect();
+            let expected = ["identity", "read", "mysubreddits"];
+            assert_eq!(scopes.len(), expected.len());
+            for &exp in &expected {
+                assert!(scopes.contains(&exp), "missing expected scope: {exp}");
+            }
+            Json(json!({
+                "success": true,
+                "data": {
+                    "connectUrl": "https://composio.example/reddit/consent",
+                    "connectionId": "conn-reddit"
+                }
+            }))
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let client = build_client_for(base);
+    let resp = client.authorize("reddit", None).await.unwrap();
+    assert_eq!(resp.connect_url, "https://composio.example/reddit/consent");
+    assert_eq!(resp.connection_id, "conn-reddit");
+}
+
+/// Verifies that unmapped toolkits (such as Notion) do not have artificial `oauth_scopes` injected into authorize payload.
+#[tokio::test]
+async fn authorize_omits_oauth_scopes_for_unmapped_toolkit() {
+    let app = Router::new().route(
+        "/agent-integrations/composio/authorize",
+        post(|Json(body): Json<Value>| async move {
+            assert_eq!(body["toolkit"].as_str(), Some("notion"));
+            assert!(body.get("oauth_scopes").is_none());
+            Json(json!({
+                "success": true,
+                "data": {
+                    "connectUrl": "https://composio.example/notion/consent",
+                    "connectionId": "conn-notion"
+                }
+            }))
+        }),
+    );
+    let base = start_mock_backend(app).await;
+    let client = build_client_for(base);
+    let resp = client.authorize("notion", None).await.unwrap();
+    assert_eq!(resp.connect_url, "https://composio.example/notion/consent");
+    assert_eq!(resp.connection_id, "conn-notion");
+}
+
 #[tokio::test]
 async fn authorize_forwards_extra_params_and_returns_connect_url() {
     let app = Router::new().route(


### PR DESCRIPTION
Closes #5507

## Summary

- Add `REDDIT_REQUIRED_OAUTH_SCOPES` constant to `ComposioClient` specifying minimal Reddit OAuth scopes (`identity`, `read`, `mysubreddits`) required for user verification, reading posts/comments, and listing subscribed subreddits.
- Map `"reddit"` toolkit in `required_oauth_scopes_for_toolkit` in `src/openhuman/integrations/composio/client_part_01.rs` to automatically inject required scopes during authorization handoffs.
- Add unit tests in `src/openhuman/integrations/composio/client_tests_part_01_tests.rs` validating scope injection and omission for unmapped toolkits.

## Problem

- In Reddit connector integrations, authorization requests lacked explicit OAuth scopes.
- Reddit rejected token exchange with HTTP 400 Bad Request / 403 Forbidden, leaving the UI connection modal indefinitely stuck in `PENDING` until the 5-minute timeout.

## Solution

- Registered minimal non-sensitive Reddit OAuth scopes in `required_oauth_scopes_for_toolkit` mirroring the existing Gmail pattern.
- Ensures Reddit authorization flows request necessary user verification and reading permissions while avoiding broad write or private messaging scopes.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy
- [x] **Diff coverage >= 80%** - changed lines meet the gate enforced by ci-lite.yml
- [x] Coverage matrix updated (N/A: behaviour-only change)
- [x] All affected feature IDs from the matrix are listed in the PR description under Related
- [x] No new external network dependencies introduced (mock backend used per Testing Strategy)
- [x] Manual smoke checklist updated (N/A)
- [x] Linked issue closed via `Closes #5507` in the Related section

## Impact

- Fixes Reddit integration connection failures and timeouts without requesting unnecessary write or private messaging permissions.

## Related

- Closes #5507


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Reddit authorization now requests the required access scopes for identity, reading content, and subscribed communities.

- **Bug Fixes**
  - Improved OAuth authorization handling so unsupported integrations do not receive unnecessary scope parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->