### PR TITLE
test: drop the stale meetAutoOrchestratorHandoff snapshot assertion

### DIFF
--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -5493,17 +5493,6 @@ async fn json_rpc_app_state_snapshot_returns_runtime_shape() {
         Some(true),
         "expected chatOnboardingCompleted=true from test config: {body}"
     );
-    // #1299 — Meet auto-orchestrator handoff is the privacy gate that
-    // controls whether ending a Meet call hands the transcript to the
-    // orchestrator agent. Default is OFF on a fresh config so meeting
-    // notes never auto-broadcast to Slack #general etc. without consent.
-    assert_eq!(
-        body.get("meetAutoOrchestratorHandoff")
-            .and_then(Value::as_bool),
-        Some(false),
-        "expected meetAutoOrchestratorHandoff=false default: {body}"
-    );
-
     let runtime = body.get("runtime").expect("expected runtime object");
     assert!(
         runtime.get("localAi").and_then(Value::as_object).is_some(),


### PR DESCRIPTION
## What

Removes the `meetAutoOrchestratorHandoff` assertion from
`json_rpc_app_state_snapshot_returns_runtime_shape` in `tests/json_rpc_e2e.rs`. 11 deletions, tests only.

## Why

`main` is red on `Rust Core Coverage (cargo-llvm-cov)`:

```
thread 'json_rpc_app_state_snapshot_returns_runtime_shape' panicked at tests/json_rpc_e2e.rs:5500:5:
assertion `left == right` failed: expected meetAutoOrchestratorHandoff=false default
  left: None
 right: Some(false)
```

#5674 removed the meetings domain, so the app-state snapshot no longer carries the field, but this assertion still required it. The gate it guarded (#1299 — don't auto-hand a Meet transcript to the orchestrator without consent) no longer has anything to guard: there is no Meet call to end.

This is the third instance of the same drift. #5681 fixed the first two (the `config_*_meet_settings` RPC expectations in `config_auth_app_state_connectivity_e2e.rs` and `domain_modules_e2e.rs`); this one was missed there because it asserts the **snapshot field name**, not the RPC method name, so a `meet_settings` grep did not reach it.

Like the other two, this fails on every PR that merges `main` — it is currently the sole `Rust Core Coverage` failure on #5664, #5667, #5668, #5669 and #5671.

## Not included

`tests/raw_coverage/*.rs` still contain `[meet] auto_orchestrator_handoff = …` blocks in their TOML config fixtures. Those are inert — an unknown config section is ignored, and those tests pass — so they are left alone rather than widening this fix.

## Verification

```
$ git grep -c meetAutoOrchestratorHandoff tests/
0
$ cargo fmt --check      # clean
$ cargo check --features "$(bash scripts/ci/product-features.sh)" --test json_rpc_e2e
Finished `dev` profile in 1m 18s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end coverage to reflect the current runtime state snapshot without asserting a specific default value.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->