### PR TITLE
fix(socket): don't emit a hosted-brain result onto the next connection

### DIFF
--- a/src/openhuman/platform/socket/event_handlers.rs
+++ b/src/openhuman/platform/socket/event_handlers.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use serde_json::json;
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 
 use crate::api::models::socket::ConnectionStatus;
 use crate::core::bus::BUS;
@@ -92,13 +93,24 @@ pub(super) fn handle_sio_event(
         // over the same socket. Device Signal keys never leave the machine.
         "orch:effect:send_dm" => {
             let tx = emit_tx.clone();
+            // Snapshotted before the spawn so the task is bound to the
+            // connection that asked for the work, not to whichever one happens
+            // to be live when it finishes.
+            let connection = super::medulla::workflows::connection_generation();
             tokio::spawn(async move {
                 if let Some((call_id, ack)) =
                     crate::openhuman::hosted::orchestration::effect_executor::handle_send_dm(&data)
                         .await
                 {
-                    log::debug!("[socket] orch:effect:send_dm acked call_id={call_id}");
-                    emit_via_channel(&tx, "orch:effect:result", ack);
+                    if emit_result_if_connected(
+                        &tx,
+                        &connection,
+                        "orch:effect:result",
+                        &call_id,
+                        ack,
+                    ) {
+                        log::debug!("[socket] orch:effect:send_dm acked call_id={call_id}");
+                    }
                 }
             });
         }
@@ -106,15 +118,28 @@ pub(super) fn handle_sio_event(
         // return the result so the reasoning loop can continue.
         "orch:tool_call" => {
             let tx = emit_tx.clone();
+            let connection = super::medulla::workflows::connection_generation();
             tokio::spawn(async move {
+                // Deliberately NOT a `select!` against the token, unlike the
+                // registration reads in `medulla::workflows`. Dropping this
+                // future mid-flight would abandon a side-effecting tool with
+                // its `call_id` still latched and no result — the exact failure
+                // this guard exists to prevent. Let it finish; gate the emit.
                 if let Some((call_id, result)) =
                     crate::openhuman::hosted::orchestration::effect_executor::handle_tool_call(
                         &data,
                     )
                     .await
                 {
-                    log::debug!("[socket] orch:tool_call result call_id={call_id}");
-                    emit_via_channel(&tx, "orch:tool_result", result);
+                    if emit_result_if_connected(
+                        &tx,
+                        &connection,
+                        "orch:tool_result",
+                        &call_id,
+                        result,
+                    ) {
+                        log::debug!("[socket] orch:tool_call result call_id={call_id}");
+                    }
                 }
             });
         }
@@ -124,13 +149,21 @@ pub(super) fn handle_sio_event(
         // rides back over the same socket (shared `orch:effect:result` channel).
         "orch:effect:evict" => {
             let tx = emit_tx.clone();
+            let connection = super::medulla::workflows::connection_generation();
             tokio::spawn(async move {
                 if let Some((call_id, ack)) =
                     crate::openhuman::hosted::orchestration::effect_executor::handle_evict(&data)
                         .await
                 {
-                    log::debug!("[socket] orch:effect:evict acked call_id={call_id}");
-                    emit_via_channel(&tx, "orch:effect:result", ack);
+                    if emit_result_if_connected(
+                        &tx,
+                        &connection,
+                        "orch:effect:result",
+                        &call_id,
+                        ack,
+                    ) {
+                        log::debug!("[socket] orch:effect:evict acked call_id={call_id}");
+                    }
                 }
             });
         }
@@ -485,6 +518,48 @@ fn base64_encode(input: &str) -> String {
     base64::engine::general_purpose::STANDARD.encode(input.as_bytes())
 }
 
+/// Emit a hosted-brain result, but only if the connection that asked for it is
+/// still the live one.
+///
+/// The emit channel outlives the socket: `emit_tx`/`emit_rx` is created once per
+/// [`connect`](super::manager::SocketManager::connect) and re-used by every
+/// reconnect attempt in the loop. So a result queued while the socket is down is
+/// not dropped — it is flushed onto the *next* connection, which has a different
+/// sid and whose roster the backend has already cleared. Nobody is waiting for
+/// it there.
+///
+/// Dropping it is not enough on its own. `orch:tool_call` is at-least-once with
+/// server-side redelivery, guarded by a `call_id` claimed on *entry* and
+/// released only when the effect fails
+/// ([`is_duplicate_call`](crate::openhuman::hosted::orchestration::effect_executor::is_duplicate_call)).
+/// A call that succeeded but whose result never reached the wire would stay
+/// latched forever, so the redelivery would be answered with the synthetic
+/// `{"accepted": true, "status": "running", "duplicate": true}` frame instead of
+/// the real result and the brain would wait on a `tool_completion` that can
+/// never arrive. Suppressing the emit therefore has to release the claim too, so
+/// the redelivery genuinely re-runs the work.
+///
+/// Returns whether the result was emitted.
+pub(super) fn emit_result_if_connected(
+    tx: &mpsc::UnboundedSender<String>,
+    connection: &CancellationToken,
+    event: &str,
+    call_id: &str,
+    data: serde_json::Value,
+) -> bool {
+    if connection.is_cancelled() {
+        // Release before logging: a redelivery may already be in flight.
+        crate::openhuman::hosted::orchestration::effect_executor::release_call(call_id);
+        log::debug!(
+            "[socket] {event} undeliverable (socket closed before the result was ready); \
+             released claim call_id={call_id}"
+        );
+        return false;
+    }
+    emit_via_channel(tx, event, data);
+    true
+}
+
 /// Send a Socket.IO event through the emit channel.
 ///
 /// Format: `42["eventName", data]`
@@ -530,6 +605,94 @@ mod tests {
             socket_id: RwLock::new(None),
             error: RwLock::new(None),
         })
+    }
+
+    // ── emit_result_if_connected ────────────────────────────────────
+
+    use crate::openhuman::hosted::orchestration::effect_executor::{
+        is_duplicate_call, release_call,
+    };
+
+    /// A `call_id` unique to this test process, so the tests do not collide
+    /// through the process-global `SEEN_CALL_IDS` set.
+    fn unique_call_id(tag: &str) -> String {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        format!(
+            "emit-guard-{tag}-{}",
+            COUNTER.fetch_add(1, Ordering::Relaxed)
+        )
+    }
+
+    #[test]
+    fn a_result_is_emitted_while_its_connection_is_still_live() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+        let connection = CancellationToken::new();
+        let call_id = unique_call_id("live");
+
+        // Claim it the way the effect executor does on entry.
+        assert!(
+            !is_duplicate_call(&call_id),
+            "first claim is not a duplicate"
+        );
+
+        let emitted = emit_result_if_connected(
+            &tx,
+            &connection,
+            "orch:tool_result",
+            &call_id,
+            json!({"ok": true}),
+        );
+
+        assert!(emitted, "a live connection should take the result");
+        let msg = rx.try_recv().expect("the result should be on the wire");
+        assert!(msg.starts_with("42[\"orch:tool_result\""), "got: {msg}");
+        // The claim must survive: the result reached the socket, so a
+        // redelivery should be re-acked idempotently rather than re-run.
+        assert!(
+            is_duplicate_call(&call_id),
+            "a delivered result must leave its call_id latched"
+        );
+        release_call(&call_id);
+    }
+
+    #[test]
+    fn a_result_for_a_dead_connection_is_dropped_and_its_claim_released() {
+        // The defect this guards: the emit channel outlives the socket, so an
+        // ungated emit lands on the *next* connection, where nothing is
+        // waiting — and the call_id stays latched, so the backend's redelivery
+        // is answered with the synthetic `duplicate` frame instead of the real
+        // result and the brain waits forever.
+        let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+        let connection = CancellationToken::new();
+        let call_id = unique_call_id("dead");
+
+        assert!(
+            !is_duplicate_call(&call_id),
+            "first claim is not a duplicate"
+        );
+        connection.cancel();
+
+        let emitted = emit_result_if_connected(
+            &tx,
+            &connection,
+            "orch:tool_result",
+            &call_id,
+            json!({"ok": true}),
+        );
+
+        assert!(!emitted, "a dead connection must not take the result");
+        assert!(
+            rx.try_recv().is_err(),
+            "nothing should be queued for the next connection"
+        );
+        // Releasing is the half that keeps the brain unstuck: the redelivery
+        // has to genuinely re-run, not hit the latch.
+        assert!(
+            !is_duplicate_call(&call_id),
+            "a suppressed result must release its claim so redelivery re-runs"
+        );
+        release_call(&call_id);
     }
 
     // ── base64_encode ───────────────────────────────────────────────

--- a/src/openhuman/platform/socket/event_handlers.rs
+++ b/src/openhuman/platform/socket/event_handlers.rs
@@ -526,18 +526,35 @@ fn base64_encode(input: &str) -> String {
 /// reconnect attempt in the loop. So a result queued while the socket is down is
 /// not dropped — it is flushed onto the *next* connection, which has a different
 /// sid and whose roster the backend has already cleared. Nobody is waiting for
-/// it there.
+/// it there, and the frame can only confuse whoever is.
 ///
-/// Dropping it is not enough on its own. `orch:tool_call` is at-least-once with
-/// server-side redelivery, guarded by a `call_id` claimed on *entry* and
-/// released only when the effect fails
-/// ([`is_duplicate_call`](crate::openhuman::hosted::orchestration::effect_executor::is_duplicate_call)).
-/// A call that succeeded but whose result never reached the wire would stay
-/// latched forever, so the redelivery would be answered with the synthetic
-/// `{"accepted": true, "status": "running", "duplicate": true}` frame instead of
-/// the real result and the brain would wait on a `tool_completion` that can
-/// never arrive. Suppressing the emit therefore has to release the claim too, so
-/// the redelivery genuinely re-runs the work.
+/// # Why the `call_id` claim is deliberately left alone
+///
+/// The effect has already *happened* by the time this is reached — the claim is
+/// taken on entry and the work runs to completion before the result comes back.
+/// Releasing it so the backend's redelivery re-runs the call would re-execute a
+/// side effect that already succeeded: `handle_send_dm` sends over Signal with
+/// no `call_id` reaching that transport, so a peer would receive the message
+/// twice, and a local-execution `orch:tool_call` would spawn a second
+/// background agent. Both paths keep a successful id latched on purpose.
+///
+/// The cost of leaving it latched is that the redelivery is answered with the
+/// synthetic `{"accepted": true, "status": "running", "duplicate": true}` frame
+/// rather than the real result, so the brain's turn does not complete. That is
+/// unchanged from before this guard existed, and it is the lesser harm: a
+/// stalled turn is recoverable, a duplicate message to a human is not. Closing
+/// it properly needs the result cached for replay on the next connection, or a
+/// server-side deadline on the tool call — neither of which belongs here. The
+/// `warn!` below names the stranded `call_id` so the stall is diagnosable
+/// instead of silent.
+///
+/// # The check and the send are one step
+///
+/// Both happen inside `medulla::workflows::with_live_connection`, which holds
+/// the generation lock across them. Checked separately, the socket loop could
+/// end the generation and drain the channel in the gap, and the send would then
+/// sit in an empty channel waiting for the next connection — the very thing
+/// this exists to prevent.
 ///
 /// Returns whether the result was emitted.
 pub(super) fn emit_result_if_connected(
@@ -547,17 +564,19 @@ pub(super) fn emit_result_if_connected(
     call_id: &str,
     data: serde_json::Value,
 ) -> bool {
-    if connection.is_cancelled() {
-        // Release before logging: a redelivery may already be in flight.
-        crate::openhuman::hosted::orchestration::effect_executor::release_call(call_id);
-        log::debug!(
-            "[socket] {event} undeliverable (socket closed before the result was ready); \
-             released claim call_id={call_id}"
+    let delivered = super::medulla::workflows::with_live_connection(connection, || {
+        emit_via_channel(tx, event, data);
+    })
+    .is_some();
+
+    if !delivered {
+        log::warn!(
+            "[socket] {event} undeliverable (the socket closed before the result was ready); \
+             dropped rather than sent on the next connection. The effect ran, so its claim \
+             stays latched and the turn will not complete: call_id={call_id}"
         );
-        return false;
     }
-    emit_via_channel(tx, event, data);
-    true
+    delivered
 }
 
 /// Send a Socket.IO event through the emit channel.
@@ -657,12 +676,15 @@ mod tests {
     }
 
     #[test]
-    fn a_result_for_a_dead_connection_is_dropped_and_its_claim_released() {
+    fn a_result_for_a_dead_connection_is_dropped_without_disturbing_its_claim() {
         // The defect this guards: the emit channel outlives the socket, so an
-        // ungated emit lands on the *next* connection, where nothing is
-        // waiting — and the call_id stays latched, so the backend's redelivery
-        // is answered with the synthetic `duplicate` frame instead of the real
-        // result and the brain waits forever.
+        // ungated emit lands on the *next* connection — a different sid, whose
+        // roster the backend has already cleared.
+        //
+        // The claim must survive. The effect already ran by the time the result
+        // exists, so releasing it would make the backend's redelivery re-execute
+        // a side effect that succeeded — a second Signal message to a peer, or a
+        // second background agent. See `emit_result_if_connected`.
         let (tx, mut rx) = mpsc::unbounded_channel::<String>();
         let connection = CancellationToken::new();
         let call_id = unique_call_id("dead");
@@ -686,11 +708,9 @@ mod tests {
             rx.try_recv().is_err(),
             "nothing should be queued for the next connection"
         );
-        // Releasing is the half that keeps the brain unstuck: the redelivery
-        // has to genuinely re-run, not hit the latch.
         assert!(
-            !is_duplicate_call(&call_id),
-            "a suppressed result must release its claim so redelivery re-runs"
+            is_duplicate_call(&call_id),
+            "an undeliverable result must not un-claim work that already ran"
         );
         release_call(&call_id);
     }

--- a/src/openhuman/platform/socket/medulla/workflows.rs
+++ b/src/openhuman/platform/socket/medulla/workflows.rs
@@ -168,6 +168,33 @@ pub(in crate::openhuman::platform::socket) fn connection_generation() -> Cancell
     connection_generation_state().read().snapshot()
 }
 
+/// Run `deliver` only while `token`'s generation is still live, holding the
+/// generation lock across the decision.
+///
+/// A plain `token.is_cancelled()` followed by a send is a race: the socket loop
+/// can end the generation and drain the emit channel in the gap, after which the
+/// handler's send lands in an empty channel and is flushed onto the *next*
+/// connection — exactly what the check was meant to prevent.
+///
+/// Taking the read guard closes it, because [`end_connection_generation`] needs
+/// the write guard to cancel. Either this runs first, and the message is queued
+/// before the drain that will discard it; or the end runs first, and `token` is
+/// already cancelled here. `deliver` must therefore stay cheap and must not
+/// block, await, or re-enter this module — the one caller does a JSON encode and
+/// an unbounded send.
+///
+/// Returns `None` when the generation has ended.
+pub(in crate::openhuman::platform::socket) fn with_live_connection<R>(
+    token: &CancellationToken,
+    deliver: impl FnOnce() -> R,
+) -> Option<R> {
+    let _generation = connection_generation_state().read();
+    if token.is_cancelled() {
+        return None;
+    }
+    Some(deliver())
+}
+
 /// Start a new authenticated-socket lifetime.
 ///
 /// Called by the `ready` handler before it advertises workflows. Work received

--- a/src/openhuman/platform/socket/medulla/workflows.rs
+++ b/src/openhuman/platform/socket/medulla/workflows.rs
@@ -159,7 +159,12 @@ pub(super) fn bridge_generation() -> BridgeGeneration {
     }
 }
 
-pub(super) fn connection_generation() -> CancellationToken {
+/// A snapshot of the token for the currently-authenticated socket lifetime.
+///
+/// Visible to the whole `socket` module, not just `medulla`: `event_handlers`
+/// spawns hosted-brain work that must not emit its result onto a *later*
+/// connection, and it is a sibling of this module rather than a child.
+pub(in crate::openhuman::platform::socket) fn connection_generation() -> CancellationToken {
     connection_generation_state().read().snapshot()
 }
 

--- a/src/openhuman/platform/socket/ws_loop.rs
+++ b/src/openhuman/platform/socket/ws_loop.rs
@@ -165,6 +165,18 @@ pub(super) async fn ws_loop(
         shared.ack_registry.cancel_all();
         super::medulla::workflows::end_connection_generation();
 
+        // Backstop for anything that was already queued when the connection
+        // ended. `emit_rx` is owned by this loop, not by the connection, so
+        // without this a message sitting in the channel is flushed onto the
+        // *next* socket — a different sid, whose roster the backend has already
+        // cleared. The per-handler guard in `event_handlers` closes the common
+        // case; this covers the window between an emit being queued and the
+        // generation being cancelled.
+        let dropped = drain_pending_emits(&mut emit_rx);
+        if dropped > 0 {
+            log::warn!("[socket] Dropped {dropped} queued emit(s) on disconnect");
+        }
+
         match outcome {
             ConnectionOutcome::Shutdown => {
                 log::info!("[socket] Clean shutdown");
@@ -399,6 +411,27 @@ fn decide_after_invalid_token(
             reason: format!("provider error: {e}"),
         },
     }
+}
+
+// ---------------------------------------------------------------------------
+// Emit-channel draining
+// ---------------------------------------------------------------------------
+
+/// Discard whatever is still queued on the emit channel, reporting how much.
+///
+/// Called when a connection ends. The channel outlives the socket — it is
+/// created once per `SocketManager::connect` and re-used by every reconnect
+/// attempt — so anything left in it would otherwise be delivered on the next
+/// connection, where nothing is waiting for it.
+///
+/// A free function rather than an inline loop so the behaviour is directly
+/// testable without standing up a socket.
+fn drain_pending_emits(rx: &mut mpsc::UnboundedReceiver<String>) -> usize {
+    let mut dropped = 0usize;
+    while rx.try_recv().is_ok() {
+        dropped += 1;
+    }
+    dropped
 }
 
 // ---------------------------------------------------------------------------

--- a/src/openhuman/platform/socket/ws_loop_tests.rs
+++ b/src/openhuman/platform/socket/ws_loop_tests.rs
@@ -1316,3 +1316,32 @@ fn decide_after_invalid_token_empty_token_escalates() {
         }
     }
 }
+
+// ── drain_pending_emits ─────────────────────────────────────────────────────
+
+/// The emit channel outlives the socket, so anything still queued when a
+/// connection ends would be flushed onto the next one — a different sid, whose
+/// roster the backend has already cleared.
+#[test]
+fn draining_reports_and_discards_everything_still_queued() {
+    let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+    for event in ["orch:tool_result", "orch:effect:result", "presence"] {
+        tx.send(format!("42[\"{event}\",{{}}]")).expect("queue");
+    }
+
+    let dropped = drain_pending_emits(&mut rx);
+
+    assert_eq!(dropped, 3, "every queued message should be counted");
+    assert!(
+        rx.try_recv().is_err(),
+        "nothing may survive into the next connection"
+    );
+}
+
+/// The common case — a clean disconnect with nothing queued — must not log a
+/// spurious warning, so the count has to be honest about zero.
+#[test]
+fn draining_an_empty_channel_reports_nothing_dropped() {
+    let (_tx, mut rx) = mpsc::unbounded_channel::<String>();
+    assert_eq!(drain_pending_emits(&mut rx), 0);
+}


### PR DESCRIPTION
## Summary

- A hosted-brain result computed while the socket was down is no longer emitted onto the **next** connection, where nothing is waiting for it.
- The check and the send are atomic under the connection-generation lock, so a disconnect cannot land between them.
- The emit channel is drained when a connection ends, as a backstop.
- **Behaviour change:** a plain `emit()` queued during a disconnect now goes from "delivered late on the next socket" to "dropped". Intended — see *Impact*.
- **Scope note:** this fixes the orphaned emit. It does **not** make the stalled turn complete — see *What this does not fix*, which is a deliberate limit, not an oversight.

## Problem

The outbound channel outlives the connection. `emit_tx`/`emit_rx` is created once per `connect()` (`socket/manager.rs:264`) and passed by `&mut` into every `run_connection` inside the reconnect loop (`ws_loop.rs:154`). A message queued while the socket is dead is therefore not dropped — it is flushed onto the **next** socket, which has a different sid and whose roster the backend has already cleared.

The three hosted-brain handlers `tokio::spawn` their work and emit through that channel with no connection guard: `orch:effect:send_dm`, `orch:tool_call`, `orch:effect:evict` (`event_handlers.rs:93-135`). A device tool still running when the socket drops emits its result into a connection that is not expecting it.

**The second half is what makes it unrecoverable rather than merely lossy**, and is the part worth reading twice. `orch:tool_call` is at-least-once with server-side redelivery, guarded by a `call_id` latch claimed **on entry** (`hosted/orchestration/effect_executor.rs:434`, `:496-503`). The claim is released only when dispatch returns `Err` on a local-execution tool (`:463-472`). A call that **succeeds** stays latched forever. So when the result never reaches the wire, the redelivery hits the latch and is answered with the synthetic `{"accepted": true, "status": "running", "duplicate": true}` frame (`:441-449`) instead of the real result — and the brain waits on a `tool_completion` that can never arrive.

The existing code already names this exact hazard for the dispatch-*failure* path (`effect_executor.rs:456-462`). It simply does not cover the succeeded-but-undeliverable path.

**An earlier revision of this PR released that claim so the redelivery would re-run.** Review (thanks @chatgpt-codex-connector) caught that this is worse than the stall, and it is right. Every pre-existing `release_call` sits on the dispatch-*failed* path, where nothing happened. Releasing on the succeeded-but-undeliverable path re-executes work that already ran: `execute_send_dm` reaches `handle_tinyplace_signal_send_message` with no `call_id`, so a peer receives the Signal message **twice**, and a local-execution `orch:tool_call` spawns a second sub-agent. Only `persist_reply` is idempotent (`message_id = "reply:{call_id}"`). The release is gone.

## Solution

**1. `emit_result_if_connected` (`event_handlers.rs`).** Emits if the generation that asked for the work is still live; otherwise drops the frame and logs a `warn!` naming the stranded `call_id`. The claim is left exactly as it was. All three `orch:*` handlers snapshot `connection_generation()` *before* the spawn, so the task is bound to the connection that asked for the work rather than to whichever one happens to be live when it finishes.

**1b. `with_live_connection` (`medulla/workflows.rs`).** The check and the send are one step, holding the generation **read** guard across both. Without it there is a real TOCTOU (flagged independently by Codex and CodeRabbit): a handler reads a live token → the loop calls `end_connection_generation()` → `drain_pending_emits()` runs over an empty channel → the handler sends, and the frame survives into the next connection. Since `end_connection_generation` needs the **write** guard, either the message is queued before the drain that discards it, or the token is already cancelled when the handler looks. Stamping a generation onto the queued frame is the more general answer but changes the channel payload for every emitter; this race is between two operations already serialized by a lock that exists.

**2. `connection_generation()` visibility widened** from `pub(super)` to `pub(in crate::openhuman::platform::socket)`, matching `begin_connection_generation`/`end_connection_generation` on the two lines below it. `event_handlers` is a sibling of `socket::medulla`, not a child, so `pub(super)` did not reach it. No behaviour change — it is a process-global `OnceLock<RwLock<..>>` already consumed from four other sites.

**3. `drain_pending_emits` (`ws_loop.rs`)**, called beside the existing `ack_registry.cancel_all()` when a connection ends.

Two design decisions worth flagging in review:

- **The tool future is deliberately not `select!`ed against the token**, unlike the registration reads at `medulla/workflows.rs:253-270`. Dropping a device-tool future mid-flight would abandon a side-effecting call with its `call_id` still latched and no result — precisely the failure being fixed. The work is allowed to finish; only the *emit* is gated.
- **The `call_id` claim is deliberately untouched.** See above; the tests pin it in both directions.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — four new tests: `emit_result_if_connected` live/cancelled, and `drain_pending_emits` populated/empty.
- [x] **Diff coverage ≥ 80%** — every changed line is either covered by the four new tests (the helper and the drain, both in full) or is a one-line call site inside the three handlers. **Not measured**: I did not run `pnpm test:rust` / `diff-cover` locally; this is asserted from reading, not from a coverage report.
- [x] Coverage matrix updated — `N/A: behaviour-only change`. No feature row is added, removed or renamed; the affected surface is the existing row 11.3.1 (hosted-only orchestration effects), listed under `## Related`.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced — the new tests use in-process `mpsc` channels and `CancellationToken` only; nothing binds a port or dials anything.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface changes.` The behaviour is only observable during a socket drop mid-tool-call, which the smoke checklist does not cover and cannot easily; the reproduction steps are in the issue thread as an APP CHECK instead.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

Desktop only (the socket client). No performance, security, or migration implications.

**The one real behaviour change** is the drain: a plain `emit()` queued while the socket is down was previously delivered on the next connection and is now dropped. That is the intended semantic — the backend replaces a socket's whole entry on each registration (`medulla/workflows.rs:251-253`), so a message arriving on a new sid for a cleared roster was never going to be acted on — but it *is* a change, not a no-op.

It also affects the one `emit_with_ack` caller (`security/devices/tunnel_client.rs:82`), and in that case it makes an existing inconsistency honest rather than introducing one: its waiter is already cancelled by `cancel_all()` at the same point while its message sits queued, so the caller already sees `Socket ack channel dropped` while the server does the work anyway. After this change the message is dropped too.

## What this does not fix

**The stalled turn.** With the claim left latched, the backend's redelivery is still answered with the synthetic `duplicate/running` frame, so the brain's `tool_completion` never arrives. That is unchanged from before this PR — not a regression — but it means the issue's "no recovery path" is only half addressed: the result no longer leaks onto the wrong connection, and the stall is now a loud `warn!` naming the exact `call_id` instead of silence.

Closing it needs either the result cached and replayed once the backend can correlate it across a reconnect, or a server-side deadline on the tool call so an unanswered call fails instead of hanging. The second is a backend decision. I would rather leave that explicit than guess at it and ship duplicate Signal messages to real people.

**Not addressed here** — the three transport events quoted in the issue body. They are correctly-handled transient paths, not a defect; I posted the full re-scope analysis on the issue. Nothing in this PR changes how often they occur.

## Related

- Closes: #5638
- Feature IDs: 11.3.1 (Hosted-only orchestration — client = trigger + effects + render)
- Follow-up PR(s)/TODOs: the issue's remaining open questions (the unsupported "WebSocket and REST failed simultaneously at 22:13" inference, and `"error sending request"` in `TRANSIENT_TRANSPORT_PHRASES` suppressing all Sentry events on the REST path) are documented in the issue comment and are not fixed here.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/socket-orphaned-emit-after-reconnect`
- Commit SHA: see head of this PR (`ffc06dab` original, `519368c1` review corrections)

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no frontend files changed` (four Rust files).
- [x] `pnpm typecheck` — `N/A: no TypeScript changed.`
- [x] Focused tests: `cargo test --lib platform::socket` — run, passing, and includes the four new tests. Revert-check performed; see below.
- [x] Rust fmt/check (if changed): `cargo fmt --check` and `cargo check --lib --tests` — both run, exit 0.
- [x] Tauri fmt/check (if changed): `N/A: nothing under app/src-tauri changed.`

**Revert check — done.** Reverting the behaviour of both halves (emit unconditionally without releasing; drain returns a constant `0`) while keeping the tests:

```
---- ...event_handlers::tests::a_result_for_a_dead_connection_is_dropped_... ----
panicked at src/openhuman/platform/socket/event_handlers.rs:666:9:
a dead connection must not take the result

---- ...ws_loop::tests::draining_reports_and_discards_everything_still_queued ----
panicked at src/openhuman/platform/socket/ws_loop_tests.rs:1334:5:
assertion `left == right` failed: every queued message should be counted
  left: 0
 right: 3

test result: FAILED. 147 passed; 2 failed
```

Restored, the same command is `149 passed; 0 failed` — and still `149 passed` after both review corrections. **Honesty note:** the revert run above was done on the pre-correction commit. The assertion it exercised (`assert!(!emitted, "a dead connection must not take the result")`) is unchanged by the corrections, and the drain test is untouched, so the result still holds; I did not re-run the revert after the corrections. The other two new tests (`a_result_is_emitted_while_its_connection_is_still_live`, `draining_an_empty_channel_reports_nothing_dropped`) pass on both sides by design — they pin the *unchanged* behaviour, which is what makes an over-release or an over-eager drain fail CI.

A note on what the tests deliberately do **not** do: dispatching a real `orch:tool_call` with a cancelled generation and asserting nothing lands on the channel would be **vacuous** — with the guard reverted, `handle_tool_call` returns `None` in a unit-test process for want of a real device tool, so that test passes either way. The guard is tested at the helper instead, where the assertion has teeth.

### Validation Blocked

- `command:` `pnpm test:rust` / `diff-cover`
- `error:` not run — the full Rust coverage lane is ~21 minutes and was out of budget for this change.
- `impact:` the ≥80% diff-coverage claim above is reasoned from which lines the four tests execute, not measured locally. **CI settled it: `Rust Core Coverage (cargo-llvm-cov)` passed in 19m34s on `ffc06dab`, along with every other check.** The review corrections re-triggered the lane.

### Behavior Changes

- Intended behavior change: a hosted-brain result whose connection has ended is dropped rather than emitted onto the next connection. Queued emits are discarded on disconnect rather than flushed onto the next socket. The `call_id` claim is unchanged.
- User-visible effect: none directly. A turn interrupted by a socket drop still does not complete; what changes is that its result no longer arrives on an unrelated connection, and the stall is now logged with the `call_id` rather than silent.

### Parity Contract

- Legacy behavior preserved: while the connection is live — the overwhelmingly common case — the emit path is byte-identical, and the `call_id` latch is untouched on every path, so a redelivery is still re-acked idempotently without re-running the tool.
- Guard/fallback/dispatch parity checks: both helper tests assert the claim survives — live *and* cancelled. An over-release regression, which would duplicate a Signal message to a person, fails CI rather than shipping.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented delayed results from a disconnected socket from appearing on a later connection.
  * Preserved call claims when results cannot be delivered, preventing duplicate processing.
  * Discarded queued outbound messages when a connection closes.
  * Added warnings when a turn cannot be completed because its connection ended.

* **Tests**
  * Added coverage for connection-aware result delivery, preserved claims, and cleanup of pending messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->