### PR TITLE
Link tinymemory-bus and add the TinyMemory module client seam

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -23,3 +23,6 @@
 	path = vendor/tinybus
 	url = https://github.com/tinyhumansai/tinybus.git
 	branch = main
+[submodule "vendor/tinymemory"]
+	path = vendor/tinymemory
+	url = https://github.com/tinyhumansai/tinymemory

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4727,6 +4727,7 @@ dependencies = [
  "tinyflows",
  "tinyhumans-sdk",
  "tinyjuice",
+ "tinymemory-bus",
  "tinyplace",
  "tokio",
  "tokio-stream",
@@ -7380,6 +7381,19 @@ dependencies = [
  "tokio",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "tinymemory-bus"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "uuid 1.23.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,11 @@ tinychannels = { version = "0.1", features = ["relay-websocket"] }
 #
 # Vendored as a git submodule beside the other tiny* crates so module work can
 # change the contract in-tree, test it against OpenHuman immediately, and PR the
-# diff upstream from the submodule. After cloning:
+# diff upstream from the submodule. Pinned at the `v1.1.0` release tag — the
+# release that introduced this crate — rather than at a main commit, because a
+# TinyMemory release is also what publishes the per-platform module archives and
+# their `checksum.toml`, and the library the host links has to be the one those
+# archives were built from. After cloning:
 # `git submodule update --init vendor/tinymemory` (worktrees included).
 #
 # No `[patch."https://github.com/tinyhumansai/tinymemory"]` entry yet, and that

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,28 @@ tinycortex = { version = "0.1", features = [
 # this with the `path = "api"` dependency the engine crate already declares.
 tinycortex-api = { path = "vendor/tinycortex/api" }
 tinychannels = { version = "0.1", features = ["relay-websocket"] }
+# tinymemory-bus — the wire vocabulary for the TinyMemory TinyBus module.
+#
+# TinyMemory ships as a loadable module (a `cdylib`), so the host can load the
+# binary but cannot `use` anything out of it: the payload types and the member
+# names have to arrive as an ordinary library. This is that library, and it is
+# the *only* piece of TinyMemory the host links — no engine, no storage, no
+# traits, no async runtime. Seven pure-Rust dependencies.
+#
+# Vendored as a git submodule beside the other tiny* crates so module work can
+# change the contract in-tree, test it against OpenHuman immediately, and PR the
+# diff upstream from the submodule. After cloning:
+# `git submodule update --init vendor/tinymemory` (worktrees included).
+#
+# No `[patch."https://github.com/tinyhumansai/tinymemory"]` entry yet, and that
+# is deliberate rather than forgotten. The vendored TinyCortex pin still defines
+# the memory contract itself in `tinycortex-api`; it is only *newer* TinyCortex
+# revisions that re-export `tinymemory-api` and pull it in by git. Adding the
+# patch now would make cargo warn about a patch that matches nothing in the
+# graph. Add it in the same change that bumps the TinyCortex pin — without it,
+# the git copy and this path copy resolve as two distinct crates and
+# `MemoryEntry` from one is not `MemoryEntry` from the other.
+tinymemory-bus = { path = "vendor/tinymemory/crates/tinymemory-bus" }
 # tinybus — the message bus. Owns what `src/core/event_bus/` used to: the typed
 # pub/sub surface (`EventBus`, `EventHandler`, `SubscriptionHandle`), the
 # in-process zero-serialization request registry (`NativeRegistry`), and peer

--- a/src/openhuman/memory/driver/mod.rs
+++ b/src/openhuman/memory/driver/mod.rs
@@ -1,8 +1,16 @@
 //! Memory-driver implementations of the [`tinycortex_api`] contract.
 //!
-//! One subdirectory per driver. Today there is exactly one — [`embedded`],
-//! which wraps the in-process tinycortex engine — plus the reference
-//! `NullMemoryProvider` that ships inside the contract crate itself.
+//! One subdirectory per driver. [`embedded`] wraps the in-process tinycortex
+//! engine, and [`module`] talks to TinyMemory when it is loaded as a `TinyBus`
+//! module instead of compiled in — plus the reference `NullMemoryProvider` that
+//! ships inside the contract crate itself.
+//!
+//! The two are not interchangeable yet: [`embedded`] implements the
+//! `tinycortex_api` contract this build pins, while [`module`] speaks the
+//! `tinymemory-bus` vocabulary the loadable module was built against. They
+//! converge when the TinyCortex pin moves to a revision that re-exports
+//! `tinymemory-api` — until then [`module`] is the client seam, not a
+//! `MemoryProvider` impl.
 //!
 //! Drivers live *under* `memory/` rather than in a sibling top-level directory
 //! so the "one directory equals one feature gate" family rule holds: a memory
@@ -10,3 +18,4 @@
 //! would be meaningless.
 
 pub mod embedded;
+pub mod module;

--- a/src/openhuman/memory/driver/module/mod.rs
+++ b/src/openhuman/memory/driver/module/mod.rs
@@ -1,0 +1,266 @@
+//! Client seam for the TinyMemory driver when it is loaded as a `TinyBus`
+//! module rather than compiled in.
+//!
+//! TinyMemory ships as a `cdylib` exporting one object,
+//! [`OBJECT_PATH`](tinymemory_bus::names::OBJECT_PATH), with 89 members on it.
+//! The host loads that binary and calls into it; it cannot `use` anything out
+//! of it, so the vocabulary — the member names, the payload types, and the
+//! error-name table — arrives from the `tinymemory-bus` library instead.
+//!
+//! This module is the piece in between: it turns a member name plus typed
+//! arguments into a `TinyBus` call, and turns the reply — or the failure — back
+//! into something the memory layer can act on.
+//!
+//! # Why the error mapping is the interesting part
+//!
+//! A `TinyBus` failure is a name and a prose message. The name is the contract:
+//! [`tinymemory_bus::wire`] holds the table mapping it back to a
+//! [`MemoryError`], and the *module uses the same table in the other
+//! direction*. That is what keeps the two ends from drifting into disagreeing
+//! about what a name means — the case that matters being `PathEscape`, which
+//! reports a sandbox escape and must not be silently reclassified as a
+//! caller's malformed argument.
+//!
+//! Everything that is not a `MethodFailed` never reached the driver at all: a
+//! timeout, an unowned name, a transport fault. Those are mapped to the
+//! [`MemoryError`] variants that say so rather than being flattened into
+//! `Other`, because a host retries an [`Unreachable`](MemoryError::Unreachable)
+//! and does not retry an [`Invalid`](MemoryError::Invalid).
+//!
+//! # Scope
+//!
+//! [`MemoryModule::call`] is public and reaches **every** member: pass a name
+//! from [`tinymemory_bus::names::methods`] and the positional arguments as a
+//! tuple. The typed wrappers below cover the driver-level members and the
+//! mandatory core family, which is what a host needs to bind a driver and
+//! prove it answers. The remaining families are one `call` each and are added
+//! as the driver seam grows into them.
+
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use tinybus::{Connection, Error as BusError, Proxy};
+use tinymemory_bus::error::MemoryError;
+use tinymemory_bus::names::{methods, BUS_NAME, OBJECT_PATH};
+use tinymemory_bus::types::{MemoryCategory, MemoryEntry, MemoryTaint, NamespaceSummary};
+use tinymemory_bus::{capabilities::Capabilities, health::MemoryHealth, wire};
+
+/// A bound TinyMemory module object.
+///
+/// Addresses one store. The root object is the one at
+/// [`OBJECT_PATH`](tinymemory_bus::names::OBJECT_PATH); `OpenStore` answers
+/// with the path of a *sibling* store under the same workspace, exporting this
+/// identical interface, which [`MemoryModule::at`] binds.
+#[derive(Debug, Clone)]
+pub struct MemoryModule {
+    proxy: Proxy,
+}
+
+impl MemoryModule {
+    /// Bind the module's root object on `connection`.
+    ///
+    /// # Errors
+    ///
+    /// [`MemoryError::Invalid`] if the well-known name or object path is
+    /// rejected by `TinyBus` — unreachable in practice, since both are
+    /// constants from the contract, but the constructor is fallible rather than
+    /// panicking on a value it did not choose.
+    pub fn new(connection: &Connection) -> Result<Self, MemoryError> {
+        Self::at(connection, OBJECT_PATH)
+    }
+
+    /// Bind a specific object path on `connection` — an `OpenStore` result.
+    ///
+    /// # Errors
+    ///
+    /// [`MemoryError::Invalid`] if `object_path` is not a valid `TinyBus`
+    /// object path. Unlike [`new`](Self::new) this is reachable: the path comes
+    /// back over the wire.
+    pub fn at(connection: &Connection, object_path: &str) -> Result<Self, MemoryError> {
+        let proxy = connection
+            .proxy(BUS_NAME, object_path, BUS_NAME)
+            .map_err(|error| MemoryError::Invalid(error.to_string()))?;
+        Ok(Self { proxy })
+    }
+
+    /// Call any member by name, with `args` as its positional arguments.
+    ///
+    /// Pass a tuple for several arguments, a bare value for one, and `()` for
+    /// none — the encoding `#[tinybus::interface]` decodes on the far side.
+    /// Names come from [`tinymemory_bus::names::methods`]; spelling one by hand
+    /// is what that module exists to avoid.
+    ///
+    /// # Errors
+    ///
+    /// The driver's own [`MemoryError`], recovered through
+    /// [`tinymemory_bus::wire::from_wire`], when the call reached the module and
+    /// failed there. Otherwise the transport failure, mapped by
+    /// [`map_bus_error`].
+    pub async fn call<R: DeserializeOwned>(
+        &self,
+        member: &str,
+        args: impl Serialize + Send,
+    ) -> Result<R, MemoryError> {
+        self.proxy.call(member, args).await.map_err(map_bus_error)
+    }
+
+    /// The driver id this module reports.
+    ///
+    /// # Errors
+    ///
+    /// See [`call`](Self::call).
+    pub async fn driver_id(&self) -> Result<String, MemoryError> {
+        self.call(methods::DRIVER_ID, ()).await
+    }
+
+    /// The capability families this driver advertises.
+    ///
+    /// # Errors
+    ///
+    /// See [`call`](Self::call).
+    pub async fn capabilities(&self) -> Result<Capabilities, MemoryError> {
+        self.call(methods::CAPABILITIES, ()).await
+    }
+
+    /// The driver's liveness.
+    ///
+    /// # Errors
+    ///
+    /// See [`call`](Self::call).
+    pub async fn health(&self) -> Result<MemoryHealth, MemoryError> {
+        self.call(methods::HEALTH, ()).await
+    }
+
+    /// Ask the module to shut its store down.
+    ///
+    /// # Errors
+    ///
+    /// See [`call`](Self::call).
+    pub async fn shutdown(&self) -> Result<(), MemoryError> {
+        self.call(methods::SHUTDOWN, ()).await
+    }
+
+    /// Open a sibling store under `memory_subdir`, returning its object path.
+    ///
+    /// Bind the result with [`at`](Self::at). Asking twice for the same subdir
+    /// returns the same path rather than opening the database twice.
+    ///
+    /// # Errors
+    ///
+    /// See [`call`](Self::call).
+    pub async fn open_store(&self, memory_subdir: &str) -> Result<String, MemoryError> {
+        self.call(methods::OPEN_STORE, (memory_subdir,)).await
+    }
+
+    /// Upsert the entry at `(namespace, key)`.
+    ///
+    /// `taint` is required rather than defaulted, mirroring the contract: a
+    /// caller that could omit provenance would be able to launder
+    /// externally-sourced content into internal-trust content.
+    ///
+    /// # Errors
+    ///
+    /// See [`call`](Self::call).
+    pub async fn store(
+        &self,
+        namespace: &str,
+        key: &str,
+        content: &str,
+        category: MemoryCategory,
+        session_id: Option<&str>,
+        taint: MemoryTaint,
+    ) -> Result<(), MemoryError> {
+        self.call(
+            methods::STORE,
+            (namespace, key, content, category, session_id, taint),
+        )
+        .await
+    }
+
+    /// Fetch the entry at an exact `(namespace, key)`.
+    ///
+    /// A miss is `Ok(None)`, not an error — the contract's rule, preserved
+    /// across the wire.
+    ///
+    /// # Errors
+    ///
+    /// See [`call`](Self::call).
+    pub async fn get(
+        &self,
+        namespace: &str,
+        key: &str,
+    ) -> Result<Option<MemoryEntry>, MemoryError> {
+        self.call(methods::GET, (namespace, key)).await
+    }
+
+    /// Delete the entry at `(namespace, key)`, reporting whether it existed.
+    ///
+    /// # Errors
+    ///
+    /// See [`call`](Self::call).
+    pub async fn forget(&self, namespace: &str, key: &str) -> Result<bool, MemoryError> {
+        self.call(methods::FORGET, (namespace, key)).await
+    }
+
+    /// List entries, narrowing by namespace, category and session.
+    ///
+    /// # Errors
+    ///
+    /// See [`call`](Self::call) — and note that this member has no limit and no
+    /// cursor, so the module refuses an oversized response with
+    /// [`MemoryError::BudgetExceeded`] rather than truncating it. A short list
+    /// would be indistinguishable from a complete one.
+    pub async fn list(
+        &self,
+        namespace: Option<&str>,
+        category: Option<MemoryCategory>,
+        session_id: Option<&str>,
+    ) -> Result<Vec<MemoryEntry>, MemoryError> {
+        self.call(methods::LIST, (namespace, category, session_id))
+            .await
+    }
+
+    /// Enumerate namespaces with their aggregate counts.
+    ///
+    /// # Errors
+    ///
+    /// See [`call`](Self::call).
+    pub async fn namespaces(&self) -> Result<Vec<NamespaceSummary>, MemoryError> {
+        self.call(methods::NAMESPACES, ()).await
+    }
+}
+
+/// Turn a `TinyBus` failure into the memory error it stands for.
+///
+/// [`BusError::MethodFailed`] is the one that reached the driver: its name is
+/// the contract, and [`wire::from_wire`] is the same table the module mapped
+/// *out* through, so the variant survives the round trip. A name this build
+/// does not recognise becomes [`MemoryError::Other`] and never
+/// [`MemoryError::Invalid`] — a module newer than the host may name an error
+/// this table has no variant for, and telling a caller its input was wrong when
+/// it was not sends it into a rewrite loop over something already correct.
+///
+/// Every other variant never reached the driver, so it is a transport fact and
+/// is reported as one.
+pub(crate) fn map_bus_error(error: BusError) -> MemoryError {
+    match error {
+        BusError::MethodFailed { name, message } => wire::from_wire(&name, &message),
+        BusError::Timeout { .. } => MemoryError::Timeout(error.to_string()),
+        // The module is not running, or has not claimed its name yet. Both are
+        // "try again once it is up", which is what `Unreachable` tells a caller.
+        BusError::NameHasNoOwner(_) | BusError::Transport(_) | BusError::Io(_) => {
+            MemoryError::Unreachable(error.to_string())
+        }
+        // A member or object this build believes in and the module does not.
+        // That is a contract mismatch, not a caller mistake, so it is not
+        // `Invalid`: the argument was fine, the peer is the wrong version.
+        BusError::UnknownMethod { .. }
+        | BusError::UnknownObject { .. }
+        | BusError::UnknownInterface { .. }
+        | BusError::IncompatibleVersion { .. } => MemoryError::Backend(error.to_string()),
+        other => MemoryError::Other(anyhow::anyhow!(other.to_string())),
+    }
+}
+
+#[cfg(test)]
+#[path = "mod_tests.rs"]
+mod tests;

--- a/src/openhuman/memory/driver/module/mod_tests.rs
+++ b/src/openhuman/memory/driver/module/mod_tests.rs
@@ -1,0 +1,104 @@
+//! Tests for the TinyMemory module client seam.
+//!
+//! The behaviour worth pinning here is the error mapping. A `TinyBus` failure
+//! arrives as a name plus prose, and which [`MemoryError`] it becomes decides
+//! whether the caller retries, rewrites its input, or gives up — so a
+//! misclassification is not cosmetic. The mapping is also the one piece of this
+//! module that can be exercised without a live bus.
+
+use tinybus::Error as BusError;
+use tinymemory_bus::error::MemoryError;
+use tinymemory_bus::wire;
+
+use super::map_bus_error;
+
+/// A `MethodFailed` as the module emits one.
+fn failed(name: &str) -> BusError {
+    BusError::MethodFailed {
+        name: name.to_string(),
+        message: "prose for a human".to_string(),
+    }
+}
+
+#[test]
+fn a_driver_error_survives_the_round_trip_under_its_own_name() {
+    // The module maps out through `wire::wire_name`; this maps back through
+    // `wire::from_wire`. Same table, so the variant has to come back intact.
+    for (name, matches) in [
+        (wire::NOT_FOUND, matches!(map_bus_error(failed(wire::NOT_FOUND)), MemoryError::NotFound(_))),
+        (wire::INVALID, matches!(map_bus_error(failed(wire::INVALID)), MemoryError::Invalid(_))),
+        (
+            wire::BUDGET_EXCEEDED,
+            matches!(map_bus_error(failed(wire::BUDGET_EXCEEDED)), MemoryError::BudgetExceeded(_)),
+        ),
+        (
+            wire::UNAUTHORIZED,
+            matches!(map_bus_error(failed(wire::UNAUTHORIZED)), MemoryError::Unauthorized(_)),
+        ),
+    ] {
+        assert!(matches, "{name} did not map back to its own variant");
+    }
+}
+
+#[test]
+fn a_path_escape_is_not_flattened_into_an_invalid() {
+    // The one that matters: `PathEscape` reports a symlink or traversal that
+    // left the workspace sandbox. Reclassifying it as a malformed argument
+    // would turn a security-relevant refusal into a caller mistake.
+    let mapped = map_bus_error(failed(wire::PATH_ESCAPE));
+    assert!(
+        matches!(mapped, MemoryError::PathEscape(_)),
+        "expected PathEscape, got {mapped:?}"
+    );
+}
+
+#[test]
+fn an_unrecognised_error_name_is_opaque_rather_than_a_caller_mistake() {
+    // A module built from a newer contract may name an error this build has no
+    // variant for. Answering `Invalid` would tell the caller its input was
+    // wrong when it was not.
+    let mapped = map_bus_error(failed("ai.tinyhumans.tinymemory.Error.FromTheFuture"));
+    assert!(
+        matches!(mapped, MemoryError::Other(_)),
+        "expected Other, got {mapped:?}"
+    );
+}
+
+#[test]
+fn a_transport_failure_is_reported_as_unreachable() {
+    // Never reached the driver, so it is not the driver's error. `Unreachable`
+    // is the variant a caller retries on.
+    let mapped = map_bus_error(BusError::Transport("socket closed".to_string()));
+    assert!(
+        matches!(mapped, MemoryError::Unreachable(_)),
+        "expected Unreachable, got {mapped:?}"
+    );
+}
+
+#[test]
+fn an_unknown_member_is_a_backend_mismatch_not_an_invalid_argument() {
+    // The host believes in a member the module does not serve: a version skew.
+    // The arguments were fine, so `Invalid` would point at the wrong thing.
+    let mapped = map_bus_error(BusError::UnknownMethod {
+        interface: tinybus::name::InterfaceName::new(tinymemory_bus::names::BUS_NAME)
+            .expect("the contract's own interface name parses"),
+        member: tinybus::name::MemberName::new("FromTheFuture")
+            .expect("a PascalCase member name parses"),
+    });
+    assert!(
+        matches!(mapped, MemoryError::Backend(_)),
+        "expected Backend, got {mapped:?}"
+    );
+}
+
+#[test]
+fn the_message_of_a_mapped_error_carries_no_payload() {
+    // Neither end may put a namespace key, an entry's content or a recall query
+    // into an error string. This asserts the seam adds nothing of its own — the
+    // message is exactly the prose the module sent.
+    let mapped = map_bus_error(failed(wire::NOT_FOUND));
+    assert!(
+        mapped.to_string().contains("prose for a human"),
+        "the module's message should survive: {mapped}"
+    );
+}

--- a/src/openhuman/memory/driver/module/mod_tests.rs
+++ b/src/openhuman/memory/driver/module/mod_tests.rs
@@ -25,15 +25,33 @@ fn a_driver_error_survives_the_round_trip_under_its_own_name() {
     // The module maps out through `wire::wire_name`; this maps back through
     // `wire::from_wire`. Same table, so the variant has to come back intact.
     for (name, matches) in [
-        (wire::NOT_FOUND, matches!(map_bus_error(failed(wire::NOT_FOUND)), MemoryError::NotFound(_))),
-        (wire::INVALID, matches!(map_bus_error(failed(wire::INVALID)), MemoryError::Invalid(_))),
+        (
+            wire::NOT_FOUND,
+            matches!(
+                map_bus_error(failed(wire::NOT_FOUND)),
+                MemoryError::NotFound(_)
+            ),
+        ),
+        (
+            wire::INVALID,
+            matches!(
+                map_bus_error(failed(wire::INVALID)),
+                MemoryError::Invalid(_)
+            ),
+        ),
         (
             wire::BUDGET_EXCEEDED,
-            matches!(map_bus_error(failed(wire::BUDGET_EXCEEDED)), MemoryError::BudgetExceeded(_)),
+            matches!(
+                map_bus_error(failed(wire::BUDGET_EXCEEDED)),
+                MemoryError::BudgetExceeded(_)
+            ),
         ),
         (
             wire::UNAUTHORIZED,
-            matches!(map_bus_error(failed(wire::UNAUTHORIZED)), MemoryError::Unauthorized(_)),
+            matches!(
+                map_bus_error(failed(wire::UNAUTHORIZED)),
+                MemoryError::Unauthorized(_)
+            ),
         ),
     ] {
         assert!(matches, "{name} did not map back to its own variant");


### PR DESCRIPTION
## What changed and why

TinyMemory ships as a loadable TinyBus module — a `cdylib` exporting one object
with 89 members on it. The host can load that binary but cannot `use` anything
out of it, so the member names, the payload types and the error-name table have
to arrive as an ordinary library. They now do.

- `vendor/tinymemory` submodule, pinned at the **`v1.1.0`** tag — the release
  that introduced `tinymemory-bus`. Pinned at a tag rather than a main commit
  because a TinyMemory release is also what publishes the per-platform module
  archives and their `checksum.toml`; the library the host links has to be the
  one those archives were built from.
- `tinymemory-bus = { path = "vendor/tinymemory/crates/tinymemory-bus" }`. This
  is the *only* piece of TinyMemory the host links: no engine, no storage, no
  traits, no async runtime. Seven pure-Rust dependencies (`serde`,
  `serde_json`, `chrono`, `sha2`, `uuid`, `anyhow`, `thiserror`).
- `src/openhuman/memory/driver/module/` — the client seam.

## The client seam

`MemoryModule` binds the module's object over a `tinybus::Proxy`.
`MemoryModule::call` is public and reaches every member: pass a name from
`tinymemory_bus::names::methods` and the positional arguments as a tuple. Typed
wrappers cover the driver-level members (`DriverId`, `Capabilities`, `Health`,
`Shutdown`, `OpenStore`) and the mandatory core family (`Store`, `Get`,
`Forget`, `List`, `Namespaces`) — what a host needs to bind a driver and prove
it answers. The remaining families are one `call` each and get wrappers as the
driver seam grows into them.

`OpenStore` returns an object *path*, not a value — a sibling store under the
same workspace exporting the identical interface — so `MemoryModule::at` binds
one. `OBJECT_PATH` is the root object, not the only one.

### The error mapping is the part worth reviewing

A TinyBus failure is a name plus prose. `MethodFailed` is the one that reached
the driver, and `tinymemory_bus::wire::from_wire` maps it back — the *same table
the module mapped out through*, which is what stops the two ends drifting into
disagreeing about what a name means. The case that matters is `PathEscape`: it
reports a symlink or traversal that left the workspace sandbox, and flattening
it into `Invalid` would turn a security-relevant refusal into a caller mistake.

Everything that is not a `MethodFailed` never reached the driver, so it is
reported as the transport fact it is rather than flattened into `Other`:

| TinyBus error | becomes | why |
| --- | --- | --- |
| `Timeout` | `MemoryError::Timeout` | |
| `NameHasNoOwner`, `Transport`, `Io` | `Unreachable` | module not up yet — retryable |
| `UnknownMethod/Object/Interface`, `IncompatibleVersion` | `Backend` | version skew; the arguments were fine, so not `Invalid` |
| unrecognised error name | `Other` | a newer module may name an error this build has no variant for; answering `Invalid` would send a caller into a rewrite loop over correct input |

## Public API / behavior changes

Additive only. Nothing existing is touched: the diff is 7 files, and the only
edit to pre-existing code is `memory/driver/mod.rs` gaining `pub mod module;`
and a doc paragraph.

`module` is **not** a `MemoryProvider` impl and is not wired into driver
selection. It cannot be yet, and the module docs say so: `embedded` implements
the `tinycortex_api` contract this build pins, while `module` speaks the
`tinymemory-bus` vocabulary the loadable module was built against. At the
current TinyCortex pin those are unrelated types. They converge when the
TinyCortex pin moves to a revision that re-exports `tinymemory-api`.

## Deliberately no `[patch]` entry yet

The natural companion would be:

```toml
[patch."https://github.com/tinyhumansai/tinymemory"]
tinymemory-api = { path = "vendor/tinymemory/crates/tinymemory-api" }
tinymemory-bus = { path = "vendor/tinymemory/crates/tinymemory-bus" }
```

It is **not** here, and that is deliberate rather than forgotten. The vendored
TinyCortex pin (`ce98837`) still defines the memory contract itself in
`tinycortex-api`; only newer revisions re-export `tinymemory-api` and pull it in
by git. Adding the patch now would make cargo warn about a patch matching
nothing in the graph.

It has to land in the same change that bumps the TinyCortex pin. Without it the
git copy and this path copy resolve as two distinct crates and `MemoryEntry`
from one is not `MemoryEntry` from the other — the exact failure TinyMemory's
own root manifest documents and patches around. The comment above the dependency
in `Cargo.toml` says this so the next person to move the pin finds it.

## Validation

- `cargo build --lib` — pass
- `cargo test --lib memory::driver::module` — pass, 6 new tests
- `cargo fmt -- --check` — pass
- `cargo clippy --lib --all-features` — pass, no findings

`cargo clippy --all-targets` fails to compile `tests/subconscious_fullstack_e2e.rs`
(`await` in the non-async `fn harness_with`). **Pre-existing and unrelated** —
the file is byte-identical to `main` (`diff <(git show main:...) ...` is empty)
and nothing in this PR can affect it. Not fixed here; raising rather than
widening scope.

## Related

Depends on tinyhumansai/tinymemory#74, merged and released as `v1.1.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for connecting to TinyMemory as an external memory module.
  * Added memory operations for stores, entries, listings, namespaces, metadata, health checks, and lifecycle management.
  * Added support for targeting the root module or a specific store.

* **Bug Fixes**
  * Improved handling and reporting of memory, transport, timeout, and contract errors.

* **Tests**
  * Added coverage for error mapping and transport failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->