### PR TITLE
Take the connector vocabulary from tinyconnectors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -56,4 +56,4 @@
 [submodule "vendor/tinyconnectors"]
 	path = vendor/tinyconnectors
 	url = https://github.com/tinyhumansai/tinyconnectors
-	branch = connectors-migration
+	branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -53,3 +53,7 @@
 	path = vendor/tinyjuice
 	url = https://github.com/tinyhumansai/tinyjuice
 	branch = main
+[submodule "vendor/tinyconnectors"]
+	path = vendor/tinyconnectors
+	url = https://github.com/tinyhumansai/tinyconnectors
+	branch = connectors-migration

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6413,7 +6413,7 @@ dependencies = [
 
 [[package]]
 name = "tinyconnectors-bus"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6413,7 +6413,7 @@ dependencies = [
 
 [[package]]
 name = "tinyconnectors-bus"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4153,6 +4153,7 @@ dependencies = [
  "tinyagents",
  "tinybus",
  "tinychannels",
+ "tinyconnectors-bus",
  "tinycortex",
  "tinycortex-api",
  "tinydocs-bus",
@@ -6408,6 +6409,14 @@ dependencies = [
  "whatsapp-rust",
  "whatsapp-rust-tokio-transport",
  "whatsapp-rust-ureq-http-client",
+]
+
+[[package]]
+name = "tinyconnectors-bus"
+version = "0.2.1"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,6 +250,17 @@ tinyruntime-bus = { path = "vendor/tinyruntime/crates/tinyruntime-bus" }
 
 tinymemory = { path = "vendor/tinymemory/crates/tinymemory" }
 tinymemory-api = { path = "vendor/tinymemory/crates/tinymemory-api" }
+# tinyconnectors-bus — the OAuth connector wire contract
+# (https://github.com/tinyhumansai/tinyconnectors). Payload types and member
+# names for the connector surface, with no transport and no behaviour: this
+# crate makes calls into the loaded `tinyconnectors` module and compiles none
+# of it.
+#
+# These types previously came from `tinymemory-api::host::composio`, which held
+# them only because two crates needed to name them and there was nowhere else
+# both could. That is what this dependency fixes — one definition, owned by the
+# crate that produces the shapes.
+tinyconnectors-bus = { path = "vendor/tinyconnectors/crates/tinyconnectors-bus" }
 # tinymemory-bus is the wire contract (method names, ABI). Normally transitive
 # through tinymemory-api, but modules/memory.rs names the method constants
 # directly (EXTRACT_ENTITIES, EMBED_TEXT, EMBEDDER_SLUG) — prefer compile

--- a/src/openhuman/integrations/composio/ops/toolkits.rs
+++ b/src/openhuman/integrations/composio/ops/toolkits.rs
@@ -47,8 +47,13 @@ pub async fn composio_list_capabilities(
     _config: &Config,
 ) -> OpResult<RpcOutcome<ComposioCapabilitiesResponse>> {
     tracing::debug!("[composio] rpc list_capabilities");
+    // The matrix is still built from `tinymemory`'s provider registry, whose
+    // capability type is the parallel copy — see
+    // `integrations::composio::types::reencode`. Phase 4 moves the registry
+    // into the connector module and this conversion goes away.
     let resp = ComposioCapabilitiesResponse {
-        capabilities: capability_matrix(),
+        capabilities: super::super::types::reencode(&capability_matrix())
+            .map_err(|error| crate::rpc::OpError::internal(error))?,
     };
     let count = resp.capabilities.len();
     Ok(RpcOutcome::new(

--- a/src/openhuman/integrations/composio/ops/toolkits.rs
+++ b/src/openhuman/integrations/composio/ops/toolkits.rs
@@ -52,8 +52,7 @@ pub async fn composio_list_capabilities(
     // `integrations::composio::types::reencode`. Phase 4 moves the registry
     // into the connector module and this conversion goes away.
     let resp = ComposioCapabilitiesResponse {
-        capabilities: super::super::types::reencode(&capability_matrix())
-            .map_err(|error| crate::rpc::OpError::internal(error))?,
+        capabilities: super::super::types::reencode(&capability_matrix())?,
     };
     let count = resp.capabilities.len();
     Ok(RpcOutcome::new(

--- a/src/openhuman/integrations/composio/types.rs
+++ b/src/openhuman/integrations/composio/types.rs
@@ -18,3 +18,35 @@
 //! pins every one of them in a test for that reason.
 
 pub use tinyconnectors_bus::composio::*;
+
+/// Re-encode a value across the two parallel Composio type sets.
+///
+/// `tinymemory-api` still carries its own copy of these shapes, because
+/// `tinymemory_core::composio_host::ComposioHost` — which this crate implements
+/// — is typed against them. The two sets are field-for-field identical: the
+/// memory copy was written from the same backend envelopes the contract crate's
+/// was, which is exactly why holding them in two places was worth ending.
+///
+/// So this is a re-encode, not a translation, and it is **temporary**. Phase 4
+/// of the connector extraction deletes `ComposioHost` along with the memory-side
+/// copy, and every call to this function goes with it. Until then the
+/// conversion is explicit and in one place rather than spread across the call
+/// sites, so removing it later is a matter of deleting this function and
+/// following the compiler.
+///
+/// # Errors
+///
+/// Returns an error only if the two shapes have drifted apart — which is the
+/// failure this whole migration exists to make impossible, and is worth hearing
+/// about loudly rather than papering over.
+pub fn reencode<From, To>(value: &From) -> Result<To, String>
+where
+    From: serde::Serialize,
+    To: serde::de::DeserializeOwned,
+{
+    let json = serde_json::to_value(value)
+        .map_err(|error| format!("composio type re-encode failed to serialize: {error}"))?;
+    serde_json::from_value(json).map_err(|error| {
+        format!("composio type re-encode failed: the two copies have drifted — {error}")
+    })
+}

--- a/src/openhuman/integrations/composio/types.rs
+++ b/src/openhuman/integrations/composio/types.rs
@@ -1,15 +1,20 @@
 //! Domain types for the Composio integration.
 //!
-//! The definitions **moved to `tinymemory_api::host::composio`** during the
-//! memory extraction: the extracted sync pipelines read these fields directly
-//! on every run, so they had to live somewhere both crates can name. They are
-//! inert serde data and carry no dependencies, so the contract crate's
-//! dependency-light guarantee is unaffected.
+//! The definitions live in **`tinyconnectors_bus`**, the connector module's wire
+//! contract, and are re-exported here so every existing
+//! `integrations::composio::types::…` path keeps resolving and keeps naming the
+//! same types.
 //!
-//! Every existing `integrations::composio::types::…` path keeps resolving and
-//! keeps naming the same types. **Their serde form mirrors the backend's
-//! response envelopes** under `/agent-integrations/composio/*` — field names and
-//! `#[serde(...)]` attributes are a wire contract, not an implementation
-//! detail.
+//! They were previously reached through `tinymemory_api::host::composio`, which
+//! held them only because two crates needed to name them and there was nowhere
+//! else both could. That is no longer true: the crate that *produces* these
+//! shapes owns them, and memory takes them — or, after the sync migration,
+//! stops needing them at all.
+//!
+//! **Their serde form is a wire contract**, not an implementation detail: it
+//! mirrors the backend's response envelopes under
+//! `/agent-integrations/composio/*`, and a field renamed on one side fails at
+//! runtime with a decode error rather than at compile time. The contract crate
+//! pins every one of them in a test for that reason.
 
-pub use tinymemory_api::host::composio::*;
+pub use tinyconnectors_bus::composio::*;

--- a/src/openhuman/memory/api.rs
+++ b/src/openhuman/memory/api.rs
@@ -102,6 +102,6 @@ pub use tinymemory_api::{
 /// `tinymemory_api::host` is the in-process engine seam and must still be named
 /// on the crate.
 pub mod host {
-    pub use tinymemory_api::host::composio::{ComposioConnection, ComposioExecuteResponse};
+    pub use tinyconnectors_bus::{ComposioConnection, ComposioExecuteResponse};
     pub use tinymemory_api::host::{EvidenceRef, MemoryEvent, SpacyResponse};
 }

--- a/src/openhuman/memory/api_identity_tests.rs
+++ b/src/openhuman/memory/api_identity_tests.rs
@@ -108,7 +108,7 @@ fn host_seam_types_are_the_contract_crates() {
 
     fn connection(
         c: crate::openhuman::memory::api::host::ComposioConnection,
-    ) -> tinymemory_api::host::composio::ComposioConnection {
+    ) -> tinyconnectors_bus::ComposioConnection {
         c
     }
     let _ = connection as fn(_) -> _;

--- a/src/openhuman/memory/host_impls.rs
+++ b/src/openhuman/memory/host_impls.rs
@@ -226,7 +226,10 @@ impl ComposioHost for OpenHumanComposioHost {
                 })?
             }
         };
-        Ok(response.connections)
+        // Across the seam into `tinymemory`'s parallel copy — see
+        // `integrations::composio::types::reencode`. Removed with the trait in
+        // phase 4 of the connector extraction.
+        crate::openhuman::integrations::composio::types::reencode(&response.connections)
     }
 
     async fn execute(

--- a/src/openhuman/memory/host_impls.rs
+++ b/src/openhuman/memory/host_impls.rs
@@ -244,17 +244,20 @@ impl ComposioHost for OpenHumanComposioHost {
             create_composio_client, direct_execute, ComposioClientKind,
         };
         let config = live_config(config).await?;
-        match create_composio_client(&config).map_err(|e| format!("{e:#}"))? {
+        let response = match create_composio_client(&config).map_err(|e| format!("{e:#}"))? {
             ComposioClientKind::Backend(client) => client
                 .execute_tool(tool, arguments)
                 .await
-                .map_err(|e| format!("{e:#}")),
+                .map_err(|e| format!("{e:#}"))?,
             ComposioClientKind::Direct(direct) => {
                 direct_execute(&direct, tool, arguments, entity_id, connection_id)
                     .await
-                    .map_err(|e| format!("{e:#}"))
+                    .map_err(|e| format!("{e:#}"))?
             }
-        }
+        };
+        // Across the seam into `tinymemory`'s parallel copy — see
+        // `integrations::composio::types::reencode`.
+        crate::openhuman::integrations::composio::types::reencode(&response)
     }
 
     fn api_key(&self, config: &SeamConfig) -> Option<String> {

--- a/src/openhuman/modules/memory_host.rs
+++ b/src/openhuman/modules/memory_host.rs
@@ -37,7 +37,7 @@ use crate::openhuman::config::Config;
 use std::sync::Arc;
 use tinyagents::harness::model::{ModelRequest, ModelResponse};
 use tinybus::ObjectPath;
-use tinymemory_api::host::composio::{ComposioConnection, ComposioExecuteResponse};
+use tinyconnectors_bus::{ComposioConnection, ComposioExecuteResponse};
 use tinymemory_api::host::{MemoryEvent, SpacyResponse};
 
 const EMBEDDING_NAME: &str = "ai.tinyhumans.tinymemory.EmbeddingHost";

--- a/src/openhuman/modules/registry.rs
+++ b/src/openhuman/modules/registry.rs
@@ -746,6 +746,75 @@ const TINYMCP: ModuleRecord = ModuleRecord {
     load: LoadPolicy::Lazy,
 };
 
+const TINYCONNECTORS: ModuleRecord = ModuleRecord {
+    id: "tinyconnectors",
+    description: "OAuth connector integrations: accounts, actions, triggers, and record sync",
+    bus_name: "ai.tinyhumans.connectors.Composio",
+    object_path: "/ai/tinyhumans/connectors/Composio",
+    version: "0.3.0",
+    release_url: "https://github.com/tinyhumansai/tinyconnectors/releases/tag/v0.3.0",
+    assets: &[
+        PlatformAsset {
+            host_key: "ubuntu-24.04-x86_64",
+            archive: "tinyconnectors-0.3.0-ubuntu-24.04-x86_64.tar.gz",
+            sha256: "4990d23429bdc57c6dd2be393a043870aef2a6701f60ec643b6ecfa2b6d4fe73",
+        },
+        PlatformAsset {
+            host_key: "ubuntu-24.04-arm64",
+            archive: "tinyconnectors-0.3.0-ubuntu-24.04-arm64.tar.gz",
+            sha256: "493c88aa61837e8e04d8ef0d2ecf4cbff37c26afa1cebbcb21a9f7aff3dbcbd9",
+        },
+        PlatformAsset {
+            host_key: "ubuntu-22.04-x86_64",
+            archive: "tinyconnectors-0.3.0-ubuntu-22.04-x86_64.tar.gz",
+            sha256: "f144cfa1d94b2daa7fc267fe990bb5068ae265b43558ac217c0448e55fda1fe6",
+        },
+        PlatformAsset {
+            host_key: "ubuntu-22.04-arm64",
+            archive: "tinyconnectors-0.3.0-ubuntu-22.04-arm64.tar.gz",
+            sha256: "18ea24aca1f8419e5e63461364189684824aa01f6baabd23b9e8c60f8322f655",
+        },
+        PlatformAsset {
+            host_key: "macos-26-arm64",
+            archive: "tinyconnectors-0.3.0-macos-26-arm64.tar.gz",
+            sha256: "6a9dac7fd9becf9116d1b2423022829a9fe421a81fbf22b4174181813707debc",
+        },
+        PlatformAsset {
+            host_key: "macos-26-x86_64",
+            archive: "tinyconnectors-0.3.0-macos-26-x86_64.tar.gz",
+            sha256: "1043311728fa823ae7d071aec594b706259efd97a815640fa0509b7d9bae0b98",
+        },
+        PlatformAsset {
+            host_key: "macos-15-arm64",
+            archive: "tinyconnectors-0.3.0-macos-15-arm64.tar.gz",
+            sha256: "69a15690c6078a03a2405007f5ceeff246673cef0fc5b5c358a175eeb10441e7",
+        },
+        PlatformAsset {
+            host_key: "macos-15-x86_64",
+            archive: "tinyconnectors-0.3.0-macos-15-x86_64.tar.gz",
+            sha256: "f1b97497e73ac1ed2f7b6dbc587cf0d4b5e7381b11c7e4d50ce1554f5295a9e2",
+        },
+        PlatformAsset {
+            host_key: "windows-2025-x86_64",
+            archive: "tinyconnectors-0.3.0-windows-2025-x86_64.zip",
+            sha256: "b9ba48e2e5f51ac07028e7eac7223da2c8d8dbab1b507c137ac74751fcd4f06f",
+        },
+        PlatformAsset {
+            host_key: "windows-2022-x86_64",
+            archive: "tinyconnectors-0.3.0-windows-2022-x86_64.zip",
+            sha256: "2c248a9953eb2356f84883104754ace26ec51755729f23bbf47cefae1985b78f",
+        },
+        PlatformAsset {
+            host_key: "windows-11-arm64",
+            archive: "tinyconnectors-0.3.0-windows-11-arm64.zip",
+            sha256: "093af104fd0a6ff50e769dc4512d289b5e6f18001a1b89c4350fe1704949db9e",
+        },
+    ],
+    // Lazy: a user with no connected accounts should not pay to load it, and
+    // most sessions never touch a connector.
+    load: LoadPolicy::Lazy,
+};
+
 /// Every module this build can load.
 pub const ALL: &[ModuleRecord] = &[
     TINYDOCS,
@@ -757,6 +826,7 @@ pub const ALL: &[ModuleRecord] = &[
     TINYRUNTIME_NODEJS,
     TINYRUNTIME_PYTHON,
     TINYMCP,
+    TINYCONNECTORS,
 ];
 
 /// The record for `id`, if this build knows it.

--- a/src/openhuman/modules/registry.rs
+++ b/src/openhuman/modules/registry.rs
@@ -751,67 +751,68 @@ const TINYCONNECTORS: ModuleRecord = ModuleRecord {
     description: "OAuth connector integrations: accounts, actions, triggers, and record sync",
     bus_name: "ai.tinyhumans.connectors.Composio",
     object_path: "/ai/tinyhumans/connectors/Composio",
-    version: "0.3.0",
-    release_url: "https://github.com/tinyhumansai/tinyconnectors/releases/tag/v0.3.0",
+    version: "0.3.1",
+    release_url: "https://github.com/tinyhumansai/tinyconnectors/releases/tag/v0.3.1",
     assets: &[
         PlatformAsset {
             host_key: "ubuntu-24.04-x86_64",
-            archive: "tinyconnectors-0.3.0-ubuntu-24.04-x86_64.tar.gz",
-            sha256: "4990d23429bdc57c6dd2be393a043870aef2a6701f60ec643b6ecfa2b6d4fe73",
+            archive: "tinyconnectors-0.3.1-ubuntu-24.04-x86_64.tar.gz",
+            sha256: "e6bba93e9da6110a2799e36704c82dd96e075aa0a754d8d8e0f527b1960dcc20",
         },
         PlatformAsset {
             host_key: "ubuntu-24.04-arm64",
-            archive: "tinyconnectors-0.3.0-ubuntu-24.04-arm64.tar.gz",
-            sha256: "493c88aa61837e8e04d8ef0d2ecf4cbff37c26afa1cebbcb21a9f7aff3dbcbd9",
+            archive: "tinyconnectors-0.3.1-ubuntu-24.04-arm64.tar.gz",
+            sha256: "b4a8375e3a0a1687106c10c434fa3d99026fbc664f0810323d4aa08025cca224",
         },
         PlatformAsset {
             host_key: "ubuntu-22.04-x86_64",
-            archive: "tinyconnectors-0.3.0-ubuntu-22.04-x86_64.tar.gz",
-            sha256: "f144cfa1d94b2daa7fc267fe990bb5068ae265b43558ac217c0448e55fda1fe6",
+            archive: "tinyconnectors-0.3.1-ubuntu-22.04-x86_64.tar.gz",
+            sha256: "54108d61153f27591bac4158c42da31863f87368a1cfe2e18f6f552e954b4977",
         },
         PlatformAsset {
             host_key: "ubuntu-22.04-arm64",
-            archive: "tinyconnectors-0.3.0-ubuntu-22.04-arm64.tar.gz",
-            sha256: "18ea24aca1f8419e5e63461364189684824aa01f6baabd23b9e8c60f8322f655",
+            archive: "tinyconnectors-0.3.1-ubuntu-22.04-arm64.tar.gz",
+            sha256: "5c9ee95b917057f1c8c08e12a3f55b63c8e7048b00e16ab7bf622f4f348c5270",
         },
         PlatformAsset {
             host_key: "macos-26-arm64",
-            archive: "tinyconnectors-0.3.0-macos-26-arm64.tar.gz",
-            sha256: "6a9dac7fd9becf9116d1b2423022829a9fe421a81fbf22b4174181813707debc",
+            archive: "tinyconnectors-0.3.1-macos-26-arm64.tar.gz",
+            sha256: "ca1cdb92556850cd9d04e05fbd3edd79ef181843828339ee8702144798029156",
         },
         PlatformAsset {
             host_key: "macos-26-x86_64",
-            archive: "tinyconnectors-0.3.0-macos-26-x86_64.tar.gz",
-            sha256: "1043311728fa823ae7d071aec594b706259efd97a815640fa0509b7d9bae0b98",
+            archive: "tinyconnectors-0.3.1-macos-26-x86_64.tar.gz",
+            sha256: "cc79fe1d39d5ebddba084f2f1cfb80415cd3b5ac8de40af222bb4cbd45834114",
         },
         PlatformAsset {
             host_key: "macos-15-arm64",
-            archive: "tinyconnectors-0.3.0-macos-15-arm64.tar.gz",
-            sha256: "69a15690c6078a03a2405007f5ceeff246673cef0fc5b5c358a175eeb10441e7",
+            archive: "tinyconnectors-0.3.1-macos-15-arm64.tar.gz",
+            sha256: "ada550c550865078c479128e4ec447c8385f65128982f338500dc7f98de645fa",
         },
         PlatformAsset {
             host_key: "macos-15-x86_64",
-            archive: "tinyconnectors-0.3.0-macos-15-x86_64.tar.gz",
-            sha256: "f1b97497e73ac1ed2f7b6dbc587cf0d4b5e7381b11c7e4d50ce1554f5295a9e2",
+            archive: "tinyconnectors-0.3.1-macos-15-x86_64.tar.gz",
+            sha256: "282966dd7fd581eb1853d2153c89bf6519f454ae0e399fed56bb4c5f6a842f50",
         },
         PlatformAsset {
             host_key: "windows-2025-x86_64",
-            archive: "tinyconnectors-0.3.0-windows-2025-x86_64.zip",
-            sha256: "b9ba48e2e5f51ac07028e7eac7223da2c8d8dbab1b507c137ac74751fcd4f06f",
+            archive: "tinyconnectors-0.3.1-windows-2025-x86_64.zip",
+            sha256: "cf246d5029c00fb295accaf2088e59617096ef4312b8d65eea90870c6f553c73",
         },
         PlatformAsset {
             host_key: "windows-2022-x86_64",
-            archive: "tinyconnectors-0.3.0-windows-2022-x86_64.zip",
-            sha256: "2c248a9953eb2356f84883104754ace26ec51755729f23bbf47cefae1985b78f",
+            archive: "tinyconnectors-0.3.1-windows-2022-x86_64.zip",
+            sha256: "a48a76b5a1a13fed7174596e2012a1e94abe939065fe853b753ecf1f3de7ba94",
         },
         PlatformAsset {
             host_key: "windows-11-arm64",
-            archive: "tinyconnectors-0.3.0-windows-11-arm64.zip",
-            sha256: "093af104fd0a6ff50e769dc4512d289b5e6f18001a1b89c4350fe1704949db9e",
+            archive: "tinyconnectors-0.3.1-windows-11-arm64.zip",
+            sha256: "a6cc65c13751be840e08d03bbc1648b30a9420d774d282a14cf90529ad79c7f6",
         },
     ],
     // Lazy: a user with no connected accounts should not pay to load it, and
-    // most sessions never touch a connector.
+    // most sessions never touch a connector. Safe even signed out — the module
+    // loads without configuration and still answers the capability members.
     load: LoadPolicy::Lazy,
 };
 


### PR DESCRIPTION
First half of the connector extraction's host wiring. The Composio payload
types now come from `tinyconnectors-bus` instead of `tinymemory-api`, and
`tinyconnectors` is registered as a loadable module.

Companion to https://github.com/tinyhumansai/tinyconnectors (v0.3.x), which
holds the connector implementation migrated out of this repo and `tinymemory`.

## What changed

- **`vendor/tinyconnectors`** added as a submodule, pinned to `main`.
- **`tinyconnectors-bus`** taken as a path dependency.
- **`integrations::composio::types`** re-exports from it rather than from
  `tinymemory_api::host::composio`.
- **`TINYCONNECTORS` module record** in `modules::registry`, with the real
  SHA-256 digests from the published `checksum.toml`, `LoadPolicy::Lazy`.

## Why the types moved

They were in `tinymemory-api` only because two crates needed to name them and
there was nowhere else both could — the memory contract crate's own comment
says as much. They belong with the crate that produces the shapes. Holding one
definition in two repositories is a drift waiting to happen: both sides
serialize and deserialize fine while quietly disagreeing about a field.

## The re-encode seam

`memory/host_impls.rs` and `ops/toolkits.rs` implement or feed
`tinymemory_core::composio_host::ComposioHost`, whose signatures still use the
parallel copy. `integrations::composio::types::reencode` bridges them.

It is a re-encode, not a translation — the shapes are identical — and it is
temporary. Phase 4 of the extraction deletes `ComposioHost` along with the
memory-side copy, and every call to `reencode` goes with it. It is one function
rather than conversions spread across call sites, so removing it later is a
matter of deleting it and following the compiler.

## What has *not* changed

No behaviour. `integrations::composio` still owns the client, the OAuth
handoff, and the execute path; nothing calls the module yet. That is the next
change, and it is where the care is needed:

- **Egress enforcement must stay host-side.** `enforce_egress` and
  `emit_external_transfer` run before every Composio call today. The module
  does not do this and must not — it is host policy about the user's data.
- **`ComposioTriggerSubscriber` stays.** The backend HMAC-verifies webhooks and
  fans them out over the user's sockets; the module has no socket.
- **Scope enforcement becomes the module's.** It hides forbidden actions from
  `ListTools` and refuses them in `Execute`, so the host should not re-filter
  against a separately stored preference.

See `docs/specs/2026-08-30-host-integration.md` in the tinyconnectors repo.

## Validation

```
cargo check --all-targets     # clean
cargo test -p openhuman --lib modules::registry   # 9 passed
```

The registry tests include the uniqueness and platform-coverage checks that
guard a new `ModuleRecord`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the TinyConnectors OAuth integration.
  * Registered the Composio connector module across Ubuntu, macOS, and Windows.
  * Added connector communication contracts for connections, capabilities, and execution responses.
  * Updated the connector module to version 0.3.1.

* **Bug Fixes**
  * Improved compatibility when exchanging Composio integration data between host components.
  * Added clearer error handling for incompatible connector response formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->