### PR TITLE
fix(claude-code): decode the stdout stream across chunk boundaries

### DIFF
--- a/src/openhuman/inference/provider/claude_code/stream_parser.rs
+++ b/src/openhuman/inference/provider/claude_code/stream_parser.rs
@@ -50,8 +50,57 @@ pub enum ClaudeCodeEvent {
 #[derive(Debug, Default)]
 pub struct StreamJsonParser {
     buffer: String,
+    /// Bytes of an incomplete UTF-8 sequence carried over from the previous chunk.
+    ///
+    /// `feed_bytes` is handed arbitrary read boundaries, so a multi-byte character
+    /// can straddle two chunks. Decoding each chunk on its own replaced both halves
+    /// with U+FFFD, and the JSON still parsed -- the replacement character is legal
+    /// inside a string -- so the corruption reached the transcript silently.
+    pending: Vec<u8>,
     /// First-seen `schema_version` from a `system` event, if any.
     pub schema_version: Option<String>,
+}
+
+/// Decode `bytes` as UTF-8, returning the text and any incomplete trailing
+/// sequence to carry into the next chunk.
+///
+/// Invalid bytes are replaced, as `from_utf8_lossy` would — the stream must not
+/// stall on input that will never become valid. The difference is that only the
+/// invalid *sequence* is consumed, and decoding then continues, so an incomplete
+/// character at the very end is still carried.
+///
+/// Handing the whole remainder to `from_utf8_lossy` after the first bad byte
+/// looks equivalent and is not: it replaces a trailing partial character before
+/// its other half has arrived, which is the corruption this parser carries
+/// `pending` to avoid. One stray byte earlier in the chunk was enough to bring
+/// it back.
+fn decode_carrying_tail(bytes: &[u8]) -> (String, Vec<u8>) {
+    let mut decoded = String::new();
+    let mut rest = bytes;
+
+    loop {
+        match std::str::from_utf8(rest) {
+            Ok(text) => {
+                decoded.push_str(text);
+                return (decoded, Vec::new());
+            }
+            Err(err) => {
+                let valid = err.valid_up_to();
+                // `valid_up_to` guarantees this prefix is valid UTF-8.
+                decoded.push_str(&String::from_utf8_lossy(&rest[..valid]));
+                match err.error_len() {
+                    // An incomplete tail: hold it for the next chunk.
+                    None => return (decoded, rest[valid..].to_vec()),
+                    // One replacement per invalid sequence, matching lossy
+                    // semantics, then carry on with what follows it.
+                    Some(len) => {
+                        decoded.push(char::REPLACEMENT_CHARACTER);
+                        rest = &rest[valid + len..];
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl StreamJsonParser {
@@ -61,8 +110,21 @@ impl StreamJsonParser {
 
     /// Append a UTF-8 byte chunk and return any events whose terminating
     /// newline arrived in this chunk.
+    ///
+    /// See [`decode_carrying_tail`] for the decode contract.
     pub fn feed_bytes(&mut self, chunk: &[u8]) -> Vec<ClaudeCodeEvent> {
-        self.buffer.push_str(&String::from_utf8_lossy(chunk));
+        // Decode only complete sequences and carry the trailing partial one into the
+        // next chunk. `valid_up_to()` is the boundary; anything after it is either an
+        // incomplete tail (keep it) or genuinely invalid input (replace it, as before).
+        let bytes: &[u8] = if self.pending.is_empty() {
+            chunk
+        } else {
+            self.pending.extend_from_slice(chunk);
+            &self.pending[..]
+        };
+        let (decoded, carry) = decode_carrying_tail(bytes);
+        self.pending = carry;
+        self.buffer.push_str(&decoded);
         self.flush()
     }
 
@@ -74,6 +136,15 @@ impl StreamJsonParser {
 
     /// Drain any remaining buffered content. Call on EOF.
     pub fn end(&mut self) -> Vec<ClaudeCodeEvent> {
+        // No further chunk is coming, so a held incomplete sequence can never be
+        // completed. Release it lossily rather than dropping it: that is what the
+        // per-chunk decode produced before the carry-over existed, and silently
+        // discarding trailing bytes would be a different kind of data loss than the
+        // one this parser is fixing.
+        if !self.pending.is_empty() {
+            let tail = std::mem::take(&mut self.pending);
+            self.buffer.push_str(&String::from_utf8_lossy(&tail));
+        }
         if !self.buffer.is_empty() && !self.buffer.ends_with('\n') {
             self.buffer.push('\n');
         }

--- a/src/openhuman/inference/provider/claude_code/stream_parser_tests.rs
+++ b/src/openhuman/inference/provider/claude_code/stream_parser_tests.rs
@@ -189,6 +189,18 @@ fn feed_bytes_preserves_a_character_split_across_chunks() {
     events.extend(p.feed_bytes(&bytes[split..]));
 
     assert_eq!(events.len(), 1);
+
+    // `ParseError` carries the original line, so its Debug rendering contains
+    // the emoji too — matching the variant is what separates "decoded across
+    // the boundary" from "failed to parse and echoed the bytes back".
+    let ClaudeCodeEvent::Assistant { message } = &events[0] else {
+        panic!("expected an Assistant event, got {:?}", events[0]);
+    };
+    assert_eq!(
+        message["text"], "héllo 世界 🌍 tail",
+        "the character split across the two chunks must survive intact"
+    );
+
     let rendered = format!("{:?}", events[0]);
     assert!(
         rendered.contains("héllo 世界 🌍 tail"),
@@ -213,5 +225,17 @@ fn feed_bytes_still_replaces_genuinely_invalid_bytes() {
         events.len(),
         1,
         "the line must still be emitted, not withheld"
+    );
+
+    // Not just "an event arrived": the invalid byte has to have been REPLACED.
+    // Dropping it would also emit one event and would also parse, so the count
+    // alone cannot tell the two apart.
+    let ClaudeCodeEvent::System { session_id, .. } = &events[0] else {
+        panic!("expected a System event, got {:?}", events[0]);
+    };
+    assert_eq!(
+        session_id.as_deref(),
+        Some("\u{FFFD}"),
+        "0xFF must decode to the replacement character, not vanish"
     );
 }

--- a/src/openhuman/inference/provider/claude_code/stream_parser_tests.rs
+++ b/src/openhuman/inference/provider/claude_code/stream_parser_tests.rs
@@ -47,3 +47,171 @@ fn bad_json_becomes_parse_error() {
     let events = p.feed("not json\n");
     assert!(matches!(events[0], ClaudeCodeEvent::ParseError { .. }));
 }
+
+/// A stream that ends mid-character must not swallow the partial bytes.
+/// Before the carry-over existed, `from_utf8_lossy` turned them into U+FFFD
+/// immediately; holding them means `end()` has to release them, or the last
+/// line of a truncated stream disappears entirely.
+#[test]
+fn end_flushes_an_incomplete_trailing_sequence() {
+    let line = serde_json::json!({
+        "type": "system",
+        "session_id": "x",
+        "schema_version": "2.0"
+    })
+    .to_string();
+    let mut bytes = line.into_bytes();
+    // A lone lead byte: a genuine incomplete tail, and no newline follows.
+    bytes.push(0xE4);
+
+    let mut p = StreamJsonParser::new();
+    assert!(
+        p.feed_bytes(&bytes).is_empty(),
+        "no newline yet, nothing emitted"
+    );
+    let events = p.end();
+    assert_eq!(
+        events.len(),
+        1,
+        "the buffered line must still be emitted at EOF"
+    );
+    // The held byte is released as a replacement character rather than vanishing,
+    // which is what the per-chunk decode produced before the carry-over existed.
+    //
+    // Asserted on the field that carries it, not on the Debug rendering: a
+    // `contains` over `{:?}` passes if U+FFFD turns up anywhere in any field, so it
+    // would keep passing if the byte were released into the wrong place. The lone
+    // 0xE4 lands after the closing brace, which is why this is a `ParseError` and
+    // not a `System` event -- the released byte makes the line invalid JSON.
+    match &events[0] {
+        ClaudeCodeEvent::ParseError { line, .. } => assert!(
+            line.ends_with(char::REPLACEMENT_CHARACTER),
+            "the released byte should be the last character of the line, got {line:?}"
+        ),
+        other => panic!("expected the unparsable line to be reported, got {other:?}"),
+    }
+}
+
+/// An invalid byte earlier in the chunk must not cost the incomplete
+/// character at the end of it.
+///
+/// Handing everything after the first bad byte to `from_utf8_lossy` replaces
+/// a trailing partial sequence before its other half arrives — the exact
+/// corruption `pending` exists to prevent, reachable again through one stray
+/// byte anywhere earlier in the same read.
+#[test]
+fn an_invalid_byte_does_not_consume_a_split_character_after_it() {
+    let mut parser = StreamJsonParser::new();
+
+    // An ASCII marker holds the spot while the fixture is built as valid
+    // JSON, and is overwritten with a real invalid byte afterwards. (A NUL
+    // would not survive: serde escapes it to `\u0000`, six ASCII bytes.)
+    let line = serde_json::json!({
+        "type": "assistant",
+        "message": { "type": "text", "text": "bad@then 🌍 tail" }
+    })
+    .to_string()
+        + "\n";
+
+    let mut bytes: Vec<u8> = line.into_bytes();
+    let bad = bytes
+        .windows(8)
+        .position(|w| w == b"bad@then")
+        .expect("fixture contains the marker")
+        + 3;
+    // A lone lead byte of a 3-byte sequence: never valid on its own.
+    bytes[bad] = 0xE4;
+
+    let emoji_start = bytes
+        .windows(4)
+        .position(|w| w == "🌍".as_bytes())
+        .expect("fixture contains the emoji");
+    // Split inside the emoji, which sits after the invalid byte.
+    let split = emoji_start + 2;
+    assert!(
+        split > bad,
+        "precondition: the invalid byte has to come first for this to test anything"
+    );
+
+    let first = parser.feed_bytes(&bytes[..split]);
+    assert!(
+        first.is_empty(),
+        "no newline in the first chunk, so nothing should be emitted yet"
+    );
+
+    let events = parser.feed_bytes(&bytes[split..]);
+    assert_eq!(events.len(), 1, "the completed line must be emitted");
+
+    match &events[0] {
+        ClaudeCodeEvent::Assistant { message } => {
+            let text = message
+                .get("text")
+                .and_then(Value::as_str)
+                .expect("the fixture carries the text field");
+            assert!(
+                text.contains('🌍'),
+                "the split emoji must survive an invalid byte earlier in the chunk, got {text:?}"
+            );
+            assert!(
+                text.contains(char::REPLACEMENT_CHARACTER),
+                "the invalid byte should still surface as a replacement, got {text:?}"
+            );
+        }
+        other => panic!("expected the assistant line to parse, got {other:?}"),
+    }
+}
+
+/// `feed_bytes` is handed arbitrary read boundaries (the driver reads into an
+/// 8 KiB buffer), so a multi-byte character can straddle two chunks. Decoding
+/// each chunk independently replaced both halves with U+FFFD, and because that
+/// character is legal inside a JSON string the line still parsed -- the text was
+/// corrupted with no error raised anywhere.
+#[test]
+fn feed_bytes_preserves_a_character_split_across_chunks() {
+    let line = serde_json::json!({
+        "type": "assistant",
+        "message": { "type": "text", "text": "héllo 世界 🌍 tail" }
+    })
+    .to_string()
+        + "\n";
+
+    // Split inside the emoji: its four bytes land on both sides of the boundary.
+    let bytes = line.as_bytes();
+    let emoji_start = line.find('🌍').expect("fixture contains the emoji");
+    let split = emoji_start + 2;
+    assert!(
+        !line.is_char_boundary(split),
+        "the split must be mid-character"
+    );
+
+    let mut p = StreamJsonParser::new();
+    let mut events = p.feed_bytes(&bytes[..split]);
+    events.extend(p.feed_bytes(&bytes[split..]));
+
+    assert_eq!(events.len(), 1);
+    let rendered = format!("{:?}", events[0]);
+    assert!(
+        rendered.contains("héllo 世界 🌍 tail"),
+        "text was corrupted across the chunk boundary: {rendered}"
+    );
+    assert!(
+        !rendered.contains('\u{FFFD}'),
+        "replacement character present: {rendered}"
+    );
+}
+
+/// Bytes that can never become valid must not stall the stream: the old lossy
+/// behaviour is kept for those, so only an *incomplete tail* is carried over.
+#[test]
+fn feed_bytes_still_replaces_genuinely_invalid_bytes() {
+    let mut p = StreamJsonParser::new();
+    let mut chunk: Vec<u8> = b"{\"type\":\"system\",\"session_id\":\"".to_vec();
+    chunk.push(0xFF); // not a valid UTF-8 lead byte in any position
+    chunk.extend_from_slice(b"\",\"schema_version\":\"2.0\"}\n");
+    let events = p.feed_bytes(&chunk);
+    assert_eq!(
+        events.len(),
+        1,
+        "the line must still be emitted, not withheld"
+    );
+}


### PR DESCRIPTION
## The defect

`StreamJsonParser::feed_bytes` decoded each read chunk on its own (`stream_parser.rs:64-67`):

```rust
pub fn feed_bytes(&mut self, chunk: &[u8]) -> Vec<ClaudeCodeEvent> {
    self.buffer.push_str(&String::from_utf8_lossy(chunk));
    self.flush()
}
```

The driver reads into an 8 KiB buffer (`driver.rs:414`), so the boundary falls wherever the pipe delivers. `from_utf8_lossy` applied per chunk replaces the partial bytes on **both** sides with U+FFFD:

```
chunked  = "héllo 世界 ��� tail"
original = "héllo 世界 🌍 tail"
equal    = false
```

The JSON still parses — U+FFFD is legal inside a string — so this is **silent content corruption**, not a parse error. Any reply longer than 8 KiB can land a CJK, Cyrillic, Arabic, Devanagari or emoji character on a boundary. The app ships 14 locales including `zh-CN`, `ko`, `ru`, `ar` and `hi`, so non-English users hit it routinely and English-only users essentially never do, which is why it has survived.

## The fix

Buffer the bytes and decode only complete sequences, carrying the trailing incomplete one into the next chunk. No new dependency:

- `Utf8Error::valid_up_to()` gives the boundary.
- `error_len()` separates the two cases. `None` is an incomplete tail — hold it. `Some(_)` is genuinely invalid input — keep the old lossy handling, so a bad byte cannot stall the stream waiting for bytes that will never make it valid.

`feed(&str)` is untouched.

## Verification

Windows, `cargo test -p openhuman --lib claude_code::stream_parser`:

```
test result: ok. 7 passed; 0 failed
```

`cargo fmt --check` clean on the file.

**Mutation-checked**, after confirming the edit applied: folding the incomplete tail back into the lossy path (i.e. never carrying it over) fails exactly the new boundary case, 6 passed / 1 failed.

## Tests

`feed_bytes` had **zero coverage** before this — all five existing tests call `feed(&str)`, which is why the byte path could be wrong for as long as it was. Two cases added:

- `feed_bytes_preserves_a_character_split_across_chunks` — serialises a line containing `héllo 世界 🌍 tail`, asserts the split index is genuinely mid-character, feeds both halves, and requires both that the text round-trips and that no U+FFFD is present.
- `feed_bytes_still_replaces_genuinely_invalid_bytes` — a `0xFF` in the middle of a line must still emit the event rather than withhold it, pinning that the carry-over applies only to incomplete tails.

## Related, deliberately not in this PR

`driver.rs:424` decodes stderr the same way, and `:426` truncates that accumulator at a raw byte index (`acc.truncate(16_384)`), which panics on a multi-byte boundary — the repo already owns `util::text::utf8_safe_prefix_at_byte_boundary` for exactly that. Both are in the same file and the same bug family; I kept this PR to the stdout path so the fix and its test stay one idea. Happy to send the stderr half separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming text handling when multi-byte characters are split across incoming data chunks.
  * Preserved valid international characters and prevented invalid bytes from corrupting adjacent text.
  * Ensured incomplete text sequences are flushed when a stream ends, preventing content from being dropped.
  * Maintained replacement behavior for genuinely invalid text data.
  * Improved reliability when processing streamed responses containing partial or unexpectedly terminated text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->