### PR TITLE
Harden auth profile writes and logout cache clearing

### DIFF
--- a/src/openhuman/desktop/app_state/ops.rs
+++ b/src/openhuman/desktop/app_state/ops.rs
@@ -237,6 +237,13 @@ fn clear_current_user_failure() {
     *CURRENT_USER_FAILURE.lock() = None;
 }
 
+/// Clear all process-global current-user state after the session identity
+/// changes or is removed.
+pub fn clear_current_user_caches() {
+    *CURRENT_USER_CACHE.lock() = None;
+    clear_current_user_failure();
+}
+
 /// Record the timeout path's failure.
 ///
 /// The timeout is applied by the snapshot caller, wrapping the whole of

--- a/src/openhuman/desktop/app_state/ops_tests.rs
+++ b/src/openhuman/desktop/app_state/ops_tests.rs
@@ -635,6 +635,36 @@ fn clearing_the_record_lets_the_next_attempt_through() {
     );
 }
 
+#[test]
+fn clearing_current_user_caches_drops_positive_and_negative_entries() {
+    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.lock();
+    let _failure_lock = CURRENT_USER_FAILURE_TEST_LOCK.blocking_lock();
+    let _reset = CurrentUserFailureResetGuard;
+
+    *CURRENT_USER_CACHE.lock() = Some(CachedCurrentUser {
+        api_base: "https://api.example.test".to_string(),
+        token: "token-a".to_string(),
+        fetched_at: Instant::now(),
+        user: json!({ "id": "user-a" }),
+    });
+    record_current_user_failure(
+        "https://api.example.test",
+        "token-a",
+        CurrentUserFetchError::FetchFailed("seeded outage".to_string()),
+    );
+
+    clear_current_user_caches();
+
+    assert!(
+        CURRENT_USER_CACHE.lock().is_none(),
+        "positive current-user cache must be cleared"
+    );
+    assert!(
+        suppressed_current_user_failure("https://api.example.test", "token-a").is_none(),
+        "negative current-user cache must be cleared"
+    );
+}
+
 #[tokio::test]
 async fn fetch_current_user_cached_replays_a_recorded_failure_without_calling_the_backend() {
     let _failure_lock = CURRENT_USER_FAILURE_TEST_LOCK.lock().await;

--- a/src/openhuman/security/credentials/ops.rs
+++ b/src/openhuman/security/credentials/ops.rs
@@ -811,6 +811,7 @@ pub async fn clear_session(config: &Config) -> Result<RpcOutcome<serde_json::Val
     let removed = auth
         .remove_profile(APP_SESSION_PROVIDER, DEFAULT_AUTH_PROFILE_NAME)
         .map_err(|e| e.to_string())?;
+    crate::openhuman::desktop::app_state::clear_current_user_caches();
 
     // The core process stays alive on logout. Tear down its authenticated
     // Socket.IO transport and the user-pinned workflow bridge so neither can

--- a/src/openhuman/security/credentials/profiles.rs
+++ b/src/openhuman/security/credentials/profiles.rs
@@ -4,7 +4,10 @@ use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
-use std::fs::{self, OpenOptions};
+use std::fs;
+#[cfg(unix)]
+use std::fs::OpenOptions;
+#[cfg(unix)]
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, MutexGuard, OnceLock, TryLockError};
@@ -1041,7 +1044,7 @@ impl AuthProfilesStore {
             PERSIST_RETRY_BASE_MS,
             || {
                 self.consume_test_transient_failure_write()?;
-                fs::write(&tmp_path, &json).context("write auth profile tmp")
+                write_auth_profile_tmp(&tmp_path, &json).context("write auth profile tmp")
             },
         )
         .with_context(|| {
@@ -1523,6 +1526,26 @@ impl AuthProfilesStore {
             }
         }
     }
+}
+
+#[cfg(unix)]
+fn write_auth_profile_tmp(path: &Path, json: &[u8]) -> Result<()> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)?;
+    file.write_all(json)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn write_auth_profile_tmp(path: &Path, json: &[u8]) -> Result<()> {
+    fs::write(path, json)?;
+    Ok(())
 }
 
 /// Cross-platform best-effort check that a given OS process id is currently

--- a/src/openhuman/security/credentials/profiles_tests.rs
+++ b/src/openhuman/security/credentials/profiles_tests.rs
@@ -1093,3 +1093,38 @@ fn rename_stage_exhausts_retries_and_cleans_up_tmp() {
         "rename exhaustion must trigger best-effort tmp cleanup; leaked: {leaked:?}"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn auth_profile_store_is_owner_only_after_create_and_update() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let tmp = TempDir::new().unwrap();
+    let store = AuthProfilesStore::new(tmp.path(), false);
+
+    let profile = AuthProfile::new_token("anthropic", "default", "tok-create".into());
+    store.upsert_profile(profile, true).unwrap();
+
+    let created_mode = std::fs::metadata(store.path())
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(
+        created_mode, 0o600,
+        "auth profile store must be owner-only after initial create"
+    );
+
+    let updated = AuthProfile::new_token("anthropic", "default", "tok-update".into());
+    store.upsert_profile(updated, true).unwrap();
+
+    let updated_mode = std::fs::metadata(store.path())
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(
+        updated_mode, 0o600,
+        "auth profile store must stay owner-only after replacement writes"
+    );
+}


### PR DESCRIPTION
## Summary

- write auth-profile temp files with owner-only permissions on Unix so `auth-profiles.json` is published as `0600` after atomic replacement
- clear both positive and negative current-user caches during `clear_session` so same-token re-login cannot reuse stale session state
- add regression coverage for the file mode and cache reset behavior

Fixes #5724.
Fixes #5758.

## Tests

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_INCREMENTAL=0 cargo test -p openhuman --lib clearing_current_user_caches_drops_positive_and_negative_entries`
- `CARGO_INCREMENTAL=0 cargo test -p openhuman --lib auth_profile_store_is_owner_only_after_create_and_update`
- `CARGO_INCREMENTAL=0 cargo clippy -p openhuman -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Signing out now immediately clears cached user information and recorded lookup failures, preventing stale account state from appearing.
  - Authentication profile files on Unix systems are now restricted to the account owner, improving credential protection during creation and updates.

- **Tests**
  - Added coverage to verify cache clearing removes both successful and failed lookup records.
  - Added checks confirming secure permissions for newly created and updated authentication profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->