### PR TITLE
test: drop meet-settings expectations left behind by the meetings removal

### DIFF
--- a/tests/config_auth_app_state_connectivity_e2e.rs
+++ b/tests/config_auth_app_state_connectivity_e2e.rs
@@ -3279,7 +3279,6 @@ async fn config_runtime_flags_settings_readbacks_and_validation_paths_are_exerci
         Some(false)
     );
 
-
     let onboarding_before = rpc(
         &harness.rpc_base,
         11_008,

--- a/tests/config_auth_app_state_connectivity_e2e.rs
+++ b/tests/config_auth_app_state_connectivity_e2e.rs
@@ -2804,7 +2804,6 @@ async fn worker_a_controller_schemas_are_fully_exposed() {
                 "openhuman.config_get_dashboard_settings",
                 "openhuman.config_get_data_paths",
                 "openhuman.config_get_dictation_settings",
-                "openhuman.config_get_meet_settings",
                 "openhuman.config_get_memory_sync_settings",
                 "openhuman.config_get_onboarding_completed",
                 "openhuman.config_get_privacy_mode",
@@ -2828,7 +2827,6 @@ async fn worker_a_controller_schemas_are_fully_exposed() {
                 "openhuman.config_update_composio_trigger_settings",
                 "openhuman.config_update_dictation_settings",
                 "openhuman.config_update_local_ai_settings",
-                "openhuman.config_update_meet_settings",
                 "openhuman.config_update_memory_settings",
                 "openhuman.config_update_memory_sync_settings",
                 "openhuman.config_update_model_settings",
@@ -3281,29 +3279,6 @@ async fn config_runtime_flags_settings_readbacks_and_validation_paths_are_exerci
         Some(false)
     );
 
-    ok(
-        &rpc(
-            &harness.rpc_base,
-            11_006,
-            "openhuman.config_update_meet_settings",
-            json!({ "auto_orchestrator_handoff": true }),
-        )
-        .await,
-        "update_meet_settings true",
-    );
-    let meet = rpc(
-        &harness.rpc_base,
-        11_007,
-        "openhuman.config_get_meet_settings",
-        json!({}),
-    )
-    .await;
-    assert_eq!(
-        payload(&meet, "get_meet_settings")
-            .get("auto_orchestrator_handoff")
-            .and_then(Value::as_bool),
-        Some(true)
-    );
 
     let onboarding_before = rpc(
         &harness.rpc_base,

--- a/tests/domain_modules_e2e.rs
+++ b/tests/domain_modules_e2e.rs
@@ -362,28 +362,6 @@ async fn config_agent_tools_and_threads_mutation_paths_round_trip() {
         Some(false)
     );
 
-    let meet = rpc(
-        &harness.rpc_base,
-        30_005,
-        "openhuman.config_update_meet_settings",
-        json!({ "auto_orchestrator_handoff": true }),
-    )
-    .await;
-    ok(&meet, "update_meet_settings");
-    let meet_get = rpc(
-        &harness.rpc_base,
-        30_006,
-        "openhuman.config_get_meet_settings",
-        json!({}),
-    )
-    .await;
-    assert_eq!(
-        payload(&meet_get, "get_meet_settings")
-            .get("auto_orchestrator_handoff")
-            .and_then(Value::as_bool),
-        Some(true)
-    );
-
     let dictation = rpc(
         &harness.rpc_base,
         30_007,


### PR DESCRIPTION
## What

Removes the `config_get_meet_settings` / `config_update_meet_settings` expectations from two integration tests:

- `tests/config_auth_app_state_connectivity_e2e.rs` — two entries in the `config` schema-catalog list, and the settings round-trip in `config_runtime_flags_settings_readbacks_and_validation_paths_are_exercised`
- `tests/domain_modules_e2e.rs` — the equivalent round-trip block

47 deletions, tests only. No source change.

## Why

`main` is currently red on `Rust Core Coverage (cargo-llvm-cov)`.

#5674 removed the meetings domain, which unregistered the two `config_*_meet_settings` RPC methods, but the tests still expect them:

```
$ git grep -l config_update_meet_settings src/     # nothing
$ git grep -l config_update_meet_settings tests/   # two files
```

So two tests fail on `main`:

```
config_runtime_flags_settings_readbacks_and_validation_paths_are_exercised
  → update_meet_settings true: unexpected JSON-RPC error:
    {"code":-32000,"message":"unknown method: openhuman.config_update_meet_settings"}

worker_a_controller_schemas_are_fully_exposed
  → assertion `left == right` failed: schema catalog mismatch for namespace config
```

Because this is on `main`, it fails on **every** PR that merges it — it is currently the sole `Rust Core Coverage` failure on #5664, #5668, #5670 and #5671, none of which touch meet settings. Deleting the expectations is the correct fix: the methods are intentionally gone, so there is nothing to assert.

## Verification

```
$ git grep -c meet_settings tests/
0
$ cargo check --tests --features "$(bash scripts/ci/product-features.sh)" \
    --test config_auth_app_state_connectivity_e2e --test domain_modules_e2e
Finished `dev` profile in 2m 25s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test coverage by removing checks for retrieving and updating meeting settings.
  * Removed associated schema validation and round-trip assertions.
  * Continued coverage for analytics, dictation, search, profiles, tools, threads, and other domain functionality.
  * No user-facing product behavior changes are included in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->