### PR TITLE
Tell a deliberately null-classed driver from a modules-off build

### DIFF
--- a/src/openhuman/config/migration_helpers/core.rs
+++ b/src/openhuman/config/migration_helpers/core.rs
@@ -155,30 +155,55 @@ pub async fn migrate_openclaw_memory(
 /// and the user only discovers it later, with nothing left to re-run against.
 /// So this refuses up front and names which of the three it was.
 ///
-/// The third case is the reason this reads `driver_id()` rather than only
-/// `class()`. `admit` is pure config and never saw the feature flag, so it
-/// returns the configured id — the binding then reports `driver_id =
-/// "tinymemory"` with `class = Null` and **no** `fallback`, since nothing
-/// refused. Keying the message on the class alone put that case in the
-/// configured-null arm, which told a user whose config says `driver =
-/// "tinycortex"` that they had set it to `"null"` and sent them to edit a line
+/// Telling the third case apart needs what was *admitted*, not what was bound.
+/// `admit` is pure config and never saw the feature flag, so it answers
+/// `Module` for the configured `tinycortex`; `module_provider` then binds the
+/// null provider, and the binding reports `class = Null` with **no**
+/// `fallback`, since nothing refused. So `admitted != bound` is the signal, and
+/// it is the only one that works: `driver_id` alone does not separate this from
+/// a driver deliberately given `class = "null"`, because `admit` accepts a
+/// non-built-in id with that class (the `built_in_class` check is skipped for
+/// ids that are not built in) and returns it verbatim. Keying on the id would
+/// tell a user with a working modules build that their `modules` feature was
+/// off — the same class of misdirection this whole note exists to prevent.
+///
+/// Keying on the class alone was the original bug: it put the modules-off case
+/// in the configured-null arm and told a user whose config says `driver =
+/// "tinycortex"` that they had set it to `"null"`, sending them to edit a line
 /// that already said the opposite.
 fn target_memory_backend(config: &Config) -> Result<Arc<dyn Memory>> {
     let binding = crate::openhuman::memory::binding::for_config(config)
         .map_err(|e| anyhow::anyhow!("bind memory for migration import: {e}"))?;
     if binding.class() == crate::core::subsystem::DriverClass::Null {
-        let because = match (binding.fallback(), binding.driver_id()) {
+        let admitted = crate::openhuman::memory::binding::admit(&config.subsystems.memory).ok();
+        let because = match (binding.fallback(), admitted) {
             (Some(fallback), _) => format!(
                 "driver '{}' refused to bind: {}",
                 fallback.configured_driver, fallback.reason
             ),
-            (None, tinymemory_api::null::NULL_DRIVER_ID) => {
+            // Admitted as the null driver: the user asked for no memory.
+            (None, Some((id, crate::core::subsystem::DriverClass::Null)))
+                if id == tinymemory_api::null::NULL_DRIVER_ID =>
+            {
                 "memory is disabled by configuration ([subsystems.memory] driver = \"null\")"
                     .to_string()
             }
-            (None, driver_id) => format!(
-                "driver '{driver_id}' is configured, but this build has no memory module \
+            (None, Some((id, crate::core::subsystem::DriverClass::Null))) => format!(
+                "driver '{id}' is configured with class \"null\" under \
+                 [subsystems.memory.drivers.{id}], so every write is discarded"
+            ),
+            // Admitted as something that can hold data, bound to the null
+            // provider anyway — the module substitution.
+            (None, Some((id, _))) => format!(
+                "driver '{id}' is configured, but this build has no memory module \
                  compiled in (the 'modules' feature is off), so nothing can be written"
+            ),
+            // `admit` refused: `build` records that as a fallback, so this is
+            // unreachable. Named rather than merged into an arm that would
+            // state a cause this branch cannot actually establish.
+            (None, None) => format!(
+                "driver '{}' bound the null provider and the reason was not recorded",
+                binding.driver_id()
             ),
         };
         anyhow::bail!(

--- a/src/openhuman/config/migration_helpers/ops.rs
+++ b/src/openhuman/config/migration_helpers/ops.rs
@@ -143,7 +143,9 @@ mod tests {
 
         let source = tmp.path().join("openclaw-src");
         std::fs::create_dir_all(&source).unwrap();
-        std::fs::write(source.join("MEMORY.md"), "# Note\nwould be lost").unwrap();
+        let entry = source.join("MEMORY.md");
+        let original = "# Note\nwould be lost";
+        std::fs::write(&entry, original).unwrap();
 
         let err = migrate_openclaw(&config, Some(source), false)
             .await
@@ -160,6 +162,66 @@ mod tests {
         assert!(
             err.contains("the source workspace is untouched"),
             "refusal must still promise the source survived; got: {err}"
+        );
+        // The promise, checked rather than taken on trust: a refusal that moved
+        // or truncated the source would be the very loss it claims to prevent.
+        assert_eq!(
+            std::fs::read_to_string(&entry).expect("source entry must still be readable"),
+            original,
+            "the refused import must leave the source workspace byte-identical"
+        );
+    }
+
+    /// A driver deliberately given `class = "null"` is not a modules-off build.
+    ///
+    /// Codex raised this against the first version of the fix above, and it was
+    /// right. `admit` skips its `built_in_class` check for an id that is not
+    /// built in, so `[subsystems.memory] driver = "mynull"` with
+    /// `class = "null"` is admitted verbatim: `class = Null`, no `fallback`, and
+    /// a `driver_id` that is not `"null"`. Keyed on the id, that landed in the
+    /// modules-off arm and told a user with a perfectly good modules build that
+    /// their `modules` feature was off.
+    ///
+    /// Keying on what `admit` *answered* separates them: here it answers `Null`,
+    /// where the modules-off case answers `Module` and is then bound to the null
+    /// provider. This runs in **every** feature configuration, because the
+    /// confusion it guards against is one a modules-enabled build can hit.
+    #[tokio::test]
+    async fn apply_names_a_deliberately_null_classed_driver_rather_than_the_build() {
+        use crate::openhuman::config::schema::{MemoryDriverConfig, MemorySubsystemConfig};
+
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(&tmp);
+        let mut drivers = std::collections::BTreeMap::new();
+        drivers.insert(
+            "mynull".to_string(),
+            MemoryDriverConfig {
+                class: Some("null".to_string()),
+                ..Default::default()
+            },
+        );
+        config.subsystems.memory = MemorySubsystemConfig {
+            driver: "mynull".to_string(),
+            drivers,
+            ..Default::default()
+        };
+
+        let source = tmp.path().join("openclaw-src");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::write(source.join("MEMORY.md"), "# Note\nkeep me").unwrap();
+
+        let err = migrate_openclaw(&config, Some(source), false)
+            .await
+            .expect_err("apply must refuse a null-classed driver");
+
+        assert!(
+            err.contains("mynull") && err.contains("class"),
+            "refusal must name the driver and its configured class; got: {err}"
+        );
+        assert!(
+            !err.contains("no memory module compiled in"),
+            "a deliberately null-classed driver must not be reported as a \
+             modules-off build; got: {err}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Corrects an error message added by #5799. A driver deliberately configured with `class = "null"` was reported as "this build has no memory module compiled in", which is false on a normal modules-enabled build.
- The refusal itself is unchanged and still correct — only the *reason* it prints for one config shape.
- Found by the Codex reviewer on #5799. It was right, and the fix did not make it in before that PR merged; this is that fix, on its own.

## Problem

#5799 taught `target_memory_backend` to distinguish three ways a binding can answer the null driver, so an import refusal names the real cause instead of blaming the user's config. It got the third case right and the discriminator wrong.

It keyed the decision on `binding.driver_id()`:

```rust
(None, tinymemory_api::null::NULL_DRIVER_ID) => "…driver = \"null\" is configured…",
(None, driver_id) => format!("driver '{driver_id}' …this build has no memory module compiled in…"),
```

That last arm is a catch-all, and it catches more than the case it describes. `DriverClass::parse("null")` is a valid class, and `binding::admit` skips its `built_in_class` consistency check for an id that is not built in — the check is `match id { NULL_DRIVER_ID => …, MODULE_ID => …, _ => None }`, and `None` means "nothing to enforce". So this config is admitted verbatim:

```toml
[subsystems.memory]
driver = "mynull"

[subsystems.memory.drivers.mynull]
class = "null"
```

`admit` answers `("mynull", DriverClass::Null)`. `build` takes its `class == Null` branch and binds `NullMemoryProvider` directly, so the binding reports `class = Null`, `fallback = None`, and `driver_id = "mynull"` — which is not `"null"`, so it falls into the catch-all. A user who deliberately switched memory off via a custom driver entry, on a perfectly good build with `modules` enabled, is told their `modules` feature is off and sent to investigate their build.

That is the same class of misdirection #5799 existed to remove. Its own note argued the message must never state a cause it cannot establish; the catch-all states one it cannot.

## Solution

Key on what `admit` **answered**, not on the id it returned. That is the only signal that separates the two, because both produce a non-`null` `driver_id`:

| case | `admit` answers | binding reports |
| --- | --- | --- |
| modules compiled out | `Module` | `Null` — `module_provider` substituted it |
| driver classed `"null"` | `Null` | `Null` — consistent, nothing substituted |

`admit` is pure config and cheap, so `target_memory_backend` asks it directly and matches on the pair. Four explicit arms, each stating only what its own branch establishes, including a named arm for the `admit`-refused-but-no-fallback shape — unreachable today, because `build` records that as a fallback, but named rather than folded into a neighbour that would then be guessing.

The custom-null arm names the driver and the table it was classed in, so the reader is pointed at the line they actually wrote:

```
driver 'mynull' is configured with class "null" under
[subsystems.memory.drivers.mynull], so every write is discarded
```

Also picked up here, from CodeRabbit on the same PR: the refusal promises "the source workspace is untouched" and nothing checked it. The gates-off test now asserts the source entry is byte-identical after the refusal — a refusal that moved or truncated the source would be the exact loss it claims to prevent.

## Impact

Message text only, on a config path that discards writes either way. No behaviour change: the same imports are refused, and the `fallback` and built-in-null arms keep their previous wording verbatim. The new regression test runs in **every** feature configuration, not just gates-off, because the confusion it guards against is one a modules-enabled build can hit.

## Related

- Follows up openhuman#5799 (merged as `d54632f1e`); raised separately because the correction did not land before that PR merged. No closing keyword — nothing to close.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `apply_names_a_deliberately_null_classed_driver_rather_than_the_build` is the failure path for the misreported cause; the existing gates-off refusal test gains the source-survives assertion.
- [x] **Diff coverage ≥ 80%** — every changed line is the match arms and their tests; the new test exercises the new arm and the existing one covers the modules-off arm. Not run as `diff-cover` locally; asserted by the CI gate.
- [x] Coverage matrix updated — N/A: no feature row added, removed or renamed; message-only correction.
- [x] All affected feature IDs from the matrix are listed under `## Related` — N/A: no matrix feature IDs affected.
- [x] No new external network dependencies introduced — no new dependency of any kind.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: does not touch a release-cut surface.
- [x] Linked issue closed via `Closes #NNN` — N/A: no issue; this is review feedback from #5799.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/null-classed-driver-message`
- Commit SHA: see head

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend file changed.
- [x] `pnpm typecheck` — N/A: no TypeScript changed.
- [x] Focused tests: gates-off `openhuman::config::migration_helpers` 22 passed; gates-off full CI scope; product-set `--lib` migration_helpers. Proof the defect was live on `d54632f1e`: applying only the new test to unmodified `main` fails it (output below).
- [x] Rust fmt/check (if changed): `cargo fmt --all`; clippy `-D warnings` on the product and contributor sets; `cargo check --no-default-features`.
- [x] Tauri fmt/check (if changed) — N/A: no Tauri shell file changed.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: a driver deliberately classed `"null"` is now named as such instead of being reported as a build without the `modules` feature.
- User-visible effect: one corrected error message on the migration-import path. Nothing else.

### Parity Contract

- Legacy behavior preserved: the refusal fires in exactly the cases it fired in before. The `fallback` arm and the built-in-null arm keep their exact previous wording; only the previously over-broad catch-all is split.
- Guard/fallback/dispatch parity checks: `fallback` is still matched first; the import is still refused in every null-driver case, so no write path changes.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none.
- Canonical PR: this one.
- Resolution: N/A.

### Revert check

Applying only the new test to unmodified `d54632f1e` fails it, on its own assertion and naming the wrong cause:

```
refusal must name the driver and its configured class; got: refusing to import
memory into the null driver — driver 'mynull' is configured, but this build has
no memory module compiled in (the 'modules' feature is off), so nothing can be
written. Nothing was imported; the source workspace is untouched.
```

Adding the `core.rs` change turns it green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration error messages when memory features are unavailable, bindings fail, or a null memory driver is configured.
  * Explicitly configured null-class drivers are now identified by name and class in refusal messages.
  * Applying configuration now confirms that the source workspace remains unchanged when the operation is refused.

* **Tests**
  * Added coverage for driver-specific refusal messages and protection of source memory content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->