### PR TITLE
fix(profiles): let a profile named outside ASCII be saved

### DIFF
--- a/app/src/components/settings/panels/ProfileEditorPage.test.tsx
+++ b/app/src/components/settings/panels/ProfileEditorPage.test.tsx
@@ -78,6 +78,29 @@ describe('ProfileEditorPage', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/settings/profiles');
   });
 
+  it('create mode: a name written outside ASCII still submits, id left to the core', async () => {
+    // `slugify` keeps ASCII only, so this name resolves to an empty id. The
+    // core derives `profile-<digest>` from the name; blocking submit here made
+    // that path unreachable and left the user with no name they could use.
+    renderAt('/settings/profiles/new');
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: '研究アシスタント' } });
+    expect((screen.getByLabelText('ID') as HTMLInputElement).value).toBe('');
+
+    fireEvent.click(screen.getByText('Create'));
+    await waitFor(() => expect(mockUpsert).toHaveBeenCalled());
+    const sent = mockUpsert.mock.calls[0][0];
+    expect(sent.id).toBe('');
+    expect(sent.name).toBe('研究アシスタント');
+  });
+
+  it('create mode: a punctuation-only name is still refused', async () => {
+    renderAt('/settings/profiles/new');
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: '!!!' } });
+    fireEvent.click(screen.getByText('Create'));
+    await waitFor(() => expect(mockUpsert).not.toHaveBeenCalled());
+  });
+
   it('disables Create until a non-empty resolved id exists', () => {
     renderAt('/settings/profiles/new');
     const create = screen.getByText('Create').closest('button')!;

--- a/app/src/components/settings/panels/ProfileEditorPage.tsx
+++ b/app/src/components/settings/panels/ProfileEditorPage.tsx
@@ -130,18 +130,25 @@ const ProfileEditorPage = () => {
   };
 
   // Resolved profile id: explicit id on create (falling back to a slug of the
-  // name), or the existing id on edit. Must be non-empty to submit — a
-  // punctuation-only name slugs to '' and must not reach the RPC layer.
+  // name), or the existing id on edit.
   const resolvedId = (isCreate ? profileId.trim() || slugify(name) : profileId).trim();
 
-  const canSubmit = !submitting && (isCreate ? resolvedId.length > 0 : true);
+  // `slugify` keeps ASCII only, so a name written in Japanese, Chinese, Greek,
+  // Cyrillic or Arabic resolves to no id at all. The core derives one from the
+  // name in that case, so a nameable profile must still be submittable —
+  // otherwise there is no name in those scripts a user can save. A
+  // punctuation-only name still has nothing to name a profile with, and stays
+  // blocked as before.
+  const nameCanCarryAnId = /[\p{L}\p{N}]/u.test(name);
+
+  const canSubmit = !submitting && (isCreate ? resolvedId.length > 0 || nameCanCarryAnId : true);
 
   const handleSubmit = async () => {
     if (!canSubmit) return;
     setSubmitting(true);
     setError(null);
     const id = resolvedId;
-    if (!id) {
+    if (!id && !nameCanCarryAnId) {
       setError(t('settings.profiles.editor.idRequired'));
       setSubmitting(false);
       return;

--- a/src/openhuman/agent/profiles/ops.rs
+++ b/src/openhuman/agent/profiles/ops.rs
@@ -205,12 +205,13 @@ pub async fn upsert(profile: AgentProfile) -> Result<Value, String> {
         }
     }
     let upserted_id = profile.id.clone();
+    let upserted_name = profile.name.clone();
     let (store, workspace_dir, action_dir) = store_and_roots().await?;
     // Keep the previous inline value so SOUL.md is rewritten only when the
     // persona field itself changed. The editor submits the full profile for
     // unrelated settings saves; comparing only against the file would clobber
     // a newer manual edit with the unchanged, stale inline value.
-    let normalised_id = super::store::normalise_profile_id(&upserted_id);
+    let normalised_id = super::store::normalise_profile_id(&upserted_id, &upserted_name);
     let previous_soul_md = store
         .load()
         .map_err(|e| {

--- a/src/openhuman/agent/profiles/store.rs
+++ b/src/openhuman/agent/profiles/store.rs
@@ -548,6 +548,9 @@ fn normalise_profile(mut profile: AgentProfile) -> AgentProfile {
     if profile.id.is_empty() {
         profile.id = slugify_profile_id(&profile.name);
     }
+    if profile.id.is_empty() {
+        profile.id = profile_id_from_name_digest(&profile.name);
+    }
     profile.name = profile.name.trim().to_string();
     if profile.name.is_empty() {
         profile.name = profile.id.clone();
@@ -618,6 +621,33 @@ fn next_available_suffix(existing: &std::collections::HashSet<String>) -> String
 /// the store has slugified it.
 pub(crate) fn normalise_profile_id(input: &str) -> String {
     slugify_profile_id(input)
+}
+
+/// Profile id for a name that slugifies to nothing.
+///
+/// `slugify_profile_id` keeps only ASCII alphanumerics, so a name written
+/// entirely outside that range - Japanese, Chinese, Greek, Cyrillic, Arabic -
+/// reduces to the empty string and `validate_profile_id` rejects the upsert
+/// with "profile id must not be empty". The user supplied a name; the error
+/// blames an id they never typed.
+///
+/// Derive one from the name instead. A digest keeps it deterministic, so
+/// saving the same profile twice updates it rather than creating a second one,
+/// and two different names do not land on the same id.
+fn profile_id_from_name_digest(name: &str) -> String {
+    use sha2::{Digest, Sha256};
+
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    let digest = Sha256::digest(trimmed.as_bytes());
+    let short: String = digest
+        .iter()
+        .take(4)
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    format!("profile-{short}")
 }
 
 fn slugify_profile_id(input: &str) -> String {

--- a/src/openhuman/agent/profiles/store.rs
+++ b/src/openhuman/agent/profiles/store.rs
@@ -544,13 +544,7 @@ fn normalise_allowlist(list: Option<Vec<String>>) -> Option<Vec<String>> {
 }
 
 fn normalise_profile(mut profile: AgentProfile) -> AgentProfile {
-    profile.id = slugify_profile_id(&profile.id);
-    if profile.id.is_empty() {
-        profile.id = slugify_profile_id(&profile.name);
-    }
-    if profile.id.is_empty() {
-        profile.id = profile_id_from_name_digest(&profile.name);
-    }
+    profile.id = normalise_profile_id(&profile.id, &profile.name);
     profile.name = profile.name.trim().to_string();
     if profile.name.is_empty() {
         profile.name = profile.id.clone();
@@ -618,9 +612,22 @@ fn next_available_suffix(existing: &std::collections::HashSet<String>) -> String
 /// Normalise a raw profile id into its persisted slug form, mirroring the
 /// transformation `normalise_profile` applies on upsert. Exposed so callers
 /// (e.g. `ops::upsert`) can locate the persisted profile by its stored id after
-/// the store has slugified it.
-pub(crate) fn normalise_profile_id(input: &str) -> String {
-    slugify_profile_id(input)
+/// the store has normalised it.
+///
+/// Takes the name as well as the id because the rule needs both: an id that
+/// slugifies to nothing falls back to the name, and a name that slugifies to
+/// nothing falls back to a digest of it. A caller that mirrors only the first
+/// step looks up an id the store never wrote.
+pub(crate) fn normalise_profile_id(id: &str, name: &str) -> String {
+    let from_id = slugify_profile_id(id);
+    if !from_id.is_empty() {
+        return from_id;
+    }
+    let from_name = slugify_profile_id(name);
+    if !from_name.is_empty() {
+        return from_name;
+    }
+    profile_id_from_name_digest(name)
 }
 
 /// Profile id for a name that slugifies to nothing.
@@ -632,8 +639,12 @@ pub(crate) fn normalise_profile_id(input: &str) -> String {
 /// blames an id they never typed.
 ///
 /// Derive one from the name instead. A digest keeps it deterministic, so
-/// saving the same profile twice updates it rather than creating a second one,
-/// and two different names do not land on the same id.
+/// saving the same profile twice updates it rather than creating a second one.
+///
+/// 16 bytes, not 4: at 32 bits the birthday bound is ~65k names, and upsert
+/// replaces by id, so a collision silently overwrites someone's profile. The
+/// resulting 40-character id stays under the 64-character cap in
+/// `validate_profile_id`.
 fn profile_id_from_name_digest(name: &str) -> String {
     use sha2::{Digest, Sha256};
 
@@ -644,7 +655,7 @@ fn profile_id_from_name_digest(name: &str) -> String {
     let digest = Sha256::digest(trimmed.as_bytes());
     let short: String = digest
         .iter()
-        .take(4)
+        .take(16)
         .map(|byte| format!("{byte:02x}"))
         .collect();
     format!("profile-{short}")

--- a/src/openhuman/agent/profiles/store_tests.rs
+++ b/src/openhuman/agent/profiles/store_tests.rs
@@ -335,3 +335,78 @@ fn default_profile_has_master_and_memory_suffix() {
     assert_eq!(default.memory_dir_suffix.as_deref(), Some(""));
     assert!(default.include_agent_conversations);
 }
+
+/// A name written entirely outside ASCII slugifies to nothing, and the
+/// upsert used to fail with "profile id must not be empty" - an error about
+/// a field the user never filled in.
+#[test]
+fn a_profile_named_only_in_non_ascii_can_be_saved() {
+    let dir = tempdir().expect("tempdir");
+    let store = AgentProfileStore::new(dir.path().to_path_buf());
+    let name = "\u{7814}\u{7a76}\u{30a2}\u{30b7}\u{30b9}\u{30bf}\u{30f3}\u{30c8}";
+
+    let state = store
+        .upsert(custom("", name, "orchestrator"))
+        .expect("a profile named in Japanese must be saveable");
+
+    let saved = state
+        .profiles
+        .iter()
+        .find(|p| p.name == name)
+        .expect("the profile is in the list");
+    assert!(
+        super::super::home::validate_profile_id(&saved.id).is_ok(),
+        "derived id must be a valid one: {}",
+        saved.id
+    );
+}
+
+/// The id comes from a digest of the name, so re-saving the same profile
+/// edits it instead of adding a second copy.
+#[test]
+fn re_saving_a_non_ascii_profile_updates_it() {
+    let dir = tempdir().expect("tempdir");
+    let store = AgentProfileStore::new(dir.path().to_path_buf());
+    let name = "\u{7814}\u{7a76}\u{30a2}\u{30b7}\u{30b9}\u{30bf}\u{30f3}\u{30c8}";
+
+    store
+        .upsert(custom("", name, "orchestrator"))
+        .expect("first");
+    let state = store.upsert(custom("", name, "planner")).expect("second");
+
+    let matching: Vec<_> = state.profiles.iter().filter(|p| p.name == name).collect();
+    assert_eq!(
+        matching.len(),
+        1,
+        "re-saving must not duplicate the profile"
+    );
+    assert_eq!(matching[0].agent_id, "planner", "the edit must be applied");
+}
+
+/// Two different non-ASCII names must not collapse onto one profile.
+#[test]
+fn two_non_ascii_profiles_keep_separate_ids() {
+    let dir = tempdir().expect("tempdir");
+    let store = AgentProfileStore::new(dir.path().to_path_buf());
+
+    store
+        .upsert(custom("", "\u{7814}\u{7a76}", "orchestrator"))
+        .expect("first");
+    let state = store
+        .upsert(custom("", "\u{5206}\u{6790}", "orchestrator"))
+        .expect("second");
+
+    assert!(state.profiles.iter().any(|p| p.name == "\u{7814}\u{7a76}"));
+    assert!(state.profiles.iter().any(|p| p.name == "\u{5206}\u{6790}"));
+}
+
+/// An ASCII name still gets the readable slug it always had.
+#[test]
+fn an_ascii_name_is_unaffected() {
+    let dir = tempdir().expect("tempdir");
+    let store = AgentProfileStore::new(dir.path().to_path_buf());
+    let state = store
+        .upsert(custom("", "Research Buddy", "orchestrator"))
+        .expect("upsert");
+    assert!(state.profiles.iter().any(|p| p.id == "research-buddy"));
+}

--- a/src/openhuman/agent/profiles/store_tests.rs
+++ b/src/openhuman/agent/profiles/store_tests.rs
@@ -410,3 +410,62 @@ fn an_ascii_name_is_unaffected() {
         .expect("upsert");
     assert!(state.profiles.iter().any(|p| p.id == "research-buddy"));
 }
+
+/// `ops::upsert` looks the persisted profile up by re-deriving its id, and
+/// skips home materialization and SOUL.md sync when the lookup misses. The
+/// helper it uses has to produce exactly what the store wrote, including
+/// the digest fallback.
+#[test]
+fn normalise_profile_id_matches_what_the_store_persists() {
+    let dir = tempdir().expect("tempdir");
+    let store = AgentProfileStore::new(dir.path().to_path_buf());
+    let name = "\u{7814}\u{7a76}\u{30a2}\u{30b7}\u{30b9}\u{30bf}\u{30f3}\u{30c8}";
+
+    let state = store
+        .upsert(custom("", name, "orchestrator"))
+        .expect("upsert");
+    let persisted = state
+        .profiles
+        .iter()
+        .find(|p| p.name == name)
+        .expect("saved profile");
+
+    assert_eq!(normalise_profile_id("", name), persisted.id);
+    assert_eq!(
+        normalise_profile_id(" Custom Profile ", "ignored"),
+        "custom-profile"
+    );
+    assert_eq!(
+        normalise_profile_id("", " Custom Profile "),
+        "custom-profile"
+    );
+}
+
+/// Upsert replaces by id, so two names sharing one derived id silently
+/// overwrite each other. A 32-bit digest collides within ~65k names; these
+/// two are a measured collision at that width.
+#[test]
+fn the_derived_id_does_not_collide_for_known_32_bit_collisions() {
+    let a = "\u{7814}\u{7a76}\u{30d7}\u{30ed}\u{30d5}\u{30a3}\u{30fc}\u{30eb}110131";
+    let b = "\u{7814}\u{7a76}\u{30d7}\u{30ed}\u{30d5}\u{30a3}\u{30fc}\u{30eb}211703";
+    let id_a = profile_id_from_name_digest(a);
+    let id_b = profile_id_from_name_digest(b);
+    assert_ne!(id_a, id_b, "these two collide at a 4-byte digest");
+    for id in [&id_a, &id_b] {
+        assert!(id.len() <= 64, "id must fit the 64-char cap: {id}");
+        assert!(
+            super::super::home::validate_profile_id(id).is_ok(),
+            "derived id must be valid: {id}"
+        );
+    }
+}
+
+#[test]
+fn the_derived_id_is_stable_for_the_same_name() {
+    let name = "\u{7814}\u{7a76}";
+    assert_eq!(
+        profile_id_from_name_digest(name),
+        profile_id_from_name_digest("  \u{7814}\u{7a76}  "),
+    );
+    assert_eq!(profile_id_from_name_digest("   "), "");
+}


### PR DESCRIPTION
## A profile named in Japanese cannot be saved

`slugify_profile_id` keeps only ASCII alphanumerics:

```rust
if c.is_ascii_alphanumeric() { out.push(c); } else if !last_was_sep { out.push('-'); ... }
```

`normalise_profile` tries the id, then the name, and stops:

```rust
profile.id = slugify_profile_id(&profile.id);
if profile.id.is_empty() {
    profile.id = slugify_profile_id(&profile.name);
}
```

For a name written entirely outside ASCII both slugs are empty, and the next line in `upsert` is `validate_profile_id(&profile.id)?`. Measured against the real store:

```
upsert(name = "研究アシスタント")  ->  Err("profile id must not be empty")
```

The user typed a name. The error blames an id they were never asked for — and there is no name they can choose in Japanese, Chinese, Greek, Cyrillic or Arabic that gets past it.

## The fix

Derive an id from the name when the slug comes out empty: SHA-256 over the trimmed name, first four bytes, rendered as `profile-<8 hex>`. `sha2` is already a dependency and this is the same idiom used in `agent/experience/types.rs`.

Deterministic, which matters twice:

- saving the same profile again **edits** it instead of adding a second copy
- two different names do not land on the same id

ASCII names never reach the new branch, so `"Research Buddy"` is still `research-buddy`.

## What this PR does not fix

Partly-ASCII names still collide: `研究 A` and `分析 A` both slug to `a`, and the second upsert replaces the first. Measured:

```
upsert("研究 A") -> [..., "a"]
upsert("分析 A") -> [..., "a"]      # one entry, not two
```

That one is upsert's key semantics — the same happens for two ASCII names that slug alike — so changing it is a design decision, not a bug fix, and it does not belong in this PR. Flagging it because it has the same root cause: the slug throws non-ASCII content away rather than encoding it.

## Tests

Four cases in `profiles/store.rs`:

- a profile named only in Japanese saves, and its derived id passes `validate_profile_id`
- re-saving the same name updates the profile instead of duplicating it
- two different non-ASCII names keep separate entries
- `"Research Buddy"` still becomes `research-buddy`

Mutation-checked — removing the new branch turns 3 of the 4 red:

```
test result: FAILED. 17 passed; 3 failed
```

Restored: `20 passed`. `cargo fmt --check` clean; `cargo clippy --lib` reports nothing in this file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Profiles with names written entirely in non-ASCII characters can now be saved successfully.
  - Re-saving these profiles preserves their identity instead of creating duplicates.
  - Profile identifiers are generated consistently for names that cannot be converted into standard slugs.
  - Existing ASCII-based naming and uniqueness behavior remains unchanged.
  - Names containing only punctuation remain invalid.

- **Tests**
  - Added coverage for non-ASCII profile creation, updates, duplicate prevention, identifier consistency, and ASCII behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->