### PR TITLE
fix(agent): per-model-call ceiling; turn deadline demoted to runaway guard (#5766)

### DIFF
--- a/src/openhuman/agent/tinyagents/mod_part_01.rs
+++ b/src/openhuman/agent/tinyagents/mod_part_01.rs
@@ -107,11 +107,31 @@ pub(crate) struct ToolPolicyEnforcement {
 /// routes (chat→burst, reasoning→agentic, …) the way the harness registry can.
 /// Default per-turn wall-clock ceiling for an openhuman agent turn, in seconds
 /// (issue #4746). Applied as the harness `RunLimits::max_wall_clock_ms` so the
-/// loop interrupts a hung/slow model or tool/sub-agent call instead of parking
-/// forever with no terminal event. Deliberately generous — a normal turn, even
-/// a slow multi-step reasoning one, finishes well under it; this is a hang
-/// backstop, not a UX deadline. 10 minutes.
-const DEFAULT_AGENT_TURN_TIMEOUT_SECS: u64 = 600;
+/// loop interrupts a call instead of parking forever with no terminal event.
+///
+/// 60 minutes (#5766, was 10). With hang detection now owned by the per-call
+/// ceiling below, this is a pure runaway guard over the whole turn — its old
+/// 600s value doubled as the per-call bound (every call got the turn's
+/// *remainder*), which killed long *productive* turns: a turn that had
+/// legitimately spent ~543s across many successful calls handed its next model
+/// call a 56s budget and died. A turn's real bounds are the model/tool call
+/// caps times the per-call ceiling; this only catches what escapes those.
+const DEFAULT_AGENT_TURN_TIMEOUT_SECS: u64 = 3_600;
+
+/// Default wall-clock ceiling for a **single model call** within a turn, in
+/// seconds (#5766). Applied as the harness `RunLimits::max_model_call_ms`, so
+/// every model call (and every retry attempt) gets a fresh
+/// `min(this, turn remainder)` budget instead of only the shrinking remainder.
+/// This is the hang detector the turn ceiling used to double as — scoped to
+/// the one call that wedged, not the whole turn's history.
+///
+/// Deliberately generous — 15 minutes: a hidden-reasoning model call can be
+/// legitimately app-silent for several minutes, so this is a backstop for
+/// calls that will never return, not a latency target. Tool calls (including
+/// sub-agent delegations, which wrap entire child turns) are exempt by design
+/// in the harness and stay bounded by the turn remainder plus their own
+/// per-tool timeouts.
+const DEFAULT_MODEL_CALL_TIMEOUT_SECS: u64 = 900;
 
 /// Resolve the per-turn wall-clock ceiling in milliseconds for the harness
 /// policy. Reads `OPENHUMAN_AGENT_TURN_TIMEOUT_SECS` (falling back to
@@ -138,6 +158,32 @@ fn parse_agent_turn_wall_clock_ms(env_value: Option<&str>) -> Option<u64> {
     (secs > 0).then(|| secs.saturating_mul(1_000))
 }
 
+/// Resolve the per-model-call wall-clock ceiling in milliseconds for the
+/// harness policy. Reads `OPENHUMAN_MODEL_CALL_TIMEOUT_SECS` (falling back to
+/// [`DEFAULT_MODEL_CALL_TIMEOUT_SECS`]); `0` means "no per-call ceiling" →
+/// `None`, leaving calls bounded only by the turn's remaining wall clock as
+/// before #5766.
+fn model_call_wall_clock_ms() -> Option<u64> {
+    parse_model_call_wall_clock_ms(
+        std::env::var("OPENHUMAN_MODEL_CALL_TIMEOUT_SECS")
+            .ok()
+            .as_deref(),
+    )
+}
+
+/// Pure core of [`model_call_wall_clock_ms`]: map an optional
+/// `OPENHUMAN_MODEL_CALL_TIMEOUT_SECS` value to a per-call ceiling in
+/// milliseconds. An absent/unparseable value falls back to
+/// [`DEFAULT_MODEL_CALL_TIMEOUT_SECS`]; `0` yields `None` (opt-out). Kept
+/// env-free so it is deterministically unit-testable — the same shape as
+/// [`parse_agent_turn_wall_clock_ms`].
+fn parse_model_call_wall_clock_ms(env_value: Option<&str>) -> Option<u64> {
+    let secs = env_value
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_MODEL_CALL_TIMEOUT_SECS);
+    (secs > 0).then(|| secs.saturating_mul(1_000))
+}
+
 fn run_policy_for(max_iterations: usize, response_cache_enabled: bool) -> RunPolicy {
     let mut policy = RunPolicy::default();
     policy.limits.max_model_calls = max_iterations;
@@ -158,6 +204,14 @@ fn run_policy_for(max_iterations: usize, response_cache_enabled: bool) -> RunPol
     // turn with no per-run timeout inherits this policy-level cap. Generous by
     // design (a backstop, not a UX deadline); env-overridable, `0` disables.
     policy.limits.max_wall_clock_ms = agent_turn_wall_clock_ms();
+    // Per-model-call ceiling (#5766): each model call (and retry attempt) gets
+    // a fresh `min(ceiling, turn remainder)` budget, so hang detection is
+    // per-call instead of riding the turn deadline — which let the turn
+    // ceiling above grow from 10 to 60 minutes without a wedged call being
+    // able to hold a turn for more than this. Tool calls (incl. sub-agent
+    // delegations) are exempt in the harness and keep the remainder-only
+    // budget. Env-overridable, `0` disables.
+    policy.limits.max_model_call_ms = model_call_wall_clock_ms();
     // Crate-owned retry (Phase 3a): mirror the former `ReliableProvider` schedule
     // (2 retries, 500 ms exponential backoff). `backoff_sleep` is on so a
     // transient 429/5xx actually waits before retrying, as it did before.

--- a/src/openhuman/agent/tinyagents/tinyagents_tests.rs
+++ b/src/openhuman/agent/tinyagents/tinyagents_tests.rs
@@ -98,3 +98,45 @@ fn run_policy_for_makes_invalid_tool_arguments_recoverable() {
         "schema-invalid calls must return a corrective tool result instead of aborting the turn"
     );
 }
+
+#[test]
+fn parse_model_call_wall_clock_defaults_to_fifteen_minutes() {
+    // Absent and unparseable values both fall back to the 900s default.
+    assert_eq!(parse_model_call_wall_clock_ms(None), Some(900_000));
+    assert_eq!(
+        parse_model_call_wall_clock_ms(Some("garbage")),
+        Some(900_000)
+    );
+    assert_eq!(parse_model_call_wall_clock_ms(Some("")), Some(900_000));
+}
+
+#[test]
+fn parse_model_call_wall_clock_honors_explicit_value_and_zero_opt_out() {
+    assert_eq!(parse_model_call_wall_clock_ms(Some("300")), Some(300_000));
+    assert_eq!(parse_model_call_wall_clock_ms(Some(" 300 ")), Some(300_000));
+    // `0` disables the per-call ceiling entirely (remainder-only, pre-#5766).
+    assert_eq!(parse_model_call_wall_clock_ms(Some("0")), None);
+}
+
+#[test]
+fn run_policy_arms_the_per_model_call_ceiling_under_the_turn_ceiling() {
+    // The policy must carry the per-call ceiling, and the default per-call
+    // value must sit strictly under the default turn ceiling — a ceiling at or
+    // above the turn deadline is dead code, because `min(ceiling, remainder)`
+    // would always pick the remainder.
+    let policy = run_policy_for(10, false);
+    let per_call = policy
+        .limits
+        .max_model_call_ms
+        .expect("the per-model-call ceiling is armed by default");
+    let turn = policy
+        .limits
+        .max_wall_clock_ms
+        .expect("the turn wall-clock ceiling is armed by default");
+    assert_eq!(per_call, DEFAULT_MODEL_CALL_TIMEOUT_SECS * 1_000);
+    assert_eq!(turn, DEFAULT_AGENT_TURN_TIMEOUT_SECS * 1_000);
+    assert!(
+        per_call < turn,
+        "per-call ceiling ({per_call} ms) must be under the turn ceiling ({turn} ms)"
+    );
+}

--- a/src/openhuman/agent/tinyagents/tinyagents_tests.rs
+++ b/src/openhuman/agent/tinyagents/tinyagents_tests.rs
@@ -119,20 +119,28 @@ fn parse_model_call_wall_clock_honors_explicit_value_and_zero_opt_out() {
 }
 
 #[test]
-fn run_policy_arms_the_per_model_call_ceiling_under_the_turn_ceiling() {
-    // The policy must carry the per-call ceiling, and the default per-call
-    // value must sit strictly under the default turn ceiling — a ceiling at or
-    // above the turn deadline is dead code, because `min(ceiling, remainder)`
-    // would always pick the remainder.
+fn run_policy_wires_both_wall_clock_ceilings_from_their_resolvers() {
+    // Compare the policy against the same-process resolvers rather than
+    // hard-coded defaults, so a dev/CI environment exporting either
+    // `OPENHUMAN_MODEL_CALL_TIMEOUT_SECS` or `OPENHUMAN_AGENT_TURN_TIMEOUT_SECS`
+    // (including `0` = disabled, or a per-call value above the turn value)
+    // cannot fail the test while the wiring is correct. No env mutation —
+    // whatever the environment says, the policy must carry exactly what the
+    // resolvers produce.
     let policy = run_policy_for(10, false);
-    let per_call = policy
-        .limits
-        .max_model_call_ms
-        .expect("the per-model-call ceiling is armed by default");
-    let turn = policy
-        .limits
-        .max_wall_clock_ms
-        .expect("the turn wall-clock ceiling is armed by default");
+    assert_eq!(policy.limits.max_model_call_ms, model_call_wall_clock_ms());
+    assert_eq!(policy.limits.max_wall_clock_ms, agent_turn_wall_clock_ms());
+}
+
+#[test]
+fn default_per_call_ceiling_sits_under_the_default_turn_ceiling() {
+    // Env-free: assert the *defaults* through the pure parsers, not through
+    // the env-reading policy path. A per-call ceiling at or above the turn
+    // deadline is dead code, because `min(ceiling, remainder)` would always
+    // pick the remainder.
+    let per_call =
+        parse_model_call_wall_clock_ms(None).expect("the per-call ceiling is armed by default");
+    let turn = parse_agent_turn_wall_clock_ms(None).expect("the turn ceiling is armed by default");
     assert_eq!(per_call, DEFAULT_MODEL_CALL_TIMEOUT_SECS * 1_000);
     assert_eq!(turn, DEFAULT_AGENT_TURN_TIMEOUT_SECS * 1_000);
     assert!(


### PR DESCRIPTION
## Summary

- Agent turns now arm tinyagents' new `RunLimits::max_model_call_ms`: every model call (and retry attempt) gets a fresh `min(ceiling, turn remainder)` budget — 900s default, `OPENHUMAN_MODEL_CALL_TIMEOUT_SECS` override, `0` disables.
- The per-turn wall-clock ceiling moves 600s → 3600s (`OPENHUMAN_AGENT_TURN_TIMEOUT_SECS` unchanged as the override): with hang detection per-call, the turn deadline is a pure runaway guard.
- Bumps `vendor/tinyagents` to `eeb7345` (tinyagents#124), which also enables HTTP/2 PING keepalives on the default provider client — a dead transport fails in ~1 min even during app-silent streaming.

## Problem

The 600s turn ceiling (#4746) doubled as the per-call bound: the harness hands each call the turn's *remainder*, so long **productive** turns die — observed in the field as `model call for run `agent_turn` exceeded its remaining wall-clock budget (56636 ms)` after earlier calls in the turn legitimately consumed ~543s. The timeout is deadline-driven and non-retryable, so the whole turn fails. Stuck-loop protection does not need the turn clock: `RepeatedToolFailureMiddleware`, `RepeatProgressMiddleware`, and the model/tool call caps already cover it.

## Solution

- `run_policy_for` (single choke point for both turn paths) arms `policy.limits.max_model_call_ms` via a new env-backed resolver mirroring the existing turn-knob shape (pure `parse_*` core, unit-tested).
- Tool calls — including sub-agent delegations, which wrap entire child turns — stay remainder-bounded by design in the harness (pinned upstream by `per_model_call_ceiling_does_not_bound_tool_calls`).
- tinyagents' timeout message now names which ceiling fired ("per-model-call ceiling" vs "remaining wall-clock budget") so field triage can tell a wedged call from an exhausted turn.
- Per-SKU cap table deliberately deferred; the seam for it later is the model profile, not more env vars.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines covered by the three new unit tests; the env-reading wrapper mirrors the existing untested-by-design `agent_turn_wall_clock_ms` shape
- [x] Coverage matrix updated — `N/A: behaviour-only change` (no feature added/removed/renamed)
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix rows affected`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface touched`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Runtime: agent turns may now legitimately run up to 60 min (runaway guard) instead of dying at 10; a single wedged model call is interrupted at 15 min worst-case (previously: up to the whole remaining turn). Operators can restore the old behavior with `OPENHUMAN_MODEL_CALL_TIMEOUT_SECS=0 OPENHUMAN_AGENT_TURN_TIMEOUT_SECS=600`.
- h2 keepalives change no request semantics; plaintext HTTP/1.1 endpoints (local Ollama/LM Studio) are unaffected.

## Related

- Closes #5766
- Follow-up PR(s)/TODOs: opencompany `vendor/openhuman` bump once merged; per-SKU cap table via model profile (deferred)

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/5766-per-model-call-ceiling
- Commit SHA: (head of branch)

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend changes
- [x] `pnpm typecheck` — N/A: no TypeScript changes
- [x] Focused tests: `cargo test --lib -- openhuman::agent::tinyagents` (333 passed, 0 failed)
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean, `cargo clippy --lib` clean
- [x] Tauri fmt/check (if changed): N/A: shell untouched

### Validation Blocked

- `command:` none
- `error:` none
- `impact:` none

### Behavior Changes

- Intended behavior change: long productive agent turns no longer die at 10 minutes; wedged model calls die at ≤15 min instead of holding the turn's whole remainder.
- User-visible effect: multi-step reasoning turns and downstream workflow nodes that previously failed with "exceeded its remaining wall-clock budget" now complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the default agent turn time limit to 60 minutes.
  * Added a separate 15-minute default limit for individual model calls.
  * Added support for configuring model-call timeouts through an environment variable.
  * Each model call and retry now receives a fresh timeout based on the remaining turn time.

* **Bug Fixes**
  * Improved timeout handling so long-running calls and retries are limited independently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->