### PR TITLE
fix(tauri): resolve the shell Cargo world after the tinyagents workspace split

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -426,7 +426,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.7",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite 0.29.0",
@@ -4330,7 +4330,11 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror 2.0.20",
- "tinyagents",
+ "tinyagents-graph",
+ "tinyagents-harness",
+ "tinyagents-language",
+ "tinyagents-registry",
+ "tinyagents-session",
  "tinybus",
  "tinychannels",
  "tinychannels-bus",
@@ -4344,6 +4348,7 @@ dependencies = [
  "tinyflows-sqlite",
  "tinyhosts",
  "tinyhumans-sdk",
+ "tinyinference",
  "tinyjuice-bus",
  "tinymcp",
  "tinymcp-bus",
@@ -4351,6 +4356,7 @@ dependencies = [
  "tinymemory-api",
  "tinymemory-bus",
  "tinymemory-core",
+ "tinymemory-sources",
  "tinymemory-tinycortex",
  "tinyruntime-bus",
  "tinytools",
@@ -5925,6 +5931,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6896,8 +6913,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyagents"
-version = "2.1.1"
+name = "tinyagents-graph"
+version = "2.1.2"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures",
+ "reqwest 0.12.28",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "tinyagents-harness",
+ "tinyagents-language",
+ "tinyagents-tracing",
+ "tinyinference",
+ "tokio",
+]
+
+[[package]]
+name = "tinyagents-harness"
+version = "2.1.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6912,14 +6948,52 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.20",
+ "tinyagents-tracing",
+ "tinyinference",
  "tinytools",
  "tokio",
- "tracing",
 ]
 
 [[package]]
+name = "tinyagents-language"
+version = "2.1.2"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tinyagents-harness",
+]
+
+[[package]]
+name = "tinyagents-registry"
+version = "2.1.2"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tinyagents-graph",
+ "tinyagents-harness",
+ "tinyagents-language",
+ "tinyinference",
+]
+
+[[package]]
+name = "tinyagents-session"
+version = "2.1.2"
+dependencies = [
+ "chrono",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tinyagents-harness",
+ "tinyagents-tracing",
+]
+
+[[package]]
+name = "tinyagents-tracing"
+version = "2.1.2"
+
+[[package]]
 name = "tinybox-core"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "serde",
@@ -6928,7 +7002,7 @@ dependencies = [
 
 [[package]]
 name = "tinybox-docker"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "tinybox-core",
@@ -6936,7 +7010,7 @@ dependencies = [
 
 [[package]]
 name = "tinybox-host"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "tinybox-core",
@@ -6945,7 +7019,7 @@ dependencies = [
 
 [[package]]
 name = "tinybox-ssh"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "tinybox-core",
@@ -6954,7 +7028,7 @@ dependencies = [
 
 [[package]]
 name = "tinybus"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "flate2",
@@ -6973,7 +7047,7 @@ dependencies = [
 
 [[package]]
 name = "tinybus-macros"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6982,7 +7056,7 @@ dependencies = [
 
 [[package]]
 name = "tinychannels"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-imap",
@@ -7007,7 +7081,7 @@ dependencies = [
  "schemars 1.2.2",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.10.7",
  "sha2 0.10.9",
  "thiserror 2.0.20",
  "tinychannels-bus",
@@ -7023,7 +7097,7 @@ dependencies = [
 
 [[package]]
 name = "tinychannels-bus"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7045,7 +7119,7 @@ dependencies = [
 
 [[package]]
 name = "tinyconnectors-bus"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -7053,13 +7127,13 @@ dependencies = [
 
 [[package]]
 name = "tinycortex"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
  "block2 0.6.2",
  "chrono",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "futures",
  "log",
  "objc2 0.6.4",
@@ -7075,8 +7149,8 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "thiserror 2.0.20",
- "tinyagents",
  "tinycortex-api",
+ "tinyinference",
  "tokio",
  "toml 1.1.4+spec-1.1.0",
  "tracing",
@@ -7093,7 +7167,7 @@ dependencies = [
 
 [[package]]
 name = "tinydocs-bus"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "serde",
  "thiserror 2.0.20",
@@ -7101,7 +7175,7 @@ dependencies = [
 
 [[package]]
 name = "tinyflows"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -7155,16 +7229,16 @@ dependencies = [
 
 [[package]]
 name = "tinyhosts"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.1",
  "hex",
  "percent-encoding",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.11.0",
  "thiserror 2.0.20",
 ]
 
@@ -7184,26 +7258,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyinference"
+version = "0.2.1"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "httpdate",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.20",
+ "tokio",
+]
+
+[[package]]
 name = "tinyjuice-bus"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "tinymcp"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
- "dirs 5.0.1",
+ "base64 0.23.1",
+ "dirs 6.0.0",
  "futures-util",
  "parking_lot",
  "reqwest 0.12.28",
  "rusqlite",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "thiserror 2.0.20",
  "tinymcp-bus",
  "tokio",
@@ -7213,7 +7303,7 @@ dependencies = [
 
 [[package]]
 name = "tinymcp-bus"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "schemars 1.2.2",
  "serde",
@@ -7222,7 +7312,7 @@ dependencies = [
 
 [[package]]
 name = "tinymemory"
-version = "1.13.3"
+version = "1.13.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7277,9 +7367,9 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.20",
- "tinyagents",
  "tinycortex",
  "tinycortex-api",
+ "tinyinference",
  "tinymemory-api",
  "tinymemory-sources",
  "tinymemory-sync",
@@ -7342,7 +7432,7 @@ dependencies = [
 
 [[package]]
 name = "tinyruntime-bus"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "serde",
  "serde_json",
@@ -7392,7 +7482,7 @@ dependencies = [
 
 [[package]]
 name = "tinywallet-bus"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "bech32",
@@ -7789,7 +7879,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.8",
- "sha1",
+ "sha1 0.10.7",
  "thiserror 1.0.69",
  "utf-8",
 ]
@@ -7809,7 +7899,7 @@ dependencies = [
  "rand 0.9.5",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.7",
  "thiserror 2.0.20",
 ]
 

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -263,6 +263,11 @@ e2e-test-support = ["openhuman_core/e2e-test-support"]
 [patch."https://github.com/tinyhumansai/tinymemory"]
 tinymemory-api = { path = "../../vendor/tinymemory/crates/tinymemory-api" }
 
+[patch."https://github.com/tinyhumansai/tinyinference"]
+# tinycortex depends on tinyinference by git rev; without this the shell world
+# resolves TWO copies of the same types. Mirrors root Cargo.toml:1345.
+tinyinference = { path = "../../vendor/tinyagents/vendor/tinyinference/crates/tinyinference" }
+
 [patch.crates-io]
 # Keep reqwest defaults disabled in this independent Cargo world too. Without
 # this patch, the registry release reintroduces native-tls/OpenSSL on Linux.
@@ -270,11 +275,14 @@ motosan-ai-oauth = { path = "../../vendor/motosan-ai-oauth" }
 # TinyAgents vendored submodule (repo-root vendor/tinyagents, pinned at the
 # released tag) — same patch as the root Cargo world so both resolve the
 # in-tree SDK source. `git submodule update --init vendor/tinyagents` first.
-tinyagents = { path = "../../vendor/tinyagents" }
+# tinyagents is a workspace now — no patch entry (mirrors root Cargo.toml)
 # TinyTools rides in through tinyagents' own vendored checkout. The path must
 # match the one the core crate names, or cargo resolves two distinct packages
 # and the shell's `dyn Tool` stops being the core's. See the core manifest.
 tinytools = { path = "../../vendor/tinyagents/vendor/tinytools/crates/tinytools" }
+# tinymemory-core declares `tinyinference = "0.2"` (crates-io-shaped, unpublished),
+# so this world must patch it exactly as the root manifest does.
+tinyinference = { path = "../../vendor/tinyagents/vendor/tinyinference/crates/tinyinference" }
 # TinyFlows, TinyCortex, and TinyChannels are vendored beside
 # TinyAgents so integration work can test crate changes against OpenHuman before
 # publishing.


### PR DESCRIPTION
## Summary

- Restores dependency resolution for the `app/src-tauri` Cargo world, which has been broken since the `tinyagents` workspace split.
- Fixes the failure that stopped **Release Production run [33388976988](https://github.com/tinyhumansai/openhuman/actions/runs/33388976988)** (v0.63.18 → v0.63.19) in *Prepare build context → Refresh Cargo.lock files*.
- Brings the shell's patch table into line with the root manifest: drops the dead `tinyagents` entry and adds the two `tinyinference` patches the root already carries.
- Regenerates `app/src-tauri/Cargo.lock` using the same command the release step runs. The root `Cargo.lock` is unchanged.

## Problem

`vendor/tinyagents` is now a **virtual manifest** — `[workspace] members = ["crates/*"]`, no `[package]`. The root `Cargo.toml` was migrated to name the five member crates individually (`:200-209`), which is why the root world still resolves. `app/src-tauri/Cargo.toml:273` was left patching the workspace root as though it were a package, so that world stopped resolving entirely:

```
$ cargo update --workspace --manifest-path Cargo.toml               # exit 0
$ cargo update --workspace --manifest-path app/src-tauri/Cargo.toml # exit 101
error: failed to load source for dependency `tinyagents`
Caused by: found a virtual manifest at .../vendor/tinyagents/Cargo.toml
           instead of a package manifest
```

Nothing catches this today. `Rust Tauri Coverage` is skipped on these commits, no desktop bundle job runs on pushes to `main`, and `Feature Forwarding Gate` passes because it validates the shell's **feature list**, not whether the manifest resolves. The first thing to actually exercise it was the release.

`release` and `main` are both at `1904382d2`, so the promote carried this across; this one change covers both.

## Solution

Three changes, each mirroring what the root manifest already does and documents at `Cargo.toml:11-34`:

1. **Drop the `tinyagents` patch entry.** There is no `tinyagents` package to patch any more, and a path dependency already points at this checkout. The root removed this exact line for this exact reason.
2. **Patch `tinyinference` in `[patch.crates-io]`.** `tinymemory-core` declares `tinyinference = "0.2"` — a crates-io-shaped requirement for a crate that is not published — so this world cannot resolve without it.
3. **Patch `tinyinference` again under `[patch."https://github.com/tinyhumansai/tinyinference"]`.** `tinycortex` takes it by git rev. Without this the shell lockfile resolves **two** distinct `tinyinference` packages where the root resolves one — the "one checkout, one type identity" hazard the root manifest warns about, which would surface later as `expected ChatModel, found ChatModel` rather than as a resolution error.

Change 3 is the non-obvious one: with only 1 and 2 the release step goes green, but the desktop build would then fail confusingly. Verified after the fix: the shell lock holds exactly one `tinyinference`, matching the root.

**Suggested follow-up (not in this PR):** a cheap CI gate running `cargo metadata` on *both* manifests would have caught this at the PR that introduced it, and costs seconds.

## Submission Checklist

- [x] `N/A: manifest + lockfile change only — no executable code paths added or altered.` The behavioural test is the release step's own command; see Validation Run.
- [x] `N/A: diff coverage does not apply` — the changed lines are TOML manifest and generated lockfile entries, which carry no coverage.
- [x] `N/A: behaviour-only change` — no feature rows added, removed or renamed in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] `N/A: no feature IDs affected` — build-graph fix, no product feature touched.
- [x] No new external network dependencies introduced — all three patch entries redirect to in-tree vendored paths, which *reduces* external resolution (`tinyinference` no longer attempted from crates.io / git).
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no user-facing surface changes.` This fixes the release *pipeline*, not anything a smoke test drives.
- [x] `N/A: no linked issue` — found while diagnosing the failed release run; fixed directly rather than filed.

## Impact

- **Platform:** desktop (`app/src-tauri`) only. Restores the ability to resolve, and therefore to build and release, the desktop app.
- **Release:** unblocks Release Production. The failed run aborted before *Ensure tag does not already exist* and *Commit and push version bump*, so no tag or version bump was pushed and no cleanup is required.
- **Compatibility:** no behaviour change. Resolution now matches the root world, which is the intended invariant for the two Cargo worlds.
- **Risk if wrong:** confined to build-graph resolution; a mistake here fails loudly at `cargo metadata`/`cargo update` rather than shipping.

## Related

- Closes:
- Follow-up PR(s)/TODOs: add a CI gate running `cargo metadata` against both `Cargo.toml` and `app/src-tauri/Cargo.toml`, so shell-world resolution is checked on every PR.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/shell-cargo-world-tinyagents-split`
- Commit SHA: see head of this PR

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no JS/TS/CSS files changed.`
- [x] `pnpm typecheck` — `N/A: no TypeScript changed.`
- [x] Focused tests: **the exact commands the failing release step runs.** `cargo update --workspace --manifest-path Cargo.toml` → exit 0; `cargo update --workspace --manifest-path app/src-tauri/Cargo.toml` → **exit 101 before, exit 0 after**. Also `cargo metadata --format-version 1` on both manifests → exit 0. Duplicate check: `tinyinference` entries in `app/src-tauri/Cargo.lock` went 2 → 1, matching the root lock.
- [x] Rust fmt/check (if changed): `N/A: no .rs files changed.`
- [x] Tauri fmt/check (if changed): `N/A: no .rs files changed` — only `app/src-tauri/Cargo.toml` and its lockfile.

### Validation Blocked

- `command:` full `cargo build`/`tauri build` of the desktop app
- `error:` not attempted
- `impact:` this PR is verified to the point of **dependency resolution**, which is exactly where the release failed. A full desktop compile was not run, so a later compile-stage problem is not excluded — though the duplicate-`tinyinference` check above is specifically the type-identity failure such a build would hit.

### Behavior Changes

- Intended behavior change: none at runtime; the shell Cargo world resolves again.
- User-visible effect: none directly. Indirectly, desktop releases can be cut again.

### Parity Contract

- Legacy behavior preserved: yes — the two Cargo worlds are meant to resolve the same vendored sources, and this restores that invariant rather than changing it.
- Guard/fallback/dispatch parity checks: shell patch table now mirrors the root's treatment of `tinyagents`/`tinytools`/`tinyinference`; verified by comparing resolved `tinyinference` package counts across both lockfiles (1 and 1).

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none found
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution for TinyInference.
  * Adjusted TinyAgents workspace configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->