### PR TITLE
chore(windows): make clippy -D warnings pass on a Windows host

### DIFF
--- a/app/src-tauri/src/claude_code.rs
+++ b/app/src-tauri/src/claude_code.rs
@@ -30,7 +30,7 @@ pub fn claude_code_login_launch() -> Result<String, String> {
             .args(["/c", "start", "", "cmd", "/k", "claude login"])
             .spawn()
             .map_err(|e| format!("failed to open cmd: {e}"))?;
-        return Ok("cmd".into());
+        Ok("cmd".into())
     }
 
     #[cfg(target_os = "macos")]

--- a/app/src-tauri/src/core_process.rs
+++ b/app/src-tauri/src/core_process.rs
@@ -1001,6 +1001,7 @@ fn find_pid_on_port(port: u16) -> Option<u32> {
 }
 
 /// Pure parse of `lsof -t` output (one pid per line; first wins).
+#[cfg(unix)]
 fn parse_lsof_pid(stdout: &str) -> Option<u32> {
     stdout
         .lines()

--- a/app/src-tauri/src/core_process_tests.rs
+++ b/app/src-tauri/src/core_process_tests.rs
@@ -1,8 +1,11 @@
 use super::{
     current_rpc_token, default_core_port, generate_rpc_token, is_expected_port_clash,
-    is_openhuman_root_body, parse_lsof_pid, parse_netstat_pid, parse_ps_comm, parse_tasklist_name,
+    is_openhuman_root_body, parse_netstat_pid, parse_ps_comm, parse_tasklist_name,
     validate_kill_target, CoreProcessHandle, PortOwner, RecoveryOutcome,
 };
+// lsof is a unix tool, so its parser is only compiled there.
+#[cfg(unix)]
+use super::parse_lsof_pid;
 use std::sync::{Mutex, MutexGuard, OnceLock};
 
 fn env_lock() -> MutexGuard<'static, ()> {
@@ -307,6 +310,7 @@ fn expected_port_clash_classifier_rejects_unknown_probe_shapes() {
     ));
 }
 
+#[cfg(unix)]
 #[test]
 fn parse_lsof_pid_picks_first_pid() {
     assert_eq!(parse_lsof_pid("12345\n"), Some(12345));

--- a/app/src-tauri/src/deep_link_ipc_windows.rs
+++ b/app/src-tauri/src/deep_link_ipc_windows.rs
@@ -95,14 +95,17 @@ pub(crate) fn try_forward_deep_links() -> ForwardResult {
     ForwardResult::NoPrimary
 }
 
+/// Callback the app installs to receive deep-link URLs as they arrive.
+type LiveHandler = Box<dyn Fn(String) + Send + Sync>;
+
 static PENDING_URLS: OnceLock<Arc<Mutex<Vec<String>>>> = OnceLock::new();
-static LIVE_HANDLER: OnceLock<Mutex<Option<Box<dyn Fn(String) + Send + Sync>>>> = OnceLock::new();
+static LIVE_HANDLER: OnceLock<Mutex<Option<LiveHandler>>> = OnceLock::new();
 
 fn pending_queue() -> &'static Arc<Mutex<Vec<String>>> {
     PENDING_URLS.get_or_init(|| Arc::new(Mutex::new(Vec::new())))
 }
 
-fn live_handler() -> &'static Mutex<Option<Box<dyn Fn(String) + Send + Sync>>> {
+fn live_handler() -> &'static Mutex<Option<LiveHandler>> {
     LIVE_HANDLER.get_or_init(|| Mutex::new(None))
 }
 

--- a/src/core/auth.rs
+++ b/src/core/auth.rs
@@ -55,10 +55,11 @@
 //!   internal bearer or a stable user-managed external API key stored under
 //!   `openhuman::inference::http::EXTERNAL_OPENAI_COMPAT_PROVIDER`.
 
-use std::io::Write as _;
 use std::path::Path;
 use std::sync::OnceLock;
 
+#[cfg(unix)]
+use std::io::Write as _;
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt as _;
 

--- a/src/openhuman/inference/local/process_util.rs
+++ b/src/openhuman/inference/local/process_util.rs
@@ -17,7 +17,6 @@ const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 
 #[cfg(windows)]
 pub(crate) fn apply_no_window(cmd: &mut tokio::process::Command) {
-    use std::os::windows::process::CommandExt;
     cmd.creation_flags(CREATE_NO_WINDOW);
 }
 

--- a/src/openhuman/inference/voice/local_speech.rs
+++ b/src/openhuman/inference/voice/local_speech.rs
@@ -166,7 +166,6 @@ pub async fn synthesize_piper(
     // every TTS request (piper.exe is a console subsystem binary).
     #[cfg(windows)]
     {
-        use std::os::windows::process::CommandExt;
         cmd.creation_flags(0x08000000);
     }
     let mut child = cmd

--- a/src/openhuman/integrations/composio/trigger_history.rs
+++ b/src/openhuman/integrations/composio/trigger_history.rs
@@ -11,6 +11,7 @@ use std::sync::Mutex;
 use std::sync::{Arc, OnceLock};
 
 use chrono::Utc;
+#[cfg(not(windows))]
 use fs2::FileExt;
 
 use super::types::{ComposioTriggerHistoryEntry, ComposioTriggerHistoryResult};

--- a/src/openhuman/platform/doctor/core_part_01.rs
+++ b/src/openhuman/platform/doctor/core_part_01.rs
@@ -495,7 +495,7 @@ fn check_workspace(config: &Config, items: &mut Vec<DiagnosticItem>) {
 fn available_disk_space_mb(path: &Path) -> Option<u64> {
     #[cfg(target_os = "windows")]
     {
-        return available_disk_space_mb_windows(path);
+        available_disk_space_mb_windows(path)
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/src/openhuman/sandbox/cwd_jail/windows.rs
+++ b/src/openhuman/sandbox/cwd_jail/windows.rs
@@ -38,7 +38,7 @@ use std::process::{Child, Command};
 use std::ptr;
 
 use windows_sys::core::PWSTR;
-use windows_sys::Win32::Foundation::{CloseHandle, LocalFree, HANDLE, HLOCAL};
+use windows_sys::Win32::Foundation::{CloseHandle, LocalFree, HLOCAL};
 use windows_sys::Win32::Security::Authorization::{
     GetNamedSecurityInfoW, SetEntriesInAclW, SetNamedSecurityInfoW, EXPLICIT_ACCESS_W, SET_ACCESS,
     SE_FILE_OBJECT, TRUSTEE_IS_GROUP, TRUSTEE_IS_SID, TRUSTEE_W,
@@ -104,6 +104,12 @@ pub struct AppContainerBackend;
 impl AppContainerBackend {
     pub fn new() -> Self {
         Self
+    }
+}
+
+impl Default for AppContainerBackend {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -305,7 +311,7 @@ unsafe fn grant_sid_access(path: &Path, sid: PSID, access: u32) -> io::Result<()
     // locking out the owner / SYSTEM / Administrators. Merge instead.
     let mut sd_ptr: *mut std::ffi::c_void = ptr::null_mut();
     let mut existing_dacl: *mut ACL = ptr::null_mut();
-    let mut dacl_present: i32 = 0;
+    let dacl_present: i32 = 0;
     let rc = GetNamedSecurityInfoW(
         path_w.as_ptr(),
         SE_FILE_OBJECT,
@@ -335,7 +341,7 @@ unsafe fn grant_sid_access(path: &Path, sid: PSID, access: u32) -> io::Result<()
     };
 
     let mut new_acl: *mut ACL = ptr::null_mut();
-    let rc = SetEntriesInAclW(1, &mut ea, existing_dacl, &mut new_acl);
+    let rc = SetEntriesInAclW(1, &ea, existing_dacl, &mut new_acl);
     if rc != 0 {
         return Err(io::Error::from_raw_os_error(rc as i32));
     }

--- a/src/openhuman/security/keyring/encrypted_store.rs
+++ b/src/openhuman/security/keyring/encrypted_store.rs
@@ -297,9 +297,9 @@ impl SecretStore {
             };
 
             let hex_key = read_result.with_context(|| {
-                // `mut` is only exercised inside the #[cfg(windows)] block below.
-                #[cfg_attr(not(windows), allow(unused_mut))]
-                let mut msg = format!(
+                // The #[cfg(windows)] arm below shadows this binding rather than
+                // mutating it, so it does not need to be mutable on either platform.
+                let msg = format!(
                     "Failed to read secret key file at {}",
                     self.key_path.display()
                 );

--- a/src/openhuman/security/pairing.rs
+++ b/src/openhuman/security/pairing.rs
@@ -4,9 +4,10 @@
 // a bearer token. Tokens can be persisted in config so restarts don't require
 // re-pairing.
 
-use std::io::Write as _;
 use std::path::Path;
 
+#[cfg(unix)]
+use std::io::Write as _;
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt as _;
 


### PR DESCRIPTION
## No commit can be pushed from a Windows checkout

`.husky/pre-push` runs `cargo clippy -p openhuman -- -D warnings` and then the same for `app/src-tauri`. On a Windows host both fail before reaching anything the developer changed — 11 errors in the core crate, 4 in the Tauri crate.

Linux CI never sees them: every one sits in a path guarded by `#[cfg(windows)]` / `#[cfg(not(unix))]`, so the lint only fires where those arms are compiled. The practical effect is that the hook is unpassable on Windows, and the only way to push is `--no-verify` — which disables the TypeScript, format and lint checks too.

## What changed

**Imports only one platform uses, gated the way their neighbours already are:**

| file | import | used by |
|---|---|---|
| `core/auth.rs`, `security/pairing.rs` | `std::io::Write` | only the `#[cfg(unix)]` arm of the token writer — the `#[cfg(not(unix))]` arm calls `std::fs::write` |
| `composio/trigger_history.rs` | `fs2::FileExt` | only the `#[cfg(not(windows))]` lock/unlock path — Windows serializes through the process-local `Mutex` above it |

In both files the gate matches the `#[cfg(unix)] use std::os::unix::fs::OpenOptionsExt` line sitting directly below.

**Two imports were simply redundant:**

`inference/local/process_util.rs` and `inference/voice/local_speech.rs` import `std::os::windows::process::CommandExt` to call `creation_flags`, but that is an inherent method on `tokio::process::Command` under Windows, so the trait import adds nothing.

**Ordinary lints in Windows-only code:**

- `sandbox/cwd_jail/windows.rs` — drop the unused `HANDLE` import; drop `mut` from `dacl_present` (only ever read, via `let _ =`); pass `&ea` to `SetEntriesInAclW`, whose second parameter is `*const EXPLICIT_ACCESS_W`; add the `Default` impl clippy asks for beside `AppContainerBackend::new()`.
- `security/keyring/encrypted_store.rs` — the `#[cfg(windows)]` arm **shadows** `msg` rather than mutating it, so `mut` was unnecessary on both platforms; the `#[cfg_attr(not(windows), allow(unused_mut))]` escape hatch goes with it.
- `platform/doctor/core.rs`, `src-tauri/claude_code.rs` — on Windows the sibling `#[cfg]` blocks are stripped, so the remaining block is the function tail and `return` is noise. The macOS/Linux arms of `claude_code_login_launch` already end in a bare expression; this makes the Windows arm match.
- `src-tauri/core_process.rs` — `parse_lsof_pid` parses `lsof` output and is reachable only from the `#[cfg(unix)]` `find_pid_on_port`, so it is dead on Windows. Gated with `#[cfg(unix)]`, along with its import and test.
- `src-tauri/deep_link_ipc_windows.rs` — name the boxed callback (`type LiveHandler`) so the static and its accessor stop tripping `clippy::type_complexity`.

## Verification

No behaviour changes — every edit is an import gate, a removed `mut`/`return`, a `&mut` → `&`, a type alias, or a `Default` impl.

```
cargo clippy -p openhuman -- -D warnings                        clean
cargo clippy --manifest-path app/src-tauri/Cargo.toml -- -D warnings   clean
cargo clippy --manifest-path app/src-tauri/Cargo.toml --all-targets    clean
cargo fmt -- --check                                            clean
```

Tests for every touched module:

```
openhuman::sandbox            76 passed
openhuman::security          819 passed
openhuman::platform::doctor   22 passed
composio::trigger_history      4 passed
core::auth                    19 passed
```

This branch was pushed with the pre-push hook **running and passing** on Windows — which is the point of the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved platform-specific compilation across Unix and Windows environments.
  - Simplified internal control flow and type definitions without changing application behavior.
  - Added a default construction path for the Windows sandbox backend.
  - Removed unused imports and unnecessary mutability.

- **Chores**
  - Updated platform-specific tests and build configuration to avoid compiling unsupported Unix-only components on other platforms.
  - No user-facing functionality or runtime behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->