### PR TITLE
fix(memory): align stale capability tests with the pinned-artifact fix

### DIFF
--- a/src/core/cli_capability_tests.rs
+++ b/src/core/cli_capability_tests.rs
@@ -94,13 +94,33 @@ fn message_never_contains_a_credential_or_endpoint() {
 #[cfg(feature = "modules")]
 #[tokio::test]
 async fn bound_driver_probe_reports_the_default_module_driver() {
+    // Was asserting `capabilities() == Capabilities::all()`. That encoded
+    // #5598 as expected: the pinned v1.0.1 tinymemory artifact serves thirteen
+    // of the contract's eighteen families (missing `chunks`, `episodic`,
+    // `people`, `profile`, `retrieval`), so claiming the full contract made
+    // those five answer `UnknownMethod` instead of reporting themselves
+    // absent. `modules::memory::ARTIFACT_CAPABILITIES` was narrowed to match
+    // what is actually served (see its module docs); this pins the same
+    // corrected boundary rather than the stale full-contract claim.
     let cfg = MemorySubsystemConfig::default();
     let binding = binding_for("default", cfg.clone());
     assert_eq!(
         binding.driver_id(),
         crate::openhuman::memory::binding::MODULE_ID
     );
-    assert_eq!(binding.capabilities(), Capabilities::all());
+    let advertised = binding.capabilities();
+    assert!(advertised.contains_all(Capabilities::mandatory()));
+    assert!(advertised.contains(Capability::Tree));
+    assert!(
+        !advertised.contains(Capability::Retrieval),
+        "the pinned v1.0.1 artifact has no bus member for `retrieval` (#5598)"
+    );
+    assert!(Capabilities::all().contains_all(advertised));
+    assert_ne!(
+        advertised,
+        Capabilities::all(),
+        "advertising the whole contract is the #5598 over-claim"
+    );
 }
 
 /// The negative control that makes the assertions above mean something.

--- a/src/openhuman/memory/binding_tests.rs
+++ b/src/openhuman/memory/binding_tests.rs
@@ -361,21 +361,64 @@ fn module_class_binds_the_module_driver_not_null() {
 }
 
 #[test]
-fn module_binding_advertises_every_family() {
-    // Widened once per M3 step; M3d is the last one. The interesting assertion
-    // is the second: a *bound* context and an *unbound* one now agree, which
-    // they did not for the whole of M2/M3a-c.
+fn module_binding_advertises_the_pinned_artifacts_families() {
+    // Was `module_binding_advertises_every_family`, asserting `advertised ==
+    // Capabilities::all()`. That encoded #5598 as expected: the host claimed
+    // all eighteen contract families while the pinned v1.0.1 artifact serves
+    // thirteen, so the other five (`people`, `chunks`, `retrieval`, `profile`,
+    // `episodic`) answered `UnknownMethod` instead of reporting themselves
+    // absent. `modules::memory::ARTIFACT_CAPABILITIES` was narrowed to match
+    // what the pinned release actually serves (see its module docs); this
+    // test now pins the same, corrected boundary instead of the old
+    // "bound equals unbound-default" coincidence, which no longer holds.
     let dir = tempfile::tempdir().unwrap();
     let binding =
         for_workspace(dir.path(), &MemorySubsystemConfig::default()).expect("default bind");
     let advertised = binding.capabilities();
 
     assert!(advertised.contains_all(Capabilities::mandatory()));
-    for family in Capability::ALL {
+
+    const ARTIFACT_SERVES: [Capability; 13] = [
+        Capability::Core,
+        Capability::Recall,
+        Capability::Ingest,
+        Capability::Documents,
+        Capability::Tree,
+        Capability::Entities,
+        Capability::Graph,
+        Capability::Diff,
+        Capability::Goals,
+        Capability::ToolMemory,
+        Capability::Sources,
+        Capability::Maintenance,
+        Capability::Portability,
+    ];
+    for family in ARTIFACT_SERVES {
         assert!(advertised.contains(family), "{family} must be advertised");
     }
-    assert_eq!(advertised, Capabilities::all());
-    assert_eq!(advertised, unbound_default_capabilities());
+
+    const NOT_YET_SERVED: [Capability; 5] = [
+        Capability::People,
+        Capability::Chunks,
+        Capability::Retrieval,
+        Capability::Profile,
+        Capability::Episodic,
+    ];
+    for family in NOT_YET_SERVED {
+        assert!(
+            !advertised.contains(family),
+            "{family} has no bus member in the pinned v1.0.1 artifact (#5598); \
+             widen this only together with the registry version bump"
+        );
+    }
+
+    // The contract may be ahead of the artifact but never behind it.
+    assert!(Capabilities::all().contains_all(advertised));
+    // Unbound contexts still assume the widest set (deny-by-default is wrong
+    // pre-boot, per `unbound_default_capabilities`'s own docs) — that is a
+    // different, deliberately permissive default, not a claim that a bound
+    // module actually serves everything.
+    assert_eq!(unbound_default_capabilities(), Capabilities::all());
 }
 
 #[test]

--- a/src/openhuman/memory/ops/provider.rs
+++ b/src/openhuman/memory/ops/provider.rs
@@ -168,30 +168,33 @@ mod tests {
                 crate::openhuman::memory::api::CONTRACT_VERSION
             )
         );
-        // All eighteen families — the thirteen of M3d plus the five this port
-        // added (`chunks`, `episodic`, `people`, `profile`, `retrieval`).
-        // Spelled out rather than derived from `Capabilities::all()` on
-        // purpose: this is the wire surface the frontend reads, so the strings
-        // themselves are the assertion. A family added to the contract without
-        // a driver serving it should fail here, not silently widen.
+        // The thirteen families the pinned v1.0.1 tinymemory artifact actually
+        // serves — not the eighteen the contract crate declares. This used to
+        // assert all eighteen, including `chunks`, `episodic`, `people`,
+        // `profile`, and `retrieval`; that encoded #5598 as expected: those
+        // five have no bus member in the pinned release, so calling them
+        // answered `UnknownMethod` rather than reporting themselves absent.
+        // `modules::memory::ARTIFACT_CAPABILITIES` was narrowed to match what
+        // is actually served (see its module docs); this pins the same
+        // corrected boundary. Spelled out rather than derived from
+        // `Capabilities::all()` on purpose: this is the wire surface the
+        // frontend reads, so the strings themselves are the assertion. A
+        // family the pinned artifact starts serving should widen this
+        // deliberately, together with the registry version bump — not
+        // silently.
         assert_eq!(
             status.capabilities,
             vec![
-                "chunks",
                 "core",
                 "diff",
                 "documents",
                 "entities",
-                "episodic",
                 "goals",
                 "graph",
                 "ingest",
                 "maintenance",
-                "people",
                 "portability",
-                "profile",
                 "recall",
-                "retrieval",
                 "sources",
                 "tool_memory",
                 "tree"


### PR DESCRIPTION
## Summary

- Fixes three tests that still hardcoded the pre-#5620 "module driver advertises the whole 18-family contract" expectation, which has been red on `main` since PR #5620 merged.
- No production code changes — `modules::memory::ARTIFACT_CAPABILITIES` is untouched.
- Unblocks `Rust Core Coverage (cargo-llvm-cov)` / `PR CI Gate` on `main` and every PR based on it.

## Problem

PR #5620 ("fix(memory): advertise what the pinned module serves, not the whole contract", merged 2026-08-20T12:41Z) corrected `ModuleMemoryProvider::capabilities()` to advertise only the 13 families the pinned `tinymemory` v1.0.1 artifact actually serves (per issue #5598), instead of falsely claiming the full 18-family contract (`Capabilities::all()`). It updated `memory_tests.rs` to match the corrected behavior, but three other test files independently hardcoded the old, now-incorrect full-contract expectation and were not updated in that PR:

- `core::cli_capability::tests::bound_driver_probe_reports_the_default_module_driver` — asserted `binding.capabilities() == Capabilities::all()`
- `openhuman::memory::binding::tests::module_binding_advertises_every_family` — asserted every `Capability::ALL` variant is advertised and `advertised == unbound_default_capabilities()`
- `openhuman::memory::ops::provider::tests::bound_driver_status_reports_id_class_contract_and_capabilities` — asserted the wire status lists all 18 capability strings

All three have failed on every `main` run since #5620 merged (confirmed against `main` run `32373660712`, the merge of #5621: identical `12116 passed; 3 failed; 106 ignored` line, same three tests).

## Solution

Update all three tests to assert the corrected 13-family set instead of the full 18-family contract, mirroring the reasoning #5620 already established and got reviewed/merged: the pinned v1.0.1 artifact has no bus member for `people`, `chunks`, `retrieval`, `profile`, or `episodic` (#5598), so claiming them is the bug, not the fix. Where it strengthens the test, I also assert the 5 not-yet-served families are explicitly absent, so a future artifact bump that adds them is what should widen this — deliberately, per the comment already in `modules/memory.rs`.

I did not touch `ARTIFACT_CAPABILITIES` or any other production code — this is strictly bringing stale test assertions in line with already-accepted, already-merged behavior.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — three existing tests corrected; each now also asserts the negative case (the 5 not-yet-served families are absent), which is new coverage exercising #5598's guard from a second angle.
- N/A: Diff coverage ≥ 80% — test-only change to already-covered lines; no new production lines to cover.
- N/A: Coverage matrix updated — behaviour-only test correction, no feature added/removed/renamed.
- N/A: All affected feature IDs listed under `## Related` — no feature IDs affected.
- [x] No new external network dependencies introduced.
- N/A: Manual smoke checklist — no release-cut surface touched.
- [x] Linked issue — see `## Related` (does not close #5598, which tracks the longer-term artifact-capability gap; this only fixes the stale test debt from #5620).

## Impact

- CI-only: unblocks `Rust Core Coverage (cargo-llvm-cov)` on `main` (and therefore `PR CI Gate` on every open PR based on it). No runtime/platform behavior change.

## Related

- Follow-up PR(s)/TODOs: none. Issue #5598 (re-pinning `tinymemory` to a release that serves all 18 families) remains open and tracked separately; it is not blocking and this PR does not attempt to resolve it.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/stale-artifact-capability-tests`
- Commit SHA: e546845cc

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no `app/` files touched
- [x] `pnpm typecheck` — N/A: no TypeScript touched
- [x] Focused tests: `cargo test --lib -F modules -- bound_driver_probe_reports_the_default_module_driver module_binding_advertises_the_pinned_artifacts_families bound_driver_status_reports_id_class_contract_and_capabilities` — 3 passed, 0 failed
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean on all three touched files
- N/A: Tauri fmt/check (if changed) — no Tauri shell files touched

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none — test assertions only, correcting stale expectations to match already-merged production behavior from #5620.
- User-visible effect: none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated capability validation to reflect the capabilities currently advertised by supported memory artifacts.
  * Added checks ensuring required capabilities are present and unsupported capabilities are excluded.
  * Confirmed advertised capabilities remain within the defined contract.
  * Preserved full capability behavior for unbound contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->