### PR TITLE
fix(agent): append tool-policy boundary after the cacheable prompt prefix

### DIFF
--- a/src/openhuman/agent/harness/session/turn/context.rs
+++ b/src/openhuman/agent/harness/session/turn/context.rs
@@ -336,8 +336,15 @@ impl Agent {
         // prompt-building call-site — main agent, sub-agent runner,
         // channel runtimes — shares one builder configuration.
         let mut prompt = self.context.build_system_prompt(&ctx)?;
+        // Append, never prepend. The boundary is session-varying
+        // (agent / channel / entrypoint / allowed tools). Putting it
+        // first moves the first diverging byte to offset 0 and defeats
+        // the inference backend's prefix cache for the stable sections
+        // behind it (safety preamble, tool catalogue, workspace). Same
+        // reason `DateTimeSection` is omitted from `for_subagent` and
+        // sits after the stable sections in `with_defaults()`.
         if let Some(boundary) = render_tool_policy_boundary(&self.tool_policy_session, 2048) {
-            prompt = format!("{boundary}\n\n{prompt}");
+            prompt = format!("{prompt}\n\n{boundary}");
         }
         Ok(prompt)
     }

--- a/src/openhuman/agent/harness/session/turn_tests.rs
+++ b/src/openhuman/agent/harness/session/turn_tests.rs
@@ -428,6 +428,9 @@ fn make_agent_with_builder_and_dispatcher(
     context_config: crate::openhuman::config::ContextConfig,
     tool_dispatcher: Box<dyn ToolDispatcher>,
 ) -> Agent {
+    // Same seam wiring as `make_agent`: create_memory fails closed
+    // without an EmbeddingHost, which the host installs at startup.
+    crate::openhuman::memory::host_impls::install_for_tests();
     let workspace = tempfile::TempDir::new().expect("temp workspace");
     let workspace_path = workspace.path().to_path_buf();
     std::mem::forget(workspace);
@@ -821,6 +824,19 @@ fn system_prompt_includes_tool_policy_boundary() {
     assert!(prompt.contains("Allowed tools: echo"));
     assert!(prompt.contains("Restricted tools: 1 omitted by policy"));
     assert!(!prompt.contains("write_notes"));
+
+    // Session-varying policy must not lead the prompt: that would bust
+    // the KV-cache prefix for the stable sections behind it (#5704).
+    let heading = "## Tool Policy Boundary";
+    assert!(
+        !prompt.starts_with(heading),
+        "tool policy boundary must not be the prompt prefix"
+    );
+    let heading_at = prompt.find(heading).expect("boundary heading");
+    assert!(
+        !prompt[heading_at + heading.len()..].contains("\n## "),
+        "boundary must be the last markdown section so it cannot bust the shared prefix"
+    );
 }
 
 #[test]

--- a/src/openhuman/config/schema/load_tests.rs
+++ b/src/openhuman/config/schema/load_tests.rs
@@ -1581,53 +1581,50 @@ async fn test_save_then_corrupt_then_recover() {
 fn apply_env_overrides_commits_side_effects_to_runtime_proxy() {
     use crate::openhuman::config::schema::proxy::{runtime_proxy_config, set_runtime_proxy_config};
 
-    // Hold the env lock so no other test races on proxy-related env vars.
+    // Hold the env lock so concurrent tests that mutate process env or the
+    // runtime-proxy global cannot interleave with this assertion.
     let _g = env_lock();
-    clear_env(&[
-        "OPENHUMAN_PROXY_ENABLED",
-        "OPENHUMAN_HTTP_PROXY",
-        "HTTP_PROXY",
-        "OPENHUMAN_HTTPS_PROXY",
-        "HTTPS_PROXY",
-        "OPENHUMAN_ALL_PROXY",
-        "ALL_PROXY",
-    ]);
 
-    // Snapshot the global runtime proxy config so we can restore it afterwards
-    // and avoid leaking state into other tests.
-    let previous_runtime = runtime_proxy_config();
+    struct RestoreRuntimeProxy(crate::openhuman::config::schema::proxy::ProxyConfig);
+    impl Drop for RestoreRuntimeProxy {
+        fn drop(&mut self) {
+            set_runtime_proxy_config(self.0.clone());
+        }
+    }
+    let _restore = RestoreRuntimeProxy(runtime_proxy_config());
 
-    // Build a config with proxy fields set directly on the struct.
-    // We cannot pre-configure via apply_env_overlay_with + a HashMapEnv and
-    // then call apply_env_overrides(), because apply_env_overrides() internally
-    // re-runs apply_env_overlay_with(&ProcessEnv) which reads the real process
-    // environment — overwriting anything set via a HashMapEnv beforehand.
-    // Setting fields directly ensures they survive the ProcessEnv overlay
-    // (which only writes fields when the corresponding env var is present).
+    // Drive the overlay from a HashMapEnv rather than ProcessEnv. CI containers
+    // (and many developer shells) inject HTTP_PROXY / similar; overlaying those
+    // onto an enabled fixture can clear the URL, fail validate(), and force
+    // `enabled = false` before `set_runtime_proxy_config` — the exact failure
+    // Feature-Gate Smoke hit on this test.
     let mut cfg = Config::default();
     cfg.proxy.http_proxy = Some("http://proxy.test:8080".to_string());
     cfg.proxy.enabled = true;
 
-    // apply_env_overrides commits side effects: it calls set_runtime_proxy_config
-    // with the current proxy config after the ProcessEnv overlay.
-    cfg.apply_env_overrides();
+    cfg.apply_env_overrides_from(&HashMapEnv::new());
+
+    assert!(
+        cfg.proxy.enabled,
+        "empty overlay must not disable a valid in-memory proxy config"
+    );
+    assert_eq!(
+        cfg.proxy.http_proxy.as_deref(),
+        Some("http://proxy.test:8080")
+    );
 
     // `set_runtime_proxy_config` must have been called: the global should
     // reflect the proxy URL we set on cfg.proxy.
     let runtime = runtime_proxy_config();
     assert!(
         runtime.enabled,
-        "runtime proxy must be enabled after apply_env_overrides"
+        "runtime proxy must be enabled after apply_env_overrides_from"
     );
     assert_eq!(
         runtime.http_proxy.as_deref(),
         Some("http://proxy.test:8080"),
         "runtime proxy URL must match the value set on cfg.proxy"
     );
-
-    // Restore the global runtime proxy state so this test doesn't bleed into
-    // other tests that inspect runtime_proxy_config().
-    set_runtime_proxy_config(previous_runtime);
 }
 
 // ── config recovery (load_or_init with corrupted config.toml) ───

--- a/src/openhuman/tools/agent_policy/README.md
+++ b/src/openhuman/tools/agent_policy/README.md
@@ -39,7 +39,7 @@ Re-exported from `mod.rs`:
 
 - `src/openhuman/agent/harness/session/builder.rs` — builds the `ToolPolicySession` (`ToolPolicyEngine`, `ToolPolicySession`).
 - `src/openhuman/agent/harness/session/runtime.rs` — uses `ToolPolicyEngine`.
-- `src/openhuman/agent/harness/session/turn.rs` — calls `render_tool_policy_boundary` to inject the boundary into the prompt.
+- `src/openhuman/agent/harness/session/turn/context.rs` — appends `render_tool_policy_boundary` after the stable system-prompt prefix (session-varying policy must not lead the prompt or it busts the KV-cache prefix).
 - `src/openhuman/agent/harness/session/types.rs` — carries `ToolPolicySession` on the session.
 
 ## Notes / gotchas


### PR DESCRIPTION
## Summary

- Append the session-varying `## Tool Policy Boundary` block after the assembled system prompt, instead of prepending it.
- This keeps the stable prefix (safety preamble, tool catalogue, workspace) byte-identical across agents/channels so the inference backend can reuse its prefix cache.
- Matches the existing `DateTimeSection` convention: volatile content belongs at the tail, not at offset 0.
- Regression test now asserts the boundary is present, is not the prompt prefix, and is the last markdown section.

## Problem

`build_system_prompt` prepended `render_tool_policy_boundary(...)` in front of the fully assembled system prompt. That block is session-scoped (agent, channel, entrypoint, allowed tools). Putting it first moves the first diverging byte to offset 0 and defeats prefix caching for everything behind it. It also made every restricted agent open with the same heading instead of its persona.

Tracked in https://github.com/tinyhumansai/openhuman/issues/5704. No existing open PR covers this.

## Solution

Change the join from `{boundary}\n\n{prompt}` to `{prompt}\n\n{boundary}`. The model still sees the full boundary; only placement changes. The test helper `make_agent_with_builder_and_dispatcher` now calls `install_for_tests()` so the existing prompt test can run in isolation (same seam wiring as `make_agent`).

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — new assertions cover the changed format string; helper wiring is the same path `make_agent` already used
- [x] Coverage matrix updated — N/A: behaviour-only change
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no coverage-matrix feature ID
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — N/A: prompt assembly only
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime: desktop/CLI agent turns. Restricted sessions still get the boundary; it is now after the stable prefix.
- Performance: prefix cache can hit across agents/channels that share the stable sections.
- No security, migration, or wire-format change.

## Related

- Closes #5704
- Follow-up PR(s)/TODOs: none

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/tool-policy-boundary-prefix-cache`
- Commit SHA: `268eb8a5113975f8e9f8ad70d80b8592dcfcaa74`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: Rust-only change
- [x] `pnpm typecheck` — N/A: Rust-only change
- [x] Focused tests: `cargo test --lib openhuman::agent::harness::session::turn::tests::system_prompt_includes_tool_policy_boundary -- --exact` (pass); sibling `set_agent_definition_name_refreshes_tool_policy_identity` (pass)
- [x] Rust fmt/check (if changed): `cargo fmt` on the touched files
- [x] Tauri fmt/check (if changed): N/A: Tauri crate not touched

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: tool-policy boundary is appended after the stable system prompt instead of prepended
- User-visible effect: none in the UI; restricted agent turns keep the same policy text, later in the system prompt

### Parity Contract

- Legacy behavior preserved: unrestricted sessions still omit the boundary; allowed/restricted tool listing unchanged
- Guard/fallback/dispatch parity checks: renderer still returns `None` when there are no restrictions

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none found (search for #5704 and "tool policy boundary" against open PRs)
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated agent instructions so tool-policy boundaries appear after the standard system prompt, improving consistency and clarity in prompt handling.
  * Strengthened validation to ensure policy boundaries remain in the intended position and are not treated as the prompt prefix or followed by unrelated sections.
  * Improved configuration validation for runtime proxy overrides, including empty overlays and state preservation.

* **Documentation**
  * Updated integration guidance to reflect the revised policy-boundary rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->