### PR TITLE
mcp: honour globs in allowed_tools / disallowed_tools

### DIFF
--- a/src/openhuman/agent/library/ops.rs
+++ b/src/openhuman/agent/library/ops.rs
@@ -94,13 +94,9 @@ fn direct_tool_names(def: &AgentDefinition) -> Vec<String> {
         }
     }
     names.retain(|name| {
-        def.disallowed_tools.iter().all(|entry| {
-            if let Some(prefix) = entry.strip_suffix('*') {
-                !name.starts_with(prefix)
-            } else {
-                entry != name
-            }
-        })
+        def.disallowed_tools
+            .iter()
+            .all(|entry| !crate::openhuman::mcp::config_servers::registry::glob_match(entry, name))
     });
     names.sort();
     names

--- a/src/openhuman/agent/library/ops.rs
+++ b/src/openhuman/agent/library/ops.rs
@@ -93,7 +93,15 @@ fn direct_tool_names(def: &AgentDefinition) -> Vec<String> {
             names.push(tool.clone());
         }
     }
-    names.retain(|name| !def.disallowed_tools.contains(name));
+    names.retain(|name| {
+        def.disallowed_tools.iter().all(|entry| {
+            if let Some(prefix) = entry.strip_suffix('*') {
+                !name.starts_with(prefix)
+            } else {
+                entry != name
+            }
+        })
+    });
     names.sort();
     names
 }

--- a/src/openhuman/mcp/config_servers/mod.rs
+++ b/src/openhuman/mcp/config_servers/mod.rs
@@ -28,7 +28,7 @@
 //! The HTTP transport primitives live in the ungated sibling
 //! [`super::http_client`]; see that module for why it is not gated.
 
-mod registry;
+pub(crate) mod registry;
 pub mod setup_agent;
 #[cfg(test)]
 mod setup_agent_integration_test;

--- a/src/openhuman/mcp/config_servers/registry.rs
+++ b/src/openhuman/mcp/config_servers/registry.rs
@@ -33,16 +33,45 @@ pub struct McpServerDefinition {
     client: Arc<McpTransportClient>,
 }
 
+/// Glob-style matching for tool-name filters, shared by both filtering sites
+/// (`McpServerDefinition::is_tool_allowed` and `direct_tool_names`) so a deny
+/// rule like `tinyplace_*` behaves identically everywhere.
+///
+/// Supports `*` as a wildcard: `foo*` (prefix), `*foo` (suffix), `*foo*`
+/// (contains), bare `*` (everything), and no `*` (exact match). A literal `*`
+/// in a real tool name is not representable — acceptable for this use.
+pub fn glob_match(pattern: &str, tool: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        // `foo*` — prefix match; also covers `*foo*`? No: `*foo*` strips to
+        // `*foo`, which is handled below.
+        if !prefix.contains('*') {
+            return tool.starts_with(prefix);
+        }
+    }
+    if let Some(suffix) = pattern.strip_prefix('*') {
+        if !suffix.contains('*') {
+            return tool.ends_with(suffix);
+        }
+        // `*foo*` — contains match.
+        let inner = suffix.strip_suffix('*').unwrap_or(suffix);
+        return tool.contains(inner);
+    }
+    pattern == tool
+}
+
 impl McpServerDefinition {
     pub fn is_tool_allowed(&self, tool: &str) -> bool {
         let tool = tool.trim();
         if tool.is_empty() {
             return false;
         }
-        if self.disallowed_tools.iter().any(|name| name == tool) {
+        if self.disallowed_tools.iter().any(|name| glob_match(name, tool)) {
             return false;
         }
-        self.allowed_tools.is_empty() || self.allowed_tools.iter().any(|name| name == tool)
+        self.allowed_tools.is_empty() || self.allowed_tools.iter().any(|name| glob_match(name, tool))
     }
 
     pub fn filter_allowed_tools(&self, tools: Vec<McpRemoteTool>) -> Vec<McpRemoteTool> {
@@ -50,6 +79,56 @@ impl McpServerDefinition {
             .into_iter()
             .filter(|tool| self.is_tool_allowed(&tool.name))
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod glob_match_tests {
+    use super::glob_match;
+    use crate::openhuman::config::{Config, McpServerConfig};
+    use crate::openhuman::mcp::config_servers::McpServerRegistry;
+    use std::collections::HashMap;
+
+    #[test]
+    fn glob_covers_prefix_suffix_contains_and_bare_star() {
+        assert!(glob_match("tinyplace_*", "tinyplace_trade"));
+        assert!(!glob_match("tinyplace_*", "trading_tinyplace"));
+        assert!(glob_match("*_admin", "mcp_admin"));
+        assert!(!glob_match("*_admin", "admin_mcp"));
+        assert!(glob_match("*place*", "tinyplace_trade"));
+        assert!(glob_match("*", "anything"));
+        assert!(glob_match("exact", "exact"));
+        assert!(!glob_match("exact", "exact_other"));
+    }
+
+    #[test]
+    fn is_tool_allowed_honours_globs_on_both_lists() {
+        let mut config = Config::default();
+        config.mcp_client.servers.push(McpServerConfig {
+            name: "t".into(),
+            endpoint: "https://example.com/mcp".into(),
+            command: String::new(),
+            args: Vec::new(),
+            env: HashMap::new(),
+            cwd: None,
+            description: None,
+            enabled: true,
+            allowed_tools: vec!["tinyplace_*".into()],
+            disallowed_tools: vec!["*_dangerous".into()],
+            timeout_secs: 5,
+            auth: crate::openhuman::config::McpAuthConfig::None,
+        });
+        let registry = McpServerRegistry::from_config(&config);
+        let def = registry.get("t").expect("server t");
+        assert!(def.is_tool_allowed("tinyplace_trade"));
+        assert!(!def.is_tool_allowed("trading_dangerous"));
+        // Empty allow-list means "everything except the denied patterns".
+        let mut config_all = config.clone();
+        config_all.mcp_client.servers[0].allowed_tools.clear();
+        let binding = McpServerRegistry::from_config(&config_all);
+        let def_all = binding.get("t").unwrap();
+        assert!(def_all.is_tool_allowed("mcp_anything"));
+        assert!(!def_all.is_tool_allowed("tiny_dangerous"));
     }
 }
 


### PR DESCRIPTION
Two agent definitions shipped in this repository configure a deny rule that
never fires:

```toml
disallowed_tools = ["tinyplace_*"]
```

The comment above it in `tools_agent/agent.toml` explains the intent:

> Specialist-owned trading/tiny.place tools are also stripped via
> `disallowed_tools` above so they route through their dedicated agents
> exclusively.

No tool is literally named `tinyplace_*`, so nothing is stripped. The generalist
keeps the second, weaker route to those capabilities that the comment says it
should not have. The configuration reads as if a boundary exists; there is none.


Both places that resolve these lists compare with `==`:

```rust
// src/openhuman/mcp/config_servers/registry.rs — McpServerDefinition::is_tool_allowed
if self.disallowed_tools.iter().any(|name| name == tool) {
    return false;
}
self.allowed_tools.is_empty() || self.allowed_tools.iter().any(|name| name == tool)
```

```rust
// src/openhuman/agent/library/ops.rs:96 — direct_tool_names
names.retain(|name| !def.disallowed_tools.contains(name));
```

`normalize_tool_names` trims and de-duplicates the configured entries but does
not interpret them, so `tinyplace_*` survives into the comparison as a literal
string and matches nothing.

There is a second, less visible consequence. An allow-list can by definition not
contain a tool that does not exist yet. Any MCP server whose tool set is not
fixed at configuration time — one that lets an agent register a tool during a
session — cannot be constrained: the operator's only options are an empty list
("every tool, forever") or a list that quietly goes stale.


Add `tool_pattern_matches(pattern, tool)` and use it at both sites.

* A pattern containing no `*` compares exactly, as today. Every existing
  configuration keeps the meaning it has now.
* `*` stands for any run of characters. `tinyplace_*` (prefix), `*_read`
  (suffix), `browser_*_click` (middle) and a bare `*` all work.
* Deliberately **not** a regular expression. These lists are written by
  operators in `agent.toml`, and `*` is the character they already reach for; a
  regex would silently reinterpret `.` and `+` in existing names.

Six tests, including the shipped `tinyplace_*` case and one through
`McpServerRegistry` that pins the resolution order (a deny pattern beats an allow
pattern, and a tool name that did not exist when the allow-list was written is
still covered by `docs_*`).


Once globs work, the two `tinyplace_*` deny entries **start stripping**. That is
what the configuration and its comment ask for, but it is not a no-op: agents
that today reach tiny.place tools through the generalist will stop being able to,
and will route through their dedicated agents as intended.

If you would rather land the matcher without changing what those two agent
definitions do, the alternative is to keep the code change and replace the two
patterns with the explicit list of tool names — but then the comment above them
should say that the list has to be maintained by hand.