### PR TITLE
fix(docs): update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ High-level comparison (products evolve, so verify against each vendor). OpenHuma
 
 New contributor? Start with [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the fork/PR workflow and local validation commands, or use the copy-paste AI-agent prompt in [`CONTRIBUTING-BEGINNERS.md`](./CONTRIBUTING-BEGINNERS.md#optional--let-an-ai-coding-agent-guide-you). The short path is:
 
-1. Install Git, Node.js 24+, pnpm 10.10.0, Rust 1.93.0 (`rustfmt` + `clippy`), CMake, Ninja, ripgrep, and the platform desktop build prerequisites.
+1. Install Git, Node.js 24+, pnpm 10.10.0, Rust 1.96.1 (`rustfmt` + `clippy`), CMake, Ninja, ripgrep, and the platform desktop build prerequisites.
 2. Fork and clone the repo, then run `git submodule update --init --recursive` before `pnpm install` so the vendored Tauri/CEF sources are present.
 3. Use `pnpm dev` for web-only UI work, `pnpm --filter openhuman-app dev:app` for the desktop shell, and focused checks such as `pnpm typecheck`, `pnpm format:check`, and `cargo check -p openhuman --lib` before opening a PR.
 

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -155,7 +155,7 @@ Gespeicherte Workflows sind dauerhaft und trigger-gesteuert: sie feuern auf Zeit
 
 Neu hier? Beginne mit [`CONTRIBUTING.md`](../CONTRIBUTING.md) für den Fork-/PR-Workflow und die lokalen Prüfbefehle, oder nutze den Copy-Paste-Prompt für KI-Coding-Agenten in [`CONTRIBUTING-BEGINNERS.md`](../CONTRIBUTING-BEGINNERS.md#optional--let-an-ai-coding-agent-guide-you). Der kurze Weg:
 
-1. Installiere Git, Node.js 24+, pnpm 10.10.0, Rust 1.93.0 (`rustfmt` + `clippy`), CMake, Ninja, ripgrep sowie die plattformspezifischen Desktop-Build-Voraussetzungen.
+1. Installiere Git, Node.js 24+, pnpm 10.10.0, Rust 1.96.1 (`rustfmt` + `clippy`), CMake, Ninja, ripgrep sowie die plattformspezifischen Desktop-Build-Voraussetzungen.
 2. Forke und klone das Repo, führe dann `git submodule update --init --recursive` aus, bevor du `pnpm install` startest, damit die mitgelieferten Tauri/CEF-Quellen vorhanden sind.
 3. Nutze `pnpm dev` für reine Web-UI-Arbeit, `pnpm --filter openhuman-app dev:app` für die Desktop-Shell sowie gezielte Checks wie `pnpm typecheck`, `pnpm format:check` und `cargo check -p openhuman --lib`, bevor du einen PR öffnest.
 

--- a/docs/README.ja-JP.md
+++ b/docs/README.ja-JP.md
@@ -155,7 +155,7 @@ n8n と Zapier に強くインスパイアされた[ワークフロー](https://
 
 新しいコントリビューターの方は、まず [`CONTRIBUTING.md`](../CONTRIBUTING.md) で fork/PR ワークフローとローカル検証コマンドを確認するか、[`CONTRIBUTING-BEGINNERS.md`](../CONTRIBUTING-BEGINNERS.md#optional--let-an-ai-coding-agent-guide-you) のコピー&ペーストできる AI エージェント向けプロンプトを使ってください。最短経路は以下のとおりです:
 
-1. Git、Node.js 24+、pnpm 10.10.0、Rust 1.93.0（`rustfmt` + `clippy`）、CMake、Ninja、ripgrep、プラットフォーム向けデスクトップビルドの前提条件をインストールします。
+1. Git、Node.js 24+、pnpm 10.10.0、Rust 1.96.1（`rustfmt` + `clippy`）、CMake、Ninja、ripgrep、プラットフォーム向けデスクトップビルドの前提条件をインストールします。
 2. リポジトリを fork してクローンし、`pnpm install` の前に `git submodule update --init --recursive` を実行して、ベンダー化された Tauri/CEF のソースを取得します。
 3. ウェブのみの UI 作業には `pnpm dev` を、デスクトップシェルには `pnpm --filter openhuman-app dev:app` を使用し、PR を出す前に `pnpm typecheck`、`pnpm format:check`、`cargo check -p openhuman --lib` などの集中チェックを実行してください。
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -155,7 +155,7 @@ n8n과 Zapier에서 깊은 영감을 받은 [워크플로우](https://tinyhumans
 
 새로운 기여자인가요? 포크/PR 워크플로우 및 로컬 검증 명령에 대해서는 [`CONTRIBUTING.md`](../CONTRIBUTING.md)에서 시작하거나, [`CONTRIBUTING-BEGINNERS.md`](../CONTRIBUTING-BEGINNERS.md#optional--let-an-ai-coding-agent-guide-you)의 복사-붙여넣기 AI 에이전트 프롬프트를 사용하세요. 빠른 경로는 다음과 같습니다.
 
-1. Git, Node.js 24+, pnpm 10.10.0, Rust 1.93.0(`rustfmt` + `clippy`), CMake, Ninja, ripgrep 및 플랫폼 데스크톱 빌드 필수 구성 요소를 설치합니다.
+1. Git, Node.js 24+, pnpm 10.10.0, Rust 1.96.1(`rustfmt` + `clippy`), CMake, Ninja, ripgrep 및 플랫폼 데스크톱 빌드 필수 구성 요소를 설치합니다.
 2. 저장소를 포크하고 클론한 다음, `pnpm install` 전에 `git submodule update --init --recursive`를 실행하여 벤더링된 Tauri/CEF 소스가 존재하는지 확인합니다.
 3. 웹 전용 UI 작업에는 `pnpm dev`를, 데스크톱 쉘에는 `pnpm --filter openhuman-app dev:app`을 사용하고, PR을 열기 전에 `pnpm typecheck`, `pnpm format:check`, `cargo check -p openhuman --lib`와 같은 집중 점검을 수행합니다.
 

--- a/docs/README.ur-pk.md
+++ b/docs/README.ur-pk.md
@@ -201,7 +201,7 @@ n8n اور Zapier سے گہرے متاثر، [ورک فلوز](https://tinyhuman
 
 نیا تعاون کنندہ؟ fork/PR ورک فلو اور مقامی تصدیقی کمانڈز کے لیے [`CONTRIBUTING.md`](../CONTRIBUTING.md) سے شروع کریں، یا [`CONTRIBUTING-BEGINNERS.md`](../CONTRIBUTING-BEGINNERS.md#optional--let-an-ai-coding-agent-guide-you) میں موجود کاپی پیسٹ AI-ایجنٹ پرامپٹ استعمال کریں۔ مختصر راستہ:
 
-1. Git، Node.js 24+، pnpm 10.10.0، Rust 1.93.0 (`rustfmt` + `clippy`)، CMake، Ninja، ripgrep، اور پلیٹ فارم ڈیسک ٹاپ بلڈ کی ضروریات انسٹال کریں۔
+1. Git، Node.js 24+، pnpm 10.10.0، Rust 1.96.1 (`rustfmt` + `clippy`)، CMake، Ninja، ripgrep، اور پلیٹ فارم ڈیسک ٹاپ بلڈ کی ضروریات انسٹال کریں۔
 2. ریپو کو fork اور کلون کریں، پھر `pnpm install` سے پہلے `git submodule update --init --recursive` چلائیں تاکہ وینڈرڈ Tauri/CEF سورس موجود ہوں۔
 3. ویب صرف UI کام کے لیے `pnpm dev`، ڈیسک ٹاپ شیل کے لیے `pnpm --filter openhuman-app dev:app`، اور PR کھولنے سے پہلے فوکسڈ چیکس جیسے `pnpm typecheck`، `pnpm format:check`، اور `cargo check -p openhuman --lib` استعمال کریں۔
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -155,7 +155,7 @@ OpenHuman 跳过了等待期。连接你的账户，让[自动拉取](https://ti
 
 新贡献者？从 [`CONTRIBUTING.md`](../CONTRIBUTING.md) 了解 fork/PR 工作流和本地验证命令，或使用 [`CONTRIBUTING-BEGINNERS.md`](../CONTRIBUTING-BEGINNERS.md#optional--let-an-ai-coding-agent-guide-you) 中可直接复制粘贴的 AI 智能体提示词。快速路径：
 
-1. 安装 Git、Node.js 24+、pnpm 10.10.0、Rust 1.93.0（`rustfmt` + `clippy`）、CMake、Ninja、ripgrep，以及各平台桌面构建的前置依赖。
+1. 安装 Git、Node.js 24+、pnpm 10.10.0、Rust 1.96.1（`rustfmt` + `clippy`）、CMake、Ninja、ripgrep，以及各平台桌面构建的前置依赖。
 2. Fork 并克隆仓库，然后运行 `git submodule update --init --recursive` 之后再执行 `pnpm install`，确保内置的 Tauri/CEF 源码就位。
 3. 使用 `pnpm dev` 进行纯 Web UI 开发，`pnpm --filter openhuman-app dev:app` 用于桌面壳，在提交 PR 之前运行针对性的检查如 `pnpm typecheck`、`pnpm format:check` 和 `cargo check -p openhuman --lib`。
 


### PR DESCRIPTION
## Summary

- Update all 6 README files to say Rust 1.96.1 instead of Rust 1.93.0.
- Keep the documented Rust version consistent with `rust-toolchain.toml` and `CONTRIBUTING.md`.

## Problem

- The README and all translated README versions currently instruct contributors to install Rust 1.93.0.
- The repository actually pins Rust 1.96.1 in `rust-toolchain.toml`, and `CONTRIBUTING.md` already documents 1.96.1.

## Solution

- Updated the Rust version from `1.93.0` to `1.96.1` in all six affected README files:
  - `README.md`
  - `docs/README.zh-CN.md`
  - `docs/README.de.md`
  - `docs/README.ja-JP.md`
  - `docs/README.ko.md`
  - `docs/README.ur-pk.md`
- The documented version now matches the repository's `rust-toolchain.toml` and `CONTRIBUTING.md`.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [ ] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
  - `N/A: Documentation-only version correction; no runtime behavior changed.`

- [ ] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/ci-lite.yml`](../.github/workflows/ci-lite.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
  - `N/A: Documentation-only change; no executable code was modified.`

- [ ] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`)
  - `N/A: No features, behavior, or coverage requirements changed.`

- [ ] All affected feature IDs from the matrix are listed in the PR description under `## Related`
  - `N/A: No affected feature IDs.`

- [ ] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)
  - `N/A: No dependencies or network behavior changed.`

- [ ] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)
  - `N/A: Documentation-only change; release-cut behavior is unaffected.`

- [ ] Linked issue closed via `Closes #NNN` in the `## Related` section
  - `Closes #ISSUE_NUMBER`

## Impact

- **Runtime/platform:** None. This PR only updates contributor documentation.
- **Performance:** None.
- **Security:** None.
- **Migration:** None.
- **Compatibility:** No runtime compatibility changes. The documented Rust version is corrected to match the version already required by the repository.
- **Contributor experience:** Contributors following the README will be directed to the Rust version required by the current dependency/toolchain configuration.

## Related

Closes #5781

- Follow-up PR(s)/TODOs: None

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: `N/A: No Linear issue associated with this change.`
- URL: `N/A`

### Commit & Branch

- Branch: `fix-readme`
- Commit SHA: `<8157f414602effbc09532bd5f096d6ab7ab9a52e`

### Validation Run

- [ ] `pnpm --filter openhuman-app format:check`
  - `N/A: Documentation-only change; no application source formatting is affected.`

- [ ] `pnpm typecheck`
  - `N/A: Documentation-only change; no TypeScript source changed.`

- [ ] Focused tests:
  - `N/A: Documentation-only change; no runtime behavior changed.`

- [ ] Rust fmt/check (if changed):
  - `N/A: No Rust source files changed.`

- [ ] Tauri fmt/check (if changed):
  - `N/A: No Tauri source files changed.`

### Validation Blocked

- `command: N/A`
- `error: N/A`
- `impact: N/A: Validation was not blocked; the listed code-validation commands are not applicable to a documentation-only change.`

### Behavior Changes

- Intended behavior change: None. This PR only corrects the documented Rust prerequisite.
- User-visible effect: Contributors will see Rust `1.96.1` instead of `1.93.0` when following the "Contributing from source" instructions.

### Parity Contract

- Legacy behavior preserved: Yes. No runtime or application behavior is changed.
- Guard/fallback/dispatch parity checks: `N/A: No runtime guards, fallbacks, or dispatch logic changed.`

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None known.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): `N/A`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution and build instructions to require Rust 1.96.1 instead of Rust 1.93.0.
  * Applied the updated requirement across English, German, Japanese, Korean, Urdu, and Simplified Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->