### PR TITLE
fix(composio): require approval for agent writes

### DIFF
--- a/src/openhuman/agent/tinyagents/middleware_part_02.rs
+++ b/src/openhuman/agent/tinyagents/middleware_part_02.rs
@@ -251,6 +251,32 @@ impl Middleware<()> for ToolOutputMiddleware {
 /// letting it short-circuit cleanly. Tool-*internal* security (path/command
 /// policy via `live_policy`) stays inside each tool — it needs tool-specific
 /// operation semantics the harness boundary can't reconstruct generically.
+const COMPOSIO_EXECUTE_TOOL: &str = "composio_execute";
+const INVALID_COMPOSIO_APPROVAL_NAME: &str = "composio_execute:<invalid-action>";
+
+/// Stable identity used by persistent approval grants.
+///
+/// `composio_execute` multiplexes every Composio action through one outer tool
+/// name. Keying "Always allow" by that name would let approval for one action
+/// authorize every later action, so use the namespaced action slug instead.
+fn approval_tool_name<'a>(
+    tool_name: &'a str,
+    args: &'a serde_json::Value,
+) -> std::borrow::Cow<'a, str> {
+    if tool_name != COMPOSIO_EXECUTE_TOOL {
+        return std::borrow::Cow::Borrowed(tool_name);
+    }
+    let slug = args
+        .get("tool")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|slug| !slug.is_empty());
+    match slug {
+        Some(slug) => std::borrow::Cow::Owned(format!("{COMPOSIO_EXECUTE_TOOL}:{slug}")),
+        None => std::borrow::Cow::Borrowed(INVALID_COMPOSIO_APPROVAL_NAME),
+    }
+}
+
 pub(super) struct ApprovalSecurityMiddleware {
     /// The same `Arc`-shared tool sets the runner registers, used to resolve a
     /// call's OpenHuman `Tool` by name so `external_effect_with_args` can gate.
@@ -298,14 +324,16 @@ impl ToolMiddleware<()> for ApprovalSecurityMiddleware {
         );
         if has_ext {
             if let Some(gate) = ApprovalGate::try_global() {
+                let approval_name = approval_tool_name(&call.name, &call.arguments);
                 tracing::debug!(
                     tool = %call.name,
+                    approval_name = %approval_name,
                     "[tinyagents::mw] routing external-effect tool through approval gate"
                 );
                 let summary = summarize_action(&call.name, &call.arguments);
                 let redacted = redact_args(&call.arguments);
                 let (outcome, request_id) =
-                    gate.intercept_audited(&call.name, &summary, redacted).await;
+                    gate.intercept_audited(approval_name.as_ref(), &summary, redacted).await;
                 match outcome {
                     GateOutcome::Deny { reason } => {
                         tracing::warn!(

--- a/src/openhuman/agent/tinyagents/middleware_tests_part_02_tests.rs
+++ b/src/openhuman/agent/tinyagents/middleware_tests_part_02_tests.rs
@@ -541,6 +541,29 @@ fn approval_external_effect_resolution_walks_the_tool_sets() {
     assert!(!mw.has_external_effect("missing", &json!({})));
 }
 
+#[test]
+fn approval_identity_scopes_composio_dispatcher_grants_to_one_action() {
+    assert_eq!(
+        approval_tool_name(
+            "composio_execute",
+            &json!({ "tool": "  GMAIL_SEND_EMAIL  " })
+        ),
+        "composio_execute:GMAIL_SEND_EMAIL"
+    );
+    assert_eq!(
+        approval_tool_name("composio_execute", &json!({ "tool": "GMAIL_DELETE_EMAIL" })),
+        "composio_execute:GMAIL_DELETE_EMAIL"
+    );
+    assert_eq!(
+        approval_tool_name("composio_execute", &json!({})),
+        "composio_execute:<invalid-action>"
+    );
+    assert_eq!(
+        approval_tool_name("send_email", &json!({ "tool": "ignored" })),
+        "send_email"
+    );
+}
+
 #[tokio::test]
 async fn memory_write_without_index_read_gets_a_corrective_note() {
     let mw = MemoryProtocolMiddleware::new();

--- a/src/openhuman/integrations/composio/action_tool.rs
+++ b/src/openhuman/integrations/composio/action_tool.rs
@@ -148,6 +148,10 @@ impl Tool for ComposioActionTool {
         PermissionLevel::Write
     }
 
+    fn external_effect(&self) -> bool {
+        super::tools::action_mutates_external_state(&self.action_name)
+    }
+
     fn category(&self) -> ToolCategory {
         ToolCategory::Workflow
     }

--- a/src/openhuman/integrations/composio/action_tool_tests.rs
+++ b/src/openhuman/integrations/composio/action_tool_tests.rs
@@ -96,6 +96,25 @@ fn display_label_is_human_and_detail_pulls_recipient() {
     );
 }
 
+#[test]
+fn per_action_tool_requires_approval_for_external_writes_only() {
+    let write = ComposioActionTool::new(
+        fake_config(),
+        "GMAIL_SEND_EMAIL".to_string(),
+        "send".to_string(),
+        None,
+    );
+    let read = ComposioActionTool::new(
+        fake_config(),
+        "GMAIL_FETCH_EMAILS".to_string(),
+        "fetch".to_string(),
+        None,
+    );
+
+    assert!(write.external_effect_with_args(&serde_json::Value::Null));
+    assert!(!read.external_effect_with_args(&serde_json::Value::Null));
+}
+
 #[tokio::test]
 async fn sandbox_read_only_blocks_per_action_write_call() {
     let t = ComposioActionTool::new(

--- a/src/openhuman/integrations/composio/tools_part_01.rs
+++ b/src/openhuman/integrations/composio/tools_part_01.rs
@@ -47,6 +47,11 @@ enum ToolDecision {
 /// blocking rather than letting a potentially-mutating action slip
 /// through uncategorised.
 pub(super) async fn resolve_action_scope(slug: &str) -> ToolScope {
+    resolve_action_scope_sync(slug)
+}
+
+/// Synchronous core used by policy hooks that cannot await.
+fn resolve_action_scope_sync(slug: &str) -> ToolScope {
     let Some(toolkit) = toolkit_from_slug(slug) else {
         return ToolScope::Write;
     };
@@ -57,6 +62,14 @@ pub(super) async fn resolve_action_scope(slug: &str) -> ToolScope {
         }
     }
     classify_unknown(slug)
+}
+
+/// Whether an action must pass through the human approval gate.
+pub(super) fn action_mutates_external_state(slug: &str) -> bool {
+    matches!(
+        resolve_action_scope_sync(slug),
+        ToolScope::Write | ToolScope::Admin
+    )
 }
 
 /// Decide whether a Composio action slug should be visible / executable

--- a/src/openhuman/integrations/composio/tools_part_03.rs
+++ b/src/openhuman/integrations/composio/tools_part_03.rs
@@ -36,6 +36,17 @@ impl Tool for ComposioExecuteTool {
         // as write-level to respect channel permission caps.
         PermissionLevel::Write
     }
+    fn external_effect(&self) -> bool {
+        true
+    }
+    fn external_effect_with_args(&self, args: &Value) -> bool {
+        args.get("tool")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|slug| !slug.is_empty())
+            .map(action_mutates_external_state)
+            .unwrap_or(true)
+    }
     fn category(&self) -> ToolCategory {
         ToolCategory::Workflow
     }

--- a/src/openhuman/integrations/composio/tools_tests_part_01_tests.rs
+++ b/src/openhuman/integrations/composio/tools_tests_part_01_tests.rs
@@ -241,6 +241,23 @@ fn execute_tool_requires_tool_argument() {
     assert_eq!(required, vec!["tool"]);
 }
 
+#[test]
+fn execute_tool_requires_approval_for_external_writes_only() {
+    let tool = ComposioExecuteTool::new(fake_config_arc());
+
+    assert!(tool.external_effect_with_args(&serde_json::json!({
+        "tool": "GMAIL_SEND_EMAIL"
+    })));
+    assert!(tool.external_effect_with_args(&serde_json::json!({
+        "tool": "GMAIL_DELETE_EMAIL"
+    })));
+    assert!(!tool.external_effect_with_args(&serde_json::json!({
+        "tool": "GMAIL_FETCH_EMAILS"
+    })));
+    assert!(tool.external_effect_with_args(&serde_json::json!({})));
+    assert!(tool.external_effect_with_args(&serde_json::json!({ "tool": "  " })));
+}
+
 #[tokio::test]
 async fn execute_tool_execute_rejects_missing_tool() {
     let t = ComposioExecuteTool::new(fake_config_arc());


### PR DESCRIPTION
## Summary

- Gate Composio `Write` and `Admin` actions through the existing human approval middleware.
- Cover both agent-facing execution surfaces: `composio_execute` and dynamically registered `ComposioActionTool` instances.
- Keep curated read actions unprompted and fail closed when the dispatcher receives a missing or blank action slug.

## Problem

Composio tools declared `PermissionLevel::Write`, but neither tool surface declared an external effect. Permission caps and interactive approval are separate contracts: `ApprovalSecurityMiddleware` consults `external_effect_with_args`, whose inherited default was `false`.

As a result, agent-driven external writes such as `GMAIL_SEND_EMAIL` could execute without showing the configured approval card.

## Solution

Reuse the existing static `ToolScope` classifier as the single source of truth:

- `Write` and `Admin` actions report an external effect.
- `Read` actions do not.
- The generic dispatcher inspects its `tool` argument and defaults to effectful for malformed input.
- Per-action tools classify their fixed action slug.

This keeps the production change small and avoids a second action-classification table.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/ci-lite.yml`](../.github/workflows/ci-lite.yml). Focused branch coverage is present; the authoritative CI gate is pending.
- [x] Coverage matrix updated — N/A: behavior-only correction to existing approval-gate features; no feature row changed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: core tool-policy metadata only.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Security:** Composio writes now honor the existing interactive human-approval policy.
- **Compatibility:** Read-only actions remain unprompted; dispatch, schemas, provider calls, and stored responses are unchanged.
- **Platforms:** Shared Rust core behavior for desktop/CLI agent execution.
- **Performance:** One static catalog lookup or slug heuristic per approval check; no I/O and no new allocation path beyond existing classification.

## Related

- Closes #5862
- Related: #5299
- Affected coverage IDs: 4.4.3, 4.4.4, 4.4.5, 4.4.6
- Follow-up PR(s)/TODOs: #5299 retains the separate provider-response shaping work.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A — tracked in GitHub issue #5862.
- URL: N/A

### Commit & Branch

- Branch: `fix/5299-composio-write-approval`
- Commit SHA: `c86b738aad182c6d4084aba24aae0714258473bc`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `scripts/ci-cancel-aware.sh cargo test --manifest-path Cargo.toml --lib requires_approval_for_external_writes_only -- --nocapture` — 2 passed. `approval_identity_scopes_composio_dispatcher_grants_to_one_action` — 1 passed.
- [x] Rust fmt/check (if changed): `cargo fmt --all -- --check`; contributor and product-feature root Clippy lanes both passed with `-D warnings`.
- [x] Tauri fmt/check (if changed): N/A — no Tauri source or manifest changed; formatting passed.

Additional checks:

- `approval_external_effect_resolution_walks_the_tool_sets` — passed.
- `node scripts/ci/check-feature-forwarding.mjs` — passed.
- Full Composio unit scope — 398 passed; 2 current-main failures described below.

### Validation Blocked

- `cargo test --manifest-path Cargo.toml --lib 'openhuman::integrations::composio::'`: two existing tests fail independently of this patch (`composio_list_capabilities_does_not_require_session` expects a curated Google Calendar capability; `composio_execute_via_mock_propagates_backend_error` expects an older error string). Neither calls the changed approval classifier; the two focused regression tests pass.
- `pnpm --filter openhuman-app rust:clippy`: current `main` points the Tauri manifest at `vendor/tinyagents`, whose refreshed pinned commit is now a virtual workspace manifest. Cargo exits before compiling this patch. No Tauri files changed.
- Impact: branch-specific root Rust compilation, both root Clippy feature lanes, typecheck, formatting, and focused behavior are verified; CI remains authoritative for the repository-wide gates.

### Behavior Changes

- Intended behavior change: interactive agent calls to Composio write/admin actions produce an approval request before execution.
- User-visible effect: sending email, deleting external data, and similar mutations pause for confirmation; fetch/list actions continue directly.

### Parity Contract

- Legacy behavior preserved: action scope classification, read behavior, sandbox enforcement, dispatch arguments, and response handling.
- Guard/fallback/dispatch parity checks: dispatcher and per-action surfaces share one classifier; unknown/missing dispatcher slugs fail closed.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): #5259 contains an older, now-conflicting approval implementation plus separate response reshaping.
- Canonical PR: this PR for the focused approval-gate fix on current `main`.
- Resolution (closed/superseded/updated): supersedes only #5259's approval slice; #5259 is not closed here because its response-shaping scope remains distinct.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of whether Composio actions can modify external data.
  * External write and administrative actions now require approval, while read-only actions can proceed without it.
  * Unrecognized or incomplete action identifiers default to requiring approval for safer execution.

* **Bug Fixes**
  * “Always allow” approvals are now scoped to individual Composio actions, preventing unintended access to other actions.

* **Tests**
  * Added coverage for read, write, delete, invalid, and approval-scoping scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

