### PR TITLE
feat(turn-origin): a spawn that cannot lose the turn origin

### DIFF
--- a/src/openhuman/agent/turn_origin.rs
+++ b/src/openhuman/agent/turn_origin.rs
@@ -251,6 +251,87 @@ pub fn propagate<F: std::future::Future>(fut: F) -> impl std::future::Future<Out
     }
 }
 
+/// `tokio::spawn`, with the current turn origin carried onto the new task.
+///
+/// # Why this exists when [`propagate`] already does the carrying
+///
+/// [`propagate`] and [`capture`] read the origin **when they are called**, which
+/// has to be on the spawning task — a task-local is already gone by the time the
+/// spawned future is first polled. Both of these compile, neither warns, and
+/// only the first is right:
+///
+/// ```ignore
+/// tokio::spawn(turn_origin::propagate(work));              // correct
+/// tokio::spawn(async move { turn_origin::propagate(work).await });  // silently Unknown
+/// ```
+///
+/// The second captures inside the new task, where [`current`] is already `None`,
+/// so it scopes nothing and every external-effect tool the child calls is
+/// refused by the approval gate. The existing call sites get this right only
+/// because each one carries a hand-written comment saying to capture *here, on
+/// the spawning task* — correctness resting on reviewer attention at every
+/// future site.
+///
+/// This helper removes the ordering from the caller's hands: the capture happens
+/// inside, before the spawn, and there is no argument order that can get it
+/// wrong.
+///
+/// # Fail-closed is preserved
+///
+/// With no ambient origin nothing is scoped, so the child lands on
+/// [`AgentTurnOrigin::Unknown`] exactly as a bare `tokio::spawn` would. This
+/// only ever *carries* a decision some entry point already made; it cannot
+/// manufacture a trust root. See [`propagate`], which does the actual work.
+///
+/// # What it does not carry
+///
+/// Only the origin. A delegated agent turn usually also needs
+/// [`turn_workspace::propagate`](super::turn_workspace) and the harness fork
+/// context; those are separate wrappers and still have to be applied around the
+/// future passed in here.
+///
+/// ```ignore
+/// let join = turn_origin::spawn(turn_workspace::propagate(async move { .. }));
+/// ```
+pub fn spawn<F>(fut: F) -> tokio::task::JoinHandle<F::Output>
+where
+    F: std::future::Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    // `propagate` is evaluated here, on the caller's task, which is the whole
+    // point of routing through this function.
+    tokio::spawn(propagate(fut))
+}
+
+/// `tokio::spawn` for work that must deliberately **not** carry the caller's
+/// origin, naming why.
+///
+/// Dropping the origin is sometimes right — a detached background job that is
+/// not a continuation of the caller's turn should not inherit that turn's
+/// authority. The problem is that a bare `tokio::spawn` looks identical whether
+/// the author decided that or simply did not think about it, so a reviewer
+/// cannot tell a deliberate choice from a regression.
+///
+/// This is a plain `tokio::spawn` — the behaviour is the same — but the name and
+/// the `reason` make the choice explicit at the call site and greppable across
+/// the tree. The reason is emitted at `trace` so a live process can be asked
+/// which spawns dropped their label.
+///
+/// Prefer [`spawn`] unless the work genuinely is not a continuation of the
+/// caller's turn.
+pub fn spawn_unlabelled<F>(reason: &'static str, fut: F) -> tokio::task::JoinHandle<F::Output>
+where
+    F: std::future::Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    tracing::trace!(
+        reason,
+        parent_origin = ?current().as_ref().map(AgentTurnOrigin::class),
+        "[turn_origin] spawning without the caller's origin"
+    );
+    tokio::spawn(fut)
+}
+
 /// Read the ambient web-chat `request_id` for the current turn, when one was
 /// scoped by an [`AgentTurnOrigin::WebChat`] entry point. `None` for every
 /// other origin (channel / cron / CLI / sub-agent) and outside any scope —
@@ -444,6 +525,127 @@ mod tests {
         assert!(
             matches!(observed, Some(AgentTurnOrigin::Cli)),
             "the explicitly-scoped Cli origin must be visible on the spawned task, got {observed:?}"
+        );
+    }
+
+    // ── spawn / spawn_unlabelled ────────────────────────────────────────
+
+    /// The helper carries the label with no separate capture step, so a call
+    /// site cannot forget one.
+    #[tokio::test]
+    async fn spawn_carries_the_origin_onto_the_new_task() {
+        let observed = with_origin(AgentTurnOrigin::Cli, async {
+            spawn(async { current() })
+                .await
+                .expect("spawned task panicked")
+        })
+        .await;
+
+        assert!(
+            matches!(observed, Some(AgentTurnOrigin::Cli)),
+            "expected the parent's Cli origin on the spawned task, got {observed:?}"
+        );
+    }
+
+    /// **The reason this helper exists.**
+    ///
+    /// `propagate` reads the origin when it is *called*, so it has to be called
+    /// on the spawning task. Both forms below compile and neither warns, but
+    /// evaluating `propagate` inside the spawned future captures nothing — the
+    /// task-local is already gone — and the child silently runs unlabelled.
+    /// Every external-effect tool it calls is then refused by the approval gate.
+    ///
+    /// Routing through `spawn` makes that ordering unexpressible.
+    #[tokio::test]
+    async fn spawn_is_immune_to_capturing_inside_the_spawned_task() {
+        let (wrong, right) = with_origin(AgentTurnOrigin::Cli, async {
+            // The mistake: `propagate` evaluated on the *new* task.
+            let wrong = tokio::spawn(async move { propagate(async { current() }).await })
+                .await
+                .expect("spawned task panicked");
+
+            // The helper: capture happens before the spawn, inside `spawn`.
+            let right = spawn(async { current() })
+                .await
+                .expect("spawned task panicked");
+
+            (wrong, right)
+        })
+        .await;
+
+        assert!(
+            wrong.is_none(),
+            "precondition: capturing inside the spawned task loses the origin — \
+             this is the hazard `spawn` removes, got {wrong:?}"
+        );
+        assert!(
+            matches!(right, Some(AgentTurnOrigin::Cli)),
+            "the helper must keep the label regardless of how the call site is \
+             written, got {right:?}"
+        );
+    }
+
+    /// Fail-closed: no ambient origin in, no origin out. The helper carries a
+    /// decision, it never invents one.
+    #[tokio::test]
+    async fn spawn_does_not_manufacture_an_origin() {
+        assert!(current().is_none(), "test precondition: no ambient scope");
+
+        let observed = spawn(async { current() })
+            .await
+            .expect("spawned task panicked");
+
+        assert!(
+            observed.is_none(),
+            "an unlabelled parent must produce an unlabelled child, got {observed:?}"
+        );
+    }
+
+    /// A remote-untrusted origin crosses as itself. Delegation must not be a
+    /// privilege-escalation primitive, so no upgrade to `Cli` may happen.
+    #[tokio::test]
+    async fn spawn_preserves_an_untrusted_origin_verbatim() {
+        let observed = with_origin(
+            AgentTurnOrigin::ExternalChannel {
+                channel: "telegram".into(),
+                sender: Some("u-42".into()),
+                reply_target: "chat-7".into(),
+                message_id: "m-9".into(),
+            },
+            async {
+                spawn(async { current() })
+                    .await
+                    .expect("spawned task panicked")
+            },
+        )
+        .await;
+
+        match observed {
+            Some(AgentTurnOrigin::ExternalChannel {
+                channel, sender, ..
+            }) => {
+                assert_eq!(channel, "telegram");
+                assert_eq!(sender.as_deref(), Some("u-42"));
+            }
+            other => panic!("expected ExternalChannel carried verbatim, got {other:?}"),
+        }
+    }
+
+    /// The explicit opt-out drops the label, which is its whole purpose — the
+    /// value is that the call site says so by name instead of looking identical
+    /// to a site that forgot.
+    #[tokio::test]
+    async fn spawn_unlabelled_drops_the_origin_on_purpose() {
+        let observed = with_origin(AgentTurnOrigin::Cli, async {
+            spawn_unlabelled("test: not a continuation of this turn", async { current() })
+                .await
+                .expect("spawned task panicked")
+        })
+        .await;
+
+        assert!(
+            observed.is_none(),
+            "spawn_unlabelled must not carry the caller's origin, got {observed:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Adds `turn_origin::spawn` — a `tokio::spawn` that carries the current turn origin — and `turn_origin::spawn_unlabelled(reason, fut)`, the explicit opt-out.
- **Nothing adopts them in this PR.** No call site changes, no origin label changes, no behaviour change anywhere.
- The point is not that the origin *can* cross a spawn — it already can. It is that the current API makes it possible to write the carry **in the wrong place**, where it compiles, does not warn, and silently yields `Unknown`.

## Problem

**First, a correction to the brief this came from.** The mechanism it asks for already exists on `main @ e1c332bf0` and is adopted:

| Helper | Where | Used at |
|---|---|---|
| `capture()` | `turn_origin.rs:168` | `workflow_runs/engine.rs:198`, `:326`, `agent_teams/runtime.rs:162` |
| `with_inherited_origin()` | `turn_origin.rs:205` | the same three |
| `propagate()` | `turn_origin.rs:244` | `orchestration/ops.rs:495`, `spawn_async_subagent.rs:537` |

Fail-closed is already preserved there (`propagate_does_not_manufacture_an_origin`, `inherited_origin_stays_unlabelled_without_an_outer_scope`), and origin-survives-a-spawn is already pinned (`propagate_carries_the_origin_across_a_spawn`). So "build a spawn helper that carries the origin" was already done — by #5465, per the comment at `turn_origin.rs:425`.

**What is not done is making the correct path the easy one.** `propagate` and `capture` read the origin *when they are called*, which has to be on the spawning task — a task-local is already gone by the time the spawned future is first polled. Both of these compile and neither warns:

```rust
tokio::spawn(turn_origin::propagate(work));                        // correct
tokio::spawn(async move { turn_origin::propagate(work).await });   // silently Unknown
```

The second captures inside the new task, where `current()` is `None`, scopes nothing, and every `external_effect` tool the child calls is refused by the gate at `approval/gate.rs:810` with *"agent turn has no origin label"*. It looks right.

That the existing sites get it right is not an accident of the API — it is a hand-written comment at each one. From `spawn_async_subagent.rs:531`:

> *"they are captured **here**, on the spawning task, rather than inside the closure where they would already be gone"*

Correctness resting on a comment and reviewer attention at every future call site is exactly the failure mode #5634 reports 8 times over.

## Solution

**`turn_origin::spawn(fut)`** takes the ordering out of the caller's hands. The capture happens inside the helper, before the spawn; there is no argument order that can get it wrong. It is a one-line delegation to the already-proven `propagate`, so the fail-closed guarantee is inherited rather than re-implemented: no ambient origin in, no origin out.

**`turn_origin::spawn_unlabelled(reason, fut)`** is a plain `tokio::spawn` with a name. Dropping the origin is sometimes correct — a detached job that is not a continuation of the caller's turn should not inherit its authority. The problem is that a bare `tokio::spawn` looks identical whether the author decided that or never considered it. The name and the `&'static str` reason make the choice legible in review and greppable across the tree; the reason is emitted at `trace` so a running process can be asked which spawns dropped their label.

What it deliberately does **not** do: carry the workspace or the harness fork context. Those are separate wrappers (`turn_workspace::propagate`, `fork_context::with_parent_context`) that still have to be applied around the future passed in. Bundling them would make one helper silently responsible for three different contracts.

## Tests

Five new tests. The one that justifies the PR is `spawn_is_immune_to_capturing_inside_the_spawned_task`: it writes *both* forms in the same scope, asserts the hand-written one loses the origin, and asserts the helper keeps it. That pins the hazard itself, so a future refactor that reintroduces the ordering requirement fails rather than regressing quietly.

The other four: origin carried onto the new task; `None` in → `None` out (fail-closed); an `ExternalChannel` origin carried **verbatim** with no upgrade to `Cli`, since delegation must not be a privilege-escalation primitive; and `spawn_unlabelled` dropping the label as advertised.

**Revert check.** With `spawn`'s body reverted to `tokio::spawn(async move { propagate(fut).await })` — the exact mistake the helper exists to prevent, and the one a call site can write today — the tests report:

```
spawn_carries_the_origin_onto_the_new_task            FAILED
  expected the parent's Cli origin on the spawned task, got None
spawn_is_immune_to_capturing_inside_the_spawned_task  FAILED
  the helper must keep the label regardless of how the call site is written, got None
spawn_preserves_an_untrusted_origin_verbatim          FAILED
  expected ExternalChannel carried verbatim, got None

test result: FAILED. 12 passed; 3 failed
```

Restored, the same command is `15 passed; 0 failed`. Note the shape of that failure: it is not a compile error or a type mismatch. The reverted helper is *valid Rust that reads correctly* and silently produces `None` — which is the whole argument for the helper existing.

`spawn_does_not_manufacture_an_origin` and `spawn_unlabelled_drops_the_origin_on_purpose` pass on both sides *by design*: they pin the unchanged fail-closed behaviour, which is what would catch a future "fix" that made the helper invent an origin.

## Impact

None at runtime. Two new `pub fn`s that nothing calls yet; every existing call site is byte-identical. The helpers become load-bearing only when a site opts in, which is deliberately left for after the labelling decision on #5634.

## Related

- Refs `tinyhumansai/openhuman#5634` — the reported symptom (triage escalation denied 8x). Not fixed here: that needs an origin *label* at the triage entry point, which is a security decision pending with the owner, and this PR must not pre-empt it.
- Refs `tinyhumansai/openhuman#5746` — approval parks from background tasks having no decider. Adjacent: a park raised on a spawned task that lost its origin is one way to arrive there, but the decider question is separate.
- No closing keyword on either: this closes neither.

## Where I would adopt it, once the #5634 decision lands

Reported rather than implemented, as instructed. The six `apply_decision` sites split into two groups, and **only one group is a spawn problem at all** — which matters, because applying a propagation helper to the other three would do nothing.

**Group A — the origin crosses a `tokio::spawn`. `turn_origin::spawn` is the right tool.**

| Site | The spawn | `apply_decision` |
|---|---|---|
| `memory/sync/composio/bus.rs` | `:347` | `:350`, inside it |
| `desktop/notifications/rpc.rs` | `:90` | `:179`, inside it |
| `skills/webhooks/bus.rs` | `:130` | `:313` via `run_agent_trigger`, inside it |

For these, scope the origin at the **entry point, outside the spawn** (the bus dispatch / the ingest RPC — that is where the trigger's provenance is actually known), then swap the `tokio::spawn` for `turn_origin::spawn`. Anything else spawned from the same entry then inherits too. Adopting the helper before the label exists is a no-op, so it can land first and start working the moment a label is scoped.

**Group B — no spawn. A propagation helper would change nothing.**

- `integrations/task_sources/route.rs`
- `skills/webhooks/ops.rs` (`:195`)
- `agent/schemas.rs` (`:404`)

`apply_decision` runs on the caller's task here, so it already inherits whatever the caller scoped. It reads `Unknown` because **nobody upstream scoped anything**, not because a boundary was crossed. These need `with_origin` at their entry point and nothing else. Reaching for `turn_origin::spawn` here would be a wasted change that looks like a fix.

**`dispatch_target_agent` / `run_subagent` — neither needs it.** `dispatch_target_agent` (`agent/triage/escalation.rs:266`) does not spawn; it awaits `with_parent_context(...)` inline, so it runs on the caller's task and inherits naturally. `run_subagent` is a plain `async fn` (`harness/subagent_runner/ops/runner.rs:316`). This is Group B: the escalation path is unlabelled because the triage entry point scopes no origin, and the fix is a label there. **This is worth stating explicitly because #5634 reads like a propagation bug and is not one** — propagating harder would not have fixed it.

I verified `with_origin` and `turn_origin` counts are `0` in all six files, so none of this is contradicted by an existing label.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — five new tests, including the hazard-pinning one and two fail-closed cases.
- [x] **Diff coverage ≥ 80%** — the diff is two functions and their tests; both functions are executed by the new tests. **Not measured locally** (`pnpm test:rust` / `diff-cover` not run); asserted from reading, CI settles it.
- [x] Coverage matrix updated — `N/A: no feature row added, removed or renamed.` Two internal helpers with no call sites; the affected surface is the existing origin/approval behaviour, unchanged.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no feature behaviour changes`, so no feature ID is affected.
- [x] No new external network dependencies introduced — the tests are in-process `tokio::spawn` and task-locals only.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no runtime behaviour changes`, so there is nothing new to smoke.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A: deliberately closes nothing.` This is the mechanism; #5634 needs a labelling decision and #5746 a decider decision, neither of which is here.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/turn-origin-spawn-helper`
- Commit SHA: see head of this PR

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no frontend files changed` (one Rust file).
- [x] `pnpm typecheck` — `N/A: no TypeScript changed.`
- [x] Focused tests: `cargo test --lib turn_origin` — run, passing. Revert-check performed; output above.
- [x] Rust fmt/check (if changed): `cargo fmt` and `cargo check --lib --tests` — both run, exit 0.
- [x] Tauri fmt/check (if changed): `N/A: nothing under app/src-tauri changed.`

### Validation Blocked

- `command:` `pnpm test:rust` / `diff-cover`
- `error:` not run — the full Rust coverage lane is ~20 minutes and was out of budget for a two-function change.
- `impact:` the ≥80% diff-coverage claim is reasoned from which lines the tests execute, not measured. CI settles it.

### Behavior Changes

- Intended behavior change: none. Two additive helpers with no call sites.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: entirely — no existing call site, origin label, or gate decision changes.
- Guard/fallback/dispatch parity checks: the fail-closed contract is inherited from `propagate` rather than re-implemented, and pinned independently by `spawn_does_not_manufacture_an_origin`. A future change that made the helper substitute a default origin — handing every unlabelled call site a trust root it never earned — fails that test.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable context propagation for tasks running asynchronously.
  * Added an explicit option to run tasks without inherited context, including a reason for doing so.
  * Preserved safety behavior for untrusted or missing context without creating fabricated attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->