### PR TITLE
fix(memory): stop recall from hiding a failed chunk read as a missing chunk

### DIFF
--- a/src/openhuman/memory/read_rpc/chunks.rs
+++ b/src/openhuman/memory/read_rpc/chunks.rs
@@ -287,8 +287,6 @@ pub async fn recall_rpc(
     query: String,
     k: u32,
 ) -> Result<RpcOutcome<RecallResponse>, String> {
-    use rusqlite::params;
-
     let limit = k.clamp(1, MAX_LIST_LIMIT) as usize;
     log::debug!(
         "[memory_tree::read::recall] query_len={} k={}",
@@ -336,54 +334,18 @@ pub async fn recall_rpc(
             with_connection(&cfg, |conn| {
                 let mut out = Vec::with_capacity(leaves.len());
                 for (chunk_id, score) in leaves {
-                    let row = conn
-                        .query_row(
-                            "SELECT id, source_kind, source_id, source_ref, owner,
-                                    timestamp_ms, token_count, lifecycle_status,
-                                    content_path, content, tags_json,
-                                    CASE WHEN embedding IS NULL THEN 0 ELSE 1 END
-                               FROM mem_tree_chunks WHERE id = ?1",
-                            params![chunk_id],
-                            |r| {
-                                let id: String = r.get(0)?;
-                                let source_kind: String = r.get(1)?;
-                                let source_id: String = r.get(2)?;
-                                let source_ref: Option<String> = r.get(3)?;
-                                let owner: String = r.get(4)?;
-                                let timestamp_ms: i64 = r.get(5)?;
-                                let token_count: i64 = r.get(6)?;
-                                let lifecycle_status: String = r.get(7)?;
-                                let content_path: Option<String> = r.get(8)?;
-                                let content: String = r.get(9)?;
-                                let tags_json: String = r.get(10)?;
-                                let has_emb: i64 = r.get(11)?;
-                                let preview: String =
-                                    content.chars().take(PREVIEW_MAX_CHARS).collect();
-                                let tags: Vec<String> =
-                                    serde_json::from_str(&tags_json).unwrap_or_default();
-                                Ok(ChunkRow {
-                                    id,
-                                    source_kind,
-                                    source_id,
-                                    source_ref,
-                                    owner,
-                                    timestamp_ms,
-                                    token_count: token_count.max(0) as u32,
-                                    lifecycle_status,
-                                    content_path,
-                                    content_preview: if preview.is_empty() {
-                                        None
-                                    } else {
-                                        Some(preview)
-                                    },
-                                    has_embedding: has_emb != 0,
-                                    tags,
-                                })
-                            },
-                        )
-                        .ok();
-                    if let Some(r) = row {
-                        out.push((r, score));
+                    match hydrate_chunk(conn, &chunk_id) {
+                        Ok(Some(row)) => out.push((row, score)),
+                        // The tree can point at a chunk the store no longer has.
+                        // That is expected, and skipping it is the right answer.
+                        Ok(None) => {}
+                        // Anything else is a read that failed. Skip the row so one
+                        // bad chunk cannot sink the whole recall, but say so - a
+                        // recall that silently returns fewer hits than it found is
+                        // indistinguishable from a recall that found less.
+                        Err(e) => {
+                            log::warn!("[memory_tree::read::recall] skipping chunk {chunk_id}: {e}")
+                        }
                     }
                 }
                 Ok(out)
@@ -408,6 +370,65 @@ pub async fn recall_rpc(
         },
         format!("memory_tree::read: recall n={n}"),
     ))
+}
+
+/// Read one chunk row by id for recall hydration.
+///
+/// `Ok(None)` means the row is not there - the tree can outlive a chunk. Every
+/// other failure is returned so the caller can report it instead of turning a
+/// broken read into an absent chunk.
+pub(super) fn hydrate_chunk(
+    conn: &rusqlite::Connection,
+    chunk_id: &str,
+) -> rusqlite::Result<Option<ChunkRow>> {
+    use rusqlite::params;
+
+    match conn.query_row(
+        "SELECT id, source_kind, source_id, source_ref, owner,
+                timestamp_ms, token_count, lifecycle_status,
+                content_path, content, tags_json,
+                CASE WHEN embedding IS NULL THEN 0 ELSE 1 END
+           FROM mem_tree_chunks WHERE id = ?1",
+        params![chunk_id],
+        |r| {
+            let id: String = r.get(0)?;
+            let source_kind: String = r.get(1)?;
+            let source_id: String = r.get(2)?;
+            let source_ref: Option<String> = r.get(3)?;
+            let owner: String = r.get(4)?;
+            let timestamp_ms: i64 = r.get(5)?;
+            let token_count: i64 = r.get(6)?;
+            let lifecycle_status: String = r.get(7)?;
+            let content_path: Option<String> = r.get(8)?;
+            let content: String = r.get(9)?;
+            let tags_json: String = r.get(10)?;
+            let has_emb: i64 = r.get(11)?;
+            let preview: String = content.chars().take(PREVIEW_MAX_CHARS).collect();
+            let tags: Vec<String> = serde_json::from_str(&tags_json).unwrap_or_default();
+            Ok(ChunkRow {
+                id,
+                source_kind,
+                source_id,
+                source_ref,
+                owner,
+                timestamp_ms,
+                token_count: token_count.max(0) as u32,
+                lifecycle_status,
+                content_path,
+                content_preview: if preview.is_empty() {
+                    None
+                } else {
+                    Some(preview)
+                },
+                has_embedding: has_emb != 0,
+                tags,
+            })
+        },
+    ) {
+        Ok(row) => Ok(Some(row)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e),
+    }
 }
 
 // ── small helpers ───────────────────────────────────────────────────────

--- a/src/openhuman/memory/read_rpc_tests.rs
+++ b/src/openhuman/memory/read_rpc_tests.rs
@@ -1042,3 +1042,47 @@ async fn wipe_all_clears_ingest_gate() {
         "wipe_all must clear mem_tree_ingested_sources so a wiped source can re-ingest"
     );
 }
+
+#[tokio::test]
+async fn hydrate_chunk_reads_a_seeded_row() {
+    let (_tmp, cfg) = test_config();
+    insert_raw_chunk(&cfg, "c-hydrate", "chat", "slack:#eng", 1, "[]", "hello", 1);
+    let row = with_connection(&cfg, |conn| {
+        Ok(crate::openhuman::memory::read_rpc::chunks::hydrate_chunk(conn, "c-hydrate").unwrap())
+    })
+    .unwrap()
+    .expect("the seeded chunk must be found");
+    assert_eq!(row.id, "c-hydrate");
+    assert_eq!(row.content_preview.as_deref(), Some("hello"));
+}
+
+#[tokio::test]
+async fn hydrate_chunk_reports_a_missing_row_as_none() {
+    let (_tmp, cfg) = test_config();
+    let row = with_connection(&cfg, |conn| {
+        Ok(crate::openhuman::memory::read_rpc::chunks::hydrate_chunk(conn, "nope").unwrap())
+    })
+    .unwrap();
+    assert!(row.is_none(), "an absent chunk is not an error");
+}
+
+/// A row that cannot be read is not the same thing as a row that is not there.
+/// Recall used to collapse both into "skip", so a broken read came back as a
+/// quietly shorter result set.
+#[tokio::test]
+async fn hydrate_chunk_surfaces_a_broken_row_instead_of_hiding_it() {
+    let (_tmp, cfg) = test_config();
+    insert_raw_chunk(&cfg, "c-broken", "chat", "slack:#eng", 1, "[]", "hello", 1);
+    let err = with_connection(&cfg, |conn| {
+        conn.execute(
+            "UPDATE mem_tree_chunks SET token_count = 'not-a-number' WHERE id = ?1",
+            params!["c-broken"],
+        )?;
+        Ok(crate::openhuman::memory::read_rpc::chunks::hydrate_chunk(conn, "c-broken").err())
+    })
+    .unwrap();
+    assert!(
+        err.is_some(),
+        "a row that fails to map must be reported, not turned into None"
+    );
+}


### PR DESCRIPTION
## `.ok()` answers two different questions with one word

`recall_rpc` hydrates each retrieved leaf like this:

```rust
let row = conn.query_row(SQL, params![chunk_id], |r| { ... }).ok();
if let Some(r) = row {
    out.push((r, score));
}
```

`.ok()` collapses two outcomes that are not the same thing:

| outcome | what it means | what happens |
|---|---|---|
| `QueryReturnedNoRows` | the tree points at a chunk the store no longer has | skipped — correct |
| any other `Err` | **the read failed** | skipped, silently |

The second row is the bug. A chunk that cannot be mapped — a column holding the wrong type after a migration or an out-of-band write — drops out of the result set with no error and no log. Recall then returns fewer hits than it actually retrieved, and from the outside that is indistinguishable from a recall that simply found less.

## The fix

Pull the query into `hydrate_chunk()`, which answers the two questions separately:

```rust
Ok(row) => Ok(Some(row)),
Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
Err(e) => Err(e),
```

The caller still **skips** a bad row rather than failing the whole recall — one broken chunk should not sink a search — but it now says which chunk and why:

```rust
Err(e) => log::warn!("[memory_tree::read::recall] skipping chunk {chunk_id}: {e}"),
```

Same behaviour for every healthy row; the only change is that a failure stops being invisible.

## Tests

Three cases in the existing `read_rpc_tests.rs` harness:

- a seeded row is read back, preview included
- a missing id is `Ok(None)`, not an error
- a row whose `token_count` holds text comes back as `Err` instead of vanishing

I first tried to force the failure with `content = NULL` and the DB refused it (`NOT NULL constraint failed: mem_tree_chunks.content`), so the test uses a column-type mismatch instead — SQLite affinity lets a value of the wrong type sit in the column, which is exactly the class of damage this path used to hide.

Mutation-checked — restoring the swallow (`Err(_) => Ok(None)`) turns the third test red:

```
failures:
    hydrate_chunk_surfaces_a_broken_row_instead_of_hiding_it
test result: FAILED. 2 passed; 1 failed
```

Full `read_rpc` suite: `41 passed; 0 failed; 4 ignored`. `cargo fmt --check` and `cargo clippy --lib` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recall data loading so missing records are skipped without disrupting results.
  - Ensured unreadable or malformed records are handled individually while allowing other records to load.
  - Preserved clear error reporting for data that cannot be read.

- **Tests**
  - Added coverage for successful loading, missing records, and malformed records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->