### PR TITLE
docs: pin dead tinymemory core/src link to the vendored commit

### DIFF
--- a/src/openhuman/memory/README.md
+++ b/src/openhuman/memory/README.md
@@ -56,7 +56,7 @@ tinymemory_core::<domain>::*;` plus the handler/schema modules that name
 
 ## What lives in the extracted crate (for reference)
 
-See [`vendor/tinymemory/core/src/`](https://github.com/tinyhumansai/tinymemory/tree/main/core/src) for
+See [`vendor/tinymemory/core/src/`](https://github.com/tinyhumansai/tinymemory/tree/38a34d2ea10e7eedda1b50cdc786016c0f73b6dc/core/src) for
 the storage primitives (`store/`), ingestion queue (`ingestion/`), sync
 lifecycle types (`sync_events.rs`), remember classification (`remember.rs`),
 ingest orchestration (`ingest_pipeline.rs`), the `Memory`/`MemoryEntry`/etc.


### PR DESCRIPTION
## Summary

`src/openhuman/memory/README.md` links to `https://github.com/tinyhumansai/tinymemory/tree/main/core/src`, which now 404s -- caught by this repo's own `Markdown Link Check` CI job (`lychee`) on an unrelated PR (#5650).

## Root cause

`tinymemory`'s `main` branch has since restructured into a Cargo workspace: `core/` became `crates/tinymemory-core/`. A link pinned to `main` stopped resolving once that migration landed, even though nothing in *this* repo changed.

## Fix

`vendor/tinymemory` (this repo's submodule) is still pinned to commit `38a34d2ea10e7eedda1b50cdc786016c0f73b6dc`, from before the restructure. At that exact commit, `core/src` exists and contains all six files the README names by path (`sync_events.rs`, `remember.rs`, `ingest_pipeline.rs`, `traits.rs`, `preferences.rs`, `rpc_models.rs`) -- verified directly against that commit's tree via the GitHub API.

Pinning the link to that commit SHA instead of `main` fixes the 404 while staying accurate to what's actually vendored here, rather than repointing to tinymemory's current (and possibly further-diverged) directory layout.

## Testing

- Confirmed via the GitHub contents API that `core/src` at commit `38a34d2` contains exactly the six files/dirs the README describes.
- HTTP-checked both URLs directly:
  - Old (`tree/main/core/src`): **404**
  - New (`tree/38a34d2.../core/src`): **200**

Split out of #5650 as an unrelated, separately-scoped fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `tinymemory-core` source reference to a fixed version for improved consistency and reproducibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->