### PR TITLE
fix(release): sign updater artifacts with the CLI the release lane installs

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -94,7 +94,12 @@ jobs:
           fetch-depth: 1
       - name: Install patchelf
         run: sudo apt-get update -qq && sudo apt-get install -y -qq patchelf
-      - name: Syntax check release script
-        run: bash -n scripts/release/strip-appimage-graphics-libs.sh
+      - name: Syntax check release scripts
+        run: |
+          bash -n scripts/release/strip-appimage-graphics-libs.sh
+          bash -n scripts/release/upload-macos-artifacts.sh
+          bash -n scripts/release/tauri-signer.sh
       - name: Run AppImage RPATH sanitize + libxdo guard test (issue #3224)
         run: bash scripts/release/test-strip-appimage-rpaths.sh
+      - name: Run updater-signing guard test (issue #5658)
+        run: bash scripts/release/test-tauri-signer.sh

--- a/scripts/release/strip-appimage-graphics-libs.sh
+++ b/scripts/release/strip-appimage-graphics-libs.sh
@@ -32,6 +32,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APPIMAGE_RUNTIME_VALIDATOR="${APPIMAGE_RUNTIME_VALIDATOR:-$SCRIPT_DIR/validate-appimage-runtime.sh}"
+# shellcheck source=scripts/release/tauri-signer.sh
+. "$SCRIPT_DIR/tauri-signer.sh"
 
 EXCLUDE_PATTERNS=(
   'libGL.so.*'
@@ -844,19 +846,22 @@ strip_one_appimage() {
 
 resign_artifact() {
   local file="$1"
+  # No key configured means this is an unsigned lane (a PR build): the bundler
+  # produced no .sig either, so there is nothing to invalidate. Skipping is
+  # correct here and is the ONLY case in which signing may be skipped.
   if [ -z "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
     return
   fi
-  if ! command -v cargo-tauri >/dev/null 2>&1; then
-    echo "[strip-libs] WARNING: cargo-tauri not on PATH; cannot re-sign $file" >&2
-    return
-  fi
   echo "[strip-libs] Re-signing $file"
-  rm -f "$file.sig"
-  cargo tauri signer sign \
-    --private-key "$TAURI_SIGNING_PRIVATE_KEY" \
-    --password "${TAURI_SIGNING_PRIVATE_KEY_PASSWORD:-}" \
-    "$file" >/dev/null
+  # Previously guarded by `command -v cargo-tauri` with a warn-and-return. CI
+  # never installs cargo-tauri, so that branch was always taken and this leg
+  # shipped a .sig covering the pre-strip bytes. Stripping rewrites the
+  # AppImage, so a signature that is merely left behind cannot verify -- fail
+  # the job instead of publishing it (#5658).
+  if ! tauri_signer_sign "$file"; then
+    echo "[strip-libs] ERROR: could not re-sign $file after stripping; refusing to publish an artifact whose signature does not match its bytes" >&2
+    exit 1
+  fi
 }
 
 main() {

--- a/scripts/release/tauri-signer.sh
+++ b/scripts/release/tauri-signer.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Shared Tauri updater-signing helper for the release scripts.
+#
+# Sourced, not executed — it only defines `tauri_signer_sign` and deliberately
+# sets no shell options, so it inherits the caller's `set -euo pipefail`.
+#
+# Why this exists (#5658): the release lane builds the desktop app with the npm
+# `@tauri-apps/cli` — `pnpm tauri build` in .github/workflows/build-desktop.yml
+# — and never installs the `cargo-tauri` crate. Both release scripts none the
+# less reached for `cargo tauri signer sign`, the one form that is not present
+# on the runner:
+#
+#   * upload-macos-artifacts.sh called it unguarded, so every Release Production
+#     run died with `error: no such command: tauri` (exit 101) at the final
+#     upload step of a ~50-minute job, after the DMG had already been replaced.
+#   * strip-appimage-graphics-libs.sh guarded it with `command -v cargo-tauri`
+#     and returned on failure. That guard has always been taken, so the Linux
+#     leg silently published an updater tarball whose .sig still covered the
+#     pre-strip bytes — a signature that cannot verify on an installed client.
+#
+# Resolution order below prefers the CLI the lane actually installs, and the
+# helper FAILS instead of skipping when no signer is available. An updater
+# artifact published without a valid signature is worse than a failed job:
+# clients verify the signature, so a bad .sig breaks updates for everyone who
+# already has the app, and it does so silently at release time.
+
+# Sign "$1" with the Tauri updater key, writing "$1.sig" alongside it.
+#
+# Requires TAURI_SIGNING_PRIVATE_KEY to be set; TAURI_SIGNING_PRIVATE_KEY_PASSWORD
+# is optional and may be empty for an unencrypted key. The password is always
+# passed explicitly so an encrypted key cannot stall a non-interactive runner on
+# a passphrase prompt.
+#
+# Returns 0 only when a non-empty .sig was produced; non-zero otherwise. Callers
+# that legitimately have nothing to sign (an unsigned PR build with no key
+# configured) must decide that *before* calling this.
+tauri_signer_sign() {
+  local file="$1"
+  local key="${TAURI_SIGNING_PRIVATE_KEY:-}"
+  local password="${TAURI_SIGNING_PRIVATE_KEY_PASSWORD:-}"
+
+  if [ -z "$key" ]; then
+    echo "[tauri-signer] ERROR: TAURI_SIGNING_PRIVATE_KEY is not set; refusing to publish an unsigned updater artifact: $file" >&2
+    return 1
+  fi
+  if [ ! -f "$file" ]; then
+    echo "[tauri-signer] ERROR: nothing to sign, no such file: $file" >&2
+    return 1
+  fi
+
+  local script_dir repo_root app_dir app_bin
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  repo_root="$(cd "$script_dir/../.." && pwd)"
+  app_dir="$repo_root/app"
+  app_bin="$app_dir/node_modules/.bin/tauri"
+
+  # Drop any stale signature first so the check below cannot pass on a leftover
+  # .sig from an earlier bundle. This is the Linux failure mode exactly.
+  rm -f "$file.sig"
+
+  local sign_status=0
+  if [ -x "$app_bin" ]; then
+    # The binary `pnpm install` puts in the workspace — what `pnpm tauri build`
+    # resolves to in build-desktop.yml. Invoked directly so neither pnpm nor a
+    # package.json script indirection can swallow `--private-key`.
+    "$app_bin" signer sign --private-key "$key" --password "$password" "$file" || sign_status=$?
+  elif command -v pnpm >/dev/null 2>&1 && [ -d "$app_dir" ]; then
+    # Same CLI, reached through the workspace when the .bin shim is not where we
+    # expect it (a different hoisting layout, for instance). Must run *from*
+    # app/: `pnpm --dir <path> exec` takes pnpm's recursive path and fails with
+    # ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL instead.
+    ( cd "$app_dir" && pnpm exec tauri signer sign --private-key "$key" --password "$password" "$file" ) || sign_status=$?
+  elif command -v cargo-tauri >/dev/null 2>&1; then
+    # Only for a developer machine that happens to have the cargo subcommand
+    # installed. CI never has it — that is the bug this file exists to fix.
+    cargo-tauri signer sign --private-key "$key" --password "$password" "$file" || sign_status=$?
+  else
+    echo "[tauri-signer] ERROR: no Tauri CLI available to sign $file" >&2
+    echo "[tauri-signer]   looked for: $app_bin" >&2
+    echo "[tauri-signer]               (cd $app_dir && pnpm exec tauri)" >&2
+    echo "[tauri-signer]               cargo-tauri on PATH" >&2
+    echo "[tauri-signer]   The release lane installs the npm CLI with 'pnpm install'; see .github/workflows/build-desktop.yml." >&2
+    return 1
+  fi
+
+  if [ "$sign_status" -ne 0 ]; then
+    echo "[tauri-signer] ERROR: Tauri signer exited with status $sign_status for $file" >&2
+    return 1
+  fi
+  if [ ! -s "$file.sig" ]; then
+    echo "[tauri-signer] ERROR: signer reported success but $file.sig is missing or empty" >&2
+    return 1
+  fi
+
+  echo "[tauri-signer] Signed $(basename "$file")"
+}

--- a/scripts/release/test-tauri-signer.sh
+++ b/scripts/release/test-tauri-signer.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Regression test for scripts/release/tauri-signer.sh (#5658).
+#
+# The property under test is not "signing works" — it is that signing can never
+# silently no-op. The macOS leg used to die on `cargo tauri`, and the Linux leg
+# used to warn-and-return, leaving a .sig that covered pre-strip bytes. Both
+# shapes must now fail.
+#
+# Deliberately dependency-free: a stub stands in for the Tauri CLI, so this runs
+# on any runner without pnpm, node or a signing key.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PASS=0
+FAIL=0
+
+check() {
+  if [ "$1" = "$2" ]; then
+    echo "  ok   — $3"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL — $3 (got '$1', want '$2')" >&2
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# A throwaway repo tree so the helper's repo-root resolution has something to
+# find, and so a stub CLI can sit where `pnpm install` would have put the real one.
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/repo/scripts/release" "$TMP/repo/app/node_modules/.bin"
+cp "$SCRIPT_DIR/tauri-signer.sh" "$TMP/repo/scripts/release/tauri-signer.sh"
+
+# shellcheck source=scripts/release/tauri-signer.sh
+. "$TMP/repo/scripts/release/tauri-signer.sh"
+
+STUB="$TMP/repo/app/node_modules/.bin/tauri"
+BIN_DIR="$TMP/repo/app/node_modules/.bin"
+
+# Records its argv, then behaves as STUB_MODE dictates.
+write_stub() {
+  cat > "$STUB" <<STUB_EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" > "$TMP/argv"
+case "\${STUB_MODE:-ok}" in
+  ok)      printf 'signature\n' > "\${!#}.sig" ;;
+  nosig)   : ;;
+  boom)    exit 3 ;;
+esac
+STUB_EOF
+  chmod +x "$STUB"
+}
+write_stub
+
+export TAURI_SIGNING_PRIVATE_KEY="dummy-private-key"
+export TAURI_SIGNING_PRIVATE_KEY_PASSWORD="dummy-password"
+
+run() { # run <expected_rc> <label> [env assignments...]
+  local want="$1" label="$2"; shift 2
+  local rc=0
+  set +e
+  ( "$@" ) >/dev/null 2>&1
+  rc=$?
+  set -e
+  check "$rc" "$want" "$label"
+}
+
+echo "[test-tauri-signer] happy path"
+printf 'payload\n' > "$TMP/ok.tar.gz"
+run 0 "signs when the npm CLI is present" tauri_signer_sign "$TMP/ok.tar.gz"
+check "$([ -s "$TMP/ok.tar.gz.sig" ] && echo yes || echo no)" "yes" "writes a non-empty .sig"
+# Pin the invocation contract: subcommand and both flags, in the form the npm
+# CLI accepts. `cargo tauri ...` regressing back in would not match this.
+check "$(cat "$TMP/argv")" \
+  "signer sign --private-key dummy-private-key --password dummy-password $TMP/ok.tar.gz" \
+  "invokes 'signer sign' with --private-key and --password"
+
+echo "[test-tauri-signer] failure paths"
+printf 'payload\n' > "$TMP/nokey.tar.gz"
+run 1 "fails when TAURI_SIGNING_PRIVATE_KEY is unset" \
+  env -u TAURI_SIGNING_PRIVATE_KEY bash -c \
+  ". '$TMP/repo/scripts/release/tauri-signer.sh'; tauri_signer_sign '$TMP/nokey.tar.gz'"
+
+run 1 "fails when the file to sign does not exist" tauri_signer_sign "$TMP/absent.tar.gz"
+
+printf 'payload\n' > "$TMP/boom.tar.gz"
+STUB_MODE=boom run 1 "fails when the signer exits non-zero" tauri_signer_sign "$TMP/boom.tar.gz"
+
+printf 'payload\n' > "$TMP/nosig.tar.gz"
+STUB_MODE=nosig run 1 "fails when the signer produces no .sig" tauri_signer_sign "$TMP/nosig.tar.gz"
+
+echo "[test-tauri-signer] a stale signature is never left behind"
+# The Linux regression exactly: bytes were rewritten, signing did not happen,
+# and the previous .sig stayed on disk to be published.
+printf 'payload\n' > "$TMP/stale.tar.gz"
+printf 'SIGNATURE-OVER-OLD-BYTES\n' > "$TMP/stale.tar.gz.sig"
+STUB_MODE=boom run 1 "fails when re-signing rewritten bytes fails" tauri_signer_sign "$TMP/stale.tar.gz"
+check "$([ -e "$TMP/stale.tar.gz.sig" ] && echo present || echo removed)" "removed" \
+  "removes the stale .sig instead of shipping it"
+
+echo "[test-tauri-signer] no Tauri CLI available at all"
+rm -f "$STUB"
+if PATH=/usr/bin:/bin command -v pnpm >/dev/null 2>&1 || PATH=/usr/bin:/bin command -v cargo-tauri >/dev/null 2>&1; then
+  echo "  skip — pnpm or cargo-tauri lives in /usr/bin:/bin here, cannot isolate"
+else
+  printf 'payload\n' > "$TMP/nocli.tar.gz"
+  set +e
+  ( PATH=/usr/bin:/bin; tauri_signer_sign "$TMP/nocli.tar.gz" ) >/dev/null 2>&1
+  rc=$?
+  set -e
+  check "$rc" "1" "fails loudly rather than skipping when no CLI is installed"
+fi
+mkdir -p "$BIN_DIR"
+
+echo
+if [ "$FAIL" -ne 0 ]; then
+  echo "[test-tauri-signer] $PASS passed, $FAIL FAILED" >&2
+  exit 1
+fi
+echo "[test-tauri-signer] $PASS passed, 0 failed"

--- a/scripts/release/upload-macos-artifacts.sh
+++ b/scripts/release/upload-macos-artifacts.sh
@@ -15,6 +15,10 @@ VERSION="${3:?}"
 ARCH="${4:?}"
 UPLOAD_REPO="${UPLOAD_REPO:-tinyhumansai/openhuman}"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/release/tauri-signer.sh
+. "$SCRIPT_DIR/tauri-signer.sh"
+
 # ── Re-upload DMG ────────────────────────────────────────────────────────────
 DMG_PATH="$(find "$BUNDLE_DIR/dmg" -name '*.dmg' -maxdepth 1 2>/dev/null | head -1)"
 if [ -n "$DMG_PATH" ]; then
@@ -42,13 +46,12 @@ if [ -n "$APP_PATH" ] && [ -d "$APP_PATH" ]; then
     exit 1
   fi
 
-  # Tauri CLI reads the key from env and writes <file>.sig alongside.
-  # TAURI_SIGNING_PRIVATE_KEY_PASSWORD is optional (may be empty for unencrypted key).
+  # Signs via the npm @tauri-apps/cli the lane installs, and fails the job if no
+  # signer is available -- shipping an updater tarball whose .sig is missing or
+  # stale breaks updates for every installed client (#5658).
   echo "[upload] Signing updater tarball with Tauri signer..."
-  cargo tauri signer sign --private-key "$TAURI_SIGNING_PRIVATE_KEY" "$APP_ZIP"
-
-  if [ ! -f "${APP_ZIP}.sig" ]; then
-    echo "[upload] ERROR: ${APP_ZIP}.sig was not produced" >&2
+  if ! tauri_signer_sign "$APP_ZIP"; then
+    echo "[upload] ERROR: could not sign ${APP_ZIP}; refusing to upload an unsignatured updater artifact" >&2
     exit 1
   fi
 


### PR DESCRIPTION
## Summary

- Fixes the invocation that has been failing every **Release Production** run on both macOS legs: `upload-macos-artifacts.sh` called `cargo tauri signer sign`, but no workflow installs `cargo-tauri`.
- Routes both updater-signing call sites through a new `scripts/release/tauri-signer.sh`, which resolves the CLI the lane actually installs (the npm `@tauri-apps/cli`) and **fails instead of skipping** when no signer is available.
- Fixes a second, quieter defect on the Linux leg: its `command -v cargo-tauri` guard has *always* been taken, so it published updater tarballs whose `.sig` covered pre-strip bytes.
- Adds a dependency-free regression test pinning the invocation shape and every failure path, wired into the existing release-script job.

**Release-blocking.** Production releases cannot complete until this lands.

## Problem

Run [32475039986](https://github.com/tinyhumansai/openhuman/actions/runs/32475039986), `release` @ `2b220b826`, v0.63.15. Both `Desktop: aarch64-apple-darwin` (49m50s) and `Desktop: x86_64-apple-darwin` (44m22s) died at the final step after ~50 minutes of work:

```
[upload] Signing updater tarball with Tauri signer...
error: no such command: `tauri`
help: find a package to install `tauri` with `cargo search cargo-tauri`
##[error]Process completed with exit code 101.
```

The lane builds with `pnpm tauri build` — the npm `@tauri-apps/cli` (`build-desktop.yml:436`). `cargo-tauri` is installed by no workflow at all; the only `cargo install` anywhere in `.github/` is `tauri-driver`, a different binary, in a Dockerfile. So the CLI is present as an npm binary and absent as a cargo subcommand, and the script reached for the form that does not exist.

The same wrong invocation exists on the Linux leg, where it fails differently and worse. `resign_artifact()` in `strip-appimage-graphics-libs.sh` guarded the call with `command -v cargo-tauri` and returned on failure. Since `cargo-tauri` is never installed, **that branch has always been taken**. The surrounding code rewrites the AppImage and then rebuilds its updater tarball:

```
mv "$rebuilt" "$original"          # AppImage bytes are now different
...
resign_artifact "$original"        # silently skipped
tar -czf "$tar" ...                # tarball rebuilt from the new bytes
resign_artifact "$tar"             # silently skipped again
```

so the `.sig` left on disk is the bundler's original, covering bytes that no longer exist. That is worse than a failed job: it fails on the client, after publication, for everyone who already has the app. Nothing in the lane would have reported it.

## Solution

A single shared helper, `scripts/release/tauri-signer.sh`, sourced by both scripts so they cannot drift apart again. It resolves the CLI once, in this order:

1. `app/node_modules/.bin/tauri` — what `pnpm install` puts in the workspace and what `pnpm tauri build` resolves to. Invoked directly, so neither pnpm nor a `package.json` script indirection can swallow `--private-key`.
2. `(cd app && pnpm exec tauri …)` — the same CLI through the workspace, if the `.bin` shim is not where we expect it.
3. `cargo-tauri` — for a developer machine that happens to have the cargo subcommand. CI never does.
4. Otherwise **fail**, naming all three paths it looked in.

It also removes any stale `.sig` *before* signing and verifies a non-empty one was produced afterwards, so neither an unsigned nor a mismatched updater artifact can reach a release.

Design decisions worth a reviewer's attention:

- **The Linux guard is deliberately not kept.** The issue asked whether it should stay; it should not. `command -v cargo-tauri || { warn; return; }` is precisely the mechanism that let a bad signature ship silently, and once the invocation is corrected the guard protects nothing — the npm CLI is present in the same job that just built the app with it. It is replaced by a hard failure.
- **One skip survives, and it is correct:** an unset `TAURI_SIGNING_PRIVATE_KEY` still returns early on the Linux path. That means an unsigned PR build, where the bundler produced no `.sig` either, so there is nothing to invalidate. It is now the *only* path that may skip, and it is commented as such.
- **macOS now passes `--password` too**, matching what Linux already did. An encrypted key with no password would otherwise stall a non-interactive runner on a passphrase prompt.

## Impact

Release/CI only — no runtime, app or user-facing code changes. Desktop macOS and Linux release legs are affected; Windows, mobile, web and CLI are untouched.

Security-relevant in the right direction: the Linux leg stops publishing updater artifacts with signatures that cannot verify, and no path can now publish an unsigned or unsignatured one.

`release` needs the same fix. The failing run was on `release` @ `2b220b826`, and the defective line is byte-identical on both branches — this PR targets `main` per the fleet standard, so please promote or cherry-pick it to `release` before the next cut.

## Related

- Closes: #5658
- Follow-up PR(s)/TODOs: two follow-ups noted in the issue are **not** addressed here and are worth filing separately — (a) the failure-cleanup job deletes the tag even when release assets were already uploaded, making a re-run structurally impossible; (b) `upload-macos-artifacts.sh` deletes and re-uploads the DMG *before* the step that can fail, so a failed run still mutates the release.

---

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `scripts/release/test-tauri-signer.sh`, 10 assertions: happy path, the invocation contract, and five failure paths (absent key, absent file, signer exits non-zero, signer exits 0 without a `.sig`, no CLI installed), plus the stale-`.sig` case. Run locally on macOS: 10 passed, 0 failed. Each assertion was checked against a reverted helper — restoring the warn-and-return guard, dropping the stale-`.sig` removal, and dropping `--password` each fail exactly one case and no others.
- [x] **Diff coverage ≥ 80%** — `N/A: shell-only change.` Every changed line is Bash in `scripts/release/` and `.github/workflows/`; neither Vitest nor cargo-llvm-cov instruments these, so `diff-cover` sees no changed lines to score. Behavioural coverage is the shell test above. I did **not** run `pnpm test:coverage` or `pnpm test:rust` — no Rust or TypeScript changed, and local builds are disallowed on this machine.
- [x] Coverage matrix updated — `N/A: behaviour-only change` to release scripts; no feature rows added, removed or renamed in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix feature IDs apply`; this touches the release lane, not a product feature.
- [x] No new external network dependencies introduced — no new network calls. The signer runs a CLI that `pnpm install` already places in the workspace; the `gh` calls in the macOS script are unchanged.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no new manual step.` This restores a step that was already meant to run and is verified by CI, not by hand. The real proof is a green Release Production run, which needs a maintainer dispatch (see below).
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `Closes #5658`, same repo, so the bare reference resolves correctly.

## Impact

See `## Impact` above.

---

## AI Authored PR Metadata

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5658-tauri-signer-invocation`
- Commit SHA: `c37811ffd50c2b431353900501461917132a7969`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no TypeScript, JavaScript, JSON or CSS changed.` Prettier does not format `.sh`, and the one YAML file changed keeps the surrounding two-space style (verified by eye and by a tab scan: none).
- [x] `pnpm typecheck` — `N/A: no TypeScript changed.`
- [x] Focused tests: `bash scripts/release/test-tauri-signer.sh` → **10 passed, 0 failed**. Also `bash -n` clean on all four affected scripts (`tauri-signer.sh`, `upload-macos-artifacts.sh`, `strip-appimage-graphics-libs.sh`, `validate-appimage-runtime.sh`), and I confirmed `strip-appimage-graphics-libs.sh` still sources cleanly, since `validate-appimage-runtime.sh` and `test-strip-appimage-rpaths.sh` both source it.
- [x] Rust fmt/check (if changed): `N/A: no Rust changed.`
- [x] Tauri fmt/check (if changed): `N/A: no Tauri/Rust changed.`

### Validation Blocked

- `command:` `bash scripts/release/test-strip-appimage-rpaths.sh`
- `error:` `patchelf` is not installed on this macOS machine; the test is Linux-oriented and runs on `ubuntu-latest` in CI.
- `impact:` The pre-existing AppImage test could not be re-run locally after the edit to `strip-appimage-graphics-libs.sh`. The edit is confined to `resign_artifact()`, which that test does not exercise, and the file still sources cleanly. CI covers it.
- `command:` Release Production workflow dispatch
- `error:` requires maintainer permissions and repository secrets.
- `impact:` **This fix is not verified end-to-end.** I verified the invocation itself against the real `@tauri-apps/cli` 2.11.4 — generated a throwaway minisign keypair, signed a file through the helper, and got a valid 400-byte `.sig` — and confirmed `tauri signer sign` exposes exactly `--private-key` and `--password`. What I cannot verify is a full macOS release leg. Please dispatch a Release Production run before trusting it.

### Behavior Changes

- Intended behavior change: updater signing uses the npm Tauri CLI at both call sites and fails the job when no signer is available, instead of erroring out on macOS and silently skipping on Linux.
- User-visible effect: none in the app. Downstream, macOS releases regain their `.app.tar.gz` + `.app.tar.gz.sig` assets (and `Publish updater manifest (latest.json)` stops being skipped), and Linux AppImage updater artifacts start carrying a signature that actually matches their bytes.

### Parity Contract

- Legacy behavior preserved: the DMG upload path, the tarball layout, asset names and the `gh release upload --clobber` calls are untouched. The unsigned-lane skip (no `TAURI_SIGNING_PRIVATE_KEY`) behaves exactly as before.
- Guard/fallback/dispatch parity checks: the removed `command -v cargo-tauri` guard is intentionally not replaced by an equivalent — see the second bullet under `## Solution`. `cargo-tauri` survives only as the last resolution step, so a developer machine that has it keeps working.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none — `gh api search/issues` for PRs referencing 5658 returns 0 results, and the issue timeline has no linked PR.
- Canonical PR: this one.
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release artifact signing reliability across AppImage and macOS updater packages.
  * Signing now reports failures clearly instead of silently continuing.
  * Prevented stale or missing signature files from being published.
  * Added fallback support for available Tauri signing tools.

* **Tests**
  * Added automated coverage for successful signing, invalid inputs, signer failures, unavailable tools, and stale signatures.
  * Expanded release validation to syntax-check scripts and run signing safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->