### PR TITLE
fix(skills): accept allowed-tools as a comma string, not only a sequence

### DIFF
--- a/src/openhuman/skills/ops_types.rs
+++ b/src/openhuman/skills/ops_types.rs
@@ -88,7 +88,13 @@ pub struct WorkflowFrontmatter {
     pub metadata: HashMap<String, serde_yaml::Value>,
     /// Tools the skill author asserts their instructions rely on
     /// (non-binding hint; the host decides what to expose).
-    #[serde(default, rename = "allowed-tools", alias = "allowed_tools")]
+    #[serde(
+        default,
+        rename = "allowed-tools",
+        alias = "allowed_tools",
+        alias = "tools",
+        deserialize_with = "de_string_or_seq"
+    )]
     pub allowed_tools: Vec<String>,
     /// Domain events that should activate this skill.
     ///
@@ -106,6 +112,32 @@ pub struct WorkflowFrontmatter {
     /// a migration warning when read.
     #[serde(flatten)]
     pub extra: HashMap<String, serde_yaml::Value>,
+}
+
+/// Deserialize `allowed-tools` from either a YAML sequence (`[Bash, Read]`) or a
+/// single scalar string in Claude Code's convention (`allowed-tools: Bash,
+/// Read, Grep`). A bare scalar is split on commas and trimmed. Without this,
+/// skills authored for the `claude` CLI — which writes a comma-joined string —
+/// fail frontmatter parsing, and their declared tools (Bash, etc.) get dropped,
+/// surfacing as "tool not available" at run time.
+fn de_string_or_seq<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrSeq {
+        Seq(Vec<String>),
+        Str(String),
+    }
+    Ok(match StringOrSeq::deserialize(deserializer)? {
+        StringOrSeq::Seq(v) => v,
+        StringOrSeq::Str(s) => s
+            .split(',')
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .collect(),
+    })
 }
 
 pub(crate) fn metadata_string(fm: &WorkflowFrontmatter, key: &str) -> Option<String> {
@@ -274,4 +306,41 @@ pub(crate) struct LegacyWorkflowManifest {
     pub tools: Vec<String>,
     #[serde(default)]
     pub prompts: Vec<String>,
+}
+
+#[cfg(test)]
+mod allowed_tools_tests {
+    use super::*;
+
+    #[test]
+    fn allowed_tools_accepts_yaml_sequence() {
+        let fm: WorkflowFrontmatter =
+            serde_yaml::from_str("allowed-tools:\n  - Bash\n  - Read\n").unwrap();
+        assert_eq!(fm.allowed_tools, vec!["Bash", "Read"]);
+    }
+
+    #[test]
+    fn allowed_tools_accepts_comma_string() {
+        // Claude Code convention: a scalar comma-joined string. Before the
+        // string-or-seq deserializer this failed with "invalid type: string,
+        // expected a sequence" and the skill's tools were silently dropped.
+        let fm: WorkflowFrontmatter =
+            serde_yaml::from_str("allowed-tools: Bash, Read, Grep, Skill, WebFetch").unwrap();
+        assert_eq!(
+            fm.allowed_tools,
+            vec!["Bash", "Read", "Grep", "Skill", "WebFetch"]
+        );
+    }
+
+    #[test]
+    fn allowed_tools_accepts_tools_alias() {
+        let fm: WorkflowFrontmatter = serde_yaml::from_str("tools: Bash, Read").unwrap();
+        assert_eq!(fm.allowed_tools, vec!["Bash", "Read"]);
+    }
+
+    #[test]
+    fn allowed_tools_defaults_empty_when_absent() {
+        let fm: WorkflowFrontmatter = serde_yaml::from_str("name: foo").unwrap();
+        assert!(fm.allowed_tools.is_empty());
+    }
 }

--- a/src/openhuman/skills/ops_types.rs
+++ b/src/openhuman/skills/ops_types.rs
@@ -309,54 +309,5 @@ pub(crate) struct LegacyWorkflowManifest {
 }
 
 #[cfg(test)]
-mod allowed_tools_tests {
-    use super::*;
-
-    #[test]
-    fn allowed_tools_accepts_yaml_sequence() {
-        let fm: WorkflowFrontmatter =
-            serde_yaml::from_str("allowed-tools:\n  - Bash\n  - Read\n").unwrap();
-        assert_eq!(fm.allowed_tools, vec!["Bash", "Read"]);
-    }
-
-    #[test]
-    fn allowed_tools_accepts_comma_string() {
-        // Claude Code convention: a scalar comma-joined string. Before the
-        // string-or-seq deserializer this failed with "invalid type: string,
-        // expected a sequence" and the skill's tools were silently dropped.
-        let fm: WorkflowFrontmatter =
-            serde_yaml::from_str("allowed-tools: Bash, Read, Grep, Skill, WebFetch").unwrap();
-        assert_eq!(
-            fm.allowed_tools,
-            vec!["Bash", "Read", "Grep", "Skill", "WebFetch"]
-        );
-    }
-
-    #[test]
-    fn allowed_tools_trims_whitespace_and_drops_empty_tokens() {
-        // Hand-authored frontmatter is ragged: padding around each name and a
-        // stray comma that yields an empty token. Both are dropped rather than
-        // surfacing as a bogus tool name.
-        let fm: WorkflowFrontmatter =
-            serde_yaml::from_str(r#"allowed-tools: " Bash, , Read, ""#).unwrap();
-        assert_eq!(fm.allowed_tools, vec!["Bash", "Read"]);
-    }
-
-    #[test]
-    fn allowed_tools_accepts_tools_alias() {
-        let fm: WorkflowFrontmatter = serde_yaml::from_str("tools: Bash, Read").unwrap();
-        assert_eq!(fm.allowed_tools, vec!["Bash", "Read"]);
-    }
-
-    #[test]
-    fn allowed_tools_accepts_snake_case_alias() {
-        let fm: WorkflowFrontmatter = serde_yaml::from_str("allowed_tools: Bash, Read").unwrap();
-        assert_eq!(fm.allowed_tools, vec!["Bash", "Read"]);
-    }
-
-    #[test]
-    fn allowed_tools_defaults_empty_when_absent() {
-        let fm: WorkflowFrontmatter = serde_yaml::from_str("name: foo").unwrap();
-        assert!(fm.allowed_tools.is_empty());
-    }
-}
+#[path = "ops_types_tests.rs"]
+mod ops_types_tests;

--- a/src/openhuman/skills/ops_types.rs
+++ b/src/openhuman/skills/ops_types.rs
@@ -333,8 +333,24 @@ mod allowed_tools_tests {
     }
 
     #[test]
+    fn allowed_tools_trims_whitespace_and_drops_empty_tokens() {
+        // Hand-authored frontmatter is ragged: padding around each name and a
+        // stray comma that yields an empty token. Both are dropped rather than
+        // surfacing as a bogus tool name.
+        let fm: WorkflowFrontmatter =
+            serde_yaml::from_str(r#"allowed-tools: " Bash, , Read, ""#).unwrap();
+        assert_eq!(fm.allowed_tools, vec!["Bash", "Read"]);
+    }
+
+    #[test]
     fn allowed_tools_accepts_tools_alias() {
         let fm: WorkflowFrontmatter = serde_yaml::from_str("tools: Bash, Read").unwrap();
+        assert_eq!(fm.allowed_tools, vec!["Bash", "Read"]);
+    }
+
+    #[test]
+    fn allowed_tools_accepts_snake_case_alias() {
+        let fm: WorkflowFrontmatter = serde_yaml::from_str("allowed_tools: Bash, Read").unwrap();
         assert_eq!(fm.allowed_tools, vec!["Bash", "Read"]);
     }
 

--- a/src/openhuman/skills/ops_types_tests.rs
+++ b/src/openhuman/skills/ops_types_tests.rs
@@ -1,0 +1,49 @@
+use super::*;
+
+#[test]
+fn allowed_tools_accepts_yaml_sequence() {
+    let fm: WorkflowFrontmatter =
+        serde_yaml::from_str("allowed-tools:\n  - Bash\n  - Read\n").unwrap();
+    assert_eq!(fm.allowed_tools, vec!["Bash", "Read"]);
+}
+
+#[test]
+fn allowed_tools_accepts_comma_string() {
+    // Claude Code convention: a scalar comma-joined string. Before the
+    // string-or-seq deserializer this failed with "invalid type: string,
+    // expected a sequence" and the skill's tools were silently dropped.
+    let fm: WorkflowFrontmatter =
+        serde_yaml::from_str("allowed-tools: Bash, Read, Grep, Skill, WebFetch").unwrap();
+    assert_eq!(
+        fm.allowed_tools,
+        vec!["Bash", "Read", "Grep", "Skill", "WebFetch"]
+    );
+}
+
+#[test]
+fn allowed_tools_trims_whitespace_and_drops_empty_tokens() {
+    // Hand-authored frontmatter is ragged: padding around each name and a
+    // stray comma that yields an empty token. Both are dropped rather than
+    // surfacing as a bogus tool name.
+    let fm: WorkflowFrontmatter =
+        serde_yaml::from_str(r#"allowed-tools: " Bash, , Read, ""#).unwrap();
+    assert_eq!(fm.allowed_tools, vec!["Bash", "Read"]);
+}
+
+#[test]
+fn allowed_tools_accepts_tools_alias() {
+    let fm: WorkflowFrontmatter = serde_yaml::from_str("tools: Bash, Read").unwrap();
+    assert_eq!(fm.allowed_tools, vec!["Bash", "Read"]);
+}
+
+#[test]
+fn allowed_tools_accepts_snake_case_alias() {
+    let fm: WorkflowFrontmatter = serde_yaml::from_str("allowed_tools: Bash, Read").unwrap();
+    assert_eq!(fm.allowed_tools, vec!["Bash", "Read"]);
+}
+
+#[test]
+fn allowed_tools_defaults_empty_when_absent() {
+    let fm: WorkflowFrontmatter = serde_yaml::from_str("name: foo").unwrap();
+    assert!(fm.allowed_tools.is_empty());
+}


### PR DESCRIPTION
## Summary

- Fixes skills that declare `allowed-tools` as a comma-separated string (Claude Code's convention) failing to parse, which silently drops their tools and surfaces as "tool not available" at run time.
- Adds a string-or-sequence deserializer so `allowed-tools` accepts **either** a YAML list or a comma-joined scalar, plus a `tools` alias.
- Affects popular community catalogs (e.g. `antigravity-awesome-skills`) that ship the scalar form.

## Problem

`WorkflowFrontmatter::allowed_tools` deserializes as `Vec<String>`. A skill written as:

```yaml
allowed-tools: Bash, Read, Grep, Skill, WebFetch
```

fails with `invalid type: string, expected a sequence`, logged as `[skills] failed to parse frontmatter`. The frontmatter is rejected and the skill's declared tools are dropped, so running that skill reports its tools (Bash, etc.) as unavailable. This is common: skills authored for the `claude` CLI use the scalar form, and OpenHuman refreshes such catalogs by default.

## Solution

- `de_string_or_seq`: an untagged `Seq(Vec<String>) | Str(String)` deserializer. A scalar is split on commas and trimmed; empties dropped. A YAML list passes through unchanged.
- Add `alias = "tools"` so the common `tools:` key maps to the same field.
- No change to the serialized (write) form.

## Submission Checklist

- [x] Tests added or updated — `allowed_tools_accepts_yaml_sequence`, `allowed_tools_accepts_comma_string`, `allowed_tools_accepts_tools_alias`, `allowed_tools_defaults_empty_when_absent` (happy + the previously-failing scalar edge case).
- [x] **Diff coverage ≥ 80%** — the changed lines are the deserializer + field attrs, all exercised by the new tests. `pnpm test:rust` passes locally.
- [x] Coverage matrix updated — `N/A: parser-tolerance fix, no feature row change`.
- [x] All affected feature IDs listed under `## Related` — `N/A`.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist — `N/A: does not touch release-cut surfaces`.
- [x] Linked issue closed via `Closes #NNN` — `N/A` (no dedicated issue; addresses the tool-availability observation noted in #5648).

## Impact

- Skills subsystem, parse-time only. More skills load successfully; no change for skills that already used a YAML list. No migration, no new deps.

## Related

- Closes: N/A (addresses the "tool not available" observation in #5648)
- Follow-up PR(s)/TODOs: none.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/skill-allowed-tools`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow configuration parsing to accept allowed tools provided as either lists or comma-separated values.
  * Added support for the existing `tools` alias and `allowed_tools` naming format.
  * Empty entries and extra whitespace are now handled automatically.
  * Missing tool settings continue to default correctly.
  * Workflow tool settings are interpreted consistently across supported configuration formats.
* **Tests**
  * Added coverage for supported formats, aliases, whitespace handling, empty entries, and default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->