### PR TITLE
fix(claude-code): report the unparsable stream lines the parser keeps

### DIFF
--- a/src/openhuman/inference/provider/claude_code/driver.rs
+++ b/src/openhuman/inference/provider/claude_code/driver.rs
@@ -18,27 +18,40 @@ use tokio::sync::mpsc;
 /// infinite loop, MCP deadlock) we kill the child and surface a timeout.
 const TURN_TIMEOUT: Duration = Duration::from_secs(300);
 
-/// Characters of an unparsable stream line kept in the log: enough to recognise
-/// the shape of the line, not so much that a whole model reply lands in the log.
-const PARSE_ERROR_PREVIEW_CHARS: usize = 200;
+/// Classify the shape of an unparsable stream line without quoting it.
+///
+/// This says whether Claude spoke JSON at all - the one thing that tells a
+/// crashed CLI apart from a protocol change - and nothing about what the line
+/// said.
+fn parse_error_line_shape(line: &str) -> &'static str {
+    match line.trim_start().chars().next() {
+        Some('{') => "json object",
+        Some('[') => "json array",
+        Some('"') => "json string",
+        Some(_) => "non-json",
+        None => "blank",
+    }
+}
 
 /// Render the log line for a `ParseError` event, or `None` for anything else.
 ///
 /// The parser keeps `ParseError` precisely so an unparsable line is reported
 /// instead of vanishing, but the event mapper turns it into no deltas - so the
 /// driver loop is the only place left that can say anything about it.
+///
+/// The line itself is never quoted. It is whatever Claude Code wrote to stdout
+/// - a malformed event, or a well-formed one of an unknown type - so it can
+/// carry the user's prompt, the model's reply, or a credential, and the desktop
+/// build routes `log` into rotating support logs and Sentry breadcrumbs. Shape,
+/// size, and the parser's own reason are enough to act on; content is not.
 fn parse_error_log_line(ev: &ClaudeCodeEvent) -> Option<String> {
     let ClaudeCodeEvent::ParseError { line, reason } = ev else {
         return None;
     };
-    let preview: String = line.chars().take(PARSE_ERROR_PREVIEW_CHARS).collect();
-    let ellipsis = if preview.chars().count() < line.chars().count() {
-        "..."
-    } else {
-        ""
-    };
     Some(format!(
-        "[claude-code][driver] dropping unparsable stream line ({reason}): {preview}{ellipsis}"
+        "[claude-code][driver] dropping unparsable stream line ({reason}): {} of {} bytes",
+        parse_error_line_shape(line),
+        line.len()
     ))
 }
 

--- a/src/openhuman/inference/provider/claude_code/driver.rs
+++ b/src/openhuman/inference/provider/claude_code/driver.rs
@@ -18,10 +18,34 @@ use tokio::sync::mpsc;
 /// infinite loop, MCP deadlock) we kill the child and surface a timeout.
 const TURN_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// Characters of an unparsable stream line kept in the log: enough to recognise
+/// the shape of the line, not so much that a whole model reply lands in the log.
+const PARSE_ERROR_PREVIEW_CHARS: usize = 200;
+
+/// Render the log line for a `ParseError` event, or `None` for anything else.
+///
+/// The parser keeps `ParseError` precisely so an unparsable line is reported
+/// instead of vanishing, but the event mapper turns it into no deltas - so the
+/// driver loop is the only place left that can say anything about it.
+fn parse_error_log_line(ev: &ClaudeCodeEvent) -> Option<String> {
+    let ClaudeCodeEvent::ParseError { line, reason } = ev else {
+        return None;
+    };
+    let preview: String = line.chars().take(PARSE_ERROR_PREVIEW_CHARS).collect();
+    let ellipsis = if preview.chars().count() < line.chars().count() {
+        "..."
+    } else {
+        ""
+    };
+    Some(format!(
+        "[claude-code][driver] dropping unparsable stream line ({reason}): {preview}{ellipsis}"
+    ))
+}
+
 use super::event_mapper::EventMapper;
 use super::input_builder::build_stdin;
 use super::session_store::{generate_uuid_v4, is_uuid_v4, SessionStore};
-use super::stream_parser::StreamJsonParser;
+use super::stream_parser::{ClaudeCodeEvent, StreamJsonParser};
 use crate::openhuman::agent::messages::ChatMessage;
 use crate::openhuman::inference::provider::types::{ChatResponse, ProviderDelta};
 
@@ -441,6 +465,9 @@ pub async fn run_turn(ctx: TurnContext<'_>) -> anyhow::Result<ChatResponse> {
                 break;
             }
             for ev in parser.feed_bytes(&buf[..n]) {
+                if let Some(msg) = parse_error_log_line(&ev) {
+                    log::warn!("{msg}");
+                }
                 for delta in mapper.handle(ev) {
                     if let Some(tx) = ctx.stream {
                         let _ = tx.send(delta).await;
@@ -449,6 +476,9 @@ pub async fn run_turn(ctx: TurnContext<'_>) -> anyhow::Result<ChatResponse> {
             }
         }
         for ev in parser.end() {
+            if let Some(msg) = parse_error_log_line(&ev) {
+                log::warn!("{msg}");
+            }
             for delta in mapper.handle(ev) {
                 if let Some(tx) = ctx.stream {
                     let _ = tx.send(delta).await;

--- a/src/openhuman/inference/provider/claude_code/driver.rs
+++ b/src/openhuman/inference/provider/claude_code/driver.rs
@@ -39,11 +39,12 @@ fn parse_error_line_shape(line: &str) -> &'static str {
 /// instead of vanishing, but the event mapper turns it into no deltas - so the
 /// driver loop is the only place left that can say anything about it.
 ///
-/// The line itself is never quoted. It is whatever Claude Code wrote to stdout
-/// - a malformed event, or a well-formed one of an unknown type - so it can
-/// carry the user's prompt, the model's reply, or a credential, and the desktop
-/// build routes `log` into rotating support logs and Sentry breadcrumbs. Shape,
-/// size, and the parser's own reason are enough to act on; content is not.
+/// The line itself is never quoted. It is whatever Claude Code wrote to
+/// stdout (a malformed event, or a well-formed one of an unknown type), so it
+/// can carry the user's prompt, the model's reply, or a credential, and the
+/// desktop build routes `log` into rotating support logs and Sentry
+/// breadcrumbs. Shape, size, and the parser's own reason are enough to act on;
+/// content is not.
 fn parse_error_log_line(ev: &ClaudeCodeEvent) -> Option<String> {
     let ClaudeCodeEvent::ParseError { line, reason } = ev else {
         return None;

--- a/src/openhuman/inference/provider/claude_code/driver_tests.rs
+++ b/src/openhuman/inference/provider/claude_code/driver_tests.rs
@@ -186,8 +186,8 @@ fn parse_error_events_produce_a_log_line() {
         reason: "expected value at line 1 column 2".to_string(),
     };
     let msg = parse_error_log_line(&ev).expect("a ParseError must be reported");
-    assert!(msg.contains("{not json"), "{msg}");
     assert!(msg.contains("expected value at line 1 column 2"), "{msg}");
+    assert!(msg.contains("9 bytes"), "{msg}");
 }
 
 #[test]
@@ -198,36 +198,43 @@ fn other_events_produce_nothing() {
     assert!(parse_error_log_line(&ev).is_none());
 }
 
+/// An unparsable line can be a well-formed event of an unknown type, so it
+/// can hold the prompt, the reply, or a credential. None of it is quoted.
 #[test]
-fn a_long_line_is_previewed_not_dumped() {
+fn the_line_itself_is_never_quoted() {
+    let ev = ClaudeCodeEvent::ParseError {
+        line: r#"{"type":"secret_leak","api_key":"sk-ant-not-in-the-log"}"#.to_string(),
+        reason: "unknown event type `secret_leak`".to_string(),
+    };
+    let msg = parse_error_log_line(&ev).unwrap();
+    assert!(!msg.contains("sk-ant-not-in-the-log"), "{msg}");
+    assert!(!msg.contains("api_key"), "{msg}");
+}
+
+/// Size is reported instead of content, so a truncated stream still reads
+/// differently from a chatty one.
+#[test]
+fn the_size_of_the_line_is_reported() {
     let ev = ClaudeCodeEvent::ParseError {
         line: "x".repeat(5_000),
         reason: "trailing characters".to_string(),
     };
-    let msg = parse_error_log_line(&ev).unwrap();
-    assert!(msg.ends_with("..."), "a truncated line must say so: {msg}");
-    assert_eq!(msg.matches('x').count(), PARSE_ERROR_PREVIEW_CHARS);
+    assert!(parse_error_log_line(&ev).unwrap().contains("5000 bytes"));
 }
 
 #[test]
-fn a_short_line_is_not_marked_as_truncated() {
-    let ev = ClaudeCodeEvent::ParseError {
-        line: "oops".to_string(),
-        reason: "r".to_string(),
+fn the_shape_of_the_line_is_reported() {
+    let shape = |line: &str| {
+        parse_error_log_line(&ClaudeCodeEvent::ParseError {
+            line: line.to_string(),
+            reason: "r".to_string(),
+        })
+        .unwrap()
     };
-    assert!(!parse_error_log_line(&ev).unwrap().ends_with("..."));
-}
-
-/// The preview counts characters, so a multi-byte line is not split
-/// mid-character the way byte slicing would split it.
-#[test]
-fn a_multibyte_line_is_previewed_on_character_boundaries() {
-    let ev = ClaudeCodeEvent::ParseError {
-        line: "\u{65e5}".repeat(5_000),
-        reason: "r".to_string(),
-    };
-    let msg = parse_error_log_line(&ev).unwrap();
-    assert_eq!(msg.matches('\u{65e5}').count(), PARSE_ERROR_PREVIEW_CHARS);
+    assert!(shape(r#"  {"type":"x"}"#).contains("json object"));
+    assert!(shape("[1,2]").contains("json array"));
+    assert!(shape("panic: claude-code crashed").contains("non-json"));
+    assert!(shape("   ").contains("blank"));
 }
 
 use super::*;

--- a/src/openhuman/inference/provider/claude_code/driver_tests.rs
+++ b/src/openhuman/inference/provider/claude_code/driver_tests.rs
@@ -178,3 +178,56 @@ fn full_access_reads_persisted_toggle_when_env_unset() {
     }
     let _ = std::fs::remove_dir_all(&ws);
 }
+
+#[test]
+fn parse_error_events_produce_a_log_line() {
+    let ev = ClaudeCodeEvent::ParseError {
+        line: "{not json".to_string(),
+        reason: "expected value at line 1 column 2".to_string(),
+    };
+    let msg = parse_error_log_line(&ev).expect("a ParseError must be reported");
+    assert!(msg.contains("{not json"), "{msg}");
+    assert!(msg.contains("expected value at line 1 column 2"), "{msg}");
+}
+
+#[test]
+fn other_events_produce_nothing() {
+    let ev = ClaudeCodeEvent::Error {
+        message: "boom".to_string(),
+    };
+    assert!(parse_error_log_line(&ev).is_none());
+}
+
+#[test]
+fn a_long_line_is_previewed_not_dumped() {
+    let ev = ClaudeCodeEvent::ParseError {
+        line: "x".repeat(5_000),
+        reason: "trailing characters".to_string(),
+    };
+    let msg = parse_error_log_line(&ev).unwrap();
+    assert!(msg.ends_with("..."), "a truncated line must say so: {msg}");
+    assert_eq!(msg.matches('x').count(), PARSE_ERROR_PREVIEW_CHARS);
+}
+
+#[test]
+fn a_short_line_is_not_marked_as_truncated() {
+    let ev = ClaudeCodeEvent::ParseError {
+        line: "oops".to_string(),
+        reason: "r".to_string(),
+    };
+    assert!(!parse_error_log_line(&ev).unwrap().ends_with("..."));
+}
+
+/// The preview counts characters, so a multi-byte line is not split
+/// mid-character the way byte slicing would split it.
+#[test]
+fn a_multibyte_line_is_previewed_on_character_boundaries() {
+    let ev = ClaudeCodeEvent::ParseError {
+        line: "\u{65e5}".repeat(5_000),
+        reason: "r".to_string(),
+    };
+    let msg = parse_error_log_line(&ev).unwrap();
+    assert_eq!(msg.matches('\u{65e5}').count(), PARSE_ERROR_PREVIEW_CHARS);
+}
+
+use super::*;


### PR DESCRIPTION
## The variant exists to be logged, and nothing logs it

`stream_parser.rs`:

```rust
/// JSONL line that failed to parse. Kept so the driver can log without
/// dropping silently. Not surfaced as a `ProviderDelta`.
ParseError {
    line: String,
    reason: String,
},
```

The driver hands every event straight to the mapper:

```rust
for ev in parser.feed_bytes(&buf[..n]) {
    for delta in mapper.handle(ev) { ... }
}
```

and `event_mapper.rs:108` is where it lands:

```rust
ClaudeCodeEvent::RateLimit { .. } | ClaudeCodeEvent::ParseError { .. } => Vec::new(),
```

`grep -rn ParseError` over the provider finds no `log::` call anywhere in between. So the line is dropped exactly as silently as if the parser had thrown it away — which makes the variant, and the comment justifying it, dead weight.

## Why it matters

When the CLI emits a line this parser cannot read — schema drift after a `claude` upgrade, a stray non-JSON line on stdout, a truncated write — the turn quietly loses that content and there is nothing in the log to explain the gap. That is the same failure mode as #5718, one layer up.

## The fix

Log it in the driver loop, where the comment says it belongs.

The message is built by a small function that **returns** the string rather than logging inline, so it is unit-testable without a log harness.

Two deliberate choices:

- **The line is previewed, not dumped.** A stream line can carry an entire model reply; that does not belong in a warn-level log. 200 characters is enough to recognise the shape of the line.
- **The preview counts characters, not bytes**, so a multi-byte line is not split mid-character.

## Tests

5 cases in the existing `driver.rs` test module (6 → 11 in `claude_code::driver`):

- a `ParseError` produces a message carrying both the line and the reason
- other events produce `None`
- a 5,000-char line is truncated to 200 and marked `...`
- a short line is not marked truncated
- a 5,000-char CJK line yields exactly 200 characters

Mutation-checked — replacing the preview with the full line turns 2 of them red:

```
test result: FAILED. 9 passed; 2 failed
```

and restoring it returns `11 passed`. `cargo fmt --check` and `cargo clippy --lib` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics when Claude Code stream events cannot be parsed.
  * Parse errors no longer log rejected content, helping prevent sensitive prompt, response, or credential data from appearing in logs.
  * Error details now report the parser reason, input shape, and byte length for both incremental and completed events.
* **Tests**
  * Added coverage for JSON and non-JSON inputs, multibyte text, input sizing, content omission, and shape classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->