### PR TITLE
refactor(agent): move tool calling and tool rendering into tinyagents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -351,6 +351,45 @@ A move never changes the wire surface — RPC namespaces are string literals in 
 
 **Skills runtime**: the QuickJS per-skill VM engine is gone. `src/openhuman/skills/` holds skill metadata/tool descriptors; execution of installed `SKILL.md` workflows lives in `src/openhuman/skills/runtime/` (starts/cancels runs, hosts the `skill_executor` agent, reuses `runtime_node`/`runtime_python`).
 
+### Tool calling lives in tinyagents — `src/openhuman/agent/dispatcher.rs` is a seam
+
+How a model is told to ask for a tool, how the ask is parsed, how results are
+rendered back, and how a transcript is replayed onto the provider wire are one
+thing — a **dialect** — and all four live in
+`tinyagents::harness::tool_calling::dialect` (`XmlDialect` / `PFormatDialect` /
+`NativeDialect`). They belong together because a catalogue advertising one
+grammar next to a parser expecting another is a silent whole-turn failure: the
+model emits a call, nothing recognises it, the iteration is spent, and no error
+is logged anywhere.
+
+`dispatcher.rs` keeps two things and delegates the rest:
+
+- **The vocabulary.** `ParsedToolCall` / `ToolExecutionResult` are named for
+  ~190 call sites, and `ConversationMessage` is the durable JSONL record on
+  existing installations' disks. The crate speaks its own thin `TranscriptEntry`
+  instead, so the conversions in `dispatcher.rs` are the seam — field-wise maps
+  that keep the wire bytes identical while the logic sits upstream. **A
+  conversion that decides something is a second implementation in disguise; put
+  the judgement in the crate.**
+- **The `Tool` trait object.** The crate takes `ToolSchema`s, never a host's
+  tool type — same reason the parse seam already documents: depending on
+  OpenHuman's `Tool` would make the crate unusable by a second host.
+
+Two consequences worth knowing before editing this area:
+
+- **Executing a tool did not move and will not.** The security policy, approval
+  gate, sandbox, per-call timeout and progress events are OpenHuman's. A dialect
+  decides what the model reads and writes; it never decides what is allowed to
+  happen. That line is what keeps the policy auditable in one place.
+- **The catalogue has one renderer.** `ToolsSection` calls the crate's
+  `render_pformat_catalogue`, which builds each `Call as:` signature from the
+  same schema its parser reconstructs arguments from — so prompt order and parse
+  order agree by construction. The local copy this replaced carried a comment
+  promising the two "stay in lockstep", which is the shape of a bug waiting to
+  happen, not a guarantee. `humanize_tool_name` and `context_detail_from_args`
+  in `tools/traits.rs` are re-exports/wrappers over the crate for the same
+  reason; only the ellipsis is OpenHuman's.
+
 **Rules:**
 
 - New functionality → dedicated subdirectory (`openhuman/<domain>/mod.rs` + siblings). No new root-level `*.rs` files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -388,7 +388,7 @@ Two consequences worth knowing before editing this area:
   promising the two "stay in lockstep", which is the shape of a bug waiting to
   happen, not a guarantee. `humanize_tool_name` and `context_detail_from_args`
   in `tools/traits.rs` are re-exports/wrappers over the crate for the same
-  reason; only the ellipsis is OpenHuman's.
+  reason; only the trimming rule (80 chars, `…`) is OpenHuman's.
 
 **Rules:**
 

--- a/src/openhuman/agent/dispatcher.rs
+++ b/src/openhuman/agent/dispatcher.rs
@@ -1,12 +1,49 @@
+//! Tool dialects — OpenHuman's adapter over
+//! [`tinyagents::harness::tool_calling::dialect`].
+//!
+//! The dialects themselves moved to the crate: how a model is told to ask for a
+//! tool, how it is parsed when it does, how results are rendered back, and how
+//! a transcript is replayed onto the provider wire so the next iteration is
+//! well-formed. None of that is OpenHuman-specific, and keeping a second copy
+//! of it here is how a catalogue and its parser drift apart.
+//!
+//! # What stayed
+//!
+//! Two things, both of them vocabulary.
+//!
+//! First, the **types**. [`ParsedToolCall`] and [`ToolExecutionResult`] are
+//! named and shaped for ~190 call sites across the harness, and
+//! [`ConversationMessage`] is the durable JSONL record existing installations
+//! already have on disk. The crate speaks its own thin
+//! [`TranscriptEntry`](tinyagents::harness::tool_calling::dialect::TranscriptEntry)
+//! instead, so the conversions below are the seam — a handful of field-wise
+//! maps that keep the wire bytes identical while the logic lives upstream.
+//!
+//! Second, the **[`Tool`] trait object**. The crate takes
+//! [`ToolSchema`](tinyagents::harness::tool::ToolSchema)s, never a host's tool
+//! type, for the reason the parse seam already documents: a crate that depended
+//! on OpenHuman's `Tool` could not be used by a second host. So
+//! [`ToolDispatcher::prompt_instructions`] reads names and schemas off the
+//! slice and hands the crate exactly what it needs.
+//!
+//! # What did not move, and will not
+//!
+//! Executing a tool. The security policy, the approval gate, the sandbox, the
+//! per-call timeout, the progress events — those are OpenHuman's, and a dialect
+//! never decides what is *allowed to happen*, only what the model reads and
+//! writes. That line is what keeps the policy auditable in one place.
+
 use crate::openhuman::agent::context::prompt::ToolCallFormat;
-use crate::openhuman::agent::harness::parse_tool_calls;
 use crate::openhuman::agent::messages::{ChatMessage, ConversationMessage, ToolResultMessage};
-use crate::openhuman::agent::pformat::{self, PFormatRegistry};
-use crate::openhuman::inference::provider::ChatResponse;
+use crate::openhuman::agent::pformat::PFormatRegistry;
+use crate::openhuman::inference::provider::{ChatResponse, ToolCall};
 use crate::openhuman::tools::{Tool, ToolSpec};
 use serde_json::Value;
-use std::fmt::Write;
-use std::sync::Arc;
+use tinyagents::harness::tool::ToolSchema;
+use tinyagents::harness::tool_calling::dialect::{
+    DialectMessage, DialectResponse, DialectRole, NativeDialect, NativeToolCall, PFormatDialect,
+    ToolDialect, ToolOutcome, ToolResultEntry, TranscriptEntry, XmlDialect,
+};
 
 /// A parsed tool call representation after being extracted from an LLM response.
 #[derive(Debug, Clone)]
@@ -37,6 +74,9 @@ pub struct ToolExecutionResult {
 /// Different LLMs have different "dialects" for calling tools. The dispatcher
 /// abstracts these differences, allowing the agent loop to remain agnostic of
 /// the specific formatting required by the provider.
+///
+/// Each implementation below is a thin projection of one
+/// [`ToolDialect`] into OpenHuman's own vocabulary.
 pub trait ToolDispatcher: Send + Sync {
     /// Parse the LLM response to extract narrative text and any tool calls.
     fn parse_response(&self, response: &ChatResponse) -> (String, Vec<ParsedToolCall>);
@@ -67,6 +107,200 @@ pub trait ToolDispatcher: Send + Sync {
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// The seam: OpenHuman vocabulary ↔ crate vocabulary
+//
+// Every function here is field-wise and lossless in the direction it is used.
+// If one of them ever needs a judgement call, that judgement belongs in the
+// crate — a conversion that decides something is a second implementation
+// wearing a disguise.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Project a provider response into the shape a dialect reads.
+fn to_dialect_response(response: &ChatResponse) -> DialectResponse {
+    DialectResponse {
+        text: response.text.clone(),
+        tool_calls: response.tool_calls.iter().map(to_native_call).collect(),
+    }
+}
+
+fn to_native_call(call: &ToolCall) -> NativeToolCall {
+    NativeToolCall {
+        id: call.id.clone(),
+        name: call.name.clone(),
+        arguments: call.arguments.clone(),
+        extra_content: call.extra_content.clone(),
+    }
+}
+
+fn from_native_call(call: &NativeToolCall) -> ToolCall {
+    ToolCall {
+        id: call.id.clone(),
+        name: call.name.clone(),
+        arguments: call.arguments.clone(),
+        extra_content: call.extra_content.clone(),
+    }
+}
+
+fn from_parsed_calls(calls: Vec<tinyagents::harness::tool_calling::ParsedToolCall>) -> Vec<ParsedToolCall> {
+    calls
+        .into_iter()
+        .map(|call| ParsedToolCall {
+            name: call.name,
+            arguments: call.arguments,
+            tool_call_id: call.id,
+        })
+        .collect()
+}
+
+fn to_outcomes(results: &[ToolExecutionResult]) -> Vec<ToolOutcome> {
+    results
+        .iter()
+        .map(|result| ToolOutcome {
+            name: result.name.clone(),
+            output: result.output.clone(),
+            success: result.success,
+            tool_call_id: result.tool_call_id.clone(),
+        })
+        .collect()
+}
+
+/// Project one durable OpenHuman record onto the crate's transcript entry.
+fn to_transcript_entry(message: &ConversationMessage) -> TranscriptEntry {
+    match message {
+        ConversationMessage::Chat(chat) => TranscriptEntry::Chat(to_dialect_message(chat)),
+        ConversationMessage::AssistantToolCalls {
+            text,
+            tool_calls,
+            reasoning_content,
+            extra_metadata,
+        } => TranscriptEntry::AssistantToolCalls {
+            text: text.clone(),
+            tool_calls: tool_calls.iter().map(to_native_call).collect(),
+            reasoning_content: reasoning_content.clone(),
+            extra_metadata: extra_metadata.clone(),
+        },
+        ConversationMessage::ToolResults(results) => TranscriptEntry::ToolResults(
+            results
+                .iter()
+                .map(|result| ToolResultEntry {
+                    tool_call_id: result.tool_call_id.clone(),
+                    content: result.content.clone(),
+                })
+                .collect(),
+        ),
+    }
+}
+
+fn to_transcript(history: &[ConversationMessage]) -> Vec<TranscriptEntry> {
+    history.iter().map(to_transcript_entry).collect()
+}
+
+fn from_transcript_entry(entry: TranscriptEntry) -> ConversationMessage {
+    match entry {
+        TranscriptEntry::Chat(message) => ConversationMessage::Chat(from_dialect_message(message)),
+        TranscriptEntry::AssistantToolCalls {
+            text,
+            tool_calls,
+            reasoning_content,
+            extra_metadata,
+        } => ConversationMessage::AssistantToolCalls {
+            text,
+            tool_calls: tool_calls.iter().map(from_native_call).collect(),
+            reasoning_content,
+            extra_metadata,
+        },
+        TranscriptEntry::ToolResults(results) => ConversationMessage::ToolResults(
+            results
+                .into_iter()
+                .map(|result| ToolResultMessage {
+                    tool_call_id: result.tool_call_id,
+                    content: result.content,
+                })
+                .collect(),
+        ),
+    }
+}
+
+fn to_dialect_message(message: &ChatMessage) -> DialectMessage {
+    // `role` is a free-form string in the durable record; anything the crate
+    // does not model is a `user` turn, which is what every provider treats an
+    // unrecognized role as anyway.
+    let role = match message.role.as_str() {
+        "system" => DialectRole::System,
+        "assistant" => DialectRole::Assistant,
+        "tool" => DialectRole::Tool,
+        _ => DialectRole::User,
+    };
+    DialectMessage {
+        role,
+        content: message.content.clone(),
+        extra_metadata: message.extra_metadata.clone(),
+    }
+}
+
+fn from_dialect_message(message: DialectMessage) -> ChatMessage {
+    ChatMessage {
+        id: None,
+        role: message.role.as_str().to_string(),
+        content: message.content,
+        extra_metadata: message.extra_metadata,
+    }
+}
+
+fn to_schemas(specs: &[ToolSpec]) -> Vec<ToolSchema> {
+    specs
+        .iter()
+        .map(|spec| ToolSchema::new(&spec.name, &spec.description, spec.parameters.clone()))
+        .collect()
+}
+
+fn schemas_from_tools(tools: &[Box<dyn Tool>]) -> Vec<ToolSchema> {
+    tools
+        .iter()
+        .map(|tool| ToolSchema::new(tool.name(), tool.description(), tool.parameters_schema()))
+        .collect()
+}
+
+fn from_format(format: tinyagents::harness::tool_calling::dialect::ToolCallFormat) -> ToolCallFormat {
+    use tinyagents::harness::tool_calling::dialect::ToolCallFormat as Crate;
+    match format {
+        Crate::PFormat => ToolCallFormat::PFormat,
+        Crate::Json => ToolCallFormat::Json,
+        Crate::Native => ToolCallFormat::Native,
+    }
+}
+
+/// Shared body of every `ToolDispatcher` impl below: convert in, delegate,
+/// convert out. Written once as functions rather than repeated per dispatcher
+/// so a new dialect is a `impl ToolDispatcher` of five one-line forwards.
+fn dispatch_parse(dialect: &dyn ToolDialect, response: &ChatResponse) -> (String, Vec<ParsedToolCall>) {
+    let (text, calls) = dialect.parse_response(&to_dialect_response(response));
+    (text, from_parsed_calls(calls))
+}
+
+fn dispatch_format_results(
+    dialect: &dyn ToolDialect,
+    results: &[ToolExecutionResult],
+) -> ConversationMessage {
+    from_transcript_entry(dialect.format_results(&to_outcomes(results)))
+}
+
+fn dispatch_provider_messages(
+    dialect: &dyn ToolDialect,
+    history: &[ConversationMessage],
+) -> Vec<ChatMessage> {
+    dialect
+        .to_provider_messages(&to_transcript(history))
+        .into_iter()
+        .map(from_dialect_message)
+        .collect()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The three dispatchers
+// ─────────────────────────────────────────────────────────────────────────────
+
 /// Legacy dispatcher using XML-style tags (`<tool_call>`) with JSON bodies.
 ///
 /// This is robust and works well with models that aren't natively trained for
@@ -75,54 +309,35 @@ pub trait ToolDispatcher: Send + Sync {
 pub struct XmlToolDispatcher;
 
 impl XmlToolDispatcher {
-    /// Internal helper to extract tool calls from a raw text string.
-    fn parse_tool_calls_from_text(response: &str) -> (String, Vec<ParsedToolCall>) {
-        let (text, calls) = parse_tool_calls(response);
-        let parsed_calls = calls
-            .into_iter()
-            .map(|call| ParsedToolCall {
-                name: call.name,
-                arguments: call.arguments,
-                tool_call_id: None,
-            })
-            .collect::<Vec<_>>();
-        (text, parsed_calls)
-    }
-
     /// Extract serializable specs for all tools in the registry.
     pub fn tool_specs(tools: &[Box<dyn Tool>]) -> Vec<ToolSpec> {
         tools.iter().map(|tool| tool.spec()).collect()
+    }
+
+    /// Render the protocol block plus the full-schema catalogue.
+    pub fn prompt_instructions_from_specs(specs: &[ToolSpec]) -> String {
+        XmlDialect::instructions(&to_schemas(specs))
+    }
+
+    /// Internal helper to extract tool calls from a raw text string.
+    #[cfg(test)]
+    pub(crate) fn parse_tool_calls_from_text(response: &str) -> (String, Vec<ParsedToolCall>) {
+        let (text, calls) = XmlDialect::parse_text(response);
+        (text, from_parsed_calls(calls))
     }
 }
 
 impl ToolDispatcher for XmlToolDispatcher {
     fn parse_response(&self, response: &ChatResponse) -> (String, Vec<ParsedToolCall>) {
-        let text = response.text_or_empty();
-        let (parsed_text, parsed_calls) = Self::parse_tool_calls_from_text(text);
-        tracing::debug!(
-            parse_mode = "text_fallback",
-            parsed_tool_calls = parsed_calls.len(),
-            "xml dispatcher parsed response"
-        );
-        (parsed_text, parsed_calls)
+        dispatch_parse(&XmlDialect, response)
     }
 
     fn format_results(&self, results: &[ToolExecutionResult]) -> ConversationMessage {
-        let mut content = String::new();
-        for result in results {
-            let status = if result.success { "ok" } else { "error" };
-            let _ = writeln!(
-                content,
-                "<tool_result name=\"{}\" status=\"{}\">\n{}\n</tool_result>",
-                result.name, status, result.output
-            );
-        }
-        ConversationMessage::Chat(ChatMessage::user(format!("[Tool results]\n{content}")))
+        dispatch_format_results(&XmlDialect, results)
     }
 
     fn prompt_instructions(&self, tools: &[Box<dyn Tool>]) -> String {
-        let specs = Self::tool_specs(tools);
-        Self::prompt_instructions_from_specs(&specs)
+        XmlDialect::instructions(&schemas_from_tools(tools))
     }
 
     fn prompt_instructions_for_specs(&self, specs: &[ToolSpec]) -> Option<String> {
@@ -130,61 +345,15 @@ impl ToolDispatcher for XmlToolDispatcher {
     }
 
     fn to_provider_messages(&self, history: &[ConversationMessage]) -> Vec<ChatMessage> {
-        history
-            .iter()
-            .flat_map(|msg| match msg {
-                ConversationMessage::Chat(chat) => vec![chat.clone()],
-                ConversationMessage::AssistantToolCalls {
-                    text,
-                    extra_metadata,
-                    ..
-                } => {
-                    let mut msg = ChatMessage::assistant(text.clone().unwrap_or_default());
-                    msg.extra_metadata = extra_metadata.clone();
-                    vec![msg]
-                }
-                ConversationMessage::ToolResults(results) => {
-                    let mut content = String::new();
-                    for result in results {
-                        let _ = writeln!(
-                            content,
-                            "<tool_result id=\"{}\">\n{}\n</tool_result>",
-                            result.tool_call_id, result.content
-                        );
-                    }
-                    vec![ChatMessage::user(format!("[Tool results]\n{content}"))]
-                }
-            })
-            .collect()
+        dispatch_provider_messages(&XmlDialect, history)
     }
 
     fn should_send_tool_specs(&self) -> bool {
-        // XML dispatcher embeds tool schemas in prompt text instead of
-        // sending native tool specs through the provider API.
-        false
+        XmlDialect.should_send_tool_specs()
     }
-}
 
-impl XmlToolDispatcher {
-    pub fn prompt_instructions_from_specs(specs: &[ToolSpec]) -> String {
-        let mut instructions = String::new();
-        instructions.push_str("## Tool Use Protocol\n\n");
-        instructions
-            .push_str("To use a tool, wrap a JSON object in <tool_call></tool_call> tags:\n\n");
-        instructions.push_str(
-            "```\n<tool_call>\n{\"name\": \"tool_name\", \"arguments\": {\"param\": \"value\"}}\n</tool_call>\n```\n\n",
-        );
-        instructions.push_str("### Available Tools\n\n");
-
-        for spec in specs {
-            let _ = writeln!(
-                instructions,
-                "- **{}**: {}\n  Parameters: `{}`",
-                spec.name, spec.description, spec.parameters
-            );
-        }
-
-        instructions
+    fn tool_call_format(&self) -> ToolCallFormat {
+        from_format(XmlDialect.tool_call_format())
     }
 }
 
@@ -193,413 +362,83 @@ impl XmlToolDispatcher {
 ///
 /// P-format is designed to significantly reduce token usage compared to JSON.
 /// It uses positional arguments based on an alphabetical sort of the tool's
-/// parameters.
-///
-/// On the parse side the dispatcher tries p-format **first** and falls
-/// back to the existing JSON-in-tag parser if the body doesn't match
-/// the bracket pattern. This keeps the dispatcher backwards-compatible
-/// with models that still emit JSON tool calls.
+/// parameters, and falls back to the JSON-in-tag parser per tag so a model that
+/// mixes the two forms is still understood.
 pub struct PFormatToolDispatcher {
-    /// Registry of tool parameter layouts used to reconstruct named arguments from positional ones.
-    registry: Arc<PFormatRegistry>,
+    dialect: PFormatDialect,
 }
 
 impl PFormatToolDispatcher {
     /// Create a new P-Format dispatcher with the given tool registry.
     pub fn new(registry: PFormatRegistry) -> Self {
         Self {
-            registry: Arc::new(registry),
+            dialect: PFormatDialect::new(registry),
         }
-    }
-
-    /// Convert the registry-driven positional parser output into the dispatcher's
-    /// `ParsedToolCall` shape. Always called inside a `<tool_call>` tag.
-    fn try_parse_pformat_body(&self, body: &str) -> Option<ParsedToolCall> {
-        let (name, args) = pformat::parse_call(body, self.registry.as_ref())?;
-        Some(ParsedToolCall {
-            name,
-            arguments: args,
-            tool_call_id: None,
-        })
     }
 }
 
 impl ToolDispatcher for PFormatToolDispatcher {
     fn parse_response(&self, response: &ChatResponse) -> (String, Vec<ParsedToolCall>) {
-        let text = response.text_or_empty();
-
-        // Run the JSON parser first — it gives us the narrative text
-        // and a Vec of JSON-parsed calls. We then walk the tags
-        // ourselves and resolve each one individually: if p-format
-        // succeeds, use that; otherwise keep the JSON entry. This
-        // per-tag selection means a response mixing p-format and JSON
-        // tags is handled correctly instead of the old all-or-nothing.
-        //
-        // `XmlToolDispatcher::parse_tool_calls_from_text` is the
-        // canonical adapter from the internal `harness::parse`
-        // `ParsedToolCall` to the dispatcher's `ParsedToolCall`.
-        let json_pass = XmlToolDispatcher::parse_tool_calls_from_text(text);
-
-        // Walk tags manually, building a combined list that prefers
-        // p-format but falls back to JSON per tag.
-        let mut combined_calls = Vec::new();
-        let mut json_idx: usize = 0; // index into json_pass.1
-        let mut remaining = text;
-        let tags: &[(&str, &str)] = &[
-            ("<tool_call>", "</tool_call>"),
-            ("<toolcall>", "</toolcall>"),
-            ("<tool-call>", "</tool-call>"),
-            ("<invoke>", "</invoke>"),
-        ];
-        while !remaining.is_empty() {
-            let next = tags
-                .iter()
-                .filter_map(|(open, close)| remaining.find(open).map(|i| (i, *open, *close)))
-                .min_by_key(|(i, _, _)| *i);
-
-            let Some((open_idx, open_tag, close_tag)) = next else {
-                break;
-            };
-
-            let after_open = &remaining[open_idx + open_tag.len()..];
-            let Some(close_idx) = after_open.find(close_tag) else {
-                break;
-            };
-
-            let body = &after_open[..close_idx];
-
-            // Try p-format first; if that fails, take the
-            // corresponding JSON entry (if one exists at this index).
-            if let Some(parsed) = self.try_parse_pformat_body(body) {
-                combined_calls.push(parsed);
-                // Advance the JSON index too — both parsers walk the
-                // same ordered set of tags, so they stay in lockstep.
-                json_idx += 1;
-            } else if let Some(json_call) = json_pass.1.get(json_idx) {
-                combined_calls.push(json_call.clone());
-                json_idx += 1;
-            }
-
-            remaining = &after_open[close_idx + close_tag.len()..];
-        }
-
-        if !combined_calls.is_empty() {
-            tracing::debug!(
-                parse_mode = "pformat_combined",
-                parsed_tool_calls = combined_calls.len(),
-                "pformat dispatcher parsed response (per-tag selection)"
-            );
-            return (json_pass.0, combined_calls);
-        }
-
-        // No tags found at all (or all tags failed both parsers) —
-        // return the full JSON pass which also handles markdown
-        // code-block and GLM fallbacks.
-        tracing::debug!(
-            parse_mode = "pformat_fallback_json",
-            parsed_tool_calls = json_pass.1.len(),
-            "pformat dispatcher fell back to JSON-in-tag path"
-        );
-        json_pass
+        dispatch_parse(&self.dialect, response)
     }
 
     fn format_results(&self, results: &[ToolExecutionResult]) -> ConversationMessage {
-        // Same wrapping format as XML dispatcher — `<tool_result>` tags
-        // are unaffected by the call-side syntax change.
-        let mut content = String::new();
-        for result in results {
-            let status = if result.success { "ok" } else { "error" };
-            let _ = writeln!(
-                content,
-                "<tool_result name=\"{}\" status=\"{}\">\n{}\n</tool_result>",
-                result.name, status, result.output
-            );
-        }
-        ConversationMessage::Chat(ChatMessage::user(format!("[Tool results]\n{content}")))
+        dispatch_format_results(&self.dialect, results)
     }
 
     fn prompt_instructions(&self, _tools: &[Box<dyn Tool>]) -> String {
-        // Protocol description ONLY — the tool catalogue is rendered by
-        // the upstream `ToolsSection` (which now reads
-        // `PromptContext::tool_call_format` and emits the same positional
-        // signatures we'd otherwise duplicate here). Keeping this string
-        // protocol-only avoids the wasteful "tools listed twice" pattern
-        // the legacy `XmlToolDispatcher` carries forward, and means
-        // adding a new tool only changes the prompt in one place.
-        let mut instructions = String::new();
-        instructions.push_str("## Tool Use Protocol\n\n");
-        instructions.push_str(
-            "Tool calls use **P-Format** (Parameter-Format): compact, positional, \
-             pipe-delimited syntax wrapped in `<tool_call>` tags. ~80% cheaper on tokens \
-             than JSON.\n\n",
-        );
-        instructions
-            .push_str("```\n<tool_call>\nget_weather[London|metric]\n</tool_call>\n```\n\n");
-        instructions.push_str(
-            "**Rules:**\n\
-             - Form: `name[arg1|arg2|...|argN]`. Arguments are positional and must match the \
-               order shown in each tool's `Call as:` signature in the `## Tools` section above \
-               (alphabetical by parameter name).\n\
-             - Empty calls: `name[]` for zero-arg tools.\n\
-             - Empty argument: `name[||value]` is three positional values, the first two empty.\n\
-             - Escapes inside argument values: `\\|` → `|`, `\\]` → `]`, `\\\\` → `\\`.\n\
-             - You may emit multiple `<tool_call>` blocks in a single response. Each tag holds \
-               exactly one call.\n\
-             - After tool execution, results appear in `<tool_result>` tags. Continue reasoning \
-               with the results until you can give a final answer.\n\
-             - If you genuinely need a complex nested argument that p-format can't express, \
-               you may fall back to the JSON form: \
-               `<tool_call>{\"name\":\"...\",\"arguments\":{...}}</tool_call>`. Prefer p-format \
-               for everything else.\n\n",
-        );
-
-        instructions
+        // Protocol description ONLY — the catalogue is rendered by the upstream
+        // `ToolsSection`, from the same schemas this dialect parses against.
+        PFormatDialect::instructions()
     }
 
     fn to_provider_messages(&self, history: &[ConversationMessage]) -> Vec<ChatMessage> {
-        // Identical to XML dispatcher — history serialization is
-        // independent of the call-body format.
-        history
-            .iter()
-            .flat_map(|msg| match msg {
-                ConversationMessage::Chat(chat) => vec![chat.clone()],
-                ConversationMessage::AssistantToolCalls {
-                    text,
-                    extra_metadata,
-                    ..
-                } => {
-                    let mut msg = ChatMessage::assistant(text.clone().unwrap_or_default());
-                    msg.extra_metadata = extra_metadata.clone();
-                    vec![msg]
-                }
-                ConversationMessage::ToolResults(results) => {
-                    let mut content = String::new();
-                    for result in results {
-                        let _ = writeln!(
-                            content,
-                            "<tool_result id=\"{}\">\n{}\n</tool_result>",
-                            result.tool_call_id, result.content
-                        );
-                    }
-                    vec![ChatMessage::user(format!("[Tool results]\n{content}"))]
-                }
-            })
-            .collect()
+        dispatch_provider_messages(&self.dialect, history)
     }
 
     fn should_send_tool_specs(&self) -> bool {
-        // P-format is text-based — the model never receives a structured
-        // tool spec, only the catalogue inside the system prompt.
-        false
+        self.dialect.should_send_tool_specs()
     }
 
     fn tool_call_format(&self) -> ToolCallFormat {
-        ToolCallFormat::PFormat
+        from_format(self.dialect.tool_call_format())
     }
 }
 
 /// Dispatcher for models with native, structured tool-calling support (e.g., OpenAI, Anthropic).
 ///
 /// This dispatcher leverages the provider's built-in APIs for identifying and
-/// reporting tool calls, which is generally more reliable than text-based parsing.
-/// It still supports a text-based fallback for robustness against models that
-/// might "forget" to use the structured API.
+/// reporting tool calls, which is generally more reliable than text-based
+/// parsing. It still supports a text-based fallback for robustness against
+/// models that might "forget" to use the structured API, and drops half-finished
+/// tool cycles while serializing so a bisected transcript cannot trip the
+/// provider's 400 (TAURI-RUST-7) — see
+/// [`pair_tool_cycles`](tinyagents::harness::tool_calling::dialect::pair_tool_cycles).
 pub struct NativeToolDispatcher;
 
 impl ToolDispatcher for NativeToolDispatcher {
     fn parse_response(&self, response: &ChatResponse) -> (String, Vec<ParsedToolCall>) {
-        let text = response.text.clone().unwrap_or_default();
-        let calls: Vec<ParsedToolCall> = response
-            .tool_calls
-            .iter()
-            .map(|tc| ParsedToolCall {
-                name: tc.name.clone(),
-                arguments: serde_json::from_str(&tc.arguments).unwrap_or_else(|e| {
-                    tracing::warn!(
-                        tool = %tc.name,
-                        error = %e,
-                        "Failed to parse native tool call arguments as JSON; defaulting to empty object"
-                    );
-                    Value::Object(serde_json::Map::new())
-                }),
-                tool_call_id: Some(tc.id.clone()),
-            })
-            .collect();
-
-        if !calls.is_empty() {
-            tracing::debug!(
-                parse_mode = "native_structured",
-                parsed_tool_calls = calls.len(),
-                "native dispatcher parsed response"
-            );
-            return (text, calls);
-        }
-
-        if !text.is_empty() {
-            let (fallback_text, fallback_calls) =
-                XmlToolDispatcher::parse_tool_calls_from_text(&text);
-            if !fallback_calls.is_empty() {
-                let display_text = if fallback_text.is_empty() {
-                    text
-                } else {
-                    fallback_text
-                };
-                tracing::debug!(
-                    parse_mode = "text_fallback",
-                    parsed_tool_calls = fallback_calls.len(),
-                    "native dispatcher parsed response"
-                );
-                return (display_text, fallback_calls);
-            }
-        }
-
-        tracing::debug!(
-            parse_mode = "none",
-            parsed_tool_calls = 0,
-            "native dispatcher parsed response"
-        );
-        (text, calls)
+        dispatch_parse(&NativeDialect, response)
     }
 
     fn format_results(&self, results: &[ToolExecutionResult]) -> ConversationMessage {
-        let messages = results
-            .iter()
-            .map(|result| ToolResultMessage {
-                tool_call_id: result
-                    .tool_call_id
-                    .clone()
-                    .unwrap_or_else(|| "unknown".to_string()),
-                content: result.output.clone(),
-            })
-            .collect();
-        ConversationMessage::ToolResults(messages)
+        dispatch_format_results(&NativeDialect, results)
     }
 
     fn prompt_instructions(&self, _tools: &[Box<dyn Tool>]) -> String {
-        [
-            "## Tool Use Protocol",
-            "",
-            "When a tool is needed, emit tool calls directly via the model's native tool-calling output.",
-            "Do not only narrate intent (for example, avoid \"Let me check...\") without emitting the tool call.",
-            "After tool results are provided, continue reasoning and then produce the final answer.",
-            "",
-        ]
-        .join("\n")
+        NativeDialect.prompt_instructions(&[])
     }
 
     fn to_provider_messages(&self, history: &[ConversationMessage]) -> Vec<ChatMessage> {
-        // TAURI-RUST-7: providers (incl. the OpenHuman backend) reject any
-        // assistant `tool_calls` message that isn't immediately followed by
-        // `tool` messages responding to every `tool_call_id`, with
-        // `400 An assistant message with 'tool_calls' must be followed by
-        // tool messages responding to each 'tool_call_id'`. Cached transcript
-        // restores, mid-turn aborts, and history compaction can all produce a
-        // bisected tool cycle (assistant tool_calls preserved, ToolResults
-        // dropped or never persisted). Filter those out here, just before
-        // serialising to provider wire format, so a bisected pair never
-        // reaches the wire. Symmetric drop: a `ToolResults` whose preceding
-        // `AssistantToolCalls` was dropped is also stripped to keep the
-        // sequence well-formed.
-        // CodeRabbit follow-up: backend's 400 says "insufficient tool messages
-        // following tool_calls", which fires on either (a) zero following tool
-        // messages, or (b) a tool message set whose `tool_call_id`s don't
-        // cover every `tool_calls[].id` on the opener. Adjacency alone is
-        // not sufficient — require the full set of opener ids to equal the
-        // set of follower `tool_call_id`s.
-        let mut paired_indices: Vec<usize> = Vec::with_capacity(history.len());
-        for (i, msg) in history.iter().enumerate() {
-            match msg {
-                ConversationMessage::AssistantToolCalls { tool_calls, .. } => {
-                    let Some(ConversationMessage::ToolResults(results)) = history.get(i + 1) else {
-                        log::debug!(
-                            "[agent][dispatcher] dropping unpaired AssistantToolCalls at index \
-                             {i} of {} (no immediately following ToolResults — would trip \
-                             provider 400 'tool_calls must be followed by tool messages')",
-                            history.len()
-                        );
-                        continue;
-                    };
-                    let opener_ids: std::collections::BTreeSet<&str> =
-                        tool_calls.iter().map(|tc| tc.id.as_str()).collect();
-                    let result_ids: std::collections::BTreeSet<&str> =
-                        results.iter().map(|r| r.tool_call_id.as_str()).collect();
-                    if !opener_ids.is_empty() && opener_ids == result_ids {
-                        paired_indices.push(i);
-                    } else {
-                        log::debug!(
-                            "[agent][dispatcher] dropping AssistantToolCalls at index {i}: \
-                             tool_call_id set mismatch between opener ({:?}) and ToolResults \
-                             ({:?})",
-                            opener_ids,
-                            result_ids
-                        );
-                    }
-                }
-                ConversationMessage::ToolResults(_) => {
-                    let preceded_by_kept_tool_calls = i > 0
-                        && matches!(
-                            history.get(i - 1),
-                            Some(ConversationMessage::AssistantToolCalls { .. })
-                        )
-                        && paired_indices.last() == Some(&(i - 1));
-                    if preceded_by_kept_tool_calls {
-                        paired_indices.push(i);
-                    } else {
-                        log::debug!(
-                            "[agent][dispatcher] dropping orphan ToolResults at index {i} \
-                             (no preceding AssistantToolCalls in the emitted sequence)"
-                        );
-                    }
-                }
-                ConversationMessage::Chat(_) => {
-                    paired_indices.push(i);
-                }
-            }
-        }
-
-        paired_indices
-            .into_iter()
-            .flat_map(|i| match &history[i] {
-                ConversationMessage::Chat(chat) => vec![chat.clone()],
-                ConversationMessage::AssistantToolCalls {
-                    text,
-                    tool_calls,
-                    reasoning_content,
-                    extra_metadata,
-                } => {
-                    let mut payload = serde_json::json!({
-                        "content": text,
-                        "tool_calls": tool_calls,
-                    });
-                    if let Some(rc) = reasoning_content {
-                        payload["reasoning_content"] = serde_json::Value::String(rc.clone());
-                    }
-                    let mut msg = ChatMessage::assistant(payload.to_string());
-                    msg.extra_metadata = extra_metadata.clone();
-                    vec![msg]
-                }
-                ConversationMessage::ToolResults(results) => results
-                    .iter()
-                    .map(|result| {
-                        ChatMessage::tool(
-                            serde_json::json!({
-                                "tool_call_id": result.tool_call_id,
-                                "content": result.content,
-                            })
-                            .to_string(),
-                        )
-                    })
-                    .collect(),
-            })
-            .collect()
+        dispatch_provider_messages(&NativeDialect, history)
     }
 
     fn should_send_tool_specs(&self) -> bool {
-        true
+        NativeDialect.should_send_tool_specs()
     }
 
     fn tool_call_format(&self) -> ToolCallFormat {
-        ToolCallFormat::Native
+        from_format(NativeDialect.tool_call_format())
     }
 }
 

--- a/src/openhuman/agent/dispatcher.rs
+++ b/src/openhuman/agent/dispatcher.rs
@@ -142,7 +142,9 @@ fn from_native_call(call: &NativeToolCall) -> ToolCall {
     }
 }
 
-fn from_parsed_calls(calls: Vec<tinyagents::harness::tool_calling::ParsedToolCall>) -> Vec<ParsedToolCall> {
+fn from_parsed_calls(
+    calls: Vec<tinyagents::harness::tool_calling::ParsedToolCall>,
+) -> Vec<ParsedToolCall> {
     calls
         .into_iter()
         .map(|call| ParsedToolCall {
@@ -262,7 +264,9 @@ fn schemas_from_tools(tools: &[Box<dyn Tool>]) -> Vec<ToolSchema> {
         .collect()
 }
 
-fn from_format(format: tinyagents::harness::tool_calling::dialect::ToolCallFormat) -> ToolCallFormat {
+fn from_format(
+    format: tinyagents::harness::tool_calling::dialect::ToolCallFormat,
+) -> ToolCallFormat {
     use tinyagents::harness::tool_calling::dialect::ToolCallFormat as Crate;
     match format {
         Crate::PFormat => ToolCallFormat::PFormat,
@@ -274,7 +278,10 @@ fn from_format(format: tinyagents::harness::tool_calling::dialect::ToolCallForma
 /// Shared body of every `ToolDispatcher` impl below: convert in, delegate,
 /// convert out. Written once as functions rather than repeated per dispatcher
 /// so a new dialect is a `impl ToolDispatcher` of five one-line forwards.
-fn dispatch_parse(dialect: &dyn ToolDialect, response: &ChatResponse) -> (String, Vec<ParsedToolCall>) {
+fn dispatch_parse(
+    dialect: &dyn ToolDialect,
+    response: &ChatResponse,
+) -> (String, Vec<ParsedToolCall>) {
     let (text, calls) = dialect.parse_response(&to_dialect_response(response));
     (text, from_parsed_calls(calls))
 }

--- a/src/openhuman/agent/dispatcher_tests.rs
+++ b/src/openhuman/agent/dispatcher_tests.rs
@@ -549,3 +549,28 @@ fn to_provider_messages_drops_pair_with_extra_unsolicited_results() {
         "extra unsolicited tool_call_ids must invalidate the pair, kept: {roles:?}"
     );
 }
+
+// `ChatMessage.role` is a free-form `String` in the durable transcript record,
+// but `to_dialect_message`/`from_dialect_message` route it through the
+// crate's closed `DialectRole` (system/user/assistant/tool) — the same four
+// roles every dispatcher already spoke before this seam existed. A role
+// outside that vocabulary (nothing in this codebase produces one today; see
+// the doc comment on `to_dialect_message`) is treated as a `user` turn on the
+// way out, matching how every provider already treats an unrecognized role.
+// This pins that intentional behaviour so it does not silently drift.
+#[test]
+fn to_provider_messages_treats_unrecognized_role_as_user() {
+    let dispatcher = XmlToolDispatcher;
+    let mut developer_message = crate::openhuman::agent::messages::ChatMessage::user("hi");
+    developer_message.role = "developer".to_string();
+    let history = vec![ConversationMessage::Chat(developer_message)];
+
+    let out = dispatcher.to_provider_messages(&history);
+
+    assert_eq!(out.len(), 1);
+    assert_eq!(
+        out[0].role, "user",
+        "an unrecognized role must fall back to `user`, not be dropped or panic"
+    );
+    assert_eq!(out[0].content, "hi");
+}

--- a/src/openhuman/agent/harness/mod.rs
+++ b/src/openhuman/agent/harness/mod.rs
@@ -70,11 +70,9 @@ pub(crate) use graph::run_channel_turn_via_graph;
 #[cfg(feature = "channels")]
 pub(crate) use instructions::build_tool_instructions_filtered;
 pub(crate) use parse::parse_tool_calls_with_pformat;
-// The bare text parser has no production call site left here: the dispatcher
-// reaches it through `tinyagents`' dialect layer now. Only this module's own
-// tests still name it through the harness path.
-#[cfg(test)]
-pub(crate) use parse::parse_tool_calls;
+// No `parse_tool_calls` re-export: the dispatcher reaches the bare text parser
+// through `tinyagents`' dialect layer now, and the tests that still use it name
+// `parse::parse_tool_calls` directly.
 
 #[cfg(test)]
 mod harness_gap_tests;

--- a/src/openhuman/agent/harness/mod.rs
+++ b/src/openhuman/agent/harness/mod.rs
@@ -69,7 +69,12 @@ pub use turn_subagent_usage::{LastTurnUsage, SubagentUsageEntry};
 pub(crate) use graph::run_channel_turn_via_graph;
 #[cfg(feature = "channels")]
 pub(crate) use instructions::build_tool_instructions_filtered;
-pub(crate) use parse::{parse_tool_calls, parse_tool_calls_with_pformat};
+pub(crate) use parse::parse_tool_calls_with_pformat;
+// The bare text parser has no production call site left here: the dispatcher
+// reaches it through `tinyagents`' dialect layer now. Only this module's own
+// tests still name it through the harness path.
+#[cfg(test)]
+pub(crate) use parse::parse_tool_calls;
 
 #[cfg(test)]
 mod harness_gap_tests;

--- a/src/openhuman/agent/prompts/sections.rs
+++ b/src/openhuman/agent/prompts/sections.rs
@@ -767,4 +767,3 @@ fn sanitize_identity_field(s: &str) -> String {
         .collect::<Vec<_>>()
         .join(" ")
 }
-

--- a/src/openhuman/agent/prompts/sections.rs
+++ b/src/openhuman/agent/prompts/sections.rs
@@ -425,32 +425,31 @@ impl PromptSection for ToolsSection {
             }
             return Ok(ctx.dispatcher_instructions.to_string());
         }
-        let mut out = String::from("## Tools\n\n");
+        // One rendering shape for every dispatcher: a compact P-Format
+        // signature (`name[a|b|c]`), rendered by the crate from the same
+        // schemas its parser reconstructs arguments with — so the order the
+        // model reads is by construction the order the parser expects. For
+        // `Native` dispatchers the provider already has the full JSON schema in
+        // the API request (handled above); for `Json` / `PFormat` text
+        // dispatchers the dispatcher's own `prompt_instructions` block
+        // (appended below) carries whatever schema detail the wire format needs.
         let has_filter = !ctx.visible_tool_names.is_empty();
-        for tool in ctx.tools {
-            // Skip tools not in the visible set when a filter is active.
-            if has_filter && !ctx.visible_tool_names.contains(tool.name) {
-                continue;
-            }
-
-            // One rendering shape for every dispatcher: a compact
-            // P-Format signature (`name[a|b|c]`). The signature comes
-            // straight from the parameter schema (alphabetical by
-            // property name — see `pformat` module docs for why) so
-            // model and parser agree on argument ordering. For
-            // `Native` dispatchers the provider already has the full
-            // JSON schema in the API request, so repeating it in the
-            // prompt is pure token bloat; for `Json` / `PFormat` text
-            // dispatchers the dispatcher's own `prompt_instructions`
-            // block (appended below) carries whatever schema detail
-            // the wire format needs.
-            let signature = render_pformat_signature_for_prompt(tool);
-            let _ = writeln!(
-                out,
-                "- **{}**: {}\n  Call as: `{}`",
-                tool.name, tool.description, signature
-            );
-        }
+        let visible: Vec<ToolSchema> = ctx
+            .tools
+            .iter()
+            .filter(|tool| !has_filter || ctx.visible_tool_names.contains(tool.name))
+            .map(|tool| {
+                ToolSchema::new(
+                    tool.name,
+                    tool.description,
+                    tool.parameters_schema
+                        .as_deref()
+                        .and_then(|schema| serde_json::from_str(schema).ok())
+                        .unwrap_or(serde_json::Value::Null),
+                )
+            })
+            .collect();
+        let mut out = render_pformat_catalogue(&visible);
         if !ctx.dispatcher_instructions.is_empty() {
             out.push('\n');
             out.push_str(ctx.dispatcher_instructions);
@@ -767,25 +766,3 @@ fn sanitize_identity_field(s: &str) -> String {
         .join(" ")
 }
 
-/// Build a P-Format signature line (`name[a|b|c]`) from a [`PromptTool`].
-/// Local to this module so [`ToolsSection`] doesn't have to depend on
-/// the agent crate's `pformat` helper. The two implementations stay in
-/// lockstep — both use BTreeMap iteration order on the schema's
-/// `properties` field.
-fn render_pformat_signature_for_prompt(tool: &PromptTool<'_>) -> String {
-    let names: Vec<String> = tool
-        .parameters_schema
-        .as_deref()
-        .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
-        .and_then(|v| {
-            v.get("properties")
-                .and_then(|p| p.as_object())
-                .map(|m| m.keys().cloned().collect())
-        })
-        .unwrap_or_default();
-    if names.is_empty() {
-        format!("{}[]", tool.name)
-    } else {
-        format!("{}[{}]", tool.name, names.join("|"))
-    }
-}

--- a/src/openhuman/agent/prompts/sections.rs
+++ b/src/openhuman/agent/prompts/sections.rs
@@ -441,14 +441,21 @@ impl PromptSection for ToolsSection {
             .iter()
             .filter(|tool| !has_filter || ctx.visible_tool_names.contains(tool.name))
             .map(|tool| {
-                ToolSchema::new(
-                    tool.name,
-                    tool.description,
-                    tool.parameters_schema
-                        .as_deref()
-                        .and_then(|schema| serde_json::from_str(schema).ok())
-                        .unwrap_or(serde_json::Value::Null),
-                )
+                let parameters = match tool.parameters_schema.as_deref() {
+                    Some(schema) => match serde_json::from_str(schema) {
+                        Ok(value) => value,
+                        Err(err) => {
+                            log::warn!(
+                                "[prompts][tools] tool '{}' has an unparsable parameters_schema \
+                                 ({err}); rendering it with no arguments",
+                                tool.name
+                            );
+                            serde_json::Value::Null
+                        }
+                    },
+                    None => serde_json::Value::Null,
+                };
+                ToolSchema::new(tool.name, tool.description, parameters)
             })
             .collect();
         let mut out = render_pformat_catalogue(&visible);

--- a/src/openhuman/agent/prompts/sections.rs
+++ b/src/openhuman/agent/prompts/sections.rs
@@ -12,6 +12,8 @@ use super::render_helpers::{
 use super::types::*;
 use anyhow::Result;
 use std::fmt::Write;
+use tinyagents::harness::tool::ToolSchema;
+use tinyagents::harness::tool_calling::dialect::render_pformat_catalogue;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Special sections (archetype, dynamic, reflection)

--- a/src/openhuman/tools/traits.rs
+++ b/src/openhuman/tools/traits.rs
@@ -147,35 +147,22 @@ pub struct ToolSpec {
 /// `gmail_read_message` → "Gmail Read Message". Used as the default for
 /// [`Tool::display_label`] and as a safety net for any tool that doesn't
 /// supply a curated phrase, so a timeline row never shows raw `snake_case`.
-pub fn humanize_tool_name(name: &str) -> String {
-    let trimmed = name
-        .strip_prefix("composio_")
-        .or_else(|| name.strip_prefix("mcp_"))
-        .unwrap_or(name);
+///
+/// Re-exported from [`tinyagents::harness::tool`]: naming a tool for a human is
+/// not OpenHuman-specific, and two copies of the prefix list is how one of them
+/// silently stops stripping a prefix the other does.
+pub use tinyagents::harness::tool::humanize_tool_name;
 
-    let mut out = String::with_capacity(trimmed.len());
-    let mut capitalize = true;
-    for ch in trimmed.chars() {
-        if ch == '_' || ch == '-' {
-            if !out.is_empty() && !out.ends_with(' ') {
-                out.push(' ');
-            }
-            capitalize = true;
-        } else if capitalize {
-            out.extend(ch.to_uppercase());
-            capitalize = false;
-        } else {
-            out.push(ch);
-        }
-    }
-
-    let label = out.trim();
-    if label.is_empty() {
-        name.to_string()
-    } else {
-        label.to_string()
-    }
-}
+/// Trimming rule for [`context_detail_from_args`].
+///
+/// OpenHuman elides with a single `…` rather than three dots, because the
+/// detail sits inline in a timeline row where three characters of budget are
+/// worth having. That is the only thing this host changes about the rule.
+const CONTEXT_DETAIL: tinyagents::harness::tool::ContextDetailOptions =
+    tinyagents::harness::tool::ContextDetailOptions {
+        max_chars: 80,
+        ellipsis: "…",
+    };
 
 /// Pull the single most-relevant contextual argument out of a tool-call's
 /// args for the timeline "detail" (the bracketed context after the label).
@@ -186,70 +173,11 @@ pub fn humanize_tool_name(name: &str) -> String {
 /// steven@gmail.com" / `Read(src/openhuman/web3/wallet/ops.rs)` without every tool
 /// hand-writing a [`Tool::display_detail`] override. Returns `None` when no
 /// recognized key carries a usable scalar.
+///
+/// The key list and the scan live in [`tinyagents::harness::tool`]; this wrapper
+/// supplies OpenHuman's [`CONTEXT_DETAIL`] trimming.
 pub fn context_detail_from_args(args: &serde_json::Value) -> Option<String> {
-    /// Common "what is this acting on" keys, most-specific first.
-    const CONTEXT_KEYS: &[&str] = &[
-        "to",
-        "recipient",
-        "recipient_email",
-        "to_email",
-        "email",
-        "query",
-        "q",
-        "search",
-        "search_query",
-        "url",
-        "file_path",
-        "path",
-        "command",
-        "cmd",
-        "subject",
-        "title",
-        "channel",
-        "channel_id",
-        "repo",
-        "repository",
-        "name",
-        "id",
-    ];
-
-    let obj = args.as_object()?;
-    for key in CONTEXT_KEYS {
-        let Some(value) = obj.get(*key) else { continue };
-        if let Some(rendered) = render_context_value(value) {
-            return Some(rendered);
-        }
-    }
-    None
-}
-
-/// Render a single arg value to a compact detail string, or `None` when it
-/// carries nothing useful (empty string, object, null).
-fn render_context_value(value: &serde_json::Value) -> Option<String> {
-    /// Max characters for a timeline detail before it is elided.
-    const MAX_DETAIL: usize = 80;
-
-    let raw = match value {
-        serde_json::Value::String(s) => s.trim().to_string(),
-        serde_json::Value::Number(n) => n.to_string(),
-        serde_json::Value::Bool(b) => b.to_string(),
-        serde_json::Value::Array(items) => items
-            .iter()
-            .filter_map(|v| v.as_str())
-            .collect::<Vec<_>>()
-            .join(", "),
-        _ => String::new(),
-    };
-    let raw = raw.split_whitespace().collect::<Vec<_>>().join(" ");
-    if raw.is_empty() {
-        return None;
-    }
-    if raw.chars().count() > MAX_DETAIL {
-        let truncated: String = raw.chars().take(MAX_DETAIL.saturating_sub(1)).collect();
-        Some(format!("{truncated}…"))
-    } else {
-        Some(raw)
-    }
+    tinyagents::harness::tool::context_detail_from_args_with(args, CONTEXT_DETAIL)
 }
 
 /// Core tool trait — implement for any capability (built-in or integration-based).


### PR DESCRIPTION
## Summary

- Moves the whole tool-calling **dialect** layer into `tinyagents`
  (tinyhumansai/tinyagents#116) and reduces `agent/dispatcher.rs` to a seam:
  583 lines deleted, 373 added, and none of the ~190 call sites changed.
- Deletes `render_pformat_signature_for_prompt` from `agent/prompts/sections.rs`
  — a local reimplementation of the crate's `render_signature_from_schema` whose
  own comment promised the two "stay in lockstep".
- `tools/traits.rs` now re-exports `humanize_tool_name` and wraps
  `context_detail_from_args` over the crate; only the `…` ellipsis stays
  OpenHuman's, passed as an explicit option.
- No behaviour change intended anywhere, with one deliberate exception noted
  under **Impact**: the p-format parser is now the crate's strictly-superset
  implementation.
- New AGENTS.md section recording the seam and, more importantly, what did
  **not** move and why.

## Problem

`dispatcher.rs` owned four things: the tool catalogue the model reads, the
syntax it writes calls in, the envelope results come back in, and the shape
history is replayed in on the wire. None of that is OpenHuman-specific — and we
had a second copy of each in `tinyagents`, plus a third copy of the p-format
signature renderer in the prompt builder.

That is not merely untidy. The four are one contract: a catalogue advertising
one grammar next to a parser expecting another is a **silent** whole-turn
failure — the model emits a call, nothing recognises it, the iteration is spent,
and nothing is logged. Two copies of that contract, edited independently, is how
it happens. The prompt-side copy already carried a comment asking future editors
to keep it in lockstep by hand, which is a bug waiting rather than a guarantee.

The loop and context engineering are not part of this problem: since #4249 every
turn drives through `AgentHarness::invoke` with `ContextCompressionMiddleware` /
`MessageTrimMiddleware` / budget / retry. The dialect layer was the duplicate
that was left.

## Solution

`tinyagents::harness::tool_calling::dialect` owns `ToolDialect` +
`XmlDialect` / `PFormatDialect` / `NativeDialect`, the tool-catalogue renderers,
and `pair_tool_cycles` (the bisected-tool-cycle repair, TAURI-RUST-7).
`dispatcher.rs` keeps exactly two things and delegates the rest:

- **The vocabulary.** `ParsedToolCall` / `ToolExecutionResult` are named for
  ~190 call sites and `ConversationMessage` is the durable JSONL record already
  on installations' disks. The crate speaks a thin `TranscriptEntry` instead, so
  the conversions in `dispatcher.rs` are the seam — field-wise maps that keep the
  wire bytes identical while the logic sits upstream. They are deliberately
  dumb: a conversion that *decides* something is a second implementation in
  disguise, and that judgement belongs in the crate.
- **The `Tool` trait object.** The crate takes `ToolSchema`s, never a host's
  tool type — the same reason the existing parse seam documents: depending on
  OpenHuman's `Tool` would make the crate unusable by a second host.

Tool **execution** did not move and should not: the security policy, approval
gate, sandbox, per-call timeout and progress events stay here. A dialect decides
what the model reads and writes; it never decides what is allowed to happen.
That line is what keeps the policy auditable in one place.

`ToolsSection` now calls the crate's `render_pformat_catalogue`, which builds
each `Call as:` signature from the same schema the parser reconstructs arguments
from — so prompt order and parse order agree by construction rather than by
convention.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — 18 new tests land with the crate-side module (`vendor/tinyagents`), covering both directions of each dialect plus the failure paths: unregistered p-format tool name, unparseable native arguments, a call narrated as text, and three broken-transcript shapes. The existing `dispatcher_tests.rs`, `prompts/mod_tests.rs` and `tools/traits.rs` tests are the parity guard for this side and are unchanged.
- [ ] **Diff coverage ≥ 80%** — pending CI. The OpenHuman diff is almost entirely deletion plus field-wise conversions exercised by the existing dispatcher/prompt tests.
- [x] Coverage matrix updated — `N/A: refactor, no feature added, removed or renamed`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix rows affected`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated — `N/A: no release-cut surface touched`
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue`

## Impact

- **Desktop / CLI / core**, agent turns only. No RPC surface, no config, no
  storage format change; `ConversationMessage` is untouched on disk.
- **One deliberate behaviour change.** `PFormatToolDispatcher::parse_response`
  now runs `tinyagents`' `parse_tool_calls_with_pformat` instead of the local
  per-tag walk. It is a strict superset: where the old code fell back to the
  JSON call at the same *ordinal index*, the crate re-parses the tag body
  itself, so a body holding several calls contributes all of them and a GLM-
  grammar body is recovered instead of dropped. Everything the old path parsed,
  this parses identically.
- **Security posture unchanged.** The p-format registry is still built from the
  agent's real tools, and the parser still refuses to invent argument names for
  an unknown tool — the guard that stops a model tunnelling arbitrary JSON
  through a guessed tool name. There is a test for it on the crate side now.
- **Tool result content is now XML-escaped.** tinyhumansai/tinyagents#116 took
  a CodeRabbit security fix while it was open (CWE-74): `dialect/text.rs`'s
  `escape_xml` now escapes `&`, `<`, `>` and `"` in tool **names** and tool
  **output bodies** before they are interpolated into the `<tool_result …>`
  envelope, so tool-controlled output can no longer forge envelope boundaries.
  This lands in OpenHuman with the `vendor/tinyagents` re-pin to
  4b343dc072fcaf814e6b73794e15895d109d6a18 and is a deliberate upstream
  security fix, not an accident of this port. Prompt bytes are otherwise
  unchanged — the protocol blocks and catalogue lines still move verbatim —
  but `<tool_result>` envelope *content* reaching a text-mode model (XML and
  p-format dispatchers) is no longer byte-identical to pre-PR: a tool
  returning source code, HTML or JSON now renders with `&lt;` / `&gt;` /
  `&amp;` / `&quot;` entities where it previously rendered raw. Native tool
  calling is unaffected — it does not use this envelope.

## Related

- Depends on: tinyhumansai/tinyagents#116 — merged to `main` at
  4b343dc072fcaf814e6b73794e15895d109d6a18; `vendor/tinyagents` is re-pinned to
  that commit in this PR.
- Closes:
- Follow-up PR(s)/TODOs: converge `harness::tool::prompt::prompt_tool_instructions`
  with `XmlDialect::instructions` upstream — they differ slightly today and
  merging them would change prompt bytes for existing `agent_loop` hosts.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `tool-dialect-to-tinyagents`
- Commit SHA: see head of branch

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no frontend files touched`
- [x] `pnpm typecheck` — `N/A: no TypeScript touched`
- [x] Focused tests: `cargo test --lib --features "$(bash scripts/ci/product-features.sh)" -- openhuman::agent::dispatcher openhuman::agent::prompts openhuman::tools::traits openhuman::agent::harness::parse` → **118 passed, 0 failed**
- [x] Rust fmt/check (if changed): `cargo check --manifest-path Cargo.toml` → clean
- [x] Tauri fmt/check (if changed): `N/A: shell untouched`

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: p-format parsing upgrades to the crate's superset
  implementation (see **Impact**).
- User-visible effect: a model that emits several calls in one `<tool_call>`
  body, or a GLM-grammar body, now has those calls executed instead of dropped.
- Second intended behavior change (landed via the tinyagents#116 re-pin, not
  authored in this PR): `<tool_result>` envelope content is now XML-escaped
  for the XML and p-format dispatchers (see **Impact**). A tool result
  containing `<`, `>`, `&` or `"` now reaches a text-mode model as escaped
  entities instead of raw text. Native tool calling is unaffected.

### Parity Contract

- Legacy behavior preserved: protocol prompt text, catalogue lines, native
  assistant/tool JSON payloads and the `ConversationMessage` on-disk shape are
  all byte-identical. The conversions in `dispatcher.rs` are field-wise and
  lossless. **Exception:** `<tool_result>` envelope content for the XML and
  p-format dispatchers is no longer byte-identical — see **Impact** and
  **Behavior Changes** for the upstream XML-escaping fix that landed with the
  tinyagents#116 re-pin.
- Guard/fallback/dispatch parity checks: `dispatcher_tests.rs`,
  `prompts/mod_tests.rs`, `harness/session/*_tests.rs` and `agent/tests.rs` all
  exercise the three dispatchers through the unchanged `ToolDispatcher` trait
  and are unmodified by this PR — that is the parity evidence.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved consistency when interpreting tool calls and displaying results across supported formats.
  * Standardized tool catalogues, schemas, and prompt instructions.
  * Improved tool-name presentation and context details, including concise context truncation.
  * Invalid or unavailable tool parameter schemas are handled more clearly.
  * Unrecognized conversation roles now safely default to user messages.
  * Preserved existing approval, security, timeout, sandboxing, and progress-reporting behavior.

* **Refactor**
  * Consolidated shared tool-handling and transcript-conversion behavior for more consistent results across dispatch modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

