### PR TITLE
feat(agent): per-turn TurnOverrides — suppress goal, tools, memory and transcript autoload for one turn

### DIFF
--- a/src/openhuman/agent/harness/session/builder/setters.rs
+++ b/src/openhuman/agent/harness/session/builder/setters.rs
@@ -692,6 +692,7 @@ impl AgentBuilder {
             archivist_hook: self.archivist_hook,
             synthesized_tool_names: std::collections::HashSet::new(),
             pending_synthesized_tools_mask: std::collections::HashSet::new(),
+            pending_turn_overrides: super::super::types::TurnOverrides::default(),
         })
     }
 }

--- a/src/openhuman/agent/harness/session/mod.rs
+++ b/src/openhuman/agent/harness/session/mod.rs
@@ -49,7 +49,7 @@ pub use migration::{migrate_session_layout_if_needed, MigrationOutcome};
 #[cfg(test)]
 mod tests;
 
-pub use types::{Agent, AgentBuilder};
+pub use types::{Agent, AgentBuilder, TurnOverrides};
 
 // Re-export the duplicate-tool-spec guard for sibling harness modules
 // (`session::runtime`, `subagent_runner`) so all provider call sites

--- a/src/openhuman/agent/harness/session/runtime.rs
+++ b/src/openhuman/agent/harness/session/runtime.rs
@@ -418,6 +418,19 @@ impl Agent {
         self.history.clear();
     }
 
+    /// Set the overrides applied to the **next** [`Self::turn`] call.
+    ///
+    /// The overrides are consumed at the top of the next turn (they apply to a
+    /// single turn, then reset to the default), so a caller running a chat /
+    /// small-talk turn calls this immediately before [`Self::turn`]. Callers
+    /// that never touch this get the unchanged full-agentic behaviour. See
+    /// [`TurnOverrides`](super::types::TurnOverrides) for the fields and the
+    /// motivating case (#1725: a bare greeting must not run the task loop nor
+    /// inherit a prior task's goal / tools / memory).
+    pub fn set_next_turn_overrides(&mut self, overrides: super::types::TurnOverrides) {
+        self.pending_turn_overrides = overrides;
+    }
+
     /// Seed the next turn's LLM context from an authoritative message
     /// log (e.g. the web channel's per-thread conversation JSONL).
     ///

--- a/src/openhuman/agent/harness/session/turn/core.rs
+++ b/src/openhuman/agent/harness/session/turn/core.rs
@@ -180,6 +180,21 @@ impl Agent {
     /// 6. **Background Tasks**: Triggers episodic memory indexing and facts
     ///    extraction asynchronously.
     pub async fn turn(&mut self, user_message: &str) -> Result<String> {
+        // Consume any per-turn overrides the caller set for THIS turn (#1725).
+        // Taking them resets the field to the default, so they apply to exactly
+        // one turn — a chat/small-talk turn runs tool-less, memory-less and
+        // goal-less without permanently altering the agent, and the following
+        // turn is back to full-agentic behaviour. Callers that never opt in get
+        // `TurnOverrides::default()` (all-false) and the unchanged path.
+        let turn_overrides = std::mem::take(&mut self.pending_turn_overrides);
+        if turn_overrides != super::super::types::TurnOverrides::default() {
+            log::info!(
+                "[agent_loop] per-turn overrides active: suppress_active_goal={} suppress_tools={} suppress_memory_agent={}",
+                turn_overrides.suppress_active_goal,
+                turn_overrides.suppress_tools,
+                turn_overrides.suppress_memory_agent
+            );
+        }
         self.emit_progress(AgentProgress::TurnStarted).await;
         log::info!("[agent] turn started — awaiting user message processing");
         log::info!(
@@ -516,7 +531,16 @@ impl Agent {
         // Capture the workspace path for the budget stop hook built after the
         // `turn_body` coroutine (which borrows `&mut self`) is constructed.
         let goal_workspace_dir = self.workspace_dir.clone();
-        let active_goal = {
+        let active_goal = if turn_overrides.suppress_active_goal {
+            // Chat / small-talk turn: do NOT load, auto-resume, inject, or
+            // budget-arm this thread's goal. A goal an earlier task left
+            // uncompleted must not steer an unrelated greeting (#1725, the
+            // "stale goal replays every turn" half of the context leak).
+            log::debug!(
+                "[thread_goals] active_goal suppressed for this turn (chat/small-talk override)"
+            );
+            None
+        } else {
             let loaded = crate::openhuman::threads::goals::runtime::load_for_current_thread(
                 &self.workspace_dir,
             )
@@ -681,7 +705,12 @@ impl Agent {
         // turn and finishes in the background if the work runs long. So the recall
         // path is byte-for-byte identical across voice and chat.
         let (enriched, memory_agent_context_injected) = self
-            .inject_triggered_memory_agent_context(user_message, enriched, &parent_context)
+            .inject_triggered_memory_agent_context(
+                user_message,
+                enriched,
+                &parent_context,
+                turn_overrides.suppress_memory_agent,
+            )
             .await;
         if memory_agent_context_injected {
             agent_context_prepared_sources.push(harness::AgentContextPreparedSource {
@@ -748,6 +777,7 @@ impl Agent {
                 temperature,
                 max_iterations,
                 artifact_store,
+                turn_overrides.suppress_tools,
             ))
             .await
         }; // end of `turn_body` async block
@@ -868,6 +898,7 @@ impl Agent {
         artifact_store: Option<
             crate::openhuman::agent::harness::tool_result_artifacts::ToolResultArtifactStore,
         >,
+        suppress_tools: bool,
     ) -> Result<String> {
         let turn_started = std::time::Instant::now();
         // This turn's stamped user message is already the last entry in
@@ -933,10 +964,25 @@ impl Agent {
         .map(|prepared| prepared.messages)
         .unwrap_or(messages);
 
+        // Per-turn tool scope (#1725). A chat / small-talk turn runs with an
+        // EMPTY tool set: the provider request carries no tool schema, so the
+        // model cannot enter the tool loop and answers in a single call. The
+        // agent's durable `self.tools` / `self.visible_tool_names` are left
+        // untouched — the next un-overridden turn gets the full toolbelt back.
+        let (turn_tools, turn_visible_tool_names) = if suppress_tools {
+            (
+                std::sync::Arc::new(Vec::new()),
+                std::collections::HashSet::new(),
+            )
+        } else {
+            (self.tools.clone(), self.visible_tool_names.clone())
+        };
+
         tracing::info!(
             model = %effective_model,
             max_iterations,
-            tools = self.tools.len(),
+            tools = turn_tools.len(),
+            suppress_tools,
             "[agent_loop] routing chat turn through the tinyagents harness"
         );
 
@@ -990,8 +1036,8 @@ impl Agent {
                     turn_models,
                     model: effective_model.to_string(),
                     messages,
-                    tools: self.tools.clone(),
-                    visible_tool_names: self.visible_tool_names.clone(),
+                    tools: turn_tools,
+                    visible_tool_names: turn_visible_tool_names,
                     max_iterations,
                     on_progress: self.on_progress.clone(),
                     context_window,
@@ -1429,9 +1475,22 @@ impl Agent {
         user_message: &str,
         enriched: String,
         parent_context: &ParentExecutionContext,
+        force_skip: bool,
     ) -> (String, bool) {
         const MEMORY_AGENT_ID: &str = "agent_memory";
         const MAX_MEMORY_AGENT_BLOCK_CHARS: usize = 8000;
+
+        if force_skip {
+            // Per-turn override (#1725): a chat / small-talk turn skips the
+            // pre-turn memory-agent retrieval even when this agent's policy is
+            // `Always`, so a greeting never pulls a prior task's remembered
+            // context into an unrelated reply.
+            log::debug!(
+                "[agent_memory:trigger] skipped agent_id={} (per-turn suppress_memory_agent override)",
+                self.agent_definition_id
+            );
+            return (enriched, false);
+        }
 
         if self.trigger_memory_agent != TriggerMemoryAgent::Always {
             log::debug!(

--- a/src/openhuman/agent/harness/session/turn/core.rs
+++ b/src/openhuman/agent/harness/session/turn/core.rs
@@ -213,7 +213,10 @@ impl Agent {
         // On a fresh session (empty history), look for a previous
         // transcript to pre-populate the exact provider messages for
         // KV cache prefix reuse.
-        if self.history.is_empty() && self.cached_transcript_messages.is_none() {
+        if self.history.is_empty()
+            && self.cached_transcript_messages.is_none()
+            && !turn_overrides.suppress_transcript_autoload
+        {
             self.try_load_session_transcript();
         }
 

--- a/src/openhuman/agent/harness/session/turn_tests.rs
+++ b/src/openhuman/agent/harness/session/turn_tests.rs
@@ -386,6 +386,13 @@ fn make_agent(visible_tool_names: Option<HashSet<String>>) -> Agent {
         backend: "none".into(),
         ..crate::openhuman::config::MemoryConfig::default()
     };
+    // `create_memory` reaches the engine's embedding seam, which fails loudly
+    // when unwired rather than degrading — a deliberate choice, so an unwired
+    // host cannot corrupt an embedding space quietly. Nothing in a unit test
+    // runs the startup wiring that installs it, so the helper installs it
+    // itself. `install_for_tests` is idempotent (a `Once`), so every helper in
+    // this file calling it costs one install for the whole binary.
+    crate::openhuman::memory::host_impls::install_for_tests();
     let mem: Arc<dyn Memory> =
         Arc::from(tinymemory_core::store::create_memory(&memory_cfg, &workspace_path).unwrap());
 
@@ -440,6 +447,13 @@ fn make_agent_with_builder_and_dispatcher(
         backend: "none".into(),
         ..crate::openhuman::config::MemoryConfig::default()
     };
+    // `create_memory` reaches the engine's embedding seam, which fails loudly
+    // when unwired rather than degrading — a deliberate choice, so an unwired
+    // host cannot corrupt an embedding space quietly. Nothing in a unit test
+    // runs the startup wiring that installs it, so the helper installs it
+    // itself. `install_for_tests` is idempotent (a `Once`), so every helper in
+    // this file calling it costs one install for the whole binary.
+    crate::openhuman::memory::host_impls::install_for_tests();
     let mem: Arc<dyn Memory> =
         Arc::from(tinymemory_core::store::create_memory(&memory_cfg, &workspace_path).unwrap());
 
@@ -997,6 +1011,13 @@ async fn turn_triggers_configured_memory_agent_before_parent_prompt() {
         backend: "none".into(),
         ..crate::openhuman::config::MemoryConfig::default()
     };
+    // `create_memory` reaches the engine's embedding seam, which fails loudly
+    // when unwired rather than degrading — a deliberate choice, so an unwired
+    // host cannot corrupt an embedding space quietly. Nothing in a unit test
+    // runs the startup wiring that installs it, so the helper installs it
+    // itself. `install_for_tests` is idempotent (a `Once`), so every helper in
+    // this file calling it costs one install for the whole binary.
+    crate::openhuman::memory::host_impls::install_for_tests();
     let mem: Arc<dyn Memory> =
         Arc::from(tinymemory_core::store::create_memory(&memory_cfg, &workspace_path).unwrap());
 
@@ -1172,6 +1193,13 @@ async fn turn_override_suppress_memory_agent_skips_memory_trigger() {
         backend: "none".into(),
         ..crate::openhuman::config::MemoryConfig::default()
     };
+    // `create_memory` reaches the engine's embedding seam, which fails loudly
+    // when unwired rather than degrading — a deliberate choice, so an unwired
+    // host cannot corrupt an embedding space quietly. Nothing in a unit test
+    // runs the startup wiring that installs it, so the helper installs it
+    // itself. `install_for_tests` is idempotent (a `Once`), so every helper in
+    // this file calling it costs one install for the whole binary.
+    crate::openhuman::memory::host_impls::install_for_tests();
     let mem: Arc<dyn Memory> =
         Arc::from(tinymemory_core::store::create_memory(&memory_cfg, &workspace_path).unwrap());
 

--- a/src/openhuman/agent/harness/session/turn_tests.rs
+++ b/src/openhuman/agent/harness/session/turn_tests.rs
@@ -49,6 +49,10 @@ impl ChatModel<()> for DummyProvider {
 struct SequenceProvider {
     responses: AsyncMutex<Vec<anyhow::Result<ChatResponse>>>,
     requests: AsyncMutex<Vec<Vec<ChatMessage>>>,
+    /// Number of tool declarations the provider was offered on each call, in
+    /// call order. Lets a test assert per-turn tool suppression (#1725): a
+    /// chat/small-talk turn must send an empty tool schema.
+    tool_counts: AsyncMutex<Vec<usize>>,
 }
 
 #[async_trait]
@@ -64,6 +68,7 @@ impl ChatModel<()> for SequenceProvider {
         _state: &(),
         request: ModelRequest,
     ) -> tinyagents::Result<ModelResponse> {
+        self.tool_counts.lock().await.push(request.tools.len());
         self.requests.lock().await.push(
             request
                 .messages
@@ -877,6 +882,7 @@ async fn turn_runs_full_tool_cycle_with_context_and_hooks() {
             }),
         ]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let provider: Arc<dyn ChatModel<()>> = provider_impl.clone();
     let hook_calls = Arc::new(AsyncMutex::new(Vec::<TurnContext>::new()));
@@ -976,6 +982,7 @@ async fn turn_triggers_configured_memory_agent_before_parent_prompt() {
             }),
         ]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let provider: Arc<dyn ChatModel<()>> = provider_impl.clone();
     let workspace = tempfile::TempDir::new().expect("temp workspace");
@@ -1037,6 +1044,178 @@ async fn turn_triggers_configured_memory_agent_before_parent_prompt() {
     }));
 }
 
+/// #1725: a per-turn `suppress_tools` override sends an EMPTY tool schema to the
+/// provider, so a chat / small-talk turn cannot enter the tool loop — even
+/// though the agent was built WITH a tool. The default (no override) path still
+/// offers the tool, proving the suppression is per-turn and not a rebuild.
+#[tokio::test]
+async fn turn_override_suppress_tools_sends_empty_tool_schema() {
+    let provider_impl = Arc::new(SequenceProvider {
+        responses: AsyncMutex::new(vec![Ok(ChatResponse {
+            text: Some("hi there".into()),
+            tool_calls: vec![],
+            usage: None,
+            reasoning_content: None,
+        })]),
+        requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
+    });
+    let provider: Arc<dyn ChatModel<()>> = provider_impl.clone();
+    let mut agent = make_agent_with_builder(
+        provider,
+        vec![Box::new(EchoTool)],
+        Vec::new(),
+        crate::openhuman::config::AgentConfig {
+            max_tool_iterations: 3,
+            max_history_messages: 10,
+            ..crate::openhuman::config::AgentConfig::default()
+        },
+        crate::openhuman::config::ContextConfig::default(),
+    );
+
+    agent.set_next_turn_overrides(crate::openhuman::agent::harness::session::TurnOverrides {
+        suppress_tools: true,
+        ..Default::default()
+    });
+    let response = agent.turn("hey").await.expect("turn should succeed");
+    assert_eq!(response, "hi there");
+
+    let counts = provider_impl.tool_counts.lock().await;
+    assert_eq!(counts.len(), 1, "small-talk turn is a single provider call");
+    assert_eq!(
+        counts[0], 0,
+        "suppress_tools must send an empty tool schema (no tool loop possible)"
+    );
+}
+
+/// The control case for the test above: with NO override the same agent offers
+/// its tool, and the override state has reset after the previous turn — so the
+/// suppression is genuinely one-shot.
+#[tokio::test]
+async fn turn_without_override_offers_tools_and_resets_after_a_suppressed_turn() {
+    let provider_impl = Arc::new(SequenceProvider {
+        responses: AsyncMutex::new(vec![
+            Ok(ChatResponse {
+                text: Some("first".into()),
+                tool_calls: vec![],
+                usage: None,
+                reasoning_content: None,
+            }),
+            Ok(ChatResponse {
+                text: Some("second".into()),
+                tool_calls: vec![],
+                usage: None,
+                reasoning_content: None,
+            }),
+        ]),
+        requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
+    });
+    let provider: Arc<dyn ChatModel<()>> = provider_impl.clone();
+    let mut agent = make_agent_with_builder(
+        provider,
+        vec![Box::new(EchoTool)],
+        Vec::new(),
+        crate::openhuman::config::AgentConfig {
+            max_tool_iterations: 3,
+            max_history_messages: 10,
+            ..crate::openhuman::config::AgentConfig::default()
+        },
+        crate::openhuman::config::ContextConfig::default(),
+    );
+
+    // Turn 1: suppressed.
+    agent.set_next_turn_overrides(crate::openhuman::agent::harness::session::TurnOverrides {
+        suppress_tools: true,
+        ..Default::default()
+    });
+    agent.turn("hi").await.expect("turn 1 succeeds");
+    // Turn 2: no override set — the field must have reset to default.
+    agent
+        .turn("now do the work")
+        .await
+        .expect("turn 2 succeeds");
+
+    let counts = provider_impl.tool_counts.lock().await;
+    assert_eq!(counts.len(), 2);
+    assert_eq!(counts[0], 0, "turn 1 suppressed its tools");
+    assert!(
+        counts[1] >= 1,
+        "turn 2 must have the full toolbelt back (one-shot suppression, not a rebuild)"
+    );
+}
+
+/// #1725: a per-turn `suppress_memory_agent` override skips the pre-turn
+/// `agent_memory` retrieval even when the agent's policy is `Always`, so a
+/// greeting is a SINGLE provider call with no "## Memory agent context" block.
+#[tokio::test]
+async fn turn_override_suppress_memory_agent_skips_memory_trigger() {
+    crate::openhuman::memory::host_impls::install_for_tests();
+    crate::openhuman::agent::harness::definition::AgentDefinitionRegistry::init_global_builtins()
+        .expect("built-in agent definitions should load");
+
+    let provider_impl = Arc::new(SequenceProvider {
+        responses: AsyncMutex::new(vec![Ok(ChatResponse {
+            text: Some("parent final".into()),
+            tool_calls: vec![],
+            usage: None,
+            reasoning_content: None,
+        })]),
+        requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
+    });
+    let provider: Arc<dyn ChatModel<()>> = provider_impl.clone();
+    let workspace = tempfile::TempDir::new().expect("temp workspace");
+    let workspace_path = workspace.path().to_path_buf();
+    let _workspace_env = WorkspaceEnvGuard::set(&workspace_path);
+    let memory_cfg = crate::openhuman::config::MemoryConfig {
+        backend: "none".into(),
+        ..crate::openhuman::config::MemoryConfig::default()
+    };
+    let mem: Arc<dyn Memory> =
+        Arc::from(tinymemory_core::store::create_memory(&memory_cfg, &workspace_path).unwrap());
+
+    let mut agent = Agent::builder()
+        .chat_model(provider)
+        .tools(vec![Box::new(EchoTool)])
+        .memory(mem)
+        .tool_dispatcher(Box::new(XmlToolDispatcher))
+        .config(crate::openhuman::config::AgentConfig {
+            max_tool_iterations: 3,
+            max_history_messages: 10,
+            ..crate::openhuman::config::AgentConfig::default()
+        })
+        .workspace_dir(workspace_path)
+        .auto_save(false)
+        .event_context("turn-test-session", "turn-test-channel")
+        .trigger_memory_agent(
+            crate::openhuman::agent::harness::definition::TriggerMemoryAgent::Always,
+        )
+        .build()
+        .unwrap();
+
+    agent.set_next_turn_overrides(crate::openhuman::agent::harness::session::TurnOverrides {
+        suppress_memory_agent: true,
+        suppress_tools: true,
+        suppress_active_goal: true,
+    });
+    let response = agent.turn("hi there").await.expect("turn should succeed");
+    assert_eq!(response, "parent final");
+
+    let requests = provider_impl.requests.lock().await;
+    assert_eq!(
+        requests.len(),
+        1,
+        "suppress_memory_agent must skip the memory-agent subagent call (only the parent turn runs)"
+    );
+    assert!(
+        !requests[0]
+            .iter()
+            .any(|msg| msg.content.contains("## Memory agent context")),
+        "no memory-agent context block may be injected on a suppressed turn"
+    );
+}
+
 #[tokio::test]
 async fn turn_uses_cached_transcript_prefix_on_first_iteration() {
     let provider_impl = Arc::new(SequenceProvider {
@@ -1047,6 +1226,7 @@ async fn turn_uses_cached_transcript_prefix_on_first_iteration() {
             reasoning_content: None,
         })]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let provider: Arc<dyn ChatModel<()>> = provider_impl.clone();
     let mut agent = make_agent_with_builder(
@@ -1098,6 +1278,7 @@ async fn turn_accepts_valid_required_output_without_repair() {
             reasoning_content: None,
         })]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let provider: Arc<dyn ChatModel<()>> = provider_impl.clone();
 
@@ -1154,6 +1335,7 @@ async fn turn_repairs_missing_required_output_via_reprompt() {
             }),
         ]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let provider: Arc<dyn ChatModel<()>> = provider_impl.clone();
 
@@ -1216,6 +1398,7 @@ async fn turn_synthesizes_required_output_when_reprompt_also_omits() {
             }),
         ]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let provider: Arc<dyn ChatModel<()>> = provider_impl.clone();
 
@@ -1282,6 +1465,7 @@ async fn turn_appends_required_output_block_when_streamed_to_preserve_consistenc
             }),
         ]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let provider: Arc<dyn ChatModel<()>> = provider_impl.clone();
 
@@ -1387,6 +1571,7 @@ async fn turn_appends_only_block_not_restated_answer_when_streamed() {
             }),
         ]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let provider: Arc<dyn ChatModel<()>> = provider_impl.clone();
 
@@ -1478,6 +1663,7 @@ async fn turn_appends_synthesized_block_when_streamed_reprompt_also_omits() {
             }),
         ]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let provider: Arc<dyn ChatModel<()>> = provider_impl.clone();
 
@@ -1552,6 +1738,7 @@ async fn turn_synthesizes_required_output_when_reprompt_call_fails() {
             Err(anyhow::anyhow!("provider boom")),
         ]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let provider: Arc<dyn ChatModel<()>> = provider_impl.clone();
 
@@ -1613,6 +1800,7 @@ async fn turn_emits_checkpoint_when_max_tool_iterations_are_exceeded() {
             }),
         ]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let mut agent = make_agent_with_builder(
         provider,
@@ -1666,6 +1854,7 @@ async fn turn_errors_on_empty_provider_response() {
             reasoning_content: None,
         })]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let mut agent = make_agent_with_builder(
         provider,
@@ -1707,6 +1896,7 @@ async fn turn_checkpoint_falls_back_to_deterministic_summary_when_model_summary_
             }),
         ]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let mut agent = make_agent_with_builder(
         provider,
@@ -1747,6 +1937,7 @@ async fn turn_checkpoint_rejects_pformat_wrapup_without_streaming_it() {
             }),
         ]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let tools: Vec<Box<dyn Tool>> = vec![Box::new(EchoTool)];
     let registry = crate::openhuman::agent::pformat::build_registry(&tools);
@@ -1820,6 +2011,7 @@ async fn turn_synthesizes_final_answer_when_tool_turn_yields_no_text() {
             }),
         ]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let mut agent = make_agent_with_builder(
         provider,
@@ -1899,6 +2091,7 @@ async fn turn_final_answer_falls_back_to_deterministic_summary_when_reprompt_emp
             }),
         ]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let mut agent = make_agent_with_builder(
         provider,
@@ -1956,6 +2149,7 @@ async fn summarize_turn_wrapup_rejects_prompt_tool_call_and_preserves_usage() {
             reasoning_content: None,
         })]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let agent = make_agent_with_builder(
         provider,
@@ -2009,6 +2203,7 @@ async fn turn_checkpoint_usage_is_folded_into_transcript_accounting() {
             }),
         ]),
         requests: AsyncMutex::new(Vec::new()),
+        tool_counts: AsyncMutex::new(Vec::new()),
     });
     let mut agent = make_agent_with_builder(
         provider,

--- a/src/openhuman/agent/harness/session/turn_tests.rs
+++ b/src/openhuman/agent/harness/session/turn_tests.rs
@@ -1198,6 +1198,7 @@ async fn turn_override_suppress_memory_agent_skips_memory_trigger() {
         suppress_memory_agent: true,
         suppress_tools: true,
         suppress_active_goal: true,
+        suppress_transcript_autoload: false,
     });
     let response = agent.turn("hi there").await.expect("turn should succeed");
     assert_eq!(response, "parent final");

--- a/src/openhuman/agent/harness/session/turn_tests.rs
+++ b/src/openhuman/agent/harness/session/turn_tests.rs
@@ -447,12 +447,7 @@ fn make_agent_with_builder_and_dispatcher(
         backend: "none".into(),
         ..crate::openhuman::config::MemoryConfig::default()
     };
-    // `create_memory` reaches the engine's embedding seam, which fails loudly
-    // when unwired rather than degrading — a deliberate choice, so an unwired
-    // host cannot corrupt an embedding space quietly. Nothing in a unit test
-    // runs the startup wiring that installs it, so the helper installs it
-    // itself. `install_for_tests` is idempotent (a `Once`), so every helper in
-    // this file calling it costs one install for the whole binary.
+    // The embedding seam, as above.
     crate::openhuman::memory::host_impls::install_for_tests();
     let mem: Arc<dyn Memory> =
         Arc::from(tinymemory_core::store::create_memory(&memory_cfg, &workspace_path).unwrap());
@@ -1011,12 +1006,7 @@ async fn turn_triggers_configured_memory_agent_before_parent_prompt() {
         backend: "none".into(),
         ..crate::openhuman::config::MemoryConfig::default()
     };
-    // `create_memory` reaches the engine's embedding seam, which fails loudly
-    // when unwired rather than degrading — a deliberate choice, so an unwired
-    // host cannot corrupt an embedding space quietly. Nothing in a unit test
-    // runs the startup wiring that installs it, so the helper installs it
-    // itself. `install_for_tests` is idempotent (a `Once`), so every helper in
-    // this file calling it costs one install for the whole binary.
+    // The embedding seam, as above.
     crate::openhuman::memory::host_impls::install_for_tests();
     let mem: Arc<dyn Memory> =
         Arc::from(tinymemory_core::store::create_memory(&memory_cfg, &workspace_path).unwrap());
@@ -1193,12 +1183,7 @@ async fn turn_override_suppress_memory_agent_skips_memory_trigger() {
         backend: "none".into(),
         ..crate::openhuman::config::MemoryConfig::default()
     };
-    // `create_memory` reaches the engine's embedding seam, which fails loudly
-    // when unwired rather than degrading — a deliberate choice, so an unwired
-    // host cannot corrupt an embedding space quietly. Nothing in a unit test
-    // runs the startup wiring that installs it, so the helper installs it
-    // itself. `install_for_tests` is idempotent (a `Once`), so every helper in
-    // this file calling it costs one install for the whole binary.
+    // The embedding seam, as above.
     crate::openhuman::memory::host_impls::install_for_tests();
     let mem: Arc<dyn Memory> =
         Arc::from(tinymemory_core::store::create_memory(&memory_cfg, &workspace_path).unwrap());

--- a/src/openhuman/agent/harness/session/types.rs
+++ b/src/openhuman/agent/harness/session/types.rs
@@ -22,6 +22,40 @@ use crate::openhuman::tools::{Tool, ToolSpec};
 use std::path::PathBuf;
 use std::sync::Arc;
 
+/// Per-turn behaviour overrides applied to a **single** [`Agent::turn`] call.
+///
+/// Defaults to all-`false`, so an agent built and driven exactly as before
+/// behaves identically — the overrides only take effect when a caller opts in
+/// via [`Agent::set_next_turn_overrides`] before dispatching a turn. The turn
+/// consumes (takes) them at its start, so they apply to exactly one turn and
+/// then reset to the default; a caller that wants a run of chat turns re-sets
+/// them each time.
+///
+/// The motivating case (opencompany issue #1725) is a bare greeting / small-talk
+/// turn that should run as a cheap conversational reply instead of the full
+/// agentic task loop: no tools to loop on, no pre-turn memory-agent retrieval,
+/// and no stale per-thread goal re-injected from a prior task. Each field is an
+/// independent, additive suppression so a caller can compose exactly the
+/// reduction it wants.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct TurnOverrides {
+    /// Skip loading, auto-resuming, and injecting this thread's durable
+    /// `[active_goal]` block for this turn (and skip arming the goal budget
+    /// stop hook). Prevents an uncompleted goal left by a prior task from
+    /// steering an unrelated chat turn.
+    pub suppress_active_goal: bool,
+    /// Run this turn with **no** tools regardless of the agent's built tool
+    /// set — the provider request carries an empty tool schema, so the model
+    /// cannot enter the tool loop and answers in one shot. The agent's durable
+    /// `tools` / `tool_specs` are left untouched, so the next (un-overridden)
+    /// turn has its full toolbelt back.
+    pub suppress_tools: bool,
+    /// Force [`TriggerMemoryAgent::Never`] behaviour for this turn — skip the
+    /// pre-turn `agent_memory` retrieval even when the agent's policy is
+    /// `Always`. The agent's built policy is left untouched for later turns.
+    pub suppress_memory_agent: bool,
+}
+
 /// An autonomous or semi-autonomous AI agent.
 ///
 /// The `Agent` is the central component that manages conversation state,
@@ -419,6 +453,14 @@ pub struct Agent {
     ///
     /// Empty at construction time and whenever `tools` is fully reconciled.
     pub(super) pending_synthesized_tools_mask: std::collections::HashSet<String>,
+    /// Overrides applied to the **next** [`Agent::turn`] call, then reset.
+    ///
+    /// Defaults to [`TurnOverrides::default`] (no suppression), so an agent
+    /// driven exactly as before is byte-for-byte unchanged. A caller sets this
+    /// via [`Agent::set_next_turn_overrides`] immediately before dispatching a
+    /// chat / small-talk turn; `turn()` takes it at the top so it applies to
+    /// one turn only. See [`TurnOverrides`] for the motivating case (#1725).
+    pub(super) pending_turn_overrides: TurnOverrides,
 }
 
 /// A builder for creating `Agent` instances with custom configuration.

--- a/src/openhuman/agent/harness/session/types.rs
+++ b/src/openhuman/agent/harness/session/types.rs
@@ -54,6 +54,15 @@ pub struct TurnOverrides {
     /// pre-turn `agent_memory` retrieval even when the agent's policy is
     /// `Always`. The agent's built policy is left untouched for later turns.
     pub suppress_memory_agent: bool,
+    /// Skip auto-resuming this turn from the agent's most-recent on-disk
+    /// transcript (`try_load_session_transcript`, which resolves the *latest*
+    /// transcript for the agent name -- NOT thread-scoped). A host that has just
+    /// re-bound the in-memory history to a different chat sets this so a cleared
+    /// history is not silently repopulated from an unrelated thread's transcript
+    /// (opencompany #1725). Thread-correct resume via
+    /// `Agent::seed_resume_from_thread_transcript` still works -- it seeds
+    /// `cached_transcript_messages`, which this path never touches.
+    pub suppress_transcript_autoload: bool,
 }
 
 /// An autonomous or semi-autonomous AI agent.

--- a/src/openhuman/threads/goals/runtime.rs
+++ b/src/openhuman/threads/goals/runtime.rs
@@ -90,6 +90,54 @@ pub async fn pause_for_current_thread(workspace_dir: &Path) {
     }
 }
 
+/// Mark the active goal for the ambient thread `Complete` (the originating
+/// task settled successfully). Best-effort; safe to call when there is no goal
+/// or no thread scope. Emits `ThreadGoalUpdated` so the UI chip refreshes.
+///
+/// This is the lifecycle counterpart the pause/resume pair was missing: without
+/// a settle, a goal a finished task left behind stays `Active` and is
+/// re-injected as an `[active_goal]` block on every later turn — including
+/// unrelated chat (#1725). A caller that owns a task's lifecycle calls this
+/// when the task reaches a terminal, satisfied state so the goal can't linger.
+pub async fn complete_for_current_thread(workspace_dir: &Path) {
+    let Some(thread_id) = current_thread_id() else {
+        return;
+    };
+    match store::complete(workspace_dir, &thread_id).await {
+        Ok(goal) => {
+            if matches!(goal.status, ThreadGoalStatus::Complete) {
+                BUS.publish(DomainEvent::ThreadGoalUpdated {
+                    thread_id: goal.thread_id.clone(),
+                    goal_id: goal.goal_id.clone(),
+                    status: goal.status.as_str().to_string(),
+                });
+            }
+        }
+        Err(e) => {
+            tracing::debug!(thread_id = %thread_id, error = %e, "[thread_goals] complete_for_current_thread failed");
+        }
+    }
+}
+
+/// Delete the goal row for the ambient thread entirely (the originating task was
+/// abandoned / superseded, and no completion contract should persist).
+/// Best-effort; safe to call when there is no goal or no thread scope.
+///
+/// Clearing removes the row rather than moving it to a terminal status, so a
+/// later turn loads `None` and injects no `[active_goal]` block at all — the
+/// strongest guarantee that a stale objective cannot leak forward (#1725).
+pub async fn clear_for_current_thread(workspace_dir: &Path) {
+    let Some(thread_id) = current_thread_id() else {
+        return;
+    };
+    match store::clear(workspace_dir, &thread_id).await {
+        Ok(_existed) => {}
+        Err(e) => {
+            tracing::debug!(thread_id = %thread_id, error = %e, "[thread_goals] clear_for_current_thread failed");
+        }
+    }
+}
+
 /// The per-turn token total used for budget accounting (prompt + completion).
 fn turn_tokens(input: u64, output: u64) -> u64 {
     crate_budget::turn_tokens(input, output)
@@ -270,6 +318,68 @@ mod tests {
             assert_eq!(g.tokens_used, 0, "paused goal must not accrue usage");
         })
         .await;
+    }
+
+    #[tokio::test]
+    async fn complete_for_current_thread_settles_active_goal() {
+        // A goal an originating task left behind is settled to `Complete` so a
+        // later turn stops re-injecting its `[active_goal]` block (#1725).
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        crate::openhuman::agent::tinyagents::thread_context::with_thread_id("t-complete", async {
+            store::set(&dir, "t-complete", "obj", Some(1000))
+                .await
+                .unwrap();
+            complete_for_current_thread(&dir).await;
+            let g = store::get(&dir, "t-complete").await.unwrap().unwrap();
+            assert_eq!(
+                g.status,
+                ThreadGoalStatus::Complete,
+                "an originating task's settle must mark the goal Complete, not leave it Active"
+            );
+            assert!(
+                !g.status.is_active(),
+                "a completed goal must not stay active (it would keep steering unrelated turns)"
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn clear_for_current_thread_removes_the_goal_row() {
+        // Clearing deletes the row entirely, so a later turn loads `None` and
+        // injects no goal block at all — the strongest anti-leak guarantee.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        crate::openhuman::agent::tinyagents::thread_context::with_thread_id("t-clear", async {
+            store::set(&dir, "t-clear", "obj", Some(1000))
+                .await
+                .unwrap();
+            clear_for_current_thread(&dir).await;
+            let g = store::get(&dir, "t-clear").await.unwrap();
+            assert!(
+                g.is_none(),
+                "clearing must delete the goal row so no [active_goal] can leak forward"
+            );
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn complete_and_clear_are_safe_without_a_goal_or_thread() {
+        // Best-effort contract: both are no-ops (never panic) when there is no
+        // goal for the thread, and when called outside any thread scope.
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        crate::openhuman::agent::tinyagents::thread_context::with_thread_id("t-empty", async {
+            complete_for_current_thread(&dir).await;
+            clear_for_current_thread(&dir).await;
+            assert!(store::get(&dir, "t-empty").await.unwrap().is_none());
+        })
+        .await;
+        // No ambient thread scope at all.
+        complete_for_current_thread(&dir).await;
+        clear_for_current_thread(&dir).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Add `TurnOverrides` — a per-turn, one-shot suppression struct on `Agent`, set via `set_next_turn_overrides` and consumed by the next `turn()` only.
- Four flags: `suppress_active_goal`, `suppress_tools`, `suppress_memory_agent`, `suppress_transcript_autoload`.
- Add `complete_for_current_thread` / `clear_for_current_thread` to `threads::goals::runtime` — the terminal counterpart the existing `pause_for_current_thread` never had.
- Defaults are no-suppression, so every existing caller is byte-for-byte unchanged.

## Problem

Four defects, all one shape: state that is correct for an agentic task turn leaks into a turn that is not one.

1. **A bare greeting runs the whole task loop.** A small-talk turn pays for the full tool schema, the pre-turn memory retrieval and the active-goal block — a conversational reply billed as an agentic task.
2. **A finished task's goal steers unrelated turns.** The goal API had `pause_for_current_thread` but no terminal counterpart, so a goal a completed task left behind stayed `Active` and was re-injected as an `[active_goal]` block on every later turn, including unrelated chat.
3. **A memory-policy of `Always` cannot be waived for one turn**, even where there is nothing to retrieve against.
4. **A cleared history is silently repopulated from an unrelated thread.** `turn()` auto-resumes a fresh, empty-history session from the agent's latest on-disk transcript, and that transcript is resolved *by agent name* — it is not thread-scoped. A host that has just re-bound its in-memory history to a different chat thread gets the previous thread's transcript back underneath it.

The fourth is the one worth reading twice: it is silent, it produces a plausible reply grounded in the wrong conversation, and there is no way to opt out of it from outside the crate.

**Rebase note.** The five substantive commits are @oxoxDev's, written against a base ~830 commits back and carried forward unchanged. Two commits on top are adaptations this branch needed to be correct on today's `main`, kept separate so the original work is reviewable as written:

- `3be4366e3d` — `create_memory` now requires the TinyMemory host seams, which fail loudly when unwired (a deliberate choice: an unwired embedding host would otherwise corrupt an embedding space quietly). One test helper in `turn_tests.rs` predated that and panicked; its three siblings in the same file already called `install_for_tests()`, so this is the same one-liner in the fourth. Worth knowing that the failure was **ordering-dependent** — the seam is a process-global, so whichever test reached the unwired helper first blew up while the others passed on a neighbour's install.
- `9bf7df4712` — comment de-duplication in that same helper, no behaviour.

## Solution

`TurnOverrides` is taken at the top of `turn()` and reset there, so it applies to exactly one turn and cannot leak into the next:

- `suppress_active_goal` skips loading, auto-resuming, injecting and budget-arming this thread's goal.
- `suppress_tools` sends an **empty tool schema** for the turn. `self.tools` is untouched — the durable tool belt is not edited, the model simply cannot enter the tool loop this turn.
- `suppress_memory_agent` skips the pre-turn `agent_memory` retrieval even where the agent's policy is `Always`.
- `suppress_transcript_autoload` guards the `try_load_session_transcript()` fallback. Thread-correct resume via `seed_resume_from_thread_transcript` is unaffected — that path seeds `cached_transcript_messages` up front and never reaches the fallback.

The two goal helpers mirror `pause_for_current_thread` exactly, including being best-effort: safe to call with no goal and with no ambient thread scope, because a caller settling a goal should not have to know whether one exists.

**Design note — why one struct rather than four arguments.** These are consumed together, at one point, by one turn. A struct means a host sets what it means and the defaults cover the rest; four booleans threaded through `turn()` would be four signature changes for every future flag, and a call site whose meaning depends on argument order.

**Trade-off — one-shot, not sticky.** The overrides reset after the turn that reads them. A host wanting them on several turns sets them several times, which is more calls but is the safe direction: a sticky flag that outlives its reason is a silently tool-less agent, and that failure is invisible in a transcript.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `session/turn_tests.rs`: `suppress_tools` sends an empty schema (happy path), the override **resets after one turn** so the full tool belt returns (the edge case that matters — a leaked flag is a silently tool-less agent), and `suppress_memory_agent` skips the `agent_memory` subagent call. `SequenceProvider` gained per-call tool-count recording to make the empty schema assertable.
- [ ] **Diff coverage ≥ 80%** — not measured locally; `pnpm test:coverage` / `pnpm test:rust` were not run here (see Validation Blocked). The Rust change is 440 lines of which 196 are the new tests; CI's `rust-core-coverage` job is the authority.
- [x] Coverage matrix updated — `N/A: no feature row added, removed or renamed.` `TurnOverrides` is a new opt-in seam on an existing feature (the agent turn), not a feature of its own.
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix rows affected, per the row above.`
- [x] No new external network dependencies introduced — `N/A: no new dependency of any kind.` The tests drive the existing in-crate `SequenceProvider`, no network.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no user-visible surface.` This is a library seam with no default behaviour change; nothing in the desktop app calls it yet.
- [x] Linked issue closed via `Closes #NNN` — `N/A: no upstream issue.` The motivating issue is `tinyhumansai/opencompany#1725`, in a different repository, and this PR does not close it — it is one of the pieces that issue needs.

## Impact

- **Runtime/platform:** none by default. Every field defaults to `false` and `turn()` behaves exactly as before for a caller that never calls `set_next_turn_overrides`. Desktop, CLI and library embedders are all unchanged unless they opt in.
- **Performance:** the motivating case is a *reduction* — a small-talk turn skips the tool schema, the memory retrieval and the goal block, which is the per-turn prompt cost this exists to avoid paying twice.
- **Security:** `suppress_tools` narrows what a turn can do; it can never widen it. It sends an empty schema rather than editing `self.tools`, so no durable permission state is touched and no policy check is bypassed.
- **Migration / compatibility:** additive. New public struct, one new field on `Agent`, one new setter, two new free functions on the goals runtime. No existing signature changes.

## Related

- Closes: `N/A` — no upstream issue. Refs `tinyhumansai/opencompany#1725`, which is the downstream consumer.
- Follow-up PR(s)/TODOs: OpenCompany pins this branch as its vendored OpenHuman; that pin moves to the merged SHA once this lands.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: `N/A` — not a Linear-tracked change.
- URL: `N/A`

### Commit & Branch

- Branch: `chore/rebase-turn-overrides-on-main`
- Commit SHA: `9bf7df4712` (7 commits — the 5 feature/test commits by @oxoxDev, then two rebase adaptations: `3be4366e3d`, `9bf7df4712`)

### Validation Run

- [ ] `pnpm --filter openhuman-app format:check` — blocked, see below.
- [ ] `pnpm typecheck` — blocked, see below.
- [x] Focused tests: `GGML_NATIVE=OFF cargo test --lib -- turn_override turn_without_override` — **3 passed, 0 failed**.
- [x] Rust fmt/check (if changed): `cargo fmt --manifest-path Cargo.toml --all --check` clean; `GGML_NATIVE=OFF cargo check --manifest-path Cargo.toml` clean.
- [x] Tauri fmt/check (if changed): `N/A: no file under app/src-tauri/ is touched.` The whole diff is `src/openhuman/`.

### Validation Blocked

- `command:` `pnpm typecheck` (and the `format:check` that shares its install)
- `error:` `src/components/ai-elements/Conversation.tsx(7,67): error TS2307: Cannot find module '@assistant-ui/react'`, plus `Property 'iconOnly' does not exist on type ... ButtonProps` and ~40 more of the same shape.
- `impact:` **None on this PR.** These are stale `node_modules` in the checkout this branch was prepared in, not a defect in the change: the diff touches **zero** files under `app/` (`git diff --name-only upstream/main..HEAD | grep '^app/'` is empty), so no TypeScript in this repository can be affected by it. CI installs from the lockfile and will run both commands against a clean tree. The pre-push hook was bypassed for this reason and this reason only.

### Behavior Changes

- Intended behavior change: a host can suppress the goal block, the tool schema, the memory retrieval and the non-thread-scoped transcript autoload for a single turn.
- User-visible effect: none until a host opts in. In OpenCompany, which does, a bare greeting becomes a cheap conversational reply instead of an agentic task turn, and a chat thread stops being seeded from a different thread's transcript.

### Parity Contract

- Legacy behavior preserved: `TurnOverrides::default()` is all-`false`, and `turn()` takes the same branch it always did on that value. No existing call site passes overrides, so the compiled behaviour for every current caller is unchanged.
- Guard/fallback/dispatch parity checks: `turn_without_override_offers_tools_and_resets_after_a_suppressed_turn` is exactly this assertion — it runs a suppressed turn and then an ordinary one, and pins that the second gets the full tool belt back.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none.
- Canonical PR: this one.
- Resolution: `N/A`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-turn controls to suppress active goals, tools, memory retrieval, or transcript loading.
  * Added the ability to complete or clear the active thread goal.
  * Tool suppression enables single-response turns without tool schemas.
* **Bug Fixes**
  * Per-turn settings now reset automatically after use, preventing them from affecting subsequent turns.
  * Goal updates are handled safely when no active thread or goal is available.
* **Tests**
  * Added coverage for tool suppression, override reset behavior, memory retrieval suppression, and goal lifecycle actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->