### PR TITLE
ci: compile raw coverage on source changes

### DIFF
--- a/scripts/__tests__/coverage-runner-status.test.mjs
+++ b/scripts/__tests__/coverage-runner-status.test.mjs
@@ -245,3 +245,36 @@ test("required-features matching is exact, not substring — a superset name doe
   assert.doesNotMatch(res.output, /RAN-THE-TARGET/, res.output);
   assert.match(res.output, /rc=0/, res.output);
 });
+
+test("source changes compile the aggregate raw coverage target", () => {
+  const res = withRunnerFunctions(
+    ["compile_raw_coverage_target"],
+    [
+      "PRODUCT_FEATURES='voice web3'",
+      "log() { printf '%s\\n' \"$*\"; }",
+      "bash() { printf 'BASH_ARGS'; printf ' <%s>' \"$@\"; printf '\\n'; }",
+    ].join("\n"),
+    "compile_raw_coverage_target",
+  );
+
+  assert.equal(res.status, 0, res.output);
+  assert.match(
+    res.output,
+    /BASH_ARGS <scripts\/ci-cancel-aware\.sh> <cargo> <test> <--features> <voice web3> <--test> <raw_coverage_all> <--no-run>/,
+  );
+});
+
+test("raw coverage compile failures fail the source-change guard", () => {
+  const res = withRunnerFunctions(
+    ["compile_raw_coverage_target"],
+    [
+      "PRODUCT_FEATURES='voice web3'",
+      "log() { :; }",
+      "bash() { return 17; }",
+    ].join("\n"),
+    "compile_raw_coverage_target && exit 1; rc=$?; echo \"rc=${rc}\"",
+  );
+
+  assert.equal(res.status, 0, res.output);
+  assert.match(res.output, /rc=17/);
+});

--- a/scripts/ci/rust-coverage-changed.sh
+++ b/scripts/ci/rust-coverage-changed.sh
@@ -218,6 +218,13 @@ run_integration_target() {
   fi
 }
 
+compile_raw_coverage_target() {
+  log "compiling raw coverage integration target for src/** change"
+  bash scripts/ci-cancel-aware.sh cargo test \
+    --features "${PRODUCT_FEATURES}" \
+    --test raw_coverage_all --no-run
+}
+
 run_full() {
   log "running FULL instrumented suite (reason: $1)"
   llvm_cov clean --workspace
@@ -257,6 +264,8 @@ while IFS= read -r f; do
 done < <(printf '%s\n' "${CHANGED_FILES}" | xargs -n1 printf '%s\n' 2>/dev/null || true)
 log "received ${#files[@]} changed rust file(s)"
 
+src_changed=false
+
 if [ "${#files[@]}" -eq 0 ]; then
   run_full "empty changed-file list — scoping unsafe"
 fi
@@ -267,6 +276,9 @@ fi
 lib_filters_raw=""
 test_targets_raw=""
 for f in "${files[@]}"; do
+  case "${f}" in
+    src/*) src_changed=true ;;
+  esac
   if [ ! -e "${f}" ]; then
     # dorny/paths-filter includes deleted paths. They contain no changed lines
     # to cover and, for tests, no longer correspond to runnable Cargo targets.
@@ -373,6 +385,13 @@ done < <(printf '%s' "${test_targets_raw}" | sort -u)
 
 if [ "${#lib_filters[@]}" -eq 0 ] && [ "${#test_targets[@]}" -eq 0 ]; then
   run_full "no scoped test targets derivable from the change set"
+fi
+
+if [ "${src_changed}" = true ]; then
+  # Scoped lib tests cannot compile integration targets that are not selected by
+  # a domain mapping. Build the aggregate raw-coverage target on every src/**
+  # change so source-only PRs cannot leave a broken integration suite behind.
+  compile_raw_coverage_target
 fi
 
 # Drop artifacts from previous coverage runs so merged profdata only reflects


### PR DESCRIPTION
## Summary

- Compile the aggregate `raw_coverage_all` integration target whenever a PR changes `src/**`.
- Keep the existing changed-module coverage lane and its scoped test execution unchanged.
- Fail early when a source-only change makes an unmapped integration target stop compiling.

## Problem

A source-only PR can break `tests/raw_coverage/*.rs` while the changed-files lane runs only filtered `--lib` tests. Because `raw_coverage_all` is selected only when a raw-coverage test file changes, the breakage can remain green until an unrelated PR touches that test tree. This closes #5700.

## Solution

- Track whether the changed-file list contains any `src/**` path, including deleted paths.
- Run `cargo test --features "$PRODUCT_FEATURES" --test raw_coverage_all --no-run` through the repository cancellation-aware wrapper before the scoped coverage run.
- Keep this compile-only: the raw suites are not executed on every source PR, so the fast lane does not become a second full coverage lane.
- Add regression coverage for the exact command and for propagation of a compile failure.

## Submission Checklist

- [x] Tests added or updated (happy path + failure/edge path).
- [x] **Diff coverage ≥ 80%** — pending CI's merged coverage gate.
- [x] Coverage matrix updated — N/A: CI guard behavior only; no feature rows changed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no feature IDs affected.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — N/A: CI script only.
- [x] Linked issue closed via `Closes #5700` in the `## Related` section.

## Impact

- Runtime/platform impact: CI only; no shipped binaries or user-facing behavior change.
- Performance: adds one compile-only Cargo invocation for source changes; raw coverage tests remain scoped and are not executed by this guard.
- Security/migration impact: none.

## Related

- Closes #5700
- Follow-up PR(s)/TODOs: CI will provide the added wall-clock measurement for a representative source-only PR.

## Validation

- `bash -n scripts/ci/rust-coverage-changed.sh` — passed.
- `git diff --check` — passed.
- `node --test scripts/__tests__/coverage-runner-status.test.mjs` — attempted locally; the Windows Node/Git Bash environment cannot preserve positional arguments in the repository's Bash extraction harness, and the pre-existing tests fail for that environment. The new test is designed for the Linux CI runner used by this workflow.
- Commit is SSH-signed and verified as `ANISAYAK MITRA <266799942+anisayakmitra-in@users.noreply.github.com>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Rust coverage validation to detect source changes more reliably.
  - Coverage checks now compile the complete raw-coverage test target before execution.
  - Compilation failures are correctly surfaced with their original status.

- **Tests**
  - Added regression coverage to verify source-change detection, configured feature handling, no-run compilation, and failure propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->