### PR TITLE
fix(test): re-anchor style-section assertions to the renamed STYLE.md heading

### DIFF
--- a/tests/raw_coverage/agent_harness_leftovers_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/agent_harness_leftovers_raw_coverage_e2e.rs
@@ -690,7 +690,7 @@ fn subagent_prompt_renderer_handles_formats_caps_and_stale_tool_indices() -> Res
     assert!(json_prompt.contains("extra"));
     assert!(json_prompt.contains("truncated at 2000 chars"));
     assert!(json_prompt.contains("## Safety"));
-    assert!(json_prompt.contains("## Output style"));
+    assert!(json_prompt.contains("# Writing style"));
 
     let native_prompt = render_subagent_system_prompt(
         tmp.path(),

--- a/tests/raw_coverage/agent_prompts_subagent_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/agent_prompts_subagent_raw_coverage_e2e.rs
@@ -391,7 +391,7 @@ fn prompt_sections_render_files_identity_memory_tools_and_ambient_blocks() -> Re
     assert!(rendered.contains("curated user body"));
     assert!(rendered.contains("### work (last updated 2026-05-29)"));
     assert!(rendered.contains("Call as: `echo[a|b]`"));
-    assert!(rendered.contains("## Output style"));
+    assert!(rendered.contains("# Writing style"));
 
     let user_files = render_user_files(&ctx)?;
     assert!(user_files.contains("curated memory body"));

--- a/tests/raw_coverage/inference_agent_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/inference_agent_raw_coverage_e2e.rs
@@ -2922,7 +2922,7 @@ fn agent_pformat_and_prompt_renderers_cover_public_paths() {
     .expect("subagent builder");
     assert!(built.contains("coverage soul"));
     assert!(built.contains("coverage profile"));
-    assert!(built.contains("Output style"));
+    assert!(built.contains("# Writing style"));
 
     let narrow = render_subagent_system_prompt(
         workspace.path(),


### PR DESCRIPTION
## Summary

- Re-anchors three `tests/raw_coverage/` assertions from the old prompt heading `## Output style` to its current name `# Writing style`.
- Fixes `main`, which is red on `assertion failed: json_prompt.contains("## Output style")` in the Rust Core Coverage lane.
- Two of the three were latent: the coverage lane runs *changed modules only*, so they had never been exercised and would have fired the moment their module was touched.
- Test-only change. No production code touched.

## Problem

The prompt style section was renamed from `## Output style` to `# Writing style`. It now lives in `src/openhuman/agent/prompts/STYLE.md`, whose sole heading is `# Writing style`, and is pulled into every rendered prompt as `GLOBAL_STYLE_SUFFIX` (`builder.rs:28`, `include_str!("STYLE.md")`).

`ffcc22dc4` updated the two in-tree callers under `src/` (`agent/prompts/mod_tests.rs:149`, `agent/tinyagents/host/context_composer.rs:396`), but three assertions under `tests/raw_coverage/` were missed:

| file | line | asserted |
|---|---|---|
| `agent_harness_leftovers_raw_coverage_e2e.rs` | 693 | `json_prompt.contains("## Output style")` |
| `agent_prompts_subagent_raw_coverage_e2e.rs` | 394 | `rendered.contains("## Output style")` |
| `inference_agent_raw_coverage_e2e.rs` | 2925 | `built.contains("Output style")` |

Only the first has actually failed so far. `Rust Core Coverage (cargo-llvm-cov)` runs `raw_coverage_all` module-by-module and only for changed modules, so the other two sat green-by-omission. That scoping is why a rename that landed on 2026-08-23 only turned `main` red days later.

## Solution

Each assertion is re-anchored to `# Writing style`, matching the fix `ffcc22dc4` applied to the two `src/` sites, rather than deleted. The section still exists and each test is still checking the same property it always was: that the built prompt carries the global style suffix. The anchor is unambiguous, `STYLE.md` contains exactly one heading and no `## Writing style` exists anywhere.

I also swept every heading assertion in `tests/raw_coverage/` (21 distinct `contains("#...")` strings) against the sources. These three were the only orphans. `## Comments` / `## Description` resolve into the vendored memory readers and `### \`shell\`` / `### USER.md` are built dynamically at runtime, so all are sound.

### Revert-check

With each fix reverted, the failure names that exact assertion at that exact line, and the first reproduces CI's message verbatim:

```
agent_harness_leftovers_..rs:693:5: assertion failed: json_prompt.contains("## Output style")
agent_prompts_subagent_..rs:394:5: assertion failed: rendered.contains("## Output style")
inference_agent_..rs:2925:5:       assertion failed: built.contains("Output style")
```

With the fixes applied, all three modules pass: 8/8, 6/6, 28/28.

## Submission Checklist

- [x] N/A: test-only change. This PR *is* the test fix; it adds no production code to cover. The failure path is the revert-check above.
- [x] N/A: diff coverage. All three changed lines are assertion lines inside tests that execute and pass.
- [x] N/A: no feature rows added, removed, or renamed. Behaviour-only correction to existing assertions.
- [x] N/A: no feature IDs affected.
- [x] No new external network dependencies introduced.
- [x] N/A: does not touch release-cut surfaces.
- [x] N/A: no linked issue. This fixes a red `main` directly; no tracking issue was filed.

## Impact

None at runtime. Test-only. Unblocks the Rust Core Coverage lane on `main`, which is currently failing for every PR that touches these modules.

## Related

- Closes: N/A, no tracking issue.
- Follow-up PR(s)/TODOs: the coverage lane's changed-modules-only scoping means an orphaned assertion can sit green in `main` indefinitely. Worth considering a periodic full-target run to catch this class earlier.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/style-heading-orphan-coverage`
- Commit SHA: `5c30e4af2`

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend files changed.
- [x] N/A: `pnpm typecheck` — no TypeScript changed.
- [x] Focused tests: `cargo test -p openhuman --test raw_coverage_all` for the three affected modules, run with the full CI feature list on rustc 1.96.1 (matching the lane). All pass; revert-check reproduces each failure. Ran the whole `raw_coverage_all` target too: 441 passed, 30 failed, none of them mine, and the failures reproduce identically on a pristine `upstream/main` tree. They are the known one-workspace-per-process interference plus tests needing a built tinymemory module (`OPENHUMAN_MODULE_PATH`), which CI avoids by running module-by-module.
- [x] N/A: Rust fmt/check — no formatting change, three string literals edited in place. `cargo test` compiled the target clean.
- [x] N/A: Tauri fmt/check — no Tauri code changed.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none. Assertions re-anchored to the current heading.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: yes. Each test guards the same property as before, that the rendered prompt carries `GLOBAL_STYLE_SUFFIX`.
- Guard/fallback/dispatch parity checks: N/A, no dispatch or fallback logic touched.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated prompt-rendering test expectations to reflect the renamed writing-style section heading.
  - Aligned coverage checks across subagent and inference scenarios with the current prompt format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->