### PR TITLE
fix(feedback): preserve API error messages

### DIFF
--- a/app/src/components/feedback/FeedbackAdminMenu.tsx
+++ b/app/src/components/feedback/FeedbackAdminMenu.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import { useT } from '../../lib/i18n/I18nContext';
 import { feedbackApi } from '../../services/api/feedbackApi';
+import { messageForApiError } from '../../services/apiError';
 import type { FeedbackItem, FeedbackStatus } from '../../types/feedback';
 import { NativeSelect } from '../ui';
 
@@ -40,7 +41,7 @@ export default function FeedbackAdminMenu({ item, onUpdated }: FeedbackAdminMenu
       onUpdated(updated);
     } catch (err) {
       log('updateStatus failed id=%s status=%s error=%O', item.id, status, err);
-      setError(err instanceof Error ? err.message : t('feedback.admin.updateFailed'));
+      setError(messageForApiError(err, t('feedback.admin.updateFailed')));
     } finally {
       setPending(false);
     }

--- a/app/src/components/feedback/FeedbackComments.test.tsx
+++ b/app/src/components/feedback/FeedbackComments.test.tsx
@@ -73,4 +73,15 @@ describe('<FeedbackComments />', () => {
 
     expect(await screen.findByText('nope')).toBeInTheDocument();
   });
+
+  it('surfaces the string from a plain apiClient rejection', async () => {
+    mockGetFeedback.mockRejectedValueOnce({
+      success: false,
+      error: 'Comments are temporarily unavailable.',
+    });
+
+    renderWithProviders(<FeedbackComments feedbackId="f1" onCommentAdded={() => {}} />);
+
+    expect(await screen.findByText('Comments are temporarily unavailable.')).toBeInTheDocument();
+  });
 });

--- a/app/src/components/feedback/FeedbackComments.test.tsx
+++ b/app/src/components/feedback/FeedbackComments.test.tsx
@@ -66,6 +66,23 @@ describe('<FeedbackComments />', () => {
     expect(onCommentAdded).toHaveBeenCalledTimes(1);
   });
 
+  it('surfaces an API error when posting a comment fails', async () => {
+    mockGetFeedback.mockResolvedValueOnce({ feedback: { id: 'f1' }, comments: [] });
+    mockAddComment.mockRejectedValueOnce({ success: false, error: 'Comment could not be posted.' });
+    const onCommentAdded = vi.fn();
+
+    renderWithProviders(<FeedbackComments feedbackId="f1" onCommentAdded={onCommentAdded} />);
+    await screen.findByText('No comments yet.');
+
+    fireEvent.change(screen.getByPlaceholderText('Add a comment'), {
+      target: { value: 'a new comment' },
+    });
+    fireEvent.click(screen.getByText('Post'));
+
+    expect(await screen.findByText('Comment could not be posted.')).toBeInTheDocument();
+    expect(onCommentAdded).not.toHaveBeenCalled();
+  });
+
   it('surfaces a load error', async () => {
     mockGetFeedback.mockRejectedValueOnce(new Error('nope'));
 

--- a/app/src/components/feedback/FeedbackComments.tsx
+++ b/app/src/components/feedback/FeedbackComments.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useUser } from '../../hooks/useUser';
 import { useT } from '../../lib/i18n/I18nContext';
 import { feedbackApi } from '../../services/api/feedbackApi';
+import { messageForApiError } from '../../services/apiError';
 import type { FeedbackComment } from '../../types/feedback';
 import { Button, TextArea } from '../ui';
 
@@ -53,7 +54,7 @@ export default function FeedbackComments({ feedbackId, onCommentAdded }: Feedbac
       .catch((error: unknown) => {
         if (requestId !== loadRequestIdRef.current) return;
         log('load comments failed id=%s error=%O', feedbackId, error);
-        setLoadError(error instanceof Error ? error.message : t('feedback.comments.loadError'));
+        setLoadError(messageForApiError(error, t('feedback.comments.loadError')));
       })
       .finally(() => {
         if (requestId === loadRequestIdRef.current) setIsLoading(false);
@@ -75,7 +76,7 @@ export default function FeedbackComments({ feedbackId, onCommentAdded }: Feedbac
       onCommentAdded();
     } catch (error) {
       log('post comment failed id=%s error=%O', feedbackId, error);
-      setPostError(error instanceof Error ? error.message : t('feedback.comments.postError'));
+      setPostError(messageForApiError(error, t('feedback.comments.postError')));
     } finally {
       setPosting(false);
     }

--- a/app/src/components/feedback/FeedbackSubmitForm.tsx
+++ b/app/src/components/feedback/FeedbackSubmitForm.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 
 import { useT } from '../../lib/i18n/I18nContext';
 import { feedbackApi } from '../../services/api/feedbackApi';
+import { messageForApiError } from '../../services/apiError';
 import type { CreateFeedbackResult, FeedbackQuality, FeedbackType } from '../../types/feedback';
 import { Button, TextArea, TextField } from '../ui';
 
@@ -20,24 +21,6 @@ const VALIDATE_DEBOUNCE_MS = 300;
 const QUALITY_HINT_ID = 'feedback-quality-hint';
 
 type SubmitStatus = 'idle' | 'loading' | 'accepted' | 'rejected' | 'error';
-
-/**
- * Reads the server's message off a rejected API call, falling back to
- * `fallback` when neither shape carries one. `apiClient` rejects with a plain
- * `{ success, error }` object rather than an `Error`, so an `instanceof Error`
- * check alone drops the reason and substitutes generic failure copy.
- */
-function messageForApiError(err: unknown, fallback: string): string {
-  if (err instanceof Error) return err.message;
-  // apiClient rejects with a plain `{ success, error }` object, not an Error.
-  // Without this the server's reason is replaced by generic failure copy, and a
-  // blocked submitter is told nothing they can act on.
-  if (err && typeof err === 'object' && 'error' in err) {
-    const { error } = err as { error?: unknown };
-    if (typeof error === 'string' && error.trim()) return error;
-  }
-  return fallback;
-}
 
 interface FeedbackSubmitFormProps {
   /** Called with the published item when a submission is accepted. */

--- a/app/src/components/settings/panels/FeedbackPanel.test.tsx
+++ b/app/src/components/settings/panels/FeedbackPanel.test.tsx
@@ -97,11 +97,16 @@ describe('<Feedback />', () => {
   });
 
   it('surfaces a load error without also showing the empty state', async () => {
-    mockList.mockRejectedValueOnce(new Error('boom'));
+    mockList.mockRejectedValueOnce({
+      success: false,
+      error: 'Feedback is temporarily unavailable.',
+    });
 
     renderWithProviders(<Feedback />, { initialEntries: ['/?view=main'] });
 
-    await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument());
+    await waitFor(() =>
+      expect(screen.getByText('Feedback is temporarily unavailable.')).toBeInTheDocument()
+    );
     // The empty-state copy must not render alongside the error banner.
     expect(
       screen.queryByText('No feedback yet. Be the first to share an idea.')

--- a/app/src/components/settings/panels/FeedbackPanel.tsx
+++ b/app/src/components/settings/panels/FeedbackPanel.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useUser } from '../../../hooks/useUser';
 import { useT } from '../../../lib/i18n/I18nContext';
 import { feedbackApi } from '../../../services/api/feedbackApi';
+import { messageForApiError } from '../../../services/apiError';
 import type {
   FeedbackItem,
   FeedbackSort,
@@ -82,7 +83,7 @@ const FeedbackPanel = () => {
       } catch (error) {
         if (requestId !== loadRequestIdRef.current) return;
         log('load failed page=%d error=%O', page, error);
-        setLoadError(error instanceof Error ? error.message : t('feedback.loadError'));
+        setLoadError(messageForApiError(error, t('feedback.loadError')));
       } finally {
         if (requestId === loadRequestIdRef.current) setIsLoading(false);
       }

--- a/app/src/services/apiError.test.ts
+++ b/app/src/services/apiError.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { messageForApiError } from './apiError';
+
+describe('messageForApiError', () => {
+  it('uses the message from an Error', () => {
+    expect(messageForApiError(new Error('Connection lost'), 'Try again.')).toBe('Connection lost');
+  });
+
+  it('uses the string error from an apiClient rejection', () => {
+    expect(
+      messageForApiError({ success: false, error: 'You have already reported this.' }, 'Try again.')
+    ).toBe('You have already reported this.');
+  });
+
+  it.each([
+    new Error(''),
+    { success: false, error: '' },
+    { success: false, error: '   ' },
+    { success: false, error: { reason: 'Not safe to display' } },
+    { success: false },
+    null,
+  ])('uses the fallback for a blank or missing display message: %j', error => {
+    expect(messageForApiError(error, 'Try again.')).toBe('Try again.');
+  });
+});

--- a/app/src/services/apiError.ts
+++ b/app/src/services/apiError.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns the display-safe message carried by an API rejection.
+ *
+ * `apiClient` rejects with plain `{ success, error }` objects rather than
+ * `Error` instances, while other callers may still throw an `Error`. Keep this
+ * boundary narrow: only a non-empty string may reach the UI, never the raw
+ * rejected payload.
+ */
+export function messageForApiError(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim()) return error.message;
+
+  if (error && typeof error === 'object' && 'error' in error) {
+    const { error: message } = error as { error?: unknown };
+    if (typeof message === 'string' && message.trim()) return message;
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
## Summary

- Extract the feedback submit form's API-error parser into a shared frontend helper.
- Preserve actionable string messages from plain `{ success: false, error }` rejections across feedback loading, comments, and administration.
- Keep blank, nested, or non-string rejection payloads behind the existing translated fallback copy.
- Add helper edge-case coverage plus component regressions for submission and post-comment failures.

## Problem

The feedback API client rejects unsuccessful responses as plain objects rather than `Error` instances. Several feedback surfaces only handled `Error`, so they discarded the server's actionable message and displayed generic failure copy.

## Solution

`messageForApiError` accepts only a non-empty `Error.message` or a non-empty string `error` property. All other shapes use the caller-provided fallback, so raw or nested rejection payloads never reach the UI. The five existing feedback error paths now share this behavior without changing transport, request lifecycle, logging, or backend enforcement.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage >= 80%** - focused Vitest coverage reports 100% lines for the helper, `FeedbackComments`, and `FeedbackAdmin`; 96.55% for `FeedbackPanel`; and 98.44% for `FeedbackSubmit`.
- [x] Coverage matrix updated - N/A: behavior-only change; no feature row added, removed, or renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` - N/A: no coverage-matrix feature ID changes.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces - N/A: focused frontend error-rendering change, not a release-cut surface.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Feedback users now see a server-provided string reason when an API request is rejected.
- No API, backend, persistence, migration, performance, or dependency change.
- Non-string and nested payloads continue to fall back to translated generic copy.

## Related

- Closes #5440
- Follow-up PR(s)/TODOs: None.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A - GitHub issue #5440
- URL: N/A - GitHub issue linked above

### Commit & Branch

- Branch: `fix/5440-feedback-api-errors`
- Commit SHA: `f8525a6f0184c1c0f4058de97e3d95a499bf5b46`

### Validation Run

- [x] Node `v24.20.0` with pnpm `10.10.0`
- [x] Focused tests: 5 Vitest files, 48 tests passed; the new post-comment plain API-error regression resolves the initial fetch, rejects the comment request, and asserts the visible message.
- [x] Changed-files coverage: 17 files, 134 tests passed.
- [x] Full repository pre-push hook: formatting, lint (existing warnings only), TypeScript, Rust clippy, command-token lint, and UI-token lint passed.
- [x] `git diff --check`

### Behavior Changes

- Intended behavior change: preserve display-safe API error strings in all feedback rejection paths.
- User-visible effect: actionable server messages replace generic feedback errors when available.

### Parity Contract

- Legacy behavior preserved: `Error.message` handling, translated fallbacks, request cancellation guards, pending/loading state, and logging are unchanged.
- Guard/fallback/dispatch parity checks: blank, missing, nested, and non-string payloads fall back; plain string API errors and `Error.message` render; no raw payload stringification is introduced.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None found in the final open-PR and path-overlap scan.
- Canonical PR: This draft.
- Resolution (closed/superseded/updated): N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feedback error messages by displaying meaningful API-provided details when available.
  * Added localized fallback messages when error details are missing or invalid.
  * Prevented raw or unusable error values from appearing in the feedback interface.

* **Tests**
  * Added coverage for comment submission, feedback loading, and various API error formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->