### PR TITLE
fix(mcp): resolve connected-tool lookups by workspace, not the process default

### DIFF
--- a/src/openhuman/mcp/registry/mod.rs
+++ b/src/openhuman/mcp/registry/mod.rs
@@ -88,6 +88,35 @@ pub mod connections {
         }
     }
 
+    /// Every tool on every connected server in `config`'s workspace.
+    ///
+    /// The counterpart to [`all_connected_tools`] for a caller that holds a
+    /// `Config`. It resolves through [`host::for_config`], which is keyed by
+    /// workspace, rather than through the process-wide default — so it answers
+    /// about the workspace the caller named instead of whichever one
+    /// `mcp::init` happened to claim first.
+    ///
+    /// That distinction is invisible in the shipped app, which opens one
+    /// workspace, and decisive in a test binary: `resolve` hands back a lone
+    /// host but returns `None` once a second one exists, so an ambient lookup
+    /// silently reports nothing connected as soon as two tests each open their
+    /// own temporary workspace in one process.
+    ///
+    /// A host that cannot be opened yields an empty list rather than an error:
+    /// the callers fold this into a tool list, and MCP being unavailable must
+    /// not fail the listing.
+    pub async fn all_connected_tools_for_config(
+        config: &Config,
+    ) -> Vec<(String, String, tinymcp_bus::McpTool)> {
+        match host::for_config(config) {
+            Ok(service) => service.dynamic().connections().all_connected_tools().await,
+            Err(error) => {
+                tracing::debug!(?error, "[mcp] no host for workspace; reporting no tools");
+                Vec::new()
+            }
+        }
+    }
+
     /// Every tool on every connected server, paired with its server.
     pub async fn all_connected_tools() -> Vec<(String, String, tinymcp_bus::McpTool)> {
         match host::try_service() {

--- a/src/openhuman/mcp/registry/mod.rs
+++ b/src/openhuman/mcp/registry/mod.rs
@@ -73,6 +73,7 @@ pub use types::{ConnStatus, InstalledServer, McpTool};
 /// completes should see.
 #[cfg(feature = "mcp")]
 pub mod connections {
+    use crate::openhuman::config::Config;
     pub use tinymcp_bus::ConnectedServerOverview;
 
     use crate::openhuman::mcp::host;

--- a/src/openhuman/mcp/registry/mod.rs
+++ b/src/openhuman/mcp/registry/mod.rs
@@ -201,6 +201,24 @@ pub mod connections {
         }
     }
 
+    /// Drop a connection held in `config`'s workspace.
+    ///
+    /// The counterpart to [`disconnect`] for a caller that holds a `Config`,
+    /// for the same reason [`all_connected_tools_for_config`] exists: the
+    /// by-server-id form resolves through the process default, which stops
+    /// answering once a second workspace is open. A caller that connected
+    /// through [`connect`] already named a workspace and should close over the
+    /// same one.
+    pub async fn disconnect_for_config(config: &Config, server_id: &str) -> bool {
+        match host::for_config(config) {
+            Ok(service) => service.dynamic().connections().disconnect(server_id).await,
+            Err(error) => {
+                tracing::debug!(?error, "[mcp] no host for workspace; nothing to disconnect");
+                false
+            }
+        }
+    }
+
     /// The most recent failure message for a server.
     pub async fn last_error_for(server_id: &str) -> Option<String> {
         host::try_service()?

--- a/src/openhuman/mcp/registry/stub.rs
+++ b/src/openhuman/mcp/registry/stub.rs
@@ -103,6 +103,8 @@ pub mod oauth {
 
 /// Global in-process registry of connected MCP servers.
 pub mod connections {
+    use crate::openhuman::config::Config;
+
     /// Re-exported from the ungated `types` module — the SAME type the enabled
     /// build uses, not a mirrored copy, so the orchestrator prompt builder's
     /// field access can never drift between builds.

--- a/src/openhuman/mcp/registry/stub.rs
+++ b/src/openhuman/mcp/registry/stub.rs
@@ -124,4 +124,10 @@ pub mod connections {
     pub async fn all_connected_tools() -> Vec<(String, String, McpTool)> {
         Vec::new()
     }
+
+    /// Empty, for the same reason as [`all_connected_tools`]. The workspace the
+    /// caller names changes nothing when the registry is compiled out.
+    pub async fn all_connected_tools_for_config(_config: &Config) -> Vec<(String, String, McpTool)> {
+        Vec::new()
+    }
 }

--- a/src/openhuman/mcp/registry/stub.rs
+++ b/src/openhuman/mcp/registry/stub.rs
@@ -127,7 +127,9 @@ pub mod connections {
 
     /// Empty, for the same reason as [`all_connected_tools`]. The workspace the
     /// caller names changes nothing when the registry is compiled out.
-    pub async fn all_connected_tools_for_config(_config: &Config) -> Vec<(String, String, McpTool)> {
+    pub async fn all_connected_tools_for_config(
+        _config: &Config,
+    ) -> Vec<(String, String, McpTool)> {
         Vec::new()
     }
 }

--- a/src/openhuman/tools/registry/mod.rs
+++ b/src/openhuman/tools/registry/mod.rs
@@ -6,7 +6,7 @@ mod providers;
 mod schemas;
 mod types;
 
-pub use ops::{get_tool, list_tools, registry_entries};
+pub use ops::{get_tool, list_tools, registry_entries, registry_entries_for_config};
 pub use providers::{
     capability_provider_by_id, capability_provider_diagnostics, capability_provider_registry,
     is_capability_provider_trusted_enabled, list_capability_providers,

--- a/src/openhuman/tools/registry/ops.rs
+++ b/src/openhuman/tools/registry/ops.rs
@@ -51,7 +51,7 @@ pub async fn diagnostics() -> Result<RpcOutcome<ToolPolicyDiagnostics>, String> 
 pub fn diagnostics_for_config(config: &Config) -> RpcOutcome<ToolPolicyDiagnostics> {
     log::debug!("[tool_registry] diagnostics_for_config start");
 
-    let tools = registry_entries();
+    let tools = registry_entries_for_config(config);
     let total_tools = tools.len();
     let enabled_tools = tools.iter().filter(|entry| entry.enabled).count();
     let mcp_stdio_tools = tools
@@ -220,7 +220,30 @@ pub fn get_tool(tool_id: &str) -> Result<RpcOutcome<ToolRegistryEntry>, String> 
 /// 1. MCP stdio server tools (existing `mcp::server` surface)
 /// 2. Controller-backed tools (existing `tools` namespace)
 /// 3. Connected MCP client server tools (new `mcp_clients` domain)
+///
+/// The connected-client tools come from whichever workspace `mcp::init` claimed
+/// as the process default. That is right for the shipped app, which opens one;
+/// a caller that holds a `Config` should prefer
+/// [`registry_entries_for_config`], which names the workspace it means.
 pub fn registry_entries() -> Vec<ToolRegistryEntry> {
+    build_registry_entries(None)
+}
+
+/// The same snapshot, with connected-client tools read from `config`'s
+/// workspace rather than the process default.
+///
+/// The two differ only when more than one workspace is open in a process.
+/// `mcp::host::resolve` returns a lone host but `None` once a second exists, so
+/// the ambient form silently reports nothing connected in a test binary where
+/// several cases each open their own temporary workspace — which is how
+/// `tool_registry_entries_include_connected_mcp_client_tools` came to pass
+/// alone and fail beside its neighbours.
+pub fn registry_entries_for_config(config: &Config) -> Vec<ToolRegistryEntry> {
+    build_registry_entries(Some(config))
+}
+
+/// The shared body. `config` selects the MCP host; everything else is identical.
+fn build_registry_entries(config: Option<&Config>) -> Vec<ToolRegistryEntry> {
     let mut entries = BTreeMap::new();
 
     for spec in crate::openhuman::mcp::server::tool_specs() {
@@ -245,7 +268,14 @@ pub fn registry_entries() -> Vec<ToolRegistryEntry> {
                 // (kind = CurrentThread) panics on block_in_place.
                 if handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread {
                     tokio::task::block_in_place(|| {
-                        handle.block_on(connections::all_connected_tools())
+                        handle.block_on(async {
+                            match config {
+                                Some(config) => {
+                                    connections::all_connected_tools_for_config(config).await
+                                }
+                                None => connections::all_connected_tools().await,
+                            }
+                        })
                     })
                 } else {
                     Vec::new()

--- a/tests/raw_coverage/tool_registry_approval_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/tool_registry_approval_raw_coverage_e2e.rs
@@ -673,7 +673,7 @@ async fn tool_registry_entries_include_connected_mcp_client_tools() {
     // but `None` once another case in this binary has opened a second one — so
     // the ambient form reports nothing connected here purely because of who
     // else ran first.
-    let entries = registry_entries_for_config(&config);
+    let entries = registry_entries_for_config(&other_config);
     let client_entry = entries
         .iter()
         .find(|entry| entry.tool_id == format!("mcp-client::{}::echo", server.server_id))

--- a/tests/raw_coverage/tool_registry_approval_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/tool_registry_approval_raw_coverage_e2e.rs
@@ -654,6 +654,19 @@ async fn tool_registry_entries_include_connected_mcp_client_tools() {
         .expect("connect test mcp server");
     assert_eq!(tools.first().map(|tool| tool.name.as_str()), Some("echo"));
 
+    // A second workspace, so that scoping is what the assertions below测 test.
+    // With one workspace open, `registry_entries()` and the config-scoped form
+    // agree, and this case would keep passing if the forwarding regressed.
+    let other_tmp = tempdir().expect("second tempdir");
+    let other_config = Config {
+        workspace_dir: other_tmp.path().to_path_buf(),
+        ..Config::default()
+    };
+    let other_server = test_mcp_server();
+    connections::connect(&other_config, &other_server)
+        .await
+        .expect("connect second test mcp server");
+
     // Config-scoped, not ambient: this case connects through
     // `host::for_config(&config)`, keyed by its own tempdir. `registry_entries()`
     // resolves through the process default instead, which returns a lone host
@@ -670,10 +683,29 @@ async fn tool_registry_entries_include_connected_mcp_client_tools() {
     assert_eq!(client_entry.route["server_id"], json!(server.server_id));
     assert!(client_entry.tags.iter().any(|tag| tag == "mcp_client"));
 
+    // The other workspace's server must NOT leak in. This is the assertion that
+    // fails if a config-scoped lookup falls back to the process default.
+    assert!(
+        !entries.iter().any(
+            |entry| entry.tool_id == format!("mcp-client::{}::echo", other_server.server_id)
+        ),
+        "entries for one workspace must not include another workspace's server"
+    );
+
+    // Symmetrically, from the second workspace's side.
+    let other_entries = registry_entries_for_config(&other_config);
+    assert!(other_entries
+        .iter()
+        .any(|entry| entry.tool_id == format!("mcp-client::{}::echo", other_server.server_id)));
+    assert!(!other_entries
+        .iter()
+        .any(|entry| entry.tool_id == format!("mcp-client::{}::echo", server.server_id)));
+
     // Config-scoped for the same reason as the lookup above: this connection
     // lives in the host keyed by `config`'s workspace, and the by-id form
     // resolves through the process default.
     assert!(connections::disconnect_for_config(&config, &server.server_id).await);
+    assert!(connections::disconnect_for_config(&other_config, &other_server.server_id).await);
 }
 
 #[tokio::test]

--- a/tests/raw_coverage/tool_registry_approval_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/tool_registry_approval_raw_coverage_e2e.rs
@@ -37,7 +37,7 @@ use openhuman_core::openhuman::tools::registry::{
     all_tool_registry_controller_schemas, all_tool_registry_registered_controllers,
     capability_provider_by_id, capability_provider_diagnostics, capability_provider_registry,
     denials, get_tool, is_capability_provider_trusted_enabled, list_capability_providers,
-    list_tools, normalize_capability_provider_id, registry_entries,
+    list_tools, normalize_capability_provider_id, registry_entries, registry_entries_for_config,
     CapabilityProviderRegistryError,
 };
 
@@ -654,7 +654,13 @@ async fn tool_registry_entries_include_connected_mcp_client_tools() {
         .expect("connect test mcp server");
     assert_eq!(tools.first().map(|tool| tool.name.as_str()), Some("echo"));
 
-    let entries = registry_entries();
+    // Config-scoped, not ambient: this case connects through
+    // `host::for_config(&config)`, keyed by its own tempdir. `registry_entries()`
+    // resolves through the process default instead, which returns a lone host
+    // but `None` once another case in this binary has opened a second one — so
+    // the ambient form reports nothing connected here purely because of who
+    // else ran first.
+    let entries = registry_entries_for_config(&config);
     let client_entry = entries
         .iter()
         .find(|entry| entry.tool_id == format!("mcp-client::{}::echo", server.server_id))

--- a/tests/raw_coverage/tool_registry_approval_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/tool_registry_approval_raw_coverage_e2e.rs
@@ -673,7 +673,7 @@ async fn tool_registry_entries_include_connected_mcp_client_tools() {
     // but `None` once another case in this binary has opened a second one — so
     // the ambient form reports nothing connected here purely because of who
     // else ran first.
-    let entries = registry_entries_for_config(&other_config);
+    let entries = registry_entries_for_config(&config);
     let client_entry = entries
         .iter()
         .find(|entry| entry.tool_id == format!("mcp-client::{}::echo", server.server_id))

--- a/tests/raw_coverage/tool_registry_approval_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/tool_registry_approval_raw_coverage_e2e.rs
@@ -670,7 +670,10 @@ async fn tool_registry_entries_include_connected_mcp_client_tools() {
     assert_eq!(client_entry.route["server_id"], json!(server.server_id));
     assert!(client_entry.tags.iter().any(|tag| tag == "mcp_client"));
 
-    assert!(connections::disconnect(&server.server_id).await);
+    // Config-scoped for the same reason as the lookup above: this connection
+    // lives in the host keyed by `config`'s workspace, and the by-id form
+    // resolves through the process default.
+    assert!(connections::disconnect_for_config(&config, &server.server_id).await);
 }
 
 #[tokio::test]

--- a/tests/raw_coverage/tool_registry_approval_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/tool_registry_approval_raw_coverage_e2e.rs
@@ -654,9 +654,9 @@ async fn tool_registry_entries_include_connected_mcp_client_tools() {
         .expect("connect test mcp server");
     assert_eq!(tools.first().map(|tool| tool.name.as_str()), Some("echo"));
 
-    // A second workspace, so that scoping is what the assertions below测 test.
-    // With one workspace open, `registry_entries()` and the config-scoped form
-    // agree, and this case would keep passing if the forwarding regressed.
+    // A second workspace, so that scoping is what the assertions below actually
+    // test. With one workspace open, `registry_entries()` and the config-scoped
+    // form agree, and this case would keep passing if the forwarding regressed.
     let other_tmp = tempdir().expect("second tempdir");
     let other_config = Config {
         workspace_dir: other_tmp.path().to_path_buf(),


### PR DESCRIPTION
## What

Adds a config-scoped counterpart to three MCP lookups that resolve through the process-wide default workspace, and points `diagnostics_for_config` and one test at them.

| Added | Existing ambient form |
| --- | --- |
| `connections::all_connected_tools_for_config(&Config)` | `all_connected_tools()` |
| `connections::disconnect_for_config(&Config, &str)` | `disconnect(&str)` |
| `tools::registry::registry_entries_for_config(&Config)` | `registry_entries()` |

No new concept — this is the `diagnostics()` / `diagnostics_for_config()` pair already in `tools/registry/ops.rs`, extended to the calls underneath it. `registry_entries()` and `registry_entries_for_config()` share one body.

## Why

`registry_entries()` reaches connected MCP tools through `connections::all_connected_tools()` then `host::try_service()`, which has no `Config` and resolves via `resolve(DEFAULT_WORKSPACE, &hosts)` in `src/openhuman/mcp/host.rs`. That returns a host when the process default matches **or when exactly one is open**, and `None` otherwise.

That is correct for the shipped app, which opens one workspace and sets the default in `mcp::init`. It does not survive `raw_coverage_all`, which globs every `tests/raw_coverage/*.rs` into a single process: once two cases have each opened their own `tempdir()` workspace through `host::for_config`, the ambient lookup resolves to `None` and reports nothing connected.

`tool_registry_entries_include_connected_mcp_client_tools` connects with `connections::connect(&config, &server)` — which already names a workspace via `for_config` — and then read back ambiently. It passed alone and failed beside its neighbours:

```
test result: FAILED. 11 passed; 1 failed
panicked at tool_registry_approval_raw_coverage_e2e.rs:661: connected mcp client entry
```

**Production semantics are unchanged.** `list_tools()` and `get_tool()` genuinely hold no `Config` and keep resolving ambiently, and in a one-workspace process the two forms agree.

## Also fixed

`diagnostics_for_config(config)` was calling the **ambient** `registry_entries()` — a config-scoped function reading a process-global registry. It now uses the config-scoped form, which is what its name already promised.

## How this surfaced

`Rust Core Coverage` is a **changed-modules-only** lane: it derives its target list from the diff, so a raw-coverage target nothing selects is never compiled or run. #5688 touched `src/openhuman/tools/` and `src/openhuman/memory/`, which selected two targets that had rotted unnoticed — this one, and a `raw_coverage_all` that would not compile at all (fixed in that PR).

That gap is worth a separate look: a broken raw-coverage target can sit green on `main` indefinitely until some PR happens to touch the right module.

## Verification

- `cargo test --features "$(bash scripts/ci/product-features.sh)" --no-default-features --test raw_coverage_all -- tool_registry_approval_raw_coverage_e2e:: --test-threads=1` — **12 passed, 0 failed**, the exact filter CI ran.
- `cargo check --no-default-features` — clean. This caught a real stub drift: `stub.rs`'s `connections` module referenced `Config` without importing it, invisible in the enabled build.
- `cargo fmt --check` — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added workspace-specific tool registry lookups for more accurate tool availability.
  - MCP tools and connection controls now operate within the selected workspace configuration.
  - Added support for listing and disconnecting workspace-specific MCP connections.

- **Bug Fixes**
  - Prevented MCP tools from appearing across the wrong workspace.
  - Improved handling when a workspace’s MCP host is unavailable.
  - Ensured tool discovery remains consistent whether MCP support is enabled or disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->