### PR TITLE
fix(triage): label the turn origin at every triage dispatch site

### DIFF
--- a/src/openhuman/agent/schemas.rs
+++ b/src/openhuman/agent/schemas.rs
@@ -401,9 +401,17 @@ fn handle_triage_evaluate(params: Map<String, Value>) -> ControllerFuture {
         match outcome {
             crate::openhuman::agent::triage::TriageOutcome::Decision(run) => {
                 if !dry_run {
-                    crate::openhuman::agent::triage::apply_decision(run.clone(), &envelope)
-                        .await
-                        .map_err(|e| format!("apply_decision failed: {e}"))?;
+                    // Locally initiated: this is the desktop's own RPC surface,
+                    // so the dispatch keeps the authority its caller already
+                    // had. The envelope it builds may name a remote *source*,
+                    // but the request itself is local (#5634).
+                    let origin = crate::openhuman::agent::triage::local_trigger_origin();
+                    crate::openhuman::agent::turn_origin::with_origin(
+                        origin,
+                        crate::openhuman::agent::triage::apply_decision(run.clone(), &envelope),
+                    )
+                    .await
+                    .map_err(|e| format!("apply_decision failed: {e}"))?;
                 }
 
                 Ok(serde_json::json!({

--- a/src/openhuman/agent/triage/mod.rs
+++ b/src/openhuman/agent/triage/mod.rs
@@ -36,10 +36,12 @@ pub mod envelope;
 pub mod escalation;
 pub mod evaluator;
 pub mod events;
+pub mod origin;
 pub mod routing;
 
 pub use decision::{parse_triage_decision, ParseError, TriageAction, TriageDecision};
 pub use envelope::{TriggerEnvelope, TriggerSource};
 pub use escalation::apply_decision;
 pub use evaluator::{run_triage, TriageOutcome, TriageResolutionPath, TriageRun};
+pub use origin::{local_trigger_origin, remote_trigger_origin};
 pub use routing::{build_local_provider_with_config, resolve_provider, ResolvedProvider};

--- a/src/openhuman/agent/triage/origin.rs
+++ b/src/openhuman/agent/triage/origin.rs
@@ -1,0 +1,75 @@
+//! The turn origin a triage dispatch runs under.
+//!
+//! [`apply_decision`](super::apply_decision) reaches the approval gate, and the
+//! gate decides what an escalation may do from the [`AgentTurnOrigin`] scoped
+//! around the call. `AGENT_TURN_ORIGIN` is a `tokio::task_local`, and every
+//! triage caller either spawns or is itself a fresh entry point, so there is no
+//! ambient origin to inherit — an unscoped call reads `Unknown` and the gate
+//! fails closed (openhuman#5634). Propagation helpers cannot fix that: there is
+//! nothing to propagate, so inheriting would stay `Unknown`.
+//!
+//! Which label a caller scopes is decided by **provenance of the payload**, not
+//! by how the code got there, and the two answers live here so the distinction
+//! is one grep rather than six judgement calls:
+//!
+//! - [`local_trigger_origin`] — the caller and the payload are both local.
+//! - [`remote_trigger_origin`] — the payload arrived from outside and is
+//!   attacker-influenceable.
+//!
+//! Deliberately *not* offered: a single blanket label. A webhook body and a
+//! desktop notification are not the same trust proposition, and one label for
+//! both would have to be the weaker of the two.
+
+use crate::openhuman::agent::turn_origin::{AgentTurnOrigin, TrustedAutomationSource};
+
+use super::envelope::TriggerEnvelope;
+
+/// The origin for a triage dispatch the local machine initiated.
+///
+/// [`AgentTurnOrigin::Cli`] is a trust root: the gate allows without prompting
+/// and persists no audit row. That is correct here and only here — these
+/// callers are the desktop's own RPC surface acting on data the machine already
+/// holds, so the escalation gets exactly the authority the caller already had.
+/// A payload that came in over the network must not use this; see
+/// [`remote_trigger_origin`].
+#[must_use]
+pub fn local_trigger_origin() -> AgentTurnOrigin {
+    AgentTurnOrigin::Cli
+}
+
+/// The origin for a triage dispatch driven by a payload from outside.
+///
+/// `TrustedAutomation { source: Workflow { require_approval: true } }`: the
+/// dispatch itself is legitimate automation, but the content steering it is
+/// remote, so the gate must not auto-allow. That variant parks every
+/// external-effect call, publishes `ApprovalRequested`, and writes the
+/// `pending_approvals` audit row.
+///
+/// **This does not restore remote escalation.** With no surface able to decide
+/// a park raised from a background trigger, these parks TTL-deny — the same
+/// outcome as before, now reached with an audit trail and a visible pending
+/// approval instead of silently as `Unknown`. The decider surface is
+/// openhuman#5746.
+///
+/// Explicitly not [`AgentTurnOrigin::Cli`]: that would hand a full trust root,
+/// with no audit row, to attacker-influenceable content — the posture
+/// [`TrustedAutomationSource::SubconsciousTainted`] exists to prevent.
+///
+/// `job_id` is the envelope's kind slug and correlation id, which is what an
+/// operator reading a pending row needs to find the trigger. Both are
+/// system-generated (Composio's `metadata.uuid`, a webhook tunnel id, a task
+/// source id) — never payload text, which the gate would otherwise surface at
+/// `info` as `flow_id`.
+#[must_use]
+pub fn remote_trigger_origin(envelope: &TriggerEnvelope) -> AgentTurnOrigin {
+    AgentTurnOrigin::TrustedAutomation {
+        job_id: format!("{}:{}", envelope.source.slug(), envelope.external_id),
+        source: TrustedAutomationSource::Workflow {
+            require_approval: true,
+        },
+    }
+}
+
+#[cfg(test)]
+#[path = "origin_tests.rs"]
+mod tests;

--- a/src/openhuman/agent/triage/origin_tests.rs
+++ b/src/openhuman/agent/triage/origin_tests.rs
@@ -128,6 +128,45 @@ fn every_dispatch_site_scopes_an_origin() {
                      approval gate as `Unknown` and is denied (openhuman#5634). Scope \
                      `remote_trigger_origin` or `local_trigger_origin` by provenance."
                 );
+
+                // Every dispatch in the file must be inside a scope. Text
+                // cannot prove *which* scope wraps *which* call, but an
+                // unscoped call added beside a scoped one changes this ratio,
+                // which is the shape the previous version of this test missed.
+                let dispatches = text.matches("apply_decision(").count();
+                let scopes = text.matches("with_origin(").count();
+                assert_eq!(
+                    dispatches, scopes,
+                    "{rel} has {dispatches} triage dispatch(es) but {scopes} origin scope(s); \
+                     every `apply_decision` call needs its own `with_origin` (openhuman#5634)"
+                );
+
+                // The provenance assertion — the reason two labels exist. A
+                // remote payload scoped with the local trust root is the exact
+                // defect this module prevents, and it is indistinguishable from
+                // a correct file if the test only asks whether *some* origin
+                // was scoped.
+                if let Some((_, kind)) = KNOWN_SITES.iter().find(|(path, _)| *path == rel) {
+                    let (want, reject) = match *kind {
+                        "remote" => ("remote_trigger_origin", "local_trigger_origin"),
+                        "local" => ("local_trigger_origin", "remote_trigger_origin"),
+                        other => panic!("KNOWN_SITES has unknown provenance {other:?} for {rel}"),
+                    };
+                    assert!(
+                        text.contains(want),
+                        "{rel} is recorded as `{kind}` provenance but does not scope `{want}`"
+                    );
+                    assert!(
+                        !text.contains(reject),
+                        "{rel} is recorded as `{kind}` provenance but scopes `{reject}`. \
+                         A remote, attacker-influenceable payload must never take the local \
+                         trust root: that grants authority the caller never had, which is the \
+                         defect openhuman#5634 exists to prevent. If the provenance genuinely \
+                         changed, change the KNOWN_SITES entry deliberately — do not widen \
+                         this assertion."
+                    );
+                }
+
                 found.push(rel);
             }
         }

--- a/src/openhuman/agent/triage/origin_tests.rs
+++ b/src/openhuman/agent/triage/origin_tests.rs
@@ -1,0 +1,144 @@
+//! The two labels are a security decision (openhuman#5634), so they are pinned
+//! by identity rather than by "is not `Unknown`" — a future edit that swapped
+//! the remote label for `Cli` would still satisfy the weaker assertion while
+//! handing a trust root to remote content.
+
+use super::*;
+use crate::openhuman::agent::triage::envelope::TriggerEnvelope;
+
+fn composio_envelope() -> TriggerEnvelope {
+    TriggerEnvelope::from_composio(
+        "gmail",
+        "new_message",
+        "ti_meta_id",
+        "ti_bCCTKZlajKi4",
+        serde_json::json!({ "subject": "hello" }),
+    )
+}
+
+#[test]
+fn a_local_dispatch_is_the_trust_root() {
+    assert!(
+        matches!(local_trigger_origin(), AgentTurnOrigin::Cli),
+        "local triage keeps the authority the caller already had"
+    );
+}
+
+#[test]
+fn a_remote_dispatch_parks_instead_of_being_trusted() {
+    let origin = remote_trigger_origin(&composio_envelope());
+    match origin {
+        AgentTurnOrigin::TrustedAutomation { source, .. } => assert_eq!(
+            source,
+            TrustedAutomationSource::Workflow {
+                require_approval: true
+            },
+            "remote payloads must force a park, not auto-allow"
+        ),
+        other => panic!("remote triage must not run as {}", other.class()),
+    }
+}
+
+#[test]
+fn a_remote_dispatch_is_never_the_trust_root() {
+    // The rejected option, pinned so reintroducing it fails here first.
+    assert!(
+        !matches!(
+            remote_trigger_origin(&composio_envelope()),
+            AgentTurnOrigin::Cli
+        ),
+        "`Cli` grants a full trust root with no audit row — never for remote content"
+    );
+}
+
+#[test]
+fn the_job_id_identifies_the_trigger_without_quoting_it() {
+    let envelope = composio_envelope();
+    let AgentTurnOrigin::TrustedAutomation { job_id, .. } = remote_trigger_origin(&envelope) else {
+        panic!("remote triage must be trusted automation");
+    };
+    assert_eq!(job_id, "composio:ti_bCCTKZlajKi4");
+    // The gate renders `job_id` as `flow_id` at `info`, so payload text must
+    // not reach it.
+    assert!(
+        !job_id.contains("hello"),
+        "job_id must not carry payload content, got {job_id:?}"
+    );
+}
+
+/// A tripwire, not a style check.
+///
+/// The labels above are only worth anything if every dispatch site actually
+/// scopes one, and the failure mode is silent: a seventh caller that forgets
+/// reads `Unknown`, the gate fails closed, and the symptom is a denied
+/// escalation in a staging log weeks later — which is precisely how
+/// openhuman#5634 was found. `AGENT_TURN_ORIGIN` is a task-local, so the
+/// compiler cannot enforce this.
+///
+/// Adding a call site is therefore meant to fail here. Fix it by scoping the
+/// label its provenance calls for and adding the path below — not by deleting
+/// the entry.
+#[test]
+fn every_dispatch_site_scopes_an_origin() {
+    const KNOWN_SITES: &[(&str, &str)] = &[
+        // Remote payloads — park and audit.
+        ("src/openhuman/memory/sync/composio/bus.rs", "remote"),
+        ("src/openhuman/integrations/task_sources/route.rs", "remote"),
+        ("src/openhuman/skills/webhooks/ops.rs", "remote"),
+        ("src/openhuman/skills/webhooks/bus.rs", "remote"),
+        // Locally initiated — trust root.
+        ("src/openhuman/desktop/notifications/rpc.rs", "local"),
+        ("src/openhuman/agent/schemas.rs", "local"),
+    ];
+
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let mut found: Vec<String> = Vec::new();
+    let mut stack = vec![root.join("src")];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().is_none_or(|ext| ext != "rs") {
+                continue;
+            }
+            let rel = path
+                .strip_prefix(root)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .replace('\\', "/");
+            // The triage module defines and tests `apply_decision`; it is the
+            // callee, not a call site. Test files model callers rather than
+            // being them.
+            if rel.starts_with("src/openhuman/agent/triage/") || rel.ends_with("_tests.rs") {
+                continue;
+            }
+            let Ok(text) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            if text.contains("apply_decision(") {
+                assert!(
+                    text.contains("with_origin("),
+                    "{rel} dispatches triage without scoping an origin, so it reaches the \
+                     approval gate as `Unknown` and is denied (openhuman#5634). Scope \
+                     `remote_trigger_origin` or `local_trigger_origin` by provenance."
+                );
+                found.push(rel);
+            }
+        }
+    }
+
+    found.sort();
+    let mut expected: Vec<String> = KNOWN_SITES.iter().map(|(p, _)| (*p).to_string()).collect();
+    expected.sort();
+    assert_eq!(
+        found, expected,
+        "the set of triage dispatch sites changed; label the new one by provenance \
+         and record it in KNOWN_SITES"
+    );
+}

--- a/src/openhuman/config/schema/autonomy.rs
+++ b/src/openhuman/config/schema/autonomy.rs
@@ -40,6 +40,17 @@ pub struct AutonomyConfig {
     /// Hard security blocks (`is_always_forbidden`, `is_workspace_internal_path`,
     /// `ToolPolicyMiddleware`) live on independent code paths inside the tool
     /// implementations themselves and are unaffected by this setting.
+    ///
+    /// It also bypasses **parking**, which is worth knowing before enabling it.
+    /// A remote-origin triage dispatch — a Composio or webhook payload reaching
+    /// `triage.escalate` — normally parks for a decision and writes a
+    /// `pending_approvals` audit row. With this flag on it is allowed
+    /// immediately and **no audit row is written**, so those dispatches leave no
+    /// approval trail. Accepted deliberately as the cost of a blanket
+    /// "approve everything" switch (openhuman#5634); the alternative was to make
+    /// this flag mean "approve everything except…", which is harder to reason
+    /// about.
+    ///
     /// Defaults to `false` — existing users see no behavior change.
     #[serde(default)]
     pub auto_approve_all: bool,

--- a/src/openhuman/desktop/notifications/rpc.rs
+++ b/src/openhuman/desktop/notifications/rpc.rs
@@ -15,8 +15,9 @@ use uuid::Uuid;
 use crate::core::bus::BUS;
 use crate::core::events::DomainEvent;
 use crate::openhuman::agent::triage::{
-    apply_decision, run_triage, TriageOutcome, TriggerEnvelope, TriggerSource,
+    apply_decision, local_trigger_origin, run_triage, TriageOutcome, TriggerEnvelope, TriggerSource,
 };
+use crate::openhuman::agent::turn_origin::with_origin;
 use crate::openhuman::config::rpc as config_rpc;
 use crate::rpc::RpcOutcome;
 
@@ -176,7 +177,15 @@ pub async fn handle_ingest(params: Map<String, Value>) -> Result<Value, String> 
                     if score >= latest_settings.importance_threshold
                         && latest_settings.route_to_orchestrator
                     {
-                        if let Err(e) = apply_decision(triage_run, &envelope).await {
+                        // Locally initiated: a desktop notification the machine
+                        // already holds, escalated by the user's own routing
+                        // setting. Scoped inside the spawned task because
+                        // `AGENT_TURN_ORIGIN` does not cross `tokio::spawn`
+                        // (#5634).
+                        let origin = local_trigger_origin();
+                        if let Err(e) =
+                            with_origin(origin, apply_decision(triage_run, &envelope)).await
+                        {
                             tracing::warn!(
                                 id = %id_for_triage,
                                 error = %e,

--- a/src/openhuman/integrations/task_sources/route.rs
+++ b/src/openhuman/integrations/task_sources/route.rs
@@ -12,7 +12,10 @@
 
 use serde_json::json;
 
-use crate::openhuman::agent::triage::{apply_decision, run_triage, TriageOutcome, TriggerEnvelope};
+use crate::openhuman::agent::triage::{
+    apply_decision, remote_trigger_origin, run_triage, TriageOutcome, TriggerEnvelope,
+};
+use crate::openhuman::agent::turn_origin::with_origin;
 use crate::openhuman::config::Config;
 use crate::openhuman::threads::todos::ops::{
     add as todo_add, remove as todo_remove, BoardLocation, CardPatch,
@@ -249,7 +252,10 @@ async fn dispatch_triage(
 
     match outcome {
         TriageOutcome::Decision(run) => {
-            apply_decision(run, &envelope)
+            // Remote payload: the task arrived from an external board, so the
+            // dispatch parks rather than running on a trust root (#5634).
+            let origin = remote_trigger_origin(&envelope);
+            with_origin(origin, apply_decision(run, &envelope))
                 .await
                 .map_err(|e| format!("[task_sources:route] apply_decision failed: {e}"))?;
             tracing::debug!(

--- a/src/openhuman/memory/sync/composio/bus.rs
+++ b/src/openhuman/memory/sync/composio/bus.rs
@@ -55,7 +55,10 @@ use async_trait::async_trait;
 
 use crate::core::bus::BUS;
 use crate::core::events::DomainEvent;
-use crate::openhuman::agent::triage::{apply_decision, run_triage, TriageOutcome, TriggerEnvelope};
+use crate::openhuman::agent::triage::{
+    apply_decision, remote_trigger_origin, run_triage, TriageOutcome, TriggerEnvelope,
+};
+use crate::openhuman::agent::turn_origin::with_origin;
 use crate::openhuman::config::rpc as config_rpc;
 use crate::openhuman::integrations::composio::trigger_history;
 use tinybus::EventHandler;
@@ -347,7 +350,13 @@ impl EventHandler<DomainEvent> for ComposioTriggerSubscriber {
         tokio::spawn(async move {
             match run_triage(&envelope).await {
                 Ok(TriageOutcome::Decision(run)) => {
-                    if let Err(e) = apply_decision(run, &envelope).await {
+                    // Remote payload: a Composio trigger body is
+                    // attacker-influenceable, so the dispatch parks rather than
+                    // running on a trust root (#5634). Scoped here, inside the
+                    // spawned task, because `AGENT_TURN_ORIGIN` is a task-local
+                    // and does not cross `tokio::spawn`.
+                    let origin = remote_trigger_origin(&envelope);
+                    if let Err(e) = with_origin(origin, apply_decision(run, &envelope)).await {
                         tracing::error!(
                             label = %envelope.display_label,
                             error = %e,

--- a/src/openhuman/security/approval/gate.rs
+++ b/src/openhuman/security/approval/gate.rs
@@ -2474,6 +2474,85 @@ mod tests {
         }
     }
 
+    /// openhuman#5634: the six triage dispatch sites scoped no origin, so every
+    /// proactive escalation reached this gate as `Unknown` and was refused —
+    /// `intercept_with_unknown_origin_denies` below is that behaviour.
+    ///
+    /// A remote trigger now carries
+    /// `TrustedAutomation { Workflow { require_approval: true } }`, which parks
+    /// and persists the `pending_approvals` row instead. This asserts the park
+    /// and the row, not a successful escalation: with no surface able to decide
+    /// a background park these still TTL-deny (openhuman#5746). The gain is the
+    /// audit trail, not restored function.
+    #[tokio::test]
+    async fn a_remote_triage_escalation_parks_with_an_audit_row_rather_than_an_unknown_denial() {
+        use crate::openhuman::agent::triage::{remote_trigger_origin, TriggerEnvelope};
+
+        let (gate, _dir) = test_gate();
+        let envelope = TriggerEnvelope::from_composio(
+            "gmail",
+            "new_message",
+            "ti_meta",
+            "ti_bCCTKZlajKi4",
+            serde_json::json!({ "subject": "hello" }),
+        );
+
+        // `Box::pin` + a short timeout drives the future into the park without
+        // waiting out the TTL; nothing decides it, so it must still be pending.
+        let mut fut = Box::pin(turn_origin::with_origin(
+            remote_trigger_origin(&envelope),
+            gate.intercept(
+                "triage.escalate",
+                "escalate to orchestrator",
+                serde_json::json!({}),
+            ),
+        ));
+        let parked = tokio::time::timeout(Duration::from_millis(300), &mut fut).await;
+        assert!(
+            parked.is_err(),
+            "a remote escalation must park for a decision, not resolve immediately \
+             (an immediate Deny here is the `Unknown` regression this pins)"
+        );
+
+        let pending = gate.list_pending().unwrap();
+        assert_eq!(
+            pending.len(),
+            1,
+            "the park must persist exactly one pending_approvals row, got {pending:?}"
+        );
+        assert_eq!(pending[0].tool_name, "triage.escalate");
+    }
+
+    /// The counterpart: a locally initiated triage dispatch keeps the authority
+    /// its caller already had, so it is allowed without a prompt and writes no
+    /// row. Pinned alongside the remote case because the security decision on
+    /// openhuman#5634 is that these two are *different*, and a later
+    /// simplification to one blanket label would have to break one of them.
+    #[tokio::test]
+    async fn a_local_triage_escalation_is_allowed_without_a_prompt() {
+        use crate::openhuman::agent::triage::local_trigger_origin;
+
+        let (gate, _dir) = test_gate();
+        let outcome = turn_origin::with_origin(
+            local_trigger_origin(),
+            gate.intercept(
+                "triage.escalate",
+                "escalate to orchestrator",
+                serde_json::json!({}),
+            ),
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, GateOutcome::Allow),
+            "a locally initiated escalation must not be gated, got {outcome:?}"
+        );
+        assert!(
+            gate.list_pending().unwrap().is_empty(),
+            "a trust-root origin persists no pending row"
+        );
+    }
+
     #[tokio::test]
     async fn intercept_with_unknown_origin_denies() {
         // Unlabelled call site (no origin scope) maps to `Unknown` and is

--- a/src/openhuman/security/approval/gate.rs
+++ b/src/openhuman/security/approval/gate.rs
@@ -584,6 +584,23 @@ impl ApprovalGate {
         // weaken — `is_always_forbidden`, `is_workspace_internal_path`, or
         // `ToolPolicyMiddleware`, which all run inside the tool
         // implementation itself, not the approval gate.
+        //
+        // Known and accepted: a **remote-origin triage** dispatch is not in the
+        // protected set either. Since openhuman#5634 a Composio/webhook payload
+        // reaching `triage.escalate` carries
+        // `TrustedAutomation { Workflow { require_approval: true } }`, which
+        // normally parks and writes a `pending_approvals` row — and with this
+        // flag on it is allowed here instead, leaving no approval trail for
+        // those dispatches. The gate owner ruled that enabling a blanket
+        // "approve everything" switch opts into that globally rather than
+        // carving out an exception, because the alternatives either narrow what
+        // the flag means for every user who set it or turn it into "approve
+        // everything except…". Decision and the options weighed:
+        // https://github.com/tinyhumansai/openhuman/issues/5634#issuecomment-5396604125
+        //
+        // `auto_approve_all_allows_a_remote_triage_dispatch_without_an_audit_row`
+        // below pins that outcome, so a change to this exclusion list has to
+        // confront the decision rather than discover it.
         let auto_all = self.is_auto_approve_all_enabled()
             && !matches!(
                 &origin,
@@ -1907,6 +1924,71 @@ mod tests {
         assert!(
             gate.list_pending().unwrap().is_empty(),
             "auto_approve_all must short-circuit before any pending row is persisted"
+        );
+    }
+
+    /// The `auto_approve_all` × remote-origin-triage interaction, pinned by
+    /// name because it is a **decision**, not an emergent behaviour.
+    ///
+    /// Since openhuman#5634 a Composio/webhook payload reaching
+    /// `triage.escalate` carries `Workflow { require_approval: true }`, so
+    /// normally it parks and writes a `pending_approvals` row — that is
+    /// `a_remote_triage_escalation_parks_with_an_audit_row_rather_than_an_unknown_denial`
+    /// above. With `auto_approve_all` on it is allowed immediately and writes
+    /// no row, which means for those users #5634 moved this path from
+    /// `Unknown` → hard Deny to Allow-with-no-audit-trail.
+    ///
+    /// The gate owner accepted that rather than carving out an exception:
+    /// https://github.com/tinyhumansai/openhuman/issues/5634#issuecomment-5396604125
+    ///
+    /// So this test exists to be *broken on purpose*. If a future change adds
+    /// this origin to the bypass exclusion list, this fails, and whoever is
+    /// making that change has to reopen the decision instead of discovering the
+    /// behaviour by accident. Deleting it to make a change pass is the one
+    /// wrong response.
+    #[tokio::test]
+    async fn auto_approve_all_allows_a_remote_triage_dispatch_without_an_audit_row() {
+        use crate::openhuman::agent::triage::{remote_trigger_origin, TriggerEnvelope};
+
+        let _env = crate::openhuman::config::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let (gate, dir) = test_gate();
+        let policy = crate::openhuman::security::SecurityPolicy {
+            auto_approve_all: true,
+            ..crate::openhuman::security::SecurityPolicy::default()
+        };
+        let _policy_guard = crate::openhuman::security::live_policy::install_scoped(
+            Arc::new(policy),
+            dir.path().to_path_buf(),
+            dir.path().to_path_buf(),
+        );
+
+        let envelope = TriggerEnvelope::from_composio(
+            "gmail",
+            "new_message",
+            "ti_meta",
+            "ti_bCCTKZlajKi4",
+            serde_json::json!({ "subject": "hello" }),
+        );
+
+        let outcome = turn_origin::with_origin(
+            remote_trigger_origin(&envelope),
+            gate.intercept(
+                "triage.escalate",
+                "escalate to orchestrator",
+                serde_json::json!({}),
+            ),
+        )
+        .await;
+
+        assert!(
+            matches!(outcome, GateOutcome::Allow),
+            "auto_approve_all opts into the bypass globally, including remote triage;              got {outcome:?}"
+        );
+        assert!(
+            gate.list_pending().unwrap().is_empty(),
+            "the bypass short-circuits before the park, so no pending_approvals row is              written — this is the documented cost of the flag, not a defect"
         );
     }
 

--- a/src/openhuman/security/policy/types.rs
+++ b/src/openhuman/security/policy/types.rs
@@ -274,7 +274,10 @@ pub struct SecurityPolicy {
     /// prompting — a blanket bypass, not just the `auto_approve` allowlist
     /// above. `TrustedAutomationSource::SubconsciousTainted` and
     /// `AgentTurnOrigin::Unknown` origins are still denied by the gate
-    /// regardless of this flag. Sourced from `autonomy.auto_approve_all`;
+    /// regardless of this flag. A remote-origin triage dispatch is *not* in
+    /// that protected set: with this flag on it is allowed without parking and
+    /// without a `pending_approvals` audit row (openhuman#5634, accepted).
+    /// Sourced from `autonomy.auto_approve_all`;
     /// observed live via `live_policy`. Does not affect
     /// `is_always_forbidden`, `is_workspace_internal_path`, or
     /// `ToolPolicyMiddleware`, which are independent code paths.

--- a/src/openhuman/skills/webhooks/bus.rs
+++ b/src/openhuman/skills/webhooks/bus.rs
@@ -310,9 +310,16 @@ async fn run_agent_trigger(
 
     match outcome {
         crate::openhuman::agent::triage::TriageOutcome::Decision(run) => {
-            crate::openhuman::agent::triage::apply_decision(run.clone(), envelope)
-                .await
-                .map_err(|e| format!("apply_decision failed: {e}"))?;
+            // Remote payload: an inbound webhook body is
+            // attacker-influenceable, so the dispatch parks rather than running
+            // on a trust root (#5634).
+            let origin = crate::openhuman::agent::triage::remote_trigger_origin(envelope);
+            crate::openhuman::agent::turn_origin::with_origin(
+                origin,
+                crate::openhuman::agent::triage::apply_decision(run.clone(), envelope),
+            )
+            .await
+            .map_err(|e| format!("apply_decision failed: {e}"))?;
 
             Ok(format!(
                 "Triage decision: {} (agent: {:?})",

--- a/src/openhuman/skills/webhooks/ops.rs
+++ b/src/openhuman/skills/webhooks/ops.rs
@@ -190,9 +190,15 @@ pub async fn trigger_agent(
 
     match outcome {
         crate::openhuman::agent::triage::TriageOutcome::Decision(run) => {
+            // Remote payload: a webhook body is attacker-influenceable, so the
+            // dispatch parks rather than running on a trust root (#5634).
+            let origin = crate::openhuman::agent::triage::remote_trigger_origin(&envelope);
             tokio::time::timeout(
                 std::time::Duration::from_secs(60),
-                crate::openhuman::agent::triage::apply_decision(run.clone(), &envelope),
+                crate::openhuman::agent::turn_origin::with_origin(
+                    origin,
+                    crate::openhuman::agent::triage::apply_decision(run.clone(), &envelope),
+                ),
             )
             .await
             .map_err(|_| "apply_decision timed out after 60s".to_string())?


### PR DESCRIPTION
## Summary

- Scopes an explicit `AgentTurnOrigin` at all six `apply_decision` dispatch sites, which previously scoped none and therefore reached the approval gate as `Unknown`.
- Labels by **provenance of the payload**, not by call path: two locally initiated sites get the trust root, four sites carrying remote content get `TrustedAutomation { Workflow { require_approval: true } }` — park, publish `ApprovalRequested`, write the `pending_approvals` audit row.
- Adds `agent/triage/origin.rs` so the two labels and the reasoning for each live in one greppable place rather than six judgement calls.
- Adds a source tripwire that fails if a seventh dispatch site appears without a label — the regression is otherwise silent.
- **Does not restore remote escalation.** Those parks still TTL-deny; see below.
- **With `autonomy.auto_approve_all` on, remote triage is allowed without parking and without an audit row.** Found in review, referred to the gate owner, [accepted and documented](https://github.com/tinyhumansai/openhuman/issues/5634#issuecomment-5396604125) rather than patched — see *Interaction with `auto_approve_all`* below.

## Problem

`AGENT_TURN_ORIGIN` is a `tokio::task_local`. It does not cross `tokio::spawn`, and the triage callers are fresh entry points with no ambient origin on the stack, so `turn_origin::current()` returned `None` at every one. The gate mapped that to `AgentTurnOrigin::Unknown` and refused:

```
[approval::gate] agent turn has no origin label — refusing to execute
external_effect tool from unlabelled call site tool="triage.escalate"
[triage::escalation] approval gate denied dispatch action=ESCALATE
```

Verified on `main @ e1c332bf0`: `grep -c with_origin` was **0** in all six files.

Two things are worth stating because they rule out the cheaper fixes:

- **Propagation cannot fix this.** `propagate` / `with_inherited_origin` inherit an ambient origin, and there is none here — a Composio webhook has no parent turn. Inheriting `Unknown` stays `Unknown`, correctly, since a helper must never invent a trust root. A propagation helper is in flight separately and is complementary, not a substitute.
- **Allow-listing `triage.escalate` past the gate would only move the denial.** `dispatch_target_agent` (`agent/triage/escalation.rs:266`) and `run_subagent` scope no origin either, so the sub-agent's own external-effect calls would hit the same `Unknown` one at a time.

## Interaction with `auto_approve_all` — read this before approving

Raised by the Codex reviewer on this PR, verified against the code, and referred to the approval-gate owner because it touched the recorded decision rather than the implementation of it. [Ruled: accept and document.](https://github.com/tinyhumansai/openhuman/issues/5634#issuecomment-5396604125)

The blanket bypass at `security/approval/gate.rs` excludes only `SubconsciousTainted` and `Unknown`. `Workflow { require_approval: true }` is not in that set, so with `autonomy.auto_approve_all = true` a remote triage dispatch is allowed immediately — it does not park and **no `pending_approvals` row is written**.

The honest before/after **for users who have that flag on**:

| | remote triage dispatch |
|---|---|
| today (`Unknown`) | hard **Deny** |
| after this PR | **Allow**, no park, no audit row |

Default is `false` (`config/schema/autonomy.rs`, `security/policy/types.rs`), so this is opt-in and unchanged for everyone else. It was accepted because the alternatives are worse for a labelling fix to carry: excluding the origin overturns the pinned `auto_approve_all_overrides_require_approval_workflow` test and narrows what the flag means for every user who set it, and a new parks-and-protected variant turns the flag into "approve everything except…". No existing origin satisfies parks + audit row + bypass-protected — `SubconsciousTainted` is protected but hard-`Deny`s with no row.

Documented in the three places someone meets it: both `auto_approve_all` field docs, a note extending the bypass-construction comment, and `auto_approve_all_allows_a_remote_triage_dispatch_without_an_audit_row`, which pins the outcome by name so a future change to the exclusion list has to reopen the decision rather than discover the behaviour.

## Solution

Implements the approval-gate owner's recorded decision on #5634 ([comment](https://github.com/tinyhumansai/openhuman/issues/5634#issuecomment-5395168434)).

| Site | Provenance | Label |
|---|---|---|
| `desktop/notifications/rpc.rs` | local | `Cli` |
| `agent/schemas.rs` | local | `Cli` |
| `memory/sync/composio/bus.rs` | remote | `TrustedAutomation { Workflow { require_approval: true } }` |
| `skills/webhooks/ops.rs` | remote | ” |
| `skills/webhooks/bus.rs` | remote | ” |
| `integrations/task_sources/route.rs` | remote | ” |

`Cli` is a full trust root: allow without prompt, no audit row. Correct for the two local sites — the desktop's own RPC surface acting on data the machine already holds, granting exactly the authority the caller had. Explicitly **not** used for the four remote sites: that is the posture `TrustedAutomationSource::SubconsciousTainted` exists to prevent, and it is pinned by a test so reintroducing it fails.

`job_id` is `"{source_slug}:{external_id}"` — what an operator reading a pending row needs to find the trigger, and both halves are system-generated (Composio's `metadata.uuid`, a webhook tunnel id, a task-source id). The gate renders `job_id` as `flow_id` at `info`, so payload text must not reach it; a test asserts it does not.

### What this does not do

**Remote escalation still does not complete.** With no surface able to decide a park raised from a background trigger, these parks TTL-deny. That is the accepted interim state, not an oversight: the outcome is the same as before, now reached *with* an audit trail and a visible pending approval instead of silently as `Unknown`. The decider surface that actually restores function is #5746. This PR therefore does not carry a closing keyword for #5634.

One thing flagged rather than decided: `agent/schemas.rs` builds an envelope whose `source` may name `composio`/`webhook`, so its payload is caller-supplied even though the caller is local. It is labelled `Cli` per the decision — the RPC is the desktop's own surface — and noted here so a reviewer sees it was considered rather than missed.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — 7 new tests; both revert-checks below
- [x] **Diff coverage ≥ 80%** — every changed line is exercised: the two constructors and the tripwire by `triage::origin` tests, the gate consequences by the two `gate.rs` tests, and each of the six call sites by the tripwire that reads them. `pnpm test:coverage` / `pnpm test:rust` were **not** run locally (they build the full workspace); the CI gate is authoritative here and I am asserting from what the tests touch, not from a measured local number.
- [x] N/A: behaviour-only change — no feature rows added, removed or renamed, so `docs/TEST-COVERAGE-MATRIX.md` is unchanged.
- [x] N/A: no matrix feature IDs apply — this changes an internal security label, not a matrix-tracked feature.
- [x] No new external network dependencies introduced — no network is touched; the gate tests use `test_gate()` with a `TempDir`.
- [x] N/A: does not touch a release-cut surface — no UI, installer, or launch path; `docs/RELEASE-MANUAL-SMOKE.md` unchanged.
- [x] N/A: deliberately no closing keyword — #5634 closes when #5746 lands or TTL-denial for background parks is accepted as documented policy. Closing it on this PR would mark a labelling fix as a restored capability.

## Impact

Desktop/core only; no UI, no migration, no performance-sensitive path.

**Security posture changes, in the intended direction**, and reviewers should read it as a change rather than a no-op:

- Four remote paths move from *silently denied* to *parked with a persisted audit row*. Each parked escalation now writes a `pending_approvals` row and publishes `ApprovalRequested`, so a background trigger becomes visible where it previously vanished into a warning. Volume follows trigger volume — a chatty webhook now produces rows that TTL-expire rather than nothing at all. That is the audit trail the 2026-08-23 triage note asked for, and it is worth knowing before it appears.
- Two local paths move from *denied* to *allowed without prompt*. No new authority: they run as the caller that already invoked them.
- `job_id` reaches the gate's `info` log as `flow_id`. Deliberately constructed from system ids only.

## Related

- Refs: #5634 — implements the labelling decision; intentionally **not** closed by this PR (see above).
- Refs: #5746 — the decider surface for background parks; that is what restores remote escalation.
- Follow-up PR(s)/TODOs: a spawn-propagation helper in `agent/turn_origin.rs` is in flight separately. It deliberately changes no site's label and does not overlap this change; `turn_origin.rs` is untouched here.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5634-triage-origin-labels`
- Commit SHA: `3280364`

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend files changed (Rust only).
- [x] N/A: `pnpm typecheck` — no TypeScript changed.
- [x] Focused tests: `cargo test --lib triage::origin` (5 passed), `cargo test --lib triage_escalation` (2 passed), plus every touched module — `approval::` 123 passed, `webhooks::` 83 passed, `notifications::` 70 passed, `task_sources::` 61 passed, `triage::` 75 passed / 1 pre-existing failure (see below).
- [x] Rust fmt/check (if changed): `cargo fmt --all -- --check` exit 0; `cargo check --lib --tests` exit 0; `cargo clippy -p openhuman --no-deps -- -D warnings` exit 0.
- [x] N/A: Tauri fmt/check — `app/src-tauri` untouched.

### Validation Blocked

- `command:` `cargo test` (whole suite) and `pnpm test:coverage`
- `error:` not run — full-workspace builds, out of scope for a change this size on this machine
- `impact:` the six call sites are covered by focused module runs above and by `cargo check --lib --tests`, which compiles every test target. Assertions in modules outside those filters were not executed; CI is authoritative.

**Two pre-existing failures confirmed against clean `main`, not introduced here** — both re-run with my changes stashed and observed identical:
- `triage::escalation::tests::build_triage_parent_scopes_allowed_subagents_to_target` — `no EmbeddingHost installed`, a test-isolation dependency on globally-installed state.
- `cargo clippy --lib --tests -- -D warnings` reports **418** pre-existing errors on clean main (`await_holding_lock` etc. in e2e test targets) vs 384 on this branch. Not the lane CI runs; the CI-shaped `clippy -p openhuman --no-deps` is clean. The one lint inside a file I touched (`skills/webhooks/bus.rs:383`) is a pre-existing test shifted +7 lines by my edit.

### Behavior Changes

- Intended behavior change: triage escalations now carry an origin label; remote ones park and audit instead of being denied as `Unknown`, local ones are allowed.
- User-visible effect: none directly. Remote escalation still does not complete (TTL-denies); the difference is that it is now recorded and visible as a pending approval rather than dropped silently.

### Parity Contract

- Legacy behavior preserved: the gate, `apply_decision`, and the escalation control flow are unchanged — only the origin scoped around the call differs. The task-card branch already returned before the gate and still does.
- Guard/fallback/dispatch parity checks: `intercept_with_unknown_origin_denies` is untouched and still pins that an unlabelled site fails closed; the new tripwire pins that no dispatch site is unlabelled.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added context-aware handling for locally and remotely triggered actions.
  * Local actions can proceed through trusted automation without unnecessary approval prompts.
  * Remote-triggered actions are routed through approval workflows with auditable job tracking.
  * Blanket auto-approval can immediately allow eligible remote triage actions without creating approval records.

* **Bug Fixes**
  * Preserved trigger context across notifications, integrations, memory sync, and webhooks.

* **Tests**
  * Added coverage for approval behavior, trigger validation, audit records, and origin tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->