### PR TITLE
fix(threads): stop overriding the title model with an undefined hint

### DIFF
--- a/src/openhuman/threads/ops.rs
+++ b/src/openhuman/threads/ops.rs
@@ -20,9 +20,8 @@ use crate::openhuman::memory::{
 // `threads_create_new` blow the frontend's 30 s RPC budget (#5156).
 use crate::openhuman::memory::conversations;
 use crate::openhuman::threads::title::{
-    build_title_prompt, is_auto_generated_thread_title, sanitize_generated_title,
+    build_title_request, is_auto_generated_thread_title, sanitize_generated_title,
     title_from_user_message, title_log_fingerprint, THREAD_TITLE_LOG_PREFIX,
-    THREAD_TITLE_MODEL_HINT, THREAD_TITLE_SYSTEM_PROMPT,
 };
 use crate::openhuman::threads::turn_state::{
     self, ClearTurnStateRequest, ClearTurnStateResponse, GetTurnStateForRequestRequest,
@@ -34,8 +33,6 @@ use crate::rpc::RpcOutcome;
 use serde::Serialize;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use tinyagents::harness::message::Message;
-use tinyagents::harness::model::ModelRequest;
 use tinycortex::memory::conversations::{
     ConversationMessage, ConversationMessagePatch, ConversationThread, CreateConversationThread,
     CrossThreadHit,
@@ -417,41 +414,40 @@ pub async fn thread_generate_title(
         ));
     };
 
-    let chat_model = match provider::create_chat_model("summarization", &config, 0.2) {
-        Ok(model) => model,
-        Err(error) => {
-            tracing::warn!(
-                thread_id = %request.thread_id,
-                error = %error,
-                "{THREAD_TITLE_LOG_PREFIX} provider init failed; applying fallback title"
-            );
-            let updated =
-                update_thread_with_fallback_title(dir, thread, &first_user_message).await?;
-            return Ok(envelope(
-                thread_to_summary(updated),
-                Some(counts([("num_threads", 1)])),
-                None,
-            ));
-        }
-    };
+    // `_with_model_id` rather than the plain constructor: the debug line below
+    // reports the model this call actually dispatches on, and only the factory
+    // knows what the `summarization` role resolved to for this configuration.
+    let (chat_model, resolved_model) =
+        match provider::create_chat_model_with_model_id("summarization", &config, 0.2) {
+            Ok(resolved) => resolved,
+            Err(error) => {
+                tracing::warn!(
+                    thread_id = %request.thread_id,
+                    error = %error,
+                    "{THREAD_TITLE_LOG_PREFIX} provider init failed; applying fallback title"
+                );
+                let updated =
+                    update_thread_with_fallback_title(dir, thread, &first_user_message).await?;
+                return Ok(envelope(
+                    thread_to_summary(updated),
+                    Some(counts([("num_threads", 1)])),
+                    None,
+                ));
+            }
+        };
 
     tracing::debug!(
         thread_id = %request.thread_id,
         user_len = first_user_message.len(),
         assistant_len = assistant_message.len(),
-        model = THREAD_TITLE_MODEL_HINT,
+        model = %resolved_model,
         "{THREAD_TITLE_LOG_PREFIX} generating thread title"
     );
 
     let raw_title = match chat_model
         .invoke(
             &(),
-            ModelRequest::new(vec![
-                Message::system(THREAD_TITLE_SYSTEM_PROMPT),
-                Message::user(build_title_prompt(&first_user_message, &assistant_message)),
-            ])
-            .with_model(THREAD_TITLE_MODEL_HINT)
-            .with_temperature(0.2),
+            build_title_request(&first_user_message, &assistant_message),
         )
         .await
     {

--- a/src/openhuman/threads/ops_tests.rs
+++ b/src/openhuman/threads/ops_tests.rs
@@ -3,6 +3,9 @@
 //! provider calls — they pin the behaviour of the branches that all of
 //! the async `ops::*` entry points rely on.
 use super::*;
+// Re-imported here rather than through `ops`: `ops` itself no longer names
+// these, so importing them there would be an unused import in a non-test build.
+use crate::openhuman::threads::title::{build_title_prompt, THREAD_TITLE_SYSTEM_PROMPT};
 use crate::openhuman::threads::turn_state::{
     self, ClearTurnStateRequest, GetTurnStateRequest, TurnState,
 };
@@ -70,6 +73,59 @@ fn counts_empty_iter_yields_empty_map() {
 // folded into title.rs so no coverage was lost.
 
 // ── build_title_prompt ────────────────────────────────────────
+
+// ── build_title_request: the outgoing wire model (#5637) ──────
+
+#[test]
+fn build_title_request_sends_no_per_request_model_override() {
+    // The regression guard for #5637. `ModelRequest::model` is a per-request
+    // override that the managed backend resolves verbatim, so anything set
+    // here replaces the model the `summarization` provider already resolved.
+    // It used to be `"hint:summarize"` — a string no hint-alias table in the
+    // tree defines — which reached the backend as a literal model id and was
+    // answered `400 Model 'hint:summarize' is not available` on every call,
+    // for four months.
+    //
+    // Asserted as `None` rather than as some expected id on purpose: leaving
+    // it unset is the only form that is correct for every branch of
+    // `create_chat_model` (managed backend, Claude Agent SDK, Claude Code,
+    // local runtime, BYOK cloud slug). Pinning a concrete managed tier here
+    // would fix the managed route and break the other four.
+    let request = crate::openhuman::threads::title::build_title_request("hi there", "hello back");
+
+    assert!(
+        request.model.is_none(),
+        "the title request must carry no model override so the resolved \
+         `summarization` provider decides; got {:?}",
+        request.model,
+    );
+}
+
+#[test]
+fn build_title_request_carries_the_system_prompt_and_rendered_user_prompt() {
+    // Pins the rest of the request so the `model` assertion above cannot be
+    // satisfied by an empty or malformed request.
+    use tinyagents::harness::message::Message;
+
+    let request = crate::openhuman::threads::title::build_title_request("hi there", "hello back");
+
+    assert_eq!(request.messages.len(), 2, "system + user");
+    assert!(
+        matches!(request.messages[0], Message::System(_)),
+        "first message must be the system prompt, got {:?}",
+        request.messages[0],
+    );
+    assert_eq!(request.messages[0].text(), THREAD_TITLE_SYSTEM_PROMPT,);
+    assert!(
+        matches!(request.messages[1], Message::User(_)),
+        "second message must be the user prompt, got {:?}",
+        request.messages[1],
+    );
+    assert_eq!(
+        request.messages[1].text(),
+        build_title_prompt("hi there", "hello back"),
+    );
+}
 
 #[test]
 fn build_title_prompt_renders_user_and_assistant_sections_in_order() {

--- a/src/openhuman/threads/title.rs
+++ b/src/openhuman/threads/title.rs
@@ -5,8 +5,10 @@
 
 use std::hash::{Hash, Hasher};
 
+use tinyagents::harness::message::Message;
+use tinyagents::harness::model::ModelRequest;
+
 pub const THREAD_TITLE_LOG_PREFIX: &str = "[threads:title]";
-pub const THREAD_TITLE_MODEL_HINT: &str = "hint:summarize";
 pub const THREAD_TITLE_SYSTEM_PROMPT: &str = "You name chat threads from the first user message and the assistant reply. Return only the name: at most 3 words, like Fix session handoff or Gmail OAuth retry. Lead with the verb or the subject and drop filler words. No quotes. No markdown. No punctuation.";
 
 /// Words a title carries at most. Three is the whole point of the shape: a
@@ -200,6 +202,38 @@ pub fn build_title_prompt(user_message: &str, assistant_message: &str) -> String
     format!(
         "First user message:\n{user_message}\n\nAssistant reply:\n{assistant_message}\n\nReturn the best thread name."
     )
+}
+
+/// Builds the whole title-generation request.
+///
+/// # It deliberately sets no model
+///
+/// The caller has already resolved the model by building the provider for the
+/// `summarization` role, and the resolved model is the one that should
+/// dispatch. `ModelRequest::model` is a *per-request override* that the
+/// managed backend resolves verbatim, so anything set here replaces that
+/// correct model on the wire.
+///
+/// This used to override it with `"hint:summarize"`, which no lookup table in
+/// the tree defines — every hint-alias table spells the alias `summarization`.
+/// The string matched nothing, survived translation unchanged, and reached the
+/// backend as a literal model id, which answered
+/// `400 Model 'hint:summarize' is not available` on every call. Title
+/// generation then fell back to a keyword title for four months without
+/// anything escalating (#5637).
+///
+/// Leaving `model` unset is also the only form that is correct for **every**
+/// provider. `create_chat_model` resolves the `summarization` role to the
+/// managed backend, a Claude Agent SDK / Claude Code model, a local runtime,
+/// or a BYOK cloud slug; pinning any concrete tier id here would be wrong for
+/// the four non-managed branches. Unset means each provider uses its own
+/// construction-time default.
+pub fn build_title_request(user_message: &str, assistant_message: &str) -> ModelRequest {
+    ModelRequest::new(vec![
+        Message::system(THREAD_TITLE_SYSTEM_PROMPT),
+        Message::user(build_title_prompt(user_message, assistant_message)),
+    ])
+    .with_temperature(0.2)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Thread-title generation sent `model: "hint:summarize"` as a per-request override. No hint-alias table in the tree defines that string, so it reached the backend as a literal model id and was answered `400 Model 'hint:summarize' is not available` on **every** call.
- Removed the override. The request now carries no `model`, so the provider already built for the `summarization` role is what dispatches — which was correct all along.
- The `[threads:title] generating thread title` debug line reported the same bogus hint. It now reports the model that actually dispatches, via `create_chat_model_with_model_id`.
- Deleted the now-unused `THREAD_TITLE_MODEL_HINT` constant.
- **This is not pre-prod-specific.** The issue is titled "Pre-prod", but the string is invalid against every backend deployment and has been failing since `ee3f6472c` (2026-04-18) — over four months. It reproduces on **production**. The title understates it.

## Problem

`src/openhuman/threads/ops.rs` resolved the model correctly and then threw the answer away:

```rust
let chat_model = provider::create_chat_model("summarization", &config, 0.2)?;  // correct
…
    .with_model(THREAD_TITLE_MODEL_HINT)   // "hint:summarize" — overrides it on the wire
```

`ModelRequest::model` is a per-request override the managed backend resolves verbatim — `openhuman_backend_model.rs:163-165` says so directly: *"The tier/model rides `request.model`, which the backend resolves — the baked default only applies when a request omits it."* Nothing intercepts it: `threads/ops.rs` calls `ChatModel::invoke` directly, with no harness and no registry in between.

`"hint:summarize"` is unique in the repo. Every hint-alias table spells that alias `summarization`; the tree has 31× `hint:reasoning`, 10× `hint:agentic`, 8× `hint:chat`, 5× `hint:summarization` — and exactly 1× `hint:summarize`. It matched nothing, survived all three translation tables unchanged, and shipped verbatim.

Every new thread therefore got a keyword fallback title instead of a generated one. It went unnoticed for four months because the fallback is *not* obviously generic — `title_from_user_message` takes the first three specific words of the user's message, which looks like a plausible LLM title in the sidebar. The log lines are the only reliable signal.

## Solution

Delete the override rather than correct it, and let the resolved provider decide.

This is the important design point, and it is why I did **not** take the alternative of pinning the real tier (`summarization-v1`) instead: `create_chat_model` has five branches (`factory.rs:740-762`) — managed OpenHuman backend, Claude Agent SDK, Claude Code, local runtime (Ollama/LM Studio/MLX), and BYOK cloud slug. Pinning a concrete managed tier id would fix the managed route and send an unknown model string to the other four. Leaving `model` unset is the only form that is correct on all five, because each provider then uses its own construction-time default.

The request construction moved into `title::build_title_request`, next to the existing `build_title_prompt`, so the outgoing `ModelRequest` is directly assertable in a unit test. That is the only structural change; there is no behaviour in it beyond dropping the override.

### Revert-check (fleet standard: prove the test fails without the fix)

I re-added `.with_model("hint:summarize")` to `build_title_request` and re-ran the same filter. Observed:

```
test openhuman::threads::ops::tests::build_title_request_sends_no_per_request_model_override ... FAILED

thread '...build_title_request_sends_no_per_request_model_override' panicked at
src/openhuman/threads/ops_tests.rs:96:5:
the title request must carry no model override so the resolved `summarization` provider decides;
got Some("hint:summarize")

test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 10996 filtered out.
```

Exit code 101. The fix was then restored and the suite returns to 3 passed. The guard is not vacuous.

One process note, since it nearly produced a false pass: my first run used the filter `threads::ops_tests::build_title` and reported `ok. 0 passed; 0 failed; 10996 filtered out`. The test module is declared `mod tests` via `#[path = "ops_tests.rs"]` (`ops.rs:996-999`), so the real path is `threads::ops::tests::…`. A green `cargo test` that ran zero tests is not a pass.

## Impact

- Desktop/CLI: thread titles generate again wherever the `summarization` role resolves to a working provider. Worst case is a title that generates where one previously did not.
- No change to provider selection, BYOK routing, or pricing — the tier that now dispatches (`summarization-v1` on the managed route) is the one the provider was already constructed for.
- Contained: `THREAD_TITLE_MODEL_HINT` had exactly three referents, all in `src/openhuman/threads/`, and no other `.with_model()` call site in the tree passes a hint string.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — two tests in `threads/ops_tests.rs`: `build_title_request_sends_no_per_request_model_override` (the regression guard) and `build_title_request_carries_the_system_prompt_and_rendered_user_prompt` (so the first cannot pass on an empty request). Revert-check result below.
- [x] **Diff coverage ≥ 80%** — N/A to assert locally: I did not run `pnpm test:coverage` / `pnpm test:rust` (full-suite runs are disk-prohibitive in this environment). Every changed Rust line is either covered by the two new tests (`title.rs::build_title_request`) or is the call site that invokes it (`ops.rs`). Asserting from reading, not from a measured run — please let the CI gate arbitrate.
- [x] Coverage matrix updated — N/A: behaviour-only change, no feature rows added, removed or renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature IDs affected (see above).
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — the new tests are pure and touch no network, disk, or provider; the change removes a wire field rather than adding a dependency.
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: no release-cut surface changes. Noting for the maintainer that thread-title generation is a user-visible path currently broken on production, so it may be worth a smoke line in future.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Related

- Closes: #5637
- Follow-up PR(s)/TODOs:
  - `factory.rs:1221` comments *"Unrecognised hint — forward verbatim; the backend decides validity"*. The backend implements no `hint:` handling at all — `isValidModel` is an exact-id lookup — so any future unrecognised hint is a guaranteed 400 rather than a graceful degrade. Worth its own issue; not addressed here.
  - Title generation degrades silently. A permanently-invalid model string produced no escalation anywhere, which is the other half of why this lasted four months.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5637-thread-title-model-hint`
- Commit SHA: see head of this PR

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend files changed (Rust only).
- [x] `pnpm typecheck` — N/A: no TypeScript changed.
- [x] Focused tests: `cargo test --lib threads::ops::tests::build_title` — **3 passed, 0 failed** on the committed tree (post-`cargo fmt`).
- [x] Rust fmt/check (if changed): `cargo check --lib --tests` — exit 0, no errors, no warnings in `src/openhuman/threads/`. `cargo fmt` applied.
- [x] Tauri fmt/check (if changed): N/A: `app/src-tauri` untouched.

### Validation Blocked

- `command:` full `cargo test` / `pnpm test:rust`
- `error:` not run — not a failure; a full `target/` is 20-30GB and the environment is disk-constrained, so the run was deliberately scoped.
- `impact:` a scoped filter cannot see assertions in other modules. `build_title_prompt` and `THREAD_TITLE_SYSTEM_PROMPT` are now imported into the test module directly rather than inherited through `ops`'s `use super::*`; `cargo check --lib --tests` covers that whole-crate, but only CI proves no other module referenced the deleted `THREAD_TITLE_MODEL_HINT`. I grepped: it had three referents, all removed.

### Behavior Changes

- Intended behavior change: the title request no longer overrides the model, so the resolved `summarization` provider dispatches instead of an invalid literal.
- User-visible effect: new chat threads get a generated title instead of a keyword fallback.

### Parity Contract

- Legacy behavior preserved: messages, system prompt, and temperature (0.2) are byte-identical to before; only the `model` field is dropped.
- Guard/fallback/dispatch parity checks: the fallback path is untouched — a genuine provider or model failure still logs `title generation failed; applying fallback title` and applies `title_from_user_message`.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none — no PR or commit anywhere referenced #5637.
- Canonical PR: this one.
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic thread title generation by using the configured provider and model.
  * Removed an invalid model override that could interfere with title generation.
  * Preserved existing fallback behavior when title generation is unavailable.

* **Tests**
  * Added regression coverage to verify title-generation requests include the expected prompts and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->