### PR TITLE
chore(vendor): bump tinymcp to main — probe outcomes, missing-runtime terminal error

### DIFF
--- a/tests/mcp_registry_e2e.rs
+++ b/tests/mcp_registry_e2e.rs
@@ -553,7 +553,8 @@ async fn probe_alive_reflects_transport_liveness() {
         h.dynamic()
             .connections()
             .probe_alive(&server.server_id, std::time::Duration::from_secs(8))
-            .await,
+            .await
+            .is_alive(),
         "a live stub answers the tools/list probe"
     );
 
@@ -571,7 +572,8 @@ async fn probe_alive_reflects_transport_liveness() {
         !h.dynamic()
             .connections()
             .probe_alive(&server.server_id, std::time::Duration::from_secs(8))
-            .await,
+            .await
+            .is_alive(),
         "a disconnected server is not alive"
     );
 }
@@ -615,12 +617,12 @@ async fn supervisor_reconnects_a_dropped_server() {
             .await,
         "supervisor reconnects a dropped-but-installed server"
     );
-    assert!(
-        h.dynamic()
-            .connections()
-            .probe_alive(&server.server_id, std::time::Duration::from_secs(8))
-            .await
-    );
+    assert!(h
+        .dynamic()
+        .connections()
+        .probe_alive(&server.server_id, std::time::Duration::from_secs(8))
+        .await
+        .is_alive());
 
     h.dynamic()
         .connections()


### PR DESCRIPTION
## Summary

- Bumps `vendor/tinymcp` from `b88cf60` to `5909bd1` (tinymcp `main`), carrying the probe-outcome fix, the missing-runtime terminal error, and a correction to the first of those.
- **Not a branch switch, despite appearances.** The old pin sat on `mcp-redirect-downgrade`; that branch has since been merged into `main`, so this is a fast-forward and nothing is lost — evidence below.
- Adapts three `mcp_registry_e2e` assertions to the new `ProbeOutcome` return type. The bump does not compile without it.
- One commit in the range **partially reverses another** in the same range. Called out below rather than left in the diff.

## The branch question, settled first

`vendor/tinymcp` was pinned at `b88cf60`, which is the tip of `mcp-redirect-downgrade`, not `main`. That is worth checking before moving, because a branch tip can carry commits `main` never got.

It does not here:

```
compare/main...b88cf60  →  status=behind  ahead_by=0  behind_by=8  total_commits=0
compare/b88cf60...main  →  status=ahead   ahead_by=8  behind_by=0
```

`ahead_by=0` is the answer: the old pin has **nothing** `main` lacks. It is a strict ancestor.

The branch was **merged, not abandoned** — tinymcp#3, *"fix(http): refuse HTTPS→HTTP redirect downgrades"* by @senamakel, merged 2026-08-25T08:06, 7 commits, tip `b88cf60`. So that work is already in this tree today and stays in it after the bump. Nothing by another contributor is newly introduced or removed by this PR; the four substantive commits below are all fleet-authored.

## What rides along

Eight commits, four substantive and four merges:

| commit | what it is |
|---|---|
| `68eeda85` | `fix(supervisor): report what a probe observed instead of asserting a drop` — **tinymcp#5** |
| `1a535591` | `docs(supervisor): stop a public doc comment linking a private constant` |
| `9fad68b6` | `fix(error): make a missing local runtime a terminal variant, not a malformed response` — **tinymcp#7** |
| `b44b958d` | `fix(supervisor): keep the 8s probe default; the mitigation for widening it does not reach the host` |

### `b44b958d` is a behaviour change against `68eeda85`, and it is right

This is the one not to discover from the diff. tinymcp#5 widened the default `probe_timeout` from 8s to 30s, reasoning that a server answering inside a real request's budget is usable by definition, and paired it with `MissedTickBehavior::Delay` so a slow cycle could not become a burst of catch-up ticks.

That mitigation lives in `Supervisor::run` — **which this host does not call.** `src/openhuman/mcp/registry/mod.rs:313-341` builds its own `tokio::time::interval_at`, sets no missed-tick behaviour (so tokio's default `Burst` applies), and calls `Supervisor::tick` directly, once per open workspace per tick. openhuman would therefore have inherited the widened window with none of the protection, on a loop that iterates per workspace.

I verified that against this tree rather than taking the commit message's word for it:

- `grep -rn "Supervisor::run" src/` → no hits; the only driver is the hand-rolled loop above.
- `mcp/registry/mod.rs` → no `set_missed_tick_behavior`.
- `tinymcp .../supervisor/types.rs:132` → `Delay` is set inside `Supervisor::run`, and only there.

So the default returns to 8s. The churn tinymcp#5 was raised for is fixed by the consecutive-timeout run, not by the window width — a host that genuinely needs a longer probe can set `probe_timeout` itself.

## Why a test change is in a bump PR

`Connections::probe_alive` now returns `ProbeOutcome` instead of `bool`. `cargo check --lib --tests` fails on the bump alone with three `E0308`s in `tests/mcp_registry_e2e.rs` (`:553`, `:571`, `:619`). Adapting them via `ProbeOutcome::is_alive()` is what makes the pin land green, not separable work — so it is here, in its own commit, and nothing else is.

Deliberately minimal: the disconnected-server case now returns `ProbeOutcome::Missing` and could assert that specifically, which would be a better test than `!is_alive()`. Tightening assertions is not a bump PR's job; left as a follow-up.

## Verified

- `cargo check --lib --tests` — **clean, exit 0, zero errors.** Default features, which include `mcp` (`Cargo.toml:739`), and `tinymcp` is a non-optional path dependency — so this genuinely compiles the changed code rather than gating it out.
- The one remaining warning (`unused import` in `tests/transcript_search_e2e.rs:23`) is pre-existing on `main`, present in the pre-bump run, and untouched.
- `rustfmt --check` clean on the changed file.
- Only `vendor/tinymcp` and `tests/mcp_registry_e2e.rs` are modified.

Not verified: runtime behaviour. This is a compile-level check plus source review; the probe changes are exercised by tinymcp's own suite, and the supervisor loop is not driven in openhuman's e2e.

## Related

Referenced without closing keywords — cross-repo, and one of them only closes partially.

- **#5636** (MCP transport drops) — **fully addressed** by tinymcp#5 + `b44b958d`. The supervisor now reports what the probe observed instead of asserting a drop, and only tears a session down after a run of consecutive timeouts, so a single slow probe no longer causes the disconnect it then reports. **Safe to hand-close once this merges.**
- **#5600** (`uv` missing) — **partial only, and it should stay open.** tinymcp#7 makes a missing local runtime a terminal `Error::MissingRuntime` rather than a malformed-response error, which stops the retry loop and gives the user an actionable message naming the runtime. It **does not install `uv`**, and does not decide whether openhuman should ship or bootstrap one. That packaging decision is what #5600 is actually about, so this improves the failure mode and leaves the issue's substance untouched.

## Worth knowing

The crate version stays `0.3.1` across the whole range, despite a new public enum (`ProbeOutcome`), a new `Error` variant, and a changed `probe_alive` signature. That keeps the `TINYMCP` record in `src/openhuman/modules/registry.rs` self-consistent — it pins `version: "0.3.1"` with per-platform archives and sha256s, and none of that needs to move here.

It does mean the published `v0.3.1` module artifacts no longer correspond to `main`'s source. Not a live problem: openhuman takes `tinymcp` as a plain path dependency with `default-features = false`, which switches the TinyBus module adapter off, and nothing loads that module record. Flagging it because a reader could reasonably assume the pinned artifacts match the pinned source, and after this bump they do not.

`Error` is `#[non_exhaustive]`, so the added variant cannot break a downstream match.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP server liveness detection for live, disconnected, and reconnected connection states.
  * Updated connectivity checks to report probe results more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->