### PR TITLE
perf(cron): run store schema DDL once per process, not per query

### DIFF
--- a/src/openhuman/cron/store.rs
+++ b/src/openhuman/cron/store.rs
@@ -800,55 +800,77 @@ static INITIALIZED_SCHEMAS: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
 /// schema is re-migrated rather than trusted.
 const CRON_SCHEMA_VERSION: i64 = 1;
 
-/// Runs the one-time schema DDL + migrations against `conn` unless `db_path`
-/// has already been initialized in this process (see [`INITIALIZED_SCHEMAS`]).
-/// Only marks `db_path` as initialized *after* [`init_schema`] succeeds, so a
-/// transient failure is retried on the next call rather than permanently
-/// wedging the store into believing a schema exists that was never created.
+/// Ensures the schema on `conn` (a connection to `db_path`) is present and fully
+/// migrated, running the DDL + migrations at most once per process per path.
 ///
-/// **Trust, but verify.** A cache hit is confirmed against the file actually on
-/// disk before it is honoured. Before this gating existed, the DDL ran on every
+/// **The on-disk `PRAGMA user_version` is the authority, and the fast path is
+/// lock-free.** [`init_schema`] stamps [`CRON_SCHEMA_VERSION`] only after a full,
+/// successful migration, so a connection whose `user_version` already matches is
+/// known-good and returns without touching any process-global state — the common
+/// case (an already-initialized store) never acquires the initialization mutex.
+/// Reading `user_version` is a single database-header read, far cheaper than the
+/// 8-statement DDL batch + 11 metadata scans it replaces.
+///
+/// **Initialization is serialized and atomic per process.** Only a version
+/// *mismatch* takes the [`INITIALIZED_SCHEMAS`] lock, and `user_version` is
+/// re-read under it, so two first callers racing on the same fresh path run the
+/// DDL exactly once — the loser observes the winner's stamp on the recheck and
+/// returns (CodeRabbit: initialization must be atomic per path). Independent db
+/// paths contend only during that rare init window, never on the hot path.
+///
+/// **Trust, but verify.** Before this gating existed the DDL ran on every
 /// `with_connection` call, so a database deleted or replaced at runtime (a
 /// workspace reset, a manual deletion, a disk-recovery restore) self-healed on
-/// the very next call: `Connection::open` silently creates a fresh empty file,
-/// and `CREATE TABLE IF NOT EXISTS` immediately repopulated it. Caching removes
-/// that safety net, so one indexed `sqlite_master` lookup — far cheaper than the
-/// 8-statement DDL batch + 11 metadata scans — is paid on each hit to restore
-/// the self-healing rather than trusting a cache entry the filesystem may have
-/// invalidated.
+/// the next call. The version gate restores that: a stale/zero `user_version` —
+/// a fresh file, or an older/partial schema swapped in under a live process
+/// (`cron_jobs` present but missing a migrated column such as
+/// `agent_id`/`profile_id`, or the `cron_runs` table) — falls through to the
+/// idempotent [`init_schema`] and is re-migrated rather than trusted and later
+/// failing with `no such column` (CodeRabbit / Codex review on #5708).
+///
+/// [`INITIALIZED_SCHEMAS`] no longer gates the DDL — the on-disk version does —
+/// and is kept purely as a **diagnostic marker**: a path present in the set
+/// whose on-disk version no longer matches was initialized by *this* process and
+/// has since been deleted or replaced, which is worth a warning; a path absent
+/// from the set is an ordinary first-ever init and stays silent.
 fn ensure_schema_initialized(conn: &Connection, db_path: &Path) -> Result<()> {
+    let is_current = || -> bool {
+        conn.query_row("PRAGMA user_version", [], |row| row.get::<_, i64>(0))
+            .unwrap_or(0)
+            == CRON_SCHEMA_VERSION
+    };
+
+    // Lock-free fast path: an already-migrated database carries
+    // CRON_SCHEMA_VERSION in its header, so the common case never acquires the
+    // process-global initialization mutex.
+    if is_current() {
+        return Ok(());
+    }
+
+    // Mismatch ⇒ (re-)initialization is required. Serialize it so two first
+    // callers for the same path cannot both run the DDL, and re-read the version
+    // under the lock — another thread may have migrated between the lock-free
+    // read above and acquiring the guard.
     let initialized = INITIALIZED_SCHEMAS.get_or_init(|| Mutex::new(HashSet::new()));
-    // Hold the guard across the verify *and* `init_schema`, so two first callers
-    // for the same path cannot both observe a miss and both run the DDL
-    // (CodeRabbit: initialization must be atomic per path). On a cache hit the
-    // critical section is a single `PRAGMA user_version` read; on a miss it also
-    // covers the one-time init + insert.
     let mut guard = initialized
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if is_current() {
+        return Ok(());
+    }
+
+    // Diagnostic only (see the doc comment): a cached path whose on-disk schema
+    // no longer matches was deleted or replaced under a live process — a
+    // first-ever init leaves the path absent and stays silent.
     if guard.contains(db_path) {
-        // Trust, but verify — against the *whole* schema, not just one table.
-        // `user_version` is stamped only after a full `init_schema` succeeds, so
-        // a database deleted (fresh file ⇒ version 0) or replaced at runtime
-        // with an older/partial schema — `cron_jobs` present but missing a
-        // migrated column such as `agent_id`/`profile_id`, or the `cron_runs`
-        // table ⇒ a stale version — fails this check and is re-migrated, rather
-        // than being trusted and later failing with `no such column`
-        // (CodeRabbit / Codex review on #5708).
-        let version: i64 = conn
-            .query_row("PRAGMA user_version", [], |row| row.get(0))
-            .unwrap_or(0);
-        if version == CRON_SCHEMA_VERSION {
-            return Ok(());
-        }
         tracing::warn!(
             target: "cron",
             db = %db_path.display(),
-            cached_version = version,
             expected_version = CRON_SCHEMA_VERSION,
-            "[cron] schema cached as initialized but the database's user_version does not match (deleted or replaced at runtime?) — re-running schema init"
+            "[cron] a database this process already initialized no longer matches the expected schema version (deleted or replaced at runtime?) — re-running schema init"
         );
     }
+
     init_schema(conn)?;
     guard.insert(db_path.to_path_buf());
     Ok(())

--- a/src/openhuman/cron/store.rs
+++ b/src/openhuman/cron/store.rs
@@ -6,6 +6,9 @@ use crate::openhuman::cron::{
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use rusqlite::{params, Connection};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
 use uuid::Uuid;
 
 const MAX_CRON_OUTPUT_BYTES: usize = 16 * 1024;
@@ -766,19 +769,90 @@ fn add_column_if_missing(conn: &Connection, name: &str, sql_type: &str) -> Resul
     }
 }
 
-fn with_connection<T>(config: &Config, f: impl FnOnce(&Connection) -> Result<T>) -> Result<T> {
-    let db_path = config.workspace_dir.join("cron").join("jobs.db");
-    if let Some(parent) = db_path.parent() {
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create cron directory: {}", parent.display()))?;
+/// Tracks which cron database files have already had their schema DDL (the
+/// `CREATE TABLE`/`CREATE INDEX` batch plus the `add_column_if_missing`
+/// migration probes) run against them in this process. `with_connection`
+/// deliberately keeps opening a fresh `rusqlite::Connection` per call —
+/// `Connection` is `!Sync`, so caching a single shared one would need a
+/// process-wide mutex that serializes every caller. What repeats needlessly on
+/// every open is the DDL batch itself: 8 statements plus 11
+/// `PRAGMA table_info(cron_jobs)` scans, paid before every one of the 16 store
+/// ops (`due_jobs` every scheduler tick, `record_run` /
+/// `reschedule_after_run` / `record_last_run` per executed job, every
+/// RPC-driven `list_jobs` / `get_job`, …). Gating just that batch behind a
+/// per-path "already initialized" set keeps it to one execution per process per
+/// database file while every call still gets its own connection.
+///
+/// This mirrors `flows::store`'s `INITIALIZED_SCHEMAS` (R-m8), which was itself
+/// derived from this store's `with_connection` idiom — bringing the accepted
+/// gating back to the store it was copied from.
+///
+/// Keyed by path rather than a single flag: tests each open an independent
+/// per-`TempDir` workspace within the same test binary, and a bare
+/// `OnceLock<()>` would silently skip schema creation for every database path
+/// after the first test to run in the process.
+static INITIALIZED_SCHEMAS: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
+
+/// Runs the one-time schema DDL + migrations against `conn` unless `db_path`
+/// has already been initialized in this process (see [`INITIALIZED_SCHEMAS`]).
+/// Only marks `db_path` as initialized *after* [`init_schema`] succeeds, so a
+/// transient failure is retried on the next call rather than permanently
+/// wedging the store into believing a schema exists that was never created.
+///
+/// **Trust, but verify.** A cache hit is confirmed against the file actually on
+/// disk before it is honoured. Before this gating existed, the DDL ran on every
+/// `with_connection` call, so a database deleted or replaced at runtime (a
+/// workspace reset, a manual deletion, a disk-recovery restore) self-healed on
+/// the very next call: `Connection::open` silently creates a fresh empty file,
+/// and `CREATE TABLE IF NOT EXISTS` immediately repopulated it. Caching removes
+/// that safety net, so one indexed `sqlite_master` lookup — far cheaper than the
+/// 8-statement DDL batch + 11 metadata scans — is paid on each hit to restore
+/// the self-healing rather than trusting a cache entry the filesystem may have
+/// invalidated.
+fn ensure_schema_initialized(conn: &Connection, db_path: &Path) -> Result<()> {
+    use rusqlite::OptionalExtension;
+
+    let initialized = INITIALIZED_SCHEMAS.get_or_init(|| Mutex::new(HashSet::new()));
+    {
+        let guard = initialized
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if guard.contains(db_path) {
+            let schema_present: bool = conn
+                .query_row(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'cron_jobs'",
+                    [],
+                    |_| Ok(true),
+                )
+                .optional()
+                .context("Failed to probe cron schema presence")?
+                .unwrap_or(false);
+            if schema_present {
+                return Ok(());
+            }
+            tracing::warn!(
+                target: "cron",
+                db = %db_path.display(),
+                "[cron] schema cached as initialized but the database has no tables (deleted or replaced at runtime?) — re-running schema init"
+            );
+        }
     }
+    init_schema(conn)?;
+    let mut guard = initialized
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    guard.insert(db_path.to_path_buf());
+    Ok(())
+}
 
-    let conn = Connection::open(&db_path)
-        .with_context(|| format!("Failed to open cron DB: {}", db_path.display()))?;
-
+/// The actual schema DDL + post-hoc column migrations, split out of
+/// `with_connection` so [`ensure_schema_initialized`] can gate it. Does **not**
+/// carry `PRAGMA foreign_keys = ON`: that is a per-connection setting (it is not
+/// persisted in the database file) and must be reapplied on every open, so it
+/// lives in `with_connection` outside this gate.
+fn init_schema(conn: &Connection) -> Result<()> {
     conn.execute_batch(
-        "PRAGMA foreign_keys = ON;
-         CREATE TABLE IF NOT EXISTS cron_jobs (
+        "CREATE TABLE IF NOT EXISTS cron_jobs (
             id               TEXT PRIMARY KEY,
             expression       TEXT NOT NULL,
             command          TEXT NOT NULL,
@@ -826,17 +900,39 @@ fn with_connection<T>(config: &Config, f: impl FnOnce(&Connection) -> Result<T>)
     )
     .context("Failed to initialize cron schema")?;
 
-    add_column_if_missing(&conn, "schedule", "TEXT")?;
-    add_column_if_missing(&conn, "job_type", "TEXT NOT NULL DEFAULT 'shell'")?;
-    add_column_if_missing(&conn, "prompt", "TEXT")?;
-    add_column_if_missing(&conn, "name", "TEXT")?;
-    add_column_if_missing(&conn, "session_target", "TEXT NOT NULL DEFAULT 'isolated'")?;
-    add_column_if_missing(&conn, "model", "TEXT")?;
-    add_column_if_missing(&conn, "enabled", "INTEGER NOT NULL DEFAULT 1")?;
-    add_column_if_missing(&conn, "delivery", "TEXT")?;
-    add_column_if_missing(&conn, "delete_after_run", "INTEGER NOT NULL DEFAULT 0")?;
-    add_column_if_missing(&conn, "agent_id", "TEXT")?;
-    add_column_if_missing(&conn, "profile_id", "TEXT")?;
+    add_column_if_missing(conn, "schedule", "TEXT")?;
+    add_column_if_missing(conn, "job_type", "TEXT NOT NULL DEFAULT 'shell'")?;
+    add_column_if_missing(conn, "prompt", "TEXT")?;
+    add_column_if_missing(conn, "name", "TEXT")?;
+    add_column_if_missing(conn, "session_target", "TEXT NOT NULL DEFAULT 'isolated'")?;
+    add_column_if_missing(conn, "model", "TEXT")?;
+    add_column_if_missing(conn, "enabled", "INTEGER NOT NULL DEFAULT 1")?;
+    add_column_if_missing(conn, "delivery", "TEXT")?;
+    add_column_if_missing(conn, "delete_after_run", "INTEGER NOT NULL DEFAULT 0")?;
+    add_column_if_missing(conn, "agent_id", "TEXT")?;
+    add_column_if_missing(conn, "profile_id", "TEXT")?;
+
+    Ok(())
+}
+
+fn with_connection<T>(config: &Config, f: impl FnOnce(&Connection) -> Result<T>) -> Result<T> {
+    let db_path = config.workspace_dir.join("cron").join("jobs.db");
+    if let Some(parent) = db_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create cron directory: {}", parent.display()))?;
+    }
+
+    let conn = Connection::open(&db_path)
+        .with_context(|| format!("Failed to open cron DB: {}", db_path.display()))?;
+
+    // Per-connection pragma: `foreign_keys` is NOT persisted in the database
+    // file, so it must be reapplied on every open regardless of the schema-init
+    // cache below — it is required on every connection for the `cron_runs`
+    // `ON DELETE CASCADE` FK to be enforced.
+    conn.execute_batch("PRAGMA foreign_keys = ON;")
+        .context("Failed to set cron DB connection pragmas")?;
+
+    ensure_schema_initialized(&conn, &db_path)?;
 
     f(&conn)
 }

--- a/src/openhuman/cron/store.rs
+++ b/src/openhuman/cron/store.rs
@@ -793,6 +793,13 @@ fn add_column_if_missing(conn: &Connection, name: &str, sql_type: &str) -> Resul
 /// after the first test to run in the process.
 static INITIALIZED_SCHEMAS: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
 
+/// On-disk schema version stamped into `PRAGMA user_version` by [`init_schema`]
+/// and checked by [`ensure_schema_initialized`] on a cache hit. **Bump this
+/// whenever a table or `add_column_if_missing` migration is added to
+/// [`init_schema`]** so a database replaced at runtime with an older/partial
+/// schema is re-migrated rather than trusted.
+const CRON_SCHEMA_VERSION: i64 = 1;
+
 /// Runs the one-time schema DDL + migrations against `conn` unless `db_path`
 /// has already been initialized in this process (see [`INITIALIZED_SCHEMAS`]).
 /// Only marks `db_path` as initialized *after* [`init_schema`] succeeds, so a
@@ -810,37 +817,39 @@ static INITIALIZED_SCHEMAS: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
 /// the self-healing rather than trusting a cache entry the filesystem may have
 /// invalidated.
 fn ensure_schema_initialized(conn: &Connection, db_path: &Path) -> Result<()> {
-    use rusqlite::OptionalExtension;
-
     let initialized = INITIALIZED_SCHEMAS.get_or_init(|| Mutex::new(HashSet::new()));
-    {
-        let guard = initialized
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if guard.contains(db_path) {
-            let schema_present: bool = conn
-                .query_row(
-                    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'cron_jobs'",
-                    [],
-                    |_| Ok(true),
-                )
-                .optional()
-                .context("Failed to probe cron schema presence")?
-                .unwrap_or(false);
-            if schema_present {
-                return Ok(());
-            }
-            tracing::warn!(
-                target: "cron",
-                db = %db_path.display(),
-                "[cron] schema cached as initialized but the database has no tables (deleted or replaced at runtime?) — re-running schema init"
-            );
-        }
-    }
-    init_schema(conn)?;
+    // Hold the guard across the verify *and* `init_schema`, so two first callers
+    // for the same path cannot both observe a miss and both run the DDL
+    // (CodeRabbit: initialization must be atomic per path). On a cache hit the
+    // critical section is a single `PRAGMA user_version` read; on a miss it also
+    // covers the one-time init + insert.
     let mut guard = initialized
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if guard.contains(db_path) {
+        // Trust, but verify — against the *whole* schema, not just one table.
+        // `user_version` is stamped only after a full `init_schema` succeeds, so
+        // a database deleted (fresh file ⇒ version 0) or replaced at runtime
+        // with an older/partial schema — `cron_jobs` present but missing a
+        // migrated column such as `agent_id`/`profile_id`, or the `cron_runs`
+        // table ⇒ a stale version — fails this check and is re-migrated, rather
+        // than being trusted and later failing with `no such column`
+        // (CodeRabbit / Codex review on #5708).
+        let version: i64 = conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap_or(0);
+        if version == CRON_SCHEMA_VERSION {
+            return Ok(());
+        }
+        tracing::warn!(
+            target: "cron",
+            db = %db_path.display(),
+            cached_version = version,
+            expected_version = CRON_SCHEMA_VERSION,
+            "[cron] schema cached as initialized but the database's user_version does not match (deleted or replaced at runtime?) — re-running schema init"
+        );
+    }
+    init_schema(conn)?;
     guard.insert(db_path.to_path_buf());
     Ok(())
 }
@@ -911,6 +920,13 @@ fn init_schema(conn: &Connection) -> Result<()> {
     add_column_if_missing(conn, "delete_after_run", "INTEGER NOT NULL DEFAULT 0")?;
     add_column_if_missing(conn, "agent_id", "TEXT")?;
     add_column_if_missing(conn, "profile_id", "TEXT")?;
+
+    // Stamp the schema version last, so [`ensure_schema_initialized`] only
+    // trusts a cache hit whose on-disk schema is fully migrated. Bump
+    // CRON_SCHEMA_VERSION whenever a table or `add_column_if_missing` migration
+    // is added above.
+    conn.pragma_update(None, "user_version", CRON_SCHEMA_VERSION)
+        .context("Failed to stamp cron schema version")?;
 
     Ok(())
 }

--- a/src/openhuman/cron/store_tests.rs
+++ b/src/openhuman/cron/store_tests.rs
@@ -668,3 +668,48 @@ fn schema_reinitializes_when_the_database_file_is_deleted_at_runtime() {
     );
     assert_eq!(list_jobs(&config).unwrap().len(), 1);
 }
+
+/// Regression (CodeRabbit / Codex on #5708): a cache hit must be validated
+/// against the *whole* schema, not just the presence of one table. A database
+/// replaced at runtime with an older/partial schema — `cron_jobs` present but a
+/// migrated column dropped — must be re-migrated, not trusted and then failed on
+/// the incomplete schema. The `PRAGMA user_version` check is what catches it.
+#[test]
+fn older_on_disk_schema_under_a_cached_path_is_remigrated() {
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    // First use creates the full (versioned) schema and caches the path.
+    let original = add_job(&config, "*/5 * * * *", "echo v1").unwrap();
+
+    // Simulate a workspace restore of an OLDER database swapped in under the
+    // same (already-cached) path: drop a migrated column and clear the version
+    // stamp, exactly as a pre-migration database would look on disk.
+    let db_path = config.workspace_dir.join("cron").join("jobs.db");
+    {
+        let raw = rusqlite::Connection::open(&db_path).unwrap();
+        raw.execute_batch(
+            "ALTER TABLE cron_jobs DROP COLUMN profile_id;
+             PRAGMA user_version = 0;",
+        )
+        .unwrap();
+    }
+
+    // The path is still cached. With a single-table `sqlite_master` probe this
+    // would be trusted and `list_jobs` (which selects `profile_id`) would fail
+    // with `no such column`. The version check detects the drift and re-migrates.
+    let listed = list_jobs(&config)
+        .expect("an older on-disk schema under a cached path must be re-migrated, not trusted");
+    assert_eq!(
+        listed.len(),
+        1,
+        "the pre-existing row survives DROP COLUMN and the schema is repaired"
+    );
+    assert_eq!(listed[0].id, original.id);
+    // The migrated column is back (reads as None for the pre-existing row).
+    assert_eq!(get_job(&config, &original.id).unwrap().profile_id, None);
+
+    // And the store is fully usable again.
+    let recreated = add_job(&config, "*/5 * * * *", "echo v2").unwrap();
+    assert_eq!(get_job(&config, &recreated.id).unwrap().command, "echo v2");
+}

--- a/src/openhuman/cron/store_tests.rs
+++ b/src/openhuman/cron/store_tests.rs
@@ -612,3 +612,59 @@ fn dedup_named_jobs_ignores_unnamed_jobs() {
     assert_eq!(removed, 0);
     assert_eq!(list_jobs(&config).unwrap().len(), 2);
 }
+
+/// Regression: gating the DDL behind a per-path "already initialized" set
+/// (see [`INITIALIZED_SCHEMAS`]) must not cost the store its self-healing.
+///
+/// Before the gate existed, the DDL ran on every `with_connection` call, so a
+/// database deleted or replaced at runtime (a workspace reset, a manual
+/// deletion, a disk-recovery restore) recovered on the very next call —
+/// `Connection::open` creates a fresh empty file and `CREATE TABLE IF NOT
+/// EXISTS` repopulates it. With a naive cache the set still reports
+/// "initialized" while the file behind it is empty, and every query afterwards
+/// fails `no such table: cron_jobs` until the process restarts. This pins the
+/// verify-on-hit in `ensure_schema_initialized` that restores it.
+#[test]
+fn schema_reinitializes_when_the_database_file_is_deleted_at_runtime() {
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    // First use populates the per-path cache and creates the schema.
+    add_job(&config, "*/5 * * * *", "echo before-deletion").unwrap();
+    assert_eq!(
+        list_jobs(&config).unwrap().len(),
+        1,
+        "sanity: the job was persisted"
+    );
+
+    // Simulate a workspace reset / manual deletion while the process lives on.
+    let db_path = config.workspace_dir.join("cron").join("jobs.db");
+    assert!(
+        db_path.exists(),
+        "sanity: the cron db exists before deletion"
+    );
+    std::fs::remove_file(&db_path).unwrap();
+    // Defensive: drop any journal sidecars too, so SQLite cannot resurrect
+    // pages from them (cron uses the default rollback journal, not WAL, so
+    // these normally do not exist between calls — removing them is a no-op).
+    let _ = std::fs::remove_file(db_path.with_extension("db-wal"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-shm"));
+    let _ = std::fs::remove_file(db_path.with_extension("db-journal"));
+
+    // The cache still says this path is initialized. Without the verify-on-hit
+    // this errors with `no such table: cron_jobs`.
+    let after = list_jobs(&config)
+        .expect("a deleted database must be re-initialized, not left wedged at 'no such table'");
+    assert!(
+        after.is_empty(),
+        "the recreated database starts empty — the prior job is genuinely gone"
+    );
+
+    // And the store is fully usable again, not merely readable.
+    let recreated = add_job(&config, "*/5 * * * *", "echo after-deletion").unwrap();
+    assert_eq!(
+        get_job(&config, &recreated.id).unwrap().command,
+        "echo after-deletion"
+    );
+    assert_eq!(list_jobs(&config).unwrap().len(), 1);
+}


### PR DESCRIPTION
## Summary

- `cron::store`'s `with_connection` re-ran the **full schema DDL + all 11 column migrations on every single query**. This closes that drift with `flows::store`, which was *derived from* this exact `with_connection` idiom and later got the fix (`R-m8`) that `cron` never received.
- The DDL batch (8 statements) and the 11 `add_column_if_missing` probes now run **once per process per database file**, gated behind a per-path "already initialized" set — every call still gets its own fresh connection.
- Behaviour-preserving: `PRAGMA foreign_keys = ON` (a per-connection setting) still runs on every open; the self-healing on a deleted/replaced DB is preserved by a verify-on-hit and pinned by a new regression test.

## Review updates (post-open)

CodeRabbit (2× Major) and Codex (P2) reviewed the first commit; both are addressed in `cc7f7626a`, and the design now **supersedes** the `flows::store` precedent rather than merely mirroring it:

- **Complete-schema validation.** The cache-hit verify no longer trusts the presence of one table. `init_schema` stamps `PRAGMA user_version = CRON_SCHEMA_VERSION` after a full migration, and a hit is honoured only when the on-disk version matches — so a runtime-replaced older/partial DB (missing a migrated column such as `agent_id`/`profile_id`, or the `cron_runs` table) is re-migrated, not trusted then failed with `no such column`. This is exactly CodeRabbit's suggestion ("record and validate a schema version").
- **Atomic per-path init.** The `INITIALIZED_SCHEMAS` guard is now held across the verify + `init_schema` + insert, so two first callers for the same path can't both run the DDL.
- New `older_on_disk_schema_under_a_cached_path_is_remigrated` test pins the column-drift case (drops `profile_id`, resets `user_version`, asserts re-migration).

**On the `flows::store` precedent:** `flows::store` still uses the single-table `sqlite_master` probe *and* releases its lock before `init_schema` — i.e. both gaps flagged here are latent there too. Applying the same two fixes to `flows::store` is a sensible follow-up, not bundled here to keep this PR single-concern.

**Known tradeoff:** `CRON_SCHEMA_VERSION` must be bumped whenever a table/migration is added to `init_schema` (documented on the const). A future migration added without bumping it would silently skip drift-detection for older DBs. The alternative — enumerating expected columns on each hit — carries the same discipline with more surface, so `user_version` is the right call.

## Problem

Every one of the 16 store ops funnels through `with_connection`, and before this change each call paid, as pure fixed overhead *before its one real query*:

- `Connection::open` (kept — unavoidable, `Connection` is `!Sync`),
- an `execute_batch` of **8 DDL statements** (2 `CREATE TABLE`, 5 `CREATE INDEX`/partial-unique-index, and — pulled out here — 1 `PRAGMA`),
- **11 `add_column_if_missing` calls**, each of which prepares and runs `PRAGMA table_info(cron_jobs)` and linearly scans all ~17 columns (~187 discarded column comparisons per op).

None of it was gated. The call sites are a steady, process-lifetime load, not one-off startup:

- `due_jobs` — every scheduler tick (`scheduler::tick_once`, `reliability.scheduler_poll_secs`),
- `record_run` + `reschedule_after_run` + `record_last_run` — per executed job,
- `list_jobs` / `get_job` / `add_*` — every RPC-driven cron interaction.

## Solution

Mirror the accepted `flows::store` gating exactly (it documents itself as mirroring `cron::store`'s idiom, so this is bringing the fix home):

- `INITIALIZED_SCHEMAS: OnceLock<Mutex<HashSet<PathBuf>>>` — keyed by db path (not a bare flag) so each test's per-`TempDir` workspace still initializes.
- `init_schema(conn)` — the DDL batch + the 11 migrations, split out of `with_connection`.
- `ensure_schema_initialized(conn, db_path)` — runs `init_schema` on a miss and marks the path only *after* success; on a hit it does one indexed `sqlite_master` lookup to confirm the table is really on disk before trusting the cache (**trust, but verify**), so a DB deleted/replaced at runtime still self-heals instead of wedging at `no such table`.

**Correctness — the one behaviour that must not move:** `PRAGMA foreign_keys = ON` is per-connection (it is *not* persisted in the db file), so it was moved *out* of the gated DDL batch and into `with_connection`, where it still runs on every open — the `cron_runs ON DELETE CASCADE` FK stays enforced on every connection exactly as before. I deliberately did **not** add `journal_mode = WAL` or `busy_timeout` (which `flows` carries) — `cron` never had them, and this PR keeps behaviour otherwise byte-identical, gating only what already ran.

Not extracting a shared helper is intentional and matches the existing convention: `flows::store`'s `add_column_if_missing` doc already states it is *"kept per-domain rather than shared — each store owns its own connection helper and this is a handful of lines."* The same reasoning applies to the ~35-line init gate.

## Impact

- Runtime: core / CLI (cron is always-compiled, no feature gate). No wire, schema, or config change; no migration.
- Performance: removes a fixed 8-statement DDL batch + 11 metadata scans from every cron store op after the first per process, replaced by a single indexed `sqlite_master` probe. This is a "remove redundant repeated work on a recurring path" change, not a hot-loop micro-opt.
- Security/compat: none.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — new `schema_reinitializes_when_the_database_file_is_deleted_at_runtime` regression pins the verify-on-hit self-heal branch (the one path the gate could regress); the existing 20+ `cron::store` tests all still exercise the cache miss+hit legs through `with_connection`.
- [x] **Diff coverage ≥ 80%** — the new gating functions are covered by the new self-heal test plus the whole existing `cron::store` suite routing through `with_connection`. See "Validation Blocked" for why the focused run used `--no-default-features` (a pre-existing `flows` test-code break on `main`, unrelated to this PR).
- [x] N/A: behaviour-only / perf change — no feature rows added, removed, or renamed in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] N/A: no matrix feature IDs are affected by this change.
- [x] No new external network dependencies introduced.
- [x] N/A: does not touch a release-cut surface in `docs/RELEASE-MANUAL-SMOKE.md`.
- [x] N/A: no linked tracking issue — found via a code audit of the cron store's per-call overhead; the `flows::store` R-m8 precedent is the reference.

## Impact

(see Impact section above)

## Related

- Closes: N/A (no tracking issue — see checklist)
- Follow-up PR(s)/TODOs: `integrations::task_sources::store`'s `with_connection` has the identical un-gated DDL-per-call pattern (hit 3× per task inside the fetch loop). It is **intentionally not bundled here** to keep this single-concern and because those files overlap my open #5521 — separate follow-up.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `perf/cron-store-schema-init-gate`
- Commit SHA: `93d5e5ad9`

### Validation Run

- [x] N/A: no `app/` frontend changes — `pnpm --filter openhuman-app format:check` not applicable.
- [x] N/A: no TypeScript changes — `pnpm typecheck` not applicable.
- [x] Focused tests: `cargo test --lib --no-default-features cron::store` (see below for why `--no-default-features`).
- [x] Rust fmt/check: `cargo fmt` (clean); core lib + `cron::store` tests compiled and passed under `--no-default-features` (23/23); core lib under product features compiled via the shell's `cargo check` in the pre-push hook (exit 0). The core crate's own literal `default`-feature `cargo check` was not run locally — the change is feature-agnostic (std + rusqlite), so that is left to the Quality lane.
- [x] N/A: no `app/src-tauri` shell changes — Tauri fmt/check not applicable.

### Validation Blocked

- `command:` `cargo test --lib cron::store` (default features)
- `error:` pre-existing compile break in **`flows` test code** on `main` — `tinyflows::observability::ExecutionStep` gained a `transcript` field that `src/openhuman/flows/{ops_tests.rs, tinyflows/observability.rs}`'s `#[cfg(test)]` constructors don't set (E0063 ×4). Unrelated to this PR (I touch only `src/openhuman/cron/`).
- `impact:` I ran the focused suite with `--no-default-features`, which excludes the gated `flows` test code entirely while still compiling the always-on `cron` domain; the `cron::store` tests pass there (23/23). The break is `#[cfg(test)]`-only, so the core library itself still compiles — verified via the shell's pre-push `cargo check` (product features, non-test), which builds `openhuman_core` as a path dep and passed (exit 0).

### Behavior Changes

- Intended behavior change: none — this is a performance change; observable store behaviour (including deleted-DB self-heal and FK enforcement) is preserved.
- User-visible effect: none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cron database recovery when cached storage is deleted, replaced, or contains an incomplete older schema.
  * Existing scheduled jobs are now preserved during schema upgrades.
  * Missing database fields are automatically restored, helping scheduled jobs continue to be saved and processed reliably.

* **Tests**
  * Added coverage for database recreation, schema recovery, column restoration, and continued job persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->