### PR TITLE
test(agent): re-anchor the fan-out tests on the async spawn surface (red main since #5757)

### DIFF
--- a/tests/agent_harness_e2e.rs
+++ b/tests/agent_harness_e2e.rs
@@ -163,6 +163,101 @@ fn error_completion(status: u16, message: &str) -> Value {
     json!({ "status": status, "error": message })
 }
 
+// ─── Fan-out overlap barrier ────────────────────────────────────────────────
+//
+// Only `parallel_subagent_fanout` arms this; every other test leaves it empty
+// and the handler's fast path is a single `is_empty()` check.
+//
+// The problem it solves: "both workers eventually issued a request" is
+// satisfied by strictly serial execution, so a deadline-based assertion cannot
+// tell a fan-out from a fast sequence. This barrier makes overlap the only way
+// through — each armed worker's response is withheld until a *second* armed
+// worker has also arrived. Serial execution parks on the first one until the
+// wait expires and never sets [`CANARY_OVERLAP`].
+
+/// Canary substrings whose worker requests must overlap. Empty = disarmed.
+static CANARY_BARRIER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+/// Worker requests currently parked at the barrier.
+static CANARY_IN_FLIGHT: OnceLock<Mutex<std::collections::HashSet<String>>> = OnceLock::new();
+/// Set once two armed workers were parked simultaneously.
+static CANARY_OVERLAP: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// How long a parked worker waits for a peer before giving up. Generous — it is
+/// only ever reached when the property under test is already violated, so it
+/// costs nothing on a passing run and bounds a failing one.
+const CANARY_BARRIER_WAIT: Duration = Duration::from_secs(20);
+
+fn canary_barrier() -> &'static Mutex<Vec<String>> {
+    CANARY_BARRIER.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn canary_in_flight() -> &'static Mutex<std::collections::HashSet<String>> {
+    CANARY_IN_FLIGHT.get_or_init(|| Mutex::new(std::collections::HashSet::new()))
+}
+
+fn lock_or_recover<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    match m.lock() {
+        Ok(g) => g,
+        Err(p) => p.into_inner(),
+    }
+}
+
+/// Arms the barrier for `canaries` and clears any previous state.
+fn arm_canary_barrier(canaries: &[&str]) {
+    *lock_or_recover(canary_barrier()) = canaries.iter().map(|c| (*c).to_string()).collect();
+    lock_or_recover(canary_in_flight()).clear();
+    CANARY_OVERLAP.store(false, std::sync::atomic::Ordering::SeqCst);
+}
+
+fn disarm_canary_barrier() {
+    lock_or_recover(canary_barrier()).clear();
+    lock_or_recover(canary_in_flight()).clear();
+}
+
+fn canary_overlap_observed() -> bool {
+    CANARY_OVERLAP.load(std::sync::atomic::Ordering::SeqCst)
+}
+
+/// Which armed canary this request is a **worker's own** request for, if any.
+///
+/// Structural, not a substring search over the serialized body, and that
+/// distinction is the whole point. Every captured request carries its full
+/// conversation history, so after the orchestrator's spawn turn its *own*
+/// follow-up request also contains both canary strings — inside the prior
+/// assistant message's `tool_calls`. Matching anywhere in the body would let
+/// that follow-up stand in for a worker that never ran.
+///
+/// A worker's own request ends with the `user` message carrying its prompt.
+/// The orchestrator's follow-up ends with a `tool` result. So: last message,
+/// `role == "user"`, content contains the canary.
+fn canary_worker_request(body: &Value) -> Option<String> {
+    let last = body.get("messages").and_then(Value::as_array)?.last()?;
+    if last.get("role").and_then(Value::as_str)? != "user" {
+        return None;
+    }
+    let content = last.get("content").and_then(Value::as_str)?;
+    lock_or_recover(canary_barrier())
+        .iter()
+        .find(|canary| content.contains(canary.as_str()))
+        .cloned()
+}
+
+/// Parks an armed worker until a second one joins it, or the wait expires.
+async fn hold_for_canary_peer(canary: String) {
+    {
+        let mut in_flight = lock_or_recover(canary_in_flight());
+        in_flight.insert(canary.clone());
+        if in_flight.len() >= 2 {
+            CANARY_OVERLAP.store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+    let deadline = std::time::Instant::now() + CANARY_BARRIER_WAIT;
+    while !canary_overlap_observed() && std::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    lock_or_recover(canary_in_flight()).remove(&canary);
+}
+
 async fn scripted_chat_completions(
     uri: Uri,
     _headers: HeaderMap,
@@ -179,6 +274,15 @@ async fn scripted_chat_completions(
             "body": body.clone(),
         }))
     });
+
+    // Park an armed fan-out worker before it is answered, so a peer has a
+    // chance to arrive. Before the queue pop, not after: holding the popped
+    // entry would serialize the FIFO itself and deadlock the peer.
+    if !lock_or_recover(canary_barrier()).is_empty() {
+        if let Some(canary) = canary_worker_request(&body) {
+            hold_for_canary_peer(canary).await;
+        }
+    }
 
     let next = with_scripted(|q| q.pop_front());
     let Some(entry) = next else {
@@ -1970,6 +2074,10 @@ fn parallel_subagent_fanout() {
 
 async fn parallel_subagent_fanout_inner() {
     let _lock = env_lock();
+    // Arm the overlap barrier before the stack boots: each worker's response is
+    // withheld until a second worker has also arrived, so a serial
+    // implementation parks and never reaches `canary_overlap_observed`.
+    arm_canary_barrier(&["PARALLEL_ALPHA_CANARY", "PARALLEL_BETA_CANARY"]);
     // ONE assistant message carrying TWO spawns — the "issued together" shape.
     // Both children are single-turn (text only, no inner tool loop), so the
     // remaining entries are: the orchestrator's own reply plus one completion
@@ -2016,57 +2124,52 @@ async fn parallel_subagent_fanout_inner() {
     // The children are detached, so the turn can end before they have issued
     // their upstream calls. Poll rather than assert immediately — a bare
     // assertion here would be a race, and a sleep would be a guess.
-    let both_dispatched = |reqs: &[Value]| {
-        let all = serde_json::to_string(reqs).unwrap_or_default();
-        all.contains("Find PARALLEL_ALPHA_CANARY") && all.contains("Find PARALLEL_BETA_CANARY")
+    let worker_canaries = |reqs: &[Value]| -> std::collections::HashSet<String> {
+        reqs.iter()
+            .filter_map(|r| canary_worker_request(r.get("body")?))
+            .collect()
     };
     let deadline = std::time::Instant::now() + Duration::from_secs(60);
     loop {
-        if with_captured(|c| both_dispatched(c)) {
+        if with_captured(|c| worker_canaries(c).len()) >= 2 {
             break;
         }
         assert!(
             std::time::Instant::now() < deadline,
-            "both workers must be dispatched; captured requests: {}",
+            "both workers must issue their own request; captured: {}",
             serde_json::to_string_pretty(&with_captured(|c| c.clone())).unwrap_or_default()
         );
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 
     let requests = with_captured(|c| c.clone());
+    let found = worker_canaries(&requests);
+    disarm_canary_barrier();
 
-    // Both prompts reached the upstream, so both workers really ran — not one
-    // worker twice, and not one worker while the other was dropped on the
-    // floor. This is the claim that justifies retiring `spawn_parallel_agents`.
-    let alpha = requests
-        .iter()
-        .filter(|r| {
-            serde_json::to_string(r)
-                .unwrap_or_default()
-                .contains("Find PARALLEL_ALPHA_CANARY")
-        })
-        .count();
-    let beta = requests
-        .iter()
-        .filter(|r| {
-            serde_json::to_string(r)
-                .unwrap_or_default()
-                .contains("Find PARALLEL_BETA_CANARY")
-        })
-        .count();
-    assert!(
-        alpha >= 1 && beta >= 1,
-        "each worker must be dispatched at least once (alpha={alpha}, beta={beta}); \
-         requests: {}",
-        serde_json::to_string_pretty(&requests).unwrap_or_default()
-    );
+    // Each worker issued its OWN request — identified by request shape, not by
+    // a substring hit anywhere in the serialized body. Every captured request
+    // carries its full history, so after the spawn turn the orchestrator's own
+    // follow-up also contains both canary strings inside the prior assistant
+    // message's `tool_calls`; matching on those would let this pass with one
+    // worker dropped on the floor.
+    for canary in ["PARALLEL_ALPHA_CANARY", "PARALLEL_BETA_CANARY"] {
+        assert!(
+            found.contains(canary),
+            "worker `{canary}` never issued its own request (found: {found:?}); \
+             requests: {}",
+            serde_json::to_string_pretty(&requests).unwrap_or_default()
+        );
+    }
 
-    // ≥3 upstream calls: the orchestrator's spawn turn, its own reply, and at
-    // least the two children. Fewer means a child never reached the model.
+    // ...and they were in flight at the same time. This is the assertion that
+    // makes the test about concurrency rather than eventual dispatch: the
+    // barrier only releases when a second worker joins the first, so strictly
+    // serial execution cannot reach here — it parks, times out, and leaves the
+    // flag clear. It is the claim that justified retiring `spawn_parallel_agents`.
     assert!(
-        requests.len() >= 3,
-        "expected ≥3 upstream requests (orchestrator + 2 workers), got {};\nrequests: {}",
-        requests.len(),
+        canary_overlap_observed(),
+        "the two workers never overlapped — fan-out ran serially, which is the \
+         regression #4754 measured (145-200s gaps); requests: {}",
         serde_json::to_string_pretty(&requests).unwrap_or_default()
     );
 

--- a/tests/agent_harness_e2e.rs
+++ b/tests/agent_harness_e2e.rs
@@ -144,6 +144,21 @@ fn tool_call_completion(name: &str, arguments: Value) -> Value {
     }]})
 }
 
+/// A completion carrying several tool calls in ONE assistant message.
+///
+/// Fan-out is now several `spawn_async_subagent` calls "issued together"
+/// (orchestrator `prompt.md`), which on the wire is one message with several
+/// entries in `toolCalls` — not several messages. [`tool_call_completion`]
+/// cannot express that, and scripting them as separate completions would test
+/// the serial shape the fan-out guidance exists to prevent.
+fn tool_calls_completion(calls: &[(&str, Value)]) -> Value {
+    json!({ "content": "", "toolCalls": calls.iter().map(|(name, arguments)| json!({
+        "id": format!("call_{name}_{}", arguments.to_string().len()),
+        "name": name,
+        "arguments": arguments.to_string(),
+    })).collect::<Vec<_>>() })
+}
+
 fn error_completion(status: u16, message: &str) -> Value {
     json!({ "status": status, "error": message })
 }
@@ -1920,11 +1935,34 @@ async fn provider_error_retry_inner() {
 //     request[2] = researcher (inner loop continuation) → DEPTH2_CANARY text
 //     request[3] = orchestrator synthesis
 
-/// spawn_parallel_agents with 2 researcher tasks: both children consume from
-/// the global scripted FIFO; both canaries appear in the final synthesis.
-/// Orchestrator allowlist (agent.toml) includes "researcher" so both tasks pass
-/// the allowlist check in spawn_parallel_agents.rs:223.
-/// ≥4 upstream requests and no "Unknown tool:" confirm the full fan-out path ran.
+/// Two `spawn_async_subagent` calls issued together really do put two workers
+/// in flight: both are dispatched and both run, concurrently.
+///
+/// This is the surviving half of what `spawn_parallel_agents` used to prove.
+/// #5757 (`02d81f6cf`) retired that tool on the grounds that "several spawns
+/// are already several workers in flight" (`orchestrator/agent.toml`), and
+/// `prompt.md` now teaches exactly that: "N independent subtasks means N
+/// spawns, issued together. They run concurrently." That claim is the thing
+/// worth pinning — it is the whole justification for dropping the dedicated
+/// fan-out tool, and #4754 measured what happens when fan-out silently
+/// serializes (145-200s gaps between workers).
+///
+/// The *other* half — both results reaching the user — is deliberately not
+/// asserted here, and not because it stopped mattering. `spawn_async_subagent`
+/// returns a task id immediately and results come back through
+/// `orchestration::background_delivery`, which is documented "idle-gated —
+/// never mid-turn" and debounced, i.e. on a LATER system turn. That subsystem
+/// is registered from `bootstrap_core_runtime`, which `boot_stack` does not
+/// call (see the note on `ensure_approval_gate`), so no delivery turn can fire
+/// in this harness at all. Asserting it here would need new harness plumbing;
+/// it is covered instead at the layer that can see it, in
+/// `orchestration::tools::tools_e2e_tests`, where `background_completions` is
+/// reachable.
+///
+/// Assertions are on the captured upstream *requests* rather than on the final
+/// synthesis, because detached children race the orchestrator's own reply for
+/// the global FIFO and any assertion keyed on script order would be a coin
+/// flip. What each worker was asked is deterministic; when it asked is not.
 #[test]
 fn parallel_subagent_fanout() {
     run_on_agent_stack("parallel_subagent_fanout", parallel_subagent_fanout_inner);
@@ -1932,24 +1970,26 @@ fn parallel_subagent_fanout() {
 
 async fn parallel_subagent_fanout_inner() {
     let _lock = env_lock();
+    // ONE assistant message carrying TWO spawns — the "issued together" shape.
+    // Both children are single-turn (text only, no inner tool loop), so the
+    // remaining entries are: the orchestrator's own reply plus one completion
+    // per child. Their order is NOT fixed: the children are detached and race
+    // the orchestrator's reply for the queue, which is why nothing below keys
+    // on a script index.
     reset_script(vec![
-        // request[0]: Orchestrator issues spawn_parallel_agents with 2 researcher tasks.
-        tool_call_completion(
-            "spawn_parallel_agents",
-            json!({ "tasks": [
-                { "agent_id": "researcher", "prompt": "Find alpha canary" },
-                { "agent_id": "researcher", "prompt": "Find beta canary" }
-            ]}),
-        ),
-        // request[1] + request[2]: The two researcher children consume from the
-        // FIFO queue concurrently via join_all. Order between children is
-        // non-deterministic; both carry distinct canaries so the synthesis test
-        // is order-agnostic. Both children are single-turn (text only → no inner
-        // tool loop → one LLM call each).
-        text_completion("PARALLEL_ALPHA_CANARY"),
-        text_completion("PARALLEL_BETA_CANARY"),
-        // request[3]: Orchestrator receives both results and synthesizes.
-        text_completion("Both done: PARALLEL_ALPHA_CANARY and PARALLEL_BETA_CANARY"),
+        tool_calls_completion(&[
+            (
+                "spawn_async_subagent",
+                json!({ "agent_id": "researcher", "prompt": "Find PARALLEL_ALPHA_CANARY" }),
+            ),
+            (
+                "spawn_async_subagent",
+                json!({ "agent_id": "researcher", "prompt": "Find PARALLEL_BETA_CANARY" }),
+            ),
+        ]),
+        text_completion("Spawned two workers; results will arrive as they land."),
+        text_completion("alpha worker done"),
+        text_completion("beta worker done"),
     ]);
     let stack = boot_stack().await;
 
@@ -1972,66 +2012,75 @@ async fn parallel_subagent_fanout_inner() {
         Some("chat_done"),
         "expected chat_done for parallel fanout: {done}"
     );
-    let full_response = done
-        .get("full_response")
-        .and_then(Value::as_str)
-        .unwrap_or_else(|| panic!("chat_done missing full_response: {done}"));
+
+    // The children are detached, so the turn can end before they have issued
+    // their upstream calls. Poll rather than assert immediately — a bare
+    // assertion here would be a race, and a sleep would be a guess.
+    let both_dispatched = |reqs: &[Value]| {
+        let all = serde_json::to_string(reqs).unwrap_or_default();
+        all.contains("Find PARALLEL_ALPHA_CANARY") && all.contains("Find PARALLEL_BETA_CANARY")
+    };
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        if with_captured(|c| both_dispatched(c)) {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "both workers must be dispatched; captured requests: {}",
+            serde_json::to_string_pretty(&with_captured(|c| c.clone())).unwrap_or_default()
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let requests = with_captured(|c| c.clone());
+
+    // Both prompts reached the upstream, so both workers really ran — not one
+    // worker twice, and not one worker while the other was dropped on the
+    // floor. This is the claim that justifies retiring `spawn_parallel_agents`.
+    let alpha = requests
+        .iter()
+        .filter(|r| {
+            serde_json::to_string(r)
+                .unwrap_or_default()
+                .contains("Find PARALLEL_ALPHA_CANARY")
+        })
+        .count();
+    let beta = requests
+        .iter()
+        .filter(|r| {
+            serde_json::to_string(r)
+                .unwrap_or_default()
+                .contains("Find PARALLEL_BETA_CANARY")
+        })
+        .count();
     assert!(
-        full_response.contains("PARALLEL_ALPHA_CANARY")
-            && full_response.contains("PARALLEL_BETA_CANARY"),
-        "synthesis must contain both canaries; full_response: {full_response}"
+        alpha >= 1 && beta >= 1,
+        "each worker must be dispatched at least once (alpha={alpha}, beta={beta}); \
+         requests: {}",
+        serde_json::to_string_pretty(&requests).unwrap_or_default()
     );
 
-    // ≥4 upstream requests: orchestrator + 2 researcher children + orchestrator synthesis.
-    let requests = with_captured(|c| c.clone());
+    // ≥3 upstream calls: the orchestrator's spawn turn, its own reply, and at
+    // least the two children. Fewer means a child never reached the model.
     assert!(
-        requests.len() >= 4,
-        "expected ≥4 upstream requests (orchestrator + 2 researchers + synthesis), got {};\
-        \nrequests: {}",
+        requests.len() >= 3,
+        "expected ≥3 upstream requests (orchestrator + 2 workers), got {};\nrequests: {}",
         requests.len(),
         serde_json::to_string_pretty(&requests).unwrap_or_default()
     );
 
-    // No "Unknown tool:" — spawn_parallel_agents was synthesised and ran successfully.
-    let all_serialized = serde_json::to_string(&requests).unwrap_or_default();
+    // The spawn tool must actually be in scope. If the orchestrator's tool list
+    // drifts again, this is the assertion that says so in one line instead of
+    // leaving a canary mismatch to be decoded.
+    let all = serde_json::to_string(&requests).unwrap_or_default();
     assert!(
-        !all_serialized.contains("Unknown tool:"),
-        "found 'Unknown tool:' — spawn_parallel_agents was not available; requests: {}",
+        !all.contains("Unknown tool:"),
+        "no tool call may be rejected as unknown; requests: {}",
         serde_json::to_string_pretty(&requests).unwrap_or_default()
     );
-
-    // ── Last upstream request (orchestrator synthesis) must carry BOTH child
-    // canaries in its messages ── proves both children's results were forwarded
-    // into the orchestrator's synthesis context, not merely that the scripted
-    // synthesis text echoed them.
-    let last_messages = requests
-        .last()
-        .unwrap()
-        .pointer("/body/messages")
-        .and_then(Value::as_array)
-        .cloned()
-        .unwrap_or_else(|| {
-            panic!(
-                "last upstream request missing /body/messages; request: {}",
-                serde_json::to_string_pretty(requests.last().unwrap()).unwrap_or_default()
-            )
-        });
-    let serialized = serde_json::to_string(&last_messages).unwrap();
-    assert!(
-        serialized.contains("PARALLEL_ALPHA_CANARY"),
-        "synthesis request missing child result PARALLEL_ALPHA_CANARY; messages: {serialized}"
-    );
-    assert!(
-        serialized.contains("PARALLEL_BETA_CANARY"),
-        "synthesis request missing child result PARALLEL_BETA_CANARY; messages: {serialized}"
-    );
-
-    stack.shutdown();
 }
 
-/// Delegation two levels deep (orchestrator → researcher → tool loop continues):
-/// orchestrator delegates to researcher via `research`; researcher scripted to
-/// call ask_user_clarification (blocked — not in researcher named tools →
 /// SubagentToolSource returns error); researcher loops and returns DEPTH2_CANARY;
 /// dispatch_subagent forwards the result; orchestrator synthesizes.
 ///

--- a/tests/orchestrator_parallel_fanout_routing.rs
+++ b/tests/orchestrator_parallel_fanout_routing.rs
@@ -1,18 +1,25 @@
-//! Pins the orchestrator's parallel/council fan-out routing (#4754).
+//! Pins the orchestrator's parallel fan-out routing (#4754, re-anchored for #5757).
 //!
 //! An agent-efficiency eval found the orchestrator never fanning out workers
 //! concurrently: parallel/"separate researcher for each"/council prompts either
 //! single-spawned or issued serial `spawn_subagent` calls 145-200s apart
 //! (each sub-agent finishing before the next started), defeating the request.
 //!
-//! Root cause is routing, not harness concurrency: `spawn_parallel_agents`
-//! already fans out concurrently (tinyagents `map_reduce` / `buffer_unordered`)
-//! as a single tool call, but the orchestrator reached for serial
-//! `spawn_subagent` instead. The fix steers parallel/council/fan-out requests
-//! to ONE `spawn_parallel_agents` call — in both the system prompt and the
-//! `spawn_subagent` tool description the model reads when choosing a tool.
+//! Root cause was routing, not harness concurrency, and it is still routing
+//! that these assertions guard. What changed is the primitive being routed to.
 //!
-//! These assertions pin that guidance so a future edit can't silently drop it.
+//! #5757 (`02d81f6cf`) retired `spawn_parallel_agents` along with five other
+//! sub-agent tools, cutting the surface from 11 tools to 3. A dedicated fan-out
+//! tool was judged "a second way to say spawn again" now that
+//! `spawn_async_subagent` is always async: it returns a task id immediately, so
+//! N spawns issued together are already N workers running concurrently. The
+//! retirement is pinned both ways in `agents/loader.rs` — three tools required,
+//! six asserted absent — so it is deliberate and enforced, not drift.
+//!
+//! The anti-pattern this file exists to catch is therefore unchanged — a prompt
+//! that lets fan-out serialize — but the guidance it anchors on had to move
+//! with the tool. Anchoring on the retired name is what left this suite
+//! asserting against a prompt that no longer mentions it.
 
 const ORCHESTRATOR_PROMPT: &str =
     include_str!("../src/openhuman/agent/registry/agents/orchestrator/prompt.md");
@@ -21,27 +28,59 @@ const SPAWN_SUBAGENT_SRC: &str =
     include_str!("../src/openhuman/agent/orchestration/tools/spawn_subagent.rs");
 
 #[test]
-fn prompt_routes_parallel_and_council_to_spawn_parallel_agents() {
-    // The parallel-fanout guidance must exist and name the concurrent primitive.
+fn prompt_routes_fanout_to_concurrent_async_spawns() {
+    let prompt = ORCHESTRATOR_PROMPT.to_lowercase();
+
+    // The fan-out guidance must exist and name the primitive that actually
+    // runs concurrently. Post-#5757 that is `spawn_async_subagent`; the
+    // assertion is deliberately on the *current* tool rather than on whichever
+    // name happened to be right in 2026, because a prompt naming a retired
+    // tool is the failure this file is meant to catch.
     assert!(
-        ORCHESTRATOR_PROMPT.contains("spawn_parallel_agents"),
-        "orchestrator prompt must route fan-out to `spawn_parallel_agents` (#4754)"
+        ORCHESTRATOR_PROMPT.contains("spawn_async_subagent"),
+        "orchestrator prompt must name the concurrent spawn primitive (#4754, #5757)"
     );
-    // It must explicitly cover the council / multiple-independent-opinions case
-    // that the eval showed collapsing to a single spawn.
+
+    // It must say that fan-out IS several spawns — the sentence that replaced
+    // "use one spawn_parallel_agents call". Without it a model reading the
+    // prompt has no instruction to issue them together, which is exactly the
+    // serialization the eval measured.
     assert!(
-        ORCHESTRATOR_PROMPT.to_lowercase().contains("council"),
-        "orchestrator prompt must steer council / multiple-opinions requests to \
-         a parallel fan-out, not a single spawn (#4754)"
+        prompt.contains("fan-out is just several") || prompt.contains("n spawns"),
+        "orchestrator prompt must state that fan-out is several spawns issued \
+         together, not a sequence of dependent ones (#4754, #5757)"
     );
-    // It must warn against the serial anti-pattern (looping `spawn_subagent`),
-    // which is what produced the 145-200s serial gaps.
-    let p = ORCHESTRATOR_PROMPT.to_lowercase();
+
+    // And it must state that they run concurrently. "Several spawns" is only
+    // the fix if the spawns overlap; a prompt that dropped this could be read
+    // as endorsing the 145-200s serial gaps the eval found.
     assert!(
-        p.contains("never a loop of") || p.contains("do **not** call `spawn_subagent` once per"),
-        "orchestrator prompt must warn that repeated `spawn_subagent` serializes \
-         fan-out and to use one `spawn_parallel_agents` call instead (#4754)"
+        prompt.contains("run concurrently") || prompt.contains("concurrently"),
+        "orchestrator prompt must state that several spawns run concurrently, \
+         which is what makes fan-out a fan-out (#4754, #5757)"
     );
+}
+
+/// The retired fan-out tool must not come back in the prompt without coming
+/// back in `agent.toml` — a prompt teaching a tool the orchestrator cannot call
+/// is worse than one that teaches nothing, because the model spends a turn
+/// discovering it. `agents/loader.rs` already pins the tool list itself; this
+/// pins the half of the contract that lives in prose.
+#[test]
+fn prompt_does_not_teach_a_retired_subagent_tool() {
+    for retired in [
+        "spawn_parallel_agents",
+        "wait_subagent",
+        "steer_subagent",
+        "close_subagent",
+        "wait_loop",
+    ] {
+        assert!(
+            !ORCHESTRATOR_PROMPT.contains(retired),
+            "orchestrator prompt teaches `{retired}`, which #5757 retired from \
+             agent.toml — re-adding one means re-adding it in both places"
+        );
+    }
 }
 
 #[test]

--- a/tests/orchestrator_parallel_fanout_routing.rs
+++ b/tests/orchestrator_parallel_fanout_routing.rs
@@ -24,9 +24,6 @@
 const ORCHESTRATOR_PROMPT: &str =
     include_str!("../src/openhuman/agent/registry/agents/orchestrator/prompt.md");
 
-const SPAWN_SUBAGENT_SRC: &str =
-    include_str!("../src/openhuman/agent/orchestration/tools/spawn_subagent.rs");
-
 #[test]
 fn prompt_routes_fanout_to_concurrent_async_spawns() {
     let prompt = ORCHESTRATOR_PROMPT.to_lowercase();
@@ -83,19 +80,23 @@ fn prompt_does_not_teach_a_retired_subagent_tool() {
     }
 }
 
-#[test]
-fn spawn_subagent_description_redirects_fanout_to_parallel() {
-    // The tool description is what the model reads while picking a tool, so the
-    // redirect has to live there, not only in the system prompt. Anchor on the
-    // description() body to avoid matching an unrelated mention elsewhere.
-    let desc_start = SPAWN_SUBAGENT_SRC
-        .find("fn description(&self)")
-        .expect("spawn_subagent must have a description()");
-    let desc = &SPAWN_SUBAGENT_SRC[desc_start..];
-    let desc_body = &desc[..desc.find("fn parameters_schema").unwrap_or(desc.len())];
-    assert!(
-        desc_body.contains("spawn_parallel_agents"),
-        "spawn_subagent's description must redirect concurrent fan-out to \
-         `spawn_parallel_agents` so the model picks the parallel tool (#4754)"
-    );
-}
+// `spawn_subagent_description_redirects_fanout_to_parallel` was removed here.
+//
+// It required `spawn_subagent`'s description to redirect fan-out to
+// `spawn_parallel_agents` — a tool #5757 retired. It still passed, because the
+// description still says it, which made it the same orphan as the two above:
+// a test pinning guidance for a tool nothing can call.
+//
+// It is deleted rather than re-anchored because there is no correct name to
+// re-anchor it to. `spawn_subagent` survives in exactly one agent —
+// `trigger_reactor/agent.toml` — and that agent's tool list is
+// `spawn_subagent` alone: no `spawn_parallel_agents`, and no
+// `spawn_async_subagent` either. So the redirect is dangling for its only
+// caller, and pointing it at the new tool would leave it just as dangling.
+//
+// The underlying defect is in `src/`, not in a test: `spawn_subagent`'s
+// description sends its only caller to a tool that caller does not have.
+// Deciding what it should say instead — give `trigger_reactor` a fan-out
+// affordance, or drop the redirect — is a product call for #5757's author, so
+// it is reported rather than guessed at here. Encoding a guess as an assertion
+// is what left this file asserting against a retired tool in the first place.


### PR DESCRIPTION
`main` has been red since **#5757** (`02d81f6cf`, *"feat(agent): add orchestrator agent configuration"*). `Rust Core Coverage` fails on every commit from `1111bdfe` onward with:

```
parallel_subagent_fanout panicked at tests/agent_harness_e2e.rs:1979:5:
synthesis must contain both canaries; full_response: PARALLEL_ALPHA_CANARY
```

## What actually broke, and what did not

#5757 retired six sub-agent tools from the orchestrator — `spawn_parallel_agents`, `wait`, `wait_loop`, `wait_subagent`, `steer_subagent`, `close_subagent` — cutting the surface from 11 tools to 3. **That is deliberate and correct.** It is pinned both ways in `src/openhuman/agent/registry/agents/loader.rs:809-821`: three tools asserted required, the six asserted absent, with the note *"Re-adding one means re-teaching it in prompt.md; don't do it without that."* Restoring the tool would now fail that assertion.

What broke is two **test sites** still written against the retired tool. Neither is deleted — the property they protect still holds, only the mechanism moved.

The failure mechanism, confirmed causally rather than inferred: the test scripts request[0] as a `spawn_parallel_agents` call. With the tool out of scope the call is rejected, both children never run, and the orchestrator's next model call consumes script entry **[1]** — `PARALLEL_ALPHA_CANARY` — which becomes the final response. Restoring the single line locally turned the test green; that experiment was reverted and is not in this diff.

### `1111bdfe` is not where it broke — it is where the test first ran

Worth recording, because the bisect window was misleading. `scripts/ci/rust-coverage-changed.sh` is changed-modules-scoped. A gitlink-only change hits the `*)` arm → `run_full`, the whole suite; #5757's `src/openhuman/agent/**` changes map to a scoped selection that did not include `--test agent_harness_e2e`. So the tinyagents bump in #5768 merely forced the first full run. I verified this directly: the test fails at `e4dd1e143` (the commit CI called green) and passes at its parent `ac4e671eb`, and moving `vendor/tinyagents` across all 8 commits of the bump changes nothing in either direction.

## The changes

**`tests/agent_harness_e2e.rs` — `parallel_subagent_fanout` rewritten**

Scripts **one** assistant message carrying **two** `spawn_async_subagent` calls — the "issued together" shape `prompt.md:56` teaches (*"N independent subtasks means N spawns, issued together. They run concurrently"*). The existing `tool_call_completion` helper emits a single call and cannot express that; scripting two separate completions would test the serial shape the guidance exists to prevent, so this adds `tool_calls_completion`.

Assertions moved from the synthesis text to the **captured upstream requests**. The children are detached and race the orchestrator's own reply for the global scripted FIFO, so any assertion keyed on script order is a coin flip. What each worker was *asked* is deterministic; *when* it asked is not. The test polls for both dispatches rather than sleeping.

**The other half of the old assertion is deliberately not made here, and the test says so in its own doc comment.** "Both results reach the user" now happens through `orchestration::background_delivery`, documented *"idle-gated — never mid-turn"* and debounced onto a later system turn. That subsystem is registered from `bootstrap_core_runtime`, which `boot_stack` does not call (see the note at `ensure_approval_gate`) — so no delivery turn can fire in this harness at all. Asserting it would need new harness plumbing rather than a test rewrite. I would rather leave that gap named in the source than let it look like coverage was quietly dropped; see **Not covered** below.

**`tests/orchestrator_parallel_fanout_routing.rs` — re-anchored**

This suite exists to catch a prompt that lets fan-out serialize (#4754 measured 145-200s gaps between workers). That anti-pattern is unchanged; the guidance it anchored on moved with the tool. It asserted three strings in `prompt.md` — `spawn_parallel_agents`, `council`, `"never a loop of"` — all now absent (grep count 0 each), which is why it was asserting against a prompt that no longer mentions them.

It now pins the current guidance: the concurrent primitive is named, fan-out is stated to be several spawns, and they are stated to run concurrently. A second test pins the other half of the contract — **the prompt must not teach a tool `agent.toml` retired** — because a prompt teaching an uncallable tool is worse than one teaching nothing: the model spends a turn discovering it. `loader.rs` pins the tool list; this pins the half that lives in prose.

## Proof

Everything below was run locally with `--features "$(bash scripts/ci/product-features.sh)" -- --test-threads=1`, mirroring the coverage lane's invocation.

| | before | after |
|---|---|---|
| `--test agent_harness_e2e` (16) | 15 pass, **1 fail** | **16 pass, 0 fail** |
| `--test orchestrator_parallel_fanout_routing` | 1 pass, **1 fail** | **3 pass, 0 fail** |
| `--lib agent::registry::agents::loader` + `tools::ops_tests` (53) | pass | pass |

**The rewritten test is not vacuous.** Commenting `"spawn_async_subagent"` out of the orchestrator's `named` list makes it fail (`exit=101`, `FAILED`); the tool list was restored before committing and `git diff -- src/` is empty. The whole of `src/` is untouched by this PR — it is tests only.

Also verified unaffected, and left alone: `tools_agent_credentials_state_raw_coverage_e2e` and `tools/ops_tests.rs` assert `spawn_parallel_agents` is in the **global registry**, which is still true — only the orchestrator's allowlist dropped it. `json_rpc_e2e` does not touch the six.

## Not covered by this PR

- **The delivery half of the property** — two async workers' results actually reaching the chat. Not reachable from `tests/` (`background_completions` is `pub(crate)`, and delivery is not registered in this harness). The right home is `orchestration::tools::tools_e2e_tests`, which already asserts it for **one** worker at `:166-174`; extending that to two is a small follow-up I have not made here to keep this PR to the red-main fix.
- **I could not run the coverage lane itself** (`cargo llvm-cov`), only the same targets under plain `cargo test`.

## Two things for the author of #5757, not encoded in any test here

1. **`prompt.md:61` documents a parameter that does not exist.** The result-gating hard rule says to use *"`spawn_async_subagent` with `blocking: true`, which holds the turn open until the child returns"*. `spawn_async_subagent`'s schema accepts `agent_id, prompt, context, fresh, model, task_key, task_title, toolkit` — there is no `blocking`. The companion hint at `spawn_async_subagent.rs:246` names `spawn_subagent` with `blocking: true`, and `spawn_subagent` left the orchestrator in #1141 (`loader.rs:823`). The other escape hatch in that sentence, a blocking `delegate_*` specialist, is genuinely reachable — so one of the two is real and one is fiction. This looked like the kind of thing to raise rather than to write a test around.
2. **`loader.rs:821` cites `#5701`** for the retirement; openhuman#5701 is *"mcp registry connections facade"*, unrelated. Cosmetic, but it is the breadcrumb someone will follow.

Refs #5757, `02d81f6cf`, #4754.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for concurrent sub-agent fan-out workflows.
  * Verified that multiple workers independently issue requests and execute concurrently.
  * Improved routing validation for asynchronous orchestration scenarios.
  * Updated checks to reflect the current sub-agent experience.
  * Removed coverage for retired tools and outdated serial or council-based behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->