### PR TITLE
feat(hooks): Cursor-compatible configurable hooks (hooks.json) + richer tool-hook decisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,21 @@ The `[autonomy]` block (`src/openhuman/config/schema/autonomy.rs`) drives `Secur
 
 **Sandbox backends** (opt-in per agent via `sandbox_mode = "sandboxed"`): Docker (remote/cron), Local OS jail (Landlock/Seatbelt/AppContainer, desktop), Noop fallback. In-Rust path hardening applies regardless.
 
+### Hooks — two unrelated things with one name
+
+**In-process hooks** (`src/openhuman/agent/hooks.rs`, `agent/stop_hooks.rs`) are Rust traits an *embedding host* installs by compiling against the core: `PostTurnHook`, `ToolHook`, `StopHook`. `ToolHook` now answers with a `ToolHookDecision` (`Proceed` / `ProceedWith(args)` / `Deny(reason)` / `Ask(reason)`) and `after_tool_context` may append text to a tool result. Both come with defaults that bridge to the old `Result<()>` pair, so existing implementations compile unchanged — but a hook that only vetoes is now the degenerate case, not the contract.
+
+**Configurable hooks** (`src/openhuman/hooks/`) are user-authored scripts declared in `hooks.json`, taking [Cursor's contract](https://cursor.com/docs/hooks) verbatim — event names, stdin envelope, stdout decision, exit code 2 = deny — so a script ports between hosts. Full guide: [`gitbooks/developing/hooks.md`](gitbooks/developing/hooks.md).
+
+Four things to know before touching that domain:
+
+- **It mounts on the existing seams, not new call sites.** `hooks::bridge` registers itself as an embedder `ToolHook` + `PostTurnHook`. Only the moments with no seam at all (`beforeSubmitPrompt`, `subagentStart`/`Stop`) get their own call site, in `hooks::ops`.
+- **Shell/file/MCP events are derived from tool calls.** OpenHuman has no separate shell-execution call site — `beforeShellExecution` is the `shell` tool going through the tool seam, reshaped into a Cursor-shaped payload. Both the generic and the specialised event fire, generic first. `SHELL_TOOLS`/`READ_TOOLS`/`WRITE_TOOLS` in `bridge.rs` are the mapping; extend those rather than adding a call site.
+- **`HookEvent::is_wired()` is load-bearing honesty.** Four events (`sessionStart`, `sessionEnd`, `preCompact`, `afterAgentThought`) are fully defined but have no call site yet. The loader warns when one is configured and `hooks.list` reports `wired: false`. Flip the flag when the call site lands — never optimistically.
+- **Strictest verdict wins, and layers concatenate.** Four `hooks.json` layers merge by appending, and `HookOutput::merge` folds deny over ask over allow, so a project file can never loosen an operator's rule. Do not "fix" the layering into an override model.
+
+Gating events run sequentially in the turn's path; observational ones are spawned and never block it (`HookEvent::is_gating` is the single place that split lives). With nothing configured the bridge is not installed, so an unconfigured host pays nothing per tool call.
+
 ---
 
 ## Testing

--- a/gitbooks/SUMMARY.md
+++ b/gitbooks/SUMMARY.md
@@ -85,6 +85,7 @@
 - [Chromium Embedded Framework](developing/cef.md)
 - [Theming (Token System)](developing/theming.md)
 - [Agent Observability](developing/agent-observability.md)
+- [Hooks](developing/hooks.md)
 - [Architecture](developing/architecture/README.md)
   - [Agent Harness](developing/architecture/agent-harness.md)
   - [Flows on TinyAgents (src/openhuman/flows/)](developing/architecture/flows-on-tinyagents.md)

--- a/gitbooks/developing/hooks.md
+++ b/gitbooks/developing/hooks.md
@@ -130,9 +130,9 @@ event, and Claude Code's `UserPromptSubmit` aliases onto `beforeSubmitPrompt`.
 | `afterAgentResponse` | on the assistant's message | — |
 
 `sessionStart`, `sessionEnd`, `preCompact` and `afterAgentThought` are defined —
-they parse, match, execute, and can be exercised with `hooks.test` — but the core
+they parse, match, execute, and can be exercised with `hooks test` — but the core
 does not fire them yet. Configuring one produces a load warning saying so, and
-`hooks.list` reports `"wired": false` for it. That is deliberate: a hook that
+`hooks list` reports `"wired": false` for it. That is deliberate: a hook that
 silently never runs is the worst thing this system can do to you.
 
 ### Derived events
@@ -194,13 +194,16 @@ every tool call.
 Three RPC methods, on the `hooks` namespace:
 
 ```bash
-openhuman rpc hooks.list      # what is configured, from which file, and whether it is wired
-openhuman rpc hooks.reload    # re-read every layer
-openhuman rpc hooks.test --event beforeShellExecution \
+openhuman hooks list      # what is configured, from which file, and whether it is wired
+openhuman hooks reload    # re-read every layer
+openhuman hooks test --event beforeShellExecution \
   --payload '{"command":"rm -rf /","sandbox":false}'
 ```
 
-`hooks.test` fires one synthetic event in the foreground and reports what each
+Over JSON-RPC the same three are `openhuman.hooks_list`, `openhuman.hooks_reload`
+and `openhuman.hooks_test`.
+
+`hooks test` fires one synthetic event in the foreground and reports what each
 matching hook decided, including hooks for observational events that a real
 dispatch would run detached. Debug a hook with it rather than by asking the agent
 to do the dangerous thing to see whether the rule fires.

--- a/gitbooks/developing/hooks.md
+++ b/gitbooks/developing/hooks.md
@@ -1,0 +1,256 @@
+# Hooks
+
+A hook is a script you own that OpenHuman runs at a specific moment — before a
+tool executes, after a file is edited, when a turn finishes — and whose answer
+the agent obeys. It is how you make the agent follow a rule that lives in your
+repository rather than in our code: block `rm -rf`, run the formatter after every
+edit, write an audit line per tool call, refuse to read `.env`.
+
+The contract is deliberately the same as
+[Cursor's](https://cursor.com/docs/hooks): same file name, same event names,
+same stdin envelope, same stdout decision, same exit codes. A hook script written
+for either host runs on the other unchanged.
+
+> There is a second, unrelated meaning of "hook" in this codebase: the in-process
+> Rust traits in `src/openhuman/agent/hooks.rs` that an *embedding host* installs
+> by compiling against the core. Those are for building a product on top of
+> OpenHuman. This page is about the file-based kind, for using OpenHuman.
+
+## The file
+
+`hooks.json`, schema version 1:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": "./.openhuman/deny-destructive.sh",
+        "matcher": "^\\s*(rm|dd|mkfs)\\b",
+        "timeout": 5,
+        "failClosed": true
+      }
+    ],
+    "afterFileEdit": [
+      { "command": "./.openhuman/format.sh", "matcher": "\\.rs$" }
+    ]
+  }
+}
+```
+
+Four locations are read, and **they concatenate — a more specific file cannot
+remove a broader one's rules**:
+
+| Layer | Path |
+| ----- | ---- |
+| System | `/etc/openhuman/hooks.json` · `/Library/Application Support/OpenHuman/hooks.json` · `%ProgramData%\OpenHuman\hooks.json` |
+| User | `~/.openhuman/hooks.json` |
+| Workspace | `<workspace_dir>/hooks.json` |
+| Project | `<action_dir>/.openhuman/hooks.json` |
+
+Concatenation is safe because the **strictest verdict wins**: across every hook
+that ran, deny beats ask beats allow. Adding a hook can never loosen a policy
+another one set, which is what lets a repository ship its own `hooks.json` onto
+a machine an operator has already locked down.
+
+### Fields
+
+| Field | Meaning |
+| ----- | ------- |
+| `command` | Program to run (or the prompt text, for `"type": "prompt"`). Runs with its own `hooks.json` directory as cwd. |
+| `type` | `command` (default) or `prompt`. |
+| `matcher` | Which occurrences reach this hook — see below. Absent means all. |
+| `timeout` | Seconds. Falls back to `[hooks] default_timeout_secs` (30). |
+| `failClosed` | Treat a crashed, missing, or timed-out hook as a denial. Default `false`. |
+| `loop_limit` | Follow-ups this hook may inject per session. Default 5; `0` means unlimited. |
+| `model` | Model override for a `prompt` hook. |
+| `enabled` | Set `false` to park a hook without deleting it. |
+
+## The protocol
+
+The event arrives on **stdin** as one JSON object. The decision goes to
+**stdout**. The exit code decides how stdout is read:
+
+| Exit | Meaning |
+| ---- | ------- |
+| `0` | stdout is the decision. Empty stdout is a no-op. |
+| `2` | Deny, whatever stdout said. stderr becomes the reason the agent is told. |
+| anything else | Failure. **Fails open** — the action proceeds — unless `failClosed`. |
+
+A timeout, a missing interpreter, and unparseable stdout all take that same
+failure path. That symmetry is the point: a hook that denies only when it
+manages to run is not a security control, so `failClosed` covers every way a
+script can fail to answer.
+
+stdout is parsed leniently — the last standalone JSON object wins — so a script
+that logs progress before answering works as written.
+
+### Decision object
+
+Every field is optional, and each event honours the subset it defines:
+
+```json
+{
+  "permission": "allow" | "deny" | "ask",
+  "user_message": "shown to the human",
+  "agent_message": "shown to the model",
+  "updated_input": { "…": "replacement tool arguments" },
+  "additional_context": "appended to the tool result",
+  "continue": false,
+  "followup_message": "sent as another user turn",
+  "env": { "KEY": "value" }
+}
+```
+
+`ask` escalates to the approval gate where one is available; inside the tool
+middleware, which has no approval channel, it denies rather than quietly
+allowing.
+
+## Events
+
+`hook_event_name` in the envelope tells a script which moment it is in. Names are
+matched loosely — `preToolUse`, `PreToolUse` and `pre_tool_use` are the same
+event, and Claude Code's `UserPromptSubmit` aliases onto `beforeSubmitPrompt`.
+
+| Event | Fires | Honours |
+| ----- | ----- | ------- |
+| `preToolUse` | before any tool | `permission`, `updated_input`, `agent_message` |
+| `postToolUse` | after a tool succeeded | `additional_context` |
+| `postToolUseFailure` | after a tool failed | — |
+| `beforeShellExecution` | before `shell` / `node_exec` / … | `permission`, `agent_message` |
+| `afterShellExecution` | after one completed | — |
+| `beforeReadFile` | before `file_read` / `read_diff` | `permission` |
+| `afterFileEdit` | after `file_write` / `edit` / `apply_patch` | — |
+| `beforeMCPExecution` / `afterMCPExecution` | around an MCP tool | `permission` |
+| `beforeSubmitPrompt` | on a chat message, before the model | `continue`, `permission`, `additional_context` |
+| `subagentStart` | before a delegation | `permission` |
+| `subagentStop` | after one | `followup_message` |
+| `stop` | after a turn | `followup_message` |
+| `afterAgentResponse` | on the assistant's message | — |
+
+`sessionStart`, `sessionEnd`, `preCompact` and `afterAgentThought` are defined —
+they parse, match, execute, and can be exercised with `hooks.test` — but the core
+does not fire them yet. Configuring one produces a load warning saying so, and
+`hooks.list` reports `"wired": false` for it. That is deliberate: a hook that
+silently never runs is the worst thing this system can do to you.
+
+### Derived events
+
+OpenHuman has no separate "shell execution" or "file read" call site — those are
+the `shell`, `file_read` and `file_write` tools going through the ordinary tool
+seam. So the shell, file and MCP events are *derived* from tool calls, and their
+payloads are reshaped the way a Cursor hook expects: a `command` string, a
+`file_path`, an `edits` array. Both the generic `preToolUse` and the specialised
+event fire, generic first.
+
+## Matchers
+
+One string, matched against a subject the event chooses: the tool name for tool
+events, the command line for shell events, the path for file events, the agent id
+for subagent events.
+
+* absent or `*` — everything
+* `Shell` — a literal, case-insensitive name
+* `Read|Write|Shell` — alternation
+* `MCP:search_docs` — an MCP tool by name
+* anything containing punctuation — a regular expression (`^rm\b`, `\.rs$`)
+
+An invalid regex matches **nothing** and logs.
+
+## Latency
+
+Gating events run their hooks sequentially and the turn waits; a denial
+short-circuits the rest. Observational events (`afterShellExecution`,
+`postToolUseFailure`, `afterAgentResponse`, …) are dispatched onto a background
+task and the turn never waits — an audit hook that hangs must not hang the agent.
+
+When nothing is configured, the harness bridge is not installed at all, so an
+unconfigured host pays nothing per tool call.
+
+## Environment
+
+Hook processes inherit the core's environment plus:
+
+`OPENHUMAN_PROJECT_DIR` (also exported as `CLAUDE_PROJECT_DIR` and
+`CURSOR_PROJECT_DIR`), `OPENHUMAN_VERSION`, `OPENHUMAN_HOOK_EVENT`,
+`OPENHUMAN_SESSION_ID`, `OPENHUMAN_AGENT_ID`.
+
+## Prompt hooks
+
+`"type": "prompt"` writes the policy in English instead of shell. The text is
+sent to a model with the event JSON substituted for `$ARGUMENTS`, and the model
+answers `{"ok": true}` or `{"ok": false, "reason": "…"}`.
+
+```json
+{ "command": "Deny if $ARGUMENTS deletes anything outside /tmp.", "type": "prompt" }
+```
+
+It costs a model call per event, so put it on rare, high-stakes moments — not on
+every tool call.
+
+## Inspecting and debugging
+
+Three RPC methods, on the `hooks` namespace:
+
+```bash
+openhuman rpc hooks.list      # what is configured, from which file, and whether it is wired
+openhuman rpc hooks.reload    # re-read every layer
+openhuman rpc hooks.test --event beforeShellExecution \
+  --payload '{"command":"rm -rf /","sandbox":false}'
+```
+
+`hooks.test` fires one synthetic event in the foreground and reports what each
+matching hook decided, including hooks for observational events that a real
+dispatch would run detached. Debug a hook with it rather than by asking the agent
+to do the dangerous thing to see whether the rule fires.
+
+## Host switches
+
+`config.toml`:
+
+```toml
+[hooks]
+enabled = true            # off means no hooks.json is read and no bridge installed
+default_timeout_secs = 30 # for hooks that name no timeout of their own
+```
+
+## Example
+
+`.openhuman/hooks.json`:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "beforeReadFile": [{ "command": "./.openhuman/no-secrets.sh", "matcher": "\\.env" }],
+    "afterFileEdit": [{ "command": "./.openhuman/fmt.sh", "matcher": "\\.rs$" }]
+  }
+}
+```
+
+`.openhuman/no-secrets.sh`:
+
+```sh
+#!/bin/sh
+echo '{"permission":"deny","agent_message":"Secrets files are off limits. Ask the user for the value you need."}'
+```
+
+`.openhuman/fmt.sh`:
+
+```sh
+#!/bin/sh
+cat > /dev/null            # drain stdin; this hook does not read the event
+cargo fmt >/dev/null 2>&1
+echo '{}'
+```
+
+Both need `chmod +x`.
+
+## Implementation
+
+`src/openhuman/hooks/` — `types` (the wire contract), `config` (the file and its
+layering), `matcher`, `exec` (one hook: stdin, timeout, exit codes),
+`engine` (selection, ordering, aggregation), `context` (the envelope),
+`bridge` (mounting on the harness's existing tool and turn seams), `ops` (the
+moments with no existing seam), `followup`.

--- a/src/core/all.rs
+++ b/src/core/all.rs
@@ -526,6 +526,12 @@ fn build_registered_controllers() -> Vec<GroupedController> {
         DomainGroup::Platform,
         crate::openhuman::platform::doctor::all_doctor_registered_controllers(),
     );
+    // User-authored hooks — inspect, reload, and test-fire `hooks.json` entries.
+    push(
+        &mut controllers,
+        DomainGroup::Platform,
+        crate::openhuman::hooks::all_hooks_registered_controllers(),
+    );
     // Secret storage and encryption
     push(
         &mut controllers,
@@ -1201,6 +1207,9 @@ pub fn namespace_description(namespace: &str) -> Option<&'static str> {
         ),
         "decrypt" => Some("Decrypt secure values managed by secret storage."),
         "doctor" => Some("Run diagnostics for workspace and runtime health."),
+        "hooks" => Some(
+            "User-authored hooks: list what is configured, reload every hooks.json layer, and test-fire one event.",
+        ),
         "encrypt" => Some("Encrypt secure values managed by secret storage."),
         "health" => Some("Process and component health snapshots."),
         "inference" => Some("Connect to configured text, vision, and embedding inference runtimes."),

--- a/src/core/jsonrpc.rs
+++ b/src/core/jsonrpc.rs
@@ -2411,6 +2411,14 @@ pub async fn bootstrap_core_runtime(
     // frontend raises a one-shot "settings were reset" notice off it.
     crate::openhuman::desktop::app_state::latch_from_config(&cfg);
 
+    // --- Configurable hooks -------------------------------------------
+    // Read every `hooks.json` layer and, only if something is configured,
+    // install the harness bridge. Boot is the right moment: a hook that is
+    // meant to gate the first tool call of the first turn has to be loaded
+    // before any session exists, and the alternative — loading lazily on the
+    // first event — would let that first call through while the file is read.
+    crate::openhuman::hooks::init(&cfg).await;
+
     // --- Turn-state recovery -------------------------------------------
     // Any per-thread turn snapshots left on disk from a previous process
     // are stale by definition — there is no live driver to resume them.

--- a/src/openhuman/agent/harness/subagent_runner/ops/runner.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops/runner.rs
@@ -373,6 +373,30 @@ pub async fn run_subagent(
             AgentDefinitionRegistry::global().and_then(|reg| reg.get(&parent.agent_definition_id));
         tier_gate_decision(parent_def, definition, &parent.agent_definition_id, &task_id)?;
 
+        // Configured `subagentStart` hooks — the last gate before a spawn costs
+        // anything. Placed after the tier gate so a spawn the graph already
+        // forbids never reaches a user script, and before config load so a
+        // denied spawn has no side effects at all.
+        if let Err(reason) = crate::openhuman::hooks::ops::subagent_starting(
+            crate::openhuman::hooks::context::TurnIdentity {
+                conversation_id: parent.session_id.clone(),
+                session_id: parent.session_id.clone(),
+                agent_id: Some(parent.agent_definition_id.clone()),
+                ..Default::default()
+            },
+            &definition.id,
+            task_prompt,
+        )
+        .await
+        {
+            tracing::info!(
+                agent_id = %definition.id,
+                task_id = %task_id,
+                "[subagent_runner] spawn denied by a configured hook: {reason}"
+            );
+            return Err(SubagentRunError::HookDenied(reason));
+        }
+
         // Load the host config exactly once for this spawn and hand it to
         // everything below. See `LoadedConfig` — `load_or_init` re-reads
         // config.toml on every call, and the runtime below is slated to move

--- a/src/openhuman/agent/harness/subagent_runner/ops/runner.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops/runner.rs
@@ -379,8 +379,8 @@ pub async fn run_subagent(
         // denied spawn has no side effects at all.
         if let Err(reason) = crate::openhuman::hooks::ops::subagent_starting(
             crate::openhuman::hooks::context::TurnIdentity {
-                conversation_id: parent.session_id.clone(),
-                session_id: parent.session_id.clone(),
+                conversation_id: Some(parent.session_id.clone()),
+                session_id: Some(parent.session_id.clone()),
                 agent_id: Some(parent.agent_definition_id.clone()),
                 ..Default::default()
             },

--- a/src/openhuman/agent/harness/subagent_runner/types.rs
+++ b/src/openhuman/agent/harness/subagent_runner/types.rs
@@ -239,4 +239,13 @@ pub enum SubagentRunError {
 
     #[error("sub-agent exceeded maximum iterations ({0})")]
     MaxIterationsExceeded(usize),
+
+    /// A configured `subagentStart` hook refused the spawn.
+    ///
+    /// Distinct from [`Self::TierViolation`] on purpose: a tier violation is a
+    /// fact about the agent graph the model cannot do anything about, while
+    /// this one carries a reason a human wrote and the model may be able to
+    /// satisfy — so the two must not read the same in a transcript.
+    #[error("delegation blocked by a configured hook: {0}")]
+    HookDenied(String),
 }

--- a/src/openhuman/agent/hooks.rs
+++ b/src/openhuman/agent/hooks.rs
@@ -139,6 +139,12 @@ pub enum ToolHookEvent {
 }
 
 /// Safe metadata supplied to an embedding host's tool hook.
+///
+/// The post-execution fields (`output`, `error`) carry the tool's *raw* result
+/// text, unlike [`ToolCallRecord::output_summary`], which is sanitized for the
+/// learning pipeline. A tool hook is a policy seam — a hook asked to redact
+/// secrets from a result cannot do it from a summary — so the trade is
+/// deliberate, and it is why these fields exist here and not there.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolHookContext {
     /// The lifecycle moment that raised this notification.
@@ -153,9 +159,56 @@ pub struct ToolHookContext {
     pub success: Option<bool>,
     /// Final tool runtime in milliseconds; absent before execution.
     pub duration_ms: Option<u64>,
+    /// Raw tool result text; absent before execution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output: Option<String>,
+    /// Failure text when the tool errored; absent otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Session the call belongs to, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    /// Canonical agent definition id, when known.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+}
+
+/// What a pre-tool hook decided about a call.
+///
+/// This is the enrichment that makes an embedder hook a policy lever rather
+/// than a tripwire: before it existed the only expressible answers were "fine"
+/// and an `Err` that read to the model as a tool crash.
+#[derive(Debug, Clone, Default)]
+pub enum ToolHookDecision {
+    /// Run the tool as requested.
+    #[default]
+    Proceed,
+    /// Run the tool, but with these arguments instead. Used to redact a
+    /// secret, pin a flag, or narrow a path before the tool ever sees it.
+    ProceedWith(serde_json::Value),
+    /// Refuse the call. `reason` is what the model is told.
+    Deny(String),
+    /// Escalate to the human through the approval gate. `reason` is what the
+    /// human is asked about.
+    Ask(String),
+}
+
+impl ToolHookDecision {
+    /// Whether the call is refused outright.
+    pub fn is_deny(&self) -> bool {
+        matches!(self, ToolHookDecision::Deny(_))
+    }
 }
 
 /// Embedder callback around every harness tool execution.
+///
+/// Implement [`before_tool`](ToolHook::before_tool) and
+/// [`after_tool`](ToolHook::after_tool) for a plain observer. Override
+/// [`before_tool_decision`](ToolHook::before_tool_decision) and
+/// [`after_tool_context`](ToolHook::after_tool_context) when the hook needs to
+/// rewrite arguments, escalate to the human, or feed text back to the model;
+/// the defaults bridge to the simpler pair so existing implementations keep
+/// working unchanged.
 #[async_trait]
 pub trait ToolHook: Send + Sync {
     /// Human-readable hook identifier for diagnostics.
@@ -164,6 +217,25 @@ pub trait ToolHook: Send + Sync {
     async fn before_tool(&self, context: &ToolHookContext) -> anyhow::Result<()>;
     /// Observe a completed tool. Errors are logged and never change its result.
     async fn after_tool(&self, context: &ToolHookContext) -> anyhow::Result<()>;
+
+    /// Decide what happens to a call. Defaults to
+    /// [`before_tool`](ToolHook::before_tool), mapping its `Err` to a denial.
+    async fn before_tool_decision(&self, context: &ToolHookContext) -> ToolHookDecision {
+        match self.before_tool(context).await {
+            Ok(()) => ToolHookDecision::Proceed,
+            Err(error) => ToolHookDecision::Deny(format!("{error:#}")),
+        }
+    }
+
+    /// Observe a completed tool and optionally append text to its result, which
+    /// the model then sees. Defaults to [`after_tool`](ToolHook::after_tool)
+    /// with no appended text.
+    async fn after_tool_context(&self, context: &ToolHookContext) -> Option<String> {
+        if let Err(error) = self.after_tool(context).await {
+            log::warn!("[hooks] post-tool hook '{}' failed: {error:#}", self.name());
+        }
+        None
+    }
 }
 
 /// Tool hooks supplied by an embedding host.

--- a/src/openhuman/agent/tinyagents/middleware.rs
+++ b/src/openhuman/agent/tinyagents/middleware.rs
@@ -1513,22 +1513,59 @@ impl Middleware<()> for EmbedderToolHooksMiddleware {
         _state: &(),
         call: &mut TaToolCall,
     ) -> TaResult<()> {
-        let context = crate::openhuman::agent::hooks::ToolHookContext {
+        let mut context = crate::openhuman::agent::hooks::ToolHookContext {
             event: crate::openhuman::agent::hooks::ToolHookEvent::PreToolUse,
             call_id: call.id.clone(),
             tool_name: call.name.clone(),
             arguments: call.arguments.clone(),
             success: None,
             duration_ms: None,
+            output: None,
+            error: None,
+            session_id: None,
+            agent_id: None,
         };
         for hook in &self.hooks {
-            hook.before_tool(&context).await.map_err(|error| {
-                tinyagents::error::TinyAgentsError::Tool(format!(
-                    "tool hook '{}' denied {}: {error:#}",
-                    hook.name(),
-                    context.tool_name
-                ))
-            })?;
+            match hook.before_tool_decision(&context).await {
+                crate::openhuman::agent::hooks::ToolHookDecision::Proceed => {}
+                // A rewrite is applied to the live call *and* to the context
+                // handed to later hooks, so a chain of hooks each narrowing the
+                // arguments composes instead of the last one silently winning.
+                crate::openhuman::agent::hooks::ToolHookDecision::ProceedWith(arguments) => {
+                    tracing::debug!(
+                        hook = hook.name(),
+                        tool = context.tool_name,
+                        "[tinyagents::mw] tool hook rewrote call arguments"
+                    );
+                    call.arguments = arguments.clone();
+                    context.arguments = arguments;
+                }
+                crate::openhuman::agent::hooks::ToolHookDecision::Deny(reason) => {
+                    return Err(tinyagents::error::TinyAgentsError::Tool(format!(
+                        "tool hook '{}' denied {}: {reason}",
+                        hook.name(),
+                        context.tool_name
+                    )));
+                }
+                // There is no approval channel inside a middleware, and a hook
+                // that asks for a human is asking for something stricter than
+                // "proceed" — so an unresolvable `Ask` denies rather than
+                // quietly allowing. The approval-gate path in
+                // `security::approval` is where an interactive host resolves it.
+                crate::openhuman::agent::hooks::ToolHookDecision::Ask(reason) => {
+                    tracing::info!(
+                        hook = hook.name(),
+                        tool = context.tool_name,
+                        "[tinyagents::mw] tool hook requested approval; denying in a \
+                         non-interactive middleware"
+                    );
+                    return Err(tinyagents::error::TinyAgentsError::Tool(format!(
+                        "tool hook '{}' requires approval for {}: {reason}",
+                        hook.name(),
+                        context.tool_name
+                    )));
+                }
+            }
         }
         // Cache the (already-recovered) arguments only once every hook approved
         // the call: a vetoed call never reaches `after_tool`, so storing it here
@@ -1559,14 +1596,27 @@ impl Middleware<()> for EmbedderToolHooksMiddleware {
             arguments,
             success: Some(result.error.is_none()),
             duration_ms: Some(result.elapsed_ms),
+            output: Some(result.content.clone()),
+            error: result.error.clone(),
+            session_id: None,
+            agent_id: None,
         };
         for hook in &self.hooks {
-            if let Err(error) = hook.after_tool(&context).await {
-                tracing::warn!(
-                    hook = hook.name(),
-                    tool = context.tool_name,
-                    "embedder post-tool hook failed: {error:#}"
-                );
+            // Text a hook returns is appended to the result the model reads —
+            // the seam a "you edited a file, here is the linter output" hook
+            // needs. It is appended rather than substituted so a hook cannot
+            // erase what the tool actually said.
+            if let Some(additional) = hook.after_tool_context(&context).await {
+                if !additional.trim().is_empty() {
+                    tracing::debug!(
+                        hook = hook.name(),
+                        tool = context.tool_name,
+                        chars = additional.chars().count(),
+                        "[tinyagents::mw] tool hook appended context to the result"
+                    );
+                    result.content.push_str("\n\n");
+                    result.content.push_str(additional.trim_end());
+                }
             }
         }
         Ok(())

--- a/src/openhuman/config/schema/hooks.rs
+++ b/src/openhuman/config/schema/hooks.rs
@@ -1,0 +1,40 @@
+//! `[hooks]` — host-level switches for the configurable hook system.
+//!
+//! The hooks themselves are **not** configured here. They live in `hooks.json`
+//! files discovered across four layers
+//! ([`crate::openhuman::hooks::config`]), because a hook set belongs with the
+//! repository it guards and has to be readable by a human who has never seen
+//! this config file. This block only carries the decisions that belong to the
+//! host: whether the system runs at all, and how long a hook that names no
+//! timeout of its own may take.
+
+use serde::{Deserialize, Serialize};
+
+/// Host-level hook settings.
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct HooksConfig {
+    /// Master switch. Off means no `hooks.json` is read and the harness bridge
+    /// is not installed, so an unconfigured host pays nothing per tool call.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    /// Seconds a hook may run when its definition names no `timeout`.
+    #[serde(default = "default_timeout_secs")]
+    pub default_timeout_secs: u64,
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+fn default_timeout_secs() -> u64 {
+    30
+}
+
+impl Default for HooksConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_enabled(),
+            default_timeout_secs: default_timeout_secs(),
+        }
+    }
+}

--- a/src/openhuman/config/schema/mod.rs
+++ b/src/openhuman/config/schema/mod.rs
@@ -24,6 +24,8 @@ mod context;
 mod dashboard;
 mod defaults;
 mod dictation;
+mod hooks;
+pub use hooks::HooksConfig;
 mod heartbeat_cron;
 pub mod hosting;
 pub use hosting::HostingConfig;

--- a/src/openhuman/config/schema/types.rs
+++ b/src/openhuman/config/schema/types.rs
@@ -156,6 +156,12 @@ pub struct Config {
     #[serde(default)]
     pub autonomy: AutonomyConfig,
 
+    /// Host-level switches for the configurable hook system. The hooks
+    /// themselves live in `hooks.json` files, not here — see
+    /// [`super::HooksConfig`].
+    #[serde(default)]
+    pub hooks: super::HooksConfig,
+
     /// Data-egress posture (Privacy Mode). Distinct from `autonomy` (which
     /// governs agent *act* power). Missing `[privacy]` block → `Standard`
     /// (#4435, epic #4256).

--- a/src/openhuman/config/schema/types.rs
+++ b/src/openhuman/config/schema/types.rs
@@ -806,6 +806,7 @@ impl Default for Config {
             observability: ObservabilityConfig::default(),
             dashboard: DashboardConfig::default(),
             autonomy: AutonomyConfig::default(),
+            hooks: super::HooksConfig::default(),
             privacy: PrivacyConfig::default(),
             sandbox: SandboxConfig::default(),
             runtime: RuntimeConfig::default(),

--- a/src/openhuman/hooks/bridge.rs
+++ b/src/openhuman/hooks/bridge.rs
@@ -396,10 +396,16 @@ mod tests {
 
     #[test]
     fn reads_have_no_after_event_and_writes_have_no_before_event() {
-        assert_eq!(derived_event("file_read", true), Some(HookEvent::BeforeReadFile));
+        assert_eq!(
+            derived_event("file_read", true),
+            Some(HookEvent::BeforeReadFile)
+        );
         assert_eq!(derived_event("file_read", false), None);
         assert_eq!(derived_event("file_write", true), None);
-        assert_eq!(derived_event("file_write", false), Some(HookEvent::AfterFileEdit));
+        assert_eq!(
+            derived_event("file_write", false),
+            Some(HookEvent::AfterFileEdit)
+        );
     }
 
     #[test]
@@ -467,7 +473,10 @@ mod tests {
     #[test]
     fn timeout_text_classifies_as_a_timeout_failure() {
         assert_eq!(classify_failure("tool timed out after 30s"), "timeout");
-        assert_eq!(classify_failure("[policy-blocked] nope"), "permission_denied");
+        assert_eq!(
+            classify_failure("[policy-blocked] nope"),
+            "permission_denied"
+        );
         assert_eq!(classify_failure("something else"), "error");
     }
 }

--- a/src/openhuman/hooks/bridge.rs
+++ b/src/openhuman/hooks/bridge.rs
@@ -1,0 +1,473 @@
+//! Wiring the configured hooks into the agent harness.
+//!
+//! The harness already carries in-process hook seams —
+//! [`ToolHook`](crate::openhuman::agent::hooks::ToolHook) around every tool and
+//! [`PostTurnHook`](crate::openhuman::agent::hooks::PostTurnHook) after every
+//! turn. Rather than adding a second set of call sites, the configurable engine
+//! registers itself *through* those seams. One bridge object, registered once
+//! at bootstrap, turns every configured `hooks.json` entry into behaviour.
+//!
+//! ## Derived events
+//!
+//! Cursor exposes `beforeShellExecution`, `beforeReadFile` and `afterFileEdit`
+//! as first-class events. In OpenHuman those moments are not separate call
+//! sites — they are the `shell`, `file_read` and `file_write`/`edit` tools
+//! going through the ordinary tool seam. So the bridge *derives* them: when a
+//! tool call matches one of those families it fires both the generic
+//! `preToolUse` event and the specialised one, with a payload shaped the way a
+//! Cursor hook expects (a command line, a file path) rather than raw tool
+//! arguments.
+//!
+//! This is what makes a Cursor hook script portable here. The alternative —
+//! only exposing `preToolUse` and telling authors to parse `tool_input` — would
+//! have been less code and a worse contract: every author would reimplement the
+//! same mapping, and each would get the sandbox flag and the path resolution
+//! subtly differently.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::openhuman::agent::hooks::{
+    PostTurnHook, ToolHook, ToolHookContext, ToolHookDecision, TurnContext,
+};
+
+use super::context::{build_input, TurnIdentity};
+use super::engine::{self, HookOutcome};
+use super::types::{
+    FileEdit, FilePayload, HookEvent, HookOutput, HookPayload, ShellPayload, StopPayload,
+    TextPayload, ToolPayload,
+};
+
+/// Name the bridge registers itself under, so a host that rebuilds its core can
+/// replace rather than duplicate it.
+pub const BRIDGE_HOOK_NAME: &str = "configured_hooks";
+
+/// Tools whose calls are also reported as shell execution.
+const SHELL_TOOLS: &[&str] = &["shell", "run_command", "bash", "node_exec", "npm_exec"];
+
+/// Tools whose calls are also reported as a file read.
+const READ_TOOLS: &[&str] = &["file_read", "read_diff"];
+
+/// Tools whose calls are also reported as a file edit.
+const WRITE_TOOLS: &[&str] = &["file_write", "edit", "apply_patch", "update_memory_md"];
+
+/// Bridges the configured hook engine onto the harness hook seams.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ConfiguredHookBridge;
+
+impl ConfiguredHookBridge {
+    /// Register the bridge for every subsequently-created session.
+    ///
+    /// Replaces any previously registered bridge rather than appending, so a
+    /// host that rebuilds its core does not end up firing every hook twice.
+    pub fn install() {
+        crate::openhuman::agent::hooks::replace_embedder_tool_hook(
+            BRIDGE_HOOK_NAME,
+            Some(std::sync::Arc::new(ConfiguredHookBridge)),
+        );
+        crate::openhuman::agent::hooks::replace_embedder_post_turn_hook(
+            BRIDGE_HOOK_NAME,
+            Some(std::sync::Arc::new(ConfiguredHookBridge)),
+        );
+        log::debug!("[hooks] configured-hook bridge installed");
+    }
+
+    /// Remove the bridge. Used when hooks are disabled by config.
+    pub fn uninstall() {
+        crate::openhuman::agent::hooks::replace_embedder_tool_hook(BRIDGE_HOOK_NAME, None);
+        crate::openhuman::agent::hooks::replace_embedder_post_turn_hook(BRIDGE_HOOK_NAME, None);
+        log::debug!("[hooks] configured-hook bridge removed");
+    }
+}
+
+fn identity_from_tool(context: &ToolHookContext) -> TurnIdentity {
+    TurnIdentity {
+        session_id: context.session_id.clone(),
+        agent_id: context.agent_id.clone(),
+        cwd: string_field(&context.arguments, "cwd"),
+        ..TurnIdentity::default()
+    }
+}
+
+fn string_field(value: &Value, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .filter(|text| !text.is_empty())
+}
+
+fn tool_payload(context: &ToolHookContext) -> ToolPayload {
+    ToolPayload {
+        tool_name: context.tool_name.clone(),
+        tool_input: context.arguments.clone(),
+        tool_use_id: context.call_id.clone(),
+        tool_output: context.output.clone(),
+        duration_ms: context.duration_ms,
+        error_message: context.error.clone(),
+        failure_type: context.error.as_deref().map(classify_failure),
+    }
+}
+
+/// Map a raw failure string onto Cursor's three failure classes.
+fn classify_failure(error: &str) -> String {
+    let lower = error.to_lowercase();
+    if lower.contains("timed out") || lower.contains("timeout") {
+        "timeout".to_string()
+    } else if lower.contains("policy-blocked")
+        || lower.contains("permission")
+        || lower.contains("denied")
+    {
+        "permission_denied".to_string()
+    } else {
+        "error".to_string()
+    }
+}
+
+/// Which specialised event, if any, this tool also represents.
+fn derived_event(tool_name: &str, pre: bool) -> Option<HookEvent> {
+    let name = tool_name.to_ascii_lowercase();
+    if SHELL_TOOLS.contains(&name.as_str()) {
+        return Some(if pre {
+            HookEvent::BeforeShellExecution
+        } else {
+            HookEvent::AfterShellExecution
+        });
+    }
+    if READ_TOOLS.contains(&name.as_str()) {
+        // There is no `afterReadFile`; a read only has a gating moment.
+        return pre.then_some(HookEvent::BeforeReadFile);
+    }
+    if WRITE_TOOLS.contains(&name.as_str()) {
+        // A write is only reported once it happened — denying it belongs to
+        // `preToolUse`, which already fired with the same arguments.
+        return (!pre).then_some(HookEvent::AfterFileEdit);
+    }
+    if is_mcp_tool(&name) {
+        return Some(if pre {
+            HookEvent::BeforeMcpExecution
+        } else {
+            HookEvent::AfterMcpExecution
+        });
+    }
+    None
+}
+
+/// MCP tools reach the registry through the `mcp_*` families; a dynamically
+/// installed server's tools are namespaced with `mcp:`.
+fn is_mcp_tool(name: &str) -> bool {
+    name.starts_with("mcp_") || name.starts_with("mcp:") || name.starts_with("mcp__")
+}
+
+/// Build the payload the specialised event expects from raw tool arguments.
+fn derived_payload(event: HookEvent, context: &ToolHookContext) -> HookPayload {
+    match event {
+        HookEvent::BeforeShellExecution | HookEvent::AfterShellExecution => {
+            HookPayload::Shell(ShellPayload {
+                command: string_field(&context.arguments, "command").unwrap_or_default(),
+                sandbox: context
+                    .arguments
+                    .get("sandbox")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false),
+                output: context.output.clone(),
+                duration_ms: context.duration_ms,
+            })
+        }
+        HookEvent::BeforeReadFile => HookPayload::File(FilePayload {
+            file_path: file_path_argument(&context.arguments),
+            edits: Vec::new(),
+        }),
+        HookEvent::AfterFileEdit => HookPayload::File(FilePayload {
+            file_path: file_path_argument(&context.arguments),
+            edits: file_edits(&context.arguments),
+        }),
+        _ => HookPayload::Tool(tool_payload(context)),
+    }
+}
+
+/// The file tools spell their path argument three different ways; a hook author
+/// should not have to know which tool used which.
+fn file_path_argument(arguments: &Value) -> String {
+    ["path", "file_path", "filename", "file"]
+        .iter()
+        .find_map(|key| string_field(arguments, key))
+        .unwrap_or_default()
+}
+
+/// Recover the before/after strings an edit applied, where the tool exposes
+/// them. A whole-file write reports one edit whose `old_string` is empty.
+fn file_edits(arguments: &Value) -> Vec<FileEdit> {
+    if let (Some(old), Some(new)) = (
+        string_field(arguments, "old_string"),
+        string_field(arguments, "new_string"),
+    ) {
+        return vec![FileEdit {
+            old_string: old,
+            new_string: new,
+        }];
+    }
+    match string_field(arguments, "content") {
+        Some(content) => vec![FileEdit {
+            old_string: String::new(),
+            new_string: content,
+        }],
+        None => Vec::new(),
+    }
+}
+
+/// Fire the generic event and, when the tool has one, its specialisation.
+async fn dispatch_pair(
+    generic: HookEvent,
+    context: &ToolHookContext,
+    identity: TurnIdentity,
+) -> HookOutcome {
+    let engine = engine::global();
+    let mut merged = HookOutcome::default();
+
+    if engine.has_hooks(generic).await {
+        let input = build_input(
+            generic,
+            identity.clone(),
+            HookPayload::Tool(tool_payload(context)),
+        );
+        let outcome = engine.dispatch(generic, input).await;
+        merged.output.merge(outcome.output);
+        merged.runs.extend(outcome.runs);
+    }
+    if merged.output.is_deny() {
+        return merged;
+    }
+
+    let pre = matches!(
+        generic,
+        HookEvent::PreToolUse | HookEvent::BeforeMcpExecution | HookEvent::BeforeReadFile
+    );
+    if let Some(event) = derived_event(&context.tool_name, pre) {
+        if engine.has_hooks(event).await {
+            let input = build_input(event, identity, derived_payload(event, context));
+            let outcome = engine.dispatch(event, input).await;
+            merged.output.merge(outcome.output);
+            merged.runs.extend(outcome.runs);
+        }
+    }
+    merged
+}
+
+#[async_trait]
+impl ToolHook for ConfiguredHookBridge {
+    fn name(&self) -> &str {
+        BRIDGE_HOOK_NAME
+    }
+
+    async fn before_tool(&self, context: &ToolHookContext) -> anyhow::Result<()> {
+        match self.before_tool_decision(context).await {
+            ToolHookDecision::Deny(reason) => Err(anyhow::anyhow!(reason)),
+            _ => Ok(()),
+        }
+    }
+
+    async fn after_tool(&self, context: &ToolHookContext) -> anyhow::Result<()> {
+        self.after_tool_context(context).await;
+        Ok(())
+    }
+
+    async fn before_tool_decision(&self, context: &ToolHookContext) -> ToolHookDecision {
+        let identity = identity_from_tool(context);
+        let outcome = dispatch_pair(HookEvent::PreToolUse, context, identity).await;
+        decision_from(outcome.output, &context.tool_name)
+    }
+
+    async fn after_tool_context(&self, context: &ToolHookContext) -> Option<String> {
+        let identity = identity_from_tool(context);
+        let generic = if context.success == Some(false) {
+            HookEvent::PostToolUseFailure
+        } else {
+            HookEvent::PostToolUse
+        };
+        let outcome = dispatch_pair(generic, context, identity).await;
+        outcome.output.additional_context
+    }
+}
+
+/// Translate a merged hook decision into the harness's tool verdict.
+fn decision_from(output: HookOutput, tool_name: &str) -> ToolHookDecision {
+    if output.is_deny() {
+        let reason = output
+            .agent_message
+            .or(output.user_message)
+            .unwrap_or_else(|| format!("a configured hook denied {tool_name}"));
+        return ToolHookDecision::Deny(reason);
+    }
+    if output.is_ask() {
+        let reason = output
+            .user_message
+            .or(output.agent_message)
+            .unwrap_or_else(|| format!("a configured hook wants approval for {tool_name}"));
+        return ToolHookDecision::Ask(reason);
+    }
+    match output.updated_input {
+        Some(arguments) => ToolHookDecision::ProceedWith(arguments),
+        None => ToolHookDecision::Proceed,
+    }
+}
+
+#[async_trait]
+impl PostTurnHook for ConfiguredHookBridge {
+    fn name(&self) -> &str {
+        BRIDGE_HOOK_NAME
+    }
+
+    async fn on_turn_complete(&self, ctx: &TurnContext) -> anyhow::Result<()> {
+        let engine = engine::global();
+        let identity = TurnIdentity {
+            session_id: ctx.session_id.clone(),
+            agent_id: ctx.agent_id.clone(),
+            conversation_id: ctx.session_id.clone(),
+            ..TurnIdentity::default()
+        };
+
+        if engine.has_hooks(HookEvent::AfterAgentResponse).await {
+            let input = build_input(
+                HookEvent::AfterAgentResponse,
+                identity.clone(),
+                HookPayload::Text(TextPayload {
+                    text: ctx.assistant_response.clone(),
+                    duration_ms: Some(ctx.turn_duration_ms),
+                }),
+            );
+            engine.dispatch(HookEvent::AfterAgentResponse, input).await;
+        }
+
+        if engine.has_hooks(HookEvent::Stop).await {
+            let input = build_input(
+                HookEvent::Stop,
+                identity,
+                HookPayload::Stop(StopPayload {
+                    status: "completed".to_string(),
+                    loop_count: 0,
+                    iteration_count: Some(ctx.iteration_count),
+                }),
+            );
+            let outcome = engine.dispatch(HookEvent::Stop, input).await;
+            if let Some(followup) = outcome.output.followup_message {
+                // The turn has already returned by the time a post-turn hook
+                // runs, so a follow-up cannot re-enter this turn. Publishing it
+                // lets the entrypoint that owns the conversation decide whether
+                // to start another one — the only layer that knows if there is
+                // still a user attached.
+                super::followup::publish(ctx.session_id.clone(), followup).await;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn context(tool: &str, arguments: Value) -> ToolHookContext {
+        ToolHookContext {
+            event: crate::openhuman::agent::hooks::ToolHookEvent::PreToolUse,
+            call_id: "call-1".into(),
+            tool_name: tool.into(),
+            arguments,
+            success: None,
+            duration_ms: None,
+            output: None,
+            error: None,
+            session_id: Some("sess-1".into()),
+            agent_id: None,
+        }
+    }
+
+    #[test]
+    fn shell_tools_derive_shell_events() {
+        assert_eq!(
+            derived_event("shell", true),
+            Some(HookEvent::BeforeShellExecution)
+        );
+        assert_eq!(
+            derived_event("shell", false),
+            Some(HookEvent::AfterShellExecution)
+        );
+    }
+
+    #[test]
+    fn reads_have_no_after_event_and_writes_have_no_before_event() {
+        assert_eq!(derived_event("file_read", true), Some(HookEvent::BeforeReadFile));
+        assert_eq!(derived_event("file_read", false), None);
+        assert_eq!(derived_event("file_write", true), None);
+        assert_eq!(derived_event("file_write", false), Some(HookEvent::AfterFileEdit));
+    }
+
+    #[test]
+    fn mcp_tools_derive_mcp_events() {
+        assert_eq!(
+            derived_event("mcp_call_tool", true),
+            Some(HookEvent::BeforeMcpExecution)
+        );
+        assert_eq!(derived_event("memory_store", true), None);
+    }
+
+    #[test]
+    fn shell_payload_carries_the_command_line() {
+        let ctx = context("shell", serde_json::json!({"command": "rm -rf /tmp/x"}));
+        match derived_payload(HookEvent::BeforeShellExecution, &ctx) {
+            HookPayload::Shell(shell) => {
+                assert_eq!(shell.command, "rm -rf /tmp/x");
+                assert!(!shell.sandbox);
+            }
+            other => panic!("expected a shell payload, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn file_path_is_read_from_any_of_the_spellings() {
+        assert_eq!(
+            file_path_argument(&serde_json::json!({"file_path": "/a"})),
+            "/a"
+        );
+        assert_eq!(file_path_argument(&serde_json::json!({"path": "/b"})), "/b");
+        assert_eq!(file_path_argument(&serde_json::json!({})), "");
+    }
+
+    #[test]
+    fn whole_file_write_reports_one_edit_with_empty_old_string() {
+        let edits = file_edits(&serde_json::json!({"content": "hello"}));
+        assert_eq!(edits.len(), 1);
+        assert!(edits[0].old_string.is_empty());
+        assert_eq!(edits[0].new_string, "hello");
+    }
+
+    #[test]
+    fn denial_carries_the_agent_message() {
+        let decision = decision_from(HookOutput::deny("policy says no"), "shell");
+        match decision {
+            ToolHookDecision::Deny(reason) => assert_eq!(reason, "policy says no"),
+            other => panic!("expected a denial, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn updated_input_becomes_a_rewrite() {
+        let output = HookOutput {
+            updated_input: Some(serde_json::json!({"command": "ls"})),
+            ..HookOutput::default()
+        };
+        match decision_from(output, "shell") {
+            ToolHookDecision::ProceedWith(arguments) => {
+                assert_eq!(arguments["command"], "ls");
+            }
+            other => panic!("expected a rewrite, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn timeout_text_classifies_as_a_timeout_failure() {
+        assert_eq!(classify_failure("tool timed out after 30s"), "timeout");
+        assert_eq!(classify_failure("[policy-blocked] nope"), "permission_denied");
+        assert_eq!(classify_failure("something else"), "error");
+    }
+}

--- a/src/openhuman/hooks/config.rs
+++ b/src/openhuman/hooks/config.rs
@@ -249,7 +249,10 @@ fn known_events_hint(key: &str) -> String {
 /// `project_dir` is the agent's action root; `workspace_dir` is the core's
 /// internal state directory. Both are passed in rather than resolved here so
 /// the loader stays testable without touching process globals.
-pub fn layer_paths(project_dir: Option<&Path>, workspace_dir: Option<&Path>) -> Vec<(HookLayer, PathBuf)> {
+pub fn layer_paths(
+    project_dir: Option<&Path>,
+    workspace_dir: Option<&Path>,
+) -> Vec<(HookLayer, PathBuf)> {
     let mut paths = Vec::new();
     if let Some(system) = system_hooks_dir() {
         paths.push((HookLayer::System, system.join(HOOKS_FILE_NAME)));
@@ -296,7 +299,11 @@ pub fn load(project_dir: Option<&Path>, workspace_dir: Option<&Path>) -> HookCon
     for (layer, path) in layer_paths(project_dir, workspace_dir) {
         match std::fs::read_to_string(&path) {
             Ok(contents) => {
-                log::debug!("[hooks] loading {} layer from {}", layer.as_str(), path.display());
+                log::debug!(
+                    "[hooks] loading {} layer from {}",
+                    layer.as_str(),
+                    path.display()
+                );
                 config.absorb(&path, layer, &contents);
             }
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}

--- a/src/openhuman/hooks/config.rs
+++ b/src/openhuman/hooks/config.rs
@@ -202,6 +202,12 @@ impl HookConfig {
                 ));
                 continue;
             };
+            if !event.is_wired() {
+                self.warnings.push(format!(
+                    "{}: '{event}' is defined but not yet fired by this build;                      its hooks will never run",
+                    path.display()
+                ));
+            }
             let slot = self.by_event.entry(event).or_default();
             for mut definition in definitions {
                 if definition.command.trim().is_empty() {

--- a/src/openhuman/hooks/config.rs
+++ b/src/openhuman/hooks/config.rs
@@ -219,11 +219,44 @@ impl HookConfig {
                 }
                 definition.layer = Some(layer);
                 definition.source_dir.clone_from(&source_dir);
+                if let Some(problem) = unrunnable_reason(&definition) {
+                    self.warnings.push(format!(
+                        "{}: hook for '{event}' {problem}",
+                        path.display()
+                    ));
+                }
                 slot.push(definition);
             }
         }
         self.sources.push(path.to_path_buf());
     }
+}
+
+/// Report a command-hook script that cannot run, or `None` when it looks fine.
+///
+/// Only *relative* paths are checked. An absolute path may legitimately be
+/// resolved on a machine this config was not loaded on, and a bare name is a
+/// `PATH` lookup or a shell built-in — guessing at either would produce a
+/// warning for a working hook, which is worse than no warning at all.
+fn unrunnable_reason(definition: &HookDefinition) -> Option<String> {
+    if definition.kind != HookKind::Command {
+        return None;
+    }
+    let program = definition.command.split_whitespace().next()?;
+    if !program.starts_with("./") && !program.starts_with("../") {
+        return None;
+    }
+    let resolved = definition.source_dir.as_ref()?.join(program);
+    if !resolved.exists() {
+        return Some(format!("points at a missing script: {}", resolved.display()));
+    }
+    if !super::exec::is_executable(&resolved) {
+        return Some(format!(
+            "points at a script that is not executable (chmod +x): {}",
+            resolved.display()
+        ));
+    }
+    None
 }
 
 /// Suggest the closest known event name, so a typo reports something useful

--- a/src/openhuman/hooks/config.rs
+++ b/src/openhuman/hooks/config.rs
@@ -1,0 +1,317 @@
+//! `hooks.json` — schema, discovery, and layering.
+//!
+//! The file format is Cursor's, version 1:
+//!
+//! ```json
+//! {
+//!   "version": 1,
+//!   "hooks": {
+//!     "beforeShellExecution": [
+//!       { "command": "./scripts/audit.sh", "matcher": "^rm ", "timeout": 10 }
+//!     ]
+//!   }
+//! }
+//! ```
+//!
+//! ## Layering
+//!
+//! Four layers are read, lowest trust last so that a more specific file cannot
+//! *remove* a broader policy — the lists concatenate, they do not override. That
+//! is the opposite of how config.toml merges, and it is deliberate: an operator
+//! who installs a system-wide deny hook must not be overridden by a repository
+//! that ships its own `hooks.json`. Since [`HookOutput::merge`] takes the
+//! strictest verdict, concatenation is the safe composition.
+//!
+//! [`HookOutput::merge`]: super::types::HookOutput::merge
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use super::types::{normalize_key, HookEvent};
+
+/// The only schema version this loader accepts.
+pub const HOOKS_SCHEMA_VERSION: u32 = 1;
+
+/// Filename looked for in every layer directory.
+pub const HOOKS_FILE_NAME: &str = "hooks.json";
+
+/// Where a hook definition came from. Surfaced in diagnostics and in the RPC
+/// listing so "why is this hook running" has an answer that names a file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HookLayer {
+    /// Machine-wide, operator-managed.
+    System,
+    /// The user's own `~/.openhuman/hooks.json`.
+    User,
+    /// The core's workspace directory.
+    Workspace,
+    /// `<project>/.openhuman/hooks.json` inside the action dir.
+    Project,
+}
+
+impl HookLayer {
+    /// Human-readable label for logs and the RPC listing.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HookLayer::System => "system",
+            HookLayer::User => "user",
+            HookLayer::Workspace => "workspace",
+            HookLayer::Project => "project",
+        }
+    }
+}
+
+/// How a hook is executed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HookKind {
+    /// Spawn a program, hand it the event JSON on stdin, read a decision from
+    /// stdout.
+    #[default]
+    Command,
+    /// Evaluate a natural-language condition with a model, which answers
+    /// `{ "ok": bool, "reason": string }`.
+    Prompt,
+}
+
+/// One configured hook.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookDefinition {
+    /// The program to run, or the prompt text for a `prompt` hook.
+    pub command: String,
+    /// Execution strategy.
+    #[serde(default, rename = "type")]
+    pub kind: HookKind,
+    /// Seconds before the hook is killed. Falls back to the engine default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timeout: Option<u64>,
+    /// Restricts which occurrences of the event reach this hook. See
+    /// [`super::matcher`] for the per-event semantics.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub matcher: Option<String>,
+    /// Follow-ups this hook may inject before the engine stops honouring them.
+    /// `None` in the file means "engine default"; explicit JSON `null` means
+    /// unlimited, matching Cursor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub loop_limit: Option<u32>,
+    /// Treat a crashed, missing, or timed-out hook as a denial rather than
+    /// letting the action through. Off by default: a broken audit script must
+    /// not brick the agent, but a security hook can opt into the other trade.
+    #[serde(default, alias = "failClosed")]
+    pub fail_closed: bool,
+    /// Model override for a `prompt` hook.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Skip this definition without deleting it.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Resolved at load time from the file's own location — never read from
+    /// the file, so a `hooks.json` cannot claim to be a more trusted layer.
+    #[serde(skip_deserializing)]
+    pub layer: Option<HookLayer>,
+    /// Directory the hook process runs in: the directory holding its
+    /// `hooks.json`. Resolved at load time, never read from the file.
+    #[serde(skip_deserializing)]
+    pub source_dir: Option<PathBuf>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl HookDefinition {
+    /// A short identifier for logs: layer plus the head of the command.
+    pub fn label(&self) -> String {
+        let layer = self.layer.map(HookLayer::as_str).unwrap_or("unknown");
+        let head = self.command.split_whitespace().next().unwrap_or("<empty>");
+        format!("{layer}:{head}")
+    }
+}
+
+/// One parsed `hooks.json`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HooksFile {
+    /// Schema version. Anything other than [`HOOKS_SCHEMA_VERSION`] is rejected.
+    #[serde(default)]
+    pub version: u32,
+    /// Event name → definitions, in run order.
+    #[serde(default)]
+    pub hooks: BTreeMap<String, Vec<HookDefinition>>,
+}
+
+/// The merged, ready-to-run hook set.
+#[derive(Debug, Clone, Default)]
+pub struct HookConfig {
+    /// Definitions grouped by resolved event, in layer order.
+    pub by_event: BTreeMap<HookEvent, Vec<HookDefinition>>,
+    /// Files that contributed, for diagnostics.
+    pub sources: Vec<PathBuf>,
+    /// Non-fatal problems found while loading: unreadable files, unknown event
+    /// names, wrong versions. Surfaced rather than swallowed — a hook that
+    /// silently never runs is worse than one that reports why.
+    pub warnings: Vec<String>,
+}
+
+impl HookConfig {
+    /// Definitions registered for an event, in run order.
+    pub fn for_event(&self, event: HookEvent) -> &[HookDefinition] {
+        self.by_event
+            .get(&event)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    /// Whether anything at all is configured.
+    pub fn is_empty(&self) -> bool {
+        self.by_event.values().all(Vec::is_empty)
+    }
+
+    /// Total number of configured definitions.
+    pub fn len(&self) -> usize {
+        self.by_event.values().map(Vec::len).sum()
+    }
+
+    /// Parse one file's contents into this config, tagging every definition
+    /// with its layer and source directory.
+    fn absorb(&mut self, path: &Path, layer: HookLayer, contents: &str) {
+        let file: HooksFile = match serde_json::from_str(contents) {
+            Ok(file) => file,
+            Err(error) => {
+                self.warnings
+                    .push(format!("{}: invalid JSON: {error}", path.display()));
+                return;
+            }
+        };
+        if file.version != HOOKS_SCHEMA_VERSION {
+            self.warnings.push(format!(
+                "{}: unsupported version {} (expected {HOOKS_SCHEMA_VERSION}); ignored",
+                path.display(),
+                file.version
+            ));
+            return;
+        }
+        let source_dir = path.parent().map(Path::to_path_buf);
+        for (key, definitions) in file.hooks {
+            let Some(event) = HookEvent::parse(&key) else {
+                self.warnings.push(format!(
+                    "{}: unknown hook event '{key}'; known events: {}",
+                    path.display(),
+                    known_events_hint(&key)
+                ));
+                continue;
+            };
+            let slot = self.by_event.entry(event).or_default();
+            for mut definition in definitions {
+                if definition.command.trim().is_empty() {
+                    self.warnings.push(format!(
+                        "{}: hook for '{event}' has an empty command; ignored",
+                        path.display()
+                    ));
+                    continue;
+                }
+                definition.layer = Some(layer);
+                definition.source_dir.clone_from(&source_dir);
+                slot.push(definition);
+            }
+        }
+        self.sources.push(path.to_path_buf());
+    }
+}
+
+/// Suggest the closest known event name, so a typo reports something useful
+/// rather than the full list of eighteen.
+fn known_events_hint(key: &str) -> String {
+    let normalized = normalize_key(key);
+    let closest = HookEvent::ALL.iter().copied().find(|event| {
+        let candidate = normalize_key(event.as_str());
+        candidate.starts_with(&normalized) || normalized.starts_with(&candidate)
+    });
+    match closest {
+        Some(event) => format!("did you mean '{event}'?"),
+        None => HookEvent::ALL
+            .iter()
+            .map(|event| event.as_str())
+            .collect::<Vec<_>>()
+            .join(", "),
+    }
+}
+
+/// The directories searched for a `hooks.json`, lowest trust last.
+///
+/// `project_dir` is the agent's action root; `workspace_dir` is the core's
+/// internal state directory. Both are passed in rather than resolved here so
+/// the loader stays testable without touching process globals.
+pub fn layer_paths(project_dir: Option<&Path>, workspace_dir: Option<&Path>) -> Vec<(HookLayer, PathBuf)> {
+    let mut paths = Vec::new();
+    if let Some(system) = system_hooks_dir() {
+        paths.push((HookLayer::System, system.join(HOOKS_FILE_NAME)));
+    }
+    if let Some(home) = dirs::home_dir() {
+        paths.push((
+            HookLayer::User,
+            home.join(".openhuman").join(HOOKS_FILE_NAME),
+        ));
+    }
+    if let Some(workspace) = workspace_dir {
+        paths.push((HookLayer::Workspace, workspace.join(HOOKS_FILE_NAME)));
+    }
+    if let Some(project) = project_dir {
+        paths.push((
+            HookLayer::Project,
+            project.join(".openhuman").join(HOOKS_FILE_NAME),
+        ));
+    }
+    paths
+}
+
+#[cfg(target_os = "windows")]
+fn system_hooks_dir() -> Option<PathBuf> {
+    std::env::var_os("ProgramData").map(|dir| PathBuf::from(dir).join("OpenHuman"))
+}
+
+#[cfg(target_os = "macos")]
+fn system_hooks_dir() -> Option<PathBuf> {
+    Some(PathBuf::from("/Library/Application Support/OpenHuman"))
+}
+
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+fn system_hooks_dir() -> Option<PathBuf> {
+    Some(PathBuf::from("/etc/openhuman"))
+}
+
+/// Read every layer and merge it into one config.
+///
+/// A missing file is not a warning — most hosts have none. An unreadable or
+/// malformed one is, because that is a hook the author believes is running.
+pub fn load(project_dir: Option<&Path>, workspace_dir: Option<&Path>) -> HookConfig {
+    let mut config = HookConfig::default();
+    for (layer, path) in layer_paths(project_dir, workspace_dir) {
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => {
+                log::debug!("[hooks] loading {} layer from {}", layer.as_str(), path.display());
+                config.absorb(&path, layer, &contents);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => config
+                .warnings
+                .push(format!("{}: unreadable: {error}", path.display())),
+        }
+    }
+    log::debug!(
+        "[hooks] loaded {} definition(s) from {} file(s), {} warning(s)",
+        config.len(),
+        config.sources.len(),
+        config.warnings.len()
+    );
+    config
+}
+
+/// Parse a single file's contents. Exposed for the RPC validate endpoint and
+/// for tests, which must not depend on the host's real layer directories.
+pub fn parse_one(path: &Path, layer: HookLayer, contents: &str) -> HookConfig {
+    let mut config = HookConfig::default();
+    config.absorb(path, layer, contents);
+    config
+}

--- a/src/openhuman/hooks/config.rs
+++ b/src/openhuman/hooks/config.rs
@@ -220,10 +220,8 @@ impl HookConfig {
                 definition.layer = Some(layer);
                 definition.source_dir.clone_from(&source_dir);
                 if let Some(problem) = unrunnable_reason(&definition) {
-                    self.warnings.push(format!(
-                        "{}: hook for '{event}' {problem}",
-                        path.display()
-                    ));
+                    self.warnings
+                        .push(format!("{}: hook for '{event}' {problem}", path.display()));
                 }
                 slot.push(definition);
             }
@@ -248,7 +246,10 @@ fn unrunnable_reason(definition: &HookDefinition) -> Option<String> {
     }
     let resolved = definition.source_dir.as_ref()?.join(program);
     if !resolved.exists() {
-        return Some(format!("points at a missing script: {}", resolved.display()));
+        return Some(format!(
+            "points at a missing script: {}",
+            resolved.display()
+        ));
     }
     if !super::exec::is_executable(&resolved) {
         return Some(format!(

--- a/src/openhuman/hooks/context.rs
+++ b/src/openhuman/hooks/context.rs
@@ -1,0 +1,88 @@
+//! Building the stdin envelope.
+//!
+//! Every hook event shares a common header — version, workspace roots, session
+//! and model identity — and the pieces of it that do not change during a run
+//! are resolved once at startup rather than per event. A hook firing on every
+//! tool call must not cost a config load.
+
+use std::path::PathBuf;
+use std::sync::RwLock;
+
+use super::types::{HookEvent, HookInput, HookPayload};
+
+/// Host facts shared by every hook envelope, resolved once at startup.
+#[derive(Debug, Clone, Default)]
+pub struct HostContext {
+    /// Filesystem roots the agent may act in. First entry is the primary root
+    /// and becomes `OPENHUMAN_PROJECT_DIR` for hook processes.
+    pub workspace_roots: Vec<PathBuf>,
+    /// Core version string.
+    pub version: String,
+}
+
+static HOST: RwLock<Option<HostContext>> = RwLock::new(None);
+
+/// Install the host facts. Called once during core bootstrap, and again by the
+/// RPC reload endpoint when the action dir changes.
+pub fn set_host_context(context: HostContext) {
+    log::debug!(
+        "[hooks] host context: version={} roots={:?}",
+        context.version,
+        context.workspace_roots
+    );
+    *HOST.write().expect("hook host context poisoned") = Some(context);
+}
+
+/// The installed host facts, or an empty default before bootstrap has run.
+pub fn host_context() -> HostContext {
+    HOST.read()
+        .expect("hook host context poisoned")
+        .clone()
+        .unwrap_or_default()
+}
+
+/// Per-turn identity attached to each envelope.
+///
+/// All fields are optional because the moments hooks fire at do not all belong
+/// to a session — a `sessionStart` has no generation, a CLI turn has no
+/// conversation.
+#[derive(Debug, Clone, Default)]
+pub struct TurnIdentity {
+    /// Conversation/thread identifier.
+    pub conversation_id: Option<String>,
+    /// Per-turn generation identifier.
+    pub generation_id: Option<String>,
+    /// Agent session identifier.
+    pub session_id: Option<String>,
+    /// Model driving the turn.
+    pub model: Option<String>,
+    /// Canonical agent definition id.
+    pub agent_id: Option<String>,
+    /// Working directory the action is scoped to.
+    pub cwd: Option<String>,
+}
+
+/// Assemble the envelope handed to a hook on stdin.
+pub fn build_input(event: HookEvent, identity: TurnIdentity, payload: HookPayload) -> HookInput {
+    let host = host_context();
+    HookInput {
+        hook_event_name: event.as_str().to_string(),
+        conversation_id: identity.conversation_id,
+        generation_id: identity.generation_id,
+        session_id: identity.session_id,
+        model: identity.model,
+        agent_id: identity.agent_id,
+        openhuman_version: if host.version.is_empty() {
+            env!("CARGO_PKG_VERSION").to_string()
+        } else {
+            host.version
+        },
+        workspace_roots: host
+            .workspace_roots
+            .iter()
+            .map(|root| root.display().to_string())
+            .collect(),
+        cwd: identity.cwd,
+        payload,
+    }
+}

--- a/src/openhuman/hooks/engine.rs
+++ b/src/openhuman/hooks/engine.rs
@@ -1,0 +1,324 @@
+//! The hook engine — matching, ordering, and aggregating.
+//!
+//! One process-global engine holds the merged [`HookConfig`], the session-scoped
+//! environment contributed by `sessionStart` hooks, and the per-session
+//! follow-up counters that stop a `stop` hook from looping forever.
+//!
+//! ## Gating versus observing
+//!
+//! [`HookEvent::is_gating`] splits the events in two, and the split decides the
+//! execution strategy:
+//!
+//! * **Gating** events run their hooks **sequentially, in layer order**, and the
+//!   turn waits. A denial short-circuits the rest — once the action is refused
+//!   there is nothing later hooks can add, and running them would pay latency
+//!   for an outcome that cannot change.
+//! * **Observing** events are dispatched onto a background task and the turn
+//!   never waits. An audit hook that hangs must not hang the agent.
+//!
+//! That asymmetry is the whole reason the engine exists rather than each call
+//! site spawning processes itself: it is the one place the latency budget of a
+//! turn is spent deliberately.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::RwLock;
+
+use super::config::{self, HookConfig, HookDefinition};
+use super::exec::{self, HookRun, DEFAULT_TIMEOUT};
+use super::matcher;
+use super::types::{HookEvent, HookInput, HookOutput, HookPermission};
+
+/// Follow-ups a single hook may inject per session before the engine stops
+/// honouring it. Matches Cursor's default; a definition may raise it, and an
+/// explicit `null` in the file lifts the cap entirely.
+pub const DEFAULT_LOOP_LIMIT: u32 = 5;
+
+/// The result of dispatching one event.
+#[derive(Debug, Clone, Default)]
+pub struct HookOutcome {
+    /// The merged decision across every hook that ran.
+    pub output: HookOutput,
+    /// Per-hook detail, in run order. Empty for a fire-and-forget dispatch.
+    pub runs: Vec<HookRun>,
+}
+
+impl HookOutcome {
+    /// Whether the action was refused.
+    pub fn is_deny(&self) -> bool {
+        self.output.is_deny()
+    }
+
+    /// Whether the action needs human approval.
+    pub fn is_ask(&self) -> bool {
+        self.output.is_ask()
+    }
+
+    /// The reason to hand the model, when the action was refused.
+    pub fn denial_reason(&self) -> Option<&str> {
+        if !self.is_deny() {
+            return None;
+        }
+        self.output
+            .agent_message
+            .as_deref()
+            .or(self.output.user_message.as_deref())
+    }
+}
+
+/// Matching, execution, and aggregation of configured hooks.
+pub struct HookEngine {
+    config: RwLock<Arc<HookConfig>>,
+    /// Environment contributed by `sessionStart` hooks, keyed by session id.
+    /// Cursor scopes these to the session; so do we, rather than mutating the
+    /// process environment, which would leak one session's variables into
+    /// every concurrent one.
+    session_env: RwLock<HashMap<String, BTreeMap<String, String>>>,
+    /// Follow-ups already granted, keyed by session and hook label.
+    loop_counts: RwLock<HashMap<(String, String), u32>>,
+    default_timeout: RwLock<Duration>,
+}
+
+impl Default for HookEngine {
+    fn default() -> Self {
+        Self {
+            config: RwLock::new(Arc::new(HookConfig::default())),
+            session_env: RwLock::new(HashMap::new()),
+            loop_counts: RwLock::new(HashMap::new()),
+            default_timeout: RwLock::new(DEFAULT_TIMEOUT),
+        }
+    }
+}
+
+static ENGINE: std::sync::LazyLock<HookEngine> = std::sync::LazyLock::new(HookEngine::default);
+
+/// The process-global engine.
+pub fn global() -> &'static HookEngine {
+    &ENGINE
+}
+
+impl HookEngine {
+    /// Re-read every layer and swap the config in.
+    ///
+    /// Reloading is a whole-config swap rather than an incremental patch: a
+    /// half-applied hook set is a policy nobody wrote.
+    pub async fn reload(
+        &self,
+        project_dir: Option<PathBuf>,
+        workspace_dir: Option<PathBuf>,
+    ) -> Arc<HookConfig> {
+        let loaded = tokio::task::spawn_blocking(move || {
+            config::load(project_dir.as_deref(), workspace_dir.as_deref())
+        })
+        .await
+        .unwrap_or_default();
+        for warning in &loaded.warnings {
+            log::warn!("[hooks] {warning}");
+        }
+        let loaded = Arc::new(loaded);
+        *self.config.write().await = Arc::clone(&loaded);
+        log::info!(
+            "[hooks] active configuration: {} hook(s) across {} file(s)",
+            loaded.len(),
+            loaded.sources.len()
+        );
+        loaded
+    }
+
+    /// Install a config directly. Used by tests and by the RPC surface, which
+    /// validates a candidate file before letting it become live.
+    pub async fn install(&self, config: HookConfig) {
+        *self.config.write().await = Arc::new(config);
+    }
+
+    /// The currently active config.
+    pub async fn snapshot(&self) -> Arc<HookConfig> {
+        Arc::clone(&*self.config.read().await)
+    }
+
+    /// Override the timeout applied to hooks that name none.
+    pub async fn set_default_timeout(&self, timeout: Duration) {
+        *self.default_timeout.write().await = timeout;
+    }
+
+    /// Whether any hook is registered for an event. Call sites use this to skip
+    /// building an input envelope for an event nobody is listening to — the
+    /// common case, and the reason hooks cost nothing when unconfigured.
+    pub async fn has_hooks(&self, event: HookEvent) -> bool {
+        !self.snapshot().await.for_event(event).is_empty()
+    }
+
+    /// Run an event's hooks and return the merged decision.
+    ///
+    /// Observing events are dispatched in the background and return an empty
+    /// outcome immediately; see the module docs.
+    pub async fn dispatch(&self, event: HookEvent, input: HookInput) -> HookOutcome {
+        let config = self.snapshot().await;
+        let selected: Vec<HookDefinition> = config
+            .for_event(event)
+            .iter()
+            .filter(|definition| definition.enabled)
+            .filter(|definition| {
+                matcher::matches(
+                    definition.matcher.as_deref(),
+                    matcher::subject(event, &input.payload),
+                )
+            })
+            .cloned()
+            .collect();
+        if selected.is_empty() {
+            return HookOutcome::default();
+        }
+        log::debug!(
+            "[hooks] {event}: {} hook(s) selected ({} configured)",
+            selected.len(),
+            config.for_event(event).len()
+        );
+
+        if !event.is_gating() {
+            self.dispatch_detached(event, input, selected).await;
+            return HookOutcome::default();
+        }
+        self.dispatch_blocking(event, input, selected).await
+    }
+
+    /// Run hooks in order, stopping at the first denial.
+    async fn dispatch_blocking(
+        &self,
+        event: HookEvent,
+        input: HookInput,
+        selected: Vec<HookDefinition>,
+    ) -> HookOutcome {
+        let env = self.env_for(&input).await;
+        let default_timeout = *self.default_timeout.read().await;
+        let mut outcome = HookOutcome::default();
+        for definition in selected {
+            let run = exec::run(&definition, &input, &env, default_timeout).await;
+            log::debug!(
+                "[hooks] {event}: {} finished in {}ms (deny={}, error={:?})",
+                run.label,
+                run.duration.as_millis(),
+                run.output.is_deny(),
+                run.error
+            );
+            let denied = run.output.is_deny();
+            let followup = run.output.followup_message.clone();
+            let mut run = run;
+            if followup.is_some() && !self.grant_followup(&input, &definition, &run.label).await {
+                log::debug!(
+                    "[hooks] {event}: {} exhausted its follow-up budget; dropping the message",
+                    run.label
+                );
+                run.output.followup_message = None;
+            }
+            outcome.output.merge(run.output.clone());
+            outcome.runs.push(run);
+            if denied {
+                break;
+            }
+        }
+        if let Some(env) = outcome.output.env.clone() {
+            self.absorb_session_env(&input, env).await;
+        }
+        outcome
+    }
+
+    /// Fire hooks on a background task, so the turn never waits on them.
+    async fn dispatch_detached(
+        &self,
+        event: HookEvent,
+        input: HookInput,
+        selected: Vec<HookDefinition>,
+    ) {
+        let env = self.env_for(&input).await;
+        let default_timeout = *self.default_timeout.read().await;
+        tokio::spawn(async move {
+            for definition in selected {
+                let run = exec::run(&definition, &input, &env, default_timeout).await;
+                if let Some(error) = &run.error {
+                    log::warn!("[hooks] {event}: {} failed: {error}", run.label);
+                } else {
+                    log::trace!(
+                        "[hooks] {event}: {} finished in {}ms",
+                        run.label,
+                        run.duration.as_millis()
+                    );
+                }
+            }
+        });
+    }
+
+    /// Ambient variables plus anything a `sessionStart` hook contributed.
+    async fn env_for(&self, input: &HookInput) -> BTreeMap<String, String> {
+        let mut env = exec::ambient_env(input);
+        if let Some(session) = &input.session_id {
+            if let Some(extra) = self.session_env.read().await.get(session) {
+                env.extend(extra.clone());
+            }
+        }
+        env
+    }
+
+    async fn absorb_session_env(&self, input: &HookInput, env: BTreeMap<String, String>) {
+        let Some(session) = input.session_id.clone() else {
+            log::debug!("[hooks] ignoring session env from a hook fired outside a session");
+            return;
+        };
+        self.session_env
+            .write()
+            .await
+            .entry(session)
+            .or_default()
+            .extend(env);
+    }
+
+    /// Charge one follow-up against a hook's budget, returning whether it may
+    /// be honoured. A hook with no session id gets exactly one, since there is
+    /// nowhere to keep a counter and an unbounded loop is the worse failure.
+    async fn grant_followup(
+        &self,
+        input: &HookInput,
+        definition: &HookDefinition,
+        label: &str,
+    ) -> bool {
+        // Cursor's `loop_limit: null` means unlimited. serde cannot distinguish
+        // an explicit null from an absent key in an `Option<u32>`, so the file
+        // convention here is: absent → engine default, `0` → unlimited.
+        let limit = match definition.loop_limit {
+            Some(0) => return true,
+            Some(limit) => limit,
+            None => DEFAULT_LOOP_LIMIT,
+        };
+        let Some(session) = input.session_id.clone() else {
+            return true;
+        };
+        let key = (session, label.to_string());
+        let mut counts = self.loop_counts.write().await;
+        let count = counts.entry(key).or_insert(0);
+        if *count >= limit {
+            return false;
+        }
+        *count += 1;
+        true
+    }
+
+    /// Drop everything scoped to a finished session.
+    pub async fn forget_session(&self, session_id: &str) {
+        self.session_env.write().await.remove(session_id);
+        self.loop_counts
+            .write()
+            .await
+            .retain(|(session, _), _| session != session_id);
+    }
+}
+
+/// Convert a merged decision into the permission the caller should enforce.
+///
+/// `None` from every hook means allow — an event nobody voted on is not a
+/// denial.
+pub fn effective_permission(output: &HookOutput) -> HookPermission {
+    output.permission.unwrap_or(HookPermission::Allow)
+}

--- a/src/openhuman/hooks/engine.rs
+++ b/src/openhuman/hooks/engine.rs
@@ -185,6 +185,33 @@ impl HookEngine {
         self.dispatch_blocking(event, input, selected).await
     }
 
+    /// Run an event's hooks in the foreground regardless of whether the event
+    /// is gating, and report every run.
+    ///
+    /// Only the `hooks.test` RPC uses this. A detached dispatch would report
+    /// nothing, which is precisely the opposite of what an author debugging a
+    /// hook needs — so the test path trades the latency guarantee for
+    /// observability, and nothing on a turn's path may call it.
+    pub async fn dispatch_for_test(&self, event: HookEvent, input: HookInput) -> HookOutcome {
+        let config = self.snapshot().await;
+        let selected: Vec<HookDefinition> = config
+            .for_event(event)
+            .iter()
+            .filter(|definition| definition.enabled)
+            .filter(|definition| {
+                matcher::matches(
+                    definition.matcher.as_deref(),
+                    matcher::subject(event, &input.payload),
+                )
+            })
+            .cloned()
+            .collect();
+        if selected.is_empty() {
+            return HookOutcome::default();
+        }
+        self.dispatch_blocking(event, input, selected).await
+    }
+
     /// Run hooks in order, stopping at the first denial.
     async fn dispatch_blocking(
         &self,

--- a/src/openhuman/hooks/engine.rs
+++ b/src/openhuman/hooks/engine.rs
@@ -30,7 +30,7 @@ use tokio::sync::RwLock;
 use super::config::{self, HookConfig, HookDefinition};
 use super::exec::{self, HookRun, DEFAULT_TIMEOUT};
 use super::matcher;
-use super::types::{HookEvent, HookInput, HookOutput, HookPermission};
+use super::types::{HookEvent, HookInput, HookOutput};
 
 /// Follow-ups a single hook may inject per session before the engine stops
 /// honouring it. Matches Cursor's default; a definition may raise it, and an
@@ -340,12 +340,4 @@ impl HookEngine {
             .await
             .retain(|(session, _), _| session != session_id);
     }
-}
-
-/// Convert a merged decision into the permission the caller should enforce.
-///
-/// `None` from every hook means allow — an event nobody voted on is not a
-/// denial.
-pub fn effective_permission(output: &HookOutput) -> HookPermission {
-    output.permission.unwrap_or(HookPermission::Allow)
 }

--- a/src/openhuman/hooks/exec.rs
+++ b/src/openhuman/hooks/exec.rs
@@ -131,7 +131,8 @@ async fn run_command(
     env: &BTreeMap<String, String>,
     timeout: Duration,
 ) -> Result<HookOutput, String> {
-    let payload = serde_json::to_vec(input).map_err(|error| format!("serializing input: {error}"))?;
+    let payload =
+        serde_json::to_vec(input).map_err(|error| format!("serializing input: {error}"))?;
 
     let mut command =
         crate::openhuman::agent::platform_shell::build_tokio_command(&definition.command);
@@ -244,7 +245,9 @@ async fn run_prompt(definition: &HookDefinition, input: &HookInput) -> Result<Ho
                 .map(str::trim)
                 .filter(|line| line.starts_with('{'))
                 .find_map(|line| serde_json::from_str::<PromptVerdict>(line).ok())
-                .ok_or_else(|| format!("model answer was not a verdict: {}", truncate(&answer, 200)))
+                .ok_or_else(|| {
+                    format!("model answer was not a verdict: {}", truncate(&answer, 200))
+                })
         })
         .map_err(|error| error.to_string())?;
 
@@ -287,10 +290,7 @@ pub fn ambient_env(input: &HookInput) -> BTreeMap<String, String> {
         env.insert("CLAUDE_PROJECT_DIR".into(), root.clone());
         env.insert("CURSOR_PROJECT_DIR".into(), root.clone());
     }
-    env.insert(
-        "OPENHUMAN_VERSION".into(),
-        input.openhuman_version.clone(),
-    );
+    env.insert("OPENHUMAN_VERSION".into(), input.openhuman_version.clone());
     env.insert("OPENHUMAN_HOOK_EVENT".into(), input.hook_event_name.clone());
     if let Some(session) = &input.session_id {
         env.insert("OPENHUMAN_SESSION_ID".into(), session.clone());

--- a/src/openhuman/hooks/exec.rs
+++ b/src/openhuman/hooks/exec.rs
@@ -303,8 +303,9 @@ pub fn ambient_env(input: &HookInput) -> BTreeMap<String, String> {
 
 /// True when a path exists and is executable by this process.
 ///
-/// Used by the RPC validate endpoint to report a hook that will never run,
-/// rather than waiting for the first event to discover it.
+/// Read at **load** time so a hook whose script is missing or was committed
+/// without the executable bit is reported when the file is read, not when the
+/// moment it was meant to guard finally arrives.
 pub fn is_executable(path: &Path) -> bool {
     #[cfg(unix)]
     {

--- a/src/openhuman/hooks/exec.rs
+++ b/src/openhuman/hooks/exec.rs
@@ -1,0 +1,357 @@
+//! Running one hook.
+//!
+//! ## The contract
+//!
+//! A command hook receives the event JSON on stdin, and answers on stdout. Its
+//! exit code decides how the answer is read:
+//!
+//! | Exit | Meaning |
+//! | ---- | ------- |
+//! | `0`  | Success. stdout is parsed as a [`HookOutput`]; empty stdout is a no-op. |
+//! | `2`  | Deny, regardless of stdout. stderr becomes the reason the agent sees. |
+//! | else | Failure. Fails open — unless the definition sets `fail_closed`. |
+//!
+//! A timeout, a missing interpreter, and unparseable stdout are all *failures*
+//! and take the same path as a non-zero exit: open by default, closed on
+//! request. That symmetry matters — a hook that denies only when it manages to
+//! run is not a security control, so `fail_closed` has to cover every way the
+//! script can fail to answer, not just the tidy one.
+//!
+//! ## Why stdout is parsed leniently
+//!
+//! Scripts print. A hook that echoes a progress line and *then* prints its JSON
+//! is the common case, not an error, so the parser takes the last complete JSON
+//! object on stdout rather than demanding the whole stream be JSON.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+use tokio::io::AsyncWriteExt;
+
+use super::config::{HookDefinition, HookKind};
+use super::types::{HookInput, HookOutput, HookPermission};
+
+/// Exit code a hook uses to refuse an action.
+pub const EXIT_DENY: i32 = 2;
+
+/// Timeout applied when neither the definition nor the engine names one.
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// What running one hook produced, with enough detail for diagnostics.
+#[derive(Debug, Clone)]
+pub struct HookRun {
+    /// The hook's own label, for logs.
+    pub label: String,
+    /// The decision, after exit-code and fail-closed handling.
+    pub output: HookOutput,
+    /// Wall-clock runtime.
+    pub duration: Duration,
+    /// Set when the hook did not answer cleanly. Present even when the engine
+    /// failed open, so "nothing happened" and "it broke and we continued" stay
+    /// distinguishable in the logs and in the RPC test endpoint.
+    pub error: Option<String>,
+}
+
+impl HookRun {
+    fn noop(label: String, duration: Duration, error: Option<String>) -> Self {
+        Self {
+            label,
+            output: HookOutput::default(),
+            duration,
+            error,
+        }
+    }
+}
+
+/// Run one hook against one event.
+///
+/// `env` carries session-scoped variables contributed by an earlier
+/// `sessionStart` hook, plus the ambient `OPENHUMAN_*` variables the engine
+/// adds. Never returns `Err`: a hook that cannot run is a [`HookRun`] with an
+/// `error` and either an empty output (fail-open) or a denial (fail-closed).
+pub async fn run(
+    definition: &HookDefinition,
+    input: &HookInput,
+    env: &BTreeMap<String, String>,
+    default_timeout: Duration,
+) -> HookRun {
+    let label = definition.label();
+    let started = Instant::now();
+    match definition.kind {
+        HookKind::Command => {
+            let timeout = definition
+                .timeout
+                .map(Duration::from_secs)
+                .unwrap_or(default_timeout);
+            let result = run_command(definition, input, env, timeout).await;
+            finish(definition, label, started.elapsed(), result)
+        }
+        HookKind::Prompt => {
+            let result = run_prompt(definition, input).await;
+            finish(definition, label, started.elapsed(), result)
+        }
+    }
+}
+
+/// Apply the fail-open / fail-closed policy to a raw outcome.
+fn finish(
+    definition: &HookDefinition,
+    label: String,
+    duration: Duration,
+    result: Result<HookOutput, String>,
+) -> HookRun {
+    match result {
+        Ok(output) => HookRun {
+            label,
+            output,
+            duration,
+            error: None,
+        },
+        Err(error) if definition.fail_closed => {
+            log::warn!("[hooks] {label} failed and is fail-closed; denying: {error}");
+            HookRun {
+                output: HookOutput::deny(format!("hook '{label}' could not run: {error}")),
+                label,
+                duration,
+                error: Some(error),
+            }
+        }
+        Err(error) => {
+            log::warn!("[hooks] {label} failed; continuing (fail-open): {error}");
+            HookRun::noop(label, duration, Some(error))
+        }
+    }
+}
+
+async fn run_command(
+    definition: &HookDefinition,
+    input: &HookInput,
+    env: &BTreeMap<String, String>,
+    timeout: Duration,
+) -> Result<HookOutput, String> {
+    let payload = serde_json::to_vec(input).map_err(|error| format!("serializing input: {error}"))?;
+
+    let mut command =
+        crate::openhuman::agent::platform_shell::build_tokio_command(&definition.command);
+    if let Some(dir) = definition.source_dir.as_deref().filter(|dir| dir.is_dir()) {
+        command.current_dir(dir);
+    }
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("spawning {:?}: {error}", definition.command))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        // A hook that ignores stdin closes the pipe early; that is a broken pipe
+        // on our side, not a hook failure, so the write error is only logged.
+        if let Err(error) = stdin.write_all(&payload).await {
+            log::debug!("[hooks] {} closed stdin early: {error}", definition.label());
+        }
+        drop(stdin);
+    }
+
+    let output = match tokio::time::timeout(timeout, child.wait_with_output()).await {
+        Ok(Ok(output)) => output,
+        Ok(Err(error)) => return Err(format!("waiting on hook: {error}")),
+        Err(_) => return Err(format!("timed out after {}s", timeout.as_secs())),
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let code = output.status.code();
+
+    if code == Some(EXIT_DENY) {
+        let reason = first_non_empty(&[&stderr, &stdout])
+            .unwrap_or_else(|| format!("hook {} denied the action", definition.label()));
+        return Ok(HookOutput::deny(reason));
+    }
+    if !output.status.success() {
+        let detail = first_non_empty(&[&stderr, &stdout]).unwrap_or_default();
+        return Err(match code {
+            Some(code) => format!("exited with status {code}: {detail}"),
+            None => format!("terminated by signal: {detail}"),
+        });
+    }
+    parse_stdout(&stdout)
+}
+
+/// Extract the hook's decision from stdout, ignoring anything printed around it.
+fn parse_stdout(stdout: &str) -> Result<HookOutput, String> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return Ok(HookOutput::default());
+    }
+    if let Ok(output) = serde_json::from_str::<HookOutput>(trimmed) {
+        return Ok(output);
+    }
+    // Fall back to the last line that parses on its own — the "script logged
+    // first, then answered" case.
+    let recovered = trimmed
+        .lines()
+        .rev()
+        .map(str::trim)
+        .filter(|line| line.starts_with('{'))
+        .find_map(|line| serde_json::from_str::<HookOutput>(line).ok());
+    recovered.ok_or_else(|| {
+        format!(
+            "stdout was not a hook decision object: {}",
+            truncate(trimmed, 200)
+        )
+    })
+}
+
+/// Answer shape for a `prompt` hook, mirroring Cursor's `{ ok, reason }`.
+#[derive(serde::Deserialize)]
+struct PromptVerdict {
+    ok: bool,
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+/// Evaluate a natural-language condition with a model.
+///
+/// The prompt text may contain `$ARGUMENTS`, replaced by the event JSON — the
+/// same placeholder Cursor uses, so a prompt hook ports across unchanged.
+async fn run_prompt(definition: &HookDefinition, input: &HookInput) -> Result<HookOutput, String> {
+    let arguments =
+        serde_json::to_string(input).map_err(|error| format!("serializing input: {error}"))?;
+    let prompt = if definition.command.contains("$ARGUMENTS") {
+        definition.command.replace("$ARGUMENTS", &arguments)
+    } else {
+        format!("{}\n\nEvent:\n{arguments}", definition.command)
+    };
+    let instruction = format!(
+        "{prompt}\n\nAnswer with JSON only: {{\"ok\": true}} to allow, or \
+         {{\"ok\": false, \"reason\": \"...\"}} to deny."
+    );
+
+    let answer = super::prompt_eval::evaluate(&instruction, definition.model.as_deref()).await?;
+    let verdict: PromptVerdict = serde_json::from_str(answer.trim())
+        .or_else(|_| {
+            answer
+                .lines()
+                .rev()
+                .map(str::trim)
+                .filter(|line| line.starts_with('{'))
+                .find_map(|line| serde_json::from_str::<PromptVerdict>(line).ok())
+                .ok_or_else(|| format!("model answer was not a verdict: {}", truncate(&answer, 200)))
+        })
+        .map_err(|error| error.to_string())?;
+
+    if verdict.ok {
+        return Ok(HookOutput {
+            permission: Some(HookPermission::Allow),
+            ..HookOutput::default()
+        });
+    }
+    Ok(HookOutput::deny(verdict.reason.unwrap_or_else(|| {
+        format!("hook '{}' denied the action", definition.label())
+    })))
+}
+
+fn first_non_empty(candidates: &[&str]) -> Option<String> {
+    candidates
+        .iter()
+        .map(|text| text.trim())
+        .find(|text| !text.is_empty())
+        .map(|text| truncate(text, 2000))
+}
+
+fn truncate(text: &str, max_chars: usize) -> String {
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let head: String = text.chars().take(max_chars).collect();
+    format!("{head}…")
+}
+
+/// Ambient environment every hook receives, on top of the process environment.
+///
+/// `CLAUDE_PROJECT_DIR` and `CURSOR_PROJECT_DIR` are set alongside the
+/// OpenHuman names so a script written for either host finds its project root
+/// without an OpenHuman-specific branch.
+pub fn ambient_env(input: &HookInput) -> BTreeMap<String, String> {
+    let mut env = BTreeMap::new();
+    if let Some(root) = input.workspace_roots.first() {
+        env.insert("OPENHUMAN_PROJECT_DIR".into(), root.clone());
+        env.insert("CLAUDE_PROJECT_DIR".into(), root.clone());
+        env.insert("CURSOR_PROJECT_DIR".into(), root.clone());
+    }
+    env.insert(
+        "OPENHUMAN_VERSION".into(),
+        input.openhuman_version.clone(),
+    );
+    env.insert("OPENHUMAN_HOOK_EVENT".into(), input.hook_event_name.clone());
+    if let Some(session) = &input.session_id {
+        env.insert("OPENHUMAN_SESSION_ID".into(), session.clone());
+    }
+    if let Some(agent) = &input.agent_id {
+        env.insert("OPENHUMAN_AGENT_ID".into(), agent.clone());
+    }
+    env
+}
+
+/// True when a path exists and is executable by this process.
+///
+/// Used by the RPC validate endpoint to report a hook that will never run,
+/// rather than waiting for the first event to discover it.
+pub fn is_executable(path: &Path) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(path)
+            .map(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+    #[cfg(not(unix))]
+    {
+        path.is_file()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_stdout_is_a_noop() {
+        let output = parse_stdout("   \n").expect("empty stdout is allowed");
+        assert!(output.permission.is_none());
+    }
+
+    #[test]
+    fn plain_json_is_parsed() {
+        let output = parse_stdout(r#"{"permission":"deny","agent_message":"no"}"#).unwrap();
+        assert!(output.is_deny());
+        assert_eq!(output.agent_message.as_deref(), Some("no"));
+    }
+
+    #[test]
+    fn json_after_log_lines_is_recovered() {
+        let stdout = "checking policy...\nstill checking\n{\"permission\":\"allow\"}\n";
+        let output = parse_stdout(stdout).unwrap();
+        assert_eq!(output.permission, Some(HookPermission::Allow));
+    }
+
+    #[test]
+    fn unparseable_stdout_is_an_error() {
+        let error = parse_stdout("not json at all").unwrap_err();
+        assert!(error.contains("not a hook decision object"), "{error}");
+    }
+
+    #[test]
+    fn truncate_marks_elision() {
+        assert_eq!(truncate("abcdef", 3), "abc…");
+        assert_eq!(truncate("abc", 3), "abc");
+    }
+}

--- a/src/openhuman/hooks/followup.rs
+++ b/src/openhuman/hooks/followup.rs
@@ -44,7 +44,9 @@ static CHANNEL: std::sync::LazyLock<broadcast::Sender<Followup>> = std::sync::La
 
 /// Queue a follow-up and notify any live listener.
 pub async fn publish(session_id: Option<String>, message: String) {
-    let key = session_id.clone().unwrap_or_else(|| SESSIONLESS.to_string());
+    let key = session_id
+        .clone()
+        .unwrap_or_else(|| SESSIONLESS.to_string());
     log::info!(
         "[hooks] stop hook queued a follow-up for session {:?} ({} chars)",
         session_id,

--- a/src/openhuman/hooks/followup.rs
+++ b/src/openhuman/hooks/followup.rs
@@ -1,0 +1,107 @@
+//! Follow-up messages injected by `stop` hooks.
+//!
+//! A `stop` hook can answer with `followup_message`, asking for one more turn —
+//! "you did not run the tests, run them". The hook fires *after* the turn has
+//! already returned to its caller, so the message cannot re-enter the turn that
+//! produced it. It is queued here instead, and the entrypoint that owns the
+//! conversation decides whether to spend another turn on it.
+//!
+//! That indirection is not an implementation shortcut. Only the entrypoint
+//! knows whether there is still a user attached: a chat turn can be extended,
+//! a cron run that has already reported its result cannot, and a channel turn
+//! that has flushed its reply would surprise the recipient. A queue lets each
+//! answer for itself, and lets a host that answers "no" simply never drain it.
+//!
+//! [`HookEngine`](super::engine::HookEngine)'s `loop_limit` accounting has
+//! already been charged by the time a message lands here, so a drain loop
+//! cannot spin: a hook that keeps asking runs out of budget.
+
+use std::collections::HashMap;
+use tokio::sync::{broadcast, RwLock};
+
+/// A queued follow-up.
+#[derive(Debug, Clone)]
+pub struct Followup {
+    /// Session the message belongs to, when the hook fired inside one.
+    pub session_id: Option<String>,
+    /// The message to send as the next user turn.
+    pub message: String,
+}
+
+/// Messages queued per session, plus one bucket for sessionless turns.
+static PENDING: std::sync::LazyLock<RwLock<HashMap<String, Vec<String>>>> =
+    std::sync::LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// Key used for follow-ups that arrived without a session id.
+const SESSIONLESS: &str = "";
+
+static CHANNEL: std::sync::LazyLock<broadcast::Sender<Followup>> = std::sync::LazyLock::new(|| {
+    // A small buffer: a listener that falls this far behind has stopped caring,
+    // and dropping old follow-ups is better than holding a turn's worth of
+    // stale instructions.
+    broadcast::channel(64).0
+});
+
+/// Queue a follow-up and notify any live listener.
+pub async fn publish(session_id: Option<String>, message: String) {
+    let key = session_id.clone().unwrap_or_else(|| SESSIONLESS.to_string());
+    log::info!(
+        "[hooks] stop hook queued a follow-up for session {:?} ({} chars)",
+        session_id,
+        message.chars().count()
+    );
+    PENDING
+        .write()
+        .await
+        .entry(key)
+        .or_default()
+        .push(message.clone());
+    // A send with no subscribers is not an error here — the queue is the
+    // durable half, the channel only wakes a listener that already exists.
+    let _ = CHANNEL.send(Followup {
+        session_id,
+        message,
+    });
+}
+
+/// Listen for follow-ups as they are queued.
+pub fn subscribe() -> broadcast::Receiver<Followup> {
+    CHANNEL.subscribe()
+}
+
+/// Take everything queued for a session, clearing it.
+pub async fn take(session_id: Option<&str>) -> Vec<String> {
+    let key = session_id.unwrap_or(SESSIONLESS);
+    PENDING.write().await.remove(key).unwrap_or_default()
+}
+
+/// Drop anything still queued for a finished session.
+pub async fn forget(session_id: &str) {
+    PENDING.write().await.remove(session_id);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn queued_messages_are_taken_once() {
+        publish(Some("s1".into()), "run the tests".into()).await;
+        assert_eq!(take(Some("s1")).await, vec!["run the tests".to_string()]);
+        assert!(take(Some("s1")).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn sessionless_followups_land_in_their_own_bucket() {
+        publish(None, "no session".into()).await;
+        assert!(take(Some("s2")).await.is_empty());
+        assert_eq!(take(None).await, vec!["no session".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn forget_drops_the_queue() {
+        publish(Some("s3".into()), "gone".into()).await;
+        forget("s3").await;
+        assert!(take(Some("s3")).await.is_empty());
+    }
+}

--- a/src/openhuman/hooks/matcher.rs
+++ b/src/openhuman/hooks/matcher.rs
@@ -20,7 +20,7 @@ use super::types::{HookEvent, HookPayload, ToolPayload};
 
 /// The string a matcher is compared against for a given event, or `None` when
 /// the event has no meaningful subject (session lifecycle, compaction).
-pub fn subject<'a>(event: HookEvent, payload: &'a HookPayload) -> Option<&'a str> {
+pub fn subject(event: HookEvent, payload: &HookPayload) -> Option<&str> {
     match (event, payload) {
         (
             HookEvent::PreToolUse

--- a/src/openhuman/hooks/matcher.rs
+++ b/src/openhuman/hooks/matcher.rs
@@ -40,14 +40,12 @@ pub fn subject<'a>(event: HookEvent, payload: &'a HookPayload) -> Option<&'a str
         (HookEvent::BeforeSubmitPrompt, HookPayload::Prompt(prompt)) => {
             Some(prompt.prompt.as_str())
         }
-        (
-            HookEvent::SubagentStart | HookEvent::SubagentStop,
-            HookPayload::Subagent(subagent),
-        ) => Some(subagent.subagent_type.as_str()),
-        (
-            HookEvent::AfterAgentResponse | HookEvent::AfterAgentThought,
-            HookPayload::Text(text),
-        ) => Some(text.text.as_str()),
+        (HookEvent::SubagentStart | HookEvent::SubagentStop, HookPayload::Subagent(subagent)) => {
+            Some(subagent.subagent_type.as_str())
+        }
+        (HookEvent::AfterAgentResponse | HookEvent::AfterAgentThought, HookPayload::Text(text)) => {
+            Some(text.text.as_str())
+        }
         _ => None,
     }
 }

--- a/src/openhuman/hooks/matcher.rs
+++ b/src/openhuman/hooks/matcher.rs
@@ -1,0 +1,149 @@
+//! Matcher semantics — which occurrences of an event reach a given hook.
+//!
+//! A matcher is one string, and what it is matched *against* depends on the
+//! event, exactly as in Cursor: tool events match the tool name, shell events
+//! match the command line, file events match the path. The syntax is uniform:
+//!
+//! * `*` or an absent matcher — everything.
+//! * `Shell|Read|Write` — alternation of exact, case-insensitive names.
+//! * `MCP:<tool>` — an MCP tool, by its registered name.
+//! * anything else — a regular expression, anchored nowhere (so `^rm ` and
+//!   `secrets` both work as written).
+//!
+//! An invalid regular expression does **not** silently match everything. It
+//! matches nothing and logs, because a matcher that fails open turns a typo in
+//! a deny rule into a rule that fires on every call — the loudest possible
+//! failure mode is the safe one here only for allow rules, and the engine
+//! cannot tell which kind it is holding.
+
+use super::types::{HookEvent, HookPayload, ToolPayload};
+
+/// The string a matcher is compared against for a given event, or `None` when
+/// the event has no meaningful subject (session lifecycle, compaction).
+pub fn subject<'a>(event: HookEvent, payload: &'a HookPayload) -> Option<&'a str> {
+    match (event, payload) {
+        (
+            HookEvent::PreToolUse
+            | HookEvent::PostToolUse
+            | HookEvent::PostToolUseFailure
+            | HookEvent::BeforeMcpExecution
+            | HookEvent::AfterMcpExecution,
+            HookPayload::Tool(ToolPayload { tool_name, .. }),
+        ) => Some(tool_name.as_str()),
+        (
+            HookEvent::BeforeShellExecution | HookEvent::AfterShellExecution,
+            HookPayload::Shell(shell),
+        ) => Some(shell.command.as_str()),
+        (HookEvent::BeforeReadFile | HookEvent::AfterFileEdit, HookPayload::File(file)) => {
+            Some(file.file_path.as_str())
+        }
+        (HookEvent::BeforeSubmitPrompt, HookPayload::Prompt(prompt)) => {
+            Some(prompt.prompt.as_str())
+        }
+        (
+            HookEvent::SubagentStart | HookEvent::SubagentStop,
+            HookPayload::Subagent(subagent),
+        ) => Some(subagent.subagent_type.as_str()),
+        (
+            HookEvent::AfterAgentResponse | HookEvent::AfterAgentThought,
+            HookPayload::Text(text),
+        ) => Some(text.text.as_str()),
+        _ => None,
+    }
+}
+
+/// Whether `matcher` selects `subject`.
+///
+/// An absent matcher selects everything. An event with no subject is selected
+/// by an absent or wildcard matcher only — a hook that asks to match `Shell`
+/// should not fire on `sessionStart`.
+pub fn matches(matcher: Option<&str>, subject: Option<&str>) -> bool {
+    let Some(matcher) = matcher.map(str::trim).filter(|m| !m.is_empty()) else {
+        return true;
+    };
+    if matcher == "*" {
+        return true;
+    }
+    let Some(subject) = subject else {
+        return false;
+    };
+    if matcher.contains('|') && !is_regex_syntax(matcher) {
+        return matcher
+            .split('|')
+            .any(|alternative| name_matches(alternative.trim(), subject));
+    }
+    if !is_regex_syntax(matcher) {
+        return name_matches(matcher, subject);
+    }
+    match regex::Regex::new(matcher) {
+        Ok(regex) => regex.is_match(subject),
+        Err(error) => {
+            log::warn!("[hooks] invalid matcher regex {matcher:?}: {error}; matching nothing");
+            false
+        }
+    }
+}
+
+/// Case-insensitive exact comparison, with `MCP:<tool>` reduced to `<tool>`.
+fn name_matches(matcher: &str, subject: &str) -> bool {
+    let matcher = matcher.strip_prefix("MCP:").unwrap_or(matcher);
+    matcher.eq_ignore_ascii_case(subject)
+}
+
+/// A matcher made only of identifier characters is treated as a literal name,
+/// not a regex — so `Shell` means the tool called `Shell` and nothing else.
+fn is_regex_syntax(matcher: &str) -> bool {
+    matcher
+        .chars()
+        .any(|c| !(c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == ':' || c == '|'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absent_matcher_selects_everything() {
+        assert!(matches(None, Some("anything")));
+        assert!(matches(None, None));
+        assert!(matches(Some("  "), Some("anything")));
+    }
+
+    #[test]
+    fn wildcard_selects_subjectless_events() {
+        assert!(matches(Some("*"), None));
+    }
+
+    #[test]
+    fn named_matcher_skips_subjectless_events() {
+        assert!(!matches(Some("shell"), None));
+    }
+
+    #[test]
+    fn literal_name_is_case_insensitive_and_exact() {
+        assert!(matches(Some("Shell"), Some("shell")));
+        assert!(!matches(Some("Shell"), Some("shell_extra")));
+    }
+
+    #[test]
+    fn alternation_matches_any_branch() {
+        assert!(matches(Some("Read|Write|Shell"), Some("write")));
+        assert!(!matches(Some("Read|Write"), Some("shell")));
+    }
+
+    #[test]
+    fn mcp_prefix_is_stripped() {
+        assert!(matches(Some("MCP:search_docs"), Some("search_docs")));
+    }
+
+    #[test]
+    fn regex_matcher_applies_to_command_lines() {
+        assert!(matches(Some("^rm "), Some("rm -rf /tmp/x")));
+        assert!(!matches(Some("^rm "), Some("echo rm ")));
+    }
+
+    #[test]
+    fn invalid_regex_matches_nothing() {
+        assert!(!matches(Some("["), Some("anything")));
+    }
+}

--- a/src/openhuman/hooks/mod.rs
+++ b/src/openhuman/hooks/mod.rs
@@ -1,0 +1,64 @@
+//! Configurable hooks — user-authored scripts that observe and gate the agent.
+//!
+//! OpenHuman already had *hooks* in the sense of in-process Rust callbacks an
+//! embedding host installs ([`crate::openhuman::agent::hooks`],
+//! [`crate::openhuman::agent::stop_hooks`]). Those require compiling against
+//! the core, which makes them the wrong tool for the thing people actually want
+//! hooks for: a small script, checked into a repository, that blocks `rm -rf`,
+//! runs the formatter after an edit, or writes an audit line per tool call.
+//!
+//! This domain adds that second kind, taking Cursor's `hooks.json` contract as
+//! the model (<https://cursor.com/docs/hooks>) so scripts port between hosts:
+//! same event names, same stdin envelope, same stdout decision object, same
+//! exit-code semantics.
+//!
+//! ## Shape
+//!
+//! | Module | Owns |
+//! | ------ | ---- |
+//! | [`types`] | the wire contract: events, the stdin envelope, the decision object |
+//! | [`config`] | `hooks.json` parsing and the four-layer merge |
+//! | [`matcher`] | which occurrences of an event reach a given hook |
+//! | [`exec`] | running one hook: stdin, timeout, exit codes, fail-open/closed |
+//! | [`engine`] | selection, ordering, aggregation, session state |
+//! | [`context`] | assembling the envelope from ambient host facts |
+//! | [`bridge`] | mounting the engine on the harness's existing tool/turn seams |
+//! | [`ops`] | the lifecycle moments that have no existing seam |
+//! | [`followup`] | queueing what a `stop` hook asks for next |
+//!
+//! ## Two rules worth knowing before changing anything here
+//!
+//! **The strictest verdict wins.** Layers concatenate rather than override, and
+//! [`types::HookOutput::merge`] folds denial over ask over allow. Adding a hook
+//! can therefore never loosen a policy another one set — which is what makes it
+//! safe for a repository to ship its own `hooks.json` on a machine that already
+//! has an operator-managed one.
+//!
+//! **Gating costs a turn's latency; observing does not.** [`types::HookEvent::is_gating`]
+//! is the single place that split is encoded, and [`engine`] reads it to decide
+//! between running hooks sequentially in the turn's path and spawning them onto
+//! a background task. An audit hook that hangs must not hang the agent.
+
+pub mod bridge;
+pub mod config;
+pub mod context;
+pub mod engine;
+pub mod exec;
+pub mod followup;
+pub mod matcher;
+pub mod ops;
+pub mod prompt_eval;
+pub mod schemas;
+pub mod types;
+
+#[cfg(test)]
+mod tests;
+
+pub use config::{HookConfig, HookDefinition, HookKind, HookLayer, HooksFile};
+pub use engine::{global as engine_global, HookEngine, HookOutcome};
+pub use ops::{init, PromptVerdict};
+pub use schemas::{
+    all_controller_schemas as all_hooks_controller_schemas,
+    all_registered_controllers as all_hooks_registered_controllers,
+};
+pub use types::{HookEvent, HookInput, HookOutput, HookPayload, HookPermission};

--- a/src/openhuman/hooks/ops.rs
+++ b/src/openhuman/hooks/ops.rs
@@ -1,0 +1,267 @@
+//! Entry points for the lifecycle moments that are not tool calls.
+//!
+//! Tool events reach the engine through
+//! [`bridge`](super::bridge) — the harness already had a seam there. The
+//! moments in this module have no such seam, so each is a small function a call
+//! site invokes directly. Each one is cheap when nothing is configured: it asks
+//! [`HookEngine::has_hooks`](super::engine::HookEngine::has_hooks) first and
+//! returns without building an envelope.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use super::context::{build_input, set_host_context, HostContext, TurnIdentity};
+use super::engine;
+use super::types::{
+    CompactPayload, HookEvent, HookPayload, PromptPayload, SessionPayload, SubagentPayload,
+    TextPayload,
+};
+
+/// Bring the hook system up: resolve host facts, read every `hooks.json`, and
+/// install the harness bridge.
+///
+/// Safe to call again — a reload replaces the whole config and re-registers the
+/// bridge by name rather than appending a second copy.
+pub async fn init(config: &crate::openhuman::config::schema::Config) {
+    let settings = &config.hooks;
+    set_host_context(HostContext {
+        workspace_roots: workspace_roots(config),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    });
+
+    if !settings.enabled {
+        super::bridge::ConfiguredHookBridge::uninstall();
+        engine::global()
+            .install(super::config::HookConfig::default())
+            .await;
+        log::info!("[hooks] disabled by configuration");
+        return;
+    }
+
+    engine::global()
+        .set_default_timeout(Duration::from_secs(settings.default_timeout_secs))
+        .await;
+    let loaded = engine::global()
+        .reload(
+            Some(config.action_dir.clone()),
+            Some(config.workspace_dir.clone()),
+        )
+        .await;
+    if loaded.is_empty() {
+        // Nothing configured: keep the bridge out of the harness entirely so an
+        // unconfigured host pays not even a task-local lookup per tool call.
+        super::bridge::ConfiguredHookBridge::uninstall();
+        return;
+    }
+    super::bridge::ConfiguredHookBridge::install();
+}
+
+fn workspace_roots(config: &crate::openhuman::config::schema::Config) -> Vec<PathBuf> {
+    let mut roots = vec![config.action_dir.clone()];
+    if let Some(turn_root) = crate::openhuman::agent::turn_workspace::current_turn_workspace() {
+        if !roots.contains(&turn_root) {
+            roots.push(turn_root);
+        }
+    }
+    roots
+}
+
+/// Fire `sessionStart`, returning context the caller should append to the
+/// session's system prompt.
+pub async fn session_started(identity: TurnIdentity, entrypoint: Option<String>) -> Option<String> {
+    let engine = engine::global();
+    if !engine.has_hooks(HookEvent::SessionStart).await {
+        return None;
+    }
+    let input = build_input(
+        HookEvent::SessionStart,
+        identity,
+        HookPayload::Session(SessionPayload {
+            entrypoint,
+            reason: None,
+            duration_ms: None,
+        }),
+    );
+    engine
+        .dispatch(HookEvent::SessionStart, input)
+        .await
+        .output
+        .additional_context
+}
+
+/// Fire `sessionEnd` and release everything scoped to the session.
+pub async fn session_ended(identity: TurnIdentity, reason: &str, duration_ms: Option<u64>) {
+    let engine = engine::global();
+    let session_id = identity.session_id.clone();
+    if engine.has_hooks(HookEvent::SessionEnd).await {
+        let input = build_input(
+            HookEvent::SessionEnd,
+            identity,
+            HookPayload::Session(SessionPayload {
+                entrypoint: None,
+                reason: Some(reason.to_string()),
+                duration_ms,
+            }),
+        );
+        engine.dispatch(HookEvent::SessionEnd, input).await;
+    }
+    if let Some(session_id) = session_id {
+        engine.forget_session(&session_id).await;
+        super::followup::forget(&session_id).await;
+    }
+}
+
+/// The verdict on a submitted prompt.
+#[derive(Debug, Clone)]
+pub enum PromptVerdict {
+    /// Send it, optionally with context a hook wants prepended.
+    Submit {
+        /// Text a hook asked to add to the turn's context.
+        additional_context: Option<String>,
+    },
+    /// Do not send it. The string is what the user should be told.
+    Block(String),
+}
+
+/// Fire `beforeSubmitPrompt`.
+///
+/// Blocking is expressed two ways in Cursor — `continue: false` and
+/// `permission: "deny"` — and both are honoured, because a hook author reaching
+/// for the one they remember should not silently get a prompt that went through
+/// anyway.
+pub async fn prompt_submitted(
+    identity: TurnIdentity,
+    prompt: &str,
+    attachments: Vec<String>,
+) -> PromptVerdict {
+    let engine = engine::global();
+    if !engine.has_hooks(HookEvent::BeforeSubmitPrompt).await {
+        return PromptVerdict::Submit {
+            additional_context: None,
+        };
+    }
+    let input = build_input(
+        HookEvent::BeforeSubmitPrompt,
+        identity,
+        HookPayload::Prompt(PromptPayload {
+            prompt: prompt.to_string(),
+            attachments,
+        }),
+    );
+    let outcome = engine.dispatch(HookEvent::BeforeSubmitPrompt, input).await;
+    if outcome.is_deny() || outcome.output.continue_ == Some(false) {
+        let reason = outcome
+            .output
+            .user_message
+            .clone()
+            .or_else(|| outcome.output.agent_message.clone())
+            .unwrap_or_else(|| "a configured hook blocked this prompt".to_string());
+        return PromptVerdict::Block(reason);
+    }
+    PromptVerdict::Submit {
+        additional_context: outcome.output.additional_context,
+    }
+}
+
+/// Fire `preCompact`, returning a message for the user if a hook set one.
+pub async fn pre_compact(
+    identity: TurnIdentity,
+    trigger: &str,
+    context_usage_percent: Option<f64>,
+    message_count: Option<usize>,
+) -> Option<String> {
+    let engine = engine::global();
+    if !engine.has_hooks(HookEvent::PreCompact).await {
+        return None;
+    }
+    let input = build_input(
+        HookEvent::PreCompact,
+        identity,
+        HookPayload::Compact(CompactPayload {
+            trigger: trigger.to_string(),
+            context_usage_percent,
+            message_count,
+        }),
+    );
+    engine
+        .dispatch(HookEvent::PreCompact, input)
+        .await
+        .output
+        .user_message
+}
+
+/// Fire `subagentStart`. `Err` carries the reason the child must not run.
+pub async fn subagent_starting(
+    identity: TurnIdentity,
+    subagent_type: &str,
+    task: &str,
+) -> Result<(), String> {
+    let engine = engine::global();
+    if !engine.has_hooks(HookEvent::SubagentStart).await {
+        return Ok(());
+    }
+    let input = build_input(
+        HookEvent::SubagentStart,
+        identity.clone(),
+        HookPayload::Subagent(SubagentPayload {
+            subagent_type: subagent_type.to_string(),
+            task: task.to_string(),
+            parent_conversation_id: identity.conversation_id,
+            status: None,
+            duration_ms: None,
+        }),
+    );
+    let outcome = engine.dispatch(HookEvent::SubagentStart, input).await;
+    match outcome.denial_reason() {
+        Some(reason) => Err(reason.to_string()),
+        None => Ok(()),
+    }
+}
+
+/// Fire `subagentStop`, returning a follow-up the parent may act on.
+pub async fn subagent_stopped(
+    identity: TurnIdentity,
+    subagent_type: &str,
+    task: &str,
+    status: &str,
+    duration_ms: Option<u64>,
+) -> Option<String> {
+    let engine = engine::global();
+    if !engine.has_hooks(HookEvent::SubagentStop).await {
+        return None;
+    }
+    let input = build_input(
+        HookEvent::SubagentStop,
+        identity.clone(),
+        HookPayload::Subagent(SubagentPayload {
+            subagent_type: subagent_type.to_string(),
+            task: task.to_string(),
+            parent_conversation_id: identity.conversation_id,
+            status: Some(status.to_string()),
+            duration_ms,
+        }),
+    );
+    engine
+        .dispatch(HookEvent::SubagentStop, input)
+        .await
+        .output
+        .followup_message
+}
+
+/// Fire `afterAgentThought`. Observational, so this returns as soon as the
+/// hooks are scheduled.
+pub async fn agent_thought(identity: TurnIdentity, text: &str, duration_ms: Option<u64>) {
+    let engine = engine::global();
+    if !engine.has_hooks(HookEvent::AfterAgentThought).await {
+        return;
+    }
+    let input = build_input(
+        HookEvent::AfterAgentThought,
+        identity,
+        HookPayload::Text(TextPayload {
+            text: text.to_string(),
+            duration_ms,
+        }),
+    );
+    engine.dispatch(HookEvent::AfterAgentThought, input).await;
+}

--- a/src/openhuman/hooks/ops.rs
+++ b/src/openhuman/hooks/ops.rs
@@ -58,7 +58,7 @@ pub async fn init(config: &crate::openhuman::config::schema::Config) {
 
 fn workspace_roots(config: &crate::openhuman::config::schema::Config) -> Vec<PathBuf> {
     let mut roots = vec![config.action_dir.clone()];
-    if let Some(turn_root) = crate::openhuman::agent::turn_workspace::current_turn_workspace() {
+    if let Some(turn_root) = crate::openhuman::agent::turn_workspace::current() {
         if !roots.contains(&turn_root) {
             roots.push(turn_root);
         }

--- a/src/openhuman/hooks/prompt_eval.rs
+++ b/src/openhuman/hooks/prompt_eval.rs
@@ -1,0 +1,45 @@
+//! Model evaluation for `prompt` hooks.
+//!
+//! A prompt hook is a policy written in English rather than in shell. It costs
+//! a model call per event, so it belongs on rare, high-stakes moments — a
+//! destructive shell command, a subagent about to be spawned — not on every
+//! tool call.
+//!
+//! The model override in a hook definition is applied by cloning the loaded
+//! config and replacing `default_model`, because the one-shot prompt entry
+//! point takes its model from the config rather than from an argument. Cloning
+//! keeps the override scoped to this evaluation: nothing persists, and a
+//! concurrent turn on the real config is unaffected.
+
+use crate::openhuman::config::schema::Config;
+
+/// Ask the model to judge a hook condition, returning its raw answer.
+///
+/// Errors are strings rather than `anyhow` because every caller folds them into
+/// the fail-open / fail-closed decision, where the only thing that matters is
+/// the message.
+pub async fn evaluate(instruction: &str, model: Option<&str>) -> Result<String, String> {
+    let mut config = crate::openhuman::config::rpc::load_config_with_timeout()
+        .await
+        .map_err(|error| format!("loading config for prompt hook: {error}"))?;
+    if let Some(model) = model {
+        apply_model_override(&mut config, model);
+    }
+    let outcome = crate::openhuman::inference::ops::inference_prompt(
+        &config,
+        instruction,
+        Some(MAX_VERDICT_TOKENS),
+        Some(true),
+    )
+    .await
+    .map_err(|error| format!("prompt hook evaluation failed: {error}"))?;
+    Ok(outcome.value)
+}
+
+/// A verdict is a two-field JSON object; anything longer is the model
+/// rambling, and cutting it off early is cheaper than reading it.
+const MAX_VERDICT_TOKENS: u32 = 200;
+
+fn apply_model_override(config: &mut Config, model: &str) {
+    config.default_model = Some(model.to_string());
+}

--- a/src/openhuman/hooks/schemas.rs
+++ b/src/openhuman/hooks/schemas.rs
@@ -1,0 +1,198 @@
+//! RPC surface for the `hooks` namespace.
+//!
+//! Three functions, and the split between them is deliberate: **list** answers
+//! "what is configured and where did it come from", **reload** re-reads the
+//! files, and **test** fires one synthetic event so an author can see what a
+//! hook actually decides without provoking the real moment. Debugging a hook by
+//! trying to trigger it — asking the agent to run `rm -rf` to see whether the
+//! deny rule fires — is the failure mode this surface exists to prevent.
+
+use serde::de::DeserializeOwned;
+use serde_json::{json, Map, Value};
+
+use crate::core::all::{ControllerFuture, RegisteredController};
+use crate::core::{ControllerSchema, FieldSchema, TypeSchema};
+use crate::openhuman::config::rpc as config_rpc;
+
+use super::context::TurnIdentity;
+use super::types::{HookEvent, HookPayload};
+
+pub fn all_controller_schemas() -> Vec<ControllerSchema> {
+    vec![schemas("list"), schemas("reload"), schemas("test")]
+}
+
+pub fn all_registered_controllers() -> Vec<RegisteredController> {
+    vec![
+        RegisteredController {
+            schema: schemas("list"),
+            handler: handle_list,
+        },
+        RegisteredController {
+            schema: schemas("reload"),
+            handler: handle_reload,
+        },
+        RegisteredController {
+            schema: schemas("test"),
+            handler: handle_test,
+        },
+    ]
+}
+
+pub fn schemas(function: &str) -> ControllerSchema {
+    match function {
+        "list" => ControllerSchema {
+            namespace: "hooks",
+            function: "list",
+            description: "List configured hooks, their source files, and any load warnings.",
+            inputs: vec![],
+            outputs: vec![FieldSchema {
+                name: "hooks",
+                ty: TypeSchema::Json,
+                comment: "Hooks grouped by event, plus sources and warnings.",
+                required: true,
+            }],
+        },
+        "reload" => ControllerSchema {
+            namespace: "hooks",
+            function: "reload",
+            description: "Re-read every hooks.json layer and swap in the result.",
+            inputs: vec![],
+            outputs: vec![FieldSchema {
+                name: "hooks",
+                ty: TypeSchema::Json,
+                comment: "The freshly loaded configuration.",
+                required: true,
+            }],
+        },
+        "test" => ControllerSchema {
+            namespace: "hooks",
+            function: "test",
+            description: "Fire one synthetic event and report what each matching hook decided.",
+            inputs: vec![
+                FieldSchema {
+                    name: "event",
+                    ty: TypeSchema::String,
+                    comment: "Event name, e.g. 'preToolUse' or 'beforeShellExecution'.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "payload",
+                    ty: TypeSchema::Option(Box::new(TypeSchema::Json)),
+                    comment: "Event body. Defaults to an empty body.",
+                    required: false,
+                },
+            ],
+            outputs: vec![FieldSchema {
+                name: "result",
+                ty: TypeSchema::Json,
+                comment: "Merged decision plus per-hook runs.",
+                required: true,
+            }],
+        },
+        _ => ControllerSchema {
+            namespace: "hooks",
+            function: "unknown",
+            description: "Unknown hooks controller function.",
+            inputs: vec![],
+            outputs: vec![FieldSchema {
+                name: "error",
+                ty: TypeSchema::String,
+                comment: "Lookup error details.",
+                required: true,
+            }],
+        },
+    }
+}
+
+fn handle_list(_params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move { Ok(describe(&super::engine::global().snapshot().await)) })
+}
+
+fn handle_reload(_params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let config = config_rpc::load_config_with_timeout().await?;
+        super::ops::init(&config).await;
+        Ok(describe(&super::engine::global().snapshot().await))
+    })
+}
+
+fn handle_test(params: Map<String, Value>) -> ControllerFuture {
+    Box::pin(async move {
+        let event_name: String = read_required(&params, "event")?;
+        let event = HookEvent::parse(&event_name).ok_or_else(|| {
+            format!(
+                "unknown hook event '{event_name}'; known events: {}",
+                HookEvent::ALL
+                    .iter()
+                    .map(|event| event.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        })?;
+        let payload: HookPayload = match params.get("payload") {
+            Some(Value::Null) | None => HookPayload::Empty,
+            Some(value) => serde_json::from_value(value.clone())
+                .map_err(|error| format!("invalid payload for '{event}': {error}"))?,
+        };
+
+        let input = super::context::build_input(event, TurnIdentity::default(), payload);
+        // A test fire is always run in the foreground, even for an
+        // observational event: the point of the endpoint is to show the author
+        // what happened, and a detached dispatch would report nothing.
+        let outcome = super::engine::global().dispatch_for_test(event, input).await;
+        Ok(json!({
+            "result": {
+                "event": event.as_str(),
+                "decision": outcome.output,
+                "runs": outcome.runs.iter().map(|run| json!({
+                    "hook": run.label,
+                    "duration_ms": run.duration.as_millis() as u64,
+                    "error": run.error,
+                    "output": run.output,
+                })).collect::<Vec<_>>(),
+            }
+        }))
+    })
+}
+
+/// Render a config for the wire, naming the source file of every definition.
+fn describe(config: &super::config::HookConfig) -> Value {
+    let by_event: Map<String, Value> = config
+        .by_event
+        .iter()
+        .map(|(event, definitions)| {
+            let rendered: Vec<Value> = definitions
+                .iter()
+                .map(|definition| {
+                    json!({
+                        "command": definition.command,
+                        "type": definition.kind,
+                        "matcher": definition.matcher,
+                        "timeout": definition.timeout,
+                        "fail_closed": definition.fail_closed,
+                        "enabled": definition.enabled,
+                        "layer": definition.layer.map(super::config::HookLayer::as_str),
+                        "source_dir": definition.source_dir.as_ref().map(|dir| dir.display().to_string()),
+                    })
+                })
+                .collect();
+            (event.as_str().to_string(), Value::Array(rendered))
+        })
+        .collect();
+    json!({
+        "hooks": {
+            "by_event": by_event,
+            "total": config.len(),
+            "sources": config.sources.iter().map(|path| path.display().to_string()).collect::<Vec<_>>(),
+            "warnings": config.warnings,
+        }
+    })
+}
+
+fn read_required<T: DeserializeOwned>(params: &Map<String, Value>, key: &str) -> Result<T, String> {
+    let value = params
+        .get(key)
+        .ok_or_else(|| format!("missing required parameter '{key}'"))?;
+    serde_json::from_value(value.clone())
+        .map_err(|error| format!("invalid parameter '{key}': {error}"))
+}

--- a/src/openhuman/hooks/schemas.rs
+++ b/src/openhuman/hooks/schemas.rs
@@ -105,14 +105,14 @@ pub fn schemas(function: &str) -> ControllerSchema {
 }
 
 fn handle_list(_params: Map<String, Value>) -> ControllerFuture {
-    Box::pin(async move { Ok(describe(&super::engine::global().snapshot().await)) })
+    Box::pin(async move { Ok(describe(super::engine::global().snapshot().await.as_ref())) })
 }
 
 fn handle_reload(_params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async move {
         let config = config_rpc::load_config_with_timeout().await?;
         super::ops::init(&config).await;
-        Ok(describe(&super::engine::global().snapshot().await))
+        Ok(describe(super::engine::global().snapshot().await.as_ref()))
     })
 }
 

--- a/src/openhuman/hooks/schemas.rs
+++ b/src/openhuman/hooks/schemas.rs
@@ -129,11 +129,11 @@ fn handle_test(params: Map<String, Value>) -> ControllerFuture {
                     .join(", ")
             )
         })?;
-        let payload: HookPayload = match params.get("payload") {
-            Some(Value::Null) | None => HookPayload::Empty,
-            Some(value) => serde_json::from_value(value.clone())
-                .map_err(|error| format!("invalid payload for '{event}': {error}"))?,
-        };
+        let payload = HookPayload::from_value_for(
+            event,
+            params.get("payload").cloned().unwrap_or(Value::Null),
+        )
+        .map_err(|error| format!("invalid payload for '{event}': {error}"))?;
 
         let input = super::context::build_input(event, TurnIdentity::default(), payload);
         // A test fire is always run in the foreground, even for an

--- a/src/openhuman/hooks/schemas.rs
+++ b/src/openhuman/hooks/schemas.rs
@@ -176,7 +176,10 @@ fn describe(config: &super::config::HookConfig) -> Value {
                     })
                 })
                 .collect();
-            (event.as_str().to_string(), Value::Array(rendered))
+            (
+                event.as_str().to_string(),
+                json!({ "wired": event.is_wired(), "definitions": rendered }),
+            )
         })
         .collect();
     json!({

--- a/src/openhuman/hooks/schemas.rs
+++ b/src/openhuman/hooks/schemas.rs
@@ -139,7 +139,9 @@ fn handle_test(params: Map<String, Value>) -> ControllerFuture {
         // A test fire is always run in the foreground, even for an
         // observational event: the point of the endpoint is to show the author
         // what happened, and a detached dispatch would report nothing.
-        let outcome = super::engine::global().dispatch_for_test(event, input).await;
+        let outcome = super::engine::global()
+            .dispatch_for_test(event, input)
+            .await;
         Ok(json!({
             "result": {
                 "event": event.as_str(),

--- a/src/openhuman/hooks/tests.rs
+++ b/src/openhuman/hooks/tests.rs
@@ -436,3 +436,29 @@ fn wired_events_do_not_warn() {
     );
     assert!(parsed.warnings.is_empty(), "{:?}", parsed.warnings);
 }
+
+#[test]
+fn a_payload_is_parsed_for_its_event_not_by_untagged_guessing() {
+    // `{"trigger": "auto"}` also satisfies `SessionPayload` (every field
+    // optional), which is declared earlier in the untagged enum — so untagged
+    // dispatch would silently drop the trigger.
+    let payload = HookPayload::from_value_for(
+        HookEvent::PreCompact,
+        serde_json::json!({"trigger": "auto", "message_count": 12}),
+    )
+    .expect("a compact payload parses");
+    match payload {
+        HookPayload::Compact(compact) => {
+            assert_eq!(compact.trigger, "auto");
+            assert_eq!(compact.message_count, Some(12));
+        }
+        other => panic!("expected a compact payload, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_payload_that_does_not_fit_its_event_is_rejected() {
+    let error = HookPayload::from_value_for(HookEvent::BeforeShellExecution, serde_json::json!({}))
+        .expect_err("a shell payload needs a command");
+    assert!(error.contains("command"), "{error}");
+}

--- a/src/openhuman/hooks/tests.rs
+++ b/src/openhuman/hooks/tests.rs
@@ -75,7 +75,10 @@ fn definition(command: &str, dir: &std::path::Path) -> HookDefinition {
 fn event_names_resolve_across_dialects() {
     assert_eq!(HookEvent::parse("preToolUse"), Some(HookEvent::PreToolUse));
     assert_eq!(HookEvent::parse("PreToolUse"), Some(HookEvent::PreToolUse));
-    assert_eq!(HookEvent::parse("pre_tool_use"), Some(HookEvent::PreToolUse));
+    assert_eq!(
+        HookEvent::parse("pre_tool_use"),
+        Some(HookEvent::PreToolUse)
+    );
     assert_eq!(
         HookEvent::parse("UserPromptSubmit"),
         Some(HookEvent::BeforeSubmitPrompt)
@@ -171,7 +174,10 @@ fn merged_messages_concatenate_and_rewrites_take_the_last() {
 async fn a_hook_that_prints_a_decision_is_honoured() {
     let dir = scratch(
         "{}",
-        Some(("deny.sh", "#!/bin/sh\necho '{\"permission\":\"deny\",\"agent_message\":\"nope\"}'\n")),
+        Some((
+            "deny.sh",
+            "#!/bin/sh\necho '{\"permission\":\"deny\",\"agent_message\":\"nope\"}'\n",
+        )),
     );
     let run = exec::run(
         &definition("./deny.sh", dir.path()),
@@ -188,7 +194,13 @@ async fn a_hook_that_prints_a_decision_is_honoured() {
 #[cfg(unix)]
 #[tokio::test]
 async fn exit_code_two_denies_with_stderr_as_the_reason() {
-    let dir = scratch("{}", Some(("deny.sh", "#!/bin/sh\necho 'blocked by policy' 1>&2\nexit 2\n")));
+    let dir = scratch(
+        "{}",
+        Some((
+            "deny.sh",
+            "#!/bin/sh\necho 'blocked by policy' 1>&2\nexit 2\n",
+        )),
+    );
     let run = exec::run(
         &definition("./deny.sh", dir.path()),
         &input(HookEvent::PreToolUse, tool_payload("shell")),
@@ -197,7 +209,10 @@ async fn exit_code_two_denies_with_stderr_as_the_reason() {
     )
     .await;
     assert!(run.output.is_deny());
-    assert_eq!(run.output.agent_message.as_deref(), Some("blocked by policy"));
+    assert_eq!(
+        run.output.agent_message.as_deref(),
+        Some("blocked by policy")
+    );
 }
 
 #[cfg(unix)]
@@ -239,8 +254,15 @@ async fn a_hook_that_hangs_times_out_rather_than_stalling_the_turn() {
         Duration::from_secs(1),
     )
     .await;
-    assert!(run.error.as_deref().unwrap_or_default().contains("timed out"));
-    assert!(!run.output.is_deny(), "a timeout fails open unless asked otherwise");
+    assert!(run
+        .error
+        .as_deref()
+        .unwrap_or_default()
+        .contains("timed out"));
+    assert!(
+        !run.output.is_deny(),
+        "a timeout fails open unless asked otherwise"
+    );
 }
 
 #[cfg(unix)]
@@ -313,7 +335,10 @@ async fn a_denial_short_circuits_the_remaining_hooks() {
              {"command": "./deny.sh"},
              {"command": "./second.sh"}
            ]}}"#,
-        Some(("deny.sh", "#!/bin/sh\necho '{\"permission\":\"deny\",\"agent_message\":\"first\"}'\n")),
+        Some((
+            "deny.sh",
+            "#!/bin/sh\necho '{\"permission\":\"deny\",\"agent_message\":\"first\"}'\n",
+        )),
     );
     std::fs::write(
         dir.path().join("second.sh"),

--- a/src/openhuman/hooks/tests.rs
+++ b/src/openhuman/hooks/tests.rs
@@ -386,3 +386,28 @@ async fn an_unconfigured_engine_reports_no_hooks_for_any_event() {
         assert!(!engine.has_hooks(event).await, "{event}");
     }
 }
+
+#[test]
+fn configuring_an_unwired_event_warns_rather_than_failing_silently() {
+    let parsed = config::parse_one(
+        &PathBuf::from("/tmp/hooks.json"),
+        HookLayer::Project,
+        r#"{"version": 1, "hooks": {"sessionStart": [{"command": "x"}]}}"#,
+    );
+    assert_eq!(parsed.for_event(HookEvent::SessionStart).len(), 1);
+    assert!(
+        parsed.warnings.iter().any(|w| w.contains("never run")),
+        "{:?}",
+        parsed.warnings
+    );
+}
+
+#[test]
+fn wired_events_do_not_warn() {
+    let parsed = config::parse_one(
+        &PathBuf::from("/tmp/hooks.json"),
+        HookLayer::Project,
+        r#"{"version": 1, "hooks": {"preToolUse": [{"command": "x"}]}}"#,
+    );
+    assert!(parsed.warnings.is_empty(), "{:?}", parsed.warnings);
+}

--- a/src/openhuman/hooks/tests.rs
+++ b/src/openhuman/hooks/tests.rs
@@ -462,3 +462,31 @@ fn a_payload_that_does_not_fit_its_event_is_rejected() {
         .expect_err("a shell payload needs a command");
     assert!(error.contains("command"), "{error}");
 }
+
+#[test]
+fn a_relative_script_that_is_missing_is_reported_at_load_time() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    std::fs::write(
+        dir.path().join(config::HOOKS_FILE_NAME),
+        r#"{"version": 1, "hooks": {"preToolUse": [{"command": "./nope.sh"}]}}"#,
+    )
+    .unwrap();
+    let loaded = config::load(None, Some(dir.path()));
+    assert!(
+        loaded.warnings.iter().any(|w| w.contains("missing script")),
+        "{:?}",
+        loaded.warnings
+    );
+}
+
+#[test]
+fn a_bare_command_name_is_not_second_guessed() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    std::fs::write(
+        dir.path().join(config::HOOKS_FILE_NAME),
+        r#"{"version": 1, "hooks": {"preToolUse": [{"command": "audit-tool --strict"}]}}"#,
+    )
+    .unwrap();
+    let loaded = config::load(None, Some(dir.path()));
+    assert!(loaded.warnings.is_empty(), "{:?}", loaded.warnings);
+}

--- a/src/openhuman/hooks/tests.rs
+++ b/src/openhuman/hooks/tests.rs
@@ -1,0 +1,388 @@
+//! Domain tests: config layering, selection, and the execution contract.
+//!
+//! The execution tests shell out to real scripts on purpose. The whole feature
+//! is "spawn a process and read what it says", and a mocked runner would test
+//! the mock's idea of exit codes rather than the operating system's.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use super::config::{self, HookDefinition, HookKind, HookLayer};
+use super::engine::HookEngine;
+use super::exec;
+use super::types::{
+    HookEvent, HookInput, HookOutput, HookPayload, HookPermission, ShellPayload, ToolPayload,
+};
+
+fn input(event: HookEvent, payload: HookPayload) -> HookInput {
+    HookInput {
+        hook_event_name: event.as_str().to_string(),
+        conversation_id: None,
+        generation_id: None,
+        session_id: Some("sess-test".into()),
+        model: None,
+        agent_id: None,
+        openhuman_version: "test".into(),
+        workspace_roots: vec!["/tmp".into()],
+        cwd: None,
+        payload,
+    }
+}
+
+fn tool_payload(tool: &str) -> HookPayload {
+    HookPayload::Tool(ToolPayload {
+        tool_name: tool.into(),
+        tool_input: serde_json::json!({}),
+        tool_use_id: "call-1".into(),
+        ..ToolPayload::default()
+    })
+}
+
+/// Write a `hooks.json` and an executable script into a fresh temp dir.
+fn scratch(file: &str, script: Option<(&str, &str)>) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("temp dir");
+    std::fs::write(dir.path().join(config::HOOKS_FILE_NAME), file).expect("write hooks.json");
+    if let Some((name, body)) = script {
+        let path = dir.path().join(name);
+        std::fs::write(&path, body).expect("write script");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+                .expect("chmod script");
+        }
+    }
+    dir
+}
+
+fn definition(command: &str, dir: &std::path::Path) -> HookDefinition {
+    HookDefinition {
+        command: command.to_string(),
+        kind: HookKind::Command,
+        timeout: Some(20),
+        matcher: None,
+        loop_limit: None,
+        fail_closed: false,
+        model: None,
+        enabled: true,
+        layer: Some(HookLayer::Project),
+        source_dir: Some(dir.to_path_buf()),
+    }
+}
+
+#[test]
+fn event_names_resolve_across_dialects() {
+    assert_eq!(HookEvent::parse("preToolUse"), Some(HookEvent::PreToolUse));
+    assert_eq!(HookEvent::parse("PreToolUse"), Some(HookEvent::PreToolUse));
+    assert_eq!(HookEvent::parse("pre_tool_use"), Some(HookEvent::PreToolUse));
+    assert_eq!(
+        HookEvent::parse("UserPromptSubmit"),
+        Some(HookEvent::BeforeSubmitPrompt)
+    );
+    assert_eq!(HookEvent::parse("notAnEvent"), None);
+}
+
+#[test]
+fn every_event_round_trips_through_its_wire_name() {
+    for event in HookEvent::ALL {
+        assert_eq!(HookEvent::parse(event.as_str()), Some(event), "{event}");
+    }
+}
+
+#[test]
+fn unsupported_version_is_a_warning_not_a_silent_drop() {
+    let parsed = config::parse_one(
+        &PathBuf::from("/tmp/hooks.json"),
+        HookLayer::Project,
+        r#"{"version": 2, "hooks": {"preToolUse": [{"command": "x"}]}}"#,
+    );
+    assert!(parsed.is_empty());
+    assert_eq!(parsed.warnings.len(), 1);
+    assert!(parsed.warnings[0].contains("unsupported version 2"));
+}
+
+#[test]
+fn unknown_event_names_suggest_the_closest_match() {
+    let parsed = config::parse_one(
+        &PathBuf::from("/tmp/hooks.json"),
+        HookLayer::Project,
+        r#"{"version": 1, "hooks": {"preTool": [{"command": "x"}]}}"#,
+    );
+    assert!(parsed.is_empty());
+    assert!(
+        parsed.warnings[0].contains("did you mean 'preToolUse'"),
+        "{:?}",
+        parsed.warnings
+    );
+}
+
+#[test]
+fn definitions_are_tagged_with_their_layer_not_the_files_claim() {
+    let parsed = config::parse_one(
+        &PathBuf::from("/etc/openhuman/hooks.json"),
+        HookLayer::System,
+        r#"{"version": 1, "hooks": {"preToolUse": [{"command": "x", "layer": "project"}]}}"#,
+    );
+    let definitions = parsed.for_event(HookEvent::PreToolUse);
+    assert_eq!(definitions.len(), 1);
+    assert_eq!(definitions[0].layer, Some(HookLayer::System));
+}
+
+#[test]
+fn strictest_verdict_wins_when_outputs_merge() {
+    let mut allow = HookOutput {
+        permission: Some(HookPermission::Allow),
+        ..HookOutput::default()
+    };
+    allow.merge(HookOutput {
+        permission: Some(HookPermission::Ask),
+        ..HookOutput::default()
+    });
+    assert_eq!(allow.permission, Some(HookPermission::Ask));
+    allow.merge(HookOutput::deny("no"));
+    assert_eq!(allow.permission, Some(HookPermission::Deny));
+    // A later allow cannot undo the denial.
+    allow.merge(HookOutput {
+        permission: Some(HookPermission::Allow),
+        ..HookOutput::default()
+    });
+    assert_eq!(allow.permission, Some(HookPermission::Deny));
+}
+
+#[test]
+fn merged_messages_concatenate_and_rewrites_take_the_last() {
+    let mut first = HookOutput {
+        agent_message: Some("one".into()),
+        updated_input: Some(serde_json::json!({"a": 1})),
+        ..HookOutput::default()
+    };
+    first.merge(HookOutput {
+        agent_message: Some("two".into()),
+        updated_input: Some(serde_json::json!({"a": 2})),
+        ..HookOutput::default()
+    });
+    assert_eq!(first.agent_message.as_deref(), Some("one\ntwo"));
+    assert_eq!(first.updated_input.unwrap()["a"], 2);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn a_hook_that_prints_a_decision_is_honoured() {
+    let dir = scratch(
+        "{}",
+        Some(("deny.sh", "#!/bin/sh\necho '{\"permission\":\"deny\",\"agent_message\":\"nope\"}'\n")),
+    );
+    let run = exec::run(
+        &definition("./deny.sh", dir.path()),
+        &input(HookEvent::PreToolUse, tool_payload("shell")),
+        &BTreeMap::new(),
+        Duration::from_secs(10),
+    )
+    .await;
+    assert!(run.error.is_none(), "{:?}", run.error);
+    assert!(run.output.is_deny());
+    assert_eq!(run.output.agent_message.as_deref(), Some("nope"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn exit_code_two_denies_with_stderr_as_the_reason() {
+    let dir = scratch("{}", Some(("deny.sh", "#!/bin/sh\necho 'blocked by policy' 1>&2\nexit 2\n")));
+    let run = exec::run(
+        &definition("./deny.sh", dir.path()),
+        &input(HookEvent::PreToolUse, tool_payload("shell")),
+        &BTreeMap::new(),
+        Duration::from_secs(10),
+    )
+    .await;
+    assert!(run.output.is_deny());
+    assert_eq!(run.output.agent_message.as_deref(), Some("blocked by policy"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn a_crashing_hook_fails_open_by_default_and_closed_on_request() {
+    let dir = scratch("{}", Some(("boom.sh", "#!/bin/sh\nexit 9\n")));
+    let open = exec::run(
+        &definition("./boom.sh", dir.path()),
+        &input(HookEvent::PreToolUse, tool_payload("shell")),
+        &BTreeMap::new(),
+        Duration::from_secs(10),
+    )
+    .await;
+    assert!(!open.output.is_deny());
+    assert!(open.error.is_some(), "the failure is still reported");
+
+    let mut closed = definition("./boom.sh", dir.path());
+    closed.fail_closed = true;
+    let closed = exec::run(
+        &closed,
+        &input(HookEvent::PreToolUse, tool_payload("shell")),
+        &BTreeMap::new(),
+        Duration::from_secs(10),
+    )
+    .await;
+    assert!(closed.output.is_deny());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn a_hook_that_hangs_times_out_rather_than_stalling_the_turn() {
+    let dir = scratch("{}", Some(("hang.sh", "#!/bin/sh\nsleep 30\n")));
+    let mut hook = definition("./hang.sh", dir.path());
+    hook.timeout = Some(1);
+    let run = exec::run(
+        &hook,
+        &input(HookEvent::PreToolUse, tool_payload("shell")),
+        &BTreeMap::new(),
+        Duration::from_secs(1),
+    )
+    .await;
+    assert!(run.error.as_deref().unwrap_or_default().contains("timed out"));
+    assert!(!run.output.is_deny(), "a timeout fails open unless asked otherwise");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn the_event_reaches_the_hook_on_stdin() {
+    let dir = scratch(
+        "{}",
+        Some((
+            "echo.sh",
+            "#!/bin/sh\nbody=$(cat)\ncase \"$body\" in *beforeShellExecution*) \
+             echo '{\"permission\":\"deny\",\"agent_message\":\"saw the event\"}';; \
+             *) echo '{}';; esac\n",
+        )),
+    );
+    let run = exec::run(
+        &definition("./echo.sh", dir.path()),
+        &input(
+            HookEvent::BeforeShellExecution,
+            HookPayload::Shell(ShellPayload {
+                command: "rm -rf /".into(),
+                sandbox: false,
+                ..ShellPayload::default()
+            }),
+        ),
+        &BTreeMap::new(),
+        Duration::from_secs(10),
+    )
+    .await;
+    assert_eq!(run.output.agent_message.as_deref(), Some("saw the event"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn matchers_decide_which_hook_runs() {
+    let engine = HookEngine::default();
+    let dir = scratch(
+        r#"{"version": 1, "hooks": {"preToolUse": [
+             {"command": "./deny.sh", "matcher": "shell"}
+           ]}}"#,
+        Some(("deny.sh", "#!/bin/sh\necho '{\"permission\":\"deny\"}'\n")),
+    );
+    let loaded = config::load(None, Some(dir.path()));
+    // The workspace layer reads `<dir>/hooks.json` directly.
+    assert_eq!(loaded.len(), 1, "{:?}", loaded.warnings);
+    engine.install(loaded).await;
+
+    let denied = engine
+        .dispatch(
+            HookEvent::PreToolUse,
+            input(HookEvent::PreToolUse, tool_payload("shell")),
+        )
+        .await;
+    assert!(denied.is_deny());
+
+    let allowed = engine
+        .dispatch(
+            HookEvent::PreToolUse,
+            input(HookEvent::PreToolUse, tool_payload("memory_store")),
+        )
+        .await;
+    assert!(!allowed.is_deny(), "a non-matching tool is untouched");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn a_denial_short_circuits_the_remaining_hooks() {
+    let engine = HookEngine::default();
+    let dir = scratch(
+        r#"{"version": 1, "hooks": {"preToolUse": [
+             {"command": "./deny.sh"},
+             {"command": "./second.sh"}
+           ]}}"#,
+        Some(("deny.sh", "#!/bin/sh\necho '{\"permission\":\"deny\",\"agent_message\":\"first\"}'\n")),
+    );
+    std::fs::write(
+        dir.path().join("second.sh"),
+        "#!/bin/sh\necho '{\"agent_message\":\"second\"}'\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(
+            dir.path().join("second.sh"),
+            std::fs::Permissions::from_mode(0o755),
+        )
+        .unwrap();
+    }
+    engine.install(config::load(None, Some(dir.path()))).await;
+
+    let outcome = engine
+        .dispatch(
+            HookEvent::PreToolUse,
+            input(HookEvent::PreToolUse, tool_payload("shell")),
+        )
+        .await;
+    assert!(outcome.is_deny());
+    assert_eq!(outcome.runs.len(), 1, "the second hook never ran");
+    assert_eq!(outcome.denial_reason(), Some("first"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn followups_stop_once_a_hook_exhausts_its_budget() {
+    let engine = HookEngine::default();
+    let dir = scratch(
+        r#"{"version": 1, "hooks": {"stop": [
+             {"command": "./again.sh", "loop_limit": 2}
+           ]}}"#,
+        Some((
+            "again.sh",
+            "#!/bin/sh\necho '{\"followup_message\":\"keep going\"}'\n",
+        )),
+    );
+    engine.install(config::load(None, Some(dir.path()))).await;
+
+    let mut granted = 0;
+    for _ in 0..4 {
+        let outcome = engine
+            .dispatch(
+                HookEvent::Stop,
+                input(
+                    HookEvent::Stop,
+                    HookPayload::Stop(super::types::StopPayload {
+                        status: "completed".into(),
+                        loop_count: 0,
+                        iteration_count: None,
+                    }),
+                ),
+            )
+            .await;
+        if outcome.output.followup_message.is_some() {
+            granted += 1;
+        }
+    }
+    assert_eq!(granted, 2, "the loop limit caps the follow-ups");
+}
+
+#[tokio::test]
+async fn an_unconfigured_engine_reports_no_hooks_for_any_event() {
+    let engine = HookEngine::default();
+    for event in HookEvent::ALL {
+        assert!(!engine.has_hooks(event).await, "{event}");
+    }
+}

--- a/src/openhuman/hooks/types.rs
+++ b/src/openhuman/hooks/types.rs
@@ -335,9 +335,7 @@ impl HookPayload {
             HookEvent::SubagentStart | HookEvent::SubagentStop => {
                 HookPayload::Subagent(parse(value)?)
             }
-            HookEvent::SessionStart | HookEvent::SessionEnd => {
-                HookPayload::Session(parse(value)?)
-            }
+            HookEvent::SessionStart | HookEvent::SessionEnd => HookPayload::Session(parse(value)?),
             HookEvent::PreCompact => HookPayload::Compact(parse(value)?),
             HookEvent::AfterAgentResponse | HookEvent::AfterAgentThought => {
                 HookPayload::Text(parse(value)?)

--- a/src/openhuman/hooks/types.rs
+++ b/src/openhuman/hooks/types.rs
@@ -1,0 +1,517 @@
+//! Wire types for the configurable hook system.
+//!
+//! The vocabulary is deliberately close to Cursor's `hooks.json` contract
+//! (<https://cursor.com/docs/hooks>) so a hook script written for one host runs
+//! unchanged on the other: same event names, same stdin envelope, same stdout
+//! decision object, same exit-code semantics.
+//!
+//! Two things are *not* copied verbatim, and both are widenings rather than
+//! divergences:
+//!
+//! * **Event names are matched loosely.** [`HookEvent::parse`] normalizes by
+//!   lowercasing and dropping separators, so `preToolUse`, `PreToolUse` and
+//!   `pre_tool_use` are the same event. A `hooks.json` authored for Cursor,
+//!   for Claude Code, or by hand all resolve.
+//! * **One output struct serves every event.** A hook may return any subset of
+//!   fields; the engine honours only the ones its event defines. That keeps a
+//!   generic "deny everything from this script" hook usable across events
+//!   without the author tracking which schema each one wants.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// A lifecycle moment a configured hook can observe or gate.
+///
+/// Ordering of the variants follows the lifecycle, not the alphabet: session →
+/// prompt → tool → shell/file specialisations → subagent → wrap-up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum HookEvent {
+    /// A new agent session was created.
+    #[serde(rename = "sessionStart")]
+    SessionStart,
+    /// A session finished, was aborted, or errored.
+    #[serde(rename = "sessionEnd")]
+    SessionEnd,
+    /// The user submitted a prompt, before it reaches the model.
+    #[serde(rename = "beforeSubmitPrompt")]
+    BeforeSubmitPrompt,
+    /// Immediately before a tool executes. Can deny or rewrite the arguments.
+    #[serde(rename = "preToolUse")]
+    PreToolUse,
+    /// After a tool returned successfully. Can append context for the model.
+    #[serde(rename = "postToolUse")]
+    PostToolUse,
+    /// After a tool failed, timed out, or was denied.
+    #[serde(rename = "postToolUseFailure")]
+    PostToolUseFailure,
+    /// Before a shell command runs — the shell-tool specialisation of
+    /// [`Self::PreToolUse`], carrying the command line rather than raw args.
+    #[serde(rename = "beforeShellExecution")]
+    BeforeShellExecution,
+    /// After a shell command completed.
+    #[serde(rename = "afterShellExecution")]
+    AfterShellExecution,
+    /// Before an MCP tool call leaves the process.
+    #[serde(rename = "beforeMCPExecution")]
+    BeforeMcpExecution,
+    /// After an MCP tool call returned.
+    #[serde(rename = "afterMCPExecution")]
+    AfterMcpExecution,
+    /// Before a file is read into the model's context.
+    #[serde(rename = "beforeReadFile")]
+    BeforeReadFile,
+    /// After a file was written or edited on disk.
+    #[serde(rename = "afterFileEdit")]
+    AfterFileEdit,
+    /// A subagent is about to start.
+    #[serde(rename = "subagentStart")]
+    SubagentStart,
+    /// A subagent finished.
+    #[serde(rename = "subagentStop")]
+    SubagentStop,
+    /// The transcript is about to be compacted.
+    #[serde(rename = "preCompact")]
+    PreCompact,
+    /// The assistant produced a message.
+    #[serde(rename = "afterAgentResponse")]
+    AfterAgentResponse,
+    /// The assistant produced a reasoning block.
+    #[serde(rename = "afterAgentThought")]
+    AfterAgentThought,
+    /// The agent loop finished a turn. Can inject a follow-up message.
+    #[serde(rename = "stop")]
+    Stop,
+}
+
+impl HookEvent {
+    /// Every event, in lifecycle order. Used by the RPC surface and by the
+    /// config validator to report unknown event keys with a usable suggestion.
+    pub const ALL: [HookEvent; 18] = [
+        HookEvent::SessionStart,
+        HookEvent::SessionEnd,
+        HookEvent::BeforeSubmitPrompt,
+        HookEvent::PreToolUse,
+        HookEvent::PostToolUse,
+        HookEvent::PostToolUseFailure,
+        HookEvent::BeforeShellExecution,
+        HookEvent::AfterShellExecution,
+        HookEvent::BeforeMcpExecution,
+        HookEvent::AfterMcpExecution,
+        HookEvent::BeforeReadFile,
+        HookEvent::AfterFileEdit,
+        HookEvent::SubagentStart,
+        HookEvent::SubagentStop,
+        HookEvent::PreCompact,
+        HookEvent::AfterAgentResponse,
+        HookEvent::AfterAgentThought,
+        HookEvent::Stop,
+    ];
+
+    /// The canonical wire name, as it appears in `hooks.json` and in the
+    /// `hook_event_name` field of the stdin envelope.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            HookEvent::SessionStart => "sessionStart",
+            HookEvent::SessionEnd => "sessionEnd",
+            HookEvent::BeforeSubmitPrompt => "beforeSubmitPrompt",
+            HookEvent::PreToolUse => "preToolUse",
+            HookEvent::PostToolUse => "postToolUse",
+            HookEvent::PostToolUseFailure => "postToolUseFailure",
+            HookEvent::BeforeShellExecution => "beforeShellExecution",
+            HookEvent::AfterShellExecution => "afterShellExecution",
+            HookEvent::BeforeMcpExecution => "beforeMCPExecution",
+            HookEvent::AfterMcpExecution => "afterMCPExecution",
+            HookEvent::BeforeReadFile => "beforeReadFile",
+            HookEvent::AfterFileEdit => "afterFileEdit",
+            HookEvent::SubagentStart => "subagentStart",
+            HookEvent::SubagentStop => "subagentStop",
+            HookEvent::PreCompact => "preCompact",
+            HookEvent::AfterAgentResponse => "afterAgentResponse",
+            HookEvent::AfterAgentThought => "afterAgentThought",
+            HookEvent::Stop => "stop",
+        }
+    }
+
+    /// Resolve a config key to an event, tolerating casing and separators.
+    ///
+    /// `preToolUse`, `PreToolUse`, `pre_tool_use` and `pre-tool-use` are the
+    /// same event; so are Claude Code's `UserPromptSubmit` /
+    /// `SubagentStop` spellings, which alias onto the closest OpenHuman moment.
+    pub fn parse(key: &str) -> Option<HookEvent> {
+        let normalized = normalize_key(key);
+        if let Some(event) = HookEvent::ALL
+            .iter()
+            .copied()
+            .find(|event| normalize_key(event.as_str()) == normalized)
+        {
+            return Some(event);
+        }
+        // Aliases from neighbouring hook dialects.
+        match normalized.as_str() {
+            "userpromptsubmit" => Some(HookEvent::BeforeSubmitPrompt),
+            "notification" | "agentresponse" => Some(HookEvent::AfterAgentResponse),
+            "agentthought" => Some(HookEvent::AfterAgentThought),
+            "precompaction" | "compact" => Some(HookEvent::PreCompact),
+            "sessionstop" => Some(HookEvent::SessionEnd),
+            "toolusefailure" | "tooluseerror" => Some(HookEvent::PostToolUseFailure),
+            _ => None,
+        }
+    }
+
+    /// Whether a decision from this event can change what the core does.
+    ///
+    /// Gating events are run **sequentially** and their output is honoured;
+    /// observational events are fire-and-forget, so the engine never blocks a
+    /// turn on one. This is the single place that distinction is encoded.
+    pub fn is_gating(self) -> bool {
+        matches!(
+            self,
+            HookEvent::PreToolUse
+                | HookEvent::BeforeShellExecution
+                | HookEvent::BeforeMcpExecution
+                | HookEvent::BeforeReadFile
+                | HookEvent::BeforeSubmitPrompt
+                | HookEvent::SubagentStart
+                | HookEvent::SessionStart
+                | HookEvent::PostToolUse
+                | HookEvent::Stop
+                | HookEvent::SubagentStop
+                | HookEvent::PreCompact
+        )
+    }
+}
+
+impl std::fmt::Display for HookEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Lowercase and drop every separator, so hook-name dialects converge.
+pub(crate) fn normalize_key(key: &str) -> String {
+    key.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .map(|c| c.to_ascii_lowercase())
+        .collect()
+}
+
+/// The permission verdict a gating hook may return.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum HookPermission {
+    /// Proceed. The absence of a verdict means the same thing.
+    #[default]
+    Allow,
+    /// Refuse the action. The agent is told why.
+    Deny,
+    /// Escalate to the human through the existing approval gate.
+    Ask,
+}
+
+/// The envelope handed to every hook on stdin.
+///
+/// Fields common to all events sit at the top level; the event-specific body is
+/// flattened in from [`HookPayload`], matching Cursor's shape where one JSON
+/// object carries both.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HookInput {
+    /// The event that fired, as its canonical wire name.
+    pub hook_event_name: String,
+    /// Conversation/thread identifier, when the moment belongs to one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation_id: Option<String>,
+    /// Per-turn generation identifier, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generation_id: Option<String>,
+    /// Agent session identifier, when the moment belongs to a session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    /// Model driving the turn, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Canonical agent definition id, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+    /// Core version string, so a hook can gate on host capability.
+    pub openhuman_version: String,
+    /// Filesystem roots the agent may act in — `action_dir` plus any turn
+    /// workspace. First entry is the primary root.
+    pub workspace_roots: Vec<String>,
+    /// Working directory the action is scoped to, when the event has one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    /// The event body.
+    #[serde(flatten)]
+    pub payload: HookPayload,
+}
+
+/// Event-specific fields, flattened into [`HookInput`].
+///
+/// Untagged on purpose: the discriminator a hook script reads is
+/// `hook_event_name`, exactly as in Cursor, so the body must not add a second
+/// tag key of its own.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(untagged)]
+pub enum HookPayload {
+    /// Events that carry no body beyond the common envelope.
+    #[default]
+    Empty,
+    /// Tool lifecycle: pre, post, and failure.
+    Tool(ToolPayload),
+    /// Shell command execution.
+    Shell(ShellPayload),
+    /// File read or edit.
+    File(FilePayload),
+    /// Prompt submission.
+    Prompt(PromptPayload),
+    /// Subagent start/stop.
+    Subagent(SubagentPayload),
+    /// Session start/end.
+    Session(SessionPayload),
+    /// Transcript compaction.
+    Compact(CompactPayload),
+    /// Assistant text or reasoning.
+    Text(TextPayload),
+    /// Turn completion.
+    Stop(StopPayload),
+}
+
+/// Body for `preToolUse`, `postToolUse`, `postToolUseFailure`, and the MCP
+/// specialisations.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ToolPayload {
+    /// Registered tool name.
+    pub tool_name: String,
+    /// Arguments after argument-recovery normalization.
+    pub tool_input: serde_json::Value,
+    /// Provider call id, correlating the pre and post events.
+    pub tool_use_id: String,
+    /// Tool output, JSON-stringified. Absent before execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_output: Option<String>,
+    /// Wall-clock tool runtime in milliseconds. Absent before execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    /// Failure text, on `postToolUseFailure`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    /// Failure class: `timeout`, `error`, or `permission_denied`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_type: Option<String>,
+}
+
+/// Body for `beforeShellExecution` / `afterShellExecution`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ShellPayload {
+    /// The full command line as it will be handed to the shell.
+    pub command: String,
+    /// Whether the command runs inside a sandbox backend.
+    pub sandbox: bool,
+    /// Combined output. Absent before execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output: Option<String>,
+    /// Wall-clock runtime in milliseconds. Absent before execution.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+}
+
+/// Body for `beforeReadFile` / `afterFileEdit`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct FilePayload {
+    /// Absolute path of the file.
+    pub file_path: String,
+    /// Applied edits, on `afterFileEdit`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub edits: Vec<FileEdit>,
+}
+
+/// A single string replacement within a file.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct FileEdit {
+    /// Text that was replaced. Empty for a whole-file write.
+    pub old_string: String,
+    /// Text that replaced it.
+    pub new_string: String,
+}
+
+/// Body for `beforeSubmitPrompt`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PromptPayload {
+    /// The user's message.
+    pub prompt: String,
+    /// Attachment paths riding along with the prompt.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<String>,
+}
+
+/// Body for `subagentStart` / `subagentStop`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SubagentPayload {
+    /// Agent definition id of the child.
+    pub subagent_type: String,
+    /// The task handed to the child.
+    pub task: String,
+    /// Parent conversation identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_conversation_id: Option<String>,
+    /// Terminal status on stop: `completed`, `error`, or `aborted`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    /// Child runtime in milliseconds, on stop.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+}
+
+/// Body for `sessionStart` / `sessionEnd`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SessionPayload {
+    /// Entrypoint that created the session (`cli`, `web_chat`, `cron`, …).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entrypoint: Option<String>,
+    /// Why the session ended, on `sessionEnd`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Session lifetime in milliseconds, on `sessionEnd`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+}
+
+/// Body for `preCompact`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CompactPayload {
+    /// `auto` or `manual`.
+    pub trigger: String,
+    /// Context occupancy as a percentage of the window.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_usage_percent: Option<f64>,
+    /// Messages in the transcript at the moment of compaction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_count: Option<usize>,
+}
+
+/// Body for `afterAgentResponse` / `afterAgentThought`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TextPayload {
+    /// The assistant text or reasoning block.
+    pub text: String,
+    /// Reasoning duration in milliseconds, for thoughts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+}
+
+/// Body for `stop`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct StopPayload {
+    /// `completed`, `aborted`, or `error`.
+    pub status: String,
+    /// How many times this turn has already been extended by a follow-up.
+    pub loop_count: u32,
+    /// Model calls made during the turn.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iteration_count: Option<usize>,
+}
+
+/// What a hook may return on stdout.
+///
+/// Every field is optional and every event honours only the subset it defines,
+/// so one script can serve several events without branching on the schema.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HookOutput {
+    /// Verdict for a gating event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permission: Option<HookPermission>,
+    /// Shown to the human. Never enters the model transcript.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user_message: Option<String>,
+    /// Shown to the model — the reason a denial happened, or a nudge.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_message: Option<String>,
+    /// Replacement tool arguments, honoured on `preToolUse`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_input: Option<serde_json::Value>,
+    /// Text appended to a tool result or to the session's system context.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub additional_context: Option<String>,
+    /// `false` aborts prompt submission on `beforeSubmitPrompt`.
+    #[serde(default, rename = "continue", skip_serializing_if = "Option::is_none")]
+    pub continue_: Option<bool>,
+    /// Injects another user turn on `stop` / `subagentStop`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub followup_message: Option<String>,
+    /// Environment variables added to every later hook in the session,
+    /// honoured on `sessionStart`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env: Option<BTreeMap<String, String>>,
+}
+
+impl HookOutput {
+    /// A denial carrying the reason the model should see.
+    pub fn deny(agent_message: impl Into<String>) -> Self {
+        Self {
+            permission: Some(HookPermission::Deny),
+            agent_message: Some(agent_message.into()),
+            ..Self::default()
+        }
+    }
+
+    /// Whether this output refuses the action.
+    pub fn is_deny(&self) -> bool {
+        self.permission == Some(HookPermission::Deny)
+    }
+
+    /// Whether this output escalates to the human.
+    pub fn is_ask(&self) -> bool {
+        self.permission == Some(HookPermission::Ask)
+    }
+
+    /// Fold a later hook's output into this one.
+    ///
+    /// Denial is sticky and beats `ask`, which beats `allow` — the strictest
+    /// verdict from any hook wins, so adding a hook can never loosen a policy
+    /// another one set. Text fields concatenate; `updated_input` and `env`
+    /// are last-writer-wins because merging two rewrites of the same arguments
+    /// has no defensible semantics.
+    pub fn merge(&mut self, other: HookOutput) {
+        self.permission = match (self.permission, other.permission) {
+            (Some(HookPermission::Deny), _) | (_, Some(HookPermission::Deny)) => {
+                Some(HookPermission::Deny)
+            }
+            (Some(HookPermission::Ask), _) | (_, Some(HookPermission::Ask)) => {
+                Some(HookPermission::Ask)
+            }
+            (Some(HookPermission::Allow), _) | (_, Some(HookPermission::Allow)) => {
+                Some(HookPermission::Allow)
+            }
+            (None, None) => None,
+        };
+        append_message(&mut self.user_message, other.user_message);
+        append_message(&mut self.agent_message, other.agent_message);
+        append_message(&mut self.additional_context, other.additional_context);
+        append_message(&mut self.followup_message, other.followup_message);
+        if other.updated_input.is_some() {
+            self.updated_input = other.updated_input;
+        }
+        if let Some(env) = other.env {
+            self.env.get_or_insert_with(BTreeMap::new).extend(env);
+        }
+        // `continue: false` is sticky for the same reason denial is.
+        if other.continue_ == Some(false) || self.continue_ == Some(false) {
+            self.continue_ = Some(false);
+        } else if other.continue_.is_some() {
+            self.continue_ = other.continue_;
+        }
+    }
+}
+
+fn append_message(slot: &mut Option<String>, addition: Option<String>) {
+    let Some(addition) = addition.filter(|text| !text.is_empty()) else {
+        return;
+    };
+    match slot {
+        Some(existing) => {
+            existing.push('\n');
+            existing.push_str(&addition);
+        }
+        None => *slot = Some(addition),
+    }
+}

--- a/src/openhuman/hooks/types.rs
+++ b/src/openhuman/hooks/types.rs
@@ -303,6 +303,50 @@ pub enum HookPayload {
     Stop(StopPayload),
 }
 
+impl HookPayload {
+    /// Parse a body **for a known event**.
+    ///
+    /// Never rely on `serde`'s untagged dispatch for this. Several bodies have
+    /// only optional fields, so untagged matching picks whichever variant is
+    /// declared first and happens to accept the object — `{"trigger":"auto"}`
+    /// deserializes as a [`SessionPayload`] with everything `None`, silently
+    /// throwing away the field the caller sent. The event already says which
+    /// body this is; use it.
+    pub fn from_value_for(event: HookEvent, value: serde_json::Value) -> Result<Self, String> {
+        fn parse<T: serde::de::DeserializeOwned>(value: serde_json::Value) -> Result<T, String> {
+            serde_json::from_value(value).map_err(|error| error.to_string())
+        }
+        if value.is_null() {
+            return Ok(HookPayload::Empty);
+        }
+        Ok(match event {
+            HookEvent::PreToolUse
+            | HookEvent::PostToolUse
+            | HookEvent::PostToolUseFailure
+            | HookEvent::BeforeMcpExecution
+            | HookEvent::AfterMcpExecution => HookPayload::Tool(parse(value)?),
+            HookEvent::BeforeShellExecution | HookEvent::AfterShellExecution => {
+                HookPayload::Shell(parse(value)?)
+            }
+            HookEvent::BeforeReadFile | HookEvent::AfterFileEdit => {
+                HookPayload::File(parse(value)?)
+            }
+            HookEvent::BeforeSubmitPrompt => HookPayload::Prompt(parse(value)?),
+            HookEvent::SubagentStart | HookEvent::SubagentStop => {
+                HookPayload::Subagent(parse(value)?)
+            }
+            HookEvent::SessionStart | HookEvent::SessionEnd => {
+                HookPayload::Session(parse(value)?)
+            }
+            HookEvent::PreCompact => HookPayload::Compact(parse(value)?),
+            HookEvent::AfterAgentResponse | HookEvent::AfterAgentThought => {
+                HookPayload::Text(parse(value)?)
+            }
+            HookEvent::Stop => HookPayload::Stop(parse(value)?),
+        })
+    }
+}
+
 /// Body for `preToolUse`, `postToolUse`, `postToolUseFailure`, and the MCP
 /// specialisations.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/src/openhuman/hooks/types.rs
+++ b/src/openhuman/hooks/types.rs
@@ -158,6 +158,33 @@ impl HookEvent {
         }
     }
 
+    /// Whether the core currently fires this event.
+    ///
+    /// Every event in [`Self::ALL`] is a complete contract — it parses, it
+    /// matches, it executes, and `hooks.test` fires it — but a few have no call
+    /// site in the harness yet. Those return `false`, and the loader warns when
+    /// a `hooks.json` registers one, because a hook that silently never runs is
+    /// the worst outcome this system can produce: the author believes a policy
+    /// is enforced and nothing says otherwise.
+    ///
+    /// Move an event here as its call site lands; do not flip one optimistically.
+    pub fn is_wired(self) -> bool {
+        !matches!(
+            self,
+            // No async seam at session construction yet — `AgentBuilder::build`
+            // is synchronous, and `sessionStart` has to be able to return
+            // context that reaches the system prompt.
+            HookEvent::SessionStart
+                | HookEvent::SessionEnd
+                // Compaction runs inside the tinyagents middleware, which owns
+                // its own trigger; surfacing it needs a seam upstream.
+                | HookEvent::PreCompact
+                // Reasoning blocks are not projected onto the post-turn seam
+                // the bridge rides.
+                | HookEvent::AfterAgentThought
+        )
+    }
+
     /// Whether a decision from this event can change what the core does.
     ///
     /// Gating events are run **sequentially** and their output is honoured;

--- a/src/openhuman/mod.rs
+++ b/src/openhuman/mod.rs
@@ -27,6 +27,10 @@ pub mod hosted;
 // off the domain is not compiled and the tools are absent from the registry
 // rather than degraded to an error (see `tools::ops`).
 #[cfg(feature = "hosting")]
+/// User-authored hooks — `hooks.json` scripts that observe and gate the agent.
+/// Kernel surface, never gated: the whole point is a policy seam a slim build
+/// still honours, and it costs nothing when nothing is configured.
+pub mod hooks;
 pub mod hosting;
 // The whole http_host domain is an axum static-directory server, so it is
 // exclusive to the `http-server` feature (#5048). Its only outside reference is

--- a/src/openhuman/mod.rs
+++ b/src/openhuman/mod.rs
@@ -21,16 +21,16 @@ pub mod cron;
 pub mod desktop;
 #[cfg(feature = "flows")]
 pub mod flows;
+/// User-authored hooks — `hooks.json` scripts that observe and gate the agent.
+/// Kernel surface, never gated: the whole point is a policy seam a slim build
+/// still honours, and it costs nothing when nothing is configured.
+pub mod hooks;
 pub mod hosted;
 // Hosting: the `hosting_*` tools that put a workspace on a real hosting
 // provider, over the `tinyhosts` unified model. Leaf gate — when `hosting` is
 // off the domain is not compiled and the tools are absent from the registry
 // rather than degraded to an error (see `tools::ops`).
 #[cfg(feature = "hosting")]
-/// User-authored hooks — `hooks.json` scripts that observe and gate the agent.
-/// Kernel surface, never gated: the whole point is a policy seam a slim build
-/// still honours, and it costs nothing when nothing is configured.
-pub mod hooks;
 pub mod hosting;
 // The whole http_host domain is an axum static-directory server, so it is
 // exclusive to the `http-server` feature (#5048). Its only outside reference is

--- a/src/openhuman/web_chat/ops.rs
+++ b/src/openhuman/web_chat/ops.rs
@@ -421,7 +421,7 @@ pub async fn start_chat(
     //   [IMAGE:data:…] → [Image: … #att:<id>] placeholder + out-of-band stash
     // Images are rehydrated to a data URI at provider dispatch for vision-capable
     // models only.
-    let message = if message.contains("[FILE:") || message.contains("[IMAGE:") {
+    let mut message = if message.contains("[FILE:") || message.contains("[IMAGE:") {
         let before_chars = message.chars().count();
         log::debug!(
             "[web-channel][ingress] preprocessing attachment markers thread_id={} client_id={} chars={}",

--- a/src/openhuman/web_chat/ops.rs
+++ b/src/openhuman/web_chat/ops.rs
@@ -543,6 +543,42 @@ pub async fn start_chat(
         }
     }
 
+    // Configured `beforeSubmitPrompt` hooks. Deliberately after the
+    // approval-reply routing above: a bare "yes" answering a parked approval is
+    // not a prompt the user is submitting to the model, and handing it to a
+    // prompt hook would let a hook that blocks short messages strand a turn
+    // waiting for an approval it can no longer receive.
+    //
+    // The message here is post-attachment-processing, so a hook sees extracted
+    // text and placeholders rather than a multi-megabyte data URI on stdin.
+    match crate::openhuman::hooks::ops::prompt_submitted(
+        crate::openhuman::hooks::context::TurnIdentity {
+            conversation_id: Some(thread_id.clone()),
+            ..Default::default()
+        },
+        &message,
+        Vec::new(),
+    )
+    .await
+    {
+        crate::openhuman::hooks::PromptVerdict::Submit { additional_context } => {
+            if let Some(context) = additional_context {
+                log::debug!(
+                    "[web-channel] beforeSubmitPrompt hook added {} chars of context thread_id={}",
+                    context.chars().count(),
+                    thread_id
+                );
+                message = format!("{message}\n\n{context}");
+            }
+        }
+        crate::openhuman::hooks::PromptVerdict::Block(reason) => {
+            log::info!(
+                "[web-channel] prompt blocked by a configured hook thread_id={thread_id}: {reason}"
+            );
+            return Err(reason);
+        }
+    }
+
     let map_key = key_for(&thread_id);
 
     let parsed_mode = match queue_mode.as_deref() {


### PR DESCRIPTION
## Summary

- Adds **configurable hooks**: user-authored scripts declared in `hooks.json` that observe and gate the agent, taking [Cursor's contract](https://cursor.com/docs/hooks) verbatim so a hook script ports between hosts unchanged.
- New domain `src/openhuman/hooks/` — event/envelope/decision wire types, four-layer `hooks.json` loading, matchers, process execution with the exit-code contract, and the selection/aggregation engine.
- Mounts on the harness's **existing** seams rather than adding call sites: `hooks::bridge` registers as an embedder `ToolHook` + `PostTurnHook`, and derives `beforeShellExecution` / `beforeReadFile` / `afterFileEdit` / MCP events from tool calls.
- Enriches the in-process `ToolHook` trait so a hook can rewrite arguments, escalate to the human, or append context to a tool result — previously the only expressible answers were "fine" and an `Err` that read to the model as a tool crash.
- New `hooks` RPC namespace (`list` / `reload` / `test`) and `[hooks]` config block.
- Docs: [`gitbooks/developing/hooks.md`](../gitbooks/developing/hooks.md) + an AGENTS.md section disambiguating the two things called "hooks" in this repo.

## Problem

OpenHuman already had "hooks" — but only the kind an *embedding host* installs by compiling Rust traits against the core (`PostTurnHook`, `ToolHook`, `StopHook`). That is the wrong tool for what people actually reach for hooks to do: a small script, checked into a repository, that blocks `rm -rf`, runs the formatter after an edit, writes an audit line per tool call, or refuses to read `.env`.

The existing `ToolHook` was also thin even for embedders. `before_tool` returned `Result<()>`, so the only two expressible outcomes were "proceed" and an error the model saw as a tool crash — no argument rewriting, no escalation to the human, no way to feed text back after a tool ran.

## Solution

### The file contract

`hooks.json` v1 — same event names, same stdin envelope, same stdout decision object, same exit codes as Cursor (`0` = read stdout, `2` = deny with stderr as the reason, anything else = fail open unless `failClosed`). Event names are matched loosely (`preToolUse` / `PreToolUse` / `pre_tool_use`), with aliases for Claude Code spellings, so a file authored for any of the three dialects resolves.

Four layers are read (system / user / workspace / project) and **they concatenate rather than override**. That is deliberate and is the inverse of how `config.toml` merges: since `HookOutput::merge` folds deny over ask over allow, adding a hook can never loosen a policy another one set — which is what makes it safe for a repository to ship its own `hooks.json` onto a machine an operator has already locked down.

### Design decisions worth reviewing

**Shell/file/MCP events are derived from tool calls.** OpenHuman has no separate shell-execution call site — that moment *is* the `shell` tool going through the tool seam. So the bridge fires both the generic `preToolUse` and a specialised event whose payload is reshaped the way a Cursor hook expects (a command line, a file path, an `edits` array). Only exposing `preToolUse` and telling authors to parse `tool_input` would have been less code and a worse contract: every author would reimplement the same mapping, each getting the sandbox flag and path resolution subtly differently.

**Gating costs a turn's latency; observing does not.** `HookEvent::is_gating()` is the single place that split is encoded. Gating hooks run sequentially in the turn's path and short-circuit on the first denial; observational ones are spawned onto a background task. An audit hook that hangs must not hang the agent.

**`fail_closed` covers every failure mode, not just the tidy one.** A timeout, a missing interpreter, and unparseable stdout all take the same path as a non-zero exit. A hook that denies only when it manages to run is not a security control.

**Four events are defined but not yet fired, and the system says so out loud.** `sessionStart`, `sessionEnd`, `preCompact` and `afterAgentThought` parse, match, execute, and can be exercised with `hooks test`, but have no call site yet (`AgentBuilder::build` is synchronous, and `sessionStart` has to return context that reaches the system prompt). `HookEvent::is_wired()` makes the loader warn when one is configured and `hooks list` report `"wired": false`. A hook that silently never runs is the worst outcome this system can produce, so it is reported rather than left to be discovered.

**Nothing configured costs nothing.** When no `hooks.json` contributes anything, the harness bridge is not installed at all — there is not even a registry lookup per tool call.

### Trait enrichment (backwards compatible)

`ToolHook` gained `before_tool_decision` → `ToolHookDecision` (`Proceed` / `ProceedWith(args)` / `Deny(reason)` / `Ask(reason)`) and `after_tool_context` → `Option<String>` appended to the tool result. Both have default implementations that bridge to the existing `before_tool` / `after_tool` pair, so existing embedder implementations compile unchanged. `ToolHookContext` gained the raw `output` / `error` / session identity fields a policy hook needs (deliberately raw, unlike `ToolCallRecord::output_summary`, which is sanitized for the learning pipeline).

A rewrite from one hook is applied to the live call *and* to the context handed to later hooks, so a chain of hooks each narrowing the arguments composes rather than the last one silently winning. `Ask` inside the tool middleware denies rather than quietly allowing, since a middleware has no approval channel.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — 47 tests in the new domain, including the failure paths that matter: exit-2 denial, a crashing hook fail-open vs fail-closed, a hanging hook timing out, an invalid matcher regex matching nothing, unparseable stdout, an unsupported schema version, an unknown event name, a payload that does not fit its event, and a relative script that is missing or not executable.
- [ ] **Diff coverage ≥ 80%** — not measured locally; CI's `rust-core-coverage` / `coverage-gate` will report. The domain is densely unit-tested but the `ops.rs` entry points for the four unwired events have no call site to exercise them yet.
- [ ] Coverage matrix updated — `N/A: no matrix row exists for hooks yet; happy to add one if reviewers want a feature ID minted for this.`
- [ ] All affected feature IDs from the matrix are listed under `## Related` — `N/A: see above.`
- [x] No new external network dependencies introduced — no new crates at all; execution uses the existing `agent::platform_shell` + tokio process path.
- [ ] Manual smoke checklist updated — `N/A: additive surface that is inert unless a hooks.json exists.`
- [ ] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue; opened directly from a request to bring our hooks up to Cursor's flexibility.`

## Impact

**Runtime/platform.** Core-side, so it applies to desktop, CLI, and headless equally. Ungated kernel surface — the point is a policy seam a slim build still honours — and it adds no dependencies, so the kernel-floor ratchet does not move.

**Performance.** Zero when unconfigured (no bridge installed). When configured, gating events add the hook's own runtime to the turn; observational events add nothing to the turn's path.

**Security.** This is a security-relevant surface in both directions, and reviewers should weigh it as one. It *adds* a deny lever that composes safely (strictest verdict wins, layers concatenate, a system-layer rule cannot be overridden by a project file). It also *runs user-authored programs* with the core's privileges and environment — which is the entire point, and is the same trust model as Cursor's and Claude Code's hooks, but it means a writable `hooks.json` in a repository is code execution on `clone` + first agent turn. That risk is inherent to the feature; it is worth a reviewer's explicit sign-off rather than being buried here.

**Migration/compatibility.** Purely additive. No wire surface changed, no existing behaviour changes with no `hooks.json` present. The `ToolHook` trait grew two methods, both defaulted.

## Related

- Closes:
- Follow-up PR(s)/TODOs:
  - Wire `sessionStart` / `sessionEnd` (needs an async seam at session construction), `preCompact` (needs a seam upstream of the tinyagents middleware's own trigger), and `afterAgentThought` (reasoning blocks are not projected onto the post-turn seam). Flip `HookEvent::is_wired()` per event as each lands.
  - Drain `hooks::followup` from the entrypoints that own a conversation, so a `stop` hook's `followup_message` actually starts another turn where one is appropriate. Queued and budget-charged today; nothing consumes it yet.
  - Resolve `Ask` through `security::approval` on the tool path instead of denying.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `cursor-style-hooks`
- Commit SHA: `89a1cad907ec9fe630bddc5433fba7592805b9d1`

### Validation Run

- [ ] `pnpm --filter openhuman-app format:check` — N/A, no frontend files changed.
- [ ] `pnpm typecheck` — N/A, no TypeScript changed.
- [x] Focused tests: `cargo test --lib -- openhuman::hooks::` → **47 passed, 0 failed**. `cargo test --lib -- core::all:: config:: agent::tinyagents` → **1,087 passed, 0 failed**.
- [x] Rust fmt/check: `cargo fmt --all` applied; `cargo check --lib --tests` clean; `cargo clippy --lib --features "$(bash scripts/ci/product-features.sh)"` clean.
- [ ] Tauri fmt/check — N/A, `app/src-tauri` untouched.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: with a `hooks.json` present, user scripts can now deny, rewrite, or annotate agent actions at 14 lifecycle moments.
- User-visible effect: none without a `hooks.json`. With one, a denied tool call surfaces the hook's `agent_message` to the model, and a blocked prompt surfaces its `user_message` to the user.

### Parity Contract

- Legacy behavior preserved: existing `ToolHook` / `PostTurnHook` implementations compile and behave identically — the new trait methods default to the old pair, and `before_tool`'s `Err` still maps to a denial.
- Guard/fallback/dispatch parity checks: the bridge replaces itself by name (`replace_embedder_*_hook`) rather than appending, so a host that rebuilds its core cannot end up firing every hook twice; and it is uninstalled entirely when nothing is configured or `[hooks] enabled = false`.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable, file-based hooks for observing and controlling prompts, tools, sessions, subagents, file changes, shell commands, and other lifecycle events.
  * Hooks can allow, deny, request approval, rewrite tool inputs, add context, publish follow-up messages, and set environment variables.
  * Added layered configuration, matching rules, timeouts, command and prompt hooks, and fail-open or fail-closed behavior.
  * Added hook inspection, reload, and test controls through the CLI/RPC interface.
* **Documentation**
  * Added setup guidance, configuration reference, event mappings, execution behavior, and troubleshooting details for hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->