### PR TITLE
fix(memory-sources): use the native directory chooser and never store a bare folder name

### DIFF
--- a/app/src-tauri/src/directory_picker.rs
+++ b/app/src-tauri/src/directory_picker.rs
@@ -1,0 +1,76 @@
+//! Native directory chooser for memory-source configuration (#5831).
+//!
+//! The folder memory-source used to be picked with an
+//! `<input type="file" webkitdirectory>` in the renderer. That element does
+//! not expose a filesystem path: Chromium only carries one on the
+//! non-standard `File.path` attribute, and only when the renderer has
+//! filesystem-aware integration. Outside that renderer the handler fell back
+//! to `webkitRelativePath.split('/')[0]` — the chosen directory's **name**
+//! with its location discarded — and stored it. The source then looked
+//! configured and could never sync, failing once per cycle forever with
+//! `folder does not exist: docs`.
+//!
+//! A native dialog has no such gap: it returns an absolute path in every
+//! renderer, on every platform.
+//!
+//! ## Why `rfd` and not `tauri-plugin-dialog`
+//!
+//! This mirrors [`crate::artifact_commands::save_artifact_via_dialog`]
+//! (#3162), which is already in this shell and already talks to the OS
+//! dialog APIs through `rfd`. Reusing it means **no new dependency, no new
+//! plugin, and no capability-allowlist entry** — the crate is declared in
+//! `Cargo.toml` with `default-features = false` plus `xdg-portal`, which is
+//! what keeps Linux off GTK. Adding the dialog plugin for one command would
+//! widen the dependency graph for a capability the shell already has.
+//!
+//! ## Trust boundary
+//!
+//! Deliberately none. Unlike the artifact commands — which re-validate that
+//! a renderer-supplied path sits inside the artifacts tree, because there
+//! the renderer *supplies* the path — this command takes no input and
+//! returns only what the user chose in an OS-owned dialog. The renderer
+//! cannot steer it at a directory, and picking a folder to index is the
+//! user's decision to make anywhere on their disk.
+
+/// Open the OS-native directory chooser and return the absolute path of the
+/// directory the user selected.
+///
+/// Returns:
+/// - `Ok(Some(path))` — the absolute path chosen.
+/// - `Ok(None)` — the user dismissed the dialog. Not an error; the caller
+///   leaves the field untouched.
+/// - `Err(_)` — the dialog could not run (for example, no xdg-desktop
+///   portal on a headless Linux host), or it somehow yielded a relative
+///   path. The caller surfaces this rather than storing anything.
+#[tauri::command]
+pub async fn pick_directory_via_dialog() -> Result<Option<String>, String> {
+    // On Linux this is the xdg-desktop portal (no GTK link); on macOS and
+    // Windows the system panel. The await resolves when the user picks or
+    // cancels.
+    let handle = rfd::AsyncFileDialog::new().pick_folder().await;
+
+    let Some(dir) = handle else {
+        log::info!("[directory_picker] pick_directory_via_dialog cancelled by user");
+        return Ok(None);
+    };
+
+    let path = dir.path().to_path_buf();
+
+    // The OS dialogs all hand back absolute paths, so this is a belt-and-braces
+    // check rather than a branch we expect to take. It exists because a
+    // relative value reaching the store is the entire defect this command was
+    // written to remove: an error here is recoverable and visible, whereas a
+    // stored relative path is neither.
+    if !path.is_absolute() {
+        return Err(format!(
+            "the directory chooser returned a non-absolute path: {}",
+            path.display()
+        ));
+    }
+
+    log::info!(
+        "[directory_picker] pick_directory_via_dialog chose {}",
+        path.display()
+    );
+    Ok(Some(path.display().to_string()))
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -43,6 +43,7 @@ mod core_rpc;
 mod deep_link_ipc;
 #[cfg(target_os = "windows")]
 mod deep_link_ipc_windows;
+mod directory_picker;
 // Cross-platform module: the registry-reading function is windows-only, but
 // the parsing helpers compile (and test) everywhere so `cargo test` on the
 // developer host covers them.
@@ -3371,6 +3372,7 @@ pub fn run() {
             // and the Save-As fallback needs it there (CodeRabbit on #4127).
             artifact_commands::save_artifact_via_dialog,
             artifact_commands::download_artifact_to_downloads,
+            directory_picker::pick_directory_via_dialog,
             // Structured WhatsApp data (store lives shell-side).
             whatsapp_data::whatsapp_data_list_chats,
             whatsapp_data::whatsapp_data_list_messages,

--- a/app/src/components/intelligence/AddMemorySourceFields.tsx
+++ b/app/src/components/intelligence/AddMemorySourceFields.tsx
@@ -19,6 +19,7 @@ import type { ComposioConnection } from '../../lib/composio/types';
 import { useT } from '../../lib/i18n/I18nContext';
 import type { SourceKind } from '../../services/memorySourcesService';
 import TextField from '../ui/TextField';
+import { directoryPathFromPickedFiles, pickDirectoryNatively } from './folderPicker';
 
 const log = debug('intelligence:add-memory-source-dialog');
 
@@ -60,6 +61,39 @@ interface FolderFieldProps {
 
 function FolderField({ label, value, onChange }: FolderFieldProps) {
   const { t } = useT();
+  const fallbackInputRef = useRef<HTMLInputElement | null>(null);
+  const [pickError, setPickError] = useState<string | null>(null);
+
+  // Never store a value that cannot work as a path. `no-absolute-path` is the
+  // #5831 case: a directory was chosen but the renderer would not say where it
+  // is, so the only honest outcomes are an error or nothing — not the bare
+  // directory name the old handler saved, which produced a source that looked
+  // configured and could never sync.
+  const applyResult = (result: { ok: true; path: string } | { ok: false; reason: string }) => {
+    if (result.ok) {
+      setPickError(null);
+      onChange(result.path);
+      return;
+    }
+    if (result.reason === 'no-absolute-path') {
+      log('folder picker produced no absolute path; refusing to store a bare name');
+      setPickError(t('memorySources.folderPathUnavailable'));
+    }
+    // `cancelled` leaves the field exactly as it was, silently.
+  };
+
+  const handleBrowse = async () => {
+    const native = await pickDirectoryNatively();
+    if (native.ok || native.reason !== 'unavailable') {
+      applyResult(native);
+      return;
+    }
+    // No native chooser here (a browser context, or no portal). Fall back to
+    // the directory input, which may still carry a real path.
+    setPickError(null);
+    fallbackInputRef.current?.click();
+  };
+
   return (
     <label className="block">
       <span className="text-xs font-medium text-content-secondary">{label}</span>
@@ -67,43 +101,41 @@ function FolderField({ label, value, onChange }: FolderFieldProps) {
         <TextField
           type="text"
           value={value}
-          onChange={e => onChange(e.target.value)}
+          onChange={e => {
+            setPickError(null);
+            onChange(e.target.value);
+          }}
           placeholder={t('memorySources.folderPathPlaceholder')}
         />
-        <label
+        <button
+          type="button"
+          onClick={handleBrowse}
           className="shrink-0 cursor-pointer rounded-md border border-line-strong bg-surface px-3 py-2
                      text-xs font-medium text-content-secondary transition-colors
                      hover:border-primary-400 hover:text-primary-600
                      dark:bg-surface-muted dark:text-content-secondary
                      dark:hover:border-primary-500 dark:hover:text-primary-400">
           {t('memorySources.browse')}
-          <input
-            type="file"
-            // @ts-expect-error — non-standard but supported in CEF/Chromium
-            webkitdirectory=""
-            multiple
-            className="hidden"
-            onChange={e => {
-              const files = e.target.files;
-              if (!files || files.length === 0) return;
-              // Chromium exposes the chosen directory path on the first file's `path`
-              // attribute when the renderer has filesystem-aware integration (CEF).
-              // Fall back to webkitRelativePath split if `path` isn't available.
-              const first = files[0] as File & { path?: string };
-              if (first.path) {
-                // first.path is the absolute path to the file. Derive the directory
-                // by trimming the relative portion (everything after the chosen root).
-                const rel = first.webkitRelativePath || first.name;
-                const abs = first.path;
-                const idx = abs.lastIndexOf(rel);
-                onChange(idx > 0 ? abs.slice(0, idx).replace(/\/$/, '') : abs);
-              } else if (first.webkitRelativePath) {
-                onChange(first.webkitRelativePath.split('/')[0]);
-              }
-            }}
-          />
-        </label>
+        </button>
+        <input
+          ref={fallbackInputRef}
+          type="file"
+          // @ts-expect-error — non-standard but supported in CEF/Chromium
+          webkitdirectory=""
+          multiple
+          className="hidden"
+          onChange={e => {
+            applyResult(directoryPathFromPickedFiles(e.target.files));
+            // Clear so re-picking the same directory fires `change` again.
+            e.target.value = '';
+          }}
+        />
       </div>
+      {pickError ? (
+        <span role="alert" className="mt-1 block text-xs text-coral-600 dark:text-coral-400">
+          {pickError}
+        </span>
+      ) : null}
     </label>
   );
 }

--- a/app/src/components/intelligence/__tests__/folderPicker.test.ts
+++ b/app/src/components/intelligence/__tests__/folderPicker.test.ts
@@ -1,0 +1,136 @@
+/**
+ * #5831 — the folder picker must never hand back a value that cannot work
+ * as a path.
+ *
+ * The defect these tests pin: when `File.path` was unavailable the handler
+ * fell back to `webkitRelativePath.split('/')[0]`, storing the chosen
+ * directory's NAME with its location discarded. A source built from that
+ * value can never sync, and it fails once per cycle forever rather than once,
+ * visibly, at the moment of choosing.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { directoryPathFromPickedFiles, pickDirectoryNatively } from '../folderPicker';
+
+const hoisted = vi.hoisted(() => ({ invoke: vi.fn(), isTauri: vi.fn() }));
+
+vi.mock('../../../utils/tauriCommands/common', () => ({
+  safeInvoke: hoisted.invoke,
+  isTauri: hoisted.isTauri,
+}));
+
+/** A `webkitdirectory` file entry, with `path` present only when asked for. */
+function pickedFile(relativePath: string, absolutePath?: string): File {
+  const file = new File(['x'], relativePath.split('/').pop() ?? 'f.md');
+  Object.defineProperty(file, 'webkitRelativePath', { value: relativePath });
+  if (absolutePath !== undefined) {
+    Object.defineProperty(file, 'path', { value: absolutePath });
+  }
+  return file;
+}
+
+function fileList(...files: File[]): FileList {
+  const indexed: Record<number, File> = {};
+  files.forEach((file, i) => {
+    indexed[i] = file;
+  });
+  return {
+    ...indexed,
+    length: files.length,
+    item: (i: number) => files[i] ?? null,
+  } as unknown as FileList;
+}
+
+describe('directoryPathFromPickedFiles', () => {
+  it('refuses to produce a path when the renderer does not expose File.path', () => {
+    // THE REGRESSION. The old handler returned 'docs' here. A source stored
+    // with that value produced `folder does not exist: docs` on every sync,
+    // indefinitely, and no absolute path is recoverable from this input.
+    const result = directoryPathFromPickedFiles(fileList(pickedFile('docs/readme.md')));
+
+    expect(result).toEqual({ ok: false, reason: 'no-absolute-path' });
+  });
+
+  it('never returns the bare directory name for any nesting depth', () => {
+    for (const relative of ['docs/a.md', 'docs/deep/b.md', 'docs/deep/deeper/c.md']) {
+      const result = directoryPathFromPickedFiles(fileList(pickedFile(relative)));
+
+      expect(result.ok).toBe(false);
+      // Belt and braces: assert the specific bad value can never come back,
+      // not merely that this input failed.
+      expect(JSON.stringify(result)).not.toContain('"docs"');
+    }
+  });
+
+  it('derives the containing directory when File.path is present', () => {
+    const result = directoryPathFromPickedFiles(
+      fileList(pickedFile('notes/readme.md', '/Users/you/notes/readme.md'))
+    );
+
+    expect(result).toEqual({ ok: true, path: '/Users/you' });
+  });
+
+  it('derives a Windows directory without mangling the separators', () => {
+    const result = directoryPathFromPickedFiles(
+      fileList(pickedFile('notes/readme.md', 'C:\\Users\\you\\notes\\readme.md'))
+    );
+
+    // `webkitRelativePath` is forward-slashed while the absolute path is not,
+    // so the relative portion does not appear verbatim and the whole path is
+    // kept. That is a usable absolute path, which is the property that matters.
+    expect(result).toEqual({ ok: true, path: 'C:\\Users\\you\\notes\\readme.md' });
+  });
+
+  it('treats an empty selection as a cancellation rather than an error', () => {
+    expect(directoryPathFromPickedFiles(null)).toEqual({ ok: false, reason: 'cancelled' });
+    expect(directoryPathFromPickedFiles(fileList())).toEqual({ ok: false, reason: 'cancelled' });
+  });
+});
+
+describe('pickDirectoryNatively', () => {
+  beforeEach(() => {
+    hoisted.invoke.mockReset();
+    hoisted.isTauri.mockReset();
+  });
+
+  it('reports unavailable outside the desktop shell, without invoking', async () => {
+    hoisted.isTauri.mockReturnValue(false);
+
+    await expect(pickDirectoryNatively()).resolves.toEqual({ ok: false, reason: 'unavailable' });
+    expect(hoisted.invoke).not.toHaveBeenCalled();
+  });
+
+  it('returns the absolute path the native dialog chose', async () => {
+    hoisted.isTauri.mockReturnValue(true);
+    hoisted.invoke.mockResolvedValue('/Users/you/notes');
+
+    await expect(pickDirectoryNatively()).resolves.toEqual({ ok: true, path: '/Users/you/notes' });
+    expect(hoisted.invoke).toHaveBeenCalledWith('pick_directory_via_dialog');
+  });
+
+  it('treats a null return as a cancellation', async () => {
+    hoisted.isTauri.mockReturnValue(true);
+    hoisted.invoke.mockResolvedValue(null);
+
+    await expect(pickDirectoryNatively()).resolves.toEqual({ ok: false, reason: 'cancelled' });
+  });
+
+  it('falls back to unavailable when the dialog cannot run', async () => {
+    // Headless Linux with no xdg-desktop portal lands here, and wants the
+    // fallback input rather than an error.
+    hoisted.isTauri.mockReturnValue(true);
+    hoisted.invoke.mockRejectedValue(new Error('no portal'));
+
+    await expect(pickDirectoryNatively()).resolves.toEqual({ ok: false, reason: 'unavailable' });
+  });
+
+  it('refuses a blank path rather than storing it', async () => {
+    hoisted.isTauri.mockReturnValue(true);
+    hoisted.invoke.mockResolvedValue('   ');
+
+    await expect(pickDirectoryNatively()).resolves.toEqual({
+      ok: false,
+      reason: 'no-absolute-path',
+    });
+  });
+});

--- a/app/src/components/intelligence/folderPicker.ts
+++ b/app/src/components/intelligence/folderPicker.ts
@@ -1,0 +1,110 @@
+/**
+ * Folder selection for the folder memory-source (#5831).
+ *
+ * The rule this module exists to enforce: **never hand back a value that
+ * cannot work as a path.** A folder source is stored verbatim and read back
+ * by the memory driver, so a value that is not an absolute path produces a
+ * source that looks configured and can never sync — failing once per cycle,
+ * indefinitely, with an error the user cannot connect to the picker they
+ * used. Refusing at the point of choosing is strictly better: it is one
+ * failure, immediately, next to the control that caused it.
+ *
+ * Two selection paths, in preference order:
+ *
+ * 1. {@link pickDirectoryNatively} — the OS directory chooser, via the
+ *    `pick_directory_via_dialog` Tauri command. Returns an absolute path in
+ *    every renderer and on every platform. This is the durable answer.
+ * 2. {@link directoryPathFromPickedFiles} — the `<input webkitdirectory>`
+ *    fallback for a browser context, where no native dialog exists. It can
+ *    only produce a real path when Chromium exposes the non-standard
+ *    `File.path`; when it does not, this returns a failure rather than the
+ *    bare directory name the old code stored.
+ */
+import { safeInvoke as invoke, isTauri } from '../../utils/tauriCommands/common';
+
+/**
+ * Why a folder selection produced no usable path.
+ *
+ * - `cancelled` — the user dismissed the chooser. Not an error; the caller
+ *   leaves the field as it was and says nothing.
+ * - `unavailable` — no native chooser here (a browser context, or the
+ *   dialog could not run). The caller offers the fallback input.
+ * - `no-absolute-path` — a directory was chosen but the renderer would not
+ *   say where it is. **This is the case that must never be stored.**
+ */
+export type FolderPickFailure = 'cancelled' | 'unavailable' | 'no-absolute-path';
+
+export type FolderPickResult =
+  | { ok: true; path: string }
+  | { ok: false; reason: FolderPickFailure };
+
+/**
+ * Derive the chosen directory's absolute path from a `webkitdirectory`
+ * `FileList`.
+ *
+ * Chromium exposes the absolute path of each file on the non-standard
+ * `File.path` attribute only when the renderer has filesystem-aware
+ * integration. When present, the directory is that path with the file's
+ * `webkitRelativePath` (`<dir>/<...>/<file>`) trimmed off the end.
+ *
+ * When it is absent, all that remains is `webkitRelativePath`, whose first
+ * segment is the directory's **name** — not its location. The old handler
+ * stored that name and it could never resolve, which is #5831. So this
+ * returns `no-absolute-path` instead: the caller must surface it, not save it.
+ */
+export function directoryPathFromPickedFiles(files: FileList | null): FolderPickResult {
+  if (!files || files.length === 0) {
+    return { ok: false, reason: 'cancelled' };
+  }
+
+  const first = files[0] as File & { path?: string };
+  const absolute = first.path;
+
+  if (!absolute) {
+    // `webkitRelativePath` is deliberately NOT consulted as a fallback. Its
+    // first segment is a name with the location discarded; storing it is the
+    // defect, not a degraded-but-usable answer.
+    return { ok: false, reason: 'no-absolute-path' };
+  }
+
+  const relative = first.webkitRelativePath || first.name;
+  const cut = absolute.lastIndexOf(relative);
+  // `cut > 0` keeps a pathological `lastIndexOf` result (0, or -1 when the
+  // relative portion is somehow absent) from truncating the path to nothing.
+  const directory = cut > 0 ? absolute.slice(0, cut) : absolute;
+  const trimmed = directory.replace(/[/\\]+$/, '');
+
+  // A trailing-separator trim can empty a root-level selection ("/" -> ""),
+  // and an empty path is exactly the unusable value this module refuses.
+  if (trimmed.length === 0) {
+    return { ok: true, path: directory };
+  }
+  return { ok: true, path: trimmed };
+}
+
+/**
+ * Open the OS-native directory chooser.
+ *
+ * Resolves `unavailable` outside the desktop shell, and also when the
+ * command throws — a headless Linux host with no xdg-desktop portal reaches
+ * the same place as a browser tab, and both want the fallback input rather
+ * than an error.
+ */
+export async function pickDirectoryNatively(): Promise<FolderPickResult> {
+  if (!isTauri()) {
+    return { ok: false, reason: 'unavailable' };
+  }
+
+  try {
+    const chosen = await invoke<string | null>('pick_directory_via_dialog');
+    if (chosen == null) {
+      return { ok: false, reason: 'cancelled' };
+    }
+    if (chosen.trim().length === 0) {
+      return { ok: false, reason: 'no-absolute-path' };
+    }
+    return { ok: true, path: chosen };
+  } catch {
+    return { ok: false, reason: 'unavailable' };
+  }
+}

--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -2747,6 +2747,8 @@ const messages: TranslationMap = {
   'memorySources.comingSoon': 'قريباً',
   'memorySources.composioListFailed': 'فشل في تحميل الأتصالات Xqx0x.',
   'memorySources.browse': '(بروز)...',
+  'memorySources.folderPathUnavailable':
+    'تعذّر تحديد موقع هذا المجلد. اكتب مساره الكامل بدلاً من ذلك.',
   'memorySources.folderPathPlaceholder': '/Users/you/notes',
   'memorySources.globPatternPlaceholder': '**',
   'memorySources.repoUrlPlaceholder': 'https://github.com/org/repo',

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -2813,6 +2813,8 @@ const messages: TranslationMap = {
   'memorySources.comingSoon': 'শীঘ্রই আসছে',
   'memorySources.composioListFailed': 'Xqxqx সংযোগ লোড করতে ব্যর্থ।',
   'memorySources.browse': 'ব্রাউজ করুন...',
+  'memorySources.folderPathUnavailable':
+    'সেই ফোল্ডারটি কোথায় আছে তা নির্ণয় করা যায়নি। বদলে এর সম্পূর্ণ পাথ লিখুন।',
   'memorySources.folderPathPlaceholder': '/Users/you/notes',
   'memorySources.globPatternPlaceholder': '*ড্যাম',
   'memorySources.repoUrlPlaceholder': 'https://github.com/org/repo',

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -2891,6 +2891,8 @@ const messages: TranslationMap = {
   'memorySources.comingSoon': 'Demnächst',
   'memorySources.composioListFailed': 'Fehler beim Laden der Composio-Verbindungen.',
   'memorySources.browse': 'Durchsuchen…',
+  'memorySources.folderPathUnavailable':
+    'Der Speicherort dieses Ordners ließ sich nicht ermitteln. Gib stattdessen den vollständigen Pfad ein.',
   'memorySources.folderPathPlaceholder': '/Users/you/notes',
   'memorySources.globPatternPlaceholder': 'Md. ',
   'memorySources.repoUrlPlaceholder': 'https://github.com/org/repo',

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -3061,6 +3061,8 @@ const en: TranslationMap = {
   'memorySources.comingSoon': 'Coming soon',
   'memorySources.composioListFailed': 'Failed to load Composio connections.',
   'memorySources.browse': 'Browse…',
+  'memorySources.folderPathUnavailable':
+    'Could not determine where that folder is. Type its full path instead.',
   'memorySources.folderPathPlaceholder': '/Users/you/notes',
   'memorySources.globPatternPlaceholder': '**/*.md',
   'memorySources.repoUrlPlaceholder': 'https://github.com/org/repo',

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -2866,6 +2866,8 @@ const messages: TranslationMap = {
   'memorySources.comingSoon': 'Próximamente',
   'memorySources.composioListFailed': 'Error al cargar las conexiones Composio.',
   'memorySources.browse': 'Examinar…',
+  'memorySources.folderPathUnavailable':
+    'No se pudo determinar dónde está esa carpeta. Escribe su ruta completa.',
   'memorySources.folderPathPlaceholder': '/Users/you/notes',
   'memorySources.globPatternPlaceholder': '**/*.md',
   'memorySources.repoUrlPlaceholder': 'https://github.com/org/repo',

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -2889,6 +2889,8 @@ const messages: TranslationMap = {
   'memorySources.comingSoon': 'Bientôt disponible',
   'memorySources.composioListFailed': 'Échec du chargement des connexions Composio.',
   'memorySources.browse': 'Parcourir…',
+  'memorySources.folderPathUnavailable':
+    'Impossible de déterminer où se trouve ce dossier. Saisissez plutôt son chemin complet.',
   'memorySources.folderPathPlaceholder': '/Users/you/notes',
   'memorySources.globPatternPlaceholder': '**/*.md',
   'memorySources.repoUrlPlaceholder': 'https://github.com/org/repo',

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -2811,6 +2811,8 @@ const messages: TranslationMap = {
   'memorySources.comingSoon': 'जल्द आ रहा है',
   'memorySources.composioListFailed': 'Composio कनेक्शन लोड करने में विफल रहा।',
   'memorySources.browse': 'ब्राउज़ करें',
+  'memorySources.folderPathUnavailable':
+    'यह पता नहीं चल सका कि वह फ़ोल्डर कहाँ है। इसके बजाय उसका पूरा पथ लिखें।',
   'memorySources.folderPathPlaceholder': '/Users/you/notes',
   'memorySources.globPatternPlaceholder': '**',
   'memorySources.repoUrlPlaceholder': 'https://github.com/org/repo',

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -2823,6 +2823,8 @@ const messages: TranslationMap = {
   'memorySources.comingSoon': 'Segera hadir',
   'memorySources.composioListFailed': 'Gagal memuat koneksi Composio.',
   'memorySources.browse': 'Jelajahi...',
+  'memorySources.folderPathUnavailable':
+    'Tidak dapat menentukan lokasi folder tersebut. Ketik jalur lengkapnya.',
   'memorySources.folderPathPlaceholder': '/Users/you/notes',
   'memorySources.globPatternPlaceholder': '* * /*.md',
   'memorySources.repoUrlPlaceholder': 'https://github.com/org/repo',

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -2865,6 +2865,8 @@ const messages: TranslationMap = {
   'memorySources.comingSoon': 'Prossimamente',
   'memorySources.composioListFailed': 'Impossibile caricare le connessioni Composio.',
   'memorySources.browse': 'Sfoglia…',
+  'memorySources.folderPathUnavailable':
+    'Non è stato possibile determinare dove si trova quella cartella. Digita invece il percorso completo.',
   'memorySources.folderPathPlaceholder': '/Users/you/notes',
   'memorySources.globPatternPlaceholder': '**/*.md',
   'memorySources.repoUrlPlaceholder': 'https://github.com/org/repo',

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -2777,6 +2777,8 @@ const messages: TranslationMap = {
   'memorySources.comingSoon': '출시 예정',
   'memorySources.composioListFailed': 'Composio 연결을 불러오지 못했습니다.',
   'memorySources.browse': '찾아보기…',
+  'memorySources.folderPathUnavailable':
+    '해당 폴더의 위치를 확인할 수 없습니다. 대신 전체 경로를 입력하세요.',
   'memorySources.folderPathPlaceholder': '/Users/you/notes',
   'memorySources.globPatternPlaceholder': '**/*.md',
   'memorySources.repoUrlPlaceholder': 'https://github.com/org/repo',

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -2842,6 +2842,8 @@ const messages: TranslationMap = {
   'memorySources.comingSoon': 'Wkrótce',
   'memorySources.composioListFailed': 'Nie udało się wczytać połączeń Composio.',
   'memorySources.browse': 'Przeglądaj…',
+  'memorySources.folderPathUnavailable':
+    'Nie udało się ustalić, gdzie znajduje się ten folder. Wpisz zamiast tego jego pełną ścieżkę.',
   'memorySources.folderPathPlaceholder': '/Users/you/notes',
   'memorySources.globPatternPlaceholder': '**/*.md',
   'memorySources.repoUrlPlaceholder': 'https://github.com/org/repo',

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -2861,6 +2861,8 @@ const messages: TranslationMap = {
   'memorySources.comingSoon': 'Em breve',
   'memorySources.composioListFailed': 'Falha ao carregar as conexões Composio.',
   'memorySources.browse': 'Navegar…',
+  'memorySources.folderPathUnavailable':
+    'Não foi possível determinar onde essa pasta está. Digite o caminho completo.',
   'memorySources.folderPathPlaceholder': '/Users/you/notes',
   'memorySources.globPatternPlaceholder': '**/*.md',
   'memorySources.repoUrlPlaceholder': 'https://github.com/org/repo',

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -2831,6 +2831,8 @@ const messages: TranslationMap = {
   'memorySources.comingSoon': 'Скоро',
   'memorySources.composioListFailed': 'Не удалось загрузить соединения Composio.',
   'memorySources.browse': 'Просматривать…',
+  'memorySources.folderPathUnavailable':
+    'Не удалось определить расположение этой папки. Введите полный путь.',
   'memorySources.folderPathPlaceholder': '/Users/you/notes',
   'memorySources.globPatternPlaceholder': '**/*.md',
   'memorySources.repoUrlPlaceholder': 'https://github.com/org/repo',

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -2659,6 +2659,7 @@ const messages: TranslationMap = {
   'memorySources.comingSoon': '即将推出',
   'memorySources.composioListFailed': '加载 Composio 连接失败。',
   'memorySources.browse': '浏览…',
+  'memorySources.folderPathUnavailable': '无法确定该文件夹的位置。请直接输入完整路径。',
   'memorySources.folderPathPlaceholder': '/Users/you/notes',
   'memorySources.globPatternPlaceholder': '**/*.md',
   'memorySources.repoUrlPlaceholder': 'https://github.com/org/repo',


### PR DESCRIPTION
## Summary

- Browse on the folder memory-source now opens the **OS-native directory chooser** and stores the absolute path it returns.
- The `webkitdirectory` fallback can no longer store a value that cannot work: when `File.path` is absent it reports an error next to the field instead of saving the bare directory name.
- Backed by `rfd`, **already in this shell** — no new dependency, no dialog plugin, no capability-allowlist entry.
- Hand-typed absolute paths are untouched. That is the current workaround and people are relying on it.

## Problem

`AddMemorySourceFields.tsx` rendered Browse as `<input type="file" webkitdirectory>`. That element carries no filesystem path. Chromium exposes one on the non-standard `File.path` only when the renderer has filesystem-aware integration, which the code's own comment said outright. Outside that renderer the handler fell through to:

```js
} else if (first.webkitRelativePath) {
  onChange(first.webkitRelativePath.split('/')[0]);   // the folder NAME, location discarded
}
```

A user who picked a folder got a source storing `docs`. Every sync then failed, once per cycle, indefinitely:

```
WRN pipeline tick failed pipeline_id="workspace:folder:src_d9a41ccf…"
    error=not found: folder does not exist: docs
```

Re-adding the same folder with a hand-typed absolute path worked immediately on the same build, same reader, same module. Only the path form differed.

The failure surfaces at sync time, far from the picker that caused it, and it never stops. Nothing in between could repair it, because there is nothing to repair: `docs` is not a relative path, it is a name whose location was thrown away.

### Why openhuman#5830 / tinycortex#158 do not cover this

Those resolve a **relative** path against the workspace, which is correct and unrelated. Resolving `docs` gives `<workspace>/docs` — still not the directory the user chose. The user would get a different wrong answer with a better error message.

## Solution

### 1. A native chooser (`pick_directory_via_dialog`)

**What the app already had, since the brief asked.** There is no `@tauri-apps/plugin-dialog` anywhere in this repo, and no existing frontend directory-picker helper. What does exist is `artifact_commands::save_artifact_via_dialog` (#3162) — a native Save-As dialog driven by the **`rfd`** crate, declared in `app/src-tauri/Cargo.toml` with `default-features = false` + `xdg-portal` (which is what keeps Linux off GTK). Its module doc records that it deliberately talks to the OS dialog APIs directly rather than pulling a Tauri dialog/fs plugin, after a `schemars` version conflict.

So this follows that precedent instead of adding the plugin the issue suggested: a sibling command in a new `directory_picker` module, ~15 lines, using the same `rfd::AsyncFileDialog` already compiled into this shell. **No new dependency, no plugin, no capability entry, no permissions surface to get wrong across three platforms.**

It takes no input and returns only what the user chose in an OS-owned dialog, so unlike the artifact commands there is no path to re-validate — that is noted in the module docs so the asymmetry does not read as an oversight.

### 2. Never store an unusable value

Selection logic moved into `folderPicker.ts` as two pure-ish functions returning a tagged result:

| outcome | meaning | what the UI does |
|---|---|---|
| `{ ok: true, path }` | an absolute path | store it |
| `cancelled` | user dismissed the chooser | nothing, silently |
| `unavailable` | no native chooser here | fall back to the directory input |
| `no-absolute-path` | a directory was chosen, its location is unknown | **show an error, store nothing** |

`webkitRelativePath` is deliberately no longer consulted as a fallback. Its first segment is the defect, not a degraded-but-usable answer.

### 3. Existence validation at save time — considered, and not added

The native chooser can only return a directory that exists, so the path this PR fixes is covered by construction. A hand-typed path that does not exist *yet* is a legitimate thing to configure ahead of creating it, which is why the issue asks for a hint rather than a rejection. Checking it from the renderer would need a new filesystem-read command and a new trust boundary for what is explicitly only a hint, and that is a bigger change than the defect warrants. Worth doing as its own piece if the hint is still wanted.

## Testing

`app/src/components/intelligence/__tests__/folderPicker.test.ts` — 10 tests, all passing.

### Revert-check

Restoring the pre-fix fallback (`return { ok: true, path: webkitRelativePath.split('/')[0] }`) fails the new assertions, reproducing the exact production value from the issue:

```
× refuses to produce a path when the renderer does not expose File.path
  AssertionError: expected { ok: true, path: 'docs' } to deeply equal { ok: false, … }
× never returns the bare directory name for any nesting depth
  AssertionError: expected true to be false

Tests  2 failed | 8 passed (10)
```

The other 8 keep passing, so the two that fail are the two that pin this defect.

### Checks run

| check | result |
|---|---|
| `vitest` (the one new file) | 10 passed |
| `pnpm typecheck` | clean |
| `pnpm i18n:check` | clean |
| `pnpm i18n:english:check` | `total unexpected English: 0` |
| `eslint` (changed files) | clean |
| `prettier --check` | clean |
| `cargo fmt --check` (`app/src-tauri`) | clean |

Per the brief I did not run the full suite or a full build.

**The Rust does not compile locally in this session** — a `cargo check` of the Tauri shell is a full build of that crate. Instead I verified the two APIs against the exact vendored source (`rfd-0.15.4`): `AsyncFileDialog::pick_folder(self) -> impl Future<Output = Option<FileHandle>>` (`file_dialog.rs:253`) and `FileHandle::path(&self) -> &Path` (`file_handle/native.rs:136`) — the same pair `save_artifact_via_dialog` already uses in this crate. The rest is two lines in `lib.rs`. The Tauri lane covers it; flagging it rather than implying a check I did not run.

Also verified `mod directory_picker;` landed **unguarded** — it sits directly after `mod deep_link_ipc_windows;`, which consumed the `#[cfg(target_os = "windows")]` above it. A module declaration inserted next to a `cfg` is an easy way to silently platform-gate something that must exist everywhere.

## i18n

One new key, `memorySources.folderPathUnavailable`, with a real translation in **all 14 locale files** (ar, bn, de, en, es, fr, hi, id, it, ko, pl, pt, ru, zh-CN). No em dashes, per the repo rule. `i18n:english:check` confirms none was left as English.

The error text avoids naming the mechanism and says what to do instead: *"Could not determine where that folder is. Type its full path instead."*

## Impact

Desktop and browser. No migration, no schema change, no config change. Existing folder sources are untouched — this only changes what a **new** selection can produce. A source already poisoned with a bare name still needs re-adding; nothing here can recover the location that was discarded when it was saved.

## Related

- Closes tinyhumansai/openhuman#5831
- Refs #5830, tinyhumansai/tinymemory#113 — the reader-side relative-path work, independent of this.

## Submission Checklist

- [x] Tests added: `folderPicker.test.ts`, 10 cases. Failure path is the revert-check above, plus explicit coverage of cancellation, an unavailable dialog, a blank return, and Windows separators.
- [x] N/A: diff coverage. The changed frontend lines are covered by the new test; the ~15 Rust lines are a dialog invocation with no branching logic to assert without a real OS dialog.
- [x] N/A: no feature rows added, removed, or renamed.
- [x] N/A: no feature IDs affected.
- [x] No new external network dependencies introduced. `rfd` was already a dependency of this shell.
- [x] N/A: does not touch release-cut surfaces.
- [x] Linked issue closed via `Closes tinyhumansai/openhuman#5831`.

## Impact (platform)

Desktop (macOS/Windows/Linux) gains the native chooser; a browser context keeps the input fallback and now fails visibly instead of silently. No performance, security, migration, or compatibility implications.

---

## AI Authored PR Metadata

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5831-native-folder-picker`
- Commit SHA: `b8943b440`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — ran `prettier --check` over the changed files; clean.
- [x] `pnpm typecheck` — clean.
- [x] Focused tests: `vitest run src/components/intelligence/__tests__/folderPicker.test.ts` — 10 passed; revert-check reproduces the `'docs'` value.
- [x] Rust fmt/check: `cargo fmt --check` clean. **`cargo check` NOT run** — it is a full build of the Tauri shell, excluded by the brief; APIs verified against the vendored `rfd-0.15.4` source instead, as described above.
- [x] N/A: Tauri fmt/check beyond the above — no other shell code changed.

### Validation Blocked

- `command:` `cargo check --manifest-path app/src-tauri/Cargo.toml`
- `error:` not a failure — excluded as a full build by the task constraints
- `impact:` the new Tauri command is unverified by a local compile. Two lines of registration plus a 15-line command using an API pair already used in the same crate, verified against the vendored source. The Tauri CI lane covers it.

### Behavior Changes

- Intended behavior change: Browse opens a native chooser; a selection that yields no absolute path is refused with a visible error rather than silently stored.
- User-visible effect: folder sources added via Browse now sync. A failed selection says so immediately instead of failing at every sync forever.

### Parity Contract

- Legacy behavior preserved: hand-typed absolute paths, and the `File.path` derivation where the renderer supplies one, both behave as before.
- Guard/fallback/dispatch parity checks: the `webkitdirectory` input remains the fallback for browser contexts and hosts with no working dialog; only its unusable output was removed.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added native folder selection through the operating system’s directory chooser.
  - Added a fallback folder picker for environments without native support.
  - Folder selections now preserve the complete absolute path across platforms.
  - Added clear guidance when the folder path cannot be determined.

- **Bug Fixes**
  - Prevented folder synchronization failures caused by storing only a folder name.
  - Cancelled selections now leave the existing folder field unchanged.

- **Localization**
  - Added the folder-path guidance message across supported languages.

- **Tests**
  - Added coverage for successful, cancelled, unavailable, and invalid folder selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->