### PR TITLE
fix(web_chat): preserve backslash for unknown JSON escape sequences

### DIFF
--- a/src/openhuman/web_chat/web_errors_part_01.rs
+++ b/src/openhuman/web_chat/web_errors_part_01.rs
@@ -157,7 +157,10 @@ pub(crate) fn extract_provider_error_detail(err: &str) -> Option<String> {
                         '\\' => out.push('\\'),
                         'n' => out.push('\n'),
                         't' => out.push('\t'),
-                        other => out.push(other),
+                        other => {
+                            out.push('\\');
+                            out.push(other);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fix data loss in extract_provider_error_detail: unrecognized JSON escape sequences silently dropped the backslash character, corrupting upstream error messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Provider error details now preserve backslashes in unknown escape sequences, improving the accuracy of displayed error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->