### PR TITLE
Unbreak main: name the missing memory module, and drain the shared store

### DIFF
--- a/src/openhuman/config/migration_helpers/core.rs
+++ b/src/openhuman/config/migration_helpers/core.rs
@@ -144,31 +144,45 @@ pub async fn migrate_openclaw_memory(
 ///
 /// # A null driver is refused, not imported into
 ///
-/// `binding` answers the null driver in two situations: `[subsystems.memory]
-/// driver = "null"` is configured, and a configured driver failed to bind and
-/// fell back. In both, every write below is discarded. An import that reports
+/// `binding` answers the null driver in three situations: `[subsystems.memory]
+/// driver = "null"` is configured; a configured driver failed to bind and fell
+/// back; and — the one this note used to miss — a driver was *admitted* as a
+/// module but this build has no module to bind, so `binding::module_provider`
+/// substituted the null provider under `#[cfg(not(feature = "modules"))]`.
+/// In all three, every write below is discarded. An import that reports
 /// "migrated N entries" having written none is silent data loss of the worst
 /// kind — the source workspace may be deleted on the strength of that report,
 /// and the user only discovers it later, with nothing left to re-run against.
-/// So this refuses up front and names which of the two it was.
+/// So this refuses up front and names which of the three it was.
+///
+/// The third case is the reason this reads `driver_id()` rather than only
+/// `class()`. `admit` is pure config and never saw the feature flag, so it
+/// returns the configured id — the binding then reports `driver_id =
+/// "tinymemory"` with `class = Null` and **no** `fallback`, since nothing
+/// refused. Keying the message on the class alone put that case in the
+/// configured-null arm, which told a user whose config says `driver =
+/// "tinycortex"` that they had set it to `"null"` and sent them to edit a line
+/// that already said the opposite.
 fn target_memory_backend(config: &Config) -> Result<Arc<dyn Memory>> {
     let binding = crate::openhuman::memory::binding::for_config(config)
         .map_err(|e| anyhow::anyhow!("bind memory for migration import: {e}"))?;
     if binding.class() == crate::core::subsystem::DriverClass::Null {
-        let because = binding.fallback().map_or_else(
-            || {
+        let because = match (binding.fallback(), binding.driver_id()) {
+            (Some(fallback), _) => format!(
+                "driver '{}' refused to bind: {}",
+                fallback.configured_driver, fallback.reason
+            ),
+            (None, tinymemory_api::null::NULL_DRIVER_ID) => {
                 "memory is disabled by configuration ([subsystems.memory] driver = \"null\")"
                     .to_string()
-            },
-            |fallback| {
-                format!(
-                    "driver '{}' refused to bind: {}",
-                    fallback.configured_driver, fallback.reason
-                )
-            },
-        );
+            }
+            (None, driver_id) => format!(
+                "driver '{driver_id}' is configured, but this build has no memory module \
+                 compiled in (the 'modules' feature is off), so nothing can be written"
+            ),
+        };
         anyhow::bail!(
-            "refusing to import OpenClaw memory into the null driver — {because}. \
+            "refusing to import memory into the null driver — {because}. \
              Nothing was imported; the source workspace is untouched."
         );
     }

--- a/src/openhuman/config/migration_helpers/ops.rs
+++ b/src/openhuman/config/migration_helpers/ops.rs
@@ -70,6 +70,17 @@ mod tests {
         }
     }
 
+    // Apply writes into the bound memory driver, which only exists when a
+    // memory module is compiled in. With `--no-default-features`,
+    // `binding::module_provider` substitutes the null provider, and
+    // `target_memory_backend` then refuses the import rather than reporting
+    // entries it discarded — correct behaviour, and the opposite of what this
+    // case asserts. Gated rather than made tolerant of both answers: a test
+    // that passes on either outcome would stop witnessing the import at all.
+    // The gates-off half of the same seam is
+    // `apply_refuses_and_names_the_build_when_no_memory_module_is_compiled_in`
+    // below.
+    #[cfg(feature = "modules")]
     #[tokio::test]
     async fn migrate_openclaw_apply_imports_markdown_entries_into_target_workspace() {
         // Regression for #1440: prior to this PR the Apply path
@@ -106,6 +117,49 @@ mod tests {
             report.stats.imported >= 1,
             "apply must import at least one entry; stats={:?}",
             report.stats
+        );
+    }
+
+    /// With no memory module compiled in, apply must refuse — and the refusal
+    /// must name the build, not the user's config.
+    ///
+    /// `admit` is pure config and never sees the feature flag, so it admits the
+    /// configured `tinycortex`; `module_provider` then substitutes the null
+    /// provider because there is no module to bind. The binding that comes back
+    /// therefore reports `class = Null` with `driver_id = "tinymemory"` and no
+    /// `fallback` — nothing refused, so there is nothing to fall back from.
+    ///
+    /// Keyed on the class alone, that landed in the configured-null arm and told
+    /// a user whose `config.toml` says `driver = "tinycortex"` that memory was
+    /// "disabled by configuration ([subsystems.memory] driver = \"null\")",
+    /// pointing them at a line that says the opposite. This asserts both halves:
+    /// the import is still refused (silent data loss stays impossible), and the
+    /// reason given is the missing module.
+    #[cfg(not(feature = "modules"))]
+    #[tokio::test]
+    async fn apply_refuses_and_names_the_build_when_no_memory_module_is_compiled_in() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(&tmp);
+
+        let source = tmp.path().join("openclaw-src");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::write(source.join("MEMORY.md"), "# Note\nwould be lost").unwrap();
+
+        let err = migrate_openclaw(&config, Some(source), false)
+            .await
+            .expect_err("apply must refuse with no memory module compiled in");
+
+        assert!(
+            err.contains("this build has no memory module compiled in"),
+            "refusal must name the missing module as the cause; got: {err}"
+        );
+        assert!(
+            !err.contains("[subsystems.memory] driver = \"null\""),
+            "refusal must not blame a config line the user did not write; got: {err}"
+        );
+        assert!(
+            err.contains("the source workspace is untouched"),
+            "refusal must still promise the source survived; got: {err}"
         );
     }
 
@@ -149,6 +203,17 @@ mod tests {
         }
     }
 
+    // Apply writes into the bound memory driver, which only exists when a
+    // memory module is compiled in. With `--no-default-features`,
+    // `binding::module_provider` substitutes the null provider, and
+    // `target_memory_backend` then refuses the import rather than reporting
+    // entries it discarded — correct behaviour, and the opposite of what this
+    // case asserts. Gated rather than made tolerant of both answers: a test
+    // that passes on either outcome would stop witnessing the import at all.
+    // The gates-off half of the same seam is
+    // `apply_refuses_and_names_the_build_when_no_memory_module_is_compiled_in`
+    // below.
+    #[cfg(feature = "modules")]
     #[tokio::test]
     async fn migrate_hermes_apply_imports_markdown_entries() {
         // Apply does real memory work; install the embedding host seam so this

--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -4303,6 +4303,68 @@ async fn json_rpc_memory_sync_and_learn() {
     let wiped = post_json_rpc(&rpc_base, 7099, "openhuman.memory_tree_wipe_all", json!({})).await;
     assert_no_jsonrpc_error(&wiped, "memory_tree_wipe_all before fresh-store checks");
 
+    // ── ...and the wipe is not enough on its own ────────────────────────────
+    //
+    // `memory_tree_wipe_all` reaches the driver through
+    // `binding::for_config(config)` — *this* case's workspace. The namespace
+    // assertions below read through `active_memory_guard()`. Those are the same
+    // binding here, but they are not the same **store**: the memory module is a
+    // native module loaded once per process, and it captures the first workspace
+    // it is given. Every later binding in this binary — one per case, each with
+    // its own tempdir — is a different `MemoryBinding` over that one captured
+    // store.
+    //
+    // So a namespace another case wrote is visible to `list_namespaces` here and
+    // is not reachable by a `purge_all` scoped to this workspace: after the wipe
+    // above reports its rows deleted, a second wipe reports `rows_deleted: 0`
+    // while `namespace_list` still answers with the other case's namespace. That
+    // asymmetry is the one-workspace-per-process property, not a defect in
+    // `wipe_all`; a `purge_all` that reached across workspaces would be the real
+    // bug the day a host binds two.
+    //
+    // openhuman#5779 is what made it bite. Before it, a session agent's memory
+    // came from `create_session_memory_with_local_ai` — an engine-built store
+    // over that case's own workspace files, invisible here. #5779 routed session
+    // memory onto `DriverMemory::for_subtree` (correctly: that is the point of
+    // #5560), and the driver is the shared module — so an agent turn in an
+    // earlier case now files `conversation_raw` where this case can see it.
+    //
+    // Draining through `memory_clear_namespace` is what makes this deterministic:
+    // it takes `active_memory_guard()` + `as_documents()`, the exact path
+    // `list_namespaces` reads through, so "cleared" and "listed" cannot disagree
+    // by construction. Do not replace this with a bigger wipe — no wipe scoped to
+    // a workspace can empty a store shared by every workspace in the process.
+    async fn list_namespaces(rpc_base: &str, id: i64) -> Vec<Value> {
+        let listed =
+            post_json_rpc(rpc_base, id, "openhuman.memory_namespace_list", json!({})).await;
+        assert_no_jsonrpc_error(&listed, "memory_namespace_list");
+        listed["result"]["result"]
+            .as_array()
+            .unwrap_or_else(|| panic!("namespace_list must answer an array, got: {listed}"))
+            .clone()
+    }
+
+    let leftover = list_namespaces(&rpc_base, 7100).await;
+    for namespace in &leftover {
+        let cleared = post_json_rpc(
+            &rpc_base,
+            7101,
+            "openhuman.memory_clear_namespace",
+            json!({ "namespace": namespace }),
+        )
+        .await;
+        assert_no_jsonrpc_error(
+            &cleared,
+            "memory_clear_namespace draining a shared namespace",
+        );
+    }
+    let remaining = list_namespaces(&rpc_base, 7102).await;
+    assert!(
+        remaining.is_empty(),
+        "draining through the same family the assertions read through must empty the \
+         listing; started with {leftover:?}, still holding {remaining:?}"
+    );
+
     // ── memory_learn_all: no namespaces → zero processed (empty store) ──────
     let learn_all = post_json_rpc(&rpc_base, 7004, "openhuman.memory_learn_all", json!({})).await;
     let learn_result = assert_no_jsonrpc_error(&learn_all, "memory_learn_all");


### PR DESCRIPTION
## Summary

- Unbreaks `main`, red on two checks since #5779 merged. Two unrelated causes, one commit each.
- **Gates off:** an import into a build with no memory module was refused with a reason that named the user's config instead of the build. Corrected, and the two apply cases that cannot run without a store are gated on `feature = "modules"`.
- **`json_rpc_memory_sync_and_learn`:** the case reaches "empty store" with a workspace-scoped wipe, which cannot empty a store shared by every workspace in the process. It now drains through the same family the assertions read.
- No behaviour change for a normally-configured build. No `vendor/*` gitlink is touched.

## Problem

Neither failure is the one the merge notes predicted, so both are worth stating precisely.

**1. `Rust Feature-Gate Smoke (gates off)` — not warnings-as-errors.** The job's five `unused variable` warnings are warnings; it exits 101 on two failing tests:

```
migration_helpers::ops::tests::migrate_hermes_apply_imports_markdown_entries
migration_helpers::ops::tests::migrate_openclaw_apply_imports_markdown_entries_into_target_workspace

  refusing to import OpenClaw memory into the null driver — memory is disabled
  by configuration ([subsystems.memory] driver = "null")
```

The config says no such thing — the default driver is `tinycortex`. `admit` is pure config and never sees the feature flag, so it admits `tinycortex`; `module_provider` then substitutes the null provider under `#[cfg(not(feature = "modules"))]`. The binding reports `class = Null`, `driver_id = "tinymemory"`, and **no** `fallback` — nothing refused, so there is nothing to fall back from. `target_memory_backend` keyed its reason on the class alone, so this landed in the configured-null arm and pointed the reader at a line that says the opposite. (The message also said "OpenClaw" on the Hermes path; same function.)

**2. `json_rpc_memory_sync_and_learn` — not a namespace-routing regression.** It fails with `memory_learn_all requires local_ai.runtime_enabled=true`, which is the symptom. The case asserts zero namespaces processed on an empty store and reaches "empty" by calling `memory_tree_wipe_all`. When the store is not empty, the handler walks past its `target_ns.is_empty()` short-circuit into the `runtime_enabled` guard, and that is what surfaces.

It fails only in the full serial target, never alone. Measured, with the case's own wipe in place:

| step | result |
| --- | --- |
| `namespace_list` before wipe | `["conversation_raw"]` |
| `memory_tree_wipe_all` | `rows_deleted: 14`, `dirs: ["raw", "document"]` |
| `namespace_list` after wipe | `["conversation_raw"]` |
| `namespace_list` +1.5s | `["conversation_raw"]` (not a race) |
| second `memory_tree_wipe_all` | `rows_deleted: 0` |
| `namespace_list` after that | `["conversation_raw"]` |

`wipe_all` reaches the driver through `binding::for_config(config)` — this case's own workspace — while the assertions read through `active_memory_guard()`. Same binding here, but not the same store: **the memory module is loaded once per process and captures the first workspace it is given**, so every later binding in the binary (one per case, each with its own tempdir) is a different `MemoryBinding` over that one captured store. Instrumenting both paths shows three distinct workspaces binding `driver=tinymemory class=module` in one run.

This is the **fourth** appearance of the one-workspace-per-process property, and it is worth saying plainly that #5779 did not re-introduce it — #5779 did the right thing and the property was what had been hiding the collision. Session memory used to come from `create_session_memory_with_local_ai`, an engine-built store over each case's own workspace files and invisible here. #5779 routed it onto `DriverMemory::for_subtree`, which is the shared module — exactly the point of #5560. So an agent turn in an earlier case now files `conversation_raw` where this case can see it. The split was masking the failure, not preventing it. That strengthens the case for the upstream per-binding-workspace work rather than weakening it.

## Solution

**Gates off.** `target_memory_backend` now matches on `(fallback, driver_id)` and names the missing module for the third case. The refusal itself stays and is correct: with no module compiled in every write is discarded, and an import reporting "migrated N" having written none is the silent data loss #5779 added this guard to prevent. The two apply cases genuinely cannot pass with the gates off — there is no store to import into — so they are gated on `feature = "modules"`, a **default** feature, so the product and contributor lanes keep running them. A new gates-off case, `apply_refuses_and_names_the_build_when_no_memory_module_is_compiled_in`, covers the other half: still refused, and refused for the stated reason.

**`json_rpc_memory_sync_and_learn`.** Drains any namespace the listing still reports via `memory_clear_namespace`, which takes `active_memory_guard()` + `as_documents()` — the exact path `list_namespaces` reads — so "cleared" and "listed" cannot disagree by construction. Deliberate choices:

- The wipe **stays**: the `queue_depth` and idle-ingestion assertions still want it.
- `memory_learn_all {}` is **not** retargeted at an explicit empty namespace list. That would have been the smaller edit, but it duplicates the `does-not-exist` case immediately below and drops coverage of the `None => all_ns` branch.
- `wipe_all` is **not** widened. A `purge_all` that reached across workspaces would be a real bug the day a host binds two; the asymmetry is the module's capture, not a defect in the handler.

## Impact

No runtime behaviour change for a build with `modules` on, which is every shipped configuration. The only user-visible change is the text of a refusal that previously misdirected the reader — and only in a build with no memory module.

## Related

- Follow-up PR(s)/TODOs: upstream per-binding-workspace work for the memory module — fourth sighting, evidence above.
- Refs openhuman#5779 (the merge these two failures arrived with; no closing keyword, nothing to close).
- Closes: N/A — `main` was red with no issue filed for it.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `apply_refuses_and_names_the_build_when_no_memory_module_is_compiled_in` (failure path, gates off); `json_rpc_memory_sync_and_learn` gains a `remaining.is_empty()` assertion that is live in the serial run (`leftover == ["conversation_raw"]`).
- [x] **Diff coverage ≥ 80%** — changed lines are the refusal arm (covered by the new gates-off test), the two `#[cfg]` attributes, and test code. Not run as `diff-cover` locally; asserted by the CI gate.
- [x] Coverage matrix updated — N/A: no feature row added, removed or renamed; this is a red-`main` fix.
- [x] All affected feature IDs from the matrix are listed under `## Related` — N/A: no matrix feature IDs affected.
- [x] No new external network dependencies introduced — no new dependency of any kind; the e2e case keeps using the existing mock upstream.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: does not touch a release-cut surface.
- [x] Linked issue closed via `Closes #NNN` — N/A: no issue filed for the red `main`; see `## Related`.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5779-gates-off-and-learn-all`
- Commit SHA: `fd8035864`, `5a33446c0`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend file changed.
- [x] `pnpm typecheck` — N/A: no TypeScript changed.
- [x] Focused tests: gates-off CI scope **952 passed**; gates-off `--features mcp` **9 passed**; product-set `--lib openhuman::config::migration_helpers` **22 passed** (both apply cases live); `--test json_rpc_e2e -- --test-threads=1` **104 passed / 0 failed** (fails on this case without the drain).
- [x] Rust fmt/check (if changed): `cargo fmt --all`; `clippy -p openhuman` clean on both the product and contributor sets with `-D warnings`; `cargo check --no-default-features` and `--features tui` clean; `cargo check -p openhuman --features <product> --tests` clean.
- [x] Tauri fmt/check (if changed) — N/A: no Tauri shell file changed.

### Validation Blocked

- `command:` N/A — nothing was blocked.
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: an import refused for want of a compiled-in memory module now says so, instead of blaming a config line the user did not write.
- User-visible effect: one corrected error message, reachable only in a build without the `modules` feature. Everything else is test-only.

### Parity Contract

- Legacy behavior preserved: the refusal still fires in every case it fired in before — this changes only which of the three reasons it prints. Both apply cases still run, and still assert the same imports, wherever a memory module exists.
- Guard/fallback/dispatch parity checks: the `fallback` arm is matched first and its text is unchanged; the configured-null arm keeps its exact previous wording; only the previously-unreachable third arm is new.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none.
- Canonical PR: this one.
- Resolution: N/A.

### Revert check

Reverting the `core.rs` change and re-running the new gates-off test fails on **its own** assertion, not incidentally:

```
refusal must name the missing module as the cause; got: refusing to import
OpenClaw memory into the null driver — memory is disabled by configuration
([subsystems.memory] driver = "null")
```

Removing the drain and re-running the full serial target reproduces the original
`memory_learn_all requires local_ai.runtime_enabled=true` on this case alone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics when memory support is unavailable, clearly distinguishing an explicitly configured null driver from a missing memory module.
  * OpenClaw and Hermes migrations now report build-related limitations accurately and avoid incorrectly blaming configuration.
  * Failed migrations leave the source workspace unchanged.
* **Reliability**
  * Improved memory synchronization handling by reliably clearing all namespaces before subsequent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->