### PR TITLE
chore(arch): bump openhuman-bin to v0.63.7 + add auto-bump pkgver()

### DIFF
--- a/packages/arch/openhuman-bin/PKGBUILD
+++ b/packages/arch/openhuman-bin/PKGBUILD
@@ -16,6 +16,7 @@ optdepends=(
 provides=('openhuman')
 conflicts=('openhuman')
 options=('!strip')
+makedepends=('python')
 source=(
   "OpenHuman_${pkgver}_amd64.AppImage::https://github.com/tinyhumansai/openhuman/releases/download/v${pkgver}/OpenHuman_${pkgver}_amd64.AppImage"
   'openhuman'
@@ -55,7 +56,12 @@ for a in d.get('assets'):
 ")
   local actual
   actual=$(sha256sum "OpenHuman_${pkgver}_amd64.AppImage" | cut -d' ' -f1)
-  if [ -n "${expected}" ] && [ "${expected}" != "${actual}" ]; then
+  if [ -z "${expected}" ]; then
+    echo "ERROR: Could not retrieve upstream digest for v${pkgver}." >&2
+    echo "  Cannot verify AppImage integrity; refusing to install unverified binary." >&2
+    exit 1
+  fi
+  if [ "${expected}" != "${actual}" ]; then
     echo "ERROR: AppImage sha256 mismatch for v${pkgver}" >&2
     echo "  expected: ${expected}" >&2
     echo "  actual:   ${actual}" >&2

--- a/packages/arch/openhuman-bin/PKGBUILD
+++ b/packages/arch/openhuman-bin/PKGBUILD
@@ -1,7 +1,8 @@
 # Maintainer: OpenHuman <hello@tinyhumans.ai>
+# Contributed-by: Luu Khoa Hoc <lkhoc200443@gmail.com>
 
 pkgname=openhuman-bin
-pkgver=0.54.0
+pkgver=0.63.7
 pkgrel=1
 pkgdesc='Personal AI desktop assistant for communities'
 arch=('x86_64')
@@ -21,15 +22,46 @@ source=(
   'openhuman.desktop'
   'openhuman.svg'
 )
+# AppImage checksum is verified at build time against the upstream-published
+# digest (prepare()), so it is intentionally SKIP here. The three local files
+# are static and pinned.
 sha256sums=(
-  '2f76bc5b6f3a0e6cf2765f414a82b26903337720d190b4f9b26a5d7e2508abab'
+  'SKIP'
   'dbd46b85be9d551363b44ec19613a5fb5df4a08f5b618cb38ffe8891a0f31eeb'
   'e357a666334449273047c02740a3e3fa34c58ff00304af8b3ec1a080a9574e99'
   '7892979a084a5e2bbc73c32fe0f447918aa9b458c50bf0bb856469c837e6401c'
 )
 
+# Auto-resolve the latest stable release tag from GitHub.
+pkgver() {
+  curl -fsSL "https://api.github.com/repos/tinyhumansai/openhuman/releases/latest" \
+    | python3 -c "import json,sys; print(json.load(sys.stdin)['tag_name'].lstrip('v'))"
+}
+
 prepare() {
   cd "${srcdir}"
+
+  # Verify the downloaded AppImage against the digest published by upstream
+  # for this exact version (sha256:<hex> in the release asset metadata).
+  local expected
+  expected=$(curl -fsSL "https://api.github.com/repos/tinyhumansai/openhuman/releases/tags/v${pkgver}" \
+    | python3 -c "
+import json, sys, re
+d = json.load(sys.stdin)
+for a in d.get('assets'):
+    if re.search(r'amd64\.AppImage$', a.get('name', '')):
+        print((a.get('digest') or '').replace('sha256:', ''))
+        break
+")
+  local actual
+  actual=$(sha256sum "OpenHuman_${pkgver}_amd64.AppImage" | cut -d' ' -f1)
+  if [ -n "${expected}" ] && [ "${expected}" != "${actual}" ]; then
+    echo "ERROR: AppImage sha256 mismatch for v${pkgver}" >&2
+    echo "  expected: ${expected}" >&2
+    echo "  actual:   ${actual}" >&2
+    exit 1
+  fi
+
   rm -rf squashfs-root
   chmod +x "OpenHuman_${pkgver}_amd64.AppImage"
   "./OpenHuman_${pkgver}_amd64.AppImage" --appimage-extract >/dev/null


### PR DESCRIPTION
## Summary
- Bump the Arch `openhuman-bin` recipe from the stale pinned `0.54.0` to the latest stable `0.63.7`.
- Add a `pkgver()` that auto-resolves the latest GitHub release tag, so the recipe no longer needs a manual version bump per release.
- `prepare()` now verifies the downloaded AppImage's `sha256` against the digest published in the release asset metadata, so the AppImage source uses `SKIP` safely.

## Why
The current PKGBUILD still pins `0.54.0` and hardcodes the AppImage checksum, so it silently drifts behind every release. Auto-bumping + digest verification keeps it current and tamper-evident with zero extra maintainer work.

## Test plan
- [x] `makepkg --syncdeps --clean --cleanbuild --force` builds `openhuman-bin 0.63.7-1` on Arch Linux (x86_64).
- [x] `pkgver()` resolves `0.63.7` from the GitHub releases API.
- [x] `prepare()` sha256 check passes against the upstream-published digest `cb2b6f8f...`.
- [x] Installed app launches clean on Hyprland (Wayland) — no `--ozone-platform=x11` workaround required.

## Notes
Local files (`openhuman`, `openhuman.desktop`, `openhuman.svg`) keep their pinned checksums. Only the AppImage is version-floated and verified at build time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the Arch package to version 0.63.7.
  - Added automatic detection of the latest available release.
  - Added build-time verification that the downloaded AppImage matches the published release checksum.
- **Chores**
  - Added contributor metadata.
  - Updated package build requirements.
  - Retained integrity checks for locally packaged files.
  - Improved package update reliability by rejecting unavailable or mismatched release verification data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->