### PR TITLE
feat(mcp): re-export the two types a downstream classifier needs

### DIFF
--- a/src/openhuman/mcp/mod.rs
+++ b/src/openhuman/mcp/mod.rs
@@ -127,7 +127,6 @@ pub mod server;
 /// neither is gated — so this is not either, exactly as before the extraction.
 pub mod http_client {
     pub use tinymcp::transport::http::{McpHttpClient, McpHttpClientBuilder};
-    pub use tinymcp::{redact_endpoint, render_tool_result};
     /// The transport's error, re-exported so a caller can inspect a failure
     /// structurally rather than by its rendered text.
     ///
@@ -143,6 +142,7 @@ pub mod http_client {
     /// for an in-process consumer, which holds the real error and should not be
     /// reduced to matching on wording that upstream is free to reword.
     pub use tinymcp::Error as McpError;
+    pub use tinymcp::{redact_endpoint, render_tool_result};
     pub use tinymcp_bus::{
         AuthorizationServerMetadata, McpAuthChallenge, McpAuthorizationContext,
         McpInitializeResult, McpRemoteTool, McpServerToolResult, McpSseEvent,

--- a/src/openhuman/mcp/mod.rs
+++ b/src/openhuman/mcp/mod.rs
@@ -128,6 +128,21 @@ pub mod server;
 pub mod http_client {
     pub use tinymcp::transport::http::{McpHttpClient, McpHttpClientBuilder};
     pub use tinymcp::{redact_endpoint, render_tool_result};
+    /// The transport's error, re-exported so a caller can inspect a failure
+    /// structurally rather than by its rendered text.
+    ///
+    /// The variant that motivates it is [`McpError::Unauthorized`], whose
+    /// `resource_metadata` is what separates a server that wants OAuth from one
+    /// that wants a static credential — the difference between offering a sign-in
+    /// path and asking for a token. That field is deliberately absent from the
+    /// message, so a caller wanting it must have the type.
+    ///
+    /// Note this crate's own `core::observability` classifier does **not** use
+    /// it: it reads rendered text, because it classifies failures that have
+    /// already crossed an RPC boundary and arrive as strings. This re-export is
+    /// for an in-process consumer, which holds the real error and should not be
+    /// reduced to matching on wording that upstream is free to reword.
+    pub use tinymcp::Error as McpError;
     pub use tinymcp_bus::{
         AuthorizationServerMetadata, McpAuthChallenge, McpAuthorizationContext,
         McpInitializeResult, McpRemoteTool, McpServerToolResult, McpSseEvent,
@@ -143,4 +158,11 @@ pub mod config_servers {
     pub use tinymcp::{
         McpRegistrySource, McpServerDefinition, McpServerRegistry, McpTransportClient,
     };
+    /// The auth shape a *definition in this registry* carries.
+    ///
+    /// Distinct from `config::McpAuthConfig`, which is the shape this
+    /// application's own TOML declares — the two were one type before the
+    /// extraction. A caller reading `McpServerDefinition::auth` needs this one,
+    /// and without the re-export cannot name it at all.
+    pub use tinymcp_bus::McpAuthConfig as McpDefinitionAuth;
 }


### PR DESCRIPTION
## Summary

Two re-exports. The MCP registry extraction into `tinymcp` moved both of these behind crate boundaries with nothing exposing them, so a downstream host can no longer name either — and both are types it must read rather than infer.

Found while porting opencompany onto current `main` (a two-day, ~2500-commit bump). These were the only two gaps that could not be closed downstream.

### `McpError`

The typed 401 moved from a standalone `McpUnauthorizedError` struct onto `tinymcp::Error::Unauthorized`. opencompany's MCP probe reads `resource_metadata` off it to tell a server that **wants OAuth** from one that **wants a static credential** — the difference between offering a Sign in button and asking for a token.

Nothing re-exported the error, so that classification had no typed path left. The fallback would be matching on the message, which this repo's own doc argues against on that exact variant:

> The status is in the message on purpose. A host classifying errors for its own reporting has only the rendered text to go on when the failure has crossed an RPC boundary […] and misclassifying this one turns preventable user state into an error report, once per retry.

That is a fallback for a string that crossed an RPC boundary, not the primary path for an in-process caller holding the real error.

### `McpDefinitionAuth`

`McpServerDefinition::auth` is `tinymcp_bus::McpAuthConfig`; `config::McpAuthConfig` is the shape this application's own TOML declares. They were **one type before the extraction and are now two with the same name**. Only the second is exported, so a caller reading a definition's auth can construct the wrong one and fail to match — which is what happened.

Exported as `McpDefinitionAuth` rather than shadowing the config name, so the two stay distinguishable at the use site.

## API Or Behavior Changes

Additive. Two `pub use` lines in `src/openhuman/mcp/mod.rs`, beside the wire types that module already carries for the same downstream-namer reason. No behaviour change, no new dependency.

## Tests

No new tests: these are re-exports of types already covered by `tinymcp`'s own suite, and there is no behaviour here to assert. Verified by the consumer — opencompany compiles against this branch and its library suite passes **5103**, where without these two it does not build at all.

- [x] `cargo fmt --check`
- [x] `pnpm rust:check`

## Documentation

Both carry rustdoc explaining what they are for and, in the second case, why it is deliberately *not* named `McpAuthConfig`.

## Why now

It unblocks opencompany's bump onto current openhuman, which is a prerequisite for run observability there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added publicly available MCP error and authentication configuration types.
  * Improved compatibility for integrations using MCP services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->