### PR TITLE
fix(flows): initialize execution step transcripts

### DIFF
--- a/src/openhuman/flows/ops_tests.rs
+++ b/src/openhuman/flows/ops_tests.rs
@@ -3205,6 +3205,7 @@ async fn observer_persists_each_step_incrementally() {
         output: json!([{ "json": { "ok": true } }]),
         duration_ms: 7,
         diagnostics: Vec::new(),
+        transcript: Vec::new(),
     });
     observer.on_step_finish(&ExecutionStep {
         node_id: "b".to_string(),
@@ -3212,6 +3213,7 @@ async fn observer_persists_each_step_incrementally() {
         output: Value::Null,
         duration_ms: 3,
         diagnostics: Vec::new(),
+        transcript: Vec::new(),
     });
 
     // The store now holds both live steps with real status + timing — proof of
@@ -3232,6 +3234,7 @@ async fn observer_persists_each_step_incrementally() {
         output: json!([{ "json": { "ok": true } }]),
         duration_ms: 42,
         diagnostics: Vec::new(),
+        transcript: Vec::new(),
     });
     let row = store::get_flow_run(&config, &run_id).unwrap().unwrap();
     assert_eq!(row.steps.len(), 2, "re-firing a node must not duplicate it");

--- a/src/openhuman/flows/tinyflows/observability.rs
+++ b/src/openhuman/flows/tinyflows/observability.rs
@@ -246,6 +246,7 @@ mod tests {
             output: Value::Null,
             duration_ms: 5,
             diagnostics: Vec::new(),
+            transcript: Vec::new(),
         });
         observer.on_run_finish(&Run {
             id: "run-1".to_string(),


### PR DESCRIPTION
Runs the authoritative CI Full matrix against release.\n\nThis change fixes the Rust Core Coverage compile failure caused by TinyFlows' required `ExecutionStep.transcript` field.\n\nDraft while full unit, Rust E2E, Playwright, and desktop E2E jobs complete.