### PR TITLE
refactor: take the tool vocabulary from tinytools

### DIFF
--- a/.github/workflows/ci-lite.yml
+++ b/.github/workflows/ci-lite.yml
@@ -567,11 +567,19 @@ jobs:
         # runtimes moved behind the `tinyruntime` TinyBus module, adding
         # `tinyruntime-bus`. 268 -> 269 on 2026-08-23: the TinyJuice wire
         # contract moved into `tinyjuice-bus`, which cannot be gated because
-        # `inference::tokenjuice` compiles in every build. See the kernel-floor
-        # history for why these raises are temporary/justified. macOS resolves
-        # one higher per the host skew recorded in the limits history — this
-        # expects the CI host.
-        run: python3 scripts/dep-sim.py --cut-nothing --expect-names 269
+        # `inference::tokenjuice` compiles in every build. 269 -> 270 on
+        # 2026-08-29: `tinytools` becomes the dependency behind the `Tool`
+        # trait/types, which cannot be gated because `tools/` is kernel
+        # surface — zero transitive additions, native build count unchanged
+        # at 2. See the kernel-floor history for why these raises are
+        # temporary/justified. macOS resolves one higher per the host skew
+        # recorded in the limits history — this expects the CI host.
+        #
+        # This number MUST move in lockstep with scripts/kernel-floor.limits —
+        # it is a second source of truth for the same Linux name count and is
+        # not derived from that file. Bump both in the same PR that raises
+        # (or lowers) the floor.
+        run: python3 scripts/dep-sim.py --cut-nothing --expect-names 270
 
       - name: Guard — new feature-gated test modules must be acknowledged
         # Self-maintaining coverage: the set of source files that #[cfg]-gate a test on

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -518,8 +518,66 @@ Two consequences worth knowing before editing this area:
   order agree by construction. The local copy this replaced carried a comment
   promising the two "stay in lockstep", which is the shape of a bug waiting to
   happen, not a guarantee. `humanize_tool_name` and `context_detail_from_args`
-  in `tools/traits.rs` are re-exports/wrappers over the crate for the same
-  reason; only the trimming rule (80 chars, `…`) is OpenHuman's.
+  now live in `tinytools` and are re-exported by both this crate and tinyagents
+  — see the section below.
+
+
+### The tool vocabulary lives in `tinytools` — `tools/traits.rs` is a re-export
+
+The `Tool` trait, `ToolResult` / `ToolContent`, `ToolSpec`, `PermissionLevel`,
+`ToolScope`, `ToolCategory`, `ToolCallOptions`, `ToolTimeout`,
+`WorkspaceDescriptor` and `SandboxMode` are defined in
+[`tinytools`](https://github.com/tinyhumansai/tinytools), which **tinyagents
+also depends on**. That is the whole point: `tinytools::Tool` and the trait the
+harness runs a loop over are the *same* trait, so a tool is implemented once and
+both sides accept it, with no conversion at the seam to get subtly wrong.
+
+`src/openhuman/tools/traits.rs` and `src/openhuman/skills/types.rs` stay as the
+import paths ~190 and ~14 call sites already name; both are now short
+re-exports. New code may name either.
+
+**It is vendored through tinyagents, not beside it.** The dependency is
+`vendor/tinyagents/vendor/tinytools/crates/tinytools` — the exact path tinyagents
+itself declares. A second `vendor/tinytools` submodule of our own would be a
+*different package* to cargo, and `tinytools::ToolResult` from one would not be
+the same type as from the other; every tool here would stop satisfying the
+harness's trait, with a type error naming the same path twice. After cloning:
+`git submodule update --init --recursive vendor/`.
+
+Four things to know before editing this area:
+
+- **The edge points one way, and `ToolRunContext` is why.** tinyagents depends
+  on tinytools, so tinytools cannot name `ToolExecutionContext` — that would be
+  a cycle. A tool that needs its isolated worktree root takes
+  `Option<&dyn ToolRunContext>` instead, which tinyagents implements for its own
+  context type. The trait exposes the workspace, the thread id and the turn
+  output budget and nothing else; the run id, event sink and cancellation token
+  stay harness-internal, because a tool reaching for those is reaching into the
+  run rather than doing its job. tinytools' CI fails if `tinyagents` appears
+  anywhere in its forward dependency tree.
+- **Host-specific tool metadata rides on an erased extension.**
+  `Tool::host_extension` / `host_call_extension` return `dyn Any`, and
+  `traits::pack_registry_handle` / `traits::generated_runtime_context` downcast
+  them back. `PackRegistryHandle` and `GeneratedToolRuntimeContext` are *our*
+  concepts and a shared vocabulary has no business naming them. Two tools and
+  one test use this; everything else returns `None` and pays nothing.
+- **Nothing that decides anything moved.** tinytools lets a tool *declare* the
+  privilege it needs and whether it reaches outside the machine. What to do
+  about those declarations is still ours and stays in one auditable place: the
+  `SecurityPolicy`, the approval gate, the sandbox, `tools/policy.rs`,
+  `tools/timeout/`, `tools/agent_policy/` and the whole `tools/registry/` +
+  `tools/toolpacks/` surface. `tools/schemas.rs` likewise stays — those are RPC
+  controllers bound to `crate::core`.
+- **The MCP conversion is a free function, not a `From` impl.**
+  `skills::types::tool_result_from_mcp` — once `ToolResult` became foreign, the
+  orphan rule forbade the trait impl. It is still written exactly once, because
+  spelled out at each call site it would be three chances to get the error flag
+  the wrong way round.
+
+`tinytools` costs the kernel floor **+1 package / +1 name / 0 native builds**
+(it adds no third-party crate this profile did not already have) and cannot be
+gated: `tools/` is kernel surface, so the trait compiles in every build. See the
+2026-08-29 entry in `scripts/kernel-floor.limits`.
 
 **Rules:**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4204,6 +4204,7 @@ dependencies = [
  "tinymemory-tinycortex",
  "tinyplace",
  "tinyruntime-bus",
+ "tinytools",
  "tinyvoice-bus",
  "tinywallet",
  "tinywallet-bus",
@@ -6366,6 +6367,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.18",
+ "tinytools",
  "tokio",
  "tracing",
 ]
@@ -6750,6 +6752,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec 0.11.6",
+]
+
+[[package]]
+name = "tinytools"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,6 +175,22 @@ tinyflows = { version = "0.8", features = ["mock"], optional = true }
 # profile, so turning it on moves neither the package count nor the native
 # build count that `scripts/check-kernel-floor.sh` ratchets.
 tinyagents = { version = "2.1", features = ["sqlite", "multimodal"] }
+# TinyTools — the tool vocabulary: the `Tool` trait, `ToolResult`, and the
+# permission / scope / timeout classifications this host enforces around a call.
+#
+# Reached through tinyagents' own vendored checkout **on purpose**, not through
+# a second `vendor/tinytools` submodule of our own. Two path dependencies on
+# the same repository are two distinct packages to cargo, and
+# `tinytools::ToolResult` from one would not be the same type as from the
+# other — every tool in this crate would stop satisfying the harness's trait,
+# with a type error that names the same path twice. tinyagents declares
+# `vendor/tinytools/crates/tinytools` relative to itself, so naming that exact
+# path here resolves to one package.
+#
+# No `[patch.crates-io]` entry: the crate is not published, so the path is the
+# whole address — the same arrangement as `tinyhumans-sdk` and the `-bus`
+# crates. After cloning: `git submodule update --init --recursive vendor/`.
+tinytools = { path = "vendor/tinyagents/vendor/tinytools/crates/tinytools" }
 # TinyCortex — Rust core for the memory engine (store/chunks/tree/retrieval/
 # queue/ingest/score + long tail), vendored as a git submodule and patched
 # below to `vendor/tinycortex`. OpenHuman's memory subsystem migrates onto this

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4434,6 +4434,7 @@ dependencies = [
  "tinymemory-tinycortex",
  "tinyplace",
  "tinyruntime-bus",
+ "tinytools",
  "tinyvoice-bus",
  "tinywallet-bus",
  "tokio",
@@ -7037,6 +7038,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.20",
+ "tinytools",
  "tokio",
  "tracing",
 ]
@@ -7442,6 +7444,16 @@ checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytools"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -296,6 +296,10 @@ motosan-ai-oauth = { path = "../../vendor/motosan-ai-oauth" }
 # released tag) — same patch as the root Cargo world so both resolve the
 # in-tree SDK source. `git submodule update --init vendor/tinyagents` first.
 tinyagents = { path = "../../vendor/tinyagents" }
+# TinyTools rides in through tinyagents' own vendored checkout. The path must
+# match the one the core crate names, or cargo resolves two distinct packages
+# and the shell's `dyn Tool` stops being the core's. See the core manifest.
+tinytools = { path = "../../vendor/tinyagents/vendor/tinytools/crates/tinytools" }
 # TinyFlows, TinyCortex, TinyChannels, and TinyPlace are vendored beside
 # TinyAgents so integration work can test crate changes against OpenHuman before
 # publishing.

--- a/scripts/kernel-floor.limits
+++ b/scripts/kernel-floor.limits
@@ -13,6 +13,39 @@
 # Simulate with: scripts/dep-sim.py --cut <crates>
 #
 # History
+#   288/270/2  2026-08-29  the tool vocabulary moved into its own crate
+#                      (+1 package, +1 NAME: `tinytools`). This entry is the
+#                      CURRENT limit; the tinyjuice entry below it left the
+#                      profile at 287/269/2 and this raises it by one on top of
+#                      that.
+#
+#                      It brings NO third-party crate this profile did not
+#                      already have. Its whole dependency list is `anyhow`,
+#                      `async-trait`, `serde` and `serde_json`, all four of them
+#                      already resolved here — measured, not assumed: the native
+#                      build count is unchanged at 2 (`libsqlite3-sys`, `ring`),
+#                      and every one of the 287 previous packages is still
+#                      exactly one package. The +1 is the crate itself.
+#
+#                      It cannot be gated. `src/openhuman/tools/` is kernel
+#                      surface — `shell.rs` alone is reached from the agent turn
+#                      path in every build — so the `Tool` trait compiles in
+#                      every configuration and the vocabulary has no feature to
+#                      hang off. Same situation as `tinyjuice-bus` below, and
+#                      for the same structural reason.
+#
+#                      What it buys is that `tinyagents` and this crate now name
+#                      the SAME tool types instead of structural twins. Before
+#                      this, both declared their own and the seam between them
+#                      was hand-written; `humanize_tool_name` and
+#                      `context_detail_from_args` existed in two copies, one of
+#                      which already carried a comment warning that two copies is
+#                      how one silently stops stripping a prefix the other does.
+#                      `WorkspaceDescriptor` and `SandboxMode` collapsed the same
+#                      way. It also deletes ~780 lines of type definitions from
+#                      this crate (`tools/traits.rs` 690 -> 125,
+#                      `skills/types.rs` 338 -> 127).
+#
 #   287/269/2  2026-08-23  the TinyJuice wire contract moved into its own crate
 #                      (+1 package, +1 NAME: `tinyjuice-bus`). This entry is
 #                      the CURRENT limit; the tinymcp entry below it left the
@@ -460,4 +493,4 @@
 #                      (libsqlite3-sys, ring) — see docs/plans MIGRATION-PLAN G6.
 # 307/284  2026-08-12  Re-baseline after the upstream lockfile resolution;
 #                      `flows` remains at two native packages.
-flows:287:269:2
+flows:288:270:2

--- a/src/openhuman/agent/harness/session/turn_tests.rs
+++ b/src/openhuman/agent/harness/session/turn_tests.rs
@@ -269,7 +269,7 @@ impl Tool for GeneratedContextTool {
         Ok(ToolResult::success("generated-output"))
     }
 
-    fn generated_runtime_context(
+    fn host_call_extension(
         &self,
         _args: &serde_json::Value,
     ) -> Option<GeneratedToolRuntimeContext> {

--- a/src/openhuman/agent/harness/session/turn_tests.rs
+++ b/src/openhuman/agent/harness/session/turn_tests.rs
@@ -272,14 +272,14 @@ impl Tool for GeneratedContextTool {
     fn host_call_extension(
         &self,
         _args: &serde_json::Value,
-    ) -> Option<GeneratedToolRuntimeContext> {
-        Some(GeneratedToolRuntimeContext {
+    ) -> Option<Box<dyn std::any::Any + Send + Sync>> {
+        Some(Box::new(GeneratedToolRuntimeContext {
             provider_id: "mail.runtime".to_string(),
             capability_id: "email.send".to_string(),
             risk: GeneratedToolRuntimeRisk::ExternalWrite,
             source_digest: Some("sha256:abc".to_string()),
             approval_id: Some("approval-1".to_string()),
-        })
+        }))
     }
 }
 

--- a/src/openhuman/agent/orchestration/tools/agent_prepare_context.rs
+++ b/src/openhuman/agent/orchestration/tools/agent_prepare_context.rs
@@ -27,8 +27,8 @@ use async_trait::async_trait;
 use serde_json::json;
 use std::fmt::Write as _;
 use tinyagents::harness::tool::ToolExecutionContext;
-use tinytools::ToolRunContext;
 use tinyagents::harness::workspace::WorkspaceDescriptor;
+use tinytools::ToolRunContext;
 
 /// The sub-agent archetype this tool drives.
 const SCOUT_AGENT_ID: &str = "context_scout";

--- a/src/openhuman/agent/orchestration/tools/agent_prepare_context.rs
+++ b/src/openhuman/agent/orchestration/tools/agent_prepare_context.rs
@@ -26,7 +26,6 @@ use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, To
 use async_trait::async_trait;
 use serde_json::json;
 use std::fmt::Write as _;
-use tinyagents::harness::tool::ToolExecutionContext;
 use tinyagents::harness::workspace::WorkspaceDescriptor;
 use tinytools::ToolRunContext;
 

--- a/src/openhuman/agent/orchestration/tools/agent_prepare_context.rs
+++ b/src/openhuman/agent/orchestration/tools/agent_prepare_context.rs
@@ -724,7 +724,7 @@ impl Tool for AgentPrepareContextTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        tool_context: Option<&ToolExecutionContext>,
+        tool_context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let prepared_sources = current_agent_context_prepared_sources();
         if !prepared_sources.is_empty() {
@@ -745,7 +745,7 @@ impl Tool for AgentPrepareContextTool {
             question,
             focus,
             &tool_catalog,
-            tool_context.and_then(|ctx| ctx.workspace.clone()),
+            tool_context.and_then(|ctx| ctx.workspace().cloned()),
         )
         .await
     }

--- a/src/openhuman/agent/orchestration/tools/agent_prepare_context.rs
+++ b/src/openhuman/agent/orchestration/tools/agent_prepare_context.rs
@@ -27,6 +27,7 @@ use async_trait::async_trait;
 use serde_json::json;
 use std::fmt::Write as _;
 use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 use tinyagents::harness::workspace::WorkspaceDescriptor;
 
 /// The sub-agent archetype this tool drives.

--- a/src/openhuman/agent/orchestration/tools/archetype_delegation.rs
+++ b/src/openhuman/agent/orchestration/tools/archetype_delegation.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use crate::openhuman::tools::traits::{
     PermissionLevel, Tool, ToolCallOptions, ToolCategory, ToolResult, ToolTimeout,
 };
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 pub struct ArchetypeDelegationTool {
     pub tool_name: String,

--- a/src/openhuman/agent/orchestration/tools/archetype_delegation.rs
+++ b/src/openhuman/agent/orchestration/tools/archetype_delegation.rs
@@ -121,7 +121,7 @@ impl Tool for ArchetypeDelegationTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        tool_context: Option<&ToolExecutionContext>,
+        tool_context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let raw_prompt = args
             .get("prompt")

--- a/src/openhuman/agent/orchestration/tools/continue_subagent.rs
+++ b/src/openhuman/agent/orchestration/tools/continue_subagent.rs
@@ -19,6 +19,7 @@ use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, To
 use async_trait::async_trait;
 use serde_json::json;
 use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 pub struct ContinueSubagentTool;
 

--- a/src/openhuman/agent/orchestration/tools/continue_subagent.rs
+++ b/src/openhuman/agent/orchestration/tools/continue_subagent.rs
@@ -49,7 +49,7 @@ impl ContinueSubagentTool {
         task_id: &str,
         agent_id: &str,
         message: &str,
-        tool_context: Option<&ToolExecutionContext>,
+        tool_context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         use crate::openhuman::agent::orchestration::subagent_sessions::{
             self, SubagentSessionStore,
@@ -167,7 +167,7 @@ impl Tool for ContinueSubagentTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        tool_context: Option<&ToolExecutionContext>,
+        tool_context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let task_id = args
             .get("task_id")
@@ -321,7 +321,7 @@ impl Tool for ContinueSubagentTool {
         }
 
         // Build options with initial_history for replay
-        let workspace_descriptor = tool_context.and_then(|ctx| ctx.workspace.clone());
+        let workspace_descriptor = tool_context.and_then(|ctx| ctx.workspace().cloned());
         let worktree_action_dir = workspace_descriptor
             .as_ref()
             .map(|descriptor| descriptor.root.clone());

--- a/src/openhuman/agent/orchestration/tools/continue_subagent.rs
+++ b/src/openhuman/agent/orchestration/tools/continue_subagent.rs
@@ -18,7 +18,6 @@ use crate::openhuman::agent::progress::AgentProgress;
 use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, ToolResult};
 use async_trait::async_trait;
 use serde_json::json;
-use tinyagents::harness::tool::ToolExecutionContext;
 use tinytools::ToolRunContext;
 
 pub struct ContinueSubagentTool;

--- a/src/openhuman/agent/orchestration/tools/delegate_graph.rs
+++ b/src/openhuman/agent/orchestration/tools/delegate_graph.rs
@@ -108,7 +108,7 @@ impl Tool for DelegateGraphTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        tool_context: Option<&ToolExecutionContext>,
+        tool_context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let agent_id = match args.get("agent_id").and_then(|v| v.as_str()) {
             Some(s) if !s.trim().is_empty() => s.trim().to_string(),
@@ -155,7 +155,7 @@ impl Tool for DelegateGraphTool {
             definition,
             task,
             max_revisions,
-            tool_context.and_then(|ctx| ctx.workspace.clone()),
+            tool_context.and_then(|ctx| ctx.workspace().cloned()),
         )
         .await
         {

--- a/src/openhuman/agent/orchestration/tools/delegate_graph.rs
+++ b/src/openhuman/agent/orchestration/tools/delegate_graph.rs
@@ -17,7 +17,7 @@ use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, To
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 /// Default reviewer-requested revision budget when the caller omits it.
 const DEFAULT_MAX_REVISIONS: usize = 2;

--- a/src/openhuman/agent/orchestration/tools/dispatch.rs
+++ b/src/openhuman/agent/orchestration/tools/dispatch.rs
@@ -32,10 +32,10 @@ pub(crate) async fn dispatch_subagent(
     prompt: &str,
     skill_filter: Option<&str>,
     model_override: Option<&str>,
-    tool_context: Option<&ToolExecutionContext>,
+    tool_context: Option<&dyn ToolRunContext>,
     mode: DispatchMode,
 ) -> anyhow::Result<ToolResult> {
-    let parent_workspace_descriptor = tool_context.and_then(|ctx| ctx.workspace.clone());
+    let parent_workspace_descriptor = tool_context.and_then(|ctx| ctx.workspace().cloned());
     let registry = match AgentDefinitionRegistry::global() {
         Some(reg) => reg,
         None => {

--- a/src/openhuman/agent/orchestration/tools/dispatch.rs
+++ b/src/openhuman/agent/orchestration/tools/dispatch.rs
@@ -8,6 +8,7 @@ use crate::openhuman::agent::harness::subagent_runner::{
 use crate::openhuman::agent::progress::AgentProgress;
 use crate::openhuman::tools::traits::{Tool as _, ToolCallOptions, ToolResult};
 use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 /// How a delegated sub-agent run should be scheduled relative to the parent
 /// turn.

--- a/src/openhuman/agent/orchestration/tools/dispatch.rs
+++ b/src/openhuman/agent/orchestration/tools/dispatch.rs
@@ -7,7 +7,6 @@ use crate::openhuman::agent::harness::subagent_runner::{
 };
 use crate::openhuman::agent::progress::AgentProgress;
 use crate::openhuman::tools::traits::{Tool as _, ToolCallOptions, ToolResult};
-use tinyagents::harness::tool::ToolExecutionContext;
 use tinytools::ToolRunContext;
 
 /// How a delegated sub-agent run should be scheduled relative to the parent

--- a/src/openhuman/agent/orchestration/tools/skill_delegation.rs
+++ b/src/openhuman/agent/orchestration/tools/skill_delegation.rs
@@ -204,7 +204,7 @@ impl Tool for SkillDelegationTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        tool_context: Option<&ToolExecutionContext>,
+        tool_context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let raw_toolkit = args
             .get("toolkit")

--- a/src/openhuman/agent/orchestration/tools/skill_delegation.rs
+++ b/src/openhuman/agent/orchestration/tools/skill_delegation.rs
@@ -23,7 +23,7 @@ use crate::openhuman::tools::orchestrator_tools::sanitise_slug;
 use crate::openhuman::tools::traits::{
     PermissionLevel, Tool, ToolCallOptions, ToolCategory, ToolResult,
 };
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 /// Canonical tool name surfaced to the orchestrator LLM.
 pub const INTEGRATIONS_DELEGATE_TOOL_NAME: &str = "delegate_to_integrations_agent";

--- a/src/openhuman/agent/orchestration/tools/spawn_async_subagent.rs
+++ b/src/openhuman/agent/orchestration/tools/spawn_async_subagent.rs
@@ -20,7 +20,6 @@ use crate::openhuman::agent::progress::AgentProgress;
 use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, ToolResult};
 use async_trait::async_trait;
 use serde_json::json;
-use tinyagents::harness::tool::ToolExecutionContext;
 use tinycortex::memory::conversations::{self as conversations, ConversationMessage};
 use tinytools::ToolRunContext;
 

--- a/src/openhuman/agent/orchestration/tools/spawn_async_subagent.rs
+++ b/src/openhuman/agent/orchestration/tools/spawn_async_subagent.rs
@@ -21,8 +21,8 @@ use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, To
 use async_trait::async_trait;
 use serde_json::json;
 use tinyagents::harness::tool::ToolExecutionContext;
-use tinytools::ToolRunContext;
 use tinycortex::memory::conversations::{self as conversations, ConversationMessage};
+use tinytools::ToolRunContext;
 
 pub struct SpawnAsyncSubagentTool;
 

--- a/src/openhuman/agent/orchestration/tools/spawn_async_subagent.rs
+++ b/src/openhuman/agent/orchestration/tools/spawn_async_subagent.rs
@@ -21,6 +21,7 @@ use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, To
 use async_trait::async_trait;
 use serde_json::json;
 use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 use tinycortex::memory::conversations::{self as conversations, ConversationMessage};
 
 pub struct SpawnAsyncSubagentTool;

--- a/src/openhuman/agent/orchestration/tools/spawn_async_subagent.rs
+++ b/src/openhuman/agent/orchestration/tools/spawn_async_subagent.rs
@@ -115,7 +115,7 @@ impl Tool for SpawnAsyncSubagentTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        tool_context: Option<&ToolExecutionContext>,
+        tool_context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let agent_id = args
             .get("agent_id")
@@ -250,7 +250,7 @@ impl Tool for SpawnAsyncSubagentTool {
             ));
         }
         let store = SubagentSessionStore::new(parent.workspace_dir.clone());
-        let workspace_descriptor = tool_context.and_then(|ctx| ctx.workspace.clone());
+        let workspace_descriptor = tool_context.and_then(|ctx| ctx.workspace().cloned());
         let effective_action_root = workspace_descriptor
             .as_ref()
             .map(|workspace| {

--- a/src/openhuman/agent/orchestration/tools/spawn_parallel_agents.rs
+++ b/src/openhuman/agent/orchestration/tools/spawn_parallel_agents.rs
@@ -19,7 +19,7 @@ use crate::openhuman::tools::traits::{
 };
 use async_trait::async_trait;
 use serde_json::json;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 pub struct SpawnParallelAgentsTool;
 

--- a/src/openhuman/agent/orchestration/tools/spawn_parallel_agents.rs
+++ b/src/openhuman/agent/orchestration/tools/spawn_parallel_agents.rs
@@ -120,10 +120,10 @@ impl Tool for SpawnParallelAgentsTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        tool_context: Option<&ToolExecutionContext>,
+        tool_context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         tracing::debug!("[spawn_parallel_agents] execute entry");
-        let workspace_descriptor = tool_context.and_then(|ctx| ctx.workspace.clone());
+        let workspace_descriptor = tool_context.and_then(|ctx| ctx.workspace().cloned());
         let cancellation = current_run_cancellation().unwrap_or_else(|| {
             tracing::debug!(
                 "[spawn_parallel_agents] no active tinyagents run cancellation token; using local token"

--- a/src/openhuman/agent/orchestration/tools/spawn_subagent.rs
+++ b/src/openhuman/agent/orchestration/tools/spawn_subagent.rs
@@ -23,10 +23,10 @@ use async_trait::async_trait;
 use serde_json::json;
 use std::path::PathBuf;
 use tinyagents::harness::tool::ToolExecutionContext;
-use tinytools::ToolRunContext;
 use tinycortex::memory::conversations::{
     self as conversations, ConversationMessage, CreateConversationThread,
 };
+use tinytools::ToolRunContext;
 
 /// Spawns a sub-agent of the requested type to handle a delegated task.
 ///

--- a/src/openhuman/agent/orchestration/tools/spawn_subagent.rs
+++ b/src/openhuman/agent/orchestration/tools/spawn_subagent.rs
@@ -22,7 +22,6 @@ use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, To
 use async_trait::async_trait;
 use serde_json::json;
 use std::path::PathBuf;
-use tinyagents::harness::tool::ToolExecutionContext;
 use tinycortex::memory::conversations::{
     self as conversations, ConversationMessage, CreateConversationThread,
 };

--- a/src/openhuman/agent/orchestration/tools/spawn_subagent.rs
+++ b/src/openhuman/agent/orchestration/tools/spawn_subagent.rs
@@ -23,6 +23,7 @@ use async_trait::async_trait;
 use serde_json::json;
 use std::path::PathBuf;
 use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 use tinycortex::memory::conversations::{
     self as conversations, ConversationMessage, CreateConversationThread,
 };

--- a/src/openhuman/agent/orchestration/tools/spawn_subagent.rs
+++ b/src/openhuman/agent/orchestration/tools/spawn_subagent.rs
@@ -172,7 +172,7 @@ impl Tool for SpawnSubagentTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        tool_context: Option<&ToolExecutionContext>,
+        tool_context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         // ── Argument extraction with back-compat ───────────────────────
         let agent_id = args
@@ -530,7 +530,7 @@ impl Tool for SpawnSubagentTool {
         }
 
         // ── Run the sub-agent ──────────────────────────────────────────
-        let workspace_descriptor = tool_context.and_then(|ctx| ctx.workspace.clone());
+        let workspace_descriptor = tool_context.and_then(|ctx| ctx.workspace().cloned());
         let worktree_action_dir = workspace_descriptor
             .as_ref()
             .map(|descriptor| descriptor.root.clone());

--- a/src/openhuman/agent/orchestration/tools/spawn_worker_thread.rs
+++ b/src/openhuman/agent/orchestration/tools/spawn_worker_thread.rs
@@ -15,7 +15,6 @@ use crate::openhuman::agent::harness::subagent_runner::{run_subagent, SubagentRu
 use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, ToolResult};
 use async_trait::async_trait;
 use serde_json::json;
-use tinyagents::harness::tool::ToolExecutionContext;
 use tinycortex::memory::conversations;
 use tinytools::ToolRunContext;
 

--- a/src/openhuman/agent/orchestration/tools/spawn_worker_thread.rs
+++ b/src/openhuman/agent/orchestration/tools/spawn_worker_thread.rs
@@ -16,8 +16,8 @@ use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, To
 use async_trait::async_trait;
 use serde_json::json;
 use tinyagents::harness::tool::ToolExecutionContext;
-use tinytools::ToolRunContext;
 use tinycortex::memory::conversations;
+use tinytools::ToolRunContext;
 
 /// Spawns a sub-agent in a dedicated worker thread.
 pub struct SpawnWorkerThreadTool;

--- a/src/openhuman/agent/orchestration/tools/spawn_worker_thread.rs
+++ b/src/openhuman/agent/orchestration/tools/spawn_worker_thread.rs
@@ -16,6 +16,7 @@ use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, To
 use async_trait::async_trait;
 use serde_json::json;
 use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 use tinycortex::memory::conversations;
 
 /// Spawns a sub-agent in a dedicated worker thread.

--- a/src/openhuman/agent/orchestration/tools/spawn_worker_thread.rs
+++ b/src/openhuman/agent/orchestration/tools/spawn_worker_thread.rs
@@ -107,7 +107,7 @@ impl Tool for SpawnWorkerThreadTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        tool_context: Option<&ToolExecutionContext>,
+        tool_context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let started = std::time::Instant::now();
 
@@ -229,7 +229,7 @@ impl Tool for SpawnWorkerThreadTool {
         // sees. Instead, we return the info in the tool result.
 
         // ── Run Subagent ──────────────────────────────────────────────
-        let workspace_descriptor = tool_context.and_then(|ctx| ctx.workspace.clone());
+        let workspace_descriptor = tool_context.and_then(|ctx| ctx.workspace().cloned());
         let worktree_action_dir = workspace_descriptor
             .as_ref()
             .map(|descriptor| descriptor.root.clone());

--- a/src/openhuman/agent/tinyagents/middleware.rs
+++ b/src/openhuman/agent/tinyagents/middleware.rs
@@ -1288,7 +1288,7 @@ impl ToolPolicyMiddleware {
             .iter()
             .flat_map(|set| set.iter())
             .find(|t| t.name() == name)
-            .and_then(|t| t.generated_runtime_context(args))
+            .and_then(|t| crate::openhuman::tools::traits::generated_runtime_context(t.as_ref(), args))
     }
 }
 

--- a/src/openhuman/agent/tinyagents/middleware.rs
+++ b/src/openhuman/agent/tinyagents/middleware.rs
@@ -1288,7 +1288,9 @@ impl ToolPolicyMiddleware {
             .iter()
             .flat_map(|set| set.iter())
             .find(|t| t.name() == name)
-            .and_then(|t| crate::openhuman::tools::traits::generated_runtime_context(t.as_ref(), args))
+            .and_then(|t| {
+                crate::openhuman::tools::traits::generated_runtime_context(t.as_ref(), args)
+            })
     }
 }
 

--- a/src/openhuman/agent/tinyagents/tools.rs
+++ b/src/openhuman/agent/tinyagents/tools.rs
@@ -11,6 +11,7 @@ use std::sync::{Arc, Mutex, PoisonError};
 use async_trait::async_trait;
 use tinyagents::harness::steering::{SteeringCommand, SteeringHandle};
 use tinyagents::harness::tool::{
+use tinytools::ToolRunContext;
     SandboxMode, Tool, ToolAccess, ToolCall as TaToolCall, ToolExecutionContext, ToolPolicy,
     ToolResult as TaToolResult, ToolRuntime, ToolSchema, ToolSideEffects,
     ToolTimeout as TaToolTimeout, WorkspaceAccess,

--- a/src/openhuman/agent/tinyagents/tools.rs
+++ b/src/openhuman/agent/tinyagents/tools.rs
@@ -11,11 +11,11 @@ use std::sync::{Arc, Mutex, PoisonError};
 use async_trait::async_trait;
 use tinyagents::harness::steering::{SteeringCommand, SteeringHandle};
 use tinyagents::harness::tool::{
-use tinytools::ToolRunContext;
     SandboxMode, Tool, ToolAccess, ToolCall as TaToolCall, ToolExecutionContext, ToolPolicy,
     ToolResult as TaToolResult, ToolRuntime, ToolSchema, ToolSideEffects,
     ToolTimeout as TaToolTimeout, WorkspaceAccess,
 };
+use tinytools::ToolRunContext;
 
 /// A captured early-exit: a sub-agent invoked an early-exit tool (e.g.
 /// `ask_user_clarification`), so the loop should pause and surface `question`

--- a/src/openhuman/agent/tinyagents/tools.rs
+++ b/src/openhuman/agent/tinyagents/tools.rs
@@ -191,10 +191,10 @@ const TINYAGENTS_TOOL_SESSION: &str = "tinyagents";
 pub(crate) async fn execute_openhuman_tool(
     tool: &dyn crate::openhuman::tools::Tool,
     call: TaToolCall,
-    context: Option<&ToolExecutionContext>,
+    context: Option<&dyn ToolRunContext>,
 ) -> TaToolResult {
     let workspace_root = context
-        .and_then(|ctx| ctx.workspace.as_ref())
+        .and_then(|ctx| ctx.workspace())
         .map(|workspace| workspace.root.display().to_string());
     tracing::debug!(
         tool = %call.name,
@@ -393,7 +393,7 @@ impl SharedToolAdapter {
     async fn call_openhuman_tool(
         &self,
         call: TaToolCall,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> tinyagents::Result<TaToolResult> {
         let found = self
             .sets

--- a/src/openhuman/agent/tools/delegate_to_personality.rs
+++ b/src/openhuman/agent/tools/delegate_to_personality.rs
@@ -9,6 +9,7 @@ use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, To
 use async_trait::async_trait;
 use serde_json::json;
 use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 pub struct DelegateToPersonalityTool;
 

--- a/src/openhuman/agent/tools/delegate_to_personality.rs
+++ b/src/openhuman/agent/tools/delegate_to_personality.rs
@@ -71,7 +71,7 @@ impl Tool for DelegateToPersonalityTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        tool_context: Option<&ToolExecutionContext>,
+        tool_context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let personality_id = args
             .get("personality_id")
@@ -219,7 +219,7 @@ impl Tool for DelegateToPersonalityTool {
             }
         };
 
-        let workspace_descriptor = tool_context.and_then(|ctx| ctx.workspace.clone());
+        let workspace_descriptor = tool_context.and_then(|ctx| ctx.workspace().cloned());
         let worktree_action_dir = workspace_descriptor
             .as_ref()
             .map(|descriptor| descriptor.root.clone());

--- a/src/openhuman/agent/tools/delegate_to_personality.rs
+++ b/src/openhuman/agent/tools/delegate_to_personality.rs
@@ -8,7 +8,6 @@ use crate::openhuman::agent::profiles::PersonalityContext;
 use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, ToolResult};
 use async_trait::async_trait;
 use serde_json::json;
-use tinyagents::harness::tool::ToolExecutionContext;
 use tinytools::ToolRunContext;
 
 pub struct DelegateToPersonalityTool;

--- a/src/openhuman/integrations/file_storage/tools.rs
+++ b/src/openhuman/integrations/file_storage/tools.rs
@@ -27,6 +27,7 @@ use crate::openhuman::tools::traits::{
     PermissionLevel, Tool, ToolCallOptions, ToolCategory, ToolResult,
 };
 use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 use super::types::{DeleteResponse, FileMeta, LinkResponse, ListFilesResponse, UploadResponse};
 

--- a/src/openhuman/integrations/file_storage/tools.rs
+++ b/src/openhuman/integrations/file_storage/tools.rs
@@ -26,7 +26,6 @@ use crate::openhuman::security::SecurityPolicy;
 use crate::openhuman::tools::traits::{
     PermissionLevel, Tool, ToolCallOptions, ToolCategory, ToolResult,
 };
-use tinyagents::harness::tool::ToolExecutionContext;
 use tinytools::ToolRunContext;
 
 use super::types::{DeleteResponse, FileMeta, LinkResponse, ListFilesResponse, UploadResponse};

--- a/src/openhuman/integrations/file_storage/tools.rs
+++ b/src/openhuman/integrations/file_storage/tools.rs
@@ -196,10 +196,10 @@ fn mime_for_path(path: &Path) -> &'static str {
 /// workspace from the execution context (mirrors `media_generation`).
 fn action_dir_for_context(
     default_action_dir: &Path,
-    context: Option<&ToolExecutionContext>,
+    context: Option<&dyn ToolRunContext>,
     tool_name: &str,
 ) -> PathBuf {
-    if let Some(workspace) = context.and_then(|ctx| ctx.workspace.as_ref()) {
+    if let Some(workspace) = context.and_then(|ctx| ctx.workspace()) {
         tracing::debug!(
             tool = tool_name,
             workspace_root = %workspace.root.display(),
@@ -400,7 +400,7 @@ impl Tool for StorageUploadFileTool {
         &self,
         args: Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let action_dir = action_dir_for_context(&self.action_dir, context, self.name());
         self.run(args, &action_dir).await
@@ -548,7 +548,7 @@ impl Tool for StorageDownloadFileTool {
         &self,
         args: Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let action_dir = action_dir_for_context(&self.action_dir, context, self.name());
         self.run(args, &action_dir).await

--- a/src/openhuman/media/generation/tools.rs
+++ b/src/openhuman/media/generation/tools.rs
@@ -27,7 +27,6 @@ use crate::openhuman::integrations::IntegrationClient;
 use crate::openhuman::tools::traits::{
     PermissionLevel, Tool, ToolCallOptions, ToolCategory, ToolResult,
 };
-use tinyagents::harness::tool::ToolExecutionContext;
 use tinytools::ToolRunContext;
 
 use super::download::persist_media;

--- a/src/openhuman/media/generation/tools.rs
+++ b/src/openhuman/media/generation/tools.rs
@@ -172,10 +172,10 @@ async fn generate_and_persist(
 
 fn action_dir_for_context(
     default_action_dir: &Path,
-    context: Option<&ToolExecutionContext>,
+    context: Option<&dyn ToolRunContext>,
     tool_name: &str,
 ) -> PathBuf {
-    if let Some(workspace) = context.and_then(|ctx| ctx.workspace.as_ref()) {
+    if let Some(workspace) = context.and_then(|ctx| ctx.workspace()) {
         tracing::debug!(
             tool = tool_name,
             workspace_root = %workspace.root.display(),
@@ -290,7 +290,7 @@ impl Tool for MediaGenerateImageTool {
         &self,
         args: Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let action_dir = action_dir_for_context(&self.action_dir, context, self.name());
         self.run(args, &action_dir).await
@@ -397,7 +397,7 @@ impl Tool for MediaGenerateVideoTool {
         &self,
         args: Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let action_dir = action_dir_for_context(&self.action_dir, context, self.name());
         self.run(args, &action_dir).await

--- a/src/openhuman/media/generation/tools.rs
+++ b/src/openhuman/media/generation/tools.rs
@@ -28,6 +28,7 @@ use crate::openhuman::tools::traits::{
     PermissionLevel, Tool, ToolCallOptions, ToolCategory, ToolResult,
 };
 use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 use super::download::persist_media;
 use super::types::MediaResponse;

--- a/src/openhuman/memory/agent/tools.rs
+++ b/src/openhuman/memory/agent/tools.rs
@@ -19,7 +19,6 @@ use crate::openhuman::tools::traits::{
 };
 use async_trait::async_trait;
 use serde_json::json;
-use tinyagents::harness::tool::ToolExecutionContext;
 use tinytools::ToolRunContext;
 
 const AGENT_ID: &str = "agent_memory";

--- a/src/openhuman/memory/agent/tools.rs
+++ b/src/openhuman/memory/agent/tools.rs
@@ -20,6 +20,7 @@ use crate::openhuman::tools::traits::{
 use async_trait::async_trait;
 use serde_json::json;
 use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 const AGENT_ID: &str = "agent_memory";
 

--- a/src/openhuman/memory/agent/tools.rs
+++ b/src/openhuman/memory/agent/tools.rs
@@ -104,7 +104,7 @@ impl Tool for CallMemoryAgentTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        tool_context: Option<&ToolExecutionContext>,
+        tool_context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let query = args
             .get("query")
@@ -178,7 +178,7 @@ impl Tool for CallMemoryAgentTool {
             task_id
         );
 
-        let workspace_descriptor = tool_context.and_then(|ctx| ctx.workspace.clone());
+        let workspace_descriptor = tool_context.and_then(|ctx| ctx.workspace().cloned());
         let worktree_action_dir = workspace_descriptor
             .as_ref()
             .map(|descriptor| descriptor.root.clone());

--- a/src/openhuman/skills/types.rs
+++ b/src/openhuman/skills/types.rs
@@ -1,6 +1,8 @@
 //! Shared tool result types used by the tool and node runtime surfaces.
-
-use serde::{Deserialize, Serialize};
+//!
+//! The definitions live in [`tinytools`]; this module is the stable host import
+//! path for the ~14 call sites that already name it, and the home of the one
+//! conversion that is genuinely ours.
 
 /// Serialized-size ceiling for a pass-through MCP content block before it
 /// reaches a model prompt.
@@ -11,140 +13,39 @@ use serde::{Deserialize, Serialize};
 /// block type but not the bytes.
 const MAX_LLM_BLOCK_BYTES: usize = 64 * 1024;
 
-/// Result of executing a tool, containing content blocks and error status.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ToolResult {
-    /// List of content blocks returned by the tool.
-    pub content: Vec<ToolContent>,
-    /// Indicates if the tool encountered an error during execution.
-    #[serde(default)]
-    pub is_error: bool,
-    /// Optional markdown rendering of the result. When the agent loop
-    /// is configured with `prefer_markdown`, this is sent to the LLM
-    /// instead of the JSON-serialised content blocks. Mirrors the
-    /// `markdownFormatted` field on Composio's backend responses
-    /// (see #1165) — markdown is significantly cheaper than JSON in
-    /// the model context window.
-    #[serde(
-        default,
-        rename = "markdownFormatted",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub markdown_formatted: Option<String>,
-}
+pub use tinytools::{ToolContent, ToolResult};
 
-impl ToolResult {
-    pub fn success(text: impl Into<String>) -> Self {
-        Self {
-            content: vec![ToolContent::Text { text: text.into() }],
-            is_error: false,
-            markdown_formatted: None,
-        }
-    }
-
-    pub fn error(message: impl Into<String>) -> Self {
-        Self {
-            content: vec![ToolContent::Text {
-                text: message.into(),
-            }],
-            is_error: true,
-            markdown_formatted: None,
-        }
-    }
-
-    pub fn json(data: serde_json::Value) -> Self {
-        Self {
-            content: vec![ToolContent::Json { data }],
-            is_error: false,
-            markdown_formatted: None,
-        }
-    }
-
-    /// Construct a successful result that carries both a JSON payload
-    /// (for programmatic consumers / debugging) and a markdown rendering
-    /// (preferred by the agent loop when `prefer_markdown` is on).
-    pub fn success_with_markdown(data: serde_json::Value, markdown: impl Into<String>) -> Self {
-        Self {
-            content: vec![ToolContent::Json { data }],
-            is_error: false,
-            markdown_formatted: Some(markdown.into()),
-        }
-    }
-
-    /// Attach (or replace) the markdown rendering on an existing result.
-    pub fn with_markdown(mut self, markdown: impl Into<String>) -> Self {
-        self.markdown_formatted = Some(markdown.into());
-        self
-    }
-
-    /// Returns the markdown rendering when present and non-empty,
-    /// otherwise falls back to [`Self::output`]. Used by the agent loop
-    /// when token-saving markdown output is requested.
-    pub fn output_for_llm(&self, prefer_markdown: bool) -> String {
-        if prefer_markdown {
-            if let Some(md) = self.markdown_formatted.as_deref() {
-                let trimmed = md.trim();
-                if !trimmed.is_empty() {
-                    return md.to_string();
-                }
-            }
-        }
-        self.output()
-    }
-
-    pub fn text(&self) -> String {
-        self.content
-            .iter()
-            .filter_map(|c| match c {
-                ToolContent::Text { text } => Some(text.as_str()),
-                ToolContent::Json { .. } => None,
+/// Converts a rendered MCP result into this application's tool result.
+///
+/// The two shapes are the same by construction — the module's was derived from
+/// this one when the client was extracted — so this is a mapping, not a
+/// translation.
+///
+/// It is a free function rather than a `From` impl because both types are now
+/// foreign to this crate: [`ToolResult`] belongs to `tinytools` and
+/// `McpToolResult` to `tinymcp_bus`, which the orphan rule forbids us from
+/// bridging with a trait impl. The reason the conversion is written **once**
+/// has not changed with its shape: spelled out at each call site, it would be
+/// as many chances to get the error flag the wrong way round.
+pub fn tool_result_from_mcp(result: tinymcp_bus::McpToolResult) -> ToolResult {
+    ToolResult {
+        content: result
+            .content
+            .into_iter()
+            .map(|block| match block {
+                tinymcp_bus::McpToolContent::Text { text } => ToolContent::Text { text },
+                tinymcp_bus::McpToolContent::Json { data } => ToolContent::Json { data },
+                // The contract's block enum is `#[non_exhaustive]`. A kind this
+                // build does not model is carried through as its JSON rather
+                // than dropped: a caller can still read it, and dropping it
+                // would lose content a server deliberately sent.
+                other => ToolContent::Json {
+                    data: elide_oversized_block(&other),
+                },
             })
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-
-    pub fn output(&self) -> String {
-        self.content
-            .iter()
-            .map(|c| match c {
-                ToolContent::Text { text } => text.clone(),
-                ToolContent::Json { data } => {
-                    serde_json::to_string_pretty(data).unwrap_or_default()
-                }
-            })
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-}
-
-impl From<tinymcp_bus::McpToolResult> for ToolResult {
-    /// Converts a rendered MCP result into this application's tool result.
-    ///
-    /// The two shapes are the same by construction — the module's was derived
-    /// from this one when the client was extracted — so this is a mapping, not
-    /// a translation. It exists because they are now types in different crates,
-    /// and a conversion written at each call site would be six chances to get
-    /// the error flag the wrong way round.
-    fn from(result: tinymcp_bus::McpToolResult) -> Self {
-        Self {
-            content: result
-                .content
-                .into_iter()
-                .map(|block| match block {
-                    tinymcp_bus::McpToolContent::Text { text } => ToolContent::Text { text },
-                    tinymcp_bus::McpToolContent::Json { data } => ToolContent::Json { data },
-                    // The contract's block enum is `#[non_exhaustive]`. A kind
-                    // this build does not model is carried through as its JSON
-                    // rather than dropped: a caller can still read it, and
-                    // dropping it would lose content a server deliberately sent.
-                    other => ToolContent::Json {
-                        data: elide_oversized_block(&other),
-                    },
-                })
-                .collect(),
-            is_error: result.is_error,
-            markdown_formatted: result.markdown_formatted,
-        }
+            .collect(),
+        is_error: result.is_error,
+        markdown_formatted: result.markdown_formatted,
     }
 }
 
@@ -173,144 +74,32 @@ fn elide_oversized_block(block: &tinymcp_bus::McpToolContent) -> serde_json::Val
     })
 }
 
-/// A single content block within a `ToolResult`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "lowercase")]
-pub enum ToolContent {
-    Text { text: String },
-    Json { data: serde_json::Value },
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
 
     #[test]
-    fn tool_result_success() {
-        let r = ToolResult::success("done");
-        assert!(!r.is_error);
-        assert_eq!(r.text(), "done");
-        assert_eq!(r.output(), "done");
-    }
-
-    #[test]
-    fn tool_result_error() {
-        let r = ToolResult::error("failed");
-        assert!(r.is_error);
-        assert_eq!(r.text(), "failed");
-    }
-
-    #[test]
-    fn tool_result_json() {
-        let r = ToolResult::json(json!({"key": "value"}));
-        assert!(!r.is_error);
-        assert!(r.text().is_empty()); // text() skips JSON blocks
-        assert!(r.output().contains("key"));
-    }
-
-    #[test]
-    fn tool_result_mixed_content() {
-        let r = ToolResult {
-            content: vec![
-                ToolContent::Text {
-                    text: "line1".into(),
-                },
-                ToolContent::Json {
-                    data: json!({"a": 1}),
-                },
-                ToolContent::Text {
-                    text: "line2".into(),
-                },
-            ],
+    fn an_mcp_result_maps_across_with_its_error_flag_intact() {
+        let ok = tool_result_from_mcp(tinymcp_bus::McpToolResult {
+            content: vec![tinymcp_bus::McpToolContent::Text {
+                text: "fine".into(),
+            }],
             is_error: false,
             markdown_formatted: None,
-        };
-        assert_eq!(r.text(), "line1\nline2");
-        let output = r.output();
-        assert!(output.contains("line1"));
-        assert!(output.contains("line2"));
-        assert!(output.contains("\"a\""));
-    }
+        });
+        assert!(!ok.is_error);
+        assert_eq!(ok.text(), "fine");
 
-    #[test]
-    fn tool_result_serde_roundtrip() {
-        let r = ToolResult::success("hello");
-        let json = serde_json::to_string(&r).unwrap();
-        let back: ToolResult = serde_json::from_str(&json).unwrap();
-        assert!(!back.is_error);
-        assert_eq!(back.text(), "hello");
-    }
-
-    #[test]
-    fn tool_content_text_serde() {
-        let c = ToolContent::Text {
-            text: "test".into(),
-        };
-        let json = serde_json::to_string(&c).unwrap();
-        assert!(json.contains("\"type\":\"text\""));
-        let back: ToolContent = serde_json::from_str(&json).unwrap();
-        match back {
-            ToolContent::Text { text } => assert_eq!(text, "test"),
-            _ => panic!("expected Text variant"),
-        }
-    }
-
-    #[test]
-    fn tool_content_json_serde() {
-        let c = ToolContent::Json {
-            data: json!({"x": 1}),
-        };
-        let json = serde_json::to_string(&c).unwrap();
-        assert!(json.contains("\"type\":\"json\""));
-        let back: ToolContent = serde_json::from_str(&json).unwrap();
-        match back {
-            ToolContent::Json { data } => assert_eq!(data["x"], 1),
-            _ => panic!("expected Json variant"),
-        }
-    }
-
-    #[test]
-    fn tool_result_empty_content() {
-        let r = ToolResult {
-            content: vec![],
-            is_error: false,
-            markdown_formatted: None,
-        };
-        assert!(r.text().is_empty());
-        assert!(r.output().is_empty());
-    }
-
-    #[test]
-    fn output_for_llm_prefers_markdown_when_requested() {
-        let r =
-            ToolResult::success_with_markdown(json!({"items": [{"id": 1}, {"id": 2}]}), "- 1\n- 2");
-        assert_eq!(r.output_for_llm(true), "- 1\n- 2");
-        // When prefer_markdown is false, falls back to JSON pretty-print.
-        let raw = r.output_for_llm(false);
-        assert!(raw.contains("\"items\""));
-    }
-
-    #[test]
-    fn output_for_llm_falls_back_to_output_when_markdown_missing() {
-        let r = ToolResult::success("plain");
-        assert_eq!(r.output_for_llm(true), "plain");
-        assert_eq!(r.output_for_llm(false), "plain");
-    }
-
-    #[test]
-    fn output_for_llm_falls_back_when_markdown_blank() {
-        let r = ToolResult::success("plain").with_markdown("   \n  ");
-        assert_eq!(r.output_for_llm(true), "plain");
-    }
-
-    #[test]
-    fn markdown_field_serde_roundtrip() {
-        let r = ToolResult::success_with_markdown(json!({"a": 1}), "**a**: 1");
-        let s = serde_json::to_string(&r).unwrap();
-        assert!(s.contains("markdownFormatted"));
-        let back: ToolResult = serde_json::from_str(&s).unwrap();
-        assert_eq!(back.markdown_formatted.as_deref(), Some("**a**: 1"));
+        let failed = tool_result_from_mcp(tinymcp_bus::McpToolResult {
+            content: vec![tinymcp_bus::McpToolContent::Text {
+                text: "boom".into(),
+            }],
+            is_error: true,
+            markdown_formatted: Some("**boom**".into()),
+        });
+        assert!(failed.is_error);
+        assert_eq!(failed.markdown_formatted.as_deref(), Some("**boom**"));
     }
 
     #[test]

--- a/src/openhuman/tools/impl/filesystem/apply_patch.rs
+++ b/src/openhuman/tools/impl/filesystem/apply_patch.rs
@@ -83,7 +83,7 @@ impl Tool for ApplyPatchTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         self.execute_in_context(args, context).await
     }
@@ -93,7 +93,7 @@ impl ApplyPatchTool {
     async fn execute_in_context(
         &self,
         args: serde_json::Value,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let edits = args
             .get("edits")

--- a/src/openhuman/tools/impl/filesystem/apply_patch.rs
+++ b/src/openhuman/tools/impl/filesystem/apply_patch.rs
@@ -14,7 +14,7 @@ use serde_json::json;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 const MAX_FILE_BYTES: u64 = 5 * 1024 * 1024;
 const MAX_EDITS: usize = 50;

--- a/src/openhuman/tools/impl/filesystem/csv_export.rs
+++ b/src/openhuman/tools/impl/filesystem/csv_export.rs
@@ -132,7 +132,7 @@ impl Tool for CsvExportTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         self.execute_in_context(args, context).await
     }
@@ -142,7 +142,7 @@ impl CsvExportTool {
     async fn execute_in_context(
         &self,
         args: serde_json::Value,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let data_str = args
             .get("data")

--- a/src/openhuman/tools/impl/filesystem/csv_export.rs
+++ b/src/openhuman/tools/impl/filesystem/csv_export.rs
@@ -3,7 +3,7 @@ use crate::openhuman::tools::traits::{Tool, ToolCallOptions, ToolResult};
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 /// Export structured data (JSON array of objects) as a CSV file to the workspace.
 pub struct CsvExportTool {

--- a/src/openhuman/tools/impl/filesystem/edit_file.rs
+++ b/src/openhuman/tools/impl/filesystem/edit_file.rs
@@ -73,7 +73,7 @@ impl Tool for EditFileTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         self.execute_in_context(args, context).await
     }
@@ -83,7 +83,7 @@ impl EditFileTool {
     async fn execute_in_context(
         &self,
         args: serde_json::Value,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let path = args
             .get("path")

--- a/src/openhuman/tools/impl/filesystem/edit_file.rs
+++ b/src/openhuman/tools/impl/filesystem/edit_file.rs
@@ -12,7 +12,7 @@ use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, To
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 const MAX_FILE_BYTES: u64 = 5 * 1024 * 1024;
 

--- a/src/openhuman/tools/impl/filesystem/file_read.rs
+++ b/src/openhuman/tools/impl/filesystem/file_read.rs
@@ -58,7 +58,7 @@ impl Tool for FileReadTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         self.execute_in_context(args, context).await
     }
@@ -68,7 +68,7 @@ impl FileReadTool {
     async fn execute_in_context(
         &self,
         args: serde_json::Value,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let path = args
             .get("path")

--- a/src/openhuman/tools/impl/filesystem/file_read.rs
+++ b/src/openhuman/tools/impl/filesystem/file_read.rs
@@ -4,7 +4,7 @@ use crate::openhuman::tools::traits::{Tool, ToolCallOptions, ToolResult};
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 const MAX_FILE_SIZE_BYTES: u64 = 10 * 1024 * 1024;
 

--- a/src/openhuman/tools/impl/filesystem/file_write.rs
+++ b/src/openhuman/tools/impl/filesystem/file_write.rs
@@ -4,7 +4,7 @@ use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, To
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 /// Write file contents with path sandboxing
 pub struct FileWriteTool {

--- a/src/openhuman/tools/impl/filesystem/file_write.rs
+++ b/src/openhuman/tools/impl/filesystem/file_write.rs
@@ -108,7 +108,7 @@ impl Tool for FileWriteTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         self.execute_in_context(args, context).await
     }
@@ -118,7 +118,7 @@ impl FileWriteTool {
     async fn execute_in_context(
         &self,
         args: serde_json::Value,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let path = args
             .get("path")

--- a/src/openhuman/tools/impl/filesystem/git_operations.rs
+++ b/src/openhuman/tools/impl/filesystem/git_operations.rs
@@ -31,8 +31,8 @@ impl GitOperationsTool {
     /// `ToolExecutionContext::from_run_context`. Otherwise falls back to the
     /// tool's configured `action_dir`, which preserves the non-isolated
     /// behaviour exactly. See #3376, #4249 (08.5).
-    fn effective_action_dir_for_context(&self, context: Option<&ToolExecutionContext>) -> PathBuf {
-        if let Some(workspace) = context.and_then(|ctx| ctx.workspace.as_ref()) {
+    fn effective_action_dir_for_context(&self, context: Option<&dyn ToolRunContext>) -> PathBuf {
+        if let Some(workspace) = context.and_then(|ctx| ctx.workspace()) {
             tracing::debug!(
                 workspace_root = %workspace.root.display(),
                 policy_id = %workspace.policy_id,
@@ -510,7 +510,7 @@ impl Tool for GitOperationsTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         self.execute_in_context(args, context).await
     }
@@ -524,7 +524,7 @@ impl GitOperationsTool {
     async fn execute_in_context(
         &self,
         args: serde_json::Value,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let operation = match args.get("operation").and_then(|v| v.as_str()) {
             Some(op) => op,

--- a/src/openhuman/tools/impl/filesystem/git_operations.rs
+++ b/src/openhuman/tools/impl/filesystem/git_operations.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use serde_json::json;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 /// Git operations tool for structured repository management.
 /// Provides safe, parsed git operations with JSON output.

--- a/src/openhuman/tools/impl/filesystem/git_operations_tests.rs
+++ b/src/openhuman/tools/impl/filesystem/git_operations_tests.rs
@@ -1,7 +1,7 @@
-use tinyagents::harness::tool::ToolExecutionContext;
 use super::*;
 use crate::openhuman::security::SecurityPolicy;
 use tempfile::TempDir;
+use tinyagents::harness::tool::ToolExecutionContext;
 
 fn test_tool(dir: &std::path::Path) -> GitOperationsTool {
     let security = Arc::new(SecurityPolicy {

--- a/src/openhuman/tools/impl/filesystem/git_operations_tests.rs
+++ b/src/openhuman/tools/impl/filesystem/git_operations_tests.rs
@@ -1,3 +1,4 @@
+use tinyagents::harness::tool::ToolExecutionContext;
 use super::*;
 use crate::openhuman::security::SecurityPolicy;
 use tempfile::TempDir;

--- a/src/openhuman/tools/impl/filesystem/glob_search.rs
+++ b/src/openhuman/tools/impl/filesystem/glob_search.rs
@@ -30,7 +30,7 @@ use glob::Pattern;
 use serde_json::json;
 use std::path::Path;
 use std::sync::Arc;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 use walkdir::WalkDir;
 
 const DEFAULT_MAX_RESULTS: usize = 500;

--- a/src/openhuman/tools/impl/filesystem/glob_search.rs
+++ b/src/openhuman/tools/impl/filesystem/glob_search.rs
@@ -94,7 +94,7 @@ impl Tool for GlobTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         self.execute_in_context(args, context).await
     }
@@ -104,7 +104,7 @@ impl GlobTool {
     async fn execute_in_context(
         &self,
         args: serde_json::Value,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let pattern_str = args
             .get("pattern")

--- a/src/openhuman/tools/impl/filesystem/grep.rs
+++ b/src/openhuman/tools/impl/filesystem/grep.rs
@@ -85,7 +85,7 @@ impl Tool for GrepTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         self.execute_in_context(args, context).await
     }
@@ -95,7 +95,7 @@ impl GrepTool {
     async fn execute_in_context(
         &self,
         args: serde_json::Value,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let pattern = args
             .get("pattern")

--- a/src/openhuman/tools/impl/filesystem/grep.rs
+++ b/src/openhuman/tools/impl/filesystem/grep.rs
@@ -12,7 +12,7 @@ use regex::Regex;
 use serde_json::json;
 use std::path::Path;
 use std::sync::Arc;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 use walkdir::WalkDir;
 
 const DEFAULT_MAX_MATCHES: usize = 200;

--- a/src/openhuman/tools/impl/filesystem/list_files.rs
+++ b/src/openhuman/tools/impl/filesystem/list_files.rs
@@ -59,7 +59,7 @@ impl Tool for ListFilesTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         self.execute_in_context(args, context).await
     }
@@ -69,7 +69,7 @@ impl ListFilesTool {
     async fn execute_in_context(
         &self,
         args: serde_json::Value,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let path = args.get("path").and_then(|v| v.as_str()).unwrap_or(".");
 

--- a/src/openhuman/tools/impl/filesystem/list_files.rs
+++ b/src/openhuman/tools/impl/filesystem/list_files.rs
@@ -9,7 +9,7 @@ use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, To
 use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 const MAX_ENTRIES: usize = 1_000;
 

--- a/src/openhuman/tools/impl/filesystem/mod.rs
+++ b/src/openhuman/tools/impl/filesystem/mod.rs
@@ -56,11 +56,11 @@ pub use update_memory_md::UpdateMemoryMdTool;
 /// model-supplied text.
 pub(super) fn security_for_tool_context(
     security: &SecurityPolicy,
-    context: Option<&ToolExecutionContext>,
+    context: Option<&dyn ToolRunContext>,
     tool: &str,
 ) -> SecurityPolicy {
     let mut scoped = security.clone();
-    if let Some(workspace) = context.and_then(|ctx| ctx.workspace.as_ref()) {
+    if let Some(workspace) = context.and_then(|ctx| ctx.workspace()) {
         tracing::debug!(
             tool,
             workspace_root = %workspace.root.display(),

--- a/src/openhuman/tools/impl/filesystem/mod.rs
+++ b/src/openhuman/tools/impl/filesystem/mod.rs
@@ -14,7 +14,7 @@ mod update_memory_md;
 
 use crate::openhuman::security::policy::{TrustedAccess, TrustedRoot};
 use crate::openhuman::security::SecurityPolicy;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 #[cfg(test)]
 #[path = "mod_tests.rs"]

--- a/src/openhuman/tools/impl/filesystem/mod_tests.rs
+++ b/src/openhuman/tools/impl/filesystem/mod_tests.rs
@@ -5,6 +5,7 @@
 //! `#[path = "mod_tests.rs"] mod tests;` so `super::*` resolves to the
 //! `filesystem` module.
 
+use tinyagents::harness::tool::ToolExecutionContext;
 use super::*;
 use crate::openhuman::security::policy::TrustedAccess;
 use std::path::Path;

--- a/src/openhuman/tools/impl/filesystem/mod_tests.rs
+++ b/src/openhuman/tools/impl/filesystem/mod_tests.rs
@@ -5,11 +5,11 @@
 //! `#[path = "mod_tests.rs"] mod tests;` so `super::*` resolves to the
 //! `filesystem` module.
 
-use tinyagents::harness::tool::ToolExecutionContext;
 use super::*;
 use crate::openhuman::security::policy::TrustedAccess;
 use std::path::Path;
 use tinyagents::harness::context::{RunConfig, RunContext};
+use tinyagents::harness::tool::ToolExecutionContext;
 use tinyagents::harness::workspace::WorkspaceDescriptor;
 
 /// A run context carrying a workspace descriptor rooted at `root`, exactly as

--- a/src/openhuman/tools/impl/filesystem/read_diff.rs
+++ b/src/openhuman/tools/impl/filesystem/read_diff.rs
@@ -16,8 +16,8 @@ impl ReadDiffTool {
         Self { workspace_dir }
     }
 
-    fn workspace_dir_for_context(&self, context: Option<&ToolExecutionContext>) -> PathBuf {
-        if let Some(workspace) = context.and_then(|ctx| ctx.workspace.as_ref()) {
+    fn workspace_dir_for_context(&self, context: Option<&dyn ToolRunContext>) -> PathBuf {
+        if let Some(workspace) = context.and_then(|ctx| ctx.workspace()) {
             tracing::debug!(
                 workspace_root = %workspace.root.display(),
                 policy_id = %workspace.policy_id,
@@ -73,7 +73,7 @@ impl Tool for ReadDiffTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let workspace_dir = self.workspace_dir_for_context(context);
         let base = args.get("base").and_then(|v| v.as_str());

--- a/src/openhuman/tools/impl/filesystem/read_diff.rs
+++ b/src/openhuman/tools/impl/filesystem/read_diff.rs
@@ -4,7 +4,7 @@ use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, To
 use async_trait::async_trait;
 use serde_json::json;
 use std::path::PathBuf;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 /// Returns `git diff` output in a structured format.
 pub struct ReadDiffTool {

--- a/src/openhuman/tools/impl/filesystem/run_linter.rs
+++ b/src/openhuman/tools/impl/filesystem/run_linter.rs
@@ -16,8 +16,8 @@ impl RunLinterTool {
         Self { workspace_dir }
     }
 
-    fn workspace_dir_for_context(&self, context: Option<&ToolExecutionContext>) -> PathBuf {
-        if let Some(workspace) = context.and_then(|ctx| ctx.workspace.as_ref()) {
+    fn workspace_dir_for_context(&self, context: Option<&dyn ToolRunContext>) -> PathBuf {
+        if let Some(workspace) = context.and_then(|ctx| ctx.workspace()) {
             tracing::debug!(
                 workspace_root = %workspace.root.display(),
                 policy_id = %workspace.policy_id,
@@ -71,7 +71,7 @@ impl Tool for RunLinterTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let workspace_dir = self.workspace_dir_for_context(context);
         let linter = args

--- a/src/openhuman/tools/impl/filesystem/run_linter.rs
+++ b/src/openhuman/tools/impl/filesystem/run_linter.rs
@@ -4,7 +4,7 @@ use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, To
 use async_trait::async_trait;
 use serde_json::json;
 use std::path::PathBuf;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 /// Runs linters (cargo clippy, eslint) and returns structured findings.
 pub struct RunLinterTool {

--- a/src/openhuman/tools/impl/filesystem/run_tests.rs
+++ b/src/openhuman/tools/impl/filesystem/run_tests.rs
@@ -16,8 +16,8 @@ impl RunTestsTool {
         Self { workspace_dir }
     }
 
-    fn workspace_dir_for_context(&self, context: Option<&ToolExecutionContext>) -> PathBuf {
-        if let Some(workspace) = context.and_then(|ctx| ctx.workspace.as_ref()) {
+    fn workspace_dir_for_context(&self, context: Option<&dyn ToolRunContext>) -> PathBuf {
+        if let Some(workspace) = context.and_then(|ctx| ctx.workspace()) {
             tracing::debug!(
                 workspace_root = %workspace.root.display(),
                 policy_id = %workspace.policy_id,
@@ -76,7 +76,7 @@ impl Tool for RunTestsTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let workspace_dir = self.workspace_dir_for_context(context);
         let runner = args

--- a/src/openhuman/tools/impl/filesystem/run_tests.rs
+++ b/src/openhuman/tools/impl/filesystem/run_tests.rs
@@ -4,7 +4,7 @@ use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, To
 use async_trait::async_trait;
 use serde_json::json;
 use std::path::PathBuf;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 /// Runs test suites (cargo test, vitest) and returns pass/fail with output.
 pub struct RunTestsTool {

--- a/src/openhuman/tools/impl/filesystem/update_memory_md.rs
+++ b/src/openhuman/tools/impl/filesystem/update_memory_md.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 /// Allowed workspace markdown files this tool may modify.
 const ALLOWED_FILES: &[&str] = &["MEMORY.md", "SKILL.md"];

--- a/src/openhuman/tools/impl/filesystem/update_memory_md.rs
+++ b/src/openhuman/tools/impl/filesystem/update_memory_md.rs
@@ -150,8 +150,8 @@ impl UpdateMemoryMdTool {
         Self { workspace_dir }
     }
 
-    fn workspace_dir_for_context(&self, context: Option<&ToolExecutionContext>) -> PathBuf {
-        if let Some(workspace) = context.and_then(|ctx| ctx.workspace.as_ref()) {
+    fn workspace_dir_for_context(&self, context: Option<&dyn ToolRunContext>) -> PathBuf {
+        if let Some(workspace) = context.and_then(|ctx| ctx.workspace()) {
             tracing::debug!(
                 workspace_root = %workspace.root.display(),
                 policy_id = %workspace.policy_id,
@@ -216,7 +216,7 @@ impl Tool for UpdateMemoryMdTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let workspace_dir = self.workspace_dir_for_context(context);
         let file = args

--- a/src/openhuman/tools/impl/network/gitbooks.rs
+++ b/src/openhuman/tools/impl/network/gitbooks.rs
@@ -82,7 +82,9 @@ impl Tool for GitbooksSearchTool {
             .call_tool("searchDocumentation", json!({ "query": query }))
             .await
         {
-            Ok(result) => Ok(result.rendered.into()),
+            Ok(result) => Ok(crate::openhuman::skills::types::tool_result_from_mcp(
+                result.rendered,
+            )),
             Err(e) => Ok(ToolResult::error(format!("gitbooks_search failed: {e}"))),
         }
     }
@@ -162,7 +164,9 @@ impl Tool for GitbooksGetPageTool {
             .call_tool("getPage", json!({ "url": url }))
             .await
         {
-            Ok(result) => Ok(result.rendered.into()),
+            Ok(result) => Ok(crate::openhuman::skills::types::tool_result_from_mcp(
+                result.rendered,
+            )),
             Err(e) => Ok(ToolResult::error(format!("gitbooks_get_page failed: {e}"))),
         }
     }

--- a/src/openhuman/tools/impl/network/mcp.rs
+++ b/src/openhuman/tools/impl/network/mcp.rs
@@ -277,7 +277,7 @@ impl Tool for McpCallTool {
         if options.prefer_markdown && result.markdown_formatted.is_none() {
             result.markdown_formatted = Some(result.output());
         }
-        Ok(result.into())
+        Ok(crate::openhuman::skills::types::tool_result_from_mcp(result))
     }
 
     async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {

--- a/src/openhuman/tools/impl/network/mcp.rs
+++ b/src/openhuman/tools/impl/network/mcp.rs
@@ -277,7 +277,9 @@ impl Tool for McpCallTool {
         if options.prefer_markdown && result.markdown_formatted.is_none() {
             result.markdown_formatted = Some(result.output());
         }
-        Ok(crate::openhuman::skills::types::tool_result_from_mcp(result))
+        Ok(crate::openhuman::skills::types::tool_result_from_mcp(
+            result,
+        ))
     }
 
     async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {

--- a/src/openhuman/tools/impl/system/mod.rs
+++ b/src/openhuman/tools/impl/system/mod.rs
@@ -67,11 +67,11 @@ pub use workspace_state::WorkspaceStateTool;
 /// model-supplied text.
 pub(super) fn security_for_tool_context(
     security: &SecurityPolicy,
-    context: Option<&ToolExecutionContext>,
+    context: Option<&dyn ToolRunContext>,
     tool: &str,
 ) -> SecurityPolicy {
     let mut scoped = security.clone();
-    if let Some(workspace) = context.and_then(|ctx| ctx.workspace.as_ref()) {
+    if let Some(workspace) = context.and_then(|ctx| ctx.workspace()) {
         tracing::debug!(
             tool,
             workspace_root = %workspace.root.display(),

--- a/src/openhuman/tools/impl/system/mod.rs
+++ b/src/openhuman/tools/impl/system/mod.rs
@@ -21,7 +21,7 @@ mod workspace_state;
 use crate::openhuman::security::policy::{TrustedAccess, TrustedRoot};
 use crate::openhuman::security::SecurityPolicy;
 use std::path::Path;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 pub use current_time::CurrentTimeTool;
 pub use detect_tools::DetectToolsTool;

--- a/src/openhuman/tools/impl/system/node_exec.rs
+++ b/src/openhuman/tools/impl/system/node_exec.rs
@@ -31,7 +31,7 @@ use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 /// Absolute ceiling a caller may request via `timeout_secs`. There is **no**
 /// default timeout — `node_exec` runs scripts that legitimately take minutes

--- a/src/openhuman/tools/impl/system/node_exec.rs
+++ b/src/openhuman/tools/impl/system/node_exec.rs
@@ -159,7 +159,7 @@ impl Tool for NodeExecTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         self.execute_in_context(args, context).await
     }
@@ -169,7 +169,7 @@ impl NodeExecTool {
     async fn execute_in_context(
         &self,
         args: serde_json::Value,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let inline_code = args
             .get("inline_code")

--- a/src/openhuman/tools/impl/system/npm_exec.rs
+++ b/src/openhuman/tools/impl/system/npm_exec.rs
@@ -27,7 +27,7 @@ use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 /// Absolute ceiling callers can request via `timeout_secs`. There is **no**
 /// default timeout — `npm install`/build steps on a cold cache or slow network

--- a/src/openhuman/tools/impl/system/npm_exec.rs
+++ b/src/openhuman/tools/impl/system/npm_exec.rs
@@ -166,7 +166,7 @@ impl Tool for NpmExecTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         self.execute_in_context(args, context).await
     }
@@ -176,7 +176,7 @@ impl NpmExecTool {
     async fn execute_in_context(
         &self,
         args: serde_json::Value,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let subcommand = match args.get("subcommand").and_then(|v| v.as_str()) {
             Some(s) => s.trim().to_string(),

--- a/src/openhuman/tools/impl/system/python_exec.rs
+++ b/src/openhuman/tools/impl/system/python_exec.rs
@@ -147,7 +147,7 @@ impl Tool for PythonExecTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         self.execute_in_context(args, context).await
     }
@@ -157,7 +157,7 @@ impl PythonExecTool {
     async fn execute_in_context(
         &self,
         args: serde_json::Value,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let inline_code = args
             .get("inline_code")

--- a/src/openhuman/tools/impl/system/python_exec.rs
+++ b/src/openhuman/tools/impl/system/python_exec.rs
@@ -26,7 +26,7 @@ use async_trait::async_trait;
 use serde_json::json;
 use std::sync::Arc;
 use std::time::Duration;
-use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 /// Absolute ceiling a caller may request via `timeout_secs`. No default timeout —
 /// Python scripts legitimately take minutes; a deadline applies only when

--- a/src/openhuman/tools/impl/system/shell.rs
+++ b/src/openhuman/tools/impl/system/shell.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tinyagents::harness::tool::ToolExecutionContext;
+use tinytools::ToolRunContext;
 
 /// Maximum output size in bytes (1MB).
 const MAX_OUTPUT_BYTES: usize = 1_048_576;

--- a/src/openhuman/tools/impl/system/shell.rs
+++ b/src/openhuman/tools/impl/system/shell.rs
@@ -147,7 +147,7 @@ impl ShellTool {
     ///
     /// Returns the per-worker git-worktree checkout when the tinyagents harness
     /// threaded a [`WorkspaceDescriptor`] into this call's
-    /// [`ToolExecutionContext`] — an edit-capable worker running with
+    /// [`ToolExecutionContext`](tinyagents::harness::tool::ToolExecutionContext) — an edit-capable worker running with
     /// `isolation = "worktree"`, whose isolated worktree root is carried on the
     /// run context (`RunContext::with_workspace`) and surfaced per tool call via
     /// `ToolExecutionContext::from_run_context`. Otherwise falls back to the

--- a/src/openhuman/tools/impl/system/shell.rs
+++ b/src/openhuman/tools/impl/system/shell.rs
@@ -985,8 +985,11 @@ mod tests {
     /// at `root`, mirroring what the tinyagents harness threads into every tool
     /// call of a worktree-isolated worker (`RunContext::with_workspace` →
     /// `ToolExecutionContext::from_run_context`).
-    fn tool_context_with_workspace(root: &std::path::Path) -> ToolExecutionContext {
+    fn tool_context_with_workspace(
+        root: &std::path::Path,
+    ) -> tinyagents::harness::tool::ToolExecutionContext {
         use tinyagents::harness::context::{RunConfig, RunContext};
+        use tinyagents::harness::tool::ToolExecutionContext;
         use tinyagents::harness::workspace::WorkspaceDescriptor;
         let ws = WorkspaceDescriptor::new(root.to_path_buf()).with_policy_id("test-worktree");
         let ctx: RunContext = RunContext::new(RunConfig::new("test-run"), ()).with_workspace(ws);

--- a/src/openhuman/tools/impl/system/shell.rs
+++ b/src/openhuman/tools/impl/system/shell.rs
@@ -153,8 +153,8 @@ impl ShellTool {
     /// `ToolExecutionContext::from_run_context`. Otherwise falls back to the
     /// shared `self.security.action_dir`, which preserves the non-isolated
     /// behaviour exactly. See #3376, #4249 (08.5).
-    fn effective_action_dir_for_context(&self, context: Option<&ToolExecutionContext>) -> PathBuf {
-        if let Some(workspace) = context.and_then(|ctx| ctx.workspace.as_ref()) {
+    fn effective_action_dir_for_context(&self, context: Option<&dyn ToolRunContext>) -> PathBuf {
+        if let Some(workspace) = context.and_then(|ctx| ctx.workspace()) {
             tracing::debug!(
                 workspace_root = %workspace.root.display(),
                 policy_id = %workspace.policy_id,
@@ -269,7 +269,7 @@ impl Tool for ShellTool {
         &self,
         args: serde_json::Value,
         _options: ToolCallOptions,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         self.execute_in_context(args, context).await
     }
@@ -279,7 +279,7 @@ impl ShellTool {
     async fn execute_in_context(
         &self,
         args: serde_json::Value,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let command = args
             .get("command")
@@ -333,7 +333,7 @@ impl ShellTool {
         &self,
         command: &str,
         requested_timeout: Option<u64>,
-        context: Option<&ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> (bool, ToolResult) {
         // Read-only `Block` + the Option-2 structural guard. Approval for
         // Write / Network / Destructive already happened at the harness

--- a/src/openhuman/tools/impl/system/shell.rs
+++ b/src/openhuman/tools/impl/system/shell.rs
@@ -10,7 +10,6 @@ use serde_json::json;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tinyagents::harness::tool::ToolExecutionContext;
 use tinytools::ToolRunContext;
 
 /// Maximum output size in bytes (1MB).

--- a/src/openhuman/tools/toolpacks/ops.rs
+++ b/src/openhuman/tools/toolpacks/ops.rs
@@ -31,7 +31,7 @@ pub fn bind_pack_registry(tools: &Arc<Vec<Box<dyn Tool>>>) {
         if name != LOAD_SKILL && name != USE_SKILL {
             continue;
         }
-        if let Some(handle) = tool.pack_registry_handle() {
+        if let Some(handle) = crate::openhuman::tools::traits::pack_registry_handle(tool.as_ref()) {
             handle.bind(weak.clone());
             bound += 1;
         }

--- a/src/openhuman/tools/toolpacks/tools.rs
+++ b/src/openhuman/tools/toolpacks/tools.rs
@@ -7,6 +7,7 @@ use serde_json::{json, Value};
 
 use super::registry;
 use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, ToolResult};
+use tinytools::ToolRunContext;
 
 pub const LOAD_SKILL: &str = "load_skill";
 pub const USE_SKILL: &str = "use_skill";

--- a/src/openhuman/tools/toolpacks/tools.rs
+++ b/src/openhuman/tools/toolpacks/tools.rs
@@ -170,7 +170,10 @@ impl Tool for LoadSkillTool {
         PermissionLevel::ReadOnly
     }
 
-    fn pack_registry_handle(&self) -> Option<&PackRegistryHandle> {
+    /// The registry handle rides on the vocabulary's erased host extension:
+    /// `PackRegistryHandle` is this host's concept, and `tinytools` has no
+    /// business naming it. `traits::pack_registry_handle` reads it back.
+    fn host_extension(&self) -> Option<&(dyn std::any::Any + Send + Sync)> {
         Some(&self.handle)
     }
 }
@@ -323,7 +326,10 @@ impl Tool for UseSkillTool {
         }
     }
 
-    fn pack_registry_handle(&self) -> Option<&PackRegistryHandle> {
+    /// The registry handle rides on the vocabulary's erased host extension:
+    /// `PackRegistryHandle` is this host's concept, and `tinytools` has no
+    /// business naming it. `traits::pack_registry_handle` reads it back.
+    fn host_extension(&self) -> Option<&(dyn std::any::Any + Send + Sync)> {
         Some(&self.handle)
     }
 }

--- a/src/openhuman/tools/toolpacks/tools.rs
+++ b/src/openhuman/tools/toolpacks/tools.rs
@@ -252,7 +252,7 @@ impl Tool for UseSkillTool {
         &self,
         args: Value,
         options: ToolCallOptions,
-        context: Option<&tinyagents::harness::tool::ToolExecutionContext>,
+        context: Option<&dyn ToolRunContext>,
     ) -> anyhow::Result<ToolResult> {
         let Some((tools, idx)) = self.resolve(&args) else {
             let skill = args.get("skill").and_then(Value::as_str).unwrap_or("");

--- a/src/openhuman/tools/traits.rs
+++ b/src/openhuman/tools/traits.rs
@@ -20,8 +20,8 @@
 //! [`policy`]: crate::openhuman::tools::policy
 
 pub use tinytools::{
-    PermissionLevel, Tool, ToolCallOptions, ToolCategory, ToolContent, ToolResult, ToolRunContext,
-    ToolScope, ToolSpec, ToolTimeout, context_detail_from_args, humanize_tool_name,
+    context_detail_from_args, humanize_tool_name, PermissionLevel, Tool, ToolCallOptions,
+    ToolCategory, ToolContent, ToolResult, ToolRunContext, ToolScope, ToolSpec, ToolTimeout,
 };
 
 use crate::openhuman::agent::tool_policy::GeneratedToolRuntimeContext;

--- a/src/openhuman/tools/traits.rs
+++ b/src/openhuman/tools/traits.rs
@@ -1,434 +1,67 @@
-use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+//! The tool trait and its vocabulary — the stable host import path.
+//!
+//! Every definition here lives in [`tinytools`], which `tinyagents` also
+//! depends on. That is what makes `tinytools::Tool` and the trait the harness
+//! runs a loop over the *same* trait: a tool is implemented once and both sides
+//! accept it, with no conversion at the seam to get subtly wrong.
+//!
+//! ~190 call sites in this crate import from `crate::openhuman::tools::traits`,
+//! so this module stays as the path they name rather than rewriting each import
+//! to point at the crate. New code may name either.
+//!
+//! # What did *not* move
+//!
+//! Everything that decides something. `tinytools` lets a tool declare the
+//! privilege it needs and whether it reaches outside the machine; this host
+//! decides what to do about those declarations — [`policy`], the security
+//! policy, the approval gate and the sandbox are all still ours, and are meant
+//! to stay in one auditable place.
+//!
+//! [`policy`]: crate::openhuman::tools::policy
+
+pub use tinytools::{
+    PermissionLevel, Tool, ToolCallOptions, ToolCategory, ToolContent, ToolResult, ToolRunContext,
+    ToolScope, ToolSpec, ToolTimeout, context_detail_from_args, humanize_tool_name,
+};
 
 use crate::openhuman::agent::tool_policy::GeneratedToolRuntimeContext;
+use crate::openhuman::tools::toolpacks::PackRegistryHandle;
 
-// Re-export the unified ToolResult from the lightweight skills types module so all tools use one type.
-pub use crate::openhuman::skills::types::{ToolContent, ToolResult};
-
-/// Controls where a tool is available.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ToolScope {
-    /// Available in agent loop, CLI, and RPC.
-    All,
-    /// Intended to mark tools available only in the autonomous agent loop.
-    /// NOTE: not yet gated — no execution path filters on `AgentOnly`, so it
-    /// currently behaves like `All`. The `AgentOnly` vs `All` reconciliation is
-    /// deferred to the Phase 2 tool-model work (docs/tinyagents-port-plan.md §5).
-    AgentOnly,
-    /// Only available via explicit CLI/RPC invocation (not autonomous agent).
-    CliRpcOnly,
+/// Reads a tool's pack-registry handle back out of the erased host extension.
+///
+/// `load_skill` / `use_skill` read the registry they themselves live in, so
+/// they cannot be handed it at construction; `toolpacks::bind_pack_registry`
+/// finds them in an already-built registry and hands them a `Weak` view of it.
+///
+/// The handle rides on [`Tool::host_extension`] rather than a typed trait
+/// method because it is *this host's* concept — a vocabulary shared with other
+/// hosts has no business naming it. Every other tool returns `None` here and
+/// pays nothing.
+pub fn pack_registry_handle(tool: &dyn Tool) -> Option<&PackRegistryHandle> {
+    tool.host_extension()
+        .and_then(|any| any.downcast_ref::<PackRegistryHandle>())
 }
 
-/// Category of a tool — used by the sub-agent runner to scope which
-/// tools a given sub-agent is allowed to see.
+/// Reads a tool's generated-tool runtime metadata back out of the erased
+/// per-call host extension.
 ///
-/// The distinction matters because:
-///
-/// - **System tools** are built-in Rust implementations (shell, file_read,
-///   file_write, cron_*, memory_*, …) that run inside the core process
-///   with direct host access.
-/// - **Workflow tools** are integration-facing tools that talk to external
-///   services (for example Composio-backed SaaS actions).
-///
-/// The orchestrator uses this category to spawn dedicated tool-execution
-/// sub-agents: one scoped to `Workflow` for service integrations (running
-/// with the backend's `agentic` model hint), and others scoped to
-/// `System` for code/file/host work.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ToolCategory {
-    /// Built-in Rust tools with direct host access.
-    #[default]
-    System,
-    /// Integration-facing tools that reach external services (Composio-backed
-    /// SaaS actions, "runners"). The Rust ident was swept to `Workflow` during
-    /// the skills→workflows unification, but this category is NOT a WORKFLOW.md
-    /// bundle — it's the integration-tool class the integrations subagent
-    /// filters on via `category_filter = "skill"`. The wire format is pinned to
-    /// `"skill"` so existing agent definitions keep parsing; the ident is
-    /// provisional and gets revisited when the integrations_agent is reworked
-    /// (Phase 4 / "runners → Intelligence").
-    #[serde(rename = "skill")]
-    Workflow,
-}
-
-impl std::fmt::Display for ToolCategory {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::System => write!(f, "system"),
-            Self::Workflow => write!(f, "skill"),
-        }
-    }
-}
-
-/// Permission level required to execute a tool.
-///
-/// Channels can set a maximum permission level to restrict which tools
-/// are available. Tools requiring a level above the channel's maximum
-/// are rejected before execution.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Default)]
-pub enum PermissionLevel {
-    /// No permission needed (metadata-only operations).
-    None = 0,
-    /// Read-only operations (file reads, memory recall, listing).
-    #[default]
-    ReadOnly = 1,
-    /// Write operations (file writes, memory store).
-    Write = 2,
-    /// Command execution (shell, scripts).
-    Execute = 3,
-    /// Dangerous/destructive operations (hardware, system-level).
-    Dangerous = 4,
-}
-
-impl std::fmt::Display for PermissionLevel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::None => write!(f, "None"),
-            Self::ReadOnly => write!(f, "ReadOnly"),
-            Self::Write => write!(f, "Write"),
-            Self::Execute => write!(f, "Execute"),
-            Self::Dangerous => write!(f, "Dangerous"),
-        }
-    }
-}
-
-/// Per-invocation options threaded from the agent loop into a tool's
-/// execution. Lets callers (the harness, orchestrator, RPC dispatcher)
-/// hint at how the tool should shape its output without polluting the
-/// tool's user-facing parameter schema.
-///
-/// Tools that opt in override [`Tool::execute_with_options`] and check
-/// these flags; tools that ignore the struct keep working unchanged
-/// because the trait's default implementation forwards to
-/// [`Tool::execute`].
-#[derive(Debug, Clone, Copy, Default)]
-pub struct ToolCallOptions {
-    /// When true, the caller (typically the agent loop) prefers a
-    /// markdown rendering of the result for direct LLM consumption,
-    /// because markdown is materially cheaper than JSON in tokens.
-    /// Tools should populate `ToolResult::markdown_formatted` when
-    /// this is set; the harness will pick that field up if present.
-    pub prefer_markdown: bool,
-}
-
-/// How the harness should bound a single tool invocation in wall-clock time.
-///
-/// Returned by [`Tool::timeout_policy`]. Separates the common "use the global
-/// timeout" case from the scripting-tool cases ("no deadline" / "this exact
-/// deadline") so the harness can hard-kill genuinely hang-prone tools while
-/// letting a long-but-legitimate script run to completion.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ToolTimeout {
-    /// Use the global, operator/config-driven tool timeout. Default for most
-    /// tools (network, MCP, etc.) — a hung call must not wedge the session.
-    Inherit,
-    /// Run without any harness-imposed deadline. Scripting tools return this
-    /// when the caller did not request an explicit budget.
-    Unbounded,
-    /// Enforce exactly this many seconds. The harness clamps it to the valid
-    /// range (`MIN_TIMEOUT_SECS..=MAX_TIMEOUT_SECS`) defensively.
-    Secs(u64),
-}
-
-/// Description of a tool for the LLM
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ToolSpec {
-    pub name: String,
-    pub description: String,
-    pub parameters: serde_json::Value,
-}
-
-/// Derive a Title-Cased, human-readable label from a raw tool name.
-///
-/// Strips common machine prefixes (`composio_`, `mcp_`) and turns
-/// snake_case / kebab-case into spaced Title Case:
-/// `gmail_read_message` → "Gmail Read Message". Used as the default for
-/// [`Tool::display_label`] and as a safety net for any tool that doesn't
-/// supply a curated phrase, so a timeline row never shows raw `snake_case`.
-///
-/// Re-exported from [`tinyagents::harness::tool`]: naming a tool for a human is
-/// not OpenHuman-specific, and two copies of the prefix list is how one of them
-/// silently stops stripping a prefix the other does.
-pub use tinyagents::harness::tool::humanize_tool_name;
-
-/// Trimming rule for [`context_detail_from_args`].
-///
-/// OpenHuman elides with a single `…` rather than three dots, because the
-/// detail sits inline in a timeline row where three characters of budget are
-/// worth having. That is the only thing this host changes about the rule.
-const CONTEXT_DETAIL: tinyagents::harness::tool::ContextDetailOptions =
-    tinyagents::harness::tool::ContextDetailOptions {
-        max_chars: 80,
-        ellipsis: "…",
-    };
-
-/// Pull the single most-relevant contextual argument out of a tool-call's
-/// args for the timeline "detail" (the bracketed context after the label).
-///
-/// Scans a prioritized list of common argument keys (recipient, query,
-/// path, command, …) and returns the first present, non-empty value as a
-/// trimmed, length-capped string — so a row can read "reading messages from
-/// steven@gmail.com" / `Read(src/openhuman/web3/wallet/ops.rs)` without every tool
-/// hand-writing a [`Tool::display_detail`] override. Returns `None` when no
-/// recognized key carries a usable scalar.
-///
-/// The key list and the scan live in [`tinyagents::harness::tool`]; this wrapper
-/// supplies OpenHuman's [`CONTEXT_DETAIL`] trimming.
-pub fn context_detail_from_args(args: &serde_json::Value) -> Option<String> {
-    tinyagents::harness::tool::context_detail_from_args_with(args, CONTEXT_DETAIL)
-}
-
-/// Core tool trait — implement for any capability (built-in or integration-based).
-#[async_trait]
-pub trait Tool: Send + Sync {
-    /// Tool name (used in LLM function calling)
-    fn name(&self) -> &str;
-
-    /// Human-readable description
-    fn description(&self) -> &str;
-
-    /// JSON schema for parameters
-    fn parameters_schema(&self) -> serde_json::Value;
-
-    /// Execute the tool with given arguments.
-    /// Returns a unified `ToolResult` (MCP content blocks + error flag).
-    async fn execute(&self, args: serde_json::Value) -> anyhow::Result<ToolResult>;
-
-    /// Execute the tool with caller-provided options.
-    ///
-    /// Default implementation forwards to [`Self::execute`] — existing
-    /// tools keep working without changes. Tools that can produce a
-    /// compact markdown rendering (saving tokens in the agent loop)
-    /// should override this method, inspect
-    /// [`ToolCallOptions::prefer_markdown`], and populate
-    /// `ToolResult::markdown_formatted` on the returned result.
-    async fn execute_with_options(
-        &self,
-        args: serde_json::Value,
-        _options: ToolCallOptions,
-    ) -> anyhow::Result<ToolResult> {
-        self.execute(args).await
-    }
-
-    /// Execute the tool with caller run context from TinyAgents.
-    ///
-    /// Default implementation forwards to [`Self::execute_with_options`], so
-    /// existing tools stay context-agnostic. Tools that need TinyAgents runtime
-    /// metadata, such as an isolated workspace descriptor, can override this
-    /// without widening [`ToolCallOptions`].
-    async fn execute_with_context(
-        &self,
-        args: serde_json::Value,
-        options: ToolCallOptions,
-        context: Option<&tinyagents::harness::tool::ToolExecutionContext>,
-    ) -> anyhow::Result<ToolResult> {
-        let _ = context;
-        self.execute_with_options(args, options).await
-    }
-
-    /// The late-bound registry handle, for the two tool-pack tools only.
-    ///
-    /// `load_skill` / `use_skill` read the registry they themselves live in, so
-    /// they cannot be handed it at construction. Returning `Some` here lets
-    /// `toolpacks::bind_pack_registry` find them in an already-built registry
-    /// and hand them a `Weak` view of it. Every other tool returns `None`.
-    fn pack_registry_handle(
-        &self,
-    ) -> Option<&crate::openhuman::tools::toolpacks::PackRegistryHandle> {
-        None
-    }
-
-    /// Whether this tool can produce a markdown rendering when
-    /// [`ToolCallOptions::prefer_markdown`] is set. Default: `false`.
-    /// Tools that override [`Self::execute_with_options`] to honor the
-    /// flag should also override this to advertise the capability —
-    /// telemetry / agent-loop diagnostics use it to attribute token
-    /// savings.
-    fn supports_markdown(&self) -> bool {
-        false
-    }
-
-    /// Permission level required to execute this tool.
-    ///
-    /// For tools that expose multiple actions with different permission
-    /// requirements, this should return the **minimum** level needed by
-    /// any action — so the tool is not statically blocked on channels that
-    /// could legitimately run the read-only actions. The per-call level is
-    /// enforced by [`Self::permission_level_with_args`].
-    ///
-    /// Channels with a lower maximum permission level will reject this tool
-    /// before any per-call check runs.
-    /// Default: `ReadOnly`. Override for write/execute/dangerous tools.
-    fn permission_level(&self) -> PermissionLevel {
-        PermissionLevel::ReadOnly
-    }
-
-    /// Args-aware version of [`Self::permission_level`].
-    ///
-    /// Tools that expose multiple actions with differing permission
-    /// requirements (e.g. `schedule list` vs `schedule create`) override
-    /// this to return the exact level for the specific call. The agent
-    /// harness calls this at call time to enforce the per-action level
-    /// against the channel's `allowed_permission`.
-    ///
-    /// Default: delegates to the arg-less [`Self::permission_level`] so
-    /// existing tools keep working without changes.
-    fn permission_level_with_args(&self, _args: &serde_json::Value) -> PermissionLevel {
-        self.permission_level()
-    }
-
-    /// Where this tool may be executed. Default: `All`.
-    /// Override to restrict (e.g. `CliRpcOnly` for phone calls).
-    fn scope(&self) -> ToolScope {
-        ToolScope::All
-    }
-
-    /// Category of this tool — `System` for built-in Rust tools (default)
-    /// or `Workflow` for integration-facing tools.
-    fn category(&self) -> ToolCategory {
-        ToolCategory::System
-    }
-
-    /// Whether two concurrent invocations of this tool are safe to
-    /// run in parallel inside a single LLM iteration.
-    ///
-    /// Read-only tools that touch no shared mutable state should
-    /// return `true` (the agent's tool loop can then `join_all` a
-    /// batch of read calls instead of awaiting them serially). Tools
-    /// that mutate the workspace, write to disk, or interact with
-    /// external services that throttle by caller should leave the
-    /// default `false`.
-    ///
-    /// The argument is provided so a tool can refine the answer per
-    /// call (e.g. a generic `bash` tool could allow parallel `ls` /
-    /// `cat` invocations and reject parallel `npm install`s) — most
-    /// tools will ignore it.
-    ///
-    /// **Wiring note:** the tinyagents harness loop (see
-    /// `crate::openhuman::agent::tinyagents::tools`) currently executes tool
-    /// calls serially regardless of this flag. Annotating tools is
-    /// still load-bearing: it lets a parallel-dispatch refactor land
-    /// without coordinating with every tool author. See the
-    /// parallel-tool dispatch follow-up issue.
-    fn is_concurrency_safe(&self, _args: &serde_json::Value) -> bool {
-        false
-    }
-
-    /// Whether this tool produces an externally-observable side effect
-    /// (outbound Slack/Telegram/email/calendar/webhook write, etc.).
-    ///
-    /// When `true`, the agent harness routes the call through the
-    /// `ApprovalGate` before `execute()` runs. Local file writes,
-    /// memory writes, and TTS `reply_speech` stay `false` — they are
-    /// either reversible inside the user's machine or considered
-    /// internal per issue #1339.
-    ///
-    /// Default: `false`. Override on tools that talk to external
-    /// services on the user's behalf.
-    fn external_effect(&self) -> bool {
-        false
-    }
-
-    /// Args-aware version of [`Self::external_effect`]. Tools whose
-    /// classification depends on the call arguments (e.g. the
-    /// `composio` tool gates `action="execute"` but lets
-    /// `action="list"` / `action="connect"` flow through unprompted)
-    /// override this method to peek at `args`.
-    ///
-    /// The harness calls this method (not the arg-less variant) at
-    /// the gate-decision point, so most tools that need per-call
-    /// gating should override here rather than [`Self::external_effect`].
-    /// Default: defer to the arg-less classification so existing
-    /// overrides keep working without changes.
-    fn external_effect_with_args(&self, _args: &serde_json::Value) -> bool {
-        self.external_effect()
-    }
-
-    /// Optional generated-tool runtime metadata for policy enforcement.
-    ///
-    /// Generated or externally supplied tools can override this to let
-    /// the agent policy layer apply provider/capability/risk rules before
-    /// execution. Built-in tools leave it unset.
-    fn generated_runtime_context(
-        &self,
-        _args: &serde_json::Value,
-    ) -> Option<GeneratedToolRuntimeContext> {
-        None
-    }
-
-    /// Per-tool cap on the character length of the result body sent
-    /// back to the model.
-    ///
-    /// When `Some(cap)` and the tool's `output_for_llm` exceeds it,
-    /// the agent's tool loop truncates the body and appends a marker
-    /// before threading the value into history — protecting the
-    /// context window from one chatty tool. When `None` (the
-    /// default), no per-tool cap applies and the global
-    /// `PayloadSummarizer` (if any) handles oversize bodies.
-    ///
-    /// Set this on tools whose output is *bounded but unpredictable*
-    /// (`bash`, `web_fetch`, etc.); leave it unset on tools where
-    /// callers genuinely want full content (`read_file`, `grep`).
-    fn max_result_size_chars(&self) -> Option<usize> {
-        None
-    }
-
-    /// How the harness should bound this invocation in wall-clock time.
-    ///
-    /// The harness wraps every `execute()` in a deadline. Most tools want the
-    /// global, operator/config-driven timeout ([`ToolTimeout::Inherit`]) so a
-    /// hung network/MCP call can't wedge a session. Scripting tools (`shell`,
-    /// `node_exec`, `npm_exec`) instead return [`ToolTimeout::Unbounded`] when
-    /// the caller did not request a budget — a build / solver / test run
-    /// legitimately takes minutes and must not be hard-killed by a default cap
-    /// (issue #4023) — and [`ToolTimeout::Secs`] only when an explicit
-    /// `timeout_secs` was supplied.
-    ///
-    /// Default: [`ToolTimeout::Inherit`] (use the global timeout).
-    fn timeout_policy(&self, _args: &serde_json::Value) -> ToolTimeout {
-        ToolTimeout::Inherit
-    }
-
-    /// Get the full spec for LLM registration
-    fn spec(&self) -> ToolSpec {
-        ToolSpec {
-            name: self.name().to_string(),
-            description: self.description().to_string(),
-            parameters: self.parameters_schema(),
-        }
-    }
-
-    /// Short, human-readable verb phrase describing this call for the chat
-    /// "agent processing" timeline (e.g. "Reading messages", "Running
-    /// command", "Reading file"). The default derives a Title-Cased label
-    /// from [`Self::name`] via [`humanize_tool_name`]; dynamic / integration
-    /// tools (Composio, MCP, generated) and high-value built-ins override to
-    /// return a curated phrase so a row never reads as raw `snake_case`.
-    ///
-    /// Paired with [`Self::display_detail`] (the specific argument), the UI
-    /// renders `label (detail)` — Claude-style `Read(path)` /
-    /// "reading messages from steven@gmail.com".
-    fn display_label(&self, _args: &serde_json::Value) -> Option<String> {
-        Some(humanize_tool_name(self.name()))
-    }
-
-    /// The specific, contextual argument for this call — the file path, email
-    /// address, command, or query pulled from `args` — shown in brackets
-    /// after [`Self::display_label`]. The default pulls the most-relevant
-    /// common argument via [`context_detail_from_args`], so any tool reads
-    /// like "reading messages from steven@gmail.com" / `Read(path)` without a
-    /// hand-written override. Tools whose meaningful arg sits under an unusual
-    /// key override to surface the right value.
-    fn display_detail(&self, args: &serde_json::Value) -> Option<String> {
-        context_detail_from_args(args)
-    }
+/// Generated or externally supplied tools carry this so the agent policy layer
+/// can apply provider / capability / risk rules before execution. Built-in
+/// tools leave it unset. Erased for the same reason as
+/// [`pack_registry_handle`].
+pub fn generated_runtime_context(
+    tool: &dyn Tool,
+    args: &serde_json::Value,
+) -> Option<GeneratedToolRuntimeContext> {
+    tool.host_call_extension(args)
+        .and_then(|any| any.downcast::<GeneratedToolRuntimeContext>().ok())
+        .map(|boxed| *boxed)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
 
     struct DummyTool;
 
@@ -445,9 +78,7 @@ mod tests {
         fn parameters_schema(&self) -> serde_json::Value {
             serde_json::json!({
                 "type": "object",
-                "properties": {
-                    "value": { "type": "string" }
-                }
+                "properties": { "value": { "type": "string" } }
             })
         }
 
@@ -461,230 +92,34 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn a_tool_written_against_this_path_satisfies_the_shared_trait() {
+        // The point of the re-export: `dyn Tool` here is `dyn tinytools::Tool`,
+        // which is what the harness accepts. If these ever became two traits,
+        // this coercion is what would stop compiling.
+        let erased: &dyn tinytools::Tool = &DummyTool;
+        let result = erased
+            .execute(serde_json::json!({ "value": "hello-tool" }))
+            .await
+            .expect("the tool runs");
+        assert_eq!(result.output(), "hello-tool");
+        assert_eq!(erased.permission_level(), PermissionLevel::ReadOnly);
+        assert_eq!(erased.scope(), ToolScope::All);
+        assert_eq!(erased.category(), ToolCategory::System);
+    }
+
+    #[test]
+    fn a_tool_carrying_no_host_extension_yields_none() {
+        let tool = DummyTool;
+        assert!(pack_registry_handle(&tool).is_none());
+        assert!(generated_runtime_context(&tool, &serde_json::Value::Null).is_none());
+    }
+
     #[test]
     fn spec_uses_tool_metadata_and_schema() {
-        let tool = DummyTool;
-        let spec = tool.spec();
-
+        let spec = DummyTool.spec();
         assert_eq!(spec.name, "dummy_tool");
         assert_eq!(spec.description, "A deterministic test tool");
         assert_eq!(spec.parameters["type"], "object");
-        assert_eq!(spec.parameters["properties"]["value"]["type"], "string");
-    }
-
-    #[tokio::test]
-    async fn execute_returns_expected_output() {
-        let tool = DummyTool;
-        let result = tool
-            .execute(serde_json::json!({ "value": "hello-tool" }))
-            .await
-            .unwrap();
-
-        assert!(!result.is_error);
-        assert_eq!(result.output(), "hello-tool");
-    }
-
-    #[test]
-    fn tool_result_serialization_roundtrip() {
-        let result = ToolResult::error("boom");
-
-        let json = serde_json::to_string(&result).unwrap();
-        let parsed: ToolResult = serde_json::from_str(&json).unwrap();
-
-        assert!(parsed.is_error);
-        assert_eq!(parsed.output(), "boom");
-    }
-
-    // ── Default trait-method values ────────────────────────────────
-
-    #[test]
-    fn default_permission_level_is_read_only() {
-        let tool = DummyTool;
-        assert_eq!(tool.permission_level(), PermissionLevel::ReadOnly);
-    }
-
-    #[test]
-    fn default_scope_is_all() {
-        let tool = DummyTool;
-        assert_eq!(tool.scope(), ToolScope::All);
-    }
-
-    #[test]
-    fn default_category_is_system() {
-        let tool = DummyTool;
-        assert_eq!(tool.category(), ToolCategory::System);
-    }
-
-    #[test]
-    fn default_is_concurrency_safe_is_false() {
-        let tool = DummyTool;
-        assert!(!tool.is_concurrency_safe(&serde_json::Value::Null));
-    }
-
-    #[test]
-    fn default_max_result_size_chars_is_none() {
-        let tool = DummyTool;
-        assert!(tool.max_result_size_chars().is_none());
-    }
-
-    #[test]
-    fn default_external_effect_is_false() {
-        let tool = DummyTool;
-        assert!(!tool.external_effect());
-    }
-
-    // ── display_label / display_detail ─────────────────────────────
-
-    #[test]
-    fn default_display_label_humanizes_tool_name() {
-        let tool = DummyTool;
-        assert_eq!(
-            tool.display_label(&serde_json::Value::Null).as_deref(),
-            Some("Dummy Tool")
-        );
-    }
-
-    #[test]
-    fn default_display_detail_pulls_context_arg() {
-        let tool = DummyTool;
-        // No object args → nothing to surface.
-        assert!(tool.display_detail(&serde_json::Value::Null).is_none());
-        // A recognized key becomes the bracketed context.
-        assert_eq!(
-            tool.display_detail(&serde_json::json!({ "path": "src/main.rs" }))
-                .as_deref(),
-            Some("src/main.rs")
-        );
-    }
-
-    #[test]
-    fn context_detail_prefers_specific_keys_and_truncates() {
-        // `to` outranks `name` for a messaging-style call.
-        assert_eq!(
-            context_detail_from_args(&serde_json::json!({
-                "name": "ignored", "to": "steven@gmail.com"
-            }))
-            .as_deref(),
-            Some("steven@gmail.com")
-        );
-        // Long values are elided to keep the row compact.
-        let long = "x".repeat(200);
-        let detail = context_detail_from_args(&serde_json::json!({ "query": long })).unwrap();
-        assert!(detail.chars().count() <= 80);
-        assert!(detail.ends_with('…'));
-        // Whitespace is collapsed.
-        assert_eq!(
-            context_detail_from_args(&serde_json::json!({ "command": "  ls   -la  " })).as_deref(),
-            Some("ls -la")
-        );
-    }
-
-    #[test]
-    fn humanize_tool_name_title_cases_snake_case() {
-        assert_eq!(
-            humanize_tool_name("gmail_read_message"),
-            "Gmail Read Message"
-        );
-        assert_eq!(humanize_tool_name("web_fetch"), "Web Fetch");
-        assert_eq!(humanize_tool_name("shell"), "Shell");
-    }
-
-    #[test]
-    fn humanize_tool_name_strips_machine_prefixes() {
-        // Composio / MCP wrappers prefix the raw action name; the timeline
-        // label should read as the action, not the transport.
-        assert_eq!(
-            humanize_tool_name("composio_gmail_send_email"),
-            "Gmail Send Email"
-        );
-        assert_eq!(
-            humanize_tool_name("mcp_notion_create_page"),
-            "Notion Create Page"
-        );
-    }
-
-    #[test]
-    fn humanize_tool_name_handles_kebab_and_empty() {
-        assert_eq!(humanize_tool_name("read-diff"), "Read Diff");
-        // Degenerate input never panics and never yields an empty label.
-        assert_eq!(humanize_tool_name(""), "");
-        assert_eq!(humanize_tool_name("___"), "___");
-    }
-
-    // ── PermissionLevel ordering ───────────────────────────────────
-
-    #[test]
-    fn permission_level_is_totally_ordered_from_none_to_dangerous() {
-        // The runtime compares PermissionLevel as `<` to reject tools whose
-        // required level exceeds the channel max, so the ordering is a
-        // load-bearing invariant.
-        assert!(PermissionLevel::None < PermissionLevel::ReadOnly);
-        assert!(PermissionLevel::ReadOnly < PermissionLevel::Write);
-        assert!(PermissionLevel::Write < PermissionLevel::Execute);
-        assert!(PermissionLevel::Execute < PermissionLevel::Dangerous);
-    }
-
-    #[test]
-    fn permission_level_default_is_read_only() {
-        assert_eq!(PermissionLevel::default(), PermissionLevel::ReadOnly);
-    }
-
-    #[test]
-    fn permission_level_display_matches_variant_name() {
-        assert_eq!(PermissionLevel::None.to_string(), "None");
-        assert_eq!(PermissionLevel::ReadOnly.to_string(), "ReadOnly");
-        assert_eq!(PermissionLevel::Write.to_string(), "Write");
-        assert_eq!(PermissionLevel::Execute.to_string(), "Execute");
-        assert_eq!(PermissionLevel::Dangerous.to_string(), "Dangerous");
-    }
-
-    #[test]
-    fn permission_level_round_trips_as_json_number() {
-        for level in [
-            PermissionLevel::None,
-            PermissionLevel::ReadOnly,
-            PermissionLevel::Write,
-            PermissionLevel::Execute,
-            PermissionLevel::Dangerous,
-        ] {
-            let s = serde_json::to_string(&level).unwrap();
-            let back: PermissionLevel = serde_json::from_str(&s).unwrap();
-            assert_eq!(back, level);
-        }
-    }
-
-    // ── ToolCategory ───────────────────────────────────────────────
-
-    #[test]
-    fn tool_category_default_is_system() {
-        assert_eq!(ToolCategory::default(), ToolCategory::System);
-    }
-
-    #[test]
-    fn tool_category_display_is_lowercase() {
-        assert_eq!(ToolCategory::System.to_string(), "system");
-        assert_eq!(ToolCategory::Workflow.to_string(), "skill");
-    }
-
-    #[test]
-    fn tool_category_serde_uses_snake_case() {
-        // The runtime relies on snake_case JSON for `category` in agent
-        // definitions — catch any rename that would break user-facing
-        // definition files.
-        let s = serde_json::to_string(&ToolCategory::System).unwrap();
-        assert_eq!(s, "\"system\"");
-        let s = serde_json::to_string(&ToolCategory::Workflow).unwrap();
-        assert_eq!(s, "\"skill\"");
-        let back: ToolCategory = serde_json::from_str("\"skill\"").unwrap();
-        assert_eq!(back, ToolCategory::Workflow);
-    }
-
-    // ── ToolScope ──────────────────────────────────────────────────
-
-    #[test]
-    fn tool_scope_variants_are_distinct() {
-        assert_ne!(ToolScope::All, ToolScope::AgentOnly);
-        assert_ne!(ToolScope::All, ToolScope::CliRpcOnly);
-        assert_ne!(ToolScope::AgentOnly, ToolScope::CliRpcOnly);
     }
 }

--- a/tests/raw_coverage/tools_approval_channels_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/tools_approval_channels_raw_coverage_e2e.rs
@@ -1558,7 +1558,11 @@ fn tools_and_tool_registry_public_surfaces_cover_schema_and_assembly_paths() {
     assert!(!default_tool.is_concurrency_safe(&json!({})));
     assert!(!default_tool.external_effect());
     assert!(!default_tool.external_effect_with_args(&json!({})));
-    assert!(default_tool.generated_runtime_context(&json!({})).is_none());
+    assert!(openhuman::openhuman::tools::traits::generated_runtime_context(
+        &default_tool,
+        &json!({})
+    )
+    .is_none());
     assert!(default_tool.max_result_size_chars().is_none());
 
     let computer = ComputerUseConfig {

--- a/tests/raw_coverage/tools_approval_channels_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/tools_approval_channels_raw_coverage_e2e.rs
@@ -1558,7 +1558,7 @@ fn tools_and_tool_registry_public_surfaces_cover_schema_and_assembly_paths() {
     assert!(!default_tool.is_concurrency_safe(&json!({})));
     assert!(!default_tool.external_effect());
     assert!(!default_tool.external_effect_with_args(&json!({})));
-    assert!(openhuman::openhuman::tools::traits::generated_runtime_context(
+    assert!(openhuman_core::openhuman::tools::traits::generated_runtime_context(
         &default_tool,
         &json!({})
     )


### PR DESCRIPTION
## What this does

The `Tool` trait and its types were declared here and, in near-identical form, in `tinyagents`. Both are now [`tinytools`](https://github.com/tinyhumansai/tinytools)', which `tinyagents` depends on too — so a tool implemented against this crate's path and the trait the harness runs a loop over are the **same trait**, not structural twins with a hand-written seam between them.

- `src/openhuman/tools/traits.rs` — **690 → 125 lines**
- `src/openhuman/skills/types.rs` — **338 → 127 lines**

Both stay as the import paths their ~190 and ~14 call sites already name, so **no consumer import changes**.

> **Merge order.** Depends on tinyhumansai/tinytools#1 and tinyhumansai/tinyagents#127. Both must merge first; `vendor/tinyagents` here points at that PR's branch and will be re-pointed at `main` before merge.

## Three things needed a decision, not a move

### 1. Tools took a type `tinytools` cannot name

`Option<&ToolExecutionContext>` would have made `tinytools` depend on `tinyagents`, which depends on `tinytools` — a cycle. Tools now take `Option<&dyn ToolRunContext>`.

The trait's width was **measured before it was chosen**: across the 44 files touching the harness context, the only fields read were `.workspace` (24 sites), `.thread_id` (1) and `.max_turn_output_tokens` (1). So the erased trait is narrow by evidence rather than by hope. The run id, event sink and cancellation token stay harness-internal.

Test helpers that build a real `ToolExecutionContext` keep doing so — it coerces to `&dyn ToolRunContext` at the call.

### 2. Two trait methods named host types

`pack_registry_handle` and `generated_runtime_context` returned `PackRegistryHandle` and `GeneratedToolRuntimeContext`. Those are *this host's* concepts and a shared vocabulary has no business naming them.

They ride `Tool::host_extension` / `host_call_extension` as `dyn Any` now, with typed readers in `traits.rs`. Two tools and one test use them; every other tool returns `None` and pays nothing.

### 3. `From<McpToolResult> for ToolResult` became a free function

Once `ToolResult` was foreign, the orphan rule forbade the impl. It is now `skills::types::tool_result_from_mcp` — still written **exactly once**, for the reason its old doc comment gave: spelled out at each of its three call sites, it would be three chances to get the error flag the wrong way round.

## Nothing that decides anything moved

`tinytools` lets a tool *declare* the privilege it needs and whether it reaches outside the machine. What to do about those declarations is still ours and stays in one auditable place: the `SecurityPolicy`, the approval gate, the sandbox, `tools/policy.rs`, `tools/timeout/`, `tools/agent_policy/`, `tools/registry/`, `tools/toolpacks/`, and `tools/schemas.rs` (RPC controllers bound to `crate::core`).

## The vendor path is load-bearing — please don't "tidy" it

The dependency is `vendor/tinyagents/vendor/tinytools/crates/tinytools` — the exact path `tinyagents` itself declares, so both resolve to **one** cargo package.

A second `vendor/tinytools` submodule of our own would be a *different package* to cargo, and its `ToolResult` a *different type*; every tool here would stop satisfying the harness's trait, with a type error naming the same path twice that reads like a compiler bug.

Asserted, not assumed — `cargo metadata` reports exactly one `tinytools` package in the graph. After cloning: `git submodule update --init --recursive vendor/`.

## Kernel floor raised — the one thing that needs a reviewer's judgement

`scripts/kernel-floor.limits`: **287 → 288 packages, 269 → 270 names, native builds unchanged at 2.**

The delta is `tinytools` itself and nothing underneath it. Its whole dependency list is `anyhow`, `async-trait`, `serde`, `serde_json` — all four already resolved in this profile. Measured rather than assumed: the native build count is unchanged (`libsqlite3-sys`, `ring`) and every one of the 287 previous packages is still exactly one package.

**It cannot be gated.** `src/openhuman/tools/` is kernel surface — `shell.rs` alone is reached from the agent turn path in every build — so the `Tool` trait compiles in every configuration and the vocabulary has no feature to hang off. Structurally the same situation as `tinyjuice-bus`. Justification is written into the limits file as that file requires.

## Verification

| Check | Result |
| --- | --- |
| `cargo check --all-targets` (product features) | clean |
| Disabled build `--no-default-features` | clean — **the only gate-drift catcher**; its core tests 579/0 |
| Kernel profile `--features flows` | clean |
| Tauri shell (`app/src-tauri`) | clean |
| `cargo test --lib` (product features) | **11,644 passed / 0 failed** |
| Feature Forwarding Gate | green |
| `scripts/check-kernel-floor.sh` | green at the raised limit |
| `cargo metadata` | exactly one `tinytools` package |

Upstream: `tinytools` 53 tests with **100% per-file line coverage**; `tinyagents` 1782/0.

Clippy reports no new findings in the 52 files this branch touches. The remaining warnings (`archivist_tests.rs`, `composio/ops_tests.rs`, a `duplicate_mod`) are pre-existing at the branch point and untouched here.

### One environmental note for whoever re-runs the suite

A full run fetches the `tinymemory` native module from GitHub releases and consumes close to the entire **unauthenticated 60/hour API quota**. Two runs back-to-back — or two in parallel — fail the second with:

```
module 'tinymemory' could not be loaded: module `github-release` refused:
GitHub release metadata could not be downloaded
```

That looks exactly like a code regression and is not one; `~/.cache/openhuman/modules/` is not retaining the artifact between runs. Unrelated to this PR, but it cost time here and will cost it again.

## Docs

`AGENTS.md` gains a section covering the seam, the one-way dependency edge, the erased host extensions, and what deliberately did not move.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized tool execution context handling across filesystem, system, media, storage, memory, and delegation tools.
  * Shared tool result and metadata types are now used consistently, including improved MCP result conversion.
  * Workspace-aware operations continue to preserve existing security and behavior.

* **Documentation**
  * Updated architecture and tool vocabulary documentation.

* **Chores**
  * Updated vendored tooling configuration and compatibility limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->