### PR TITLE
fix(flows): validate full schema on cache hit + make store init atomic

### DIFF
--- a/src/openhuman/flows/ops_tests.rs
+++ b/src/openhuman/flows/ops_tests.rs
@@ -3205,6 +3205,7 @@ async fn observer_persists_each_step_incrementally() {
         output: json!([{ "json": { "ok": true } }]),
         duration_ms: 7,
         diagnostics: Vec::new(),
+        ..Default::default()
     });
     observer.on_step_finish(&ExecutionStep {
         node_id: "b".to_string(),
@@ -3212,6 +3213,7 @@ async fn observer_persists_each_step_incrementally() {
         output: Value::Null,
         duration_ms: 3,
         diagnostics: Vec::new(),
+        ..Default::default()
     });
 
     // The store now holds both live steps with real status + timing — proof of
@@ -3232,6 +3234,7 @@ async fn observer_persists_each_step_incrementally() {
         output: json!([{ "json": { "ok": true } }]),
         duration_ms: 42,
         diagnostics: Vec::new(),
+        ..Default::default()
     });
     let row = store::get_flow_run(&config, &run_id).unwrap().unwrap();
     assert_eq!(row.steps.len(), 2, "re-firing a node must not duplicate it");

--- a/src/openhuman/flows/store.rs
+++ b/src/openhuman/flows/store.rs
@@ -47,6 +47,13 @@ use uuid::Uuid;
 /// after the first test to run in the process.
 static INITIALIZED_SCHEMAS: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
 
+/// On-disk schema version stamped into `PRAGMA user_version` by [`init_schema`]
+/// and checked by [`ensure_schema_initialized`] on a cache hit. **Bump this
+/// whenever a table or `add_column_if_missing` migration is added to
+/// [`init_schema`]** so a database replaced at runtime with an older/partial
+/// schema is re-migrated rather than trusted.
+const FLOWS_SCHEMA_VERSION: i64 = 1;
+
 /// Runs the one-time schema DDL + migrations against `conn` unless `db_path`
 /// has already been initialized in this process (see [`INITIALIZED_SCHEMAS`]).
 /// Only marks `db_path` as initialized *after* [`init_schema`] succeeds, so a
@@ -61,42 +68,47 @@ static INITIALIZED_SCHEMAS: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
 /// the very next call: `Connection::open` silently creates a fresh empty file,
 /// and `CREATE TABLE IF NOT EXISTS` immediately repopulated it. Caching removes
 /// that safety net: the set still says "initialized" while the file behind it is
-/// empty, so every subsequent query fails with `no such table` until the process
-/// restarts. One indexed `sqlite_master` lookup is far cheaper than the ~11
-/// statement DDL batch and restores the self-healing, so it is paid on each hit
-/// rather than trusting a cache entry that the filesystem may have invalidated.
+/// empty (or an older/partial schema), so subsequent queries fail with `no such
+/// table`/`no such column` until the process restarts. A single `PRAGMA
+/// user_version` read — stamped only after a full [`init_schema`] succeeds —
+/// confirms the on-disk schema is fully migrated far more cheaply than the DDL
+/// batch and restores the self-healing for *both* a missing table and a drifted
+/// column, rather than trusting a cache entry the filesystem may have
+/// invalidated. (This validates the whole schema, not just one table's
+/// presence, which the prior `sqlite_master` probe could not.)
 fn ensure_schema_initialized(conn: &Connection, db_path: &Path) -> Result<()> {
-    use rusqlite::OptionalExtension;
-
     let initialized = INITIALIZED_SCHEMAS.get_or_init(|| Mutex::new(HashSet::new()));
-    {
-        let guard = initialized
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if guard.contains(db_path) {
-            let schema_present: bool = conn
-                .query_row(
-                    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'flow_definitions'",
-                    [],
-                    |_| Ok(true),
-                )
-                .optional()
-                .context("Failed to probe flows schema presence")?
-                .unwrap_or(false);
-            if schema_present {
-                return Ok(());
-            }
-            tracing::warn!(
-                target: "flows",
-                db = %db_path.display(),
-                "[flows] schema cached as initialized but the database has no tables (deleted or replaced at runtime?) — re-running schema init"
-            );
-        }
-    }
-    init_schema(conn)?;
+    // Hold the guard across the verify *and* `init_schema`, so two first callers
+    // for the same path cannot both observe a miss and both run the DDL
+    // (initialization must be atomic per path). On a cache hit the critical
+    // section is a single `PRAGMA user_version` read; on a miss it also covers
+    // the one-time init + insert.
     let mut guard = initialized
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if guard.contains(db_path) {
+        // Trust, but verify — against the *whole* schema, not just one table.
+        // `user_version` is stamped only after a full `init_schema` succeeds, so
+        // a database deleted (fresh file ⇒ version 0) or replaced at runtime
+        // with an older/partial schema — `flow_definitions` present but missing
+        // a migrated column (`require_approval` / `graph_hash`) or one of the
+        // other tables ⇒ a stale version — fails this check and is re-migrated,
+        // rather than being trusted and later failing on the incomplete schema.
+        let version: i64 = conn
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .unwrap_or(0);
+        if version == FLOWS_SCHEMA_VERSION {
+            return Ok(());
+        }
+        tracing::warn!(
+            target: "flows",
+            db = %db_path.display(),
+            cached_version = version,
+            expected_version = FLOWS_SCHEMA_VERSION,
+            "[flows] schema cached as initialized but the database's user_version does not match (deleted or replaced at runtime?) — re-running schema init"
+        );
+    }
+    init_schema(conn)?;
     guard.insert(db_path.to_path_buf());
     Ok(())
 }
@@ -192,6 +204,13 @@ fn init_schema(conn: &Connection) -> Result<()> {
     // a hard refusal, so upgrading mid-park cannot strand an in-flight
     // approval.
     add_column_if_missing(conn, "flow_runs", "graph_hash", "TEXT")?;
+
+    // Stamp the schema version last, so [`ensure_schema_initialized`] only
+    // trusts a cache hit whose on-disk schema is fully migrated. Bump
+    // FLOWS_SCHEMA_VERSION whenever a table or `add_column_if_missing` migration
+    // is added above.
+    conn.pragma_update(None, "user_version", FLOWS_SCHEMA_VERSION)
+        .context("Failed to stamp flows schema version")?;
 
     Ok(())
 }

--- a/src/openhuman/flows/store_tests.rs
+++ b/src/openhuman/flows/store_tests.rs
@@ -1453,3 +1453,58 @@ fn schema_reinitializes_when_the_database_file_is_deleted_at_runtime() {
     let (flows_final, _) = list_flows(&config).unwrap();
     assert_eq!(flows_final.len(), 1);
 }
+
+/// Regression: a cache hit must be validated against the *whole* schema, not
+/// just the presence of one table. A database replaced at runtime with an
+/// older/partial schema — `flow_definitions` present but a migrated column
+/// dropped — must be re-migrated, not trusted and then failed on the incomplete
+/// schema. The `PRAGMA user_version` check (which supersedes the prior
+/// single-table `sqlite_master` probe) is what catches it.
+#[test]
+fn older_on_disk_schema_under_a_cached_path_is_remigrated() {
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+
+    // First use creates the full (versioned) schema and caches the path.
+    let flow = create_flow(&config, "v1".to_string(), trigger_graph(), false, true).unwrap();
+
+    // Simulate a workspace restore of an OLDER database swapped in under the
+    // same (already-cached) path: drop a migrated column and clear the version
+    // stamp, exactly as a pre-migration database would look on disk.
+    let db_path = config.workspace_dir.join("flows").join("flows.db");
+    {
+        let raw = rusqlite::Connection::open(&db_path).unwrap();
+        raw.execute_batch(
+            "ALTER TABLE flow_definitions DROP COLUMN require_approval;
+             PRAGMA user_version = 0;",
+        )
+        .unwrap();
+    }
+
+    // The path is still cached. With a single-table `sqlite_master` probe this
+    // would be trusted and `list_flows` / `get_flow` (which select
+    // `require_approval`) would fail with `no such column`. The version check
+    // detects the drift and re-migrates instead.
+    let (listed, _skipped) = list_flows(&config)
+        .expect("an older on-disk schema under a cached path must be re-migrated, not trusted");
+    assert_eq!(
+        listed.len(),
+        1,
+        "the pre-existing row survives DROP COLUMN and the schema is repaired"
+    );
+    assert_eq!(listed[0].id, flow.id);
+    // The migrated column is back (re-added with its `DEFAULT 0` ⇒ false).
+    assert!(
+        !get_flow(&config, &flow.id)
+            .unwrap()
+            .expect("flow present")
+            .require_approval
+    );
+
+    // And the store is fully usable again.
+    let recreated = create_flow(&config, "v2".to_string(), trigger_graph(), false, true).unwrap();
+    assert_eq!(
+        get_flow(&config, &recreated.id).unwrap().unwrap().id,
+        recreated.id
+    );
+}

--- a/src/openhuman/flows/tinyflows/observability.rs
+++ b/src/openhuman/flows/tinyflows/observability.rs
@@ -246,6 +246,7 @@ mod tests {
             output: Value::Null,
             duration_ms: 5,
             diagnostics: Vec::new(),
+            ..Default::default()
         });
         observer.on_run_finish(&Run {
             id: "run-1".to_string(),


### PR DESCRIPTION
## Summary

- Follow-up to #5708 (cron) / #5709 (task-sources). `flows::store` is the store those two were derived from (R-m8), and it still carries the **same two gaps** CodeRabbit + Codex flagged and I fixed there: the cache-hit verify trusted a single table, and initialization was not atomic per path. This closes both here.
- **Complete-schema validation.** Replace the single-table `sqlite_master` probe with a **`PRAGMA user_version`** check: `init_schema` stamps `FLOWS_SCHEMA_VERSION` after a full, successful migration, and a cache hit is honoured only when the on-disk version matches — so a database replaced at runtime with an older/partial schema (missing a migrated column such as `require_approval`/`graph_hash`, or one of the other tables) is re-migrated instead of trusted and then failed with `no such column`.
- **Atomic per-path init.** Hold the `INITIALIZED_SCHEMAS` guard across the verify + `init_schema` + insert so two first callers for the same path can't both run the DDL.

## Problem

`flows::store::with_connection` funnels every store op — including `upsert_flow_run_step`, called **once per node per live run**. Its schema-init gating (R-m8) was the template for the cron/task-sources gating, and it has the two defects review found in those copies:

1. **The cache-hit verify probed only `flow_definitions` via `sqlite_master`.** A database deleted at runtime yields a fresh empty file (no table → re-init, fine), but one *replaced* with an older/partial schema — `flow_definitions` present but missing `require_approval`/`graph_hash`, or missing `flow_runs`/`flow_suggestions`/`flow_revisions` — was trusted, and later `SELECT`s failed with `no such column`/`no such table`. The pre-gating code (full idempotent DDL every call) self-healed that; the single-table probe does not.
2. **`init_schema` ran with the guard released**, so two first callers for the same path could both run the DDL.

## Solution

The same fix that landed on cron/task-sources, applied to the original:

- `init_schema` stamps `PRAGMA user_version = FLOWS_SCHEMA_VERSION` after the DDL + `add_column_if_missing` migrations succeed (persistent db-file setting, like the existing WAL pragma).
- `ensure_schema_initialized` holds the guard across the whole verify + init, and on a cache hit reads `PRAGMA user_version`; a hit is honoured only when it matches, otherwise it falls through to the idempotent `init_schema` (re-migrating a drifted or fresh db). On a hit the critical section is a single `PRAGMA user_version` read — cheaper than, and equivalent in locking to, the `sqlite_master` query it replaces, so the hot `upsert_flow_run_step` path is not slowed.
- The per-connection pragmas (`busy_timeout`, `foreign_keys = ON`) and the persistent `journal_mode = WAL` are unchanged.

New `older_on_disk_schema_under_a_cached_path_is_remigrated` test drops `require_approval` and resets `user_version` under a cached path, then asserts the next store op re-migrates rather than failing `no such column`. The existing `schema_reinitializes_when_the_database_file_is_deleted_at_runtime` test still pins the deleted-file case.

### Incidental prerequisite (first commit)

The vendored `tinyflows::observability::ExecutionStep` gained a `transcript` field, but four in-repo `#[cfg(test)]` constructors used exhaustive struct literals, so the flows **test tree** doesn't compile on `main` (E0063 ×4) — the library is fine, so pushes to `main` (Rust test lanes don't run there) didn't catch it. The first commit appends `..Default::default()` to each literal — exactly the migration path the crate's own `ExecutionStep` doc prescribes (it derives `Default` for this). It's a prerequisite: the new `flows::store` test can't compile until the flows test tree does. Kept as a separate commit so it's easy to see / cherry-pick.

## Impact

- Runtime: core / CLI (behind the default `flows` feature). No wire, schema, or config change; no migration.
- Correctness: restores the pre-gating self-heal for column/table drift (not just a deleted db) and makes init atomic. No hot-path slowdown.
- Security/compat: none.

**Known tradeoff:** `FLOWS_SCHEMA_VERSION` must be bumped whenever a table/migration is added to `init_schema` (documented on the const). A future migration added without bumping it would silently skip drift-detection for older DBs. The alternative — enumerating expected columns on each hit — carries the same discipline with more surface, so `user_version` is the right call.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — new `older_on_disk_schema_under_a_cached_path_is_remigrated` pins the column-drift branch; the existing deleted-file self-heal test and the full `flows::store` suite still route through `with_connection`.
- [x] **Diff coverage ≥ 80%** — the new gating lines are covered by the new test plus the existing `flows::store` suite. Ran `cargo test --lib flows::store` locally (now that the test tree compiles again).
- [x] N/A: behaviour-preserving hardening — no feature rows added, removed, or renamed in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] N/A: no matrix feature IDs are affected by this change.
- [x] No new external network dependencies introduced.
- [x] N/A: does not touch a release-cut surface in `docs/RELEASE-MANUAL-SMOKE.md`.
- [x] N/A: no linked tracking issue — follow-up to #5708 / #5709, whose reviews (CodeRabbit + Codex) identified these two gaps in the shared pattern.

## Related

- Follow-up to: #5708 (cron), #5709 (task-sources) — same two fixes, applied to the `flows::store` precedent they were derived from.
- Closes: N/A (no tracking issue)

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `perf/flows-store-schema-validation`
- Commit SHA: `f953881e1` (hardening); `79f3f8497` (test-tree unblock)

### Validation Run

- [x] N/A: no `app/` frontend changes — `pnpm --filter openhuman-app format:check` not applicable.
- [x] N/A: no TypeScript changes — `pnpm typecheck` not applicable.
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --lib flows::store` (default `flows` feature) — passes, incl. both self-heal tests.
- [x] Rust fmt/check: `cargo fmt` (clean). `flows` is a default feature, so — unlike the cron/task-sources PRs — this compiles and tests under default features directly (the first commit is what makes the flows test tree compile again).
- [x] N/A: no `app/src-tauri` shell changes — Tauri fmt/check not applicable.

### Validation Blocked

- `command:` N/A
- `error:` N/A — the only blocker (the `ExecutionStep` test-tree break) is fixed by this PR's first commit.
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none observable in the happy path — a hardening of the runtime-replaced-db edge case + atomic init. The deleted/drifted-db self-heal is preserved (now for column drift too).
- User-visible effect: none.
