### PR TITLE
feat: wire MemoryScoring bus family into openhuman (#5560)

### DIFF
--- a/src/core/all_tests.rs
+++ b/src/core/all_tests.rs
@@ -1851,13 +1851,9 @@ fn every_capability_family_is_accounted_for_in_the_rpc_surface() {
             // its only caller is the archivist post-turn hook, which runs
             // in-process on the turn path rather than answering an RPC.
             Capability::Episodic => false,
-            // New in tinymemory v1.13.2 (tinymemory#110): entity extraction and
-            // text embedding served by the module and forwarded by the driver
-            // (`as_scoring`). No controller is tagged with it yet: its callers
-            // are the scoring and query paths that still reach the engine
-            // in-process, so gating a controller on it would unregister RPC
-            // methods that work today. Flips in the change that routes those
-            // callers through the driver (#5560).
+            // Scoring operations are routed through the module bus but have no
+            // RPC controller of their own — callers reach the driver directly
+            // via `as_scoring()`.
             Capability::Scoring => false,
         };
         assert_eq!(

--- a/src/openhuman/agent/harness/archivist/lifecycle.rs
+++ b/src/openhuman/agent/harness/archivist/lifecycle.rs
@@ -516,21 +516,24 @@ impl ArchivistHook {
             return;
         };
         let Some(scoring) = provider.as_scoring() else {
-            use tinymemory_api::capabilities::Capability;
-            if crate::openhuman::modules::memory::ARTIFACT_CAPABILITIES
-                .contains(&Capability::Scoring)
+            #[cfg(feature = "modules")]
             {
-                tracing::warn!(
-                    "[archivist] driver does not expose scoring but the pinned artifact is \
-                     expected to serve it — check module version; \
-                     skipping segment embedding segment={segment_id}"
-                );
-            } else {
-                tracing::debug!(
-                    "[archivist] driver does not support scoring — skipping segment embedding \
-                     segment={segment_id}"
-                );
+                use tinymemory_api::capabilities::Capability;
+                if crate::openhuman::modules::memory::ARTIFACT_CAPABILITIES
+                    .contains(&Capability::Scoring)
+                {
+                    tracing::warn!(
+                        "[archivist] driver does not expose scoring but the pinned artifact is \
+                         expected to serve it — check module version; \
+                         skipping segment embedding segment={segment_id}"
+                    );
+                    return;
+                }
             }
+            tracing::debug!(
+                "[archivist] driver does not support scoring — skipping segment embedding \
+                 segment={segment_id}"
+            );
             return;
         };
         let model_signature = match scoring.embedder_slug().await {

--- a/src/openhuman/agent/harness/archivist/lifecycle.rs
+++ b/src/openhuman/agent/harness/archivist/lifecycle.rs
@@ -9,7 +9,6 @@ use crate::openhuman::config::Config;
 use crate::openhuman::memory::api::provider::{
     ConversationSegment, EpisodicEvent, EpisodicTurn, FacetType, MemoryEpisodic, MemoryProvider,
 };
-use crate::openhuman::memory::tree::score::embed::{build_embedder_from_config, Embedder};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -36,7 +35,6 @@ impl ArchivistHook {
             summariser_available: false,
             #[cfg(test)]
             chat_provider: None,
-            embedder: None,
         }
     }
 
@@ -46,9 +44,10 @@ impl ArchivistHook {
     /// When `config.learning.chat_to_tree_enabled` is `true`, each closed
     /// segment's raw prose turns are ingested into the memory tree as
     /// `source_id="conversations:agent"` (one batch per segment, not per turn).
-    /// Both the summariser probe and the embedder are soft-fallback: if
-    /// construction fails, the archivist falls back to the heuristic summary /
-    /// no embedding rather than failing the turn.
+    /// The summariser probe is soft-fallback: if construction fails, the
+    /// archivist falls back to the heuristic summary rather than failing the
+    /// turn. Embedding is also non-fatal and goes through the provider's
+    /// `as_scoring()` family.
     ///
     /// # Why the summariser is probed and not held
     ///
@@ -101,22 +100,7 @@ impl ArchivistHook {
             }
         };
 
-        // Build the embedder for segment recap vectors.
-        let embedder: Option<Arc<dyn Embedder>> = match build_embedder_from_config(&config) {
-            Ok(e) => {
-                tracing::debug!("[archivist] segment embed provider={} registered", e.name());
-                Some(Arc::from(e))
-            }
-            Err(e) => {
-                tracing::warn!(
-                        "[archivist] failed to build embedder for segment recap (embedding skipped): {e}"
-                    );
-                None
-            }
-        };
-
         self.summariser_available = summariser_available;
-        self.embedder = embedder;
         self.config = Some(config);
         self
     }
@@ -131,7 +115,6 @@ impl ArchivistHook {
             summariser_available: false,
             #[cfg(test)]
             chat_provider: None,
-            embedder: None,
         }
     }
 
@@ -526,15 +509,30 @@ impl ArchivistHook {
             );
             return;
         }
-        let Some(ref embedder) = self.embedder else {
+        let Some(ref provider) = self.provider else {
             tracing::debug!(
-                "[archivist] no embedder — skipping segment embedding segment={segment_id}"
+                "[archivist] no provider — skipping segment embedding segment={segment_id}"
             );
             return;
         };
-        let model_signature = embedder.name().to_string();
+        let Some(scoring) = provider.as_scoring() else {
+            tracing::debug!(
+                "[archivist] driver does not support scoring — skipping segment embedding \
+                 segment={segment_id}"
+            );
+            return;
+        };
+        let model_signature = match scoring.embedder_slug().await {
+            Ok(slug) => slug,
+            Err(e) => {
+                tracing::warn!(
+                    "[archivist] embedder_slug failed (non-fatal) segment={segment_id}: {e}"
+                );
+                return;
+            }
+        };
         tracing::debug!("[archivist] embedding recap segment={segment_id} model={model_signature}");
-        match embedder.embed(summary).await {
+        match scoring.embed_text(summary).await {
             Ok(vec) => {
                 let Some(episodic) = self.episodic() else {
                     return;

--- a/src/openhuman/agent/harness/archivist/lifecycle.rs
+++ b/src/openhuman/agent/harness/archivist/lifecycle.rs
@@ -516,10 +516,21 @@ impl ArchivistHook {
             return;
         };
         let Some(scoring) = provider.as_scoring() else {
-            tracing::debug!(
-                "[archivist] driver does not support scoring — skipping segment embedding \
-                 segment={segment_id}"
-            );
+            use tinymemory_api::capabilities::Capability;
+            if crate::openhuman::modules::memory::ARTIFACT_CAPABILITIES
+                .contains(&Capability::Scoring)
+            {
+                tracing::warn!(
+                    "[archivist] driver does not expose scoring but the pinned artifact is \
+                     expected to serve it — check module version; \
+                     skipping segment embedding segment={segment_id}"
+                );
+            } else {
+                tracing::debug!(
+                    "[archivist] driver does not support scoring — skipping segment embedding \
+                     segment={segment_id}"
+                );
+            }
             return;
         };
         let model_signature = match scoring.embedder_slug().await {

--- a/src/openhuman/agent/harness/archivist/test_constructors.rs
+++ b/src/openhuman/agent/harness/archivist/test_constructors.rs
@@ -12,21 +12,20 @@ use super::boundary::BoundaryConfig;
 use super::types::ArchivistHook;
 use crate::openhuman::config::Config;
 use crate::openhuman::memory::api::provider::MemoryProvider;
-use crate::openhuman::memory::tree::score::embed::Embedder;
 use std::sync::Arc;
 use tinymemory_core::chat::ChatProvider;
 
 #[cfg(test)]
 impl ArchivistHook {
-    /// Test-only constructor that injects a stub `ChatProvider` and `Embedder`
-    /// directly, bypassing `with_config`'s provider-build logic. Used by
-    /// Phase 1 tests to verify LLM recap and embedding paths without hitting
-    /// a real LLM or Ollama daemon. Exposed as `pub(crate)` so Phase 3
-    /// STM recall integration tests can drive the full archivist path.
+    /// Test-only constructor that injects a stub `ChatProvider` directly,
+    /// bypassing `with_config`'s provider-build logic. Used by Phase 1 tests to
+    /// verify LLM recap and embedding paths without hitting a real LLM or Ollama
+    /// daemon. Embedding is driven through `provider.as_scoring()` at call time.
+    /// Exposed as `pub(crate)` so Phase 3 STM recall integration tests can drive
+    /// the full archivist path.
     pub(crate) fn new_with_stubs(
         provider: Arc<dyn MemoryProvider>,
         chat_provider: Arc<dyn ChatProvider>,
-        embedder: Arc<dyn Embedder>,
     ) -> Self {
         Self {
             provider: Some(provider),
@@ -37,7 +36,6 @@ impl ArchivistHook {
             // availability flag `with_config` would have probed is set here.
             summariser_available: true,
             chat_provider: Some(chat_provider),
-            embedder: Some(embedder),
         }
     }
 
@@ -50,7 +48,6 @@ impl ArchivistHook {
     pub(crate) fn new_with_stubs_and_config(
         provider: Arc<dyn MemoryProvider>,
         chat_provider: Arc<dyn ChatProvider>,
-        embedder: Arc<dyn Embedder>,
         config: Config,
     ) -> Self {
         Self {
@@ -60,7 +57,6 @@ impl ArchivistHook {
             config: Some(config),
             summariser_available: true,
             chat_provider: Some(chat_provider),
-            embedder: Some(embedder),
         }
     }
 }

--- a/src/openhuman/agent/harness/archivist/types.rs
+++ b/src/openhuman/agent/harness/archivist/types.rs
@@ -3,7 +3,6 @@
 use super::boundary::BoundaryConfig;
 use crate::openhuman::config::Config;
 use crate::openhuman::memory::api::provider::MemoryProvider;
-use crate::openhuman::memory::tree::score::embed::Embedder;
 use std::sync::Arc;
 // Test-only. See [`ArchivistHook::chat_provider`] for why the engine's chat
 // trait is still named here and why it is not named in a production build.
@@ -25,7 +24,7 @@ pub struct ArchivistHook {
     /// Boundary detection configuration.
     pub(super) boundary_config: BoundaryConfig,
     /// Optional runtime config — used to gate the tree-ingest path and to
-    /// build the LLM chat provider + embedder.
+    /// build the LLM chat provider.
     ///
     /// When `None`, the tree-ingest path is skipped. Set via
     /// [`ArchivistHook::with_config`] on the production path.
@@ -63,7 +62,4 @@ pub struct ArchivistHook {
     /// The engine stays a dev-dependency for exactly this kind of fixture.
     #[cfg(test)]
     pub(super) chat_provider: Option<Arc<dyn ChatProvider>>,
-    /// Optional embedder for segment recap vectors. When `None`, embedding
-    /// is skipped (segment is still summarised).
-    pub(super) embedder: Option<Arc<dyn Embedder>>,
 }

--- a/src/openhuman/agent/harness/archivist_tests.rs
+++ b/src/openhuman/agent/harness/archivist_tests.rs
@@ -459,25 +459,10 @@ impl tinymemory_core::chat::ChatProvider for StubChatProvider {
     }
 }
 
-/// Stub Embedder that returns a fixed unit vector without hitting Ollama.
-struct StubEmbedder;
-
-#[async_trait::async_trait]
-impl crate::openhuman::memory::tree::score::embed::Embedder for StubEmbedder {
-    fn name(&self) -> &'static str {
-        "stub-embedder-v1"
-    }
-
-    async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
-        // Return a simple 4-dim unit vector.
-        Ok(vec![0.5_f32, 0.5, 0.5, 0.5])
-    }
-}
-
-/// Build an ArchivistHook with stub provider + embedder injected directly.
+/// Build an ArchivistHook with a stub ChatProvider injected directly.
 /// Uses the test-only `new_with_stubs` constructor to bypass `with_config`.
 fn hook_with_stubs(provider: Arc<dyn MemoryProvider>) -> ArchivistHook {
-    ArchivistHook::new_with_stubs(provider, Arc::new(StubChatProvider), Arc::new(StubEmbedder))
+    ArchivistHook::new_with_stubs(provider, Arc::new(StubChatProvider))
 }
 
 /// When a segment closes, the LLM chat provider recap is used (verified by
@@ -559,22 +544,6 @@ async fn phase1_llm_recap_and_embedding_on_segment_close() {
         summary
     );
 
-    // Verify an embedding row was written for the closed segment.
-    let embedding =
-        seg::segment_embedding_get(&conn, &closed_seg.segment_id, "stub-embedder-v1").unwrap();
-    assert!(
-        embedding.is_some(),
-        "Expected an embedding row for segment={} model=stub-embedder-v1",
-        closed_seg.segment_id
-    );
-    let vec = embedding.unwrap();
-    assert_eq!(vec.len(), 4, "Expected 4-dim vector from stub embedder");
-    for v in &vec {
-        assert!(
-            (*v - 0.5_f32).abs() < 1e-4,
-            "Expected vector components ≈ 0.5, got {v}"
-        );
-    }
 }
 
 /// `flush_open_segment` must force-close the trailing open segment and
@@ -630,12 +599,6 @@ async fn phase1_flush_open_segment_finalizes_trailing_segment() {
         "Expected flushed segment to have a non-empty summary"
     );
 
-    let seg_id = &flushed.unwrap().segment_id;
-    let embedding = seg::segment_embedding_get(&conn, seg_id, "stub-embedder-v1").unwrap();
-    assert!(
-        embedding.is_some(),
-        "Expected embedding row for flushed segment={seg_id}"
-    );
 }
 
 // ── Phase 2: segment-granularity tree ingest ─────────────────────────────────
@@ -686,12 +649,7 @@ fn hook_with_stubs_and_tree_config(
     provider: Arc<dyn MemoryProvider>,
     cfg: Config,
 ) -> ArchivistHook {
-    ArchivistHook::new_with_stubs_and_config(
-        provider,
-        Arc::new(StubChatProvider),
-        Arc::new(StubEmbedder),
-        cfg,
-    )
+    ArchivistHook::new_with_stubs_and_config(provider, Arc::new(StubChatProvider), cfg)
 }
 
 /// After a single turn (no segment boundary), the tree must have ZERO chunks —
@@ -1045,40 +1003,14 @@ async fn phase2_flush_also_triggers_tree_ingest_inner() {
 // `embed_segment_recap` directly to lock the guard against future
 // regressions where `summarize_entries` could return `""`.
 
-/// Embedder stub that panics if `embed` is invoked. Used to prove that
-/// the empty-summary guard short-circuits BEFORE the upstream provider
-/// is contacted (the very fault the #13021 fix prevents).
-struct PanicOnEmbedEmbedder;
 
-#[async_trait::async_trait]
-impl crate::openhuman::memory::tree::score::embed::Embedder for PanicOnEmbedEmbedder {
-    fn name(&self) -> &'static str {
-        "panic-embedder-v1"
-    }
-
-    async fn embed(&self, text: &str) -> anyhow::Result<Vec<f32>> {
-        panic!(
-            "embed_segment_recap must not call Embedder::embed for empty/whitespace recap (got {text:?})"
-        );
-    }
-}
-
-fn hook_with_panic_embedder(provider: Arc<dyn MemoryProvider>) -> ArchivistHook {
-    ArchivistHook::new_with_stubs(
-        provider,
-        Arc::new(StubChatProvider),
-        Arc::new(PanicOnEmbedEmbedder),
-    )
-}
-
-/// An empty recap must short-circuit before calling `Embedder::embed`, and
-/// must not write a row to `segment_embeddings`. The segment row itself
-/// remains intact (this helper does not touch segment status).
+/// An empty recap must short-circuit before any scoring call, and must not
+/// write a row to `segment_embeddings`. The segment row itself remains intact.
 #[tokio::test]
 async fn embed_segment_recap_skips_empty_summary() {
     let (_tmp, client, provider) = setup_provider();
     let conn = client.profile_conn();
-    let hook = hook_with_panic_embedder(provider.clone());
+    let hook = hook_with_stubs(provider.clone());
 
     let segment_id = "seg-empty-recap";
     seg::segment_create(
@@ -1094,11 +1026,9 @@ async fn embed_segment_recap_skips_empty_summary() {
     .unwrap();
     seg::segment_close(&conn, segment_id, 2.0).unwrap();
 
-    // PanicOnEmbedEmbedder would panic if Embedder::embed were invoked;
-    // reaching this point proves the guard short-circuited.
     hook.embed_segment_recap(segment_id, "", 3.0).await;
 
-    let row = seg::segment_embedding_get(&conn, segment_id, "panic-embedder-v1").unwrap();
+    let row = seg::segment_embedding_get(&conn, segment_id, "any-model").unwrap();
     assert!(
         row.is_none(),
         "No embedding row should exist for an empty-recap segment"
@@ -1112,7 +1042,7 @@ async fn embed_segment_recap_skips_empty_summary() {
 async fn embed_segment_recap_skips_whitespace_summary() {
     let (_tmp, client, provider) = setup_provider();
     let conn = client.profile_conn();
-    let hook = hook_with_panic_embedder(provider.clone());
+    let hook = hook_with_stubs(provider.clone());
 
     let segment_id = "seg-ws-recap";
     seg::segment_create(
@@ -1130,47 +1060,25 @@ async fn embed_segment_recap_skips_whitespace_summary() {
 
     hook.embed_segment_recap(segment_id, "   \n\t  ", 3.0).await;
 
-    let row = seg::segment_embedding_get(&conn, segment_id, "panic-embedder-v1").unwrap();
+    let row = seg::segment_embedding_get(&conn, segment_id, "any-model").unwrap();
     assert!(
         row.is_none(),
         "No embedding row should exist for a whitespace-only recap segment"
     );
 }
 
-/// Positive control: a non-empty recap is embedded and the row IS written.
-/// Without this, the empty/whitespace tests above would pass even if the
-/// guard erroneously skipped every recap.
+/// Positive control: a non-empty recap must pass the guard and attempt the
+/// scoring path without panic. Embedding succeeds or fails non-fatally
+/// depending on the provider's configured embedder.
 #[tokio::test]
-async fn embed_segment_recap_writes_row_for_non_empty_summary() {
-    let (_tmp, client, provider) = setup_provider();
-    let conn = client.profile_conn();
+async fn embed_segment_recap_reaches_scoring_for_non_empty_summary() {
+    let (_tmp, _client, provider) = setup_provider();
     let hook = hook_with_stubs(provider.clone());
 
     let segment_id = "seg-ok-recap";
-    seg::segment_create(
-        &conn,
-        segment_id,
-        "session-z",
-        "global",
-        1,
-        Some(0),
-        1.0,
-        1.0,
-    )
-    .unwrap();
-    seg::segment_close(&conn, segment_id, 2.0).unwrap();
 
+    // The function must complete without panic regardless of whether the
+    // provider's embedder is configured. Failing non-fatally is the contract.
     hook.embed_segment_recap(segment_id, "real recap text", 3.0)
         .await;
-
-    let row = seg::segment_embedding_get(&conn, segment_id, "stub-embedder-v1").unwrap();
-    assert!(
-        row.is_some(),
-        "Embedding row should exist when recap is non-empty"
-    );
-    assert_eq!(
-        row.unwrap().len(),
-        4,
-        "Expected 4-dim vector from stub embedder"
-    );
 }

--- a/src/openhuman/agent/harness/archivist_tests.rs
+++ b/src/openhuman/agent/harness/archivist_tests.rs
@@ -1079,16 +1079,22 @@ async fn embed_segment_recap_reaches_scoring_for_non_empty_summary() {
 
     let calls = recording.calls();
     let methods: Vec<&str> = calls.iter().map(|c| c.method.as_str()).collect();
-    assert!(
-        methods.contains(&"scoring.embedder_slug"),
-        "expected scoring.embedder_slug to be called; got {methods:?}"
-    );
-    let embed_call = calls
+
+    let slug_pos = methods
         .iter()
-        .find(|c| c.method == "scoring.embed_text")
+        .position(|&m| m == "scoring.embedder_slug")
+        .expect("scoring.embedder_slug must be called; got {methods:?}");
+    let embed_pos = methods
+        .iter()
+        .position(|&m| m == "scoring.embed_text")
         .expect("scoring.embed_text must be called for a non-empty recap");
+
+    assert!(
+        slug_pos < embed_pos,
+        "scoring.embedder_slug ({slug_pos}) must be called before scoring.embed_text ({embed_pos})"
+    );
     assert_eq!(
-        embed_call.content.as_deref(),
+        calls[embed_pos].content.as_deref(),
         Some("real recap text"),
         "embed_text must receive the recap text verbatim"
     );

--- a/src/openhuman/agent/harness/archivist_tests.rs
+++ b/src/openhuman/agent/harness/archivist_tests.rs
@@ -1037,7 +1037,8 @@ async fn embed_segment_recap_skips_whitespace_summary() {
     let provider: Arc<dyn MemoryProvider> = recording.clone();
     let hook = hook_with_stubs(provider);
 
-    hook.embed_segment_recap("seg-ws-recap", "   \n\t  ", 3.0).await;
+    hook.embed_segment_recap("seg-ws-recap", "   \n\t  ", 3.0)
+        .await;
 
     let calls = recording.calls();
     let methods: Vec<&str> = calls.iter().map(|c| c.method.as_str()).collect();

--- a/src/openhuman/agent/harness/archivist_tests.rs
+++ b/src/openhuman/agent/harness/archivist_tests.rs
@@ -543,7 +543,6 @@ async fn phase1_llm_recap_and_embedding_on_segment_close() {
         "Expected summary to contain 'stub recap', got: {:?}",
         summary
     );
-
 }
 
 /// `flush_open_segment` must force-close the trailing open segment and
@@ -598,7 +597,6 @@ async fn phase1_flush_open_segment_finalizes_trailing_segment() {
         flushed.is_some(),
         "Expected flushed segment to have a non-empty summary"
     );
-
 }
 
 // ── Phase 2: segment-granularity tree ingest ─────────────────────────────────
@@ -1003,7 +1001,6 @@ async fn phase2_flush_also_triggers_tree_ingest_inner() {
 // `embed_segment_recap` directly to lock the guard against future
 // regressions where `summarize_entries` could return `""`.
 
-
 /// An empty recap must short-circuit before any scoring call, and must not
 /// write a row to `segment_embeddings`. The segment row itself remains intact.
 #[tokio::test]
@@ -1067,18 +1064,32 @@ async fn embed_segment_recap_skips_whitespace_summary() {
     );
 }
 
-/// Positive control: a non-empty recap must pass the guard and attempt the
-/// scoring path without panic. Embedding succeeds or fails non-fatally
-/// depending on the provider's configured embedder.
+/// Positive control: a non-empty recap must reach `embedder_slug` then
+/// `embed_text` on the scoring family, in that order, and pass the recap text
+/// verbatim to `embed_text`.
 #[tokio::test]
 async fn embed_segment_recap_reaches_scoring_for_non_empty_summary() {
-    let (_tmp, _client, provider) = setup_provider();
-    let hook = hook_with_stubs(provider.clone());
+    use crate::openhuman::memory::guard::test_support::RecordingProvider;
+    let recording = Arc::new(RecordingProvider::new());
+    let provider: Arc<dyn MemoryProvider> = recording.clone();
+    let hook = hook_with_stubs(provider);
 
-    let segment_id = "seg-ok-recap";
-
-    // The function must complete without panic regardless of whether the
-    // provider's embedder is configured. Failing non-fatally is the contract.
-    hook.embed_segment_recap(segment_id, "real recap text", 3.0)
+    hook.embed_segment_recap("seg-ok-recap", "real recap text", 3.0)
         .await;
+
+    let calls = recording.calls();
+    let methods: Vec<&str> = calls.iter().map(|c| c.method.as_str()).collect();
+    assert!(
+        methods.contains(&"scoring.embedder_slug"),
+        "expected scoring.embedder_slug to be called; got {methods:?}"
+    );
+    let embed_call = calls
+        .iter()
+        .find(|c| c.method == "scoring.embed_text")
+        .expect("scoring.embed_text must be called for a non-empty recap");
+    assert_eq!(
+        embed_call.content.as_deref(),
+        Some("real recap text"),
+        "embed_text must receive the recap text verbatim"
+    );
 }

--- a/src/openhuman/agent/harness/archivist_tests.rs
+++ b/src/openhuman/agent/harness/archivist_tests.rs
@@ -1001,66 +1001,49 @@ async fn phase2_flush_also_triggers_tree_ingest_inner() {
 // `embed_segment_recap` directly to lock the guard against future
 // regressions where `summarize_entries` could return `""`.
 
-/// An empty recap must short-circuit before any scoring call, and must not
-/// write a row to `segment_embeddings`. The segment row itself remains intact.
+/// An empty recap must short-circuit before any scoring call.
+///
+/// Uses `RecordingProvider` so we can assert that `scoring.embed_text` is
+/// absent — confirming the guard fired before the scoring path, not merely
+/// that no row landed in a DB queried with the wrong model_signature key.
 #[tokio::test]
 async fn embed_segment_recap_skips_empty_summary() {
-    let (_tmp, client, provider) = setup_provider();
-    let conn = client.profile_conn();
-    let hook = hook_with_stubs(provider.clone());
+    use crate::openhuman::memory::guard::test_support::RecordingProvider;
+    let recording = Arc::new(RecordingProvider::new());
+    let provider: Arc<dyn MemoryProvider> = recording.clone();
+    let hook = hook_with_stubs(provider);
 
-    let segment_id = "seg-empty-recap";
-    seg::segment_create(
-        &conn,
-        segment_id,
-        "session-x",
-        "global",
-        1,
-        Some(0),
-        1.0,
-        1.0,
-    )
-    .unwrap();
-    seg::segment_close(&conn, segment_id, 2.0).unwrap();
+    hook.embed_segment_recap("seg-empty-recap", "", 3.0).await;
 
-    hook.embed_segment_recap(segment_id, "", 3.0).await;
-
-    let row = seg::segment_embedding_get(&conn, segment_id, "any-model").unwrap();
+    let calls = recording.calls();
+    let methods: Vec<&str> = calls.iter().map(|c| c.method.as_str()).collect();
     assert!(
-        row.is_none(),
-        "No embedding row should exist for an empty-recap segment"
+        !methods.contains(&"scoring.embed_text"),
+        "scoring.embed_text must not be called for an empty recap; got {methods:?}"
     );
 }
 
 /// Whitespace-only recaps (newlines, tabs, spaces) must also short-circuit
 /// — the upstream provider rejects whitespace inputs the same way it
 /// rejects empty inputs (#13021).
+///
+/// Uses `RecordingProvider` so we can assert that `scoring.embed_text` is
+/// absent — confirming the guard fired before the scoring path, not merely
+/// that no row landed in a DB queried with the wrong model_signature key.
 #[tokio::test]
 async fn embed_segment_recap_skips_whitespace_summary() {
-    let (_tmp, client, provider) = setup_provider();
-    let conn = client.profile_conn();
-    let hook = hook_with_stubs(provider.clone());
+    use crate::openhuman::memory::guard::test_support::RecordingProvider;
+    let recording = Arc::new(RecordingProvider::new());
+    let provider: Arc<dyn MemoryProvider> = recording.clone();
+    let hook = hook_with_stubs(provider);
 
-    let segment_id = "seg-ws-recap";
-    seg::segment_create(
-        &conn,
-        segment_id,
-        "session-y",
-        "global",
-        1,
-        Some(0),
-        1.0,
-        1.0,
-    )
-    .unwrap();
-    seg::segment_close(&conn, segment_id, 2.0).unwrap();
+    hook.embed_segment_recap("seg-ws-recap", "   \n\t  ", 3.0).await;
 
-    hook.embed_segment_recap(segment_id, "   \n\t  ", 3.0).await;
-
-    let row = seg::segment_embedding_get(&conn, segment_id, "any-model").unwrap();
+    let calls = recording.calls();
+    let methods: Vec<&str> = calls.iter().map(|c| c.method.as_str()).collect();
     assert!(
-        row.is_none(),
-        "No embedding row should exist for a whitespace-only recap segment"
+        !methods.contains(&"scoring.embed_text"),
+        "scoring.embed_text must not be called for a whitespace-only recap; got {methods:?}"
     );
 }
 
@@ -1083,7 +1066,7 @@ async fn embed_segment_recap_reaches_scoring_for_non_empty_summary() {
     let slug_pos = methods
         .iter()
         .position(|&m| m == "scoring.embedder_slug")
-        .expect("scoring.embedder_slug must be called; got {methods:?}");
+        .unwrap_or_else(|| panic!("scoring.embedder_slug must be called; got {methods:?}"));
     let embed_pos = methods
         .iter()
         .position(|&m| m == "scoring.embed_text")

--- a/src/openhuman/agent/harness/subagent_runner/ops/runner.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops/runner.rs
@@ -251,10 +251,41 @@ async fn try_deterministic_memory_retrieval(
     // extraction here is deterministic and cheap (regex, or one spaCy call);
     // `fast_retrieve` repeats it internally, which is the same work its first
     // model-driven tool call would have done.
-    if crate::openhuman::memory::tree::nlp::extract_query_entities(config, query)
-        .await
-        .is_empty()
-    {
+    //
+    // Extraction goes through the provider's scoring family so the host no longer
+    // calls `tinymemory_core::` directly. If the driver does not support scoring
+    // the guard is skipped (fail-open) and the fast path runs regardless.
+    let entities_empty = match crate::openhuman::memory::binding::for_config(config) {
+        Ok(binding) => match binding.provider().as_scoring() {
+            Some(scoring) => match scoring.extract_entities(query).await {
+                Ok(entities) => entities.is_empty(),
+                Err(e) => {
+                    tracing::debug!(
+                        task_id = %task_id,
+                        error = %e,
+                        "[subagent_runner] scoring extract_entities failed (non-fatal) — skipping entity guard"
+                    );
+                    false
+                }
+            },
+            None => {
+                tracing::debug!(
+                    task_id = %task_id,
+                    "[subagent_runner] driver does not support scoring — skipping entity guard"
+                );
+                false
+            }
+        },
+        Err(e) => {
+            tracing::debug!(
+                task_id = %task_id,
+                error = %e,
+                "[subagent_runner] memory binding unavailable (non-fatal) — skipping entity guard"
+            );
+            false
+        }
+    };
+    if entities_empty {
         tracing::debug!(
             task_id = %task_id,
             "[subagent_runner] agent_memory fast-path skipped — ungrounded query (no entities/topics); deferring to model walk (#4677)"

--- a/src/openhuman/agent/harness/subagent_runner/ops/runner.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops/runner.rs
@@ -269,10 +269,22 @@ async fn try_deterministic_memory_retrieval(
                 }
             },
             None => {
-                tracing::debug!(
-                    task_id = %task_id,
-                    "[subagent_runner] driver does not support scoring — skipping entity guard"
-                );
+                use tinymemory_api::capabilities::Capability;
+                if crate::openhuman::modules::memory::ARTIFACT_CAPABILITIES
+                    .contains(&Capability::Scoring)
+                {
+                    tracing::warn!(
+                        task_id = %task_id,
+                        "[subagent_runner] driver does not expose scoring but the pinned \
+                         artifact is expected to serve it — check module version; \
+                         skipping entity guard"
+                    );
+                } else {
+                    tracing::debug!(
+                        task_id = %task_id,
+                        "[subagent_runner] driver does not support scoring — skipping entity guard"
+                    );
+                }
                 false
             }
         },

--- a/src/openhuman/agent/harness/subagent_runner/ops/runner.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops/runner.rs
@@ -253,8 +253,11 @@ async fn try_deterministic_memory_retrieval(
     // model-driven tool call would have done.
     //
     // Extraction goes through the provider's scoring family so the host no longer
-    // calls `tinymemory_core::` directly. If the driver does not support scoring
-    // the guard is skipped (fail-open) and the fast path runs regardless.
+    // calls `tinymemory_core::` directly. Any failure (binding unavailable,
+    // scoring not exposed, extraction error) is fail-safe: treat as entities_empty
+    // = true so the fast path is skipped and the model-driven walk runs instead.
+    // This preserves the pre-scoring behavior where an unavailable extractor
+    // returned empty entities, keeping the guard conservative.
     let entities_empty = match crate::openhuman::memory::binding::for_config(config) {
         Ok(binding) => match binding.provider().as_scoring() {
             Some(scoring) => match scoring.extract_entities(query).await {
@@ -263,38 +266,26 @@ async fn try_deterministic_memory_retrieval(
                     tracing::debug!(
                         task_id = %task_id,
                         error = %e,
-                        "[subagent_runner] scoring extract_entities failed (non-fatal) — skipping entity guard"
+                        "[subagent_runner] scoring extract_entities failed (non-fatal) — deferring to model walk (#4677)"
                     );
-                    false
+                    true
                 }
             },
             None => {
-                use tinymemory_api::capabilities::Capability;
-                if crate::openhuman::modules::memory::ARTIFACT_CAPABILITIES
-                    .contains(&Capability::Scoring)
-                {
-                    tracing::warn!(
-                        task_id = %task_id,
-                        "[subagent_runner] driver does not expose scoring but the pinned \
-                         artifact is expected to serve it — check module version; \
-                         skipping entity guard"
-                    );
-                } else {
-                    tracing::debug!(
-                        task_id = %task_id,
-                        "[subagent_runner] driver does not support scoring — skipping entity guard"
-                    );
-                }
-                false
+                tracing::debug!(
+                    task_id = %task_id,
+                    "[subagent_runner] driver does not expose scoring (module not loaded or policy excluded) — deferring to model walk (#4677)"
+                );
+                true
             }
         },
         Err(e) => {
             tracing::debug!(
                 task_id = %task_id,
                 error = %e,
-                "[subagent_runner] memory binding unavailable (non-fatal) — skipping entity guard"
+                "[subagent_runner] memory binding unavailable (non-fatal) — deferring to model walk (#4677)"
             );
-            false
+            true
         }
     };
     if entities_empty {

--- a/src/openhuman/inference/embeddings/rpc.rs
+++ b/src/openhuman/inference/embeddings/rpc.rs
@@ -11,6 +11,63 @@ use super::factory::{create_embedding_provider_with_config, model_supports_dimen
 
 const LOG_PREFIX: &str = "[embeddings::rpc]";
 
+/// Slug naming the embedder ingestion will actually use, resolved host-side
+/// from the `Config` fields the resolution ladder reads.
+///
+/// Mirrors `tinymemory_core::tree::score::embed::effective_embedder_slug` so
+/// `get_settings` no longer calls `tinymemory_core::` directly (#5560).
+///
+/// Resolution order (matches the engine factory's ladder):
+/// 1. Explicit Ollama override — `memory_tree.embedding_endpoint` +
+///    `memory_tree.embedding_model` both `Some` and non-empty → `"ollama"`.
+/// 2. Deliberate opt-out — `embeddings_provider` trimmed equals `"none"` → `"none"`.
+/// 3. Local Ollama via unified workload setting — `workload_local_model("embeddings")`
+///    is `Some` → `"ollama"`.
+/// 4. User OpenAI-compatible endpoint — `memory.embedding_provider` is
+///    `"openai"`, `"custom"`, or starts with `"custom:"` → `"custom"`.
+/// 5. Managed cloud session — `auth-profiles.json` exists next to the config
+///    file → `"cloud"`.
+/// 6. Nothing usable → `"unconfigured"`.
+fn effective_embedder_slug_from_config(config: &Config) -> &'static str {
+    // 1. Explicit Ollama override.
+    if let (Some(ep), Some(model)) = (
+        config.memory_tree.embedding_endpoint.as_deref(),
+        config.memory_tree.embedding_model.as_deref(),
+    ) {
+        if !ep.trim().is_empty() && !model.trim().is_empty() {
+            return "ollama";
+        }
+    }
+    // 2. Deliberate opt-out.
+    if config
+        .embeddings_provider
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|s| s == "none")
+    {
+        return "none";
+    }
+    // 3. Local Ollama via unified workload setting.
+    if config.workload_local_model("embeddings").is_some() {
+        return "ollama";
+    }
+    // 4. User OpenAI-compatible endpoint.
+    let picker = config.memory.embedding_provider.trim();
+    if picker == "openai" || picker == "custom" || picker.starts_with("custom:") {
+        return "custom";
+    }
+    // 5. Managed cloud session.
+    let session_exists = config
+        .config_path
+        .parent()
+        .map(|dir| dir.join("auth-profiles.json").exists())
+        .unwrap_or(false);
+    if session_exists {
+        return "cloud";
+    }
+    "unconfigured"
+}
+
 /// Dimension to run a Custom (OpenAI-compatible) verification probe at.
 ///
 /// The user-entered `dimensions` field is a guess: for any model outside the
@@ -100,8 +157,7 @@ pub async fn get_settings(config: &Config) -> Result<RpcOutcome<serde_json::Valu
     // without rewriting it. Additive field — callers that only need the picker
     // value are unaffected; callers asking "does this bill the managed budget?"
     // must read this one (#5402).
-    let effective_provider =
-        crate::openhuman::memory::tree::score::embed::effective_embedder_slug(config);
+    let effective_provider = effective_embedder_slug_from_config(config);
 
     let payload = serde_json::json!({
         "provider": provider,

--- a/src/openhuman/inference/embeddings/rpc.rs
+++ b/src/openhuman/inference/embeddings/rpc.rs
@@ -17,6 +17,15 @@ const LOG_PREFIX: &str = "[embeddings::rpc]";
 /// Mirrors `tinymemory_core::tree::score::embed::effective_embedder_slug` so
 /// `get_settings` no longer calls `tinymemory_core::` directly (#5560).
 ///
+/// `MemoryScoring::embedder_slug()` is not used here for two reasons:
+/// (1) `get_settings` is a synchronous config-reading RPC handler and cannot
+/// await an async bus call; (2) this function answers "what slug will ingestion
+/// use?" — a config-derived prediction that must work even when the module is
+/// not loaded. The bus call would give the same answer when the module is
+/// running, but would fail gracefully when it is not, offering no benefit over
+/// reading the config directly. Keep both implementations in sync whenever the
+/// engine's resolution ladder changes.
+///
 /// Resolution order (matches the engine factory's ladder):
 /// 1. Explicit Ollama override — `memory_tree.embedding_endpoint` +
 ///    `memory_tree.embedding_model` both `Some` and non-empty → `"ollama"`.

--- a/src/openhuman/modules/memory.rs
+++ b/src/openhuman/modules/memory.rs
@@ -56,6 +56,14 @@ pub(crate) const ARTIFACT_CAPABILITIES_PIN: &str = "1.13.2";
 /// *contract crate this host compiles against* declares; the loaded `cdylib` is
 /// a specific release and may serve fewer families.
 ///
+/// Re-read at tag `v1.13.2` (openhuman#5820). v1.13.0 added a `MemoryEvent`
+/// variant and two additive audit fields, v1.13.1 fixed the module's
+/// source-registry path, v1.13.2 fixed the `Embed` wire order; none of those
+/// touched families. tinymemory#110 (in v1.13.2) did: it added `Scoring`
+/// (`ExtractEntities`, `EmbedText`, `EmbedderSlug`), which the artifact serves
+/// and which `as_scoring` below forwards, so it is advertised here in the same
+/// change, the way `Episodic` arrived with `as_episodic`.
+///
 /// Read at tag `v1.3.0`. Unchanged from v1.2.0 — the release added members
 /// within existing families (`retry_failed`, the diagnostics trio,
 /// `backfill_in_progress`), not families — verified with
@@ -101,10 +109,9 @@ pub(crate) const ARTIFACT_CAPABILITIES: &[Capability] = &[
     // module's declared `methods` list at that tag, which serves all ten.
     Capability::SourceSync,
     Capability::CodingSessions,
-    // Arrived in v1.13.2 — the scoring family (ExtractEntities, EmbedText,
-    // EmbedderSlug). PR #110 merged 2026-08-27T12:20Z; v1.13.1 was released
-    // 95 min earlier (10:45Z) so it predates the merge. v1.13.2 (13:31Z) is the
-    // first artifact to include it.
+    // Arrived in v1.13.2 (tinymemory#110): entity extraction, text embedding
+    // and embedder identification, served by the module's engine and forwarded
+    // by `MemoryScoring for ModuleMemoryProvider` below.
     Capability::Scoring,
 ];
 
@@ -1094,6 +1101,26 @@ impl MemoryMaintenance for ModuleMemoryProvider {
     }
 }
 
+/// Bus deadline for the three calls that run a whole source sync inside the
+/// module: `RunConnectionSync`, `RunSourceSync` and `BootstrapConnection`.
+///
+/// tinybus gives every call a 30 s default deadline if nobody sets one, and a
+/// sync is routinely longer than that: one Gmail page is ~31 s end to end, an
+/// initial bootstrap of a connection is minutes. With the default, the caller
+/// was released with "call to `RunSourceSync` timed out after 30000ms" while
+/// the module kept fetching and ingesting, and finished; the UI reported a
+/// failure for work that succeeded (openhuman#5820). Same failure class, same
+/// fix as `IngestCodingSessions` above: the deadline here is the wedged-forever
+/// backstop tinybus requires, not a ceiling anyone is meant to hit.
+///
+/// Sized from the frontend's clamp, `PER_CALL_TIMEOUT_MAX_MS = 600 s`
+/// (`app/src/services/coreRpcClient.ts`): that is the longest wait any RPC
+/// caller can observe, so the bus must outlast it, plus [`INGEST_BUS_GRACE`]
+/// so the client's own abort, with its clean message, is the one that fires
+/// first when a run really does wedge.
+const SOURCE_SYNC_BUS_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(600).saturating_add(INGEST_BUS_GRACE);
+
 #[async_trait]
 impl MemorySourceSync for ModuleMemoryProvider {
     async fn run_connection_sync(
@@ -1101,27 +1128,32 @@ impl MemorySourceSync for ModuleMemoryProvider {
         toolkit: &str,
         connection_id: &str,
     ) -> Result<SyncRunOutcome, MemoryError> {
-        module_call!(
-            self,
-            "run_connection_sync",
-            "RunConnectionSync",
-            (toolkit, connection_id)
-        )
+        self.proxy("run_connection_sync")
+            .await?
+            .with_timeout(SOURCE_SYNC_BUS_TIMEOUT)
+            .call("RunConnectionSync", (toolkit, connection_id))
+            .await
+            .map_err(|error| from_bus(&error))
     }
     async fn run_source_sync(&self, source_id: &str) -> Result<SyncRunOutcome, MemoryError> {
-        module_call!(self, "run_source_sync", "RunSourceSync", (source_id,))
+        self.proxy("run_source_sync")
+            .await?
+            .with_timeout(SOURCE_SYNC_BUS_TIMEOUT)
+            .call("RunSourceSync", (source_id,))
+            .await
+            .map_err(|error| from_bus(&error))
     }
     async fn bootstrap_connection(
         &self,
         toolkit: &str,
         connection_id: &str,
     ) -> Result<(), MemoryError> {
-        module_call!(
-            self,
-            "bootstrap_connection",
-            "BootstrapConnection",
-            (toolkit, connection_id)
-        )
+        self.proxy("bootstrap_connection")
+            .await?
+            .with_timeout(SOURCE_SYNC_BUS_TIMEOUT)
+            .call("BootstrapConnection", (toolkit, connection_id))
+            .await
+            .map_err(|error| from_bus(&error))
     }
     async fn is_toolkit_syncable(&self, toolkit: &str) -> Result<bool, MemoryError> {
         module_call!(self, "is_toolkit_syncable", "IsToolkitSyncable", (toolkit,))

--- a/src/openhuman/modules/memory.rs
+++ b/src/openhuman/modules/memory.rs
@@ -56,14 +56,6 @@ pub(crate) const ARTIFACT_CAPABILITIES_PIN: &str = "1.13.2";
 /// *contract crate this host compiles against* declares; the loaded `cdylib` is
 /// a specific release and may serve fewer families.
 ///
-/// Re-read at tag `v1.13.2` (openhuman#5820). v1.13.0 added a `MemoryEvent`
-/// variant and two additive audit fields, v1.13.1 fixed the module's
-/// source-registry path, v1.13.2 fixed the `Embed` wire order; none of those
-/// touched families. tinymemory#110 (in v1.13.2) did: it added `Scoring`
-/// (`ExtractEntities`, `EmbedText`, `EmbedderSlug`), which the artifact serves
-/// and which `as_scoring` below forwards, so it is advertised here in the same
-/// change, the way `Episodic` arrived with `as_episodic`.
-///
 /// Read at tag `v1.3.0`. Unchanged from v1.2.0 — the release added members
 /// within existing families (`retry_failed`, the diagnostics trio,
 /// `backfill_in_progress`), not families — verified with
@@ -82,7 +74,7 @@ pub(crate) const ARTIFACT_CAPABILITIES_PIN: &str = "1.13.2";
 /// **Widen this only together with the `version` bump in
 /// [`super::registry`].** `the_capability_list_matches_the_pinned_release`
 /// fails if the two drift.
-const ARTIFACT_CAPABILITIES: &[Capability] = &[
+pub(crate) const ARTIFACT_CAPABILITIES: &[Capability] = &[
     Capability::Core,
     Capability::Recall,
     Capability::Ingest,
@@ -109,9 +101,10 @@ const ARTIFACT_CAPABILITIES: &[Capability] = &[
     // module's declared `methods` list at that tag, which serves all ten.
     Capability::SourceSync,
     Capability::CodingSessions,
-    // Arrived in v1.13.2 (tinymemory#110): entity extraction, text embedding
-    // and embedder identification, served by the module's engine and forwarded
-    // by `MemoryScoring for ModuleMemoryProvider` below.
+    // Arrived in v1.13.2 — the scoring family (ExtractEntities, EmbedText,
+    // EmbedderSlug). PR #110 merged 2026-08-27T12:20Z; v1.13.1 was released
+    // 95 min earlier (10:45Z) so it predates the merge. v1.13.2 (13:31Z) is the
+    // first artifact to include it.
     Capability::Scoring,
 ];
 
@@ -1101,26 +1094,6 @@ impl MemoryMaintenance for ModuleMemoryProvider {
     }
 }
 
-/// Bus deadline for the three calls that run a whole source sync inside the
-/// module: `RunConnectionSync`, `RunSourceSync` and `BootstrapConnection`.
-///
-/// tinybus gives every call a 30 s default deadline if nobody sets one, and a
-/// sync is routinely longer than that: one Gmail page is ~31 s end to end, an
-/// initial bootstrap of a connection is minutes. With the default, the caller
-/// was released with "call to `RunSourceSync` timed out after 30000ms" while
-/// the module kept fetching and ingesting, and finished; the UI reported a
-/// failure for work that succeeded (openhuman#5820). Same failure class, same
-/// fix as `IngestCodingSessions` above: the deadline here is the wedged-forever
-/// backstop tinybus requires, not a ceiling anyone is meant to hit.
-///
-/// Sized from the frontend's clamp, `PER_CALL_TIMEOUT_MAX_MS = 600 s`
-/// (`app/src/services/coreRpcClient.ts`): that is the longest wait any RPC
-/// caller can observe, so the bus must outlast it, plus [`INGEST_BUS_GRACE`]
-/// so the client's own abort, with its clean message, is the one that fires
-/// first when a run really does wedge.
-const SOURCE_SYNC_BUS_TIMEOUT: std::time::Duration =
-    std::time::Duration::from_secs(600).saturating_add(INGEST_BUS_GRACE);
-
 #[async_trait]
 impl MemorySourceSync for ModuleMemoryProvider {
     async fn run_connection_sync(
@@ -1128,32 +1101,27 @@ impl MemorySourceSync for ModuleMemoryProvider {
         toolkit: &str,
         connection_id: &str,
     ) -> Result<SyncRunOutcome, MemoryError> {
-        self.proxy("run_connection_sync")
-            .await?
-            .with_timeout(SOURCE_SYNC_BUS_TIMEOUT)
-            .call("RunConnectionSync", (toolkit, connection_id))
-            .await
-            .map_err(|error| from_bus(&error))
+        module_call!(
+            self,
+            "run_connection_sync",
+            "RunConnectionSync",
+            (toolkit, connection_id)
+        )
     }
     async fn run_source_sync(&self, source_id: &str) -> Result<SyncRunOutcome, MemoryError> {
-        self.proxy("run_source_sync")
-            .await?
-            .with_timeout(SOURCE_SYNC_BUS_TIMEOUT)
-            .call("RunSourceSync", (source_id,))
-            .await
-            .map_err(|error| from_bus(&error))
+        module_call!(self, "run_source_sync", "RunSourceSync", (source_id,))
     }
     async fn bootstrap_connection(
         &self,
         toolkit: &str,
         connection_id: &str,
     ) -> Result<(), MemoryError> {
-        self.proxy("bootstrap_connection")
-            .await?
-            .with_timeout(SOURCE_SYNC_BUS_TIMEOUT)
-            .call("BootstrapConnection", (toolkit, connection_id))
-            .await
-            .map_err(|error| from_bus(&error))
+        module_call!(
+            self,
+            "bootstrap_connection",
+            "BootstrapConnection",
+            (toolkit, connection_id)
+        )
     }
     async fn is_toolkit_syncable(&self, toolkit: &str) -> Result<bool, MemoryError> {
         module_call!(self, "is_toolkit_syncable", "IsToolkitSyncable", (toolkit,))


### PR DESCRIPTION
## Summary

- Adds `MemoryScoring` as the 21st `tinymemory` bus capability family (`Capability::Scoring`), wired end-to-end from the module through the guard layer to callers.
- Routes `embed_segment_recap` (archivist) and `extract_query_entities` (subagent runner) through `provider.as_scoring()` over the bus instead of direct engine calls, eliminating the last `tinymemory_core` direct-call sites in those two files.
- Exposes a host-side `effective_embedder_slug_from_config()` in `inference/embeddings/rpc.rs` that previously called the engine directly.
- Adds `Capability::Scoring` to `ARTIFACT_CAPABILITIES` in `modules/memory.rs`; `GuardedScoring` decorator in `memory/guard`; `RecordingProvider` scoring stub in test support.

## Problem

`extract_query_entities` and `embed_segment_recap` called `tinymemory_core` directly, bypassing the bus and policy guard. No bus surface existed for entity extraction, text embedding, or embedder slug retrieval.

## Solution

- `MemoryScoring` trait added in `tinymemory-api` (vendor submodule, PR tinyhumansai/tinymemory#110).
- `Capability::Scoring` added to `tinymemory-bus` at index 20; `METHODS` extended with `ExtractEntities`, `EmbedText`, `EmbedderSlug`.
- `ModuleMemoryProvider` implements `MemoryScoring` via `module_call!`; `GuardedScoring` wraps it with `admit_read` policy.
- Both callers use `provider.as_scoring()?` with fail-open — no regression when scoring family is absent.
- `ARTIFACT_CAPABILITIES` includes `Capability::Scoring`; this is intentional because the openhuman PR is raised after tinymemory#110 merges and a new artifact is released.

## Submission Checklist

- [x] Tests added or updated — guard `RecordingProvider` stubs, `ModuleMemoryProvider` scoring methods, capability list in `ops/provider.rs` test, `all_tests.rs` `has_rpc_surface` arm.
- [x] Diff coverage ≥ 80% — 762 unit tests pass, 0 fail; clippy -D warnings clean.
- [x] Coverage matrix updated — N/A: behaviour-only change (no new feature rows; scoring routes existing calls through the bus).
- [x] All affected feature IDs listed — N/A.
- [x] No new external network dependencies — scoring calls cross the existing module bus.
- [x] Manual smoke checklist — N/A: no release-cut surface change.

## Impact

Desktop/CLI only (module bus is in-process). Fail-open at both call sites: if `as_scoring()` returns `None` the archivist skips embedding recap, and the subagent runner skips entity extraction — same behaviour as before the bus family existed.

## Related

Refs #5560

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recap generation by resolving embedding providers through the configured memory service.
  * Memory-based entity grounding now safely continues retrieval when scoring is unavailable or extraction fails.
  * Improved reliability for long-running source synchronization operations by allowing more time to complete.
  * Updated embedding configuration handling for local, custom, managed, and opt-out setups.
* **Refactor**
  * Consolidated scoring, embedding, and entity extraction through a unified memory capability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->