### PR TITLE
Read the write-audit health from the log the writer writes to

### DIFF
--- a/src/openhuman/tools/registry/ops.rs
+++ b/src/openhuman/tools/registry/ops.rs
@@ -5,9 +5,9 @@ use serde_json::{json, Map, Value};
 use crate::core::all;
 use crate::core::{ControllerSchema, FieldSchema, TypeSchema};
 use crate::openhuman::config::Config;
+use crate::openhuman::mcp::audit::McpWriteListQuery;
 use crate::openhuman::mcp::server::McpToolSpec;
 use crate::rpc::RpcOutcome;
-use tinymemory_core::store::chunks::store as chunk_store;
 
 use super::providers::capability_provider_diagnostics;
 use super::types::{
@@ -150,18 +150,35 @@ fn mcp_allowlists_from_config(config: &Config) -> McpAllowlistDiagnostics {
     }
 }
 
+/// How many recent writes the audit log is asked for.
+///
+/// The store has no count method, so the probe lists and counts. The value is
+/// therefore a floor: `recent_rows` saturates here rather than reporting a
+/// true total, which is enough for the question this health field answers —
+/// is the audit log receiving writes at all.
+const RECENT_WRITE_SAMPLE: u64 = tinymcp_bus::MAX_LIST_LIMIT;
+
+/// Whether the write-audit log is recording, and roughly how much.
+///
+/// Reads through `mcp::audit`, which is where the writer puts rows. It used to
+/// query the `mcp_writes` table inside the memory engine's chunk database
+/// directly; when the log moved to its own store, that query stayed behind and
+/// began counting a table nothing writes any more — so this reported zero
+/// writes in the last 24 hours on every install, indefinitely, while the log
+/// underneath it was healthy. A diagnostic that cannot fail loudly must at
+/// least read the same place the writer wrote.
 fn mcp_write_audit_health(config: &Config) -> McpWriteAuditHealth {
-    let result = chunk_store::with_connection(config, |conn| {
-        let since_ms = chrono::Utc::now()
-            .timestamp_millis()
-            .saturating_sub(24 * 60 * 60 * 1000);
-        let count: i64 = conn.query_row(
-            "SELECT COUNT(*) FROM mcp_writes WHERE timestamp_ms >= ?1",
-            rusqlite::params![since_ms],
-            |row| row.get::<_, i64>(0),
-        )?;
-        Ok(u64::try_from(count).unwrap_or(0))
-    });
+    let since_ms = chrono::Utc::now()
+        .timestamp_millis()
+        .saturating_sub(24 * 60 * 60 * 1000);
+    let query = McpWriteListQuery {
+        limit: Some(RECENT_WRITE_SAMPLE),
+        offset: None,
+        since_ms: u64::try_from(since_ms).ok(),
+        ..Default::default()
+    };
+    let result =
+        crate::openhuman::mcp::audit::list_writes(config, &query).map(|writes| writes.len() as u64);
 
     match result {
         Ok(count) => McpWriteAuditHealth {

--- a/src/openhuman/tools/registry/ops_tests.rs
+++ b/src/openhuman/tools/registry/ops_tests.rs
@@ -321,6 +321,53 @@ fn capability_provider(
     }
 }
 
+/// The health probe must read the store the writer writes to.
+///
+/// This is the invariant that broke: the audit log moved to its own database
+/// and the probe kept querying the old table inside the memory engine's chunk
+/// store, which nothing writes any more. Nothing failed — it reported zero
+/// writes forever while the log underneath was healthy. Asserting a count
+/// alone would not have caught that (zero is what a quiet install reports
+/// too), so this writes a row first and requires the probe to see it.
+#[cfg(feature = "mcp")]
+#[test]
+fn the_write_audit_probe_reads_the_store_the_writer_wrote_to() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let config = Config {
+        workspace_dir: workspace.path().to_path_buf(),
+        ..Config::default()
+    };
+
+    let before = diagnostics_for_config(&config)
+        .value
+        .mcp_write_audit
+        .recent_rows;
+    assert_eq!(before, Some(0), "a fresh workspace has recorded nothing");
+
+    crate::openhuman::mcp::audit::record_write(
+        &config,
+        crate::openhuman::mcp::audit::NewMcpWriteRecord {
+            timestamp_ms: chrono::Utc::now().timestamp_millis(),
+            client_info: "probe-test".to_string(),
+            tool_name: "memory_write".to_string(),
+            args_summary: serde_json::json!({}),
+            resulting_chunk_id: None,
+            success: true,
+            error_message: None,
+        },
+    )
+    .expect("record a write");
+
+    let after = diagnostics_for_config(&config).value.mcp_write_audit;
+    assert_eq!(
+        after.recent_rows,
+        Some(1),
+        "the probe must see a row the writer just recorded; last_error={:?}",
+        after.last_error
+    );
+    assert!(after.enabled, "the log is enabled when it is readable");
+}
+
 struct EnvRestore {
     key: &'static str,
     previous: Option<std::ffi::OsString>,


### PR DESCRIPTION
## Summary

- The MCP write-audit health probe read a table nothing writes any more, so it reported zero writes in the last 24 hours on every install — as a success, with `last_error: None`.
- Point it at `mcp::audit`, which is where the writer puts rows.
- Removes the last direct use of the memory engine from outside the memory domain (openhuman#5560).

## Problem

The write-audit log moved to its own database, `mcp_audit/mcp_audit.db`, reached through `tinymcp`. The probe in `tools::registry::ops` did not move with it — it kept running

```sql
SELECT COUNT(*) FROM mcp_writes WHERE timestamp_ms >= ?1
```

through `chunk_store::with_connection`, i.e. against the table inside the **memory engine's** chunk database. Nothing has written that table since the move: no `INSERT INTO mcp_writes` remains anywhere in `src/` or the vendored tree.

The failure mode is the awkward one. The query succeeds, so `McpWriteAuditHealth` comes back `enabled: true`, `recent_rows: Some(0)`, `last_error: None` — a confident answer from a table nobody writes. Nothing downstream can distinguish that from a quiet install, which is why it went unnoticed.

## Solution

Read through the `mcp::audit` facade, the same surface the writer uses. No `#[cfg]` at the call site: `tools::registry::ops` is ungated and `list_writes` is `mcp`-gated, but the facade's `stub.rs` mirrors it returning empty — the case that facade exists for.

Two decisions worth flagging:

**`recent_rows` is now a floor, not a total.** `AuditStore` exposes `record` and `list` but no count, so the probe lists and counts, saturating at the store's own list limit. That answers the question this field is for — *is the log receiving writes at all* — and the alternative is adding `count_since` to a vendored crate, cutting a release, and re-pinning the submodule for a health probe that does not need exactness. The cap is a named constant and documented as a floor rather than left implicit.

**The test records a write and requires the probe to see it**, instead of asserting a number. Asserting a count would not have caught this bug: the broken probe returned zero, and zero is also what a healthy install with no recent writes returns. Mutation-checked — reinstating the old query fails it with `left: Some(0)`, `right: Some(1)`.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `the_write_audit_probe_reads_the_store_the_writer_wrote_to` covers the empty-workspace case and the record-then-read case; the failure path it guards is the one this PR fixes, verified by reinstating the old query.
- [x] **Diff coverage ≥ 80%** — the changed lines are the probe body and its test; both execute in the new test.
- [x] Coverage matrix updated — `N/A: behaviour-only change`, no feature row added, removed or renamed.
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature rows affected`.
- [x] No new external network dependencies introduced — reads a local SQLite store.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: diagnostics field only, no release-cut surface`.
- [x] Linked issue — see `## Related`.

## Impact

Diagnostics only; no runtime, migration or compatibility implications. `McpWriteAuditHealth.recent_rows` starts reporting real values instead of a constant zero, and saturates at the audit store's list limit for very busy installs.

Rows written before the log moved stay in the old table and are not counted. That is deliberate and matches what `mcp/audit` already documents — an audit log is history, and nothing reads the old table any more.

## Related

Part of #5560. Not closing it: this removes the last non-memory caller of `chunk_store::with_connection`, leaving the remaining direct engine uses inside `memory/tree/`, which is the larger half of that issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected MCP write-audit health reporting so recent writes are detected from the active audit log.
  * Health diagnostics now distinguish between a healthy audit log with no activity and one containing recent writes.

* **Tests**
  * Added coverage verifying that recorded MCP writes appear in health diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->