### PR TITLE
test: drop the stale '## Memory context' assertion left by the reflection-section removal

### DIFF
--- a/tests/raw_coverage/agent_round26_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/agent_round26_raw_coverage_e2e.rs
@@ -302,7 +302,6 @@ fn prompt_renderers_cover_user_memory_identity_tools_and_subagent_variants() -> 
     assert!(built.contains("## User Memory"));
     assert!(built.contains("projects (last updated 2026-05-28)"));
     assert!(built.contains("round26_tool[alpha|zeta]"));
-    assert!(built.contains("## Memory context"));
     assert!(built.contains("## Available Personalities"));
     assert!(built.contains("Recent context: "));
 


### PR DESCRIPTION
## What

Removes one stale assertion from `prompt_renderers_cover_user_memory_identity_tools_and_subagent_variants` in `tests/raw_coverage/agent_round26_raw_coverage_e2e.rs`:

```rust
assert!(built.contains("## Memory context"));
```

One line, tests only.

## Why

`main` is red on `Rust Core Coverage (cargo-llvm-cov)`:

```
panicked at tests/raw_coverage/agent_round26_raw_coverage_e2e.rs:305:5:
assertion failed: built.contains("## Memory context")
```

`a6749d8e6` ("chore(agent): remove unused ReflectionMemoryContextSection") removed the section that emitted this header, so no built prompt contains it any more:

```
$ git grep -c '## Memory context' src/     # nothing
```

`8237942d6` ("fix(tests): remove reflection context from raw coverage e2e test") was the cleanup for that removal, but it missed this occurrence.

Because it is on `main`, it fails on every PR whose changed-module set reaches this test — it is currently the sole `Rust Core Coverage` failure on #5670, which touches only gateway, i18n, store and utils code and nothing to do with prompt rendering.

## Deliberately NOT changed

Three other tests assert `"[Memory context]"` — a **different string**, bracketed rather than a Markdown heading:

- `tests/raw_coverage/channels_large_round25_raw_coverage_e2e.rs:361`
- `tests/raw_coverage/channels_lark_email_dispatch_round21_raw_coverage_e2e.rs:253`
- `tests/raw_coverage/channels_provider_deep_raw_coverage_e2e.rs:171`

That block is still emitted, by `src/openhuman/agent/harness/memory_context.rs:66`, so those assertions are correct and are left alone. A blanket grep-and-delete on "Memory context" would have removed live coverage.

## Verification

```
$ cargo test --features "$(bash scripts/ci/product-features.sh)" \
    --test raw_coverage_all 'agent_round26_raw_coverage_e2e::' -- --test-threads=1
test agent_round26_raw_coverage_e2e::prompt_renderers_cover_user_memory_identity_tools_and_subagent_variants ... ok
test result: ok. 3 passed; 0 failed; 469 filtered out

$ cargo fmt --check    # clean
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated prompt-rendering checks to reflect the current output format.
  * Continued validation of user memory details, project summaries, and available tool information.
  * No user-facing behavior changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->