### PR TITLE
fix(flows): honor selected Composio account

### DIFF
--- a/src/openhuman/flows/tinyflows/caps/ops.rs
+++ b/src/openhuman/flows/tinyflows/caps/ops.rs
@@ -380,18 +380,12 @@ pub(crate) async fn resolve_composio_account(
 ///   connected set — and it still closes the case where an author hand-types
 ///   an arbitrary/typo'd slug.
 /// - **connection_ref**: `conn` (`"composio:<toolkit>:<connection_id>"`) is
-///   now parsed and forwarded to `direct_execute` (Composio Direct mode).
-///   Backend mode's `execute_tool` still has no per-call account-scoping
-///   path — that's a backend API gap, not something this seam can close
-///   alone — so under Backend mode, a `connection_ref` naming a SPECIFIC
-///   connected account is NOT honored: the call executes against whatever
-///   account happens to be the ambient signed-in session instead (E-m3),
-///   which — when the flow author connected/expected a *different* account
-///   for this action — means the action runs as the wrong identity, not a
-///   graceful no-op. This proceeds rather than failing closed; it logs a
-///   `warn!` naming both the requested and actually-used account so the
-///   mismatch is at least visible in logs, but nothing currently blocks the
-///   call. Documented backend-API-gap stub; see `composio_connection_id`.
+///   parsed and forwarded in both modes: Direct passes it to Composio's
+///   execute endpoint, while Backend includes it as `connectionId` in the
+///   authenticated `/agent-integrations/composio/execute` request. Omitting a
+///   ref deliberately keeps the ambient-account behavior. A supplied but
+///   stale/foreign id is still forwarded exactly so the provider rejects it;
+///   it must never degrade to the ambient account (fixes #5751 / E-m3).
 /// - **Trust gate**: invocation is also routed through the OpenHuman
 ///   `ApprovalGate` (mirrors `tinyagents/middleware.rs::ApprovalSecurityMiddleware`)
 ///   before dispatch, closing the Codex P1 finding that flow tool nodes

--- a/src/openhuman/flows/tinyflows/caps/tools/composio.rs
+++ b/src/openhuman/flows/tinyflows/caps/tools/composio.rs
@@ -27,11 +27,34 @@ use crate::openhuman::config::Config;
 use crate::openhuman::integrations::composio::client::{
     create_composio_client, direct_execute, ComposioClientKind,
 };
+use crate::openhuman::integrations::composio::ComposioExecuteResponse;
 use crate::openhuman::security::GateDecision;
 
 /// Dispatches a Composio action slug through the tier, curation, preflight and
 /// approval gates.
 pub(crate) struct ComposioToolBackend;
+
+/// Dispatches through the selected Composio mode while preserving the
+/// workflow node's exact connected-account choice.
+async fn execute_for_connection(
+    kind: ComposioClientKind,
+    slug: &str,
+    args: Option<Value>,
+    entity_id: &str,
+    connection_id: Option<&str>,
+) -> Result<ComposioExecuteResponse> {
+    match kind {
+        ComposioClientKind::Backend(client) => client
+            .execute_tool_with_connection(slug, args, connection_id)
+            .await
+            .map_err(|e| EngineError::Capability(e.to_string())),
+        ComposioClientKind::Direct(tool) => {
+            direct_execute(&tool, slug, args, entity_id, connection_id)
+                .await
+                .map_err(|e| EngineError::Capability(e.to_string()))
+        }
+    }
+}
 
 #[async_trait]
 impl ToolBackend for ComposioToolBackend {
@@ -182,75 +205,39 @@ impl ToolBackend for ComposioToolBackend {
             "[flows] tool_call: invoking composio tool"
         );
 
-        let response = match kind {
-            ComposioClientKind::Backend(client) => {
-                if let Some((id, resolved)) = &resolved_account {
-                    match resolved {
-                        Some((toolkit, _label)) => tracing::warn!(
-                            target: "flows",
-                            %slug,
-                            connection_id = %id,
-                            %toolkit,
-                            "[flows] tool_call: EXECUTING ON THE WRONG ACCOUNT — connection_ref \
-                             names a specific connected account, but backend mode has no per-call \
-                             account-scoping path yet, so this call runs against the AMBIENT \
-                             signed-in session account instead of the one requested (E-m3, \
-                             documented backend-API-gap stub, see caps.rs's OpenHumanTools doc). \
-                             Proceeds rather than failing closed."
-                        ),
-                        None => tracing::warn!(
-                            target: "flows",
-                            %slug,
-                            connection_id = %id,
-                            "[flows] tool_call: POSSIBLY EXECUTING ON THE WRONG ACCOUNT — \
-                             connection_ref names a connection id not found among the user's live \
-                             connected accounts, and backend mode has no per-call account-scoping \
-                             path to validate it against anyway — this call runs against the \
-                             AMBIENT signed-in session account regardless (E-m3, documented \
-                             backend-API-gap stub, see caps.rs's OpenHumanTools doc). Proceeds \
-                             rather than failing closed."
-                        ),
-                    }
-                }
-                client
-                    .execute_tool(slug, args_opt)
-                    .await
-                    .map_err(|e| EngineError::Capability(e.to_string()))
-            }
-            ComposioClientKind::Direct(tool) => {
-                match &resolved_account {
-                    Some((id, Some((toolkit, _label)))) => tracing::info!(
-                        target: "flows",
-                        %slug,
-                        connection_id = %id,
-                        %toolkit,
-                        "[flows] tool_call: executing against the resolved connected account"
-                    ),
-                    Some((id, None)) => tracing::warn!(
-                        target: "flows",
-                        %slug,
-                        connection_id = %id,
-                        "[flows] tool_call: connection_ref connection_id not found among the user's \
-                         live connected accounts (stale cache or foreign id) — forwarding to \
-                         Composio Direct mode as-is"
-                    ),
-                    None => tracing::debug!(
-                        target: "flows",
-                        %slug,
-                        "[flows] tool_call: no connection_ref — using the ambient signed-in account"
-                    ),
-                }
-                direct_execute(
-                    &tool,
-                    slug,
-                    args_opt,
-                    &live_config.composio.entity_id,
-                    connection_id,
-                )
-                .await
-                .map_err(|e| EngineError::Capability(e.to_string()))
-            }
-        };
+        match &resolved_account {
+            Some((id, Some((toolkit, _label)))) => tracing::info!(
+                target: "flows",
+                %slug,
+                connection_id = %id,
+                %toolkit,
+                mode = kind.mode(),
+                "[flows] tool_call: executing against the resolved connected account"
+            ),
+            Some((id, None)) => tracing::warn!(
+                target: "flows",
+                %slug,
+                connection_id = %id,
+                mode = kind.mode(),
+                "[flows] tool_call: connection_ref connection_id not found among the user's live \
+                 connected accounts (stale cache or foreign id) — forwarding the exact id so the \
+                 provider can reject it rather than falling back to an ambient account"
+            ),
+            None => tracing::debug!(
+                target: "flows",
+                %slug,
+                mode = kind.mode(),
+                "[flows] tool_call: no connection_ref — using the ambient signed-in account"
+            ),
+        }
+        let response = execute_for_connection(
+            kind,
+            slug,
+            args_opt,
+            &live_config.composio.entity_id,
+            connection_id,
+        )
+        .await;
 
         // A successful HTTP round-trip can still carry a provider-side failure
         // (`{successful: false, error: "..."}`, e.g. a Slack 400 on
@@ -275,5 +262,67 @@ impl ToolBackend for ComposioToolBackend {
         }
 
         serde_json::to_value(response?).map_err(|e| EngineError::Capability(e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::{routing::post, Json, Router};
+    use serde_json::{json, Value};
+
+    use super::*;
+    use crate::openhuman::integrations::composio::ComposioClient;
+    use crate::openhuman::integrations::IntegrationClient;
+
+    /// Regression for #5751: the flow adapter used to parse and log the chosen
+    /// account, then call `execute_tool` without it. The request therefore ran
+    /// against the ambient account. Pin the final backend JSON body so that
+    /// dropping the id at any point in this seam fails the test.
+    #[tokio::test]
+    async fn backend_dispatch_forwards_the_workflow_connection_id() {
+        let app = Router::new().route(
+            "/agent-integrations/composio/execute",
+            post(|Json(body): Json<Value>| async move {
+                assert_eq!(body["tool"], "GITHUB_LIST_REPOSITORY_ISSUES");
+                assert_eq!(body["arguments"]["owner"], "tinyhumansai");
+                assert_eq!(body["connectionId"], "ca_target_account");
+                Json(json!({
+                    "success": true,
+                    "data": {
+                        "data": { "issues": [] },
+                        "successful": true,
+                        "error": null,
+                        "costUsd": 0.0
+                    }
+                }))
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock backend");
+        let addr = listener.local_addr().expect("mock backend address");
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve mock backend");
+        });
+
+        let client = ComposioClient::new(Arc::new(IntegrationClient::new(
+            format!("http://{addr}"),
+            "test-token".to_string(),
+        )));
+        let response = execute_for_connection(
+            ComposioClientKind::Backend(client),
+            "GITHUB_LIST_REPOSITORY_ISSUES",
+            Some(json!({ "owner": "tinyhumansai" })),
+            "unused-in-backend-mode",
+            Some("ca_target_account"),
+        )
+        .await
+        .expect("backend dispatch should succeed");
+
+        assert!(response.successful);
     }
 }

--- a/src/openhuman/flows/tinyflows/caps/tools/composio.rs
+++ b/src/openhuman/flows/tinyflows/caps/tools/composio.rs
@@ -76,6 +76,8 @@ impl ToolBackend for ComposioToolBackend {
         super::super::preflight_composio_args(config, slug, args).await
     }
 
+    /// Executes a curated Composio action after account resolution and all
+    /// workflow security gates have succeeded.
     async fn invoke(
         &self,
         ctx: &ToolCallCtx<'_>,

--- a/src/openhuman/integrations/composio/client.rs
+++ b/src/openhuman/integrations/composio/client.rs
@@ -187,6 +187,22 @@ impl ComposioClient {
         tool: &str,
         arguments: Option<serde_json::Value>,
     ) -> Result<ComposioExecuteResponse> {
+        self.execute_tool_with_connection(tool, arguments, None)
+            .await
+    }
+
+    /// `POST /agent-integrations/composio/execute` — run a Composio action
+    /// against one specific connected account.
+    ///
+    /// `connection_id = None` preserves [`Self::execute_tool`]'s ambient-account
+    /// behavior. A non-empty id is forwarded as `connectionId`; the backend
+    /// verifies that the authenticated user owns it before dispatching.
+    pub async fn execute_tool_with_connection(
+        &self,
+        tool: &str,
+        arguments: Option<serde_json::Value>,
+        connection_id: Option<&str>,
+    ) -> Result<ComposioExecuteResponse> {
         let tool = tool.trim();
         if tool.is_empty() {
             anyhow::bail!("composio.execute_tool: tool slug must not be empty");
@@ -208,8 +224,16 @@ impl ComposioClient {
         // mode dispatch.
         let arguments = super::execute_prepare::prepare_execute_arguments(tool, arguments)
             .map_err(anyhow::Error::msg)?;
-        tracing::debug!(tool = %tool, "[composio] execute_tool");
-        let body = json!({ "tool": tool, "arguments": arguments });
+        let connection_id = connection_id.map(str::trim).filter(|id| !id.is_empty());
+        tracing::debug!(
+            tool = %tool,
+            connection_id = ?connection_id,
+            "[composio] execute_tool"
+        );
+        let mut body = json!({ "tool": tool, "arguments": arguments });
+        if let Some(connection_id) = connection_id {
+            body["connectionId"] = json!(connection_id);
+        }
         let mut resp = self
             .execute_tool_with_post_oauth_retry(tool, &body, POST_OAUTH_ACTION_RETRY_DELAY)
             .await?;

--- a/src/openhuman/integrations/composio/client_tests.rs
+++ b/src/openhuman/integrations/composio/client_tests.rs
@@ -418,6 +418,8 @@ async fn list_tools_filters_pass_through_as_csv_query_param() {
     assert_eq!(resp_empty_tags.tools[0].function.name, "ECHO_gmail");
 }
 
+/// Ambient execution must preserve the legacy unscoped request shape while
+/// still returning provider success and cost metadata.
 #[tokio::test]
 async fn execute_tool_returns_cost_and_success_flags() {
     let app = Router::new().route(

--- a/src/openhuman/integrations/composio/client_tests.rs
+++ b/src/openhuman/integrations/composio/client_tests.rs
@@ -424,6 +424,10 @@ async fn execute_tool_returns_cost_and_success_flags() {
         "/agent-integrations/composio/execute",
         post(|Json(body): Json<Value>| async move {
             let tool = body["tool"].as_str().unwrap_or("").to_string();
+            assert!(
+                body.get("connectionId").is_none(),
+                "ambient execute_tool calls must omit per-account scoping"
+            );
             Json(json!({
                 "success": true,
                 "data": {


### PR DESCRIPTION
## Summary

- Honor a workflow node's selected Composio connection in backend mode.
- Forward the exact account identifier as `connectionId` through the authenticated integration request.
- Preserve ambient-account behavior when no connection is selected and pin both paths with regression coverage.

## Problem

- Workflow nodes parse `connection_ref`, but backend-mode dispatch discarded the resulting connection ID before calling the integration backend.
- Multi-account workflows could therefore execute GitHub, Gmail, or Google Sheets actions against the ambient signed-in account instead of the configured account, creating privacy and data-integrity risk.

## Solution

- Add `ComposioClient::execute_tool_with_connection` while keeping `execute_tool` as the ambient-account compatibility wrapper.
- Route both backend and direct flow execution through one account-aware helper.
- Forward stale or foreign IDs unchanged so the provider rejects them instead of silently falling back.
- Add a loopback backend regression test that asserts the final request contains the selected `connectionId`; update the ambient execution test to assert that the field remains absent.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage >= 80%** - changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/ci-lite.yml`](../.github/workflows/ci-lite.yml). Focused local tests exercise selected-account and ambient-account wire behavior; CI will enforce the numeric gate.
- [x] Coverage matrix updated - N/A: behavior-only fix with no added, removed, or renamed feature row in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md)
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` - N/A: no coverage-matrix feature row applies
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces - N/A: no release-cut surface or manual smoke procedure changed
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Affects Rust-core workflow Composio dispatch in backend mode on every desktop platform.
- Selected integration accounts are now honored; calls without a selection retain existing ambient behavior.
- No schema migration, public RPC change, new dependency, or performance-sensitive path.
- Security improves by removing silent cross-account execution.

## Related

- Closes #5751
- Affected feature IDs: N/A - behavior-only fix
- Follow-up PR(s)/TODOs: N/A

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: N/A - GitHub issue #5751
- URL: N/A - GitHub issue https://github.com/tinyhumansai/openhuman/issues/5751

### Commit & Branch

- Branch: `fix/5751-flow-connection-account`
- Commit SHA: `3254d7e3acd4315d256ab2ce0e6d4cd1b233d869`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` - N/A: frontend unchanged
- [x] `pnpm typecheck` - N/A: frontend unchanged
- [x] Focused tests: `cargo test --manifest-path Cargo.toml --lib backend_dispatch_forwards_the_workflow_connection_id -- --nocapture`; `cargo test --manifest-path Cargo.toml --lib openhuman::integrations::composio::client::tests::execute_tool -- --nocapture`
- [x] Rust fmt/check (if changed): `cargo fmt --all -- --check`; `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml`; `git diff --check`
- [x] Tauri fmt/check (if changed): N/A - Tauri shell unchanged

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: backend-mode workflow tool calls execute against the account named by `connection_ref`.
- User-visible effect: multi-account workflows no longer silently operate as the ambient signed-in account.

### Parity Contract

- Legacy behavior preserved: calls without `connection_ref` omit `connectionId` and keep ambient-account dispatch.
- Guard/fallback/dispatch parity checks: existing validation, egress policy, approval gate, argument preparation, OAuth retry, provider errors, and direct-mode dispatch remain intact.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A - none found for this branch or issue
- Canonical PR: this PR
- Resolution (closed/superseded/updated): N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tools can now run against an explicitly selected connection in both supported execution modes.
  - Connection details are forwarded consistently so actions target the intended account.
- **Bug Fixes**
  - Prevented backend actions from unintentionally using an ambient or incorrect account.
  - Invalid or stale connection references are rejected instead of silently falling back.
- **Tests**
  - Added coverage for connection targeting while preserving existing ambient-account behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->