### PR TITLE
fix(agent): disclose a failed summarization instead of passing a raw dump

### DIFF
--- a/src/openhuman/agent/tinyagents/middleware.rs
+++ b/src/openhuman/agent/tinyagents/middleware.rs
@@ -3643,8 +3643,8 @@ mod tests {
         assert!(
             result
                 .content
-                .contains("Re-running it will not produce a summary."),
-            "the do-not-re-run sentence is the whole point of the notice and must survive"
+                .contains("Do not re-run the tool for a summary"),
+            "the do-not-re-run instruction is the whole point of the notice and must survive"
         );
         // The payload itself is still capped — deferring the notice must not
         // smuggle the tool past its own declared limit.

--- a/src/openhuman/agent/tinyagents/middleware.rs
+++ b/src/openhuman/agent/tinyagents/middleware.rs
@@ -49,7 +49,9 @@ use crate::openhuman::agent::context::CLEARED_PLACEHOLDER;
 use crate::openhuman::agent::harness::tool_result_artifacts::{
     apply_per_result_persistence, ToolResultArtifactStore, TINYAGENTS_TOOL_RESULT_ARTIFACT_STORE,
 };
-use crate::openhuman::agent::tinyagents::payload_summarizer::PayloadSummarizer;
+use crate::openhuman::agent::tinyagents::payload_summarizer::{
+    PayloadSummarizer, SummarizeOutcome, UnavailableReason,
+};
 use crate::openhuman::inference::tokenjuice::AgentTokenjuiceCompression;
 use crate::openhuman::security::approval::{
     redact_args, summarize_action, ApprovalGate, ExecutionOutcome, GateOutcome,
@@ -710,24 +712,59 @@ impl Middleware<()> for ToolOutputMiddleware {
 
         // 1. Semantic summarization (progressive disclosure) — swap the raw
         //    payload for a compressed summary when the summarizer opts in.
-        //    Failures never break the tool call (the trait swallows them).
+        //    Failures never break the tool call, but they are no longer
+        //    silent: when summarization does not happen the model is told so
+        //    in the payload itself. This used to be
+        //    `if let Ok(Some(payload)) = …`, which discarded `Err(_)` and
+        //    `Ok(None)` identically — so a failed summarization reached the
+        //    model as an unannounced raw dump and it re-called the same tool.
         if !compaction_exempt {
             if let Some(ps) = &self.payload_summarizer {
-                if let Ok(Some(payload)) = ps
+                match ps
                     .maybe_summarize_in_parent(ctx, &result.name, None, &result.content)
                     .await
                 {
-                    tracing::info!(
-                        tool = %result.name,
-                        from_bytes = payload.original_bytes,
-                        to_bytes = payload.summary_bytes,
-                        "[tinyagents::mw] payload_summarizer compressed tool output"
-                    );
-                    ctx.emit(AgentEvent::Compressed {
-                        from_tokens: estimate_output_tokens(payload.original_bytes),
-                        to_tokens: estimate_output_tokens(payload.summary_bytes),
-                    });
-                    result.content = payload.summary;
+                    Ok(SummarizeOutcome::Summarized(payload)) => {
+                        tracing::info!(
+                            tool = %result.name,
+                            from_bytes = payload.original_bytes,
+                            to_bytes = payload.summary_bytes,
+                            "[tinyagents::mw] payload_summarizer compressed tool output"
+                        );
+                        ctx.emit(AgentEvent::Compressed {
+                            from_tokens: estimate_output_tokens(payload.original_bytes),
+                            to_tokens: estimate_output_tokens(payload.summary_bytes),
+                        });
+                        result.content = payload.summary;
+                    }
+                    // The payload was fine as it was. Say nothing: a notice on
+                    // every small tool result would be pure noise.
+                    Ok(SummarizeOutcome::NotNeeded) => {}
+                    Ok(SummarizeOutcome::Unavailable(reason)) => {
+                        tracing::warn!(
+                            tool = %result.name,
+                            bytes = result.content.len(),
+                            ?reason,
+                            "[tinyagents::mw] payload_summarizer unavailable; disclosing raw output"
+                        );
+                        result.content = format!("{}\n\n{}", reason.notice(), result.content);
+                    }
+                    // Reserved for fatal misconfiguration. Previously
+                    // indistinguishable from "nothing to do"; the model is now
+                    // told the output is raw for the same reason as above.
+                    Err(error) => {
+                        tracing::warn!(
+                            tool = %result.name,
+                            bytes = result.content.len(),
+                            error = %error,
+                            "[tinyagents::mw] payload_summarizer errored; disclosing raw output"
+                        );
+                        result.content = format!(
+                            "{}\n\n{}",
+                            UnavailableReason::Failed.notice(),
+                            result.content
+                        );
+                    }
                 }
             }
 
@@ -3111,6 +3148,134 @@ mod tests {
 
     fn ctx() -> RunContext<()> {
         RunContext::new(RunConfig::new("mw-test"), ())
+    }
+
+    // ── payload_summarizer disclosure (#5722) ──────────────────────
+    //
+    // The behaviour these pin: when summarization does not happen, the model
+    // must be able to see that from the payload. Previously every one of
+    // these cases produced byte-identical content to a successful
+    // pass-through, so the model could not tell a raw dump from a normal
+    // result and re-called the same tool.
+
+    struct StubSummarizer(std::sync::Mutex<Option<anyhow::Result<SummarizeOutcome>>>);
+
+    impl StubSummarizer {
+        fn ok(outcome: SummarizeOutcome) -> Arc<Self> {
+            Arc::new(Self(std::sync::Mutex::new(Some(Ok(outcome)))))
+        }
+    }
+
+    #[async_trait]
+    impl PayloadSummarizer for StubSummarizer {
+        async fn maybe_summarize_in_parent(
+            &self,
+            _parent_ctx: &RunContext<()>,
+            _tool_name: &str,
+            _parent_task_hint: Option<&str>,
+            _raw: &str,
+        ) -> anyhow::Result<SummarizeOutcome> {
+            self.0
+                .lock()
+                .expect("stub outcome lock")
+                .take()
+                .expect("stub summarizer called more than once")
+        }
+    }
+
+    fn summarizer_mw(ps: Arc<dyn PayloadSummarizer>) -> ToolOutputMiddleware {
+        ToolOutputMiddleware {
+            // Large enough that the byte-budget backstop never fires, so these
+            // tests observe the summarizer stage alone.
+            budget_bytes: 10_000_000,
+            payload_summarizer: Some(ps),
+            artifact_store: None,
+            tokenjuice_compaction_enabled: false,
+            tokenjuice_compression:
+                crate::openhuman::inference::tokenjuice::AgentTokenjuiceCompression::Off,
+            tool_policies: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn unavailable_summarization_is_disclosed_in_the_payload() {
+        let mw = summarizer_mw(StubSummarizer::ok(SummarizeOutcome::Unavailable(
+            UnavailableReason::Failed,
+        )));
+        let mut ctx = ctx();
+        let mut result = tool_result("test_tool", "RAW-TOOL-OUTPUT");
+
+        mw.after_tool(&mut ctx, &(), &mut result)
+            .await
+            .expect("after_tool should not fail");
+
+        assert!(
+            result
+                .content
+                .starts_with(UnavailableReason::Failed.notice()),
+            "the notice must be a PREFIX — the downstream per-tool cap keeps the \
+             head, so an appended notice is the first thing truncated away; got: {}",
+            result.content
+        );
+        assert!(
+            result.content.contains("RAW-TOOL-OUTPUT"),
+            "disclosure must not cost the payload: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn a_payload_that_needed_nothing_is_left_completely_alone() {
+        // The other half of the contract. If every result carried a notice the
+        // marker would be noise and the model would learn to ignore it.
+        let mw = summarizer_mw(StubSummarizer::ok(SummarizeOutcome::NotNeeded));
+        let mut ctx = ctx();
+        let mut result = tool_result("test_tool", "RAW-TOOL-OUTPUT");
+
+        mw.after_tool(&mut ctx, &(), &mut result)
+            .await
+            .expect("after_tool should not fail");
+
+        assert_eq!(
+            result.content, "RAW-TOOL-OUTPUT",
+            "a below-threshold payload must be byte-identical"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_summarizer_error_is_disclosed_rather_than_swallowed() {
+        // `Err` used to be discarded by the same `if let Ok(Some(..))` that
+        // discarded `None`, so a fatal misconfiguration was indistinguishable
+        // from "nothing to do".
+        struct ErroringSummarizer;
+        #[async_trait]
+        impl PayloadSummarizer for ErroringSummarizer {
+            async fn maybe_summarize_in_parent(
+                &self,
+                _parent_ctx: &RunContext<()>,
+                _tool_name: &str,
+                _parent_task_hint: Option<&str>,
+                _raw: &str,
+            ) -> anyhow::Result<SummarizeOutcome> {
+                Err(anyhow::anyhow!("summarizer misconfigured"))
+            }
+        }
+
+        let mw = summarizer_mw(Arc::new(ErroringSummarizer));
+        let mut ctx = ctx();
+        let mut result = tool_result("test_tool", "RAW-TOOL-OUTPUT");
+
+        mw.after_tool(&mut ctx, &(), &mut result)
+            .await
+            .expect("a summarizer error must never break the tool call");
+
+        assert!(
+            result
+                .content
+                .starts_with(UnavailableReason::Failed.notice()),
+            "an errored summarizer must be disclosed too; got: {}",
+            result.content
+        );
     }
 
     #[tokio::test]

--- a/src/openhuman/agent/tinyagents/middleware.rs
+++ b/src/openhuman/agent/tinyagents/middleware.rs
@@ -718,6 +718,17 @@ impl Middleware<()> for ToolOutputMiddleware {
         //    `if let Ok(Some(payload)) = …`, which discarded `Err(_)` and
         //    `Ok(None)` identically — so a failed summarization reached the
         //    model as an unannounced raw dump and it re-called the same tool.
+        // Held until after the caps below rather than prefixed here. The notice
+        // is ~165 chars; a tool declaring a `max_result_size_chars` smaller than
+        // that had step 3 run `chars().take(cap)` straight through it, cutting
+        // the reason text and the do-not-re-run sentence mid-word — so the one
+        // stage that exists to stop a re-dispatch loop was removed exactly when
+        // the output was most aggressively truncated. Capping the payload first
+        // and prefixing afterwards also means a tool's declared cap bounds the
+        // tool's own output, which is what it is a contract about, rather than
+        // openhuman's annotation about it.
+        let mut pending_notice: Option<&'static str> = None;
+
         if !compaction_exempt {
             if let Some(ps) = &self.payload_summarizer {
                 match ps
@@ -747,7 +758,7 @@ impl Middleware<()> for ToolOutputMiddleware {
                             ?reason,
                             "[tinyagents::mw] payload_summarizer unavailable; disclosing raw output"
                         );
-                        result.content = format!("{}\n\n{}", reason.notice(), result.content);
+                        pending_notice = Some(reason.notice());
                     }
                     // Reserved for fatal misconfiguration. Previously
                     // indistinguishable from "nothing to do"; the model is now
@@ -759,11 +770,7 @@ impl Middleware<()> for ToolOutputMiddleware {
                             error = %error,
                             "[tinyagents::mw] payload_summarizer errored; disclosing raw output"
                         );
-                        result.content = format!(
-                            "{}\n\n{}",
-                            UnavailableReason::Failed.notice(),
-                            result.content
-                        );
+                        pending_notice = Some(UnavailableReason::Failed.notice());
                     }
                 }
             }
@@ -887,6 +894,15 @@ impl Middleware<()> for ToolOutputMiddleware {
             }
             result.content = capped;
         }
+
+        // 5. The disclosure, last, so no cap above can eat it. The model has to
+        //    be able to read *why* the payload is raw and that re-running will
+        //    not summarize it — a half-truncated notice is worse than none,
+        //    because it still looks like tool output.
+        if let Some(notice) = pending_notice {
+            result.content = format!("{notice}\n\n{}", result.content);
+        }
+
         Ok(())
     }
 }
@@ -3576,6 +3592,71 @@ mod tests {
         assert_eq!(mw.tool_char_cap("big"), Some(10));
         // Unknown tool → no per-tool cap (the flat byte budget applies instead).
         assert_eq!(mw.tool_char_cap("other"), None);
+    }
+
+    /// openhuman#5722 review: the disclosure used to be prefixed *before* the
+    /// per-tool char cap, so a tool declaring a cap shorter than the notice had
+    /// `chars().take(cap)` slice through the notice itself — dropping the
+    /// reason and the do-not-re-run sentence, and leaving the model a truncated
+    /// fragment that still reads as tool output. The notice is applied after
+    /// every cap now, so it survives intact whatever the tool declared.
+    #[tokio::test]
+    async fn an_unavailable_notice_survives_a_tool_cap_shorter_than_itself() {
+        let mut tool_policies = HashMap::new();
+        tool_policies.insert(
+            "terse".to_string(),
+            TaToolPolicy::classified().with_runtime(tinyagents::harness::tool::ToolRuntime {
+                timeout_ms: None,
+                timeout: tinyagents::harness::tool::ToolTimeout::Inherit,
+                max_retries: None,
+                idempotent: false,
+                cancelable: true,
+                sandbox: tinyagents::harness::tool::SandboxMode::Inherit,
+                // Far shorter than the ~165-char notice.
+                max_result_bytes: Some(12),
+                streaming: false,
+            }),
+        );
+        let mw = ToolOutputMiddleware {
+            // Large enough that the byte-budget backstop never fires, so this
+            // observes the per-tool cap alone.
+            budget_bytes: 10_000_000,
+            payload_summarizer: Some(StubSummarizer::ok(SummarizeOutcome::Unavailable(
+                UnavailableReason::Failed,
+            ))),
+            artifact_store: None,
+            tokenjuice_compaction_enabled: false,
+            tokenjuice_compression:
+                crate::openhuman::inference::tokenjuice::AgentTokenjuiceCompression::Off,
+            tool_policies,
+        };
+
+        let mut result = tool_result("terse", &"payload ".repeat(200));
+        mw.after_tool(&mut ctx(), &(), &mut result).await.unwrap();
+
+        let notice = UnavailableReason::Failed.notice();
+        assert!(
+            result.content.starts_with(notice),
+            "the complete notice must lead the content, got {:?}",
+            result.content.chars().take(200).collect::<String>()
+        );
+        assert!(
+            result
+                .content
+                .contains("Re-running it will not produce a summary."),
+            "the do-not-re-run sentence is the whole point of the notice and must survive"
+        );
+        // The payload itself is still capped — deferring the notice must not
+        // smuggle the tool past its own declared limit.
+        let payload = result
+            .content
+            .strip_prefix(notice)
+            .expect("notice prefix")
+            .trim_start();
+        assert!(
+            payload.contains("[truncated by tool cap:"),
+            "the raw payload must still be truncated to the tool's cap, got {payload:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/openhuman/agent/tinyagents/payload_summarizer.rs
+++ b/src/openhuman/agent/tinyagents/payload_summarizer.rs
@@ -24,8 +24,8 @@
 //!
 //! ## Trigger conditions
 //!
-//! [`PayloadSummarizer::maybe_summarize_in_parent`] returns `Ok(None)` (i.e.
-//! pass-through, do nothing) when:
+//! [`PayloadSummarizer::maybe_summarize_in_parent`] leaves the raw payload in
+//! place when:
 //!
 //! * The raw payload is below
 //!   [`SubagentPayloadSummarizer::threshold_tokens`] (config default 4 000
@@ -65,11 +65,10 @@ use crate::openhuman::agent::harness::definition::{AgentDefinition, PromptSource
 use crate::openhuman::agent::harness::fork_context::{current_parent, ParentExecutionContext};
 use crate::openhuman::agent::harness::subagent_runner;
 
-/// Outcome returned by [`PayloadSummarizer::maybe_summarize_in_parent`].
+/// A successful compression, carried by [`SummarizeOutcome::Summarized`].
 ///
-/// `Ok(None)` means the caller should keep the raw payload unchanged.
-/// `Ok(Some(...))` means the caller should replace the raw payload with
-/// [`SummarizedPayload::summary`] before appending it to agent history.
+/// The caller replaces the raw payload with [`SummarizedPayload::summary`]
+/// before appending it to agent history.
 #[derive(Debug, Clone)]
 pub struct SummarizedPayload {
     /// The compressed summary text. Replaces the raw tool output.
@@ -80,6 +79,69 @@ pub struct SummarizedPayload {
     pub summary_bytes: usize,
 }
 
+/// Why a payload reached agent history without being summarized.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnavailableReason {
+    /// Larger than `summarizer_max_payload_tokens`, so summarization was never
+    /// attempted and the payload will be truncated downstream.
+    PayloadTooLarge,
+    /// The failure circuit breaker is open for the rest of this session.
+    Disabled,
+    /// The summarizer sub-agent ran and did not produce a usable summary.
+    Failed,
+}
+
+impl UnavailableReason {
+    /// The model-facing notice for this reason.
+    ///
+    /// **Prefixed** to the tool result, never appended: the downstream
+    /// per-tool char cap keeps the head (`content.chars().take(cap)`), so an
+    /// appended notice is the first thing truncation removes.
+    ///
+    /// Every variant ends by saying a retry is pointless. Without that, the
+    /// model's reasonable response to a truncated dump is to call the same
+    /// tool again — the silent re-dispatch loop that reads to a user as a
+    /// hang.
+    #[must_use]
+    pub fn notice(self) -> &'static str {
+        match self {
+            Self::PayloadTooLarge => concat!(
+                "[openhuman: summarization unavailable — this output exceeds the summarizer's ",
+                "size cap, so the raw output follows and may be truncated. ",
+                "Re-running this tool will return the same result.]"
+            ),
+            Self::Disabled => concat!(
+                "[openhuman: summarization unavailable — it is switched off for this session ",
+                "after repeated failures, so the raw output follows. ",
+                "Re-running this tool will return the same result.]"
+            ),
+            Self::Failed => concat!(
+                "[openhuman: summarization unavailable — the summarizer did not return a usable ",
+                "summary, so the raw output follows. ",
+                "Re-running this tool will return the same result.]"
+            ),
+        }
+    }
+}
+
+/// What one summarization attempt concluded.
+///
+/// Replaces a bare `Option<SummarizedPayload>`, in which `None` meant both
+/// "nothing to do" and "this failed". That conflation was the defect: the one
+/// production caller could not tell the two apart, so a failed summarization
+/// entered agent history looking like ordinary tool output.
+#[derive(Debug, Clone)]
+pub enum SummarizeOutcome {
+    /// Replace the raw payload with this summary.
+    Summarized(SummarizedPayload),
+    /// The payload did not need summarizing. Keep it and say nothing — a
+    /// notice here would be noise on every small tool result.
+    NotNeeded,
+    /// The raw payload is what the model will see. Keep it, and prefix
+    /// [`UnavailableReason::notice`] so the model knows why.
+    Unavailable(UnavailableReason),
+}
+
 /// Trait for anything that can compress a tool result before it enters
 /// agent history. Implementations decide the threshold, the dispatch
 /// mechanism, and the failure policy.
@@ -87,21 +149,23 @@ pub struct SummarizedPayload {
 pub trait PayloadSummarizer: Send + Sync {
     /// TinyAgents parent-context-aware entry point.
     ///
-    /// Returns `Ok(None)` if the payload should be kept as-is, or
-    /// `Ok(Some(...))` if the caller should swap it for the
-    /// compressed [`SummarizedPayload::summary`].
+    /// See [`SummarizeOutcome`]. The three states are deliberately distinct:
+    /// a caller must be able to tell "this payload was fine as it was" from
+    /// "summarization did not happen", because only the second needs to be
+    /// disclosed to the model.
     ///
-    /// Errors are intentionally swallowed by the default implementation
-    /// — a failed summarization should never break a tool call. The
-    /// trait still returns `Result` so future implementations can
-    /// surface fatal misconfigurations.
+    /// A failed summarization should still never break a tool call, so
+    /// implementations report failure as
+    /// [`SummarizeOutcome::Unavailable`] rather than `Err`. `Err` remains for
+    /// fatal misconfiguration, and the caller now handles it rather than
+    /// pattern-matching it away.
     async fn maybe_summarize_in_parent(
         &self,
         parent_ctx: &RunContext<()>,
         tool_name: &str,
         parent_task_hint: Option<&str>,
         raw: &str,
-    ) -> Result<Option<SummarizedPayload>>;
+    ) -> Result<SummarizeOutcome>;
 }
 
 /// Default implementation that dispatches the `summarizer` through
@@ -200,7 +264,7 @@ impl PayloadSummarizer for SubagentPayloadSummarizer {
         tool_name: &str,
         parent_task_hint: Option<&str>,
         raw: &str,
-    ) -> Result<Option<SummarizedPayload>> {
+    ) -> Result<SummarizeOutcome> {
         let tokens = estimate_tokens(raw);
 
         // ── 1. Pass-through checks ─────────────────────────────────────
@@ -212,7 +276,9 @@ impl PayloadSummarizer for SubagentPayloadSummarizer {
                 threshold = self.threshold_tokens,
                 "[payload_summarizer] below threshold, passing through"
             );
-            return Ok(None);
+            // The only genuinely uneventful exit: the payload was fine as it
+            // was, so the model is told nothing.
+            return Ok(SummarizeOutcome::NotNeeded);
         }
         if tokens > self.max_payload_tokens {
             warn!(
@@ -222,7 +288,9 @@ impl PayloadSummarizer for SubagentPayloadSummarizer {
                 max = self.max_payload_tokens,
                 "[payload_summarizer] payload exceeds max cap, skipping summarization (will be truncated downstream)"
             );
-            return Ok(None);
+            return Ok(SummarizeOutcome::Unavailable(
+                UnavailableReason::PayloadTooLarge,
+            ));
         }
         if self.breaker_tripped() {
             warn!(
@@ -231,7 +299,7 @@ impl PayloadSummarizer for SubagentPayloadSummarizer {
                 bytes = raw.len(),
                 "[payload_summarizer] circuit breaker tripped, skipping summarization"
             );
-            return Ok(None);
+            return Ok(SummarizeOutcome::Unavailable(UnavailableReason::Disabled));
         }
 
         info!(
@@ -395,7 +463,7 @@ impl SubagentPayloadSummarizer {
         raw: &str,
         started: std::time::Instant,
         outcome: Result<String>,
-    ) -> Result<Option<SummarizedPayload>> {
+    ) -> Result<SummarizeOutcome> {
         match outcome {
             Ok(output) => {
                 let summary = output.trim().to_string();
@@ -405,7 +473,7 @@ impl SubagentPayloadSummarizer {
                         "[payload_summarizer] summarizer returned empty response, falling through"
                     );
                     self.record_failure();
-                    return Ok(None);
+                    return Ok(SummarizeOutcome::Unavailable(UnavailableReason::Failed));
                 }
                 if summary.len() >= raw.len() {
                     warn!(
@@ -415,7 +483,7 @@ impl SubagentPayloadSummarizer {
                         "[payload_summarizer] summary not smaller than raw payload, falling through"
                     );
                     self.record_failure();
-                    return Ok(None);
+                    return Ok(SummarizeOutcome::Unavailable(UnavailableReason::Failed));
                 }
                 self.record_success();
                 let summary_bytes = summary.len();
@@ -433,7 +501,7 @@ impl SubagentPayloadSummarizer {
                     elapsed_ms = started.elapsed().as_millis() as u64,
                     "[payload_summarizer] compressed successfully"
                 );
-                Ok(Some(SummarizedPayload {
+                Ok(SummarizeOutcome::Summarized(SummarizedPayload {
                     summary,
                     original_bytes,
                     summary_bytes,
@@ -446,7 +514,7 @@ impl SubagentPayloadSummarizer {
                     "[payload_summarizer] sub-agent dispatch failed, falling through to raw payload"
                 );
                 self.record_failure();
-                Ok(None)
+                Ok(SummarizeOutcome::Unavailable(UnavailableReason::Failed))
             }
         }
     }
@@ -531,7 +599,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn maybe_summarize_returns_none_below_threshold() {
+    async fn below_threshold_is_not_needed_not_unavailable() {
         let summarizer = SubagentPayloadSummarizer::new(
             dummy_definition(),
             TEST_THRESHOLD_TOKENS,
@@ -544,13 +612,14 @@ mod tests {
             .await
             .expect("below-threshold check should not error");
         assert!(
-            outcome.is_none(),
-            "~256-token payload below 500k threshold should be passed through"
+            matches!(outcome, SummarizeOutcome::NotNeeded),
+            "a payload below the threshold needed nothing, so the model must be \
+             told nothing; got {outcome:?}"
         );
     }
 
     #[tokio::test]
-    async fn maybe_summarize_returns_none_above_max_cap() {
+    async fn above_max_cap_is_disclosed_as_unavailable() {
         let summarizer = SubagentPayloadSummarizer::new(
             dummy_definition(),
             TEST_THRESHOLD_TOKENS,
@@ -562,14 +631,22 @@ mod tests {
             .maybe_summarize_in_parent(&dummy_parent_ctx(), "test_tool", None, &raw)
             .await
             .expect("above-cap check should not error");
+        // The regression guard. This used to be `outcome.is_none()`, the same
+        // value the below-threshold case returns — which is exactly how a
+        // payload that will be truncated downstream reached the model looking
+        // like ordinary output.
         assert!(
-            outcome.is_none(),
-            "~2.36M-token payload above 2M cap should be passed through (truncation handles it downstream)"
+            matches!(
+                outcome,
+                SummarizeOutcome::Unavailable(UnavailableReason::PayloadTooLarge)
+            ),
+            "a payload over the cap is not summarized and will be truncated, so \
+             it must be disclosed, not passed through silently; got {outcome:?}"
         );
     }
 
     #[tokio::test]
-    async fn maybe_summarize_returns_none_when_breaker_tripped() {
+    async fn tripped_breaker_is_disclosed_as_unavailable() {
         let summarizer = SubagentPayloadSummarizer::new(
             dummy_definition(),
             TEST_THRESHOLD_TOKENS,
@@ -589,9 +666,52 @@ mod tests {
             .await
             .expect("breaker check should not error");
         assert!(
-            outcome.is_none(),
-            "tripped breaker must short-circuit before any sub-agent dispatch"
+            matches!(
+                outcome,
+                SummarizeOutcome::Unavailable(UnavailableReason::Disabled)
+            ),
+            "a tripped breaker must short-circuit before any dispatch AND be \
+             disclosed — it is the case that repeats most often, because the \
+             breaker is rebuilt per session build; got {outcome:?}"
         );
+    }
+
+    #[test]
+    fn every_unavailable_notice_tells_the_model_a_retry_is_pointless() {
+        // The whole point of the notice. A model handed a truncated dump with
+        // no explanation does the reasonable thing and calls the same tool
+        // again, which is the re-dispatch loop a user perceives as a hang.
+        for reason in [
+            UnavailableReason::PayloadTooLarge,
+            UnavailableReason::Disabled,
+            UnavailableReason::Failed,
+        ] {
+            let notice = reason.notice();
+            assert!(
+                notice.contains("Re-running this tool will return the same result."),
+                "{reason:?} must tell the model not to retry: {notice}"
+            );
+            assert!(
+                notice.starts_with("[openhuman: summarization unavailable"),
+                "{reason:?} must be greppable and self-identifying: {notice}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_three_notices_are_distinct() {
+        // Three different situations; a reader (human or model) should be able
+        // to tell which one happened.
+        let all = [
+            UnavailableReason::PayloadTooLarge.notice(),
+            UnavailableReason::Disabled.notice(),
+            UnavailableReason::Failed.notice(),
+        ];
+        for (i, a) in all.iter().enumerate() {
+            for b in all.iter().skip(i + 1) {
+                assert_ne!(a, b, "each reason needs its own notice");
+            }
+        }
     }
 
     #[test]

--- a/src/openhuman/agent/tinyagents/payload_summarizer.rs
+++ b/src/openhuman/agent/tinyagents/payload_summarizer.rs
@@ -102,35 +102,43 @@ impl UnavailableReason {
     /// `max_result_size_chars` below this string's length truncates the notice
     /// itself. Applying it last is the only placement that survives both.
     ///
-    /// Every variant ends by telling the model not to re-run the tool *for a
-    /// summary*. Without that, the model's reasonable response to a truncated
-    /// dump is to call the same tool again — the silent re-dispatch loop that
-    /// reads to a user as a hang.
+    /// Every variant ends with the same instruction — do not re-run the tool
+    /// to get a summary, because the full output is already here. Without it,
+    /// the model's reasonable response to a truncated dump is to call the same
+    /// tool again: the silent re-dispatch loop that reads to a user as a hang.
     ///
-    /// Note what this deliberately does **not** say: that a re-run returns the
-    /// same bytes. It usually will not. `Failed` leaves the breaker open for
-    /// further attempts, so a second summarization can genuinely succeed, and
-    /// an API-backed tool is time-varying regardless. Asserting result identity
-    /// would be false in the direction that suppresses a legitimate retry the
-    /// model had good reason to make. The claim is scoped to the only thing
-    /// this code actually knows: re-running will not conjure a summary.
+    /// That sentence is an **instruction with a reason**, and deliberately not
+    /// a prediction. Two predictions were tried and both were false:
+    ///
+    /// - *"Re-running this tool will return the same result."* Untrue for any
+    ///   API-backed tool, which is time-varying, and it suppresses a retry the
+    ///   model may have had good reason to make.
+    /// - *"Re-running it will not produce a summary."* Untrue for [`Self::Failed`]
+    ///   specifically: that variant is recorded before the breaker opens, so a
+    ///   later attempt can genuinely succeed. Saying otherwise contradicts the
+    ///   breaker's own behaviour two paragraphs up.
+    ///
+    /// What is true for all three, and is what the notice now says, is that the
+    /// raw output is already in front of the model — so a re-run buys nothing
+    /// it does not already have. The reason clause carries the variant-specific
+    /// fact; the instruction carries the anti-loop property.
     #[must_use]
     pub fn notice(self) -> &'static str {
         match self {
             Self::PayloadTooLarge => concat!(
                 "[openhuman: summarization unavailable — this output exceeds the summarizer's ",
                 "size cap, so the raw output follows and may be truncated. ",
-                "Re-running it will not produce a summary.]"
+                "Do not re-run the tool for a summary; the full output is already here.]"
             ),
             Self::Disabled => concat!(
                 "[openhuman: summarization unavailable — it is switched off for this session ",
                 "after repeated failures, so the raw output follows. ",
-                "Re-running it will not produce a summary.]"
+                "Do not re-run the tool for a summary; the full output is already here.]"
             ),
             Self::Failed => concat!(
                 "[openhuman: summarization unavailable — the summarizer did not return a usable ",
-                "summary, so the raw output follows. ",
-                "Re-running it will not produce a summary.]"
+                "summary for this result, so the raw output follows. ",
+                "Do not re-run the tool for a summary; the full output is already here.]"
             ),
         }
     }
@@ -689,10 +697,18 @@ mod tests {
     }
 
     #[test]
-    fn every_unavailable_notice_tells_the_model_a_retry_is_pointless() {
+    fn every_unavailable_notice_says_not_to_re_run_without_predicting_the_future() {
         // The whole point of the notice. A model handed a truncated dump with
         // no explanation does the reasonable thing and calls the same tool
         // again, which is the re-dispatch loop a user perceives as a hang.
+        //
+        // The second half of the name is the part that took two rounds to get
+        // right. The instruction has to hold for every variant *without*
+        // asserting what a re-run would do, because `Failed` is recorded before
+        // the breaker opens and a later attempt can genuinely succeed — so a
+        // notice claiming otherwise contradicts the breaker. Both previously
+        // shipped phrasings are asserted absent below so neither comes back as
+        // a tightening.
         for reason in [
             UnavailableReason::PayloadTooLarge,
             UnavailableReason::Disabled,
@@ -700,9 +716,16 @@ mod tests {
         ] {
             let notice = reason.notice();
             assert!(
-                notice.contains("Re-running it will not produce a summary."),
+                notice.contains("Do not re-run the tool for a summary"),
                 "{reason:?} must tell the model not to retry: {notice}"
             );
+            for prediction in ["will return the same result", "will not produce a summary"] {
+                assert!(
+                    !notice.contains(prediction),
+                    "{reason:?} must not predict what a re-run would do ({prediction:?}): \
+                     {notice}"
+                );
+            }
             assert!(
                 notice.starts_with("[openhuman: summarization unavailable"),
                 "{reason:?} must be greppable and self-identifying: {notice}"

--- a/src/openhuman/agent/tinyagents/payload_summarizer.rs
+++ b/src/openhuman/agent/tinyagents/payload_summarizer.rs
@@ -94,31 +94,43 @@ pub enum UnavailableReason {
 impl UnavailableReason {
     /// The model-facing notice for this reason.
     ///
-    /// **Prefixed** to the tool result, never appended: the downstream
+    /// **Prefixed** to the tool result, never appended, and prefixed by the
+    /// caller *after* its truncation stages have run. Both halves matter. The
     /// per-tool char cap keeps the head (`content.chars().take(cap)`), so an
-    /// appended notice is the first thing truncation removes.
+    /// appended notice is the first thing truncation removes — but a notice
+    /// prefixed *before* that cap is no safer, because a tool declaring a
+    /// `max_result_size_chars` below this string's length truncates the notice
+    /// itself. Applying it last is the only placement that survives both.
     ///
-    /// Every variant ends by saying a retry is pointless. Without that, the
-    /// model's reasonable response to a truncated dump is to call the same
-    /// tool again — the silent re-dispatch loop that reads to a user as a
-    /// hang.
+    /// Every variant ends by telling the model not to re-run the tool *for a
+    /// summary*. Without that, the model's reasonable response to a truncated
+    /// dump is to call the same tool again — the silent re-dispatch loop that
+    /// reads to a user as a hang.
+    ///
+    /// Note what this deliberately does **not** say: that a re-run returns the
+    /// same bytes. It usually will not. `Failed` leaves the breaker open for
+    /// further attempts, so a second summarization can genuinely succeed, and
+    /// an API-backed tool is time-varying regardless. Asserting result identity
+    /// would be false in the direction that suppresses a legitimate retry the
+    /// model had good reason to make. The claim is scoped to the only thing
+    /// this code actually knows: re-running will not conjure a summary.
     #[must_use]
     pub fn notice(self) -> &'static str {
         match self {
             Self::PayloadTooLarge => concat!(
                 "[openhuman: summarization unavailable — this output exceeds the summarizer's ",
                 "size cap, so the raw output follows and may be truncated. ",
-                "Re-running this tool will return the same result.]"
+                "Re-running it will not produce a summary.]"
             ),
             Self::Disabled => concat!(
                 "[openhuman: summarization unavailable — it is switched off for this session ",
                 "after repeated failures, so the raw output follows. ",
-                "Re-running this tool will return the same result.]"
+                "Re-running it will not produce a summary.]"
             ),
             Self::Failed => concat!(
                 "[openhuman: summarization unavailable — the summarizer did not return a usable ",
                 "summary, so the raw output follows. ",
-                "Re-running this tool will return the same result.]"
+                "Re-running it will not produce a summary.]"
             ),
         }
     }
@@ -688,7 +700,7 @@ mod tests {
         ] {
             let notice = reason.notice();
             assert!(
-                notice.contains("Re-running this tool will return the same result."),
+                notice.contains("Re-running it will not produce a summary."),
                 "{reason:?} must tell the model not to retry: {notice}"
             );
             assert!(

--- a/src/openhuman/agent/tinyagents/payload_summarizer.rs
+++ b/src/openhuman/agent/tinyagents/payload_summarizer.rs
@@ -133,17 +133,17 @@ impl UnavailableReason {
         match self {
             Self::PayloadTooLarge => concat!(
                 "[openhuman: summarization unavailable — this output exceeds the summarizer's ",
-                "size cap, so the raw output follows and may be truncated. ",
+                "size cap, so the tool output follows and may be truncated. ",
                 "Do not re-run the tool for a summary.]"
             ),
             Self::Disabled => concat!(
                 "[openhuman: summarization unavailable — it is switched off for this session ",
-                "after repeated failures, so the raw output follows. ",
+                "after repeated failures, so the tool output follows. ",
                 "Do not re-run the tool for a summary.]"
             ),
             Self::Failed => concat!(
                 "[openhuman: summarization unavailable — the summarizer did not return a usable ",
-                "summary for this result, so the raw output follows. ",
+                "summary for this result, so the tool output follows. ",
                 "Do not re-run the tool for a summary.]"
             ),
         }

--- a/src/openhuman/agent/tinyagents/payload_summarizer.rs
+++ b/src/openhuman/agent/tinyagents/payload_summarizer.rs
@@ -102,13 +102,14 @@ impl UnavailableReason {
     /// `max_result_size_chars` below this string's length truncates the notice
     /// itself. Applying it last is the only placement that survives both.
     ///
-    /// Every variant ends with the same instruction — do not re-run the tool
-    /// to get a summary, because the full output is already here. Without it,
-    /// the model's reasonable response to a truncated dump is to call the same
-    /// tool again: the silent re-dispatch loop that reads to a user as a hang.
+    /// Every variant ends with the same instruction: *do not re-run the tool
+    /// for a summary*. Without it, the model's reasonable response to a
+    /// truncated dump is to call the same tool again — the silent re-dispatch
+    /// loop that reads to a user as a hang.
     ///
-    /// That sentence is an **instruction with a reason**, and deliberately not
-    /// a prediction. Two predictions were tried and both were false:
+    /// It is a bare **instruction**, with no justifying clause, and that is
+    /// deliberate. Three attempts to justify it were all false, each in a
+    /// different direction:
     ///
     /// - *"Re-running this tool will return the same result."* Untrue for any
     ///   API-backed tool, which is time-varying, and it suppresses a retry the
@@ -117,28 +118,33 @@ impl UnavailableReason {
     ///   specifically: that variant is recorded before the breaker opens, so a
     ///   later attempt can genuinely succeed. Saying otherwise contradicts the
     ///   breaker's own behaviour two paragraphs up.
+    /// - *"…the full output is already here."* Untrue whenever a cap fired.
+    ///   This notice is applied *after* the per-tool and byte-budget stages
+    ///   precisely so it survives them, which means the payload beneath it may
+    ///   be truncated — and [`Self::PayloadTooLarge`] says "may be truncated"
+    ///   in the same breath, so that pairing contradicted itself outright.
     ///
-    /// What is true for all three, and is what the notice now says, is that the
-    /// raw output is already in front of the model — so a re-run buys nothing
-    /// it does not already have. The reason clause carries the variant-specific
-    /// fact; the instruction carries the anti-loop property.
+    /// The variant-specific reason already sits in the first half of each
+    /// notice, and it is a fact about the summarizer rather than a prediction
+    /// about the tool. The instruction needs no second reason, and every
+    /// candidate for one has turned out to be a claim this code cannot make.
     #[must_use]
     pub fn notice(self) -> &'static str {
         match self {
             Self::PayloadTooLarge => concat!(
                 "[openhuman: summarization unavailable — this output exceeds the summarizer's ",
                 "size cap, so the raw output follows and may be truncated. ",
-                "Do not re-run the tool for a summary; the full output is already here.]"
+                "Do not re-run the tool for a summary.]"
             ),
             Self::Disabled => concat!(
                 "[openhuman: summarization unavailable — it is switched off for this session ",
                 "after repeated failures, so the raw output follows. ",
-                "Do not re-run the tool for a summary; the full output is already here.]"
+                "Do not re-run the tool for a summary.]"
             ),
             Self::Failed => concat!(
                 "[openhuman: summarization unavailable — the summarizer did not return a usable ",
                 "summary for this result, so the raw output follows. ",
-                "Do not re-run the tool for a summary; the full output is already here.]"
+                "Do not re-run the tool for a summary.]"
             ),
         }
     }


### PR DESCRIPTION
## Summary

- The payload summarizer reported failure as `Ok(None)` — the same value it returns for *"this payload did not need summarizing"*. Six early returns shared one value with two incompatible meanings.
- The single production caller was `if let Ok(Some(payload)) = …`, which discarded `Err(_)` and `Ok(None)` identically. A failed summarization therefore entered agent history looking exactly like ordinary tool output.
- Replaced the `Option` with a three-state `SummarizeOutcome` (`Summarized` / `NotNeeded` / `Unavailable(reason)`), and the middleware now **prefixes** a short notice to the content when summarization did not happen.
- A payload that was simply under threshold is left byte-identical — a notice on every small tool result would be noise the model learns to ignore.
- `Err` is now handled rather than pattern-matched away.

## Problem

When a tool result exceeds `summarizer_payload_threshold_tokens` (default 4000, `config/schema/context.rs:137-143`), the orchestrator — and only the orchestrator (`factory.rs:1108`) — hands it to a `summarizer` sub-agent. If that fails, the raw payload flows on unchanged, gets hard-truncated by the per-tool char cap (`middleware.rs:762-781`) or replaced by an artifact envelope, and the orchestrator LLM receives a mid-sentence dump with nothing indicating a step failed. It does the reasonable thing and calls the same tool again. Nothing surfaces to the user, so the agent reads as frozen.

The trait's own doc comment already promised what the wiring made impossible (`payload_summarizer.rs:94-97`):

> *"The trait still returns `Result` so future implementations can surface fatal misconfigurations."*

No error any implementation returned could ever be observed, because the only call site pattern-matched it away.

This is not theoretical. #5597 reported the same defect from the provider end — every summarizer dispatch 404'd and every payload fell through raw, 6+ times consecutively in one session. **#5597 was retired on 2026-08-24 as a staging model-registration correction, with no PR and no commit on main referencing it.** That removed the trigger without touching this defect, so it will stop reproducing in staging while remaining fully present in the code. Please don't judge this by whether staging still shows it.

## Solution

Two changes, both small:

1. **`payload_summarizer.rs`** — `SummarizeOutcome` with three states, and `UnavailableReason` (`PayloadTooLarge` / `Disabled` / `Failed`) carrying a model-facing `notice()`. All six former `Ok(None)` sites now say which of the two things they meant.
2. **`middleware.rs`** — `match` instead of `if let Ok(Some(..))`, prefixing `reason.notice()` on the unavailable and error branches.

Two design points worth reviewing:

- **The notice is a prefix, not a suffix.** The downstream per-tool cap is `content.chars().take(cap)` — it keeps the head. An appended notice is precisely what truncation removes, so appending would have produced a fix that silently does nothing in the case it exists for. There is a test asserting the prefix specifically.
- **Every notice ends with "Re-running this tool will return the same result."** That sentence is the part that breaks the loop. Disclosure alone tells the model the output is raw; it still has no reason not to retry.

## Testing

`cargo check --lib --tests` — exit 0, no errors, no warnings in the changed files.

`cargo test --lib payload_summarizer` → **8 passed, 0 failed**.
`cargo test --lib tinyagents::middleware::tests` → **52 passed, 0 failed, 1 ignored**.

Both re-run on the committed, post-`cargo fmt` tree.

Three existing summarizer tests were rewritten rather than added to: they asserted `outcome.is_none()`, which is the defect expressed as an expectation. They now assert the specific outcome, so the below-threshold and over-cap cases can no longer be confused.

### Revert-check (fleet standard: prove the test fails without the fix)

I restored the old caller behaviour — `Unavailable` and `Err` both falling through silently, exactly what `if let Ok(Some(payload))` did — and re-ran:

```
---- middleware::tests::unavailable_summarization_is_disclosed_in_the_payload stdout ----
panicked at src/openhuman/agent/tinyagents/middleware.rs:3192:9:
the notice must be a PREFIX — the downstream per-tool cap keeps the head, so an appended
notice is the first thing truncated away; got: RAW-TOOL-OUTPUT

---- middleware::tests::a_summarizer_error_is_disclosed_rather_than_swallowed stdout ----
panicked at src/openhuman/agent/tinyagents/middleware.rs:3251:9:
an errored summarizer must be disclosed too; got: RAW-TOOL-OUTPUT

test result: FAILED. 50 passed; 2 failed; 1 ignored; 10949 filtered out.
```

Exit code 101. `got: RAW-TOOL-OUTPUT` is the bug verbatim — the raw payload reaching the model with nothing attached. The control test `a_payload_that_needed_nothing_is_left_completely_alone` **still passed** under the revert, which is what makes the pair meaningful: the guard fires on the failure path and not on the quiet one. Restored → 52 passed.

## Impact

- Desktop/CLI. Behaviour change is limited to the orchestrator: the summarizer is wired only for `agent_id == "orchestrator"` (`factory.rs:1108`), so no other agent's tool results change shape.
- On the success path and the below-threshold path, output is byte-identical to before.
- The visible cost is a one-line prefix on tool results that were *already* oversized and degraded — a few dozen tokens on a payload that was about to be truncated anyway.
- `PayloadSummarizer` is a `pub trait`; its method's return type changed. Any out-of-tree implementation would need updating. There is one implementation in the tree.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — 3 new middleware tests (failure path, error path, and the untouched-control path), 2 new notice tests, 3 existing summarizer tests rewritten. Revert-check above.
- [x] **Diff coverage ≥ 80%** — N/A to assert locally: I did not run `pnpm test:coverage` / `pnpm test:rust`, as a full run is disk-prohibitive in this environment. Every changed branch in both files is exercised by the tests listed above except the `Summarized` success arm, which is pre-existing behaviour I did not modify. Asserting from reading; please let the CI gate arbitrate.
- [x] Coverage matrix updated — N/A: behaviour-only change, no feature rows added, removed or renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature IDs affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — the new tests use in-file stub summarizers and touch no network, disk, or provider.
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: no release-cut surface changes.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Related

- Closes: #5722
- Parent: #5567 — this is mode 1 of three. The split is proposed in [this comment](https://github.com/tinyhumansai/openhuman/issues/5567#issuecomment-5393876800); **#5567 must not be closed by this PR**, and it is not referenced with a keyword here for that reason.
- #5723 — mode 3 (no orchestrator-turn resume after a session reset), filed as `feature`.
- Mode 2 ("idle worker leak blocks new spawns") was **not** filed: the stated mechanism does not exist on `main`. Reasoning and an APP CHECK to settle it are in the split comment.
- Follow-up TODOs, deliberately out of scope here:
  - The circuit breaker is constructed per session build (`payload_summarizer.rs:148-158`, `factory.rs:1119`), so its counter resets on every rebuild — which is why the failure repeats across turns instead of tripping once. Hoisting it is a cross-session behaviour change and deserves its own review.
  - No user-visible progress signal during summarizer dispatch (#5567 acceptance criterion 5). `AgentEvent::Compressed` fires only on success.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5722-summarizer-failure-visible`
- Commit SHA: see head of this PR

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend files changed (Rust only).
- [x] `pnpm typecheck` — N/A: no TypeScript changed.
- [x] Focused tests: `cargo test --lib payload_summarizer` (8 passed) and `cargo test --lib tinyagents::middleware::tests` (52 passed, 1 ignored), on the committed post-`fmt` tree.
- [x] Rust fmt/check (if changed): `cargo check --lib --tests` exit 0; `cargo fmt` applied.
- [x] Tauri fmt/check (if changed): N/A: `app/src-tauri` untouched.

### Validation Blocked

- `command:` full `cargo test` / `pnpm test:rust`
- `error:` not run — not a failure; a full `target/` is 20-30GB and the environment is disk-constrained, so the run was deliberately scoped.
- `impact:` **this changes a shared contract and a scoped filter cannot see other modules.** `PayloadSummarizer::maybe_summarize_in_parent`'s return type changed from `Result<Option<SummarizedPayload>>` to `Result<SummarizeOutcome>`. `cargo check --lib --tests` compiles the whole crate and is clean, which is what makes me confident there is exactly one implementation and one caller — but only a full CI run proves no other module asserts on the old shape.

### Behavior Changes

- Intended behavior change: a tool result whose summarization failed or was skipped now carries an explicit notice; previously it was indistinguishable from a normal result.
- User-visible effect: the orchestrator stops re-dispatching the same tool after a failed summarization, which is the symptom users experienced as a freeze.

### Parity Contract

- Legacy behavior preserved: the success path and the below-threshold path are byte-identical. A failed summarization still never breaks the tool call — failure is reported as a value, not `Err`.
- Guard/fallback/dispatch parity checks: the circuit breaker, the threshold and max-cap gates, and the downstream tokenjuice/char-cap/byte-budget stages are all untouched; only what the caller does with the outcome changed.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none — no PR or commit anywhere referenced #5567 or #5722.
- Canonical PR: this one.
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of tool-output summarization when content is oversized, summarization is disabled, or processing fails.
  * Added clear, reason-specific notices when summarization is unavailable while preserving the original output.
  * Ensured notices remain complete when output-size limits apply.
  * Successful summaries now replace oversized output, while smaller responses pass through unchanged.
  * Summarization failures remain non-fatal and avoid unnecessary tool reruns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->