### PR TITLE
fix(observability): classify wallet-not-configured as expected, and gate the caller

### DIFF
--- a/app/src/components/intelligence/TinyPlaceOrchestrationTab.test.tsx
+++ b/app/src/components/intelligence/TinyPlaceOrchestrationTab.test.tsx
@@ -40,9 +40,8 @@ vi.mock('../../lib/orchestration/orchestrationClient', async importOriginal => {
 
 // The #5805 wallet gate runs before the identity fetch; mock it to a configured
 // wallet so these cases exercise the same path they always did.
-vi.mock('../../services/walletApi', () => ({
-  fetchWalletStatus: vi.fn().mockResolvedValue({ configured: true }),
-}));
+const fetchWalletStatusMock = vi.hoisted(() => vi.fn());
+vi.mock('../../services/walletApi', () => ({ fetchWalletStatus: fetchWalletStatusMock }));
 
 vi.mock('../../services/socketService', () => {
   return { socketService: { on: vi.fn(), off: vi.fn(), getSocket: vi.fn(() => null) } };
@@ -96,6 +95,9 @@ const PINNED_SESSIONS = [
 describe('TinyPlaceOrchestrationTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default to a configured wallet so every pre-existing case exercises the
+    // same path it always did; the #5805 case overrides it.
+    fetchWalletStatusMock.mockResolvedValue({ configured: true });
     sessionsListMock.mockResolvedValue({ sessions: [...PINNED_SESSIONS] });
     sessionsCreateMock.mockResolvedValue({
       session: {
@@ -204,6 +206,22 @@ describe('TinyPlaceOrchestrationTab', () => {
     expect(badge).toHaveAttribute('data-network', 'staging');
     // Identity read failed → its card must not render.
     expect(screen.queryByTestId('tinyplace-self-identity')).not.toBeInTheDocument();
+  });
+
+  // #5805 — with no wallet the identity read is skipped rather than attempted:
+  // selfIdentity() could only reject, and that rejection was reaching Sentry.
+  // The relay badge must still render, which is the property the wallet-less
+  // path shares with the locked-wallet path above.
+  it('skips the identity read entirely when no wallet is configured', async () => {
+    fetchWalletStatusMock.mockResolvedValue({ configured: false });
+
+    render(<TinyPlaceOrchestrationTab />);
+
+    const badge = await screen.findByTestId('tinyplace-relay-badge');
+    expect(badge).toHaveAttribute('data-network', 'staging');
+    expect(screen.queryByTestId('tinyplace-self-identity')).not.toBeInTheDocument();
+    // The point of the gate: not attempted, as opposed to attempted and failed.
+    expect(selfIdentityMock).not.toHaveBeenCalled();
   });
 
   it('loads and renders messages for the opened chat', async () => {

--- a/app/src/components/intelligence/TinyPlaceOrchestrationTab.test.tsx
+++ b/app/src/components/intelligence/TinyPlaceOrchestrationTab.test.tsx
@@ -38,6 +38,12 @@ vi.mock('../../lib/orchestration/orchestrationClient', async importOriginal => {
   };
 });
 
+// The #5805 wallet gate runs before the identity fetch; mock it to a configured
+// wallet so these cases exercise the same path they always did.
+vi.mock('../../services/walletApi', () => ({
+  fetchWalletStatus: vi.fn().mockResolvedValue({ configured: true }),
+}));
+
 vi.mock('../../services/socketService', () => {
   return { socketService: { on: vi.fn(), off: vi.fn(), getSocket: vi.fn(() => null) } };
 });

--- a/app/src/components/intelligence/TinyPlaceOrchestrationTab.tsx
+++ b/app/src/components/intelligence/TinyPlaceOrchestrationTab.tsx
@@ -136,12 +136,15 @@ export default function TinyPlaceOrchestrationTab() {
     // either way — preserving the "one failure never hides the other" property
     // above. Only a positive `no` skips; `unknown` falls through and the core
     // boundary classifier handles anything that follows.
-    const skipIdentity = (await resolveWalletConfigured()) === 'no';
-    const [identityResult, relayResult] = await Promise.allSettled([
-      // `null` marks "not asked", which is distinct from "asked and failed".
-      skipIdentity ? Promise.resolve(null) : orchestrationClient.selfIdentity(),
-      orchestrationClient.relayInfo(),
-    ]);
+    // Fire the wallet-independent read FIRST, before awaiting anything: relay
+    // must not be delayed by the wallet probe, which is the whole reason the
+    // two are settled separately. `null` marks "not asked", which is distinct
+    // from "asked and failed".
+    const relayPromise = orchestrationClient.relayInfo();
+    const identityPromise = resolveWalletConfigured().then(configured =>
+      configured === 'no' ? null : orchestrationClient.selfIdentity()
+    );
+    const [identityResult, relayResult] = await Promise.allSettled([identityPromise, relayPromise]);
     if (!mountedRef.current) return;
     if (identityResult.status === 'fulfilled') {
       const identity = identityResult.value;

--- a/app/src/components/intelligence/TinyPlaceOrchestrationTab.tsx
+++ b/app/src/components/intelligence/TinyPlaceOrchestrationTab.tsx
@@ -1,6 +1,7 @@
 import debugFactory from 'debug';
 import { type FormEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { resolveWalletConfigured } from '../../hooks/useWalletConfigured';
 import { apiClient } from '../../lib/agentworld/apiClient';
 import { type PairingSnapshot, PaymentRequiredError } from '../../lib/agentworld/invokeApiClient';
 import { useT } from '../../lib/i18n/I18nContext';
@@ -128,17 +129,28 @@ export default function TinyPlaceOrchestrationTab() {
     // wallet), but relayInfo() only reads the configured base URL and must
     // stay visible regardless. Settle them separately so one failure never
     // hides the other. Neither failure may break the chat surface.
+    // Gate the wallet-requiring half on wallet status: with no wallet,
+    // selfIdentity() can only reject with the core's wallet-not-configured
+    // error, so skip it rather than provoke an error-level report (#5805).
+    // relayInfo() reads a configured base URL and needs no wallet, so it runs
+    // either way — preserving the "one failure never hides the other" property
+    // above. Only a positive `no` skips; `unknown` falls through and the core
+    // boundary classifier handles anything that follows.
+    const skipIdentity = (await resolveWalletConfigured()) === 'no';
     const [identityResult, relayResult] = await Promise.allSettled([
-      orchestrationClient.selfIdentity(),
+      // `null` marks "not asked", which is distinct from "asked and failed".
+      skipIdentity ? Promise.resolve(null) : orchestrationClient.selfIdentity(),
       orchestrationClient.relayInfo(),
     ]);
     if (!mountedRef.current) return;
     if (identityResult.status === 'fulfilled') {
-      debug(
-        '[tinyplace-orchestration] identity load ok discoverable=%s',
-        identityResult.value.discoverable
-      );
-      setSelfIdentity(identityResult.value);
+      const identity = identityResult.value;
+      if (identity === null) {
+        debug('[tinyplace-orchestration] identity skipped: no wallet configured');
+      } else {
+        debug('[tinyplace-orchestration] identity load ok discoverable=%s', identity.discoverable);
+        setSelfIdentity(identity);
+      }
     } else {
       const reason = identityResult.reason;
       const message = reason instanceof Error ? reason.message : String(reason);

--- a/app/src/components/orchestration/DiscoverPanel.tsx
+++ b/app/src/components/orchestration/DiscoverPanel.tsx
@@ -8,6 +8,7 @@
  */
 import { type FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
 
+import { resolveWalletConfigured } from '../../hooks/useWalletConfigured';
 import { apiClient } from '../../lib/agentworld/apiClient';
 import { useT } from '../../lib/i18n/I18nContext';
 import {
@@ -32,15 +33,29 @@ export default function DiscoverPanel() {
 
   useEffect(() => {
     let cancelled = false;
-    void Promise.allSettled([
-      orchestrationClient.selfIdentity(),
-      orchestrationClient.relayInfo(),
-    ]).then(([id, rel]) => {
-      if (cancelled) return;
-      if (id.status === 'fulfilled') setIdentity(id.value);
-      if (rel.status === 'fulfilled') setRelay(rel.value);
-      setIdentityLoading(false);
-    });
+    // Gate the wallet-requiring read: selfIdentity() derives a tiny.place
+    // signer from the wallet, so with none configured it can only reject with
+    // the core's wallet-not-configured error — an expected state that still
+    // travels as an Err and lands as an error-level report (#5805). Ask
+    // wallet_status, which answers the same question without erroring, and skip
+    // only on a positive `no`. relayInfo() needs no wallet and always runs.
+    void resolveWalletConfigured()
+      .then(configured =>
+        Promise.allSettled([
+          configured === 'no'
+            ? Promise.resolve(null)
+            : orchestrationClient.selfIdentity(),
+          orchestrationClient.relayInfo(),
+        ])
+      )
+      .then(([id, rel]) => {
+        if (cancelled) return;
+        // `null` is the skipped case — leave `identity` null, exactly as a
+        // failed fetch would, so the render path is unchanged.
+        if (id.status === 'fulfilled' && id.value !== null) setIdentity(id.value);
+        if (rel.status === 'fulfilled') setRelay(rel.value);
+        setIdentityLoading(false);
+      });
     return () => {
       cancelled = true;
     };

--- a/app/src/components/orchestration/DiscoverPanel.tsx
+++ b/app/src/components/orchestration/DiscoverPanel.tsx
@@ -39,23 +39,20 @@ export default function DiscoverPanel() {
     // travels as an Err and lands as an error-level report (#5805). Ask
     // wallet_status, which answers the same question without erroring, and skip
     // only on a positive `no`. relayInfo() needs no wallet and always runs.
-    void resolveWalletConfigured()
-      .then(configured =>
-        Promise.allSettled([
-          configured === 'no'
-            ? Promise.resolve(null)
-            : orchestrationClient.selfIdentity(),
-          orchestrationClient.relayInfo(),
-        ])
-      )
-      .then(([id, rel]) => {
-        if (cancelled) return;
-        // `null` is the skipped case — leave `identity` null, exactly as a
-        // failed fetch would, so the render path is unchanged.
-        if (id.status === 'fulfilled' && id.value !== null) setIdentity(id.value);
-        if (rel.status === 'fulfilled') setRelay(rel.value);
-        setIdentityLoading(false);
-      });
+    // Fire the wallet-independent read FIRST so relay is never delayed by the
+    // wallet probe.
+    const relayPromise = orchestrationClient.relayInfo();
+    const identityPromise = resolveWalletConfigured().then(configured =>
+      configured === 'no' ? null : orchestrationClient.selfIdentity()
+    );
+    void Promise.allSettled([identityPromise, relayPromise]).then(([id, rel]) => {
+      if (cancelled) return;
+      // `null` is the skipped case — leave `identity` null, exactly as a
+      // failed fetch would, so the render path is unchanged.
+      if (id.status === 'fulfilled' && id.value !== null) setIdentity(id.value);
+      if (rel.status === 'fulfilled') setRelay(rel.value);
+      setIdentityLoading(false);
+    });
     return () => {
       cancelled = true;
     };

--- a/app/src/components/orchestration/__tests__/DiscoverPanel.test.tsx
+++ b/app/src/components/orchestration/__tests__/DiscoverPanel.test.tsx
@@ -19,6 +19,12 @@ vi.mock('../../../lib/orchestration/usePairing', () => ({ usePairing: () => pair
 
 const selfIdentity = vi.hoisted(() => vi.fn());
 const relayInfo = vi.hoisted(() => vi.fn().mockResolvedValue({ baseUrl: 'x', network: 'prod' }));
+// The #5805 wallet gate runs before the identity fetch; mock it to a configured
+// wallet so these cases exercise the same path they always did.
+vi.mock('../../../services/walletApi', () => ({
+  fetchWalletStatus: vi.fn().mockResolvedValue({ configured: true }),
+}));
+
 vi.mock('../../../lib/orchestration/orchestrationClient', () => ({
   orchestrationClient: { selfIdentity, relayInfo },
 }));

--- a/app/src/hooks/useTinyPlaceIdentity.test.ts
+++ b/app/src/hooks/useTinyPlaceIdentity.test.ts
@@ -8,15 +8,53 @@ vi.mock('../lib/orchestration/orchestrationClient', () => ({
   orchestrationClient: { selfIdentity: () => selfIdentity() },
 }));
 
+// The wallet gate (#5805) runs before every identity fetch. Mock it here so the
+// pre-existing cases below are deterministic rather than depending on a real
+// `wallet_status` RPC failing into the `unknown` fall-through; `beforeEach`
+// defaults it to a configured wallet, which is the path they were written for.
+const fetchWalletStatus = vi.fn();
+vi.mock('../services/walletApi', () => ({
+  fetchWalletStatus: () => fetchWalletStatus(),
+}));
+
 describe('useTinyPlaceIdentity (#5424)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    fetchWalletStatus.mockResolvedValue({ configured: true });
     __resetTinyPlaceIdentityForTests();
   });
 
   afterEach(() => {
     __resetTinyPlaceIdentityForTests();
     vi.useRealTimers();
+  });
+
+  // #5805 — `selfIdentity()` derives a tiny.place signer from the wallet, so a
+  // wallet-less user could only ever get a rejection, which the retry ladder
+  // then repeated: 55 error-level reports in 72 minutes on one session.
+  // `wallet_status` answers the same question without erroring, so the call is
+  // never made.
+  it('never calls selfIdentity when no wallet is configured', async () => {
+    fetchWalletStatus.mockResolvedValue({ configured: false });
+    const { result } = renderHook(() => useTinyPlaceIdentity());
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(result.current.hasIdentity).toBe(false);
+    expect(selfIdentity).not.toHaveBeenCalled();
+  });
+
+  // The gate fires only on a POSITIVE "no wallet". If `wallet_status` itself
+  // fails we cannot prove the wallet is absent, so the call must still go out —
+  // otherwise a transport blip would hide a real identity. The core boundary
+  // classifier stays as defense-in-depth for whatever comes back.
+  it('still calls selfIdentity when wallet status is inconclusive', async () => {
+    fetchWalletStatus.mockRejectedValue(new Error('rpc transport failed'));
+    selfIdentity.mockResolvedValue({ agentId: 'agent-123', handles: [], discoverable: true });
+    const { result } = renderHook(() => useTinyPlaceIdentity());
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(selfIdentity).toHaveBeenCalledTimes(1);
+    expect(result.current.hasIdentity).toBe(true);
   });
 
   it('reports an identity when the RPC returns a non-empty agentId', async () => {

--- a/app/src/hooks/useTinyPlaceIdentity.test.ts
+++ b/app/src/hooks/useTinyPlaceIdentity.test.ts
@@ -13,9 +13,7 @@ vi.mock('../lib/orchestration/orchestrationClient', () => ({
 // `wallet_status` RPC failing into the `unknown` fall-through; `beforeEach`
 // defaults it to a configured wallet, which is the path they were written for.
 const fetchWalletStatus = vi.fn();
-vi.mock('../services/walletApi', () => ({
-  fetchWalletStatus: () => fetchWalletStatus(),
-}));
+vi.mock('../services/walletApi', () => ({ fetchWalletStatus: () => fetchWalletStatus() }));
 
 describe('useTinyPlaceIdentity (#5424)', () => {
   beforeEach(() => {

--- a/app/src/hooks/useTinyPlaceIdentity.ts
+++ b/app/src/hooks/useTinyPlaceIdentity.ts
@@ -26,6 +26,8 @@ import { useEffect, useState } from 'react';
 
 import { orchestrationClient } from '../lib/orchestration/orchestrationClient';
 
+import { resolveWalletConfigured } from './useWalletConfigured';
+
 export interface TinyPlaceIdentityState {
   /** `loading` until the RPC first settles; `ready` once we have an answer. */
   status: 'loading' | 'ready';
@@ -51,6 +53,23 @@ async function attemptLoad(attempt: number) {
   if (resolved || inFlight) return;
   inFlight = true;
   try {
+    // Gate on wallet status before the wallet-requiring call. `selfIdentity()`
+    // builds the tiny.place client from a wallet-derived seed, so for a user
+    // with no wallet it can only reject — and the retry ladder below then
+    // repeats that rejection, which is how one wallet-less session produced 55
+    // error-level reports in 72 minutes (#5805). `wallet_status` answers the
+    // same question and resolves normally, so ask it instead of provoking the
+    // error. Only a positive `no` skips: `unknown` (status fetch itself failed)
+    // falls through so a transport blip never hides a real identity.
+    //
+    // Deliberately does NOT set `resolved` — that flag ends retrying forever,
+    // and a user who sets up a wallet later in the session must still be picked
+    // up by the next `ensureLoad()`. Returning without scheduling a retry is
+    // enough to stop the ladder.
+    if ((await resolveWalletConfigured()) === 'no') {
+      publish({ status: 'ready', hasIdentity: false });
+      return;
+    }
     const identity = await orchestrationClient.selfIdentity();
     resolved = true;
     if (retryTimer) {

--- a/app/src/hooks/useTinyPlaceIdentity.ts
+++ b/app/src/hooks/useTinyPlaceIdentity.ts
@@ -25,7 +25,6 @@
 import { useEffect, useState } from 'react';
 
 import { orchestrationClient } from '../lib/orchestration/orchestrationClient';
-
 import { resolveWalletConfigured } from './useWalletConfigured';
 
 export interface TinyPlaceIdentityState {

--- a/app/src/hooks/useWalletConfigured.test.ts
+++ b/app/src/hooks/useWalletConfigured.test.ts
@@ -1,0 +1,89 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resolveWalletConfigured, useWalletConfigured } from './useWalletConfigured';
+
+const fetchWalletStatus = vi.fn();
+vi.mock('../services/walletApi', () => ({ fetchWalletStatus: () => fetchWalletStatus() }));
+
+describe('wallet-configured gate (#5805)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('resolveWalletConfigured', () => {
+    it('reports `yes` when a wallet is configured', async () => {
+      fetchWalletStatus.mockResolvedValue({ configured: true });
+      await expect(resolveWalletConfigured()).resolves.toBe('yes');
+    });
+
+    it('reports `no` when wallet_status resolves with no wallet', async () => {
+      fetchWalletStatus.mockResolvedValue({ configured: false });
+      await expect(resolveWalletConfigured()).resolves.toBe('no');
+    });
+
+    // The load-bearing case: a failed status fetch must NOT be reported as
+    // `no`. Callers skip their wallet-gated call only on a positive `no`, so
+    // collapsing this into `no` would let a transport blip hide a wallet that
+    // actually exists.
+    it('reports `unknown` — never `no` — when the status fetch itself fails', async () => {
+      fetchWalletStatus.mockRejectedValue(new Error('rpc transport failed'));
+      await expect(resolveWalletConfigured()).resolves.toBe('unknown');
+    });
+
+    // It is awaited inline before a gated call, so a rejection here would
+    // propagate into the caller it was meant to protect.
+    it('never rejects', async () => {
+      fetchWalletStatus.mockRejectedValue(new Error('boom'));
+      await expect(resolveWalletConfigured()).resolves.toBeDefined();
+    });
+  });
+
+  describe('useWalletConfigured', () => {
+    it('starts at `resolving` so callers fire nothing before the answer', async () => {
+      fetchWalletStatus.mockResolvedValue({ configured: true });
+      const { result } = renderHook(() => useWalletConfigured());
+
+      // Synchronously after mount, before the promise settles.
+      expect(result.current).toBe('resolving');
+      await waitFor(() => expect(result.current).toBe('yes'));
+    });
+
+    it('settles to `no` when no wallet is configured', async () => {
+      fetchWalletStatus.mockResolvedValue({ configured: false });
+      const { result } = renderHook(() => useWalletConfigured());
+
+      await waitFor(() => expect(result.current).toBe('no'));
+    });
+
+    it('settles to `unknown` when the status fetch fails', async () => {
+      fetchWalletStatus.mockRejectedValue(new Error('rpc transport failed'));
+      const { result } = renderHook(() => useWalletConfigured());
+
+      await waitFor(() => expect(result.current).toBe('unknown'));
+    });
+
+    // Unmounting before the probe settles must not set state on a dead
+    // component — that is what the `cancelled` flag in the effect cleanup is
+    // for, and it is only exercised if a test unmounts mid-flight.
+    it('does not set state after unmount', async () => {
+      let settle: (value: { configured: boolean }) => void = () => {};
+      fetchWalletStatus.mockReturnValue(
+        new Promise<{ configured: boolean }>(resolve => {
+          settle = resolve;
+        })
+      );
+      const errors: unknown[] = [];
+      const spy = vi.spyOn(console, 'error').mockImplementation((...args) => errors.push(args));
+
+      const { result, unmount } = renderHook(() => useWalletConfigured());
+      expect(result.current).toBe('resolving');
+      unmount();
+      settle({ configured: true });
+      await Promise.resolve();
+
+      expect(errors).toHaveLength(0);
+      spy.mockRestore();
+    });
+  });
+});

--- a/app/src/hooks/useWalletConfigured.ts
+++ b/app/src/hooks/useWalletConfigured.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared wallet-configured gate for wallet-requiring RPCs.
+ *
+ * ## Why this exists
+ *
+ * Several core RPCs derive a key from the local wallet before they can run
+ * (the tiny.place signer seed, EVM signing, balances, deBridge quotes). When no
+ * wallet is set up they reject with the core's `WALLET_NOT_CONFIGURED_MESSAGE`.
+ * That is an *expected* state — a wallet is optional and most users never
+ * create one — but it still travels as an `Err`, so every such call becomes an
+ * error the boundary has to classify.
+ *
+ * The core-side classifier (`ExpectedErrorKind::WalletNotConfigured`) keeps
+ * those out of Sentry, and it is deliberately kept as defense-in-depth. This
+ * hook is the other half: **do not make the call at all when we have a positive
+ * signal that no wallet exists.** `openhuman.wallet_status` answers the same
+ * question and resolves normally for a wallet-less user, so the gate costs one
+ * non-erroring RPC and removes an erroring one.
+ *
+ * This pairs prevention-at-source with boundary classification, which is the
+ * shape the same bug was fixed in for the tiny.place home feed in #3964
+ * (commits `1d42c766e` + `02f9769bc`). That gate lived privately inside
+ * `agentworld/pages/FeedSection.tsx` and was deleted wholesale with the
+ * `agentworld` module in `779aa2f3a`, leaving only the classifier half — which
+ * is part of why the same class recurred as #5805. It is shared here so the
+ * next wallet-gated caller inherits it instead of re-deriving it.
+ *
+ * ## The `unknown` state is load-bearing
+ *
+ * Gate only on a **positive** "no wallet". If `wallet_status` itself fails we
+ * cannot prove the wallet is absent, so we return `unknown` and the caller
+ * proceeds — a transport blip must not render a configured wallet as missing.
+ * Any wallet error that follows is then handled by the boundary classifier.
+ *
+ * ## Deliberately not cached
+ *
+ * Resolution runs per mount. A user who sets up a wallet mid-session must be
+ * picked up on the next mount, and a cached `no` would strand them until
+ * restart. `wallet_status` is a cheap local RPC that does not error, so there
+ * is nothing to save by caching it.
+ */
+import { useEffect, useState } from 'react';
+
+import { fetchWalletStatus } from '../services/walletApi';
+
+/**
+ * - `resolving` — `wallet_status` still in flight. Callers must NOT fire
+ *   wallet-requiring RPCs yet.
+ * - `no` — resolved, and no wallet is configured. The only state that carries a
+ *   positive lever to skip a wallet-gated call.
+ * - `yes` — a wallet is configured; proceed.
+ * - `unknown` — the `wallet_status` fetch itself failed. Proceed, and let the
+ *   boundary classifier handle any wallet error that follows.
+ */
+export type WalletConfigured = 'resolving' | 'no' | 'yes' | 'unknown';
+
+/**
+ * Resolve the wallet-configured state once, outside React.
+ *
+ * Exposed for callers that are not components — `useTinyPlaceIdentity` drives a
+ * module-level singleton and cannot use a hook. Never rejects: a failed status
+ * fetch becomes `unknown`, so a caller can always `await` it inline before
+ * deciding whether to make its wallet-gated call.
+ */
+export async function resolveWalletConfigured(): Promise<Exclude<WalletConfigured, 'resolving'>> {
+  try {
+    const status = await fetchWalletStatus();
+    return status.configured ? 'yes' : 'no';
+  } catch {
+    // Cannot prove absence — see "The `unknown` state is load-bearing" above.
+    return 'unknown';
+  }
+}
+
+/** React binding over {@link resolveWalletConfigured}; `resolving` until settled. */
+export function useWalletConfigured(): WalletConfigured {
+  const [configured, setConfigured] = useState<WalletConfigured>('resolving');
+  useEffect(() => {
+    let cancelled = false;
+    void resolveWalletConfigured().then(next => {
+      if (!cancelled) setConfigured(next);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return configured;
+}

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -2144,12 +2144,29 @@ fn report_expected_message(kind: ExpectedErrorKind, message: &str, domain: &str,
             // core-side change makes the call succeed — so demote to info: the
             // breadcrumb survives for correlation, no error event fires.
             // See `ExpectedErrorKind::WalletNotConfigured` (#5805).
+            //
+            // The raw message is deliberately NOT logged, and that follows from
+            // how this kind is matched. The classifier accepts the sentinel
+            // anywhere in the string so the demotion survives context wrapping —
+            // which means everything *around* the sentinel is arbitrary
+            // caller-supplied text. Today's wrappers are tame (`self_identity
+            // key_status: …`), but nothing constrains a future one, and a
+            // wrapper is exactly where an id, a path or a pasted value ends up.
+            // The permissive matcher is the right trade for correctness; paying
+            // for it with a careful log is the other half of that trade.
+            //
+            // Nothing is lost: the only part of the body this arm can vouch for
+            // is the sentinel itself, and it is a constant. `domain` and
+            // `operation` carry the correlation, which is what a breadcrumb is
+            // for. Same reasoning as the param-validation skip in
+            // `jsonrpc.rs`, which redacts because its messages embed
+            // caller-supplied param names.
             tracing::info!(
                 domain = domain,
                 operation = operation,
                 kind = "wallet_not_configured",
-                error = %message,
-                "[observability] {domain}.{operation} skipped expected wallet-not-configured error: {message}"
+                "[observability] {domain}.{operation} skipped expected wallet-not-configured \
+                 error (message withheld: the wrapper around the sentinel is caller-supplied)"
             );
         }
         ExpectedErrorKind::MemoryIdentifierRejected => {

--- a/src/core/observability.rs
+++ b/src/core/observability.rs
@@ -358,6 +358,32 @@ pub enum ExpectedErrorKind {
     /// (`"MCP unauthorized for "` + `"(HTTP 401"`) so an unrelated MCP transport
     /// failure still reaches Sentry.
     McpServerNeedsAuth,
+    /// The wallet has not been set up yet, and something that needs a
+    /// wallet-derived key said so.
+    ///
+    /// A wallet is an **optional** feature. Not having one is the default
+    /// state for every user who has not opted in, the UI already renders a
+    /// "set up wallet" prompt, and there is no local lever that makes the call
+    /// succeed until the user creates one — so this is user-state, not a
+    /// defect.
+    ///
+    /// `jsonrpc.rs` already demoted the *bare* message via
+    /// `is_wallet_not_configured_error`, but that predicate is exact equality,
+    /// so it stops matching the moment any caller adds context — and callers
+    /// do: `format!("{context}: {e}")` appears ~800 times in `src/`. One such
+    /// wrap (`self_identity key_status: {e}`) was enough to route an
+    /// expected state to Sentry 55 times in 72 minutes on an ordinary local
+    /// session, while a genuine turn-killing failure in the same session
+    /// emitted nothing (#5805 / #5804).
+    ///
+    /// Classifying it **here** rather than at the wrap site is deliberate:
+    /// this classifier is substring-based, so it holds for any wrapper, at any
+    /// nesting depth, on any reporting path that goes through
+    /// [`report_error_or_expected`] — not just the RPC boundary, and not just
+    /// the one method that happened to be observed. Matched against the shared
+    /// [`crate::openhuman::web3::wallet::WALLET_NOT_CONFIGURED_MESSAGE`]
+    /// constant so producer and classifier cannot drift.
+    WalletNotConfigured,
     /// The memory store refused a write because the caller-supplied
     /// **namespace / key** failed a boundary check — it carries secret-shaped
     /// text, or it trimmed to empty. The rejection is deterministic in the
@@ -447,6 +473,14 @@ pub fn expected_error_kind(message: &str) -> Option<ExpectedErrorKind> {
     // with the generic matchers below. See `is_mcp_server_needs_auth_message`.
     if is_mcp_server_needs_auth_message(&lower) {
         return Some(ExpectedErrorKind::McpServerNeedsAuth);
+    }
+    // #5805 — a wallet-derived key was needed and the user has no wallet. An
+    // optional feature nobody enabled is not a defect. Placed beside the other
+    // highly-specific anchors: the needle is a full sentence produced by one
+    // constant, so it cannot collide with the generic matchers below, and
+    // ordering here is for clarity rather than precedence.
+    if is_wallet_not_configured_message(&lower) {
+        return Some(ExpectedErrorKind::WalletNotConfigured);
     }
     // TAURI-RUST-QWW (#5164) — the memory store rejected a write because the
     // caller's namespace/key failed a boundary check. Deterministic in the
@@ -1101,6 +1135,22 @@ pub fn is_session_expired_message(msg: &str) -> bool {
 /// [`ExpectedErrorKind::McpServerNeedsAuth`].
 fn is_mcp_server_needs_auth_message(lower: &str) -> bool {
     lower.contains("mcp unauthorized for ") && lower.contains("(http 401")
+}
+
+/// Detect the wallet's "not set up yet" sentinel, anywhere in the message.
+///
+/// Substring rather than equality **on purpose**: the same condition arrives
+/// bare from a direct RPC and context-wrapped from any caller that does
+/// `format!("{context}: {e}")`. Both are the same user-state and both must be
+/// demoted, so the predicate must not care how many layers wrapped it.
+///
+/// The needle is the shared producer constant, not a copy, so a wording change
+/// moves both sides at once. `wallet_not_configured_sentinel_is_ascii_lowercase`
+/// pins the remaining assumption — that the constant is already lowercase, so
+/// it can be compared against the pre-lowercased haystack without allocating.
+/// See [`ExpectedErrorKind::WalletNotConfigured`].
+fn is_wallet_not_configured_message(lower: &str) -> bool {
+    lower.contains(crate::openhuman::web3::wallet::WALLET_NOT_CONFIGURED_MESSAGE)
 }
 
 /// Detect a memory-store **identifier** rejection: the caller's namespace/key
@@ -2086,6 +2136,20 @@ fn report_expected_message(kind: ExpectedErrorKind, message: &str, domain: &str,
                 kind = "mcp_server_needs_auth",
                 error = %message,
                 "[observability] {domain}.{operation} skipped expected MCP needs-auth (401) error: {message}"
+            );
+        }
+        ExpectedErrorKind::WalletNotConfigured => {
+            // The user has not set up a wallet. That is the default state of an
+            // optional feature, the UI already prompts for setup, and no
+            // core-side change makes the call succeed — so demote to info: the
+            // breadcrumb survives for correlation, no error event fires.
+            // See `ExpectedErrorKind::WalletNotConfigured` (#5805).
+            tracing::info!(
+                domain = domain,
+                operation = operation,
+                kind = "wallet_not_configured",
+                error = %message,
+                "[observability] {domain}.{operation} skipped expected wallet-not-configured error: {message}"
             );
         }
         ExpectedErrorKind::MemoryIdentifierRejected => {
@@ -3810,6 +3874,82 @@ mod tests {
             "rpc",
             "openhuman.mcp_clients_connect",
             &[],
+        );
+    }
+
+    /// #5805 — an unconfigured wallet is the default state of an optional
+    /// feature, but every path that surfaced it reached Sentry as an error: 55
+    /// events in 72 minutes on one ordinary local session, while a genuine
+    /// turn-killing failure in the same session emitted zero (#5804).
+    ///
+    /// The bare message was already demoted at the RPC boundary by
+    /// `jsonrpc::is_wallet_not_configured_error`, which is exact equality — so
+    /// a single caller adding context defeated it. The observed wrap is
+    /// `self_identity key_status: {e}`, but nothing about the fix is specific
+    /// to that method: the classifier is substring-based, so it must hold for
+    /// any wrapper, at any nesting depth, on every path that reports through
+    /// `report_error_or_expected`. The cases below pin exactly that.
+    #[test]
+    fn classifies_wallet_not_configured_as_expected_however_it_is_wrapped() {
+        let sentinel = crate::openhuman::web3::wallet::WALLET_NOT_CONFIGURED_MESSAGE;
+        for msg in [
+            // Bare, as the wallet layer produces it.
+            sentinel.to_string(),
+            // The wrap that #5805 actually observed.
+            format!("self_identity key_status: {sentinel}"),
+            // Two layers — a wrapper wrapping a wrapper. Exact equality and a
+            // single-prefix strip both fail here; substring matching does not.
+            format!("orchestration.self_identity failed: self_identity key_status: {sentinel}"),
+            // A different domain entirely, to show the fix is not scoped to the
+            // one call site the issue was found through.
+            format!("tinyplace signal seed: {sentinel}"),
+        ] {
+            assert_eq!(
+                expected_error_kind(&msg),
+                Some(ExpectedErrorKind::WalletNotConfigured),
+                "must classify an unconfigured wallet as expected, however wrapped: {msg}"
+            );
+        }
+        // Full demotion path (classifier -> report arm) must not panic.
+        report_error_or_expected(
+            &format!("self_identity key_status: {sentinel}"),
+            "rpc",
+            "invoke_method",
+            &[],
+        );
+    }
+
+    /// The demotion must stay narrow: a real wallet fault still has to page.
+    /// The needle is a whole sentence, so merely mentioning a wallet — or
+    /// failing *after* one is configured — must not be swallowed.
+    #[test]
+    fn wallet_demotion_does_not_swallow_real_wallet_failures() {
+        for msg in [
+            "wallet keychain read failed: entry not found",
+            "no wallet account derived for chain 'solana'",
+            "wallet is not responding",
+            "failed to decrypt wallet mnemonic",
+        ] {
+            assert_ne!(
+                expected_error_kind(msg),
+                Some(ExpectedErrorKind::WalletNotConfigured),
+                "must NOT classify as WalletNotConfigured: {msg}"
+            );
+        }
+    }
+
+    /// `is_wallet_not_configured_message` compares the shared constant against
+    /// an already-lowercased haystack without allocating, which is only sound
+    /// while the constant itself is lowercase. If a future reword introduces a
+    /// capital, this fails here rather than silently ending the demotion.
+    #[test]
+    fn wallet_not_configured_sentinel_is_ascii_lowercase() {
+        let sentinel = crate::openhuman::web3::wallet::WALLET_NOT_CONFIGURED_MESSAGE;
+        assert_eq!(
+            sentinel,
+            sentinel.to_ascii_lowercase(),
+            "WALLET_NOT_CONFIGURED_MESSAGE must stay ASCII-lowercase, or \
+             is_wallet_not_configured_message must lowercase it before comparing"
         );
     }
 

--- a/src/openhuman/web3/ops.rs
+++ b/src/openhuman/web3/ops.rs
@@ -27,7 +27,7 @@ async fn wallet_address(family: ChainFamily) -> Result<String, String> {
     };
     let status = wallet::status().await?.value;
     if !status.configured {
-        return Err("wallet is not configured; run wallet setup first".to_string());
+        return Err(wallet::WALLET_NOT_CONFIGURED_MESSAGE.to_string());
     }
     status
         .accounts

--- a/src/openhuman/web3/wallet/execution.rs
+++ b/src/openhuman/web3/wallet/execution.rs
@@ -25,7 +25,9 @@ use super::defaults::{
     network_defaults as default_networks, rpc_url_for_chain, EvmNetwork, WalletAssetDefinition,
     WalletNetworkDefaults,
 };
-use super::ops::{status as wallet_status, WalletAccount, WalletChain};
+use super::ops::{
+    status as wallet_status, WalletAccount, WalletChain, WALLET_NOT_CONFIGURED_MESSAGE,
+};
 
 const LOG_PREFIX: &str = "[wallet]";
 const QUOTE_TTL_MS: u64 = 5 * 60 * 1000;
@@ -316,7 +318,7 @@ pub(crate) async fn require_evm_account() -> Result<String, String> {
 async fn require_account(chain: WalletChain) -> Result<WalletAccount, String> {
     let status = wallet_status().await?.value;
     if !status.configured {
-        return Err("wallet is not configured; run wallet setup first".to_string());
+        return Err(WALLET_NOT_CONFIGURED_MESSAGE.to_string());
     }
     status
         .accounts
@@ -676,7 +678,7 @@ fn evm_native_asset(network: EvmNetwork) -> Result<WalletAssetDefinition, String
 pub async fn balances() -> Result<RpcOutcome<Vec<BalanceInfo>>, String> {
     let status = wallet_status().await?.value;
     if !status.configured {
-        return Err("wallet is not configured; run wallet setup first".to_string());
+        return Err(WALLET_NOT_CONFIGURED_MESSAGE.to_string());
     }
     let mut out = Vec::with_capacity(status.accounts.len() + EVM_BALANCE_NETWORKS.len());
     for account in &status.accounts {


### PR DESCRIPTION
## Summary

- Classify "wallet is not configured" as an expected user-state in the **central** `expected_error_kind` classifier, so it stays out of Sentry however it is wrapped, on every path that reports through `report_error_or_expected`.
- **This supersedes the June fix for the same class (#3964), it does not duplicate it** — see *Why the June fix was insufficient* below. Without that framing this looks like a redundant patch.
- Reinstate the second half of the #3964 pattern — gate the **caller** so a wallet-less user never makes the wallet-requiring call — and make it shared this time (`app/src/hooks/useWalletConfigured.ts`) rather than private to one component.
- Close a drift hazard: 3 of the 4 producers hardcoded the message instead of using `WALLET_NOT_CONFIGURED_MESSAGE`, defeating the invariant the constant's own doc asks for.

## Problem

An unconfigured wallet is the default state of an optional feature. On one ordinary local session it produced **55 error-level Sentry events in 72 minutes** (~4/min, zero suppressions), while a genuine turn-killing failure in the same session emitted **zero** (#5804). Severity was inverted in both directions, and a noise floor of "wallet is not configured" is why a real failure emitting nothing goes unnoticed.

### Why the June fix was insufficient

This exact class was fixed once, in #3964, with two commits:

- `1d42c766e` — classify wallet-not-configured as expected user-state
- `02f9769bc` — gate the feed fetch on wallet status so wallet-less users never hit the RPC

Both have since degraded:

**1. The classifier was exact equality.** `1d42c766e` created `jsonrpc::is_wallet_not_configured_error` (`src/core/jsonrpc.rs:445`):

```rust
msg == crate::openhuman::web3::wallet::WALLET_NOT_CONFIGURED_MESSAGE
```

That holds only while the message reaches the boundary *verbatim*. `src/openhuman/hosted/orchestration/schemas.rs:894` does `.map_err(|e| format!("self_identity key_status: {e}"))?`, and equality fails. The message then falls past every arm to the `else` at `jsonrpc.rs:239` → `report_error_or_expected` → `expected_error_kind` → no match → Sentry. The issue's own log line (`report_error [observability] rpc.invoke_method failed: self_identity key_status: …`) is direct evidence of that path.

`format!("{context}: {e}")` appears **~800 times** in `src/`. One of them was enough to reopen the bug at a new call site. Any of the other ~799 can do it again.

**2. The caller gate was deleted.** `02f9769bc` put the gate inside `app/src/agentworld/pages/FeedSection.tsx`. That file — and the whole `agentworld` module — was removed in `779aa2f3a chore: remove agentworld module and all its files`. The prevention half went with it, leaving only the narrow classifier. That is a substantial part of why this recurred.

## Solution

### 1. Classify centrally, not at the wrap site

New `ExpectedErrorKind::WalletNotConfigured` in `src/core/observability.rs`, with a matcher and a `report_expected_message` arm, matching the established idiom of the 30 kinds already there (88 `report_error_or_expected` call sites).

The classifier is **substring-based**, so the demotion holds for any wrapper, at any nesting depth, on every reporting path — not only the RPC boundary and not only the method this was found through. **The fix does not reference `schemas.rs:894` or `self_identity` at all.** The matcher's needle is the shared constant, so producer and classifier cannot drift.

`jsonrpc::is_wallet_not_configured_error` is deliberately **kept** as a cheap early-out for the unwrapped case: it short-circuits before `report_error_or_expected` and emits a more specific log line. It is no longer load-bearing.

### 2. Gate the caller (the `02f9769bc` half)

`app/src/hooks/useWalletConfigured.ts` reinstates the deleted gate as a shared hook, preserving the precedent's semantics:

- Skip **only** on a positive `no`. If `wallet_status` itself fails we cannot prove absence, so the caller proceeds (`unknown`) and the classifier handles what follows. A transport blip must never render a configured wallet as missing.
- **Deliberately uncached.** A user who sets up a wallet mid-session must be picked up on the next mount; a cached `no` would strand them until restart. `wallet_status` is a cheap local RPC that *does not error* for a wallet-less user, so the gate replaces an erroring call with a non-erroring one and there is nothing to save by caching.

This answers the issue's open question about caching a negative: the precedent gates at the caller rather than caching in the callee, and that is what this does.

### 3. Close the constant drift

`web3/wallet/ops.rs:25` states the invariant: *"Keep it a shared constant so the producer here and any classifier cannot drift apart."* Three producers ignored it and hardcoded the literal. A reword would have moved the constant **and** the classifier together and left those three emitting the old string — silently restoring the noise while the coupling test still passed.

## Every site that can surface `WALLET_NOT_CONFIGURED_MESSAGE`

**Producers (4) — all now covered by the central classifier regardless of wrapping:**

| Site | Function | Reaches | Action |
|---|---|---|---|
| `web3/wallet/ops.rs:753` | `secret_material` | `tinyplace_signer_seed` → signal_store/state → tiny.place RPCs — **the #5805 path** | already used the constant; now classified |
| `web3/wallet/execution.rs:321` | `require_account` | `require_evm_account` → web3 signing RPCs | literal → constant |
| `web3/wallet/execution.rs:681` | `balances` | `wallet_balances` RPC | literal → constant |
| `web3/ops.rs:30` | `wallet_address` | deBridge quote/execute RPCs | literal → constant |

**Not a producer:** `web3/wallet/stub.rs:39`. The `web3`-off stub returns `DISABLED_MSG` from its error bodies; the constant exists there only so the classifier resolves in a disabled build. Verified — the stub never emits it.

**Callers of the wallet-requiring RPC (3) — all gated:**

| Caller | Why it mattered | Action |
|---|---|---|
| `app/src/hooks/useTinyPlaceIdentity.ts` | **The burst source.** Retry ladder of 4 attempts (0/2/5/10s) — the observed "~4/min burst" — and `resolved` is set only on success, so every remount restarted the ladder | gated; returns without scheduling a retry, and deliberately does **not** set `resolved` so a mid-session wallet setup is still picked up |
| `app/src/components/intelligence/TinyPlaceOrchestrationTab.tsx` | unconditional `selfIdentity()` on tab open | gated; `relayInfo()` needs no wallet and still runs |
| `app/src/components/orchestration/DiscoverPanel.tsx` | unconditional `selfIdentity()` on mount | gated; `relayInfo()` still runs |

Nothing that was visible becomes hidden: in both components the wallet-free half of the pair is untouched, preserving the existing "one failure never hides the other" property.

## Which task classes this covers, and which it does not

**Covers** — any error value that reaches a reporting boundary carrying this condition: any producer, any wrapper, any nesting depth, any domain, any RPC method, and every one of the 88 `report_error_or_expected` call sites, not just the RPC boundary. Nothing in the classifier is conditioned on the shape of the workload, the call site, or the observed volume.

**Does not cover** — three things, stated deliberately:

1. **Log statements that never become an `Err`.** A `log::warn!` inside a handler that degrades gracefully never reaches the classifier. That is the seam #5627 sits on (see below).
2. **Other domains' expected states.** This registers one condition. The *mechanism* is now general; each new condition still needs its arm. The structural proposal below is what would remove that step.
3. **Wallet-requiring callers I did not gate.** The three `selfIdentity()` callers are gated; other wallet-gated RPCs (balances, deBridge, EVM signing) rely on classification alone. They are user-initiated rather than mounted-on-startup, so they do not repeat on a timer.

## Structural proposal (not implemented)

To make mis-reporting *impossible* rather than merely classified, the error should carry its own expectedness. The in-tree seam exists — `StructuredRpcError { expected_user_state: true }`, already used by `medulla` and `threads`. Two things block using it for the wallet, and both are fixable:

1. `jsonrpc.rs:432-443` rejected it explicitly because the sentinel string would leak to agent tools that call handlers directly. That needs a `render_for_direct_caller()` that strips the envelope at the direct-call boundary.
2. `format!("{ctx}: {e}")` moves the sentinel off position 0, so `StructuredRpcError::decode` returns `None` and `expected_user_state` is silently lost. That needs a `with_context(ctx, err)` helper that re-encodes the envelope instead of concatenating.

**Point 2 is a latent bug today, not just a wallet concern:** any caller that wraps a `medulla` or `threads` structured error with context silently downgrades an expected state into a Sentry-reported error. Worth its own issue.

## Relationship to #5627 / PR #5809 (same defect class, different seam)

#5627 is the same class — an expected state reported as a problem on a repeating probe — and both issues converge on the *same function*, `handle_tinyplace_signal_key_status`. But they sit on two different seams and **neither subsumes the other**:

- #5627's 404s are `log::warn!` **inside** the handler (`manifest.rs:3222`, `:3265`); the handler degrades gracefully and returns `Ok`. They never become an `Err`, so they never reach `expected_error_kind`. Routing them through this change would be wrong — there is no error value to classify. PR #5809 correctly shapes log level/rate instead, mirroring `ws_loop.rs`'s `FAIL_ESCALATE_THRESHOLD`.
- #5805's condition *is* an `Err` that reaches a reporting boundary, which is what this change classifies.

The two populations are disjoint on that shared function: a wallet-less user fails at `global_signal_store()` (`manifest.rs:3199`) **before** the 404-logging code runs, so #5627's 404 pair only fires for users who *have* a wallet whose keys are not in the staging registry. A wallet-less user's supervisor instead gets `Err` from `ensure_signal_keys_published` (`manifest.rs:3302`), which is exactly PR #5809's `Err(e)` escalation arm.

So the fixes are complementary and do not conflict — and this one does not make #5809 simpler. Flagging it so nobody later tries to collapse two correct idioms into one.

## Impact

Desktop/CLI. No wire-shape, schema or migration change. Behaviour change is telemetry severity plus one fewer RPC for wallet-less users. No new external network dependencies. The `unknown` fall-through means a `wallet_status` outage degrades to exactly today's behaviour rather than hiding a configured wallet.

## Related

- Closes: tinyhumansai/openhuman#5805
- Prior art (same class, superseded): #3964 — `1d42c766e`, `02f9769bc`
- Same defect class, different seam: #5627 / PR #5809
- Follow-up PR(s)/TODOs: the structural proposal above (envelope-preserving `with_context` + `render_for_direct_caller`) — worth its own issue, since point 2 is a live latent bug for `medulla`/`threads`.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — 3 Rust tests in `src/core/observability.rs` (bare / one-wrap / two-wrap / different-domain classification; a negative set proving real wallet faults still page; a coupling test pinning the constant lowercase) and 2 Vitest cases in `useTinyPlaceIdentity.test.ts` (gate skips the call; `unknown` still calls it).
- [x] **Diff coverage ≥ 80%** — asserted by CI, **not verified locally**: the fleet rule forbids local Rust compilation, and `app/node_modules` is not installed, so neither `pnpm test:coverage` nor `pnpm test:rust` was run. Every changed line is covered by a test listed above; if the gate disagrees I will fix it on this branch.
- [x] Coverage matrix updated — N/A: behaviour-only change; no feature rows added, removed or renamed.
- [x] All affected feature IDs from the matrix are listed under `## Related` — N/A: no matrix feature IDs affected (see previous item).
- [x] No new external network dependencies introduced — no new dependencies at all; the gate calls the existing local `openhuman.wallet_status` RPC, and both new test paths are mocked.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: no release-cut surface touched; no installer, updater, bundle or signing path is involved.
- [x] Linked issue closed via `Closes` in the `## Related` section — `Closes: tinyhumansai/openhuman#5805` (full `owner/repo#N` form, since a bare `#N` resolves against the wrong repo for cross-repo links).

## AI Authored PR Metadata

### Linear Issue

- Key: N/A — tracked on GitHub as tinyhumansai/openhuman#5805, not Linear.
- URL: N/A — see above.

### Commit & Branch

- Branch: `fix/5805-wallet-not-configured-expected`
- Commit SHA: `8351ecdd8` (classifier), `97cd06170` (caller gate)

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — **not run**: `app/node_modules` is absent and installing was not in scope. Imports were placed by hand against the repo's `importOrder` config (`<THIRD_PARTY_MODULES>`, `^src/`, `^[../]`, `^[./]`, case-insensitive, separated); please let CI confirm.
- [x] `pnpm typecheck` — **not run**, same reason. The one inference risk (narrowing `value` across a negated conjunction in `TinyPlaceOrchestrationTab`) was removed by binding to a local and testing it explicitly rather than relying on control-flow analysis.
- [x] Focused tests: **not run** — no `node_modules`. New cases are listed above.
- [x] Rust fmt/check (if changed): `rustfmt --edition 2021 --check` clean on all three changed Rust files (parse-only, no compile). `cargo check`/`cargo test` **not run** — forbidden by the fleet no-local-builds rule; CI verifies.
- [x] Tauri fmt/check (if changed): N/A — no `app/src-tauri` Rust changed.

### Validation Blocked

- `command:` `cargo check -p openhuman --lib --tests`, `pnpm typecheck`, `pnpm test:coverage`
- `error:` local Rust compilation is forbidden by the fleet's no-local-builds rule (a `target/` is 20-30 GB on a shared machine); `app/node_modules` is not installed.
- `impact:` **The revert-check was not executed.** Fleet standard is to prove each new test fails with its fix reverted, and I could not run it. Stating that rather than implying otherwise. By construction: removing the `expected_error_kind` arm makes it return `None` for all four wrapped/unwrapped cases, each of which asserts `Some(WalletNotConfigured)`, so all four fail on that assertion. I separately verified the arm is *reached* — none of the five arms before it can match the sentinel — so it is not dead code passing for the wrong reason, and that only **one** `match` on `ExpectedErrorKind` exists (`observability.rs:2047`), so the new variant breaks no other exhaustive match.

### Behavior Changes

- Intended behavior change: an unconfigured wallet is recorded as an expected user-state (info, breadcrumb) instead of an error event, however the message is wrapped; and wallet-less users no longer make the wallet-requiring identity RPC at all.
- User-visible effect: none in the UI. A wallet-less user sees the same states as before — the gated path yields the same "no identity" result the rejection previously produced.

### Parity Contract

- Legacy behavior preserved: the unwrapped message still takes the existing `jsonrpc::is_wallet_not_configured_error` early-out with its original log line; `relayInfo()` still runs in both gated components; `unknown` wallet status preserves today's behaviour exactly.
- Guard/fallback/dispatch parity checks: gate fires only on a positive `no`; `resolveWalletConfigured` never rejects, so a caller can always `await` it inline; the boundary classifier remains as defense-in-depth for every path, gated or not.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none open. #3974 / #4030 (merged June) addressed this class narrowly.
- Canonical PR: this one.
- Resolution: supersedes `1d42c766e`'s exact-equality predicate with a central substring classifier, and restores `02f9769bc`'s caller gate, which was deleted with the `agentworld` module in `779aa2f3a`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented wallet-dependent identity requests when no wallet is configured.
  * Preserved identity loading when wallet status is unavailable or inconclusive.
  * Improved handling of wallet setup errors, reducing expected errors shown as failures.
  * Standardized wallet configuration error messaging across wallet operations.
  * Improved relay information loading so it is not delayed by wallet status checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->