### PR TITLE
fix(memory): bridge the four defaulted module members instead of refusing

### DIFF
--- a/src/openhuman/modules/memory.rs
+++ b/src/openhuman/modules/memory.rs
@@ -167,13 +167,14 @@ use tinymemory_api::provider::types::{
 };
 use tinymemory_api::provider::{
     AddressBookSeedOutcome, ChunkDetail, ChunkEmbedding, ChunkListRow, ChunkQuery,
-    ConversationSegment, CoverWindowQuery, EntityMatch, EpisodicEvent, EpisodicTurn, FacetType,
-    FastRetrieveQuery, MemoryChunks, MemoryCodingSessions, MemoryCore, MemoryDiff, MemoryDocuments,
-    MemoryEntities, MemoryEpisodic, MemoryGoals, MemoryGraph, MemoryIngest, MemoryMaintenance,
-    MemoryPeople, MemoryPortability, MemoryProfile, MemoryProvider, MemoryRecall, MemoryRetrieval,
-    MemorySourceSink, MemorySourceSync, MemoryToolMemory, MemoryTree, PersonHandle,
-    PersonInteraction, PersonRecord, PersonScore, ProfileFacet, RankedPerson, ResolvedPerson,
-    RetrievalHit, RetrievalResponse, SourceRetrievalQuery, SourceTotal, UserState,
+    ConversationSegment, CoverWindowQuery, Diagnosis, EntityMatch, EpisodicEvent, EpisodicTurn,
+    FacetType, FastRetrieveQuery, MemoryChunks, MemoryCodingSessions, MemoryCore, MemoryDiff,
+    MemoryDocuments, MemoryEntities, MemoryEpisodic, MemoryGoals, MemoryGraph, MemoryIngest,
+    MemoryMaintenance, MemoryPeople, MemoryPortability, MemoryProfile, MemoryProvider,
+    MemoryRecall, MemoryRetrieval, MemorySourceSink, MemorySourceSync, MemoryToolMemory,
+    MemoryTree, PersonHandle, PersonInteraction, PersonRecord, PersonScore, ProfileFacet,
+    RankedPerson, ResolvedPerson, RetrievalHit, RetrievalResponse, SourceRetrievalQuery,
+    SourceTotal, UserState,
 };
 use tinymemory_api::recall::OwnedRecallOpts;
 use tinymemory_api::tool_memory::ToolMemoryRule;
@@ -1079,6 +1080,9 @@ impl MemoryMaintenance for ModuleMemoryProvider {
     async fn purge_all(&self) -> Result<PurgeOutcome, MemoryError> {
         module_call!(self, "purge_all", "PurgeAll", ())
     }
+    async fn diagnose(&self) -> Result<Diagnosis, MemoryError> {
+        module_call!(self, "diagnose", "Diagnose", ())
+    }
 }
 
 #[async_trait]
@@ -1094,6 +1098,24 @@ impl MemorySourceSync for ModuleMemoryProvider {
             "RunConnectionSync",
             (toolkit, connection_id)
         )
+    }
+    async fn run_source_sync(&self, source_id: &str) -> Result<SyncRunOutcome, MemoryError> {
+        module_call!(self, "run_source_sync", "RunSourceSync", (source_id,))
+    }
+    async fn bootstrap_connection(
+        &self,
+        toolkit: &str,
+        connection_id: &str,
+    ) -> Result<(), MemoryError> {
+        module_call!(
+            self,
+            "bootstrap_connection",
+            "BootstrapConnection",
+            (toolkit, connection_id)
+        )
+    }
+    async fn is_toolkit_syncable(&self, toolkit: &str) -> Result<bool, MemoryError> {
+        module_call!(self, "is_toolkit_syncable", "IsToolkitSyncable", (toolkit,))
     }
     async fn source_sync_state(
         &self,

--- a/src/openhuman/modules/memory_tests.rs
+++ b/src/openhuman/modules/memory_tests.rs
@@ -414,3 +414,65 @@ fn the_ingest_bus_grace_is_wide_enough_to_order_the_two_timers() {
          reliably order the RPC's timeout ahead of the bus deadline"
     );
 }
+
+/// Every `MemorySourceSync` and `MemoryMaintenance` member the trait defaults
+/// must be bridged to the module rather than left to inherit the default.
+///
+/// Three of these members carry a default body that returns
+/// `Unsupported(SourceSync)`, and `diagnose` one that returns
+/// `Unsupported(Maintenance)`. A defaulted member cannot break an implementor at
+/// compile time, so when they were added to the contract `ModuleMemoryProvider`
+/// kept compiling and silently began refusing — which is #5801: the manual
+/// "Sync now" button answered `unsupported capability: source_sync` while the
+/// module's own scheduler, which never crosses this bridge, kept syncing fine.
+///
+/// The discriminator needs no module. With the host disabled, `proxy()` fails
+/// with `MemoryError::Other`, so a member that really dispatches through
+/// `module_call!` reports `Other` while one that fell through to the default
+/// reports `Unsupported`. Asserting "not Unsupported" therefore asserts the
+/// dispatch itself, which is the part that was missing.
+#[tokio::test]
+async fn the_defaulted_members_dispatch_to_the_module_instead_of_refusing() {
+    use tinymemory_api::provider::{MemoryMaintenance, MemorySourceSync};
+
+    let mut config = Config::default();
+    config.modules.enabled = false;
+    let provider = ModuleMemoryProvider::new(Arc::new(config));
+
+    let refused = |label: &str, error: MemoryError| {
+        assert!(
+            !matches!(error, MemoryError::Unsupported { .. }),
+            "{label} answered from the trait default instead of dispatching to the \
+             module — the `module_call!` arm is missing, so every caller gets \
+             `unsupported capability` however capable the artifact is. Got {error:?}"
+        );
+    };
+
+    refused(
+        "run_source_sync",
+        provider
+            .run_source_sync("src_whatever")
+            .await
+            .expect_err("a disabled host cannot succeed"),
+    );
+    refused(
+        "bootstrap_connection",
+        provider
+            .bootstrap_connection("gmail", "ca_whatever")
+            .await
+            .expect_err("a disabled host cannot succeed"),
+    );
+    refused(
+        "is_toolkit_syncable",
+        provider
+            .is_toolkit_syncable("gmail")
+            .await
+            .expect_err("a disabled host cannot succeed"),
+    );
+    refused(
+        "diagnose",
+        MemoryMaintenance::diagnose(&provider)
+            .await
+            .expect_err("a disabled host cannot succeed"),
+    );
+}


### PR DESCRIPTION
## Summary

- Implements the four `module_call!` arms the host's module bridge was missing, so they dispatch to the module instead of being answered by a refusing trait default.
- Fixes the manual "Sync now" / "All in" button, which failed for every source with `unsupported capability: source_sync` while scheduled sync worked normally.
- Found **four** members with this defect, not the one the symptom showed: `run_source_sync`, `bootstrap_connection`, `is_toolkit_syncable` and `diagnose`.
- Adds a test that asserts the dispatch itself, with no module required, and revert-checked each of the four independently.
- **Does not touch `ARTIFACT_CAPABILITIES` or `assume_full_capabilities`.** The capability list was already correct; changing it would have papered over the real gap.

## Problem

`MemorySourceSync` and `MemoryMaintenance` carry members with **default bodies that unconditionally refuse**:

```rust
// tinymemory-api/src/provider/sync.rs:153
async fn run_source_sync(&self, source_id: &str) -> Result<SyncRunOutcome, MemoryError> {
    let _ = source_id;
    Err(MemoryError::unsupported(Capability::SourceSync))
}
```

`ModuleMemoryProvider` implemented every **required** member and silently inherited the defaults. A defaulted trait member cannot break an implementor at compile time, so when these were added to the contract the bridge kept compiling and began refusing at runtime.

The refusal is raised inside the host and never reaches the wire. In the reported session three sources refused in **13ms** total, while a genuine module round-trip in the same session took 30s to time out.

The artifact was never the problem. All four are declared in the module's `METHODS` list (`tinymemory-module/src/lib.rs:770-776`) and their wire names are canonical bus constants (`tinymemory-bus/src/names.rs:287-300`). Before this change:

```
$ grep -rn "RunSourceSync" src/
(no matches)
```

## Solution

Four `module_call!` arms following the pattern the neighbouring members already use, placed to mirror the trait's own member order:

| member | wire name | trait default was at |
|---|---|---|
| `MemorySourceSync::run_source_sync` | `RunSourceSync` | `sync.rs:153` |
| `MemorySourceSync::bootstrap_connection` | `BootstrapConnection` | `sync.rs:193` |
| `MemorySourceSync::is_toolkit_syncable` | `IsToolkitSyncable` | `sync.rs:227` |
| `MemoryMaintenance::diagnose` | `Diagnose` | `records.rs:470` |

Plus the `Diagnosis` import `diagnose` needs. That is the whole production change.

### How the siblings were found

Rather than guess, I diffed every trait member carrying a refusing default against what the bridge implements. **17 members across 8 traits have such a default; 13 are implemented; these 4 were not.** The other three defaulted `MemorySourceSync` members and `MemoryMaintenance::diagnose` were the complete set — no others need a decision.

### Blast radius beyond the reported button

All four have live host call sites, all dead before this change:

- `run_source_sync` — `memory/sources/rpc.rs:574` (per-source Sync) and `rpc.rs:1055` (Sources → All in). The reported symptom.
- `is_toolkit_syncable` — `memory/sync/composio/bus.rs:137`. The host could not determine whether a toolkit was syncable.
- `bootstrap_connection` — `memory/sync/composio/bus.rs:811`. First-time bootstrap of a newly authorised connection failed silently.
- `diagnose` — the typed maintenance diagnosis an operator or agent reads.

## Testing

### The test asserts dispatch, not a live module

With the module host disabled, `proxy()` fails with `MemoryError::Other` (`memory.rs:342-357`), while an unbridged member returns `MemoryError::Unsupported`. Asserting **"not `Unsupported`"** therefore asserts that the call went through `module_call!` at all — which is precisely the thing that was missing — and needs no module, no network and no artifact.

### Revert-check, one member at a time

A single combined revert would stop at the first assertion and prove only one member. Each of the four was reverted **individually** and the failure names that member:

| reverted | failure |
|---|---|
| `run_source_sync` | `run_source_sync answered from the trait default ... Got Unsupported { capability: "source_sync" }` |
| `bootstrap_connection` | `bootstrap_connection answered from the trait default ... Got Unsupported { capability: "source_sync" }` |
| `is_toolkit_syncable` | `is_toolkit_syncable answered from the trait default ... Got Unsupported { capability: "source_sync" }` |
| `diagnose` | `diagnose answered from the trait default ... Got Unsupported { capability: "maintenance" }` |

`diagnose` reporting `maintenance` rather than `source_sync` is the check that the test discriminates per member rather than catching one capability generically. The `run_source_sync` failure reproduces the production error string exactly.

With the fix in place all four pass, and `openhuman::modules::` is green at 79 passed / 0 failed. `cargo fmt --check` and `cargo clippy --no-deps --lib` are clean.

### The trap: no lane can catch this end to end

**CI cannot prove this fixed.** The lanes run with no module or with a test artifact, which is exactly why the bug reached a user. The test above proves the dispatch exists; it cannot prove the module answers it. **The only end-to-end proof is the real app, and the maintainer can confirm it by clicking Sync** on Brain → Sources and seeing a non-zero `sync_triggered` in `[memory_sources] apply_all_in_rpc: complete`.

## Impact

Restores the manual sync trigger, Composio toolkit-syncability checks, first-time connection bootstrap, and the typed maintenance diagnosis. No behaviour change for anything already working: scheduled sync runs inside the module and never crossed this bridge.

## Left for a separate decision, deliberately not in this PR

**1. `GuardedSourceSync` and `GuardedMaintenance` have the identical hole** in all four members. It is **latent, not reachable**: every call site resolves through `binding.provider()`, which returns the *unguarded* provider (`binding.rs:93`, the same field as `unguarded_provider`), so no current caller reaches it.

I did not fix it here because the guard's forwards are not mechanical — each one must choose `admit_write` or `admit_read`, and that is a security-tier decision, not a transcription. Getting it wrong lets a `readonly` operator trigger a sync that spends money. The current behaviour fails **closed** (denies), so leaving it is safe; adding a forward with the wrong tier would fail **open**. My reading, for whoever takes it: `run_source_sync` and `bootstrap_connection` are writes (both ingest or persist), `is_toolkit_syncable` and `diagnose` are reads.

**2. The defaults themselves are the root cause and will hide the next member.** The durable fix is to remove the default bodies from these members so the compiler names every implementor that is missing one. That is a breaking trait change in `tinymemory-api` touching every implementor, so it belongs in its own change with its own review.

**3. Nothing in CI compares the artifact's `METHODS` list against the host's `module_call!` arms.** A test doing that would have caught all four statically. `is_compatible` has no call sites (`grep -rn is_compatible src/` returns two doc comments), but note it would **not** have caught this: it compares host and artifact capability sets that here already agreed.

## Related

- Closes #5801
- Root cause introduced alongside #5725 (`feat/5560-queue-and-recall-through-the-contract`), which routed the manual trigger onto the contract and moved the pin so the module serves it, but did not add the host-side arm.

## Submission Checklist

- [x] Tests added: `the_defaulted_members_dispatch_to_the_module_instead_of_refusing` covers all four members. The failure path is the per-member revert-check table above.
- [x] N/A: diff coverage. The changed lines are four `module_call!` arms plus one import; all four are executed by the new test, which fails if any is removed.
- [x] N/A: no feature rows added, removed, or renamed.
- [x] N/A: no feature IDs affected.
- [x] No new external network dependencies introduced. The test runs with the module host disabled and dials nothing.
- [x] N/A: does not touch release-cut surfaces.
- [x] Linked issue closed via `Closes #5801`.

## Impact (platform)

Desktop. No migration, no schema change, no config change.

---

## AI Authored PR Metadata

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5801-module-bridge-source-sync`
- Commit SHA: `f9a89b2b8`

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend files changed.
- [x] N/A: `pnpm typecheck` — no TypeScript changed.
- [x] Focused tests: `cargo test -p openhuman --lib -- openhuman::modules::` — 79 passed, 0 failed. Plus the four individual revert-checks above.
- [x] Rust fmt/check: `cargo fmt -p openhuman -- --check` clean; `cargo clippy -p openhuman --no-deps --lib` clean.
- [x] N/A: Tauri fmt/check — no Tauri code changed.

### Validation Blocked

- `command:` end-to-end verification against the real pinned artifact
- `error:` not blocked by a failure — no lane loads the real module, by design
- `impact:` the dispatch is proven by test; that the module answers it is provable only in the running app. See the trap note above.

### Behavior Changes

- Intended behavior change: four members now reach the module instead of returning `Unsupported`.
- User-visible effect: the manual Sync button works; Composio connection bootstrap and syncability checks work.

### Parity Contract

- Legacy behavior preserved: yes for every already-working path. Scheduled sync is untouched.
- Guard/fallback/dispatch parity checks: the capability gate is unchanged — `as_source_sync()` already returned `Some` and still does. Only the member dispatch changed.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added memory maintenance diagnostics.
  * Added source synchronization capabilities, including running syncs, bootstrapping connections, and checking toolkit compatibility.

* **Bug Fixes**
  * Memory operations now correctly forward requests and return meaningful errors when the module is unavailable.
  * Coding-session ingestion now allows additional time based on the configured ingestion budget.

* **Tests**
  * Added regression coverage for memory diagnostics and source synchronization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->