### PR TITLE
Tie each module's registry pin to its submodule pin, and catch rewinds

### DIFF
--- a/.github/workflows/ci-lite.yml
+++ b/.github/workflows/ci-lite.yml
@@ -230,6 +230,13 @@ jobs:
               - 'scripts/__tests__/**'
               # Bash helpers with node --test coverage in scripts/__tests__/.
               - 'scripts/ci/assert-coverage-presence.sh'
+              # Shared logic behind the gate CLIs, and the module-pin gate's own
+              # files. Without these a change to the checking logic would skip
+              # the lane that tests it — the gate would stop watching itself.
+              - 'scripts/lib/**'
+              - 'scripts/ci/check-module-pins.mjs'
+              - 'scripts/ci/check-submodule-monotonic.mjs'
+              - 'scripts/ci/module-pin-exemptions.json'
             # Test-wiring surface: a change here can orphan a test or add an
             # untested controller domain → run the inventory guard.
             inventory:
@@ -1040,6 +1047,51 @@ jobs:
       - name: Verify the desktop shell forwards every default-ON core gate
         run: node scripts/ci/check-feature-forwarding.mjs
 
+  module-pin-gate:
+    name: Module Pin Gate (registry pin matches submodule pin)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          # Full history and every submodule: the monotonicity half compares this
+          # branch's gitlinks against the base branch's and then asks the
+          # submodule whether the new pin is an ancestor of the old one. Both
+          # answers need real history — `fetch-depth: 1` would leave the script
+          # unable to resolve the base, which it reports as a FAILURE rather than
+          # passing on an empty comparison.
+          fetch-depth: 0
+          submodules: recursive
+          persist-credentials: false
+
+      # Nine subsystems load as downloaded cdylib modules and each is pinned
+      # twice: once as a submodule (the contract compiled here) and once as a
+      # version + digest in modules/registry.rs (the artifact loaded at runtime).
+      # Nothing compared them, so a stale pin compiled clean, passed every lane,
+      # and lost a capability on a user's machine — #5598 (capability bitmask
+      # 8191 vs 262143), #5623 (missing ListAllFacets), #5641 (missing profile
+      # family). All three were fixed by bumping a pin; none added a check.
+      #
+      # Deliberately NOT filtered on `changes`: a path filter would have to watch
+      # registry.rs, modules/memory.rs, three workflows and sixteen gitlinks, and
+      # a skipped job counts as a pass in the gate below.
+      - name: Verify each module's registry pin matches its submodule pin
+        run: node scripts/ci/check-module-pins.mjs
+
+      # The other half, and the one that has actually bitten. A pin set can be
+      # internally consistent and still be consistent with an OLDER release:
+      # 14a23b994 moved vendor/tinyagents back from #122 to #121, silently
+      # dropping a shipped fix until #5796 restored it, and #5725 did the same
+      # (undone by #5787). Both were internally consistent, so the check above
+      # would have passed them. `tinyagents` has no registry record at all — one
+      # pin, nothing to compare — so only movement direction catches it.
+      - name: Verify no vendor/ submodule pin moved backwards
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: node scripts/ci/check-submodule-monotonic.mjs
+
   pester-install:
     name: PowerShell Install Test (Pester)
     needs: [changes]
@@ -1109,6 +1161,7 @@ jobs:
       - tinycortex-tests
       - orch-ip-gate
       - feature-forwarding-gate
+      - module-pin-gate
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -1129,6 +1182,7 @@ jobs:
             ["TinyCortex Memory Tests"]="${{ needs['tinycortex-tests'].result }}"
             ["Orchestration IP Gate"]="${{ needs['orch-ip-gate'].result }}"
             ["Feature Forwarding Gate"]="${{ needs['feature-forwarding-gate'].result }}"
+            ["Module Pin Gate"]="${{ needs['module-pin-gate'].result }}"
           )
 
           failed=0

--- a/scripts/__tests__/module-pins.test.mjs
+++ b/scripts/__tests__/module-pins.test.mjs
@@ -4,7 +4,7 @@
 // the real tree, including the two commits that actually shipped a regression.
 import assert from 'node:assert/strict';
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { test } from 'node:test';
@@ -12,6 +12,8 @@ import { fileURLToPath } from 'node:url';
 
 import {
   checkPinMapCoverage,
+  classifyMove,
+  toplevelProvesSubmodule,
   classifyPin,
   parseAllList,
   parseArtifactCapabilitiesPin,
@@ -32,11 +34,29 @@ const run = (cli, args = [], env = {}) =>
     env: { ...process.env, ...env },
   });
 
-/** Is `path` a checked-out submodule? Several cases need one and must skip, not lie. */
+/**
+ * Is `vendor/tinymemory` really a checked-out submodule?
+ *
+ * NOT `rev-parse --git-dir`: git walks UPWARD, so from an uninitialised — or
+ * merely empty — `vendor/tinymemory` that command happily answers the
+ * SUPERPROJECT's `.git` and exits 0. The probe reported "present" having checked
+ * nothing, enabling a case whose CLI then failed for precisely the reason the
+ * probe was meant to detect. That is the fail-open shape this whole gate exists
+ * to prevent, reproduced inside its own test helper. Raised by Codex on #5812.
+ *
+ * `--show-toplevel` is the honest question: it answers the root of whichever
+ * repository owns that directory. Only when that root IS the submodule path is
+ * the submodule genuinely checked out. Compared through `realpathSync` because
+ * macOS resolves `/tmp/...` to `/private/tmp/...`.
+ */
 function submodulesPresent() {
+  const path = join(REPO_ROOT, 'vendor/tinymemory');
   try {
-    execFileSync('git', ['rev-parse', '--git-dir'], { cwd: join(REPO_ROOT, 'vendor/tinymemory'), stdio: 'ignore' });
-    return true;
+    const top = execFileSync('git', ['-C', path, 'rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return toplevelProvesSubmodule(realpathSync(top), realpathSync(path));
   } catch {
     return false;
   }
@@ -285,6 +305,74 @@ test('the monotonicity gate fails when run outside a git repo rather than passin
     });
     assert.notEqual(r.status, 0, 'no git repo must FAIL, not pass');
     assert.doesNotMatch(r.stdout, /check OK/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ── Review findings from #5812 ────────────────────────────────────────────────
+
+test('a comment inside ALL does not swallow the record beneath it', () => {
+  // CodeRabbit on #5812: splitting on commas before stripping comments puts the
+  // comment and the next record in one token, and filtering tokens beginning
+  // with `//` dropped both. A dropped record reads downstream as "missing from
+  // PIN_MAP" — CI fails while pointing at the wrong thing.
+  const src = [
+    'pub const ALL: &[ModuleRecord] = &[',
+    '    // the codecs',
+    '    TINYDOCS,',
+    '    TINYWALLET, // lazy',
+    '    // Eager, unlike the two codecs above.',
+    '    TINYMEMORY,',
+    '];',
+  ].join('\n');
+  assert.deepEqual(parseAllList(src), ['TINYDOCS', 'TINYWALLET', 'TINYMEMORY']);
+});
+
+test('a divergent pin is not forward', () => {
+  // Codex on #5812: asking only "is head an ancestor of base?" reads the single
+  // failed query as forward, so siblings — a side branch, or a rebased submodule
+  // history — sail through. Divergence loses the base's commits exactly as a
+  // rewind does, and a rewind onto a sibling is one rebase away from 14a23b994.
+  assert.equal(classifyMove({ headIsAncestorOfBase: true, baseIsAncestorOfHead: false }), 'rewind');
+  assert.equal(classifyMove({ headIsAncestorOfBase: false, baseIsAncestorOfHead: true }), 'forward');
+  assert.equal(classifyMove({ headIsAncestorOfBase: false, baseIsAncestorOfHead: false }), 'divergent');
+});
+
+test('the submodule probe is not fooled by the superproject above it', () => {
+  // Codex on #5812. `rev-parse --git-dir` walks upward and succeeds from any
+  // directory inside a repository, submodule or not — so it cannot answer this.
+  const root = mkdtempSync(join(tmpdir(), 'module-pins-super-'));
+  try {
+    execFileSync('git', ['init', '-q', root], { stdio: 'ignore' });
+    const notASubmodule = join(root, 'vendor', 'tinymemory');
+    mkdirSync(notASubmodule, { recursive: true });
+
+    // The old probe: succeeds, answering the SUPERPROJECT's git dir.
+    const walked = execFileSync('git', ['-C', notASubmodule, 'rev-parse', '--git-dir'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    assert.ok(walked.length > 0, 'precondition: --git-dir does walk up, which is why it cannot be used');
+
+    // The probe actually used: the toplevel is the superproject, not the path,
+    // so this correctly reports "not a checked-out submodule".
+    const top = execFileSync('git', ['-C', notASubmodule, 'rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    assert.equal(
+      toplevelProvesSubmodule(realpathSync(top), realpathSync(notASubmodule)),
+      false,
+      'a directory that merely sits inside a repo must not read as a checked-out submodule',
+    );
+
+    // ...and the positive case: the superproject root IS its own toplevel.
+    const superTop = execFileSync('git', ['-C', root, 'rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    assert.equal(toplevelProvesSubmodule(realpathSync(superTop), realpathSync(root)), true);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/__tests__/module-pins.test.mjs
+++ b/scripts/__tests__/module-pins.test.mjs
@@ -1,0 +1,291 @@
+// Tests for the module-pin gates (openhuman#5727).
+//
+// The pure logic is covered directly; the two CLIs are driven end-to-end against
+// the real tree, including the two commits that actually shipped a regression.
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  checkPinMapCoverage,
+  classifyPin,
+  parseAllList,
+  parseArtifactCapabilitiesPin,
+  parseGitlinks,
+  parseRecords,
+  parseWorkflowMemoryBlocks,
+  rewindDeclared,
+} from '../lib/module-pins.mjs';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const PINS_CLI = join(REPO_ROOT, 'scripts/ci/check-module-pins.mjs');
+const MONO_CLI = join(REPO_ROOT, 'scripts/ci/check-submodule-monotonic.mjs');
+
+const run = (cli, args = [], env = {}) =>
+  spawnSync(process.execPath, [cli, ...args], {
+    cwd: REPO_ROOT,
+    encoding: 'utf8',
+    env: { ...process.env, ...env },
+  });
+
+/** Is `path` a checked-out submodule? Several cases need one and must skip, not lie. */
+function submodulesPresent() {
+  try {
+    execFileSync('git', ['rev-parse', '--git-dir'], { cwd: join(REPO_ROOT, 'vendor/tinymemory'), stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── Registry parsing ──────────────────────────────────────────────────────────
+
+test('parses every record `ALL` lists out of the real registry', () => {
+  const src = readFileSync(join(REPO_ROOT, 'src/openhuman/modules/registry.rs'), 'utf8');
+  const names = parseAllList(src);
+  const records = parseRecords(src);
+  assert.ok(names.length >= 9, `expected at least 9 records in ALL, got ${names.length}`);
+  for (const name of names) {
+    const rec = records.get(name);
+    assert.ok(rec, `ALL lists ${name} but no such ModuleRecord parsed`);
+    assert.ok(rec.id, `${name} has no id`);
+    assert.match(rec.version, /^\d+\.\d+\.\d+$/, `${name} version looks wrong: ${rec.version}`);
+  }
+});
+
+test('parses per-platform assets, digests included', () => {
+  const src = readFileSync(join(REPO_ROOT, 'src/openhuman/modules/registry.rs'), 'utf8');
+  const mem = [...parseRecords(src).values()].find((r) => r.id === 'tinymemory');
+  assert.ok(mem, 'tinymemory record not found');
+  assert.ok(mem.assets.length > 0, 'tinymemory publishes no assets?');
+  for (const a of mem.assets) {
+    assert.match(a.sha256, /^[0-9a-f]{64}$/, `bad digest for ${a.hostKey}`);
+    assert.ok(a.archive.includes(mem.version), `${a.archive} does not carry version ${mem.version}`);
+  }
+});
+
+test('reading a registry with no ALL block throws rather than returning empty', () => {
+  assert.throws(() => parseAllList('fn main() {}'), /could not find/);
+  assert.throws(() => parseRecords('fn main() {}'), /parsed zero/);
+});
+
+test('finds ARTIFACT_CAPABILITIES_PIN and the workflow memory blocks', () => {
+  const memSrc = readFileSync(join(REPO_ROOT, 'src/openhuman/modules/memory.rs'), 'utf8');
+  assert.match(parseArtifactCapabilitiesPin(memSrc), /^\d+\.\d+\.\d+$/);
+  const wf = readFileSync(join(REPO_ROOT, '.github/workflows/ci-lite.yml'), 'utf8');
+  const blocks = parseWorkflowMemoryBlocks(wf);
+  assert.ok(blocks.versions.length > 0, 'ci-lite.yml has no memory_version block');
+  assert.equal(blocks.versions.length, blocks.digests.length, 'version/digest blocks must pair');
+});
+
+// ── Classification ────────────────────────────────────────────────────────────
+
+const base = { id: 'tinyx', version: '1.2.3', submodulePath: 'vendor/tinyx' };
+
+test('a pin sitting on its tag passes', () => {
+  const v = classifyPin({ ...base, actual: 'v1.2.3', exemption: undefined });
+  assert.equal(v.ok, true);
+  assert.equal(v.kind, 'match');
+});
+
+test('a pin past its tag fails and names both sides', () => {
+  const v = classifyPin({ ...base, actual: 'v1.2.3-7-gabc1234', exemption: undefined });
+  assert.equal(v.ok, false);
+  assert.equal(v.kind, 'drift');
+  assert.match(v.message, /1\.2\.3/);
+  assert.match(v.message, /v1\.2\.3-7-gabc1234/);
+});
+
+test('a declared exemption passes only for the exact drift it declares', () => {
+  const exemption = { id: 'tinyx', expect: 'v1.2.3-7-gabc1234', reason: 'because' };
+  const same = classifyPin({ ...base, actual: 'v1.2.3-7-gabc1234', exemption });
+  assert.equal(same.ok, true);
+  assert.equal(same.kind, 'exempt');
+
+  // Drifting FURTHER is a new fact, and must be re-declared.
+  const wider = classifyPin({ ...base, actual: 'v1.2.3-9-gdef5678', exemption });
+  assert.equal(wider.ok, false);
+  assert.equal(wider.kind, 'exemption-widened');
+});
+
+test('an exemption whose drift has been fixed fails, so it cannot linger', () => {
+  const v = classifyPin({
+    ...base,
+    actual: 'v1.2.3',
+    exemption: { id: 'tinyx', expect: 'v1.2.3-7-gabc1234', reason: 'because' },
+  });
+  assert.equal(v.ok, false);
+  assert.equal(v.kind, 'stale-exemption');
+});
+
+// ── Coverage: the half that survives the next module ──────────────────────────
+
+test('a record the pin map has never heard of fails', () => {
+  const f = checkPinMapCoverage(['tinymemory', 'tinyfuture'], ['tinymemory']);
+  assert.equal(f.length, 1);
+  assert.match(f[0], /tinyfuture/);
+  assert.match(f[0], /must not inherit an unchecked pin/);
+});
+
+test('a pin-map entry for a removed record fails', () => {
+  const f = checkPinMapCoverage(['tinymemory'], ['tinymemory', 'tinygone']);
+  assert.equal(f.length, 1);
+  assert.match(f[0], /tinygone/);
+});
+
+test('a fully covered set is clean', () => {
+  assert.deepEqual(checkPinMapCoverage(['a', 'b'], ['b', 'a']), []);
+});
+
+// ── Gitlink parsing and the rewind marker ────────────────────────────────────
+
+test('reads gitlinks out of ls-tree and ignores ordinary blobs', () => {
+  const out = [
+    '100644 blob 1111111111111111111111111111111111111111\tCargo.toml',
+    '160000 commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\tvendor/tinyagents',
+    '160000 commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\tvendor/tinymemory',
+  ].join('\n');
+  const m = parseGitlinks(out);
+  assert.equal(m.size, 2);
+  assert.equal(m.get('vendor/tinyagents'), 'a'.repeat(40));
+});
+
+test('the rewind marker is recognised anywhere on the branch, case-insensitively', () => {
+  assert.equal(rewindDeclared('Revert the bump [pin-rewind] because X'), true);
+  assert.equal(rewindDeclared('[PIN-REWIND]'), true);
+  assert.equal(rewindDeclared('an ordinary bump'), false);
+  assert.equal(rewindDeclared(undefined), false);
+});
+
+// ── End to end, against the real tree ─────────────────────────────────────────
+
+test('the pin gate passes on the tree as committed', { skip: submodulesPresent() ? false : 'submodules not checked out' }, () => {
+  const r = run(PINS_CLI);
+  assert.equal(r.status, 0, `expected pass, got:\n${r.stdout}${r.stderr}`);
+});
+
+test('the monotonicity gate catches 14a23b994, which really did drop a shipped fix', () => {
+  // vendor/tinyagents e0f3210 (tinyagents#122) -> bbcd0a6 (#121). Restored by #5796.
+  const r = run(MONO_CLI, ['14a23b994^', '14a23b994'], { PR_TITLE: '' });
+  if (/cannot resolve base ref|not in the submodule/.test(r.stderr)) {
+    // Shallow clone or absent submodule: the gate correctly refused to answer.
+    assert.equal(r.status, 1, 'an unverifiable pin must still fail, never pass');
+    return;
+  }
+  assert.equal(r.status, 1, `expected failure, got:\n${r.stdout}${r.stderr}`);
+  assert.match(r.stderr, /vendor\/tinyagents moved BACKWARDS/);
+});
+
+test('a rewind declared with [pin-rewind] is allowed through', () => {
+  const r = run(MONO_CLI, ['14a23b994^', '14a23b994'], { PR_TITLE: 'undo the bad bump [pin-rewind]' });
+  if (/cannot resolve base ref|not in the submodule/.test(r.stderr)) return;
+  assert.equal(r.status, 0, `expected pass, got:\n${r.stdout}${r.stderr}`);
+});
+
+test('an unresolvable base fails rather than passing on an empty comparison', () => {
+  const r = run(MONO_CLI, ['origin/definitely-not-a-ref', 'HEAD']);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /Refusing to pass having compared\s+nothing/);
+});
+
+// ── Fail-closed: a check that cannot complete must never report clean ─────────
+//
+// Two CI gates have shipped here that swallowed a git error and passed having
+// scanned nothing (the coverage gate and the IP gate, both via a dead `git` in
+// the container). These cases assert the opposite behaviour directly: every
+// broken input below must exit NON-ZERO.
+
+/** A throwaway repo root the pins CLI can be pointed at via argv[2]. */
+function fixtureRoot(files) {
+  const root = mkdtempSync(join(tmpdir(), 'module-pins-'));
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = join(root, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, body);
+  }
+  return root;
+}
+
+const MINIMAL_WORKFLOW = 'jobs:\n  x:\n    steps:\n      - run: |\n          memory_version="9.9.9"\n          memory_sha256="' + 'f'.repeat(64) + '"\n';
+
+test('an unparseable registry fails the gate instead of passing', () => {
+  const root = fixtureRoot({
+    'src/openhuman/modules/registry.rs': '// everything here got deleted\n',
+    'src/openhuman/modules/memory.rs': 'pub(crate) const ARTIFACT_CAPABILITIES_PIN: &str = "9.9.9";\n',
+    '.github/workflows/ci-full.yml': MINIMAL_WORKFLOW,
+    '.github/workflows/ci-lite.yml': MINIMAL_WORKFLOW,
+    '.github/workflows/e2e-reusable.yml': MINIMAL_WORKFLOW,
+  });
+  try {
+    const r = run(PINS_CLI, [root]);
+    assert.notEqual(r.status, 0, `a registry it cannot parse must FAIL, got exit 0:\n${r.stdout}`);
+    assert.match(`${r.stdout}${r.stderr}`, /could not find|FAILED/);
+    assert.doesNotMatch(r.stdout, /Module pin check OK/, 'must not claim OK on an unparseable registry');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('a missing registry file fails the gate instead of passing', () => {
+  const root = fixtureRoot({ '.github/workflows/ci-lite.yml': MINIMAL_WORKFLOW });
+  try {
+    const r = run(PINS_CLI, [root]);
+    assert.notEqual(r.status, 0, 'a missing registry must FAIL');
+    assert.match(`${r.stdout}${r.stderr}`, /missing|FAILED/);
+    assert.doesNotMatch(r.stdout, /Module pin check OK/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('records with no checked-out submodule fail the gate instead of being skipped', () => {
+  // A well-formed registry whose vendor/ tree simply is not there — exactly the
+  // shape of a lane that forgot `submodules: recursive`. Skipping would report a
+  // clean scan of nothing.
+  const registry = [
+    'const TINYDOCS: ModuleRecord = ModuleRecord {',
+    '    id: "tinydocs",',
+    '    version: "0.1.14",',
+    '    assets: &[],',
+    '};',
+    '',
+    'pub const ALL: &[ModuleRecord] = &[',
+    '    TINYDOCS,',
+    '];',
+    '',
+  ].join('\n');
+  const root = fixtureRoot({
+    'src/openhuman/modules/registry.rs': registry,
+    'src/openhuman/modules/memory.rs': 'pub(crate) const ARTIFACT_CAPABILITIES_PIN: &str = "1.12.0";\n',
+    '.github/workflows/ci-full.yml': MINIMAL_WORKFLOW,
+    '.github/workflows/ci-lite.yml': MINIMAL_WORKFLOW,
+    '.github/workflows/e2e-reusable.yml': MINIMAL_WORKFLOW,
+  });
+  try {
+    const r = run(PINS_CLI, [root]);
+    assert.notEqual(r.status, 0, 'an uninitialised submodule must FAIL, not skip');
+    assert.match(`${r.stdout}${r.stderr}`, /not a checked-out submodule|submodules: recursive/);
+    assert.doesNotMatch(r.stdout, /Module pin check OK/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('the monotonicity gate fails when run outside a git repo rather than passing', () => {
+  const root = mkdtempSync(join(tmpdir(), 'module-pins-nogit-'));
+  try {
+    const r = spawnSync(process.execPath, [MONO_CLI, 'origin/main', 'HEAD'], {
+      cwd: root,
+      encoding: 'utf8',
+      env: { ...process.env },
+    });
+    assert.notEqual(r.status, 0, 'no git repo must FAIL, not pass');
+    assert.doesNotMatch(r.stdout, /check OK/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/scripts/__tests__/module-pins.test.mjs
+++ b/scripts/__tests__/module-pins.test.mjs
@@ -10,10 +10,13 @@ import { dirname, join, resolve } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
+// Every name below is the SHIPPED implementation from scripts/lib/module-pins.mjs
+// — the same module the two CLIs in scripts/ci/ import. Nothing in this file
+// re-implements any of it, so a regression in the lib fails these tests rather
+// than passing against a local copy.
 import {
   checkPinMapCoverage,
   classifyMove,
-  toplevelProvesSubmodule,
   classifyPin,
   parseAllList,
   parseArtifactCapabilitiesPin,
@@ -21,6 +24,7 @@ import {
   parseRecords,
   parseWorkflowMemoryBlocks,
   rewindDeclared,
+  toplevelProvesSubmodule,
 } from '../lib/module-pins.mjs';
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');

--- a/scripts/ci/check-module-pins.mjs
+++ b/scripts/ci/check-module-pins.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+// Fails when a module's registry pin and its submodule pin describe different
+// releases — the drift behind openhuman#5727.
+//
+// Nine subsystems load as downloaded cdylib modules, and each is pinned TWICE,
+// independently: once as a git submodule (the source this repo compiles the
+// wire contract against) and once as a `version` + per-platform SHA-256 in
+// `src/openhuman/modules/registry.rs` (the artifact actually loaded at runtime).
+// Nothing compared the two. When they drift, the build compiles clean, every
+// lane is green, and a capability goes missing at runtime on a user's machine —
+// which is how #5598 (capability bitmask 8191 vs 262143), #5623 (missing
+// ListAllFacets) and #5641 (missing profile family) each shipped. All three were
+// a stale pin; none left behind anything that would catch the fourth.
+//
+// The module ABI gate cannot catch it: it checks magic, ABI revision, pointer
+// width, target triple, endianness, feature bits and panic strategy — none of
+// which encodes WHICH RELEASE the artifact is. A correctly-built older artifact
+// is admitted without complaint.
+//
+// Three things are checked, and the third is the one that generalises:
+//
+//   1. Every record in `ALL` sits on the tag its `version` names, unless it is
+//      declared in module-pin-exemptions.json with the exact drift it has.
+//   2. For tinymemory — the only module pinned in more than two places — the
+//      registry version, `ARTIFACT_CAPABILITIES_PIN`, and every `memory_version`
+//      / `memory_sha256` pair in the workflows all describe one release.
+//   3. Every record in `ALL` is accounted for by the pin map below. A module
+//      added without a decision here fails the gate rather than silently
+//      escaping it. Six vendored crates landed between 2026-08-20 and -27; a
+//      guard that enumerated today's modules would already be behind.
+//
+// This is deliberately NOT the whole story. A pin can satisfy every check here
+// and still be wrong, because a pin that is internally consistent can be
+// consistent with an OLDER release — see scripts/ci/check-submodule-monotonic.mjs
+// for the other half.
+//
+// No network. Requires submodules to be checked out; if one is missing this
+// FAILS rather than skipping (see `mustRun`). We have twice shipped a gate that
+// swallowed a git error and reported clean having scanned nothing.
+//
+// Usage: check-module-pins.mjs [repo-root]
+import { readFileSync, existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+// Any throw below is a check that could not be COMPLETED, which is not the same
+// as a check that passed. Report it as a failure with a legible message rather
+// than a stack trace, and never exit 0. Two gates have shipped here that
+// swallowed a git error and reported clean having scanned nothing.
+process.on('uncaughtException', (error) => {
+  console.error(`\nModule pin check FAILED\n`);
+  console.error(`  \u2717 ${error.message}\n`);
+  console.error('  This gate could not complete. That is a failure, not a pass.\n');
+  process.exit(1);
+});
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  checkPinMapCoverage,
+  classifyPin,
+  parseAllList,
+  parseArtifactCapabilitiesPin,
+  parseRecords,
+  parseWorkflowMemoryBlocks,
+} from '../lib/module-pins.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(process.argv[2] ?? join(HERE, '..', '..'));
+
+// Record id -> the submodule that is the source of truth for its version.
+//
+// `submodule: null` means "this record has no submodule of its own", and needs a
+// reason. It is NOT an exemption from drift — the two runtime providers below
+// ship out of the tinyruntime release, so they are checked against
+// `vendor/tinyruntime` via `sharesWith`.
+const PIN_MAP = {
+  tinydocs: { submodule: 'vendor/tinydocs' },
+  tinywallet: { submodule: 'vendor/tinywallet' },
+  tinymemory: { submodule: 'vendor/tinymemory' },
+  tinyjuice: { submodule: 'vendor/tinyjuice' },
+  tinyvoice: { submodule: 'vendor/tinyvoice' },
+  tinyruntime: { submodule: 'vendor/tinyruntime' },
+  tinymcp: { submodule: 'vendor/tinymcp' },
+  'tinyruntime-nodejs': {
+    submodule: null,
+    sharesWith: 'vendor/tinyruntime',
+    reason: 'published from the tinyruntime release; no repository of its own',
+  },
+  'tinyruntime-python': {
+    submodule: null,
+    sharesWith: 'vendor/tinyruntime',
+    reason: 'published from the tinyruntime release; no repository of its own',
+  },
+};
+
+const failures = [];
+const notes = [];
+const fail = (m) => failures.push(m);
+
+/** Run a command, or die. Never returns a sentinel a caller could mistake for success. */
+function mustRun(cmd, args, cwd, what) {
+  try {
+    return execFileSync(cmd, args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+  } catch (error) {
+    // Fail closed. A gate that treats "could not look" as "nothing wrong" is
+    // worse than no gate: it reports a clean scan of nothing.
+    const detail = (error.stderr || error.message || '').toString().trim().split('\n')[0];
+    throw new Error(`${what}: \`${cmd} ${args.join(' ')}\` failed in ${cwd}: ${detail}`);
+  }
+}
+
+function readOrDie(path, what) {
+  if (!existsSync(path)) throw new Error(`${what}: expected file is missing: ${path}`);
+  return readFileSync(path, 'utf8');
+}
+
+// ── Parse the registry ────────────────────────────────────────────────────────
+
+const registrySrc = readOrDie(join(ROOT, 'src/openhuman/modules/registry.rs'), 'registry');
+const allNames = parseAllList(registrySrc);
+const records = parseRecords(registrySrc);
+
+const active = [];
+for (const name of allNames) {
+  const rec = records.get(name);
+  if (!rec) { fail(`registry.rs: \`ALL\` lists ${name}, but no such ModuleRecord was parsed`); continue; }
+  if (!rec.id || !rec.version) { fail(`registry.rs: ${name} is missing an id or version`); continue; }
+  active.push(rec);
+}
+if (active.length === 0) fail('registry.rs: `ALL` resolved to zero usable records');
+
+// ── Check 3 first: is every record accounted for? ─────────────────────────────
+//
+// Before checking pins, check that we KNOW about every record. Running the pin
+// checks first would report "all pins agree" on a tree containing a module this
+// gate has never heard of.
+for (const f of checkPinMapCoverage(active.map((r) => r.id), Object.keys(PIN_MAP))) fail(f);
+
+// ── Exemptions ────────────────────────────────────────────────────────────────
+
+const exemptionsRaw = readOrDie(join(HERE, 'module-pin-exemptions.json'), 'exemptions');
+let exemptions;
+try {
+  exemptions = JSON.parse(exemptionsRaw).exemptions ?? [];
+} catch (error) {
+  throw new Error(`module-pin-exemptions.json is not valid JSON: ${error.message}`);
+}
+const exemptById = new Map(exemptions.map((e) => [e.id, e]));
+for (const e of exemptions) {
+  if (!e.id || !e.expect || !e.reason) {
+    fail(`module-pin-exemptions.json: entry ${JSON.stringify(e.id ?? e)} needs id, expect and reason`);
+  }
+  if (!active.some((r) => r.id === e.id)) {
+    fail(`module-pin-exemptions.json: "${e.id}" is not a record in modules::registry::ALL. Remove it.`);
+  }
+}
+
+// ── Check 1: registry version vs submodule tag ────────────────────────────────
+
+function describe(submodulePath) {
+  const abs = join(ROOT, submodulePath);
+  if (!existsSync(join(abs, '.git'))) {
+    // Not "skip". A lane that runs this gate must check submodules out; if it
+    // does not, the gate has scanned nothing and must say so.
+    throw new Error(
+      `${submodulePath} is not a checked-out submodule (no .git). This gate needs ` +
+        `submodules; run it in a lane with \`submodules: recursive\`.`,
+    );
+  }
+  // `--tags` so lightweight tags count; no `--exact-match`, because the drift we
+  // are hunting is exactly the "N commits past the tag" form and we want to
+  // report it rather than get an opaque failure.
+  return mustRun('git', ['describe', '--tags', 'HEAD'], abs, `describe ${submodulePath}`);
+}
+
+const describeCache = new Map();
+function describeCached(path) {
+  if (!describeCache.has(path)) describeCache.set(path, describe(path));
+  return describeCache.get(path);
+}
+
+for (const rec of active) {
+  const entry = PIN_MAP[rec.id];
+  if (!entry) continue; // already reported above
+  const path = entry.submodule ?? entry.sharesWith;
+  if (!path) {
+    fail(`PIN_MAP["${rec.id}"] has neither submodule nor sharesWith`);
+    continue;
+  }
+  const actual = describeCached(path);
+  const verdict = classifyPin({
+    id: rec.id,
+    version: rec.version,
+    submodulePath: path,
+    actual,
+    exemption: exemptById.get(rec.id),
+  });
+  if (!verdict.ok) {
+    fail(verdict.message);
+  } else if (verdict.kind === 'exempt') {
+    const why = verdict.reason.length > 96 ? `${verdict.reason.slice(0, 93)}...` : verdict.reason;
+    notes.push(`  ~ ${rec.id}: ${actual} — declared exemption: ${why}`);
+  }
+}
+
+// ── Check 2: the tinymemory pin set ───────────────────────────────────────────
+//
+// tinymemory is the only record pinned in more than two places, so it is the
+// only one with a spread this wide. Keyed off the record rather than a literal,
+// so re-pinning tinymemory does not need this file edited.
+
+const memRec = active.find((r) => r.id === 'tinymemory');
+if (!memRec) {
+  fail('modules::registry::ALL no longer has a "tinymemory" record; the tinymemory pin-set check cannot run');
+} else {
+  const memSrc = readOrDie(join(ROOT, 'src/openhuman/modules/memory.rs'), 'modules/memory.rs');
+  const pin = parseArtifactCapabilitiesPin(memSrc);
+  if (!pin) {
+    fail('src/openhuman/modules/memory.rs: could not find ARTIFACT_CAPABILITIES_PIN');
+  } else if (pin !== memRec.version) {
+    fail(
+      `ARTIFACT_CAPABILITIES_PIN and the tinymemory registry record disagree.\n` +
+        `    registry.rs version              : ${memRec.version}\n` +
+        `    modules/memory.rs PIN            : ${pin}\n` +
+        `    These name the release whose capability set the host assumes. Moving one\n` +
+        `    without the other is what #5598 looked like from the inside.`,
+    );
+  }
+
+  const WORKFLOWS = ['.github/workflows/ci-full.yml', '.github/workflows/ci-lite.yml', '.github/workflows/e2e-reusable.yml'];
+  let sawAnyBlock = false;
+  for (const wf of WORKFLOWS) {
+    const src = readOrDie(join(ROOT, wf), `workflow ${wf}`);
+    const { versions, digests, archives } = parseWorkflowMemoryBlocks(src);
+
+    if (versions.length === 0) {
+      // The blocks are how CI gets a real module to test against. If one is
+      // renamed away this check must not quietly cover fewer files.
+      fail(`${wf}: no \`memory_version="…"\` block found. If these moved, update WORKFLOWS in this script.`);
+      continue;
+    }
+    if (versions.length !== digests.length) {
+      fail(`${wf}: ${versions.length} memory_version block(s) but ${digests.length} memory_sha256 — they pair up`);
+    }
+    sawAnyBlock = true;
+
+    versions.forEach((v, i) => {
+      if (v !== memRec.version) {
+        fail(
+          `${wf}: memory_version="${v}" but the tinymemory registry record is ${memRec.version}.\n` +
+            `    CI would fetch a different release than the product pins.`,
+        );
+      }
+      const digest = digests[i];
+      if (!digest) return;
+      const known = memRec.assets.find((a) => a.sha256 === digest);
+      if (!known) {
+        fail(
+          `${wf}: memory_sha256="${digest}" matches no asset digest in the tinymemory record.\n` +
+            `    Take it verbatim from the release's checksum.toml, as registry.rs:23-25 requires.`,
+        );
+      }
+    });
+
+    // The archive name embeds the version through ${memory_version}; assert the
+    // literal half resolves to an asset the record actually publishes.
+    for (const a of archives) {
+      const resolved = a.replace(/\$\{memory_version\}/g, memRec.version);
+      if (!memRec.assets.some((asset) => asset.archive === resolved)) {
+        fail(
+          `${wf}: builds archive name "${resolved}", which the tinymemory record does not publish.\n` +
+            `    Known: ${memRec.assets.map((x) => x.archive).join(', ')}`,
+        );
+      }
+    }
+  }
+  if (!sawAnyBlock) fail('no workflow carried a memory_version block — this check scanned nothing');
+}
+
+// ── Report ────────────────────────────────────────────────────────────────────
+
+if (failures.length > 0) {
+  console.error('\nModule pin check FAILED\n');
+  for (const f of failures) console.error(`  ✗ ${f}\n`);
+  console.error(
+    'Why this gate exists: a module is pinned twice — as a submodule (the contract this\n' +
+      'build compiles against) and as a version+digest in modules/registry.rs (the artifact\n' +
+      'loaded at runtime). When they disagree the build is green and the failure lands on a\n' +
+      "user's machine. openhuman#5727.\n",
+  );
+  process.exit(1);
+}
+
+console.log(`Module pin check OK — ${active.length} record(s) in modules::registry::ALL, all pins accounted for.`);
+for (const n of notes) console.log(n);

--- a/scripts/ci/check-submodule-monotonic.mjs
+++ b/scripts/ci/check-submodule-monotonic.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+// Fails when a `vendor/*` submodule pin moves BACKWARDS — onto a commit that is
+// an ancestor of the one the base branch already had.
+//
+// This is the other half of openhuman#5727, and on the evidence it is the half
+// that actually bites. A check that only asserts "the pins agree with each
+// other" would have passed the commit that caused the most recent regression,
+// because that commit WAS internally consistent — it was consistent with an
+// older release.
+//
+//   14a23b994 "Pin v1.10.0 and route memory-source sync through the driver"
+//     vendor/tinyagents  e0f3210 -> bbcd0a6
+//
+//   $ git -C vendor/tinyagents merge-base --is-ancestor bbcd0a6 e0f3210 && echo backwards
+//   backwards
+//
+// e0f3210 is tinyagents#122 (2026-08-25); bbcd0a6 is #121 (2026-08-22). The bump
+// silently removed a shipped fix from the product and nobody noticed until #5796
+// put it back. #5787 was raised to undo the same shape on #5725.
+//
+// Note what the registry-pin check could NOT have done here: `tinyagents` has no
+// record in `modules::registry::ALL` at all — no version, no digest. It is a
+// compile-time dependency with exactly ONE pin, so "do the two pins agree?" has
+// nothing to compare. Only movement direction catches it. That is why this is a
+// separate gate over ALL sixteen submodules rather than an extra assertion in
+// check-module-pins.mjs, which can only ever see the seven that are also modules.
+//
+// A backwards move is not always wrong — reverting a bad bump is a backwards
+// move and is exactly right. It just must be deliberate, so it is declared: put
+// `[pin-rewind]` in the PR title or any commit message on the branch, naming why.
+//
+// No `gh` and no API: this reads gitlinks out of the two trees with git alone,
+// so it cannot be defeated by `gh pr view --json files` silently capping at 100
+// files — which is how the #5725 gitlink went unreviewed in the first place.
+//
+// Usage: check-submodule-monotonic.mjs [base-ref] [head-ref]
+//   Defaults: origin/$GITHUB_BASE_REF (or origin/main) .. HEAD
+import { execFileSync } from 'node:child_process';
+
+import { parseGitlinks, rewindDeclared } from '../lib/module-pins.mjs';
+
+// Any throw below is a check that could not be COMPLETED, which is not the same
+// as a check that passed. Report it as a failure with a legible message rather
+// than a stack trace, and never exit 0. Two gates have shipped here that
+// swallowed a git error and reported clean having scanned nothing.
+process.on('uncaughtException', (error) => {
+  console.error(`\nSubmodule monotonicity check FAILED\n`);
+  console.error(`  \u2717 ${error.message}\n`);
+  console.error('  This gate could not complete. That is a failure, not a pass.\n');
+  process.exit(1);
+});
+
+const rawBase = process.argv[2] ?? (process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : 'origin/main');
+const HEAD = process.argv[3] ?? 'HEAD';
+
+function run(args, cwd = '.') {
+  return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+
+/** Run, or throw with context. Never returns a value a caller could read as "fine". */
+function mustRun(args, cwd, what) {
+  try {
+    return run(args, cwd);
+  } catch (error) {
+    const detail = (error.stderr || error.message || '').toString().trim().split('\n')[0];
+    throw new Error(`${what}: \`git ${args.join(' ')}\` failed in ${cwd}: ${detail}`);
+  }
+}
+
+/** path -> gitlink sha, for every submodule recorded in `ref`'s tree. */
+function gitlinks(ref) {
+  return parseGitlinks(mustRun(['ls-tree', '-r', ref], '.', `read tree of ${ref}`));
+}
+
+// Resolve the base. A base we cannot resolve is a hard stop: continuing would
+// scan zero submodules and print a pass.
+let base;
+try {
+  base = run(['rev-parse', '--verify', `${rawBase}^{commit}`]);
+} catch {
+  try {
+    base = run(['rev-parse', '--verify', `${rawBase.replace(/^origin\//, '')}^{commit}`]);
+  } catch {
+    console.error(
+      `Submodule monotonicity check FAILED\n\n` +
+        `  ✗ cannot resolve base ref "${rawBase}".\n` +
+        `    Fetch it before running this gate (actions/checkout needs fetch-depth: 0,\n` +
+        `    or an explicit \`git fetch origin <base>\`). Refusing to pass having compared\n` +
+        `    nothing.\n`,
+    );
+    process.exit(1);
+  }
+}
+
+const mergeBase = mustRun(['merge-base', base, HEAD], '.', 'find merge base');
+const before = gitlinks(mergeBase);
+const after = gitlinks(HEAD);
+
+if (after.size === 0) {
+  console.error('Submodule monotonicity check FAILED\n\n  ✗ HEAD records zero submodules — this gate scanned nothing.\n');
+  process.exit(1);
+}
+
+// A deliberate rewind is declared on the branch, not configured in a file: the
+// declaration should travel with the commit that does it.
+const branchText = [
+  process.env.PR_TITLE ?? '',
+  (() => {
+    try { return run(['log', '--format=%B', `${mergeBase}..${HEAD}`]); } catch { return ''; }
+  })(),
+].join('\n');
+const declaredRewind = rewindDeclared(branchText);
+
+const moved = [];
+for (const [path, headSha] of after) {
+  const baseSha = before.get(path);
+  if (!baseSha || baseSha === headSha) continue;
+  moved.push({ path, baseSha, headSha, added: !before.has(path) });
+}
+
+const failures = [];
+const forward = [];
+
+for (const { path, baseSha, headSha } of moved) {
+  // Both commits must be present in the submodule's object store to answer the
+  // question. If they are not, say so and fail — do not assume forward.
+  let haveBoth = true;
+  for (const sha of [baseSha, headSha]) {
+    try {
+      run(['cat-file', '-e', `${sha}^{commit}`], path);
+    } catch {
+      haveBoth = false;
+      try {
+        run(['fetch', '--quiet', 'origin', sha], path);
+        run(['cat-file', '-e', `${sha}^{commit}`], path);
+        haveBoth = true;
+      } catch {
+        failures.push(
+          `${path}: cannot verify direction — commit ${sha.slice(0, 9)} is not in the submodule's\n` +
+            `    object store and could not be fetched. This gate does not guess: a pin whose\n` +
+            `    direction cannot be established is treated as unverified, not as forward.`,
+        );
+      }
+    }
+    if (!haveBoth) break;
+  }
+  if (!haveBoth) continue;
+
+  let backwards = false;
+  try {
+    execFileSync('git', ['merge-base', '--is-ancestor', headSha, baseSha], { cwd: path, stdio: 'ignore' });
+    backwards = true;
+  } catch (error) {
+    // Exit 1 is the honest "not an ancestor". Anything else is a broken query.
+    if (error.status !== 1) {
+      failures.push(`${path}: ancestry query failed (exit ${error.status}) — treating as unverified.`);
+      continue;
+    }
+  }
+
+  if (backwards) {
+    const oldSubject = (() => { try { return run(['log', '--format=%h %ad %s', '--date=short', '-1', baseSha], path); } catch { return baseSha.slice(0, 9); } })();
+    const newSubject = (() => { try { return run(['log', '--format=%h %ad %s', '--date=short', '-1', headSha], path); } catch { return headSha.slice(0, 9); } })();
+    const behind = (() => { try { return run(['rev-list', '--count', `${headSha}..${baseSha}`], path); } catch { return '?'; } })();
+    failures.push(
+      `${path} moved BACKWARDS by ${behind} commit(s).\n` +
+        `    base : ${oldSubject}\n` +
+        `    head : ${newSubject}\n` +
+        `    The new pin is an ancestor of the one on the base branch, so everything\n` +
+        `    merged into that submodule in between is removed from this build. That is\n` +
+        `    how 14a23b994 dropped tinyagents#122 (restored later by #5796) and how #5725\n` +
+        `    dropped eight tinyagents commits (undone by #5787). Neither showed up as a\n` +
+        `    code change — a gitlink bump is two lines and no diff.\n` +
+        `    If the rewind is deliberate, say so: put [pin-rewind] in the PR title or a\n` +
+        `    commit message on this branch, with the reason.`,
+    );
+  } else {
+    forward.push(path);
+  }
+}
+
+if (failures.length > 0 && declaredRewind) {
+  const rewinds = failures.filter((f) => f.includes('moved BACKWARDS'));
+  const other = failures.filter((f) => !f.includes('moved BACKWARDS'));
+  if (other.length === 0) {
+    console.log('Submodule monotonicity check OK — backwards move(s) declared with [pin-rewind]:\n');
+    for (const r of rewinds) console.log(`  ~ ${r.split('\n')[0]}`);
+    process.exit(0);
+  }
+  // An unverifiable pin is never waived by [pin-rewind]: the marker declares a
+  // known rewind, it does not license skipping the check.
+  console.error('\nSubmodule monotonicity check FAILED\n');
+  for (const f of other) console.error(`  ✗ ${f}\n`);
+  process.exit(1);
+}
+
+if (failures.length > 0) {
+  console.error('\nSubmodule monotonicity check FAILED\n');
+  for (const f of failures) console.error(`  ✗ ${f}\n`);
+  process.exit(1);
+}
+
+const changed = moved.length;
+console.log(
+  changed === 0
+    ? `Submodule monotonicity check OK — ${after.size} submodule(s), none moved against ${rawBase}.`
+    : `Submodule monotonicity check OK — ${changed} submodule pin(s) moved forward: ${forward.join(', ')}`,
+);

--- a/scripts/ci/check-submodule-monotonic.mjs
+++ b/scripts/ci/check-submodule-monotonic.mjs
@@ -37,7 +37,7 @@
 //   Defaults: origin/$GITHUB_BASE_REF (or origin/main) .. HEAD
 import { execFileSync } from 'node:child_process';
 
-import { parseGitlinks, rewindDeclared } from '../lib/module-pins.mjs';
+import { classifyMove, parseGitlinks, rewindDeclared } from '../lib/module-pins.mjs';
 
 // Any throw below is a check that could not be COMPLETED, which is not the same
 // as a check that passed. Report it as a failure with a legible message rather
@@ -146,24 +146,43 @@ for (const { path, baseSha, headSha } of moved) {
   }
   if (!haveBoth) continue;
 
-  let backwards = false;
-  try {
-    execFileSync('git', ['merge-base', '--is-ancestor', headSha, baseSha], { cwd: path, stdio: 'ignore' });
-    backwards = true;
-  } catch (error) {
-    // Exit 1 is the honest "not an ancestor". Anything else is a broken query.
-    if (error.status !== 1) {
-      failures.push(`${path}: ancestry query failed (exit ${error.status}) — treating as unverified.`);
-      continue;
+  /** `merge-base --is-ancestor` answers 0 (yes) or 1 (no); anything else is broken. */
+  const isAncestor = (a, b) => {
+    try {
+      execFileSync('git', ['merge-base', '--is-ancestor', a, b], { cwd: path, stdio: 'ignore' });
+      return true;
+    } catch (error) {
+      if (error.status === 1) return false;
+      throw new Error(`ancestry query failed (exit ${error.status})`);
     }
+  };
+
+  // BOTH directions. Asking only "is head an ancestor of base?" and reading a
+  // failed query as forward mistakes a DIVERGENT pin — head and base on sibling
+  // branches, or a rebased submodule history — for a fast-forward. Divergence
+  // loses the base's commits exactly as a rewind does, so it is not forward.
+  let move;
+  try {
+    move = classifyMove({
+      headIsAncestorOfBase: isAncestor(headSha, baseSha),
+      baseIsAncestorOfHead: isAncestor(baseSha, headSha),
+    });
+  } catch (error) {
+    failures.push(`${path}: ${error.message} — treating as unverified, not as forward.`);
+    continue;
   }
 
-  if (backwards) {
+  if (move === 'rewind' || move === 'divergent') {
     const oldSubject = (() => { try { return run(['log', '--format=%h %ad %s', '--date=short', '-1', baseSha], path); } catch { return baseSha.slice(0, 9); } })();
     const newSubject = (() => { try { return run(['log', '--format=%h %ad %s', '--date=short', '-1', headSha], path); } catch { return headSha.slice(0, 9); } })();
     const behind = (() => { try { return run(['rev-list', '--count', `${headSha}..${baseSha}`], path); } catch { return '?'; } })();
+    const headline =
+      move === 'rewind'
+        ? `${path} moved BACKWARDS by ${behind} commit(s).`
+        : `${path} moved SIDEWAYS — the new pin and the base pin have diverged, and ` +
+          `${behind} commit(s) on the base side are not reachable from it.`;
     failures.push(
-      `${path} moved BACKWARDS by ${behind} commit(s).\n` +
+      `${headline}\n` +
         `    base : ${oldSubject}\n` +
         `    head : ${newSubject}\n` +
         `    The new pin is an ancestor of the one on the base branch, so everything\n` +
@@ -180,8 +199,9 @@ for (const { path, baseSha, headSha } of moved) {
 }
 
 if (failures.length > 0 && declaredRewind) {
-  const rewinds = failures.filter((f) => f.includes('moved BACKWARDS'));
-  const other = failures.filter((f) => !f.includes('moved BACKWARDS'));
+  const isMove = (f) => f.includes('moved BACKWARDS') || f.includes('moved SIDEWAYS');
+  const rewinds = failures.filter(isMove);
+  const other = failures.filter((f) => !isMove(f));
   if (other.length === 0) {
     console.log('Submodule monotonicity check OK — backwards move(s) declared with [pin-rewind]:\n');
     for (const r of rewinds) console.log(`  ~ ${r.split('\n')[0]}`);

--- a/scripts/ci/module-pin-exemptions.json
+++ b/scripts/ci/module-pin-exemptions.json
@@ -1,0 +1,28 @@
+{
+  "$comment": [
+    "Records in `modules::registry::ALL` whose submodule pin deliberately does",
+    "NOT sit on the tag their `version` names. See scripts/ci/check-module-pins.mjs.",
+    "",
+    "An entry here is a claim that the drift is known and accepted, NOT a way to",
+    "silence the gate: `expect` pins the exact `git describe --tags` output, so a",
+    "record already exempt cannot drift FURTHER without failing. Widening the drift",
+    "is a deliberate edit to this file, which is a reviewable diff.",
+    "",
+    "Delete an entry the moment the pins are reconciled. An exemption that has",
+    "stopped being true fails the gate too — `expect` must still match."
+  ],
+  "exemptions": [
+    {
+      "id": "tinymcp",
+      "submodule": "vendor/tinymcp",
+      "expect": "v0.3.1-15-g5909bd1",
+      "reason": "openhuman takes tinymcp with default-features = false (Cargo.toml:296), which switches the module adapter off, so the 0.3.1 artifact this record would download is never loaded. The submodule is the compile-time contract; the record is inert. Tracked by openhuman#5727."
+    },
+    {
+      "id": "tinywallet",
+      "submodule": "vendor/tinywallet",
+      "expect": "v0.5.0-8-g8c728de",
+      "reason": "v0.5.0 is still the newest tinywallet release, so there is no tag to re-pin the record to. The eight commits past it are dependabot bumps, two of them major (coins-bip32 0.8.7 to 0.13.1, sha3 0.10.9 to 0.12.0). Whether the loaded 0.5.0 cdylib and the compiled 8c728de bus crate still agree on the wire is UNDETERMINED. Tracked by openhuman#5727."
+    }
+  ]
+}

--- a/scripts/lib/module-pins.mjs
+++ b/scripts/lib/module-pins.mjs
@@ -1,0 +1,153 @@
+// Pure parsing and decision logic for the module-pin gates (openhuman#5727).
+//
+// Everything here is a pure function over strings so it can be tested without a
+// git tree; the two CLIs in scripts/ci/ own the git calls and the process exit.
+// See scripts/ci/check-module-pins.mjs for what the gate is for.
+
+/** The record names listed in `pub const ALL`, in order. */
+export function parseAllList(src) {
+  const block = src.match(/pub const ALL: &\[ModuleRecord\] = &\[([\s\S]*?)\];/);
+  if (!block) throw new Error('registry.rs: could not find `pub const ALL`');
+  return block[1]
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && !s.startsWith('//'));
+}
+
+/** Every `const NAME: ModuleRecord = ModuleRecord { … };`, keyed by NAME. */
+export function parseRecords(src) {
+  const records = new Map();
+  const re = /(?:pub )?const ([A-Z0-9_]+): ModuleRecord = ModuleRecord \{([\s\S]*?)\n\};/g;
+  for (const m of src.matchAll(re)) {
+    const [, name, body] = m;
+    const field = (f) => {
+      const hit = body.match(new RegExp(`^\\s*${f}: "([^"]*)"`, 'm'));
+      return hit ? hit[1] : null;
+    };
+    const assets = [];
+    const assetRe =
+      /PlatformAsset \{\s*host_key: "([^"]+)",\s*archive: "([^"]+)",\s*sha256: "([^"]+)",\s*\}/g;
+    for (const a of body.matchAll(assetRe)) {
+      assets.push({ hostKey: a[1], archive: a[2], sha256: a[3] });
+    }
+    records.set(name, { name, id: field('id'), version: field('version'), assets });
+  }
+  if (records.size === 0) throw new Error('registry.rs: parsed zero ModuleRecord blocks');
+  return records;
+}
+
+/** `ARTIFACT_CAPABILITIES_PIN` from modules/memory.rs. */
+export function parseArtifactCapabilitiesPin(src) {
+  const m = src.match(/ARTIFACT_CAPABILITIES_PIN: &str = "([^"]+)"/);
+  return m ? m[1] : null;
+}
+
+/** The `memory_version` / `memory_sha256` / `memory_archive` literals in a workflow. */
+export function parseWorkflowMemoryBlocks(src) {
+  return {
+    versions: [...src.matchAll(/^\s*memory_version="([^"]+)"/gm)].map((m) => m[1]),
+    digests: [...src.matchAll(/^\s*memory_sha256="([^"]+)"/gm)].map((m) => m[1]),
+    archives: [...src.matchAll(/^\s*memory_archive="[^"]*\/(tinymemory-module-[^"]+?)"/gm)].map((m) => m[1]),
+  };
+}
+
+/**
+ * Decide what one record's pin state means.
+ *
+ * `actual` is `git describe --tags` output for the submodule; `exemption` is the
+ * matching entry from module-pin-exemptions.json, or undefined.
+ *
+ * Four outcomes, and three of them are failures — including "exempt but the
+ * pins now agree". A stale exemption is not harmless: it is a standing licence
+ * for the next real drift on that record to pass unnoticed.
+ */
+export function classifyPin({ id, version, submodulePath, actual, exemption }) {
+  const wanted = `v${version}`;
+  if (actual === wanted) {
+    if (exemption) {
+      return {
+        ok: false,
+        kind: 'stale-exemption',
+        message:
+          `"${id}" is listed in module-pin-exemptions.json, but its pins now AGREE ` +
+          `(${submodulePath} is at ${actual}). Delete the exemption — a stale exemption ` +
+          `hides the next real drift.`,
+      };
+    }
+    return { ok: true, kind: 'match' };
+  }
+  if (exemption) {
+    if (exemption.expect !== actual) {
+      return {
+        ok: false,
+        kind: 'exemption-widened',
+        message:
+          `"${id}" drift has CHANGED since it was accepted.\n` +
+          `    registry.rs version : ${version} (expects tag ${wanted})\n` +
+          `    ${submodulePath} is at : ${actual}\n` +
+          `    exemption pins      : ${exemption.expect}\n` +
+          `    An exemption accepts one specific drift, not any drift. If the new state is\n` +
+          `    intended, update \`expect\` and the reason in module-pin-exemptions.json.`,
+      };
+    }
+    return { ok: true, kind: 'exempt', reason: exemption.reason };
+  }
+  return {
+    ok: false,
+    kind: 'drift',
+    message:
+      `"${id}" registry pin and submodule pin describe different releases.\n` +
+      `    registry.rs version : ${version}  (would download the v${version} artifact)\n` +
+      `    ${submodulePath} is at : ${actual}  (what this build compiles the contract against)\n` +
+      `    Fix by moving whichever pin is stale, or — if the two are meant to differ —\n` +
+      `    declare it in scripts/ci/module-pin-exemptions.json with a reason.`,
+  };
+}
+
+/**
+ * Every record in `ALL` must be known to the pin map, and every pin-map entry
+ * must still be a record.
+ *
+ * This is the half that survives the next module landing. Six vendored crates
+ * were added between 2026-08-20 and 2026-08-27; a gate that enumerated the
+ * modules of the day would already be behind, and would report a clean scan
+ * while ignoring the newest one.
+ */
+export function checkPinMapCoverage(activeIds, pinMapIds) {
+  const failures = [];
+  for (const id of activeIds) {
+    if (!pinMapIds.includes(id)) {
+      failures.push(
+        `modules::registry::ALL contains "${id}", which scripts/ci/check-module-pins.mjs ` +
+          `does not know about.\n` +
+          `    Add it to PIN_MAP: either name the vendor/ submodule that is the source of\n` +
+          `    truth for its version, or set submodule: null with a reason (and sharesWith,\n` +
+          `    if it ships out of another crate's release).\n` +
+          `    This is deliberate: a new module must not inherit an unchecked pin.`,
+      );
+    }
+  }
+  for (const id of pinMapIds) {
+    if (!activeIds.includes(id)) {
+      failures.push(
+        `PIN_MAP has an entry for "${id}", which is no longer in modules::registry::ALL. Remove it.`,
+      );
+    }
+  }
+  return failures;
+}
+
+/** path -> gitlink sha, parsed from `git ls-tree -r <ref>` output. */
+export function parseGitlinks(lsTreeOutput) {
+  const map = new Map();
+  for (const line of lsTreeOutput.split('\n')) {
+    const m = line.match(/^160000 commit ([0-9a-f]{40})\t(.+)$/);
+    if (m) map.set(m[2], m[1]);
+  }
+  return map;
+}
+
+/** A deliberate rewind is declared on the branch that does it. */
+export function rewindDeclared(text) {
+  return /\[pin-rewind\]/i.test(text ?? '');
+}

--- a/scripts/lib/module-pins.mjs
+++ b/scripts/lib/module-pins.mjs
@@ -4,14 +4,26 @@
 // git tree; the two CLIs in scripts/ci/ own the git calls and the process exit.
 // See scripts/ci/check-module-pins.mjs for what the gate is for.
 
-/** The record names listed in `pub const ALL`, in order. */
+/**
+ * The record names listed in `pub const ALL`, in order.
+ *
+ * Line comments are stripped BEFORE splitting on commas, not filtered out after.
+ * Splitting first puts a standalone `// …` line and the record beneath it in the
+ * SAME token, so filtering tokens that begin with `//` discarded the record with
+ * the comment. `ALL` carries no comments today, so this was latent rather than
+ * live — but the records it lists are heavily commented individually, the list is
+ * where a "why is this one eager" note would naturally go, and a dropped record
+ * reads downstream as "missing from PIN_MAP": the gate would fail CI while
+ * pointing at the wrong thing entirely. Raised by CodeRabbit on #5812.
+ */
 export function parseAllList(src) {
   const block = src.match(/pub const ALL: &\[ModuleRecord\] = &\[([\s\S]*?)\];/);
   if (!block) throw new Error('registry.rs: could not find `pub const ALL`');
   return block[1]
+    .replace(/\/\/[^\n]*/g, '')
     .split(',')
     .map((s) => s.trim())
-    .filter((s) => s.length > 0 && !s.startsWith('//'));
+    .filter((s) => s.length > 0);
 }
 
 /** Every `const NAME: ModuleRecord = ModuleRecord { … };`, keyed by NAME. */
@@ -150,4 +162,43 @@ export function parseGitlinks(lsTreeOutput) {
 /** A deliberate rewind is declared on the branch that does it. */
 export function rewindDeclared(text) {
   return /\[pin-rewind\]/i.test(text ?? '');
+}
+
+/**
+ * Classify a submodule pin move from BOTH ancestry answers.
+ *
+ * "Not an ancestor" is not the same as "forward". When the new commit and the
+ * base commit are siblings — a side branch, or a submodule whose history was
+ * rebased — neither is an ancestor of the other, and a check that asks only
+ * `is-ancestor head base` sees its single query fail and calls the move forward.
+ *
+ * A divergent pin drops whatever the base branch had just as surely as a rewind
+ * does; it simply does it sideways. Since the whole point of this gate is that a
+ * pin must not silently lose commits, treating divergence as forward would
+ * defeat it: a rewind onto a sibling — 14a23b994's shape, one rebase away —
+ * would walk straight through.
+ *
+ * So both directions are asked and only a genuine descendant is forward.
+ */
+export function classifyMove({ headIsAncestorOfBase, baseIsAncestorOfHead }) {
+  if (headIsAncestorOfBase) return 'rewind';
+  if (baseIsAncestorOfHead) return 'forward';
+  return 'divergent';
+}
+
+/**
+ * Does `toplevel` prove that `path` is a checked-out submodule?
+ *
+ * `git -C <path> rev-parse --git-dir` cannot answer this: git walks UPWARD, so
+ * from an uninitialised or merely empty `vendor/<x>` it answers the
+ * SUPERPROJECT's `.git` and exits 0 — reporting "present" having checked
+ * nothing. `--show-toplevel` answers the root of whichever repository owns the
+ * directory, and only when that root IS the directory is it a real checkout.
+ *
+ * Both sides must already be realpath-resolved by the caller: macOS resolves
+ * `/tmp/...` to `/private/tmp/...`, and comparing one resolved path against one
+ * unresolved path is its own quiet false negative.
+ */
+export function toplevelProvesSubmodule(resolvedToplevel, resolvedPath) {
+  return Boolean(resolvedToplevel) && resolvedToplevel === resolvedPath;
 }


### PR DESCRIPTION
## Summary

- Nine subsystems load as downloaded cdylib modules, each pinned **twice** and independently — as a git submodule (the contract this repo compiles against) and as a `version` + per-platform SHA-256 in `modules/registry.rs` (the artifact loaded at runtime). Nothing compared them.
- Adds **two** gates, not one. They catch different mechanisms, and the second is the one that catches what has actually bitten.
- Coverage: **7 module crates / 9 records** for gate 1, **all 16 submodules** for gate 2. Neither enumerates a fixed list — crate 17 fails the gate until it is accounted for.
- Fail-closed on every path that cannot complete. 21 tests, run by the existing Scripts Self-Tests lane.

## Problem

A pin bump on either side alone produces a build that compiles clean, passes every lane, and then loses a capability at runtime on a user's machine. That is #5598 (capability bitmask 8191 vs 262143), #5623 (learning scheduler failing 260x, missing `ListAllFacets`), #5641 (memory driver missing the profile family). All three closed by bumping a pin; none left behind anything that would catch the fourth.

The module ABI gate cannot catch it: it checks magic, ABI revision, pointer width, target triple, endianness, feature bits and panic strategy — **none of which encodes which release the artifact is**. A correctly built older artifact is admitted without complaint.

`registry.rs`'s own nine tests are thorough about *internal* consistency and say nothing about the source tree. `every_asset_name_carries_the_pinned_version` states the goal exactly: *"The digests and the version have to describe one release."* One release — not one *source commit*.

## Why two gates and not one

This is the part worth reading, because the obvious single gate is not sufficient.

The obvious gate — and the one #5727 suggests — is an **equality** check: for each record, does `registry.rs`'s `version` match `vendor/<crate>`'s tag? That is gate 1, and it is worth having.

It would not have caught the most recent regression.

```console
$ git show --stat 14a23b994 | grep vendor/
 vendor/tinyagents  | 2 +-
 vendor/tinymemory  | 2 +-

$ git -C vendor/tinyagents merge-base --is-ancestor bbcd0a6 e0f3210 && echo "backwards"
backwards
```

`14a23b994` ("Pin v1.10.0 and route memory-source sync through the driver") moved `vendor/tinyagents` from `e0f3210` — tinyagents#122, 2026-08-25 — back to `bbcd0a6` — #121, 2026-08-22. Eight commits backwards. It silently removed a shipped fix from the product, and nobody noticed until #5796 restored it. #5725 did the identical eight-commit rewind, undone by #5787.

Two things make the equality gate blind to this:

1. **That commit was internally consistent.** It adopted a coordinated pin set. Every pin agreed with every other pin — they agreed on an *older* release. An equality check asks "do these two match?", and the answer was yes.
2. **`tinyagents` has no registry record at all.** It is not in `ALL`; it has no `version`, no digest, no artifact. It is a compile-time dependency with exactly **one** pin, so "do the two pins agree?" has nothing to compare. Gate 1 cannot look at it even in principle.

So the second gate asks a different question — not *do the pins agree*, but *did a pin move backwards* — and it asks it of all sixteen submodules rather than the seven that are also modules. It fails on both `14a23b994` and `77fddf591` (#5725) today; there is a test for the first.

A backwards move is not always wrong: reverting a bad bump is a backwards move and is exactly right. It just has to be deliberate, so it is declared with `[pin-rewind]` in the PR title or a commit message on the branch.

Neither gate uses `gh`. Both read gitlinks with git directly, so they cannot be defeated by `gh pr view --json files` silently capping at 100 files — which is how the #5725 gitlink went unreviewed in the first place.

## What gate 1 covers

Five pin sites move together, and they are not uniform — sites 3-5 exist **only** for tinymemory, which is the one module pinned in more than two places:

| # | Site | Scope |
|---|---|---|
| 1 | the `vendor/<name>` gitlink | all 7 module crates |
| 2 | `modules/registry.rs` version + digests | 9 records |
| 3 | `ARTIFACT_CAPABILITIES_PIN` (`modules/memory.rs`) | tinymemory only |
| 4/5 | `memory_version` / `memory_sha256` in `ci-full.yml`, `ci-lite.yml`, `e2e-reusable.yml` | tinymemory only — note `e2e-reusable.yml` carries **two** blocks, so four occurrences over three files |

Changing one character of the tinymemory version raises **ten** findings across all five sites. The tinymemory checks are keyed off the record rather than a literal, so re-pinning tinymemory needs no edit to the gate.

## The exemptions file

Two records are drifted **today**: `tinymcp` is 15 commits past `v0.3.1` and `tinywallet` is 8 past `v0.5.0`. A hard-failing gate would land red on arrival, so `scripts/ci/module-pin-exemptions.json` declares them with reasons — the issue's suggested direction (2), so a record that deliberately does not track its submodule says so rather than being indistinguishable from drift.

What stops it becoming a dumping ground:

- **`expect` pins the exact `git describe` output.** An exempt record cannot drift *further* without failing — widening the drift is a deliberate edit to this file, which is a reviewable diff.
- **A stale exemption fails.** If the pins are reconciled and the entry is left behind, the gate fails and tells you to delete it. A stale exemption is not harmless: it is a standing licence for the next real drift on that record to pass unnoticed.
- **An exemption for a record that is no longer in `ALL` fails.**
- Every entry needs `id`, `expect` and `reason`, or the gate fails.

Both behaviours are tested (`an exemption whose drift has been fixed fails, so it cannot linger`, `a declared exemption passes only for the exact drift it declares`).

Reconciling the two drifted records is separate work — for `tinywallet` there is currently no newer tag to re-pin to.

## Coverage, and what happens when crate 17 lands

Gate 1 covers the 7 module crates behind the 9 records in `ALL`; gate 2 covers all 16 submodules, enumerated from the tree rather than from a list.

A guard that silently ignores a new crate is the same failure class it is meant to prevent, so gate 1 does not enumerate modules — it **requires every record in `ALL` to be accounted for** in `PIN_MAP`, and fails otherwise:

```
✗ modules::registry::ALL contains "tinyfuture", which scripts/ci/check-module-pins.mjs
  does not know about.
    Add it to PIN_MAP: either name the vendor/ submodule that is the source of
    truth for its version, or set submodule: null with a reason (and sharesWith,
    if it ships out of another crate's release).
    This is deliberate: a new module must not inherit an unchecked pin.
```

The reverse also fails: a `PIN_MAP` entry for a record that has been removed. Six vendored crates landed between 2026-08-20 and 2026-08-27 (`tinymcp`, `tinyjuice`, `tinybox`, `tinyruntime`, `tinydocs`, `tinyvoice`), so a guard listing the modules of the day would already be behind. Gate 2 needs no equivalent, because it reads the gitlinks out of the tree.

`tinyruntime-nodejs` and `tinyruntime-python` have no repository of their own — they ship out of the tinyruntime release — so they are declared `submodule: null` with `sharesWith: vendor/tinyruntime` and checked against it.

## Fail-closed evidence

Two CI gates here have swallowed a git error and reported clean having scanned nothing, so every path that cannot complete exits **non-zero**:

| Condition | Behaviour |
|---|---|
| submodule not checked out | **fail** — "not a checked-out submodule … run it in a lane with `submodules: recursive`". Never skipped. |
| registry file missing | **fail** — "expected file is missing" |
| registry unparseable (no `ALL`, zero records) | **fail** — throws rather than returning an empty set |
| exemptions file absent or invalid JSON | **fail** |
| base ref unresolvable | **fail** — "Refusing to pass having compared nothing" |
| a commit missing from a submodule's object store | fetch it; if still absent, **fail** — "does not guess: a pin whose direction cannot be established is treated as unverified, not as forward" |
| `merge-base --is-ancestor` exits other than 0/1 | **fail** — treated as unverified |
| zero submodules in `HEAD`, or zero workflow `memory_version` blocks | **fail** — "this gate scanned nothing" |
| any uncaught throw | **fail** with a legible message, via a top-level handler — never a stack trace, never exit 0 |
| `[pin-rewind]` present | waives a **declared rewind only**; never waives an unverifiable pin |

Four tests assert this directly against broken fixtures — an unparseable registry, a missing registry, a registry whose `vendor/` tree is absent, and the monotonicity gate run outside a git repo. Each asserts both a non-zero exit **and** that the success banner is absent, which matters: see the revert check below.

The job itself is deliberately **not** filtered on `changes` — a skipped job counts as a pass in `PR CI Gate`, and a path filter would have to watch `registry.rs`, `modules/memory.rs`, three workflows and sixteen gitlinks. It is a few seconds of pure Node.

## Revert checks

Every guard was reverted and the failure confirmed to name **my** assertion, not an incidental one.

**1. Drop the stale-exemption branch** (treat any exemption as a pass) → exactly one test fails:

```
✖ an exemption whose drift has been fixed fails, so it cannot linger
  AssertionError: Expected values to be strictly equal: true !== false
      at scripts/__tests__/module-pins.test.mjs:120:10
```

Line 120 is `assert.equal(v.ok, false)`.

**2. Make `PIN_MAP` coverage permissive** → exactly one test fails: `a record the pin map has never heard of fails`.

**3. Make a missing submodule skip instead of fail** — the classic fail-open → `records with no checked-out submodule fail the gate instead of being skipped` fails at `module-pins.test.mjs:271`:

```
AssertionError: The input did not match the regular expression
/not a checked-out submodule|submodules: recursive/
```

That third one is worth calling out. The exit code stayed non-zero **by coincidence** (a `null` describe reads as drift downstream), so the status assertion alone would have missed the fail-open. The message assertion is what caught it. Both are needed, and both are in every fail-closed test.

## Impact

CI only. No product code changes, no `vendor/` gitlink moves, no Cargo manifest touched. One new job (~10 min timeout, mostly the recursive submodule checkout) wired into `PR CI Gate`.

The `scripts` path filter now also watches `scripts/lib/**` and this gate's own files. It did not before, so a change to the checking logic would have skipped the lane that tests it — the gate would have stopped watching itself.

## Related

- Closes tinyhumansai/openhuman#5727
- Would have caught: `14a23b994` (restored by #5796) and #5725 (undone by #5787). Both fail gate 2 today.
- Prior art for the shape: `check-feature-forwarding.mjs`, cited in the issue — the feature-forwarding pair is machine-checked precisely because a silent divergence once shipped `voice` missing to 56 users.
- Not addressed here: `is_compatible` has **zero call sites**, so a member inside an already-advertised capability family that the pinned artifact does not serve still fails at runtime with `UnknownMethod` rather than at build. A pin can satisfy both gates and still be wrong that way. It needs the pinned tag's `METHODS` list, which is a different question and a different mechanism — worth its own issue rather than folding in here.
- Follow-up: reconcile the two declared exemptions. `tinywallet` has no newer tag to re-pin to today.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — 21 tests in `scripts/__tests__/module-pins.test.mjs`, run by the existing Scripts Self-Tests lane. Failure paths: drift, widened exemption, stale exemption, unknown record, removed record, unparseable registry, missing registry, uninitialised submodule, unresolvable base, no git repo, and the real `14a23b994` regression.
- [x] **Diff coverage ≥ 80%** — the changed lines are two Node CLIs, one pure-logic lib and its tests; the lib is covered directly and both CLIs end-to-end. Rust diff coverage is not applicable (no Rust changed). Not run as `diff-cover` locally; asserted by the CI gate.
- [x] Coverage matrix updated — N/A: no feature row added, removed or renamed; this adds a CI gate and changes no product behaviour.
- [x] All affected feature IDs from the matrix are listed under `## Related` — N/A: no matrix feature IDs affected.
- [x] No new external network dependencies introduced — neither gate uses the network or `gh`; both read the tree with git alone. Gate 2 fetches a missing commit from the submodule's existing `origin` only when it must, and fails if it cannot.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: CI-only change; no release-cut surface touched.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `Closes tinyhumansai/openhuman#5727`.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5727-module-pin-drift-gate`
- Commit SHA: `a44888163`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no file under `app/` changed; `scripts/` is outside the prettier workspace.
- [x] `pnpm typecheck` — N/A: no TypeScript changed.
- [x] Focused tests: `node --test scripts/__tests__/module-pins.test.mjs` — **21 passed, 0 failed**. Both gates run clean on the tree (`exit 0`); gate 2 exits 1 on `14a23b994^..14a23b994` and on `#5725`'s merge.
- [x] Rust fmt/check (if changed) — N/A: no Rust changed. No cargo was run at all.
- [x] Tauri fmt/check (if changed) — N/A: no Tauri shell file changed.
- [x] Workflow validity: `ci-lite.yml` parsed with PyYAML — 16 jobs, `module-pin-gate` present with 3 steps, `pr-ci-gate.needs` includes it, checkout is `fetch-depth: 0` + `submodules: recursive`.

### Validation Blocked

- `command:` N/A — nothing was blocked.
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none at runtime. A PR that drifts a module pin, or rewinds a `vendor/` submodule, now fails CI instead of merging green.
- User-visible effect: none. This is a CI gate.

### Parity Contract

- Legacy behavior preserved: no product code is touched. The two records drifted today are declared rather than fixed, so the gate lands green on `main` as it stands and changes nothing about what is built or shipped.
- Guard/fallback/dispatch parity checks: the gate adds a job and does not modify any existing one except the `changes` path filter (widened, never narrowed) and the `PR CI Gate` aggregation (one entry added).

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none.
- Canonical PR: this one.
- Resolution: N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated checks to ensure module registry versions match their pinned submodule releases.
  * Added safeguards against vendor submodule pins moving backward or diverging unexpectedly.
  * Added support for documented exceptions and explicit rewind approvals.

* **Bug Fixes**
  * CI now fails safely when pin data is missing, malformed, unresolved, or inconsistent.
  * Updated the tinymemory test module pin used for coverage checks.

* **Tests**
  * Added comprehensive coverage for pin validation, exemptions, submodule history, and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->