### PR TITLE
test: cover the eight uncovered agent, approval and memory controllers

### DIFF
--- a/app/src/components/settings/panels/AgentsPanel.test.tsx
+++ b/app/src/components/settings/panels/AgentsPanel.test.tsx
@@ -195,10 +195,21 @@ describe('AgentsPanel', () => {
     expect(mockList).toHaveBeenCalledTimes(1);
   });
 
-  it('never calls setEnabled for the orchestrator', async () => {
-    // `handleToggle` early-returns on ORCHESTRATOR_ID (line 56) *and* the row
-    // renders its switch disabled. Asserting only `toBeDisabled()` would pass
-    // if the guard were deleted, so drive the handler directly too.
+  it('renders the orchestrator switch disabled so it cannot be toggled', async () => {
+    // Scope correction, from review: an earlier version of this case claimed to
+    // cover `handleToggle`'s ORCHESTRATOR_ID early-return (AgentsPanel.tsx:56)
+    // by clicking the switch as well as asserting it disabled. It does not —
+    // `AgentRow` renders the orchestrator's SettingsSwitch `disabled`, so the
+    // click never reaches the handler and removing the guard alone would not
+    // fail this test.
+    //
+    // My revert-proof did not catch that because the mutation removed the guard
+    // AND the `disabled` prop together, so the case went red for the second
+    // reason. A fault that changes two things proves neither individually.
+    //
+    // What this case honestly covers is the disabled control, which is the
+    // user-facing protection; the handler guard behind it is defence in depth
+    // and would need an enabled seam to exercise. Renamed to say so.
     renderPanel();
     await waitFor(() => expect(screen.getByText('Orchestrator')).toBeInTheDocument());
 

--- a/app/src/components/settings/panels/AgentsPanel.test.tsx
+++ b/app/src/components/settings/panels/AgentsPanel.test.tsx
@@ -34,6 +34,7 @@ vi.mock('../hooks/useSettingsNavigation', () => ({
 
 const mockList = vi.mocked(agentRegistryApi.list);
 const mockSetEnabled = vi.mocked(agentRegistryApi.setEnabled);
+const mockRemove = vi.mocked(agentRegistryApi.remove);
 
 const renderPanel = () =>
   render(
@@ -115,5 +116,97 @@ describe('AgentsPanel', () => {
     mockList.mockRejectedValueOnce(new Error('boom'));
     renderPanel();
     await waitFor(() => expect(screen.getByText(/Couldn't load agents/)).toBeInTheDocument());
+  });
+  // --- Paths the original five cases left uncovered -----------------------
+  //
+  // Coverage before these: 79.03% stmts / 62.50% branch, with lines 65-66
+  // (the toggle failure branch), 77-87 (`handleRemove` in full) and 131 (its
+  // wiring) unexecuted. `handleRemove` is the destructive action on this
+  // panel and had no test at all.
+
+  it('surfaces the API error message when a toggle fails', async () => {
+    // The catch branch prefers `err.message` over the generic i18n fallback,
+    // so a caller sees *why* it failed rather than "Couldn't update the agent".
+    mockSetEnabled.mockRejectedValueOnce(new Error('registry is read-only'));
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('Researcher')).toBeInTheDocument());
+
+    fireEvent.click(screen.getAllByRole('switch')[1]);
+
+    await waitFor(() => expect(screen.getByText('registry is read-only')).toBeInTheDocument());
+    // The row must not be left stuck in its busy state after a failure.
+    await waitFor(() => expect(screen.getAllByRole('switch')[1]).not.toBeDisabled());
+  });
+
+  it('falls back to the generic message when a toggle rejects a non-Error', async () => {
+    // `err instanceof Error` is the branch under test: a string rejection
+    // must not render "undefined" into the banner.
+    mockSetEnabled.mockRejectedValueOnce('nope');
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('Researcher')).toBeInTheDocument());
+
+    fireEvent.click(screen.getAllByRole('switch')[1]);
+
+    await waitFor(() => expect(screen.getByText("Couldn't update the agent")).toBeInTheDocument());
+  });
+
+  it('deletes a custom agent and reloads the list', async () => {
+    mockRemove.mockResolvedValue(true);
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('Finance')).toBeInTheDocument());
+
+    // Built-ins offer "Reset to default"; only the custom agent offers Delete.
+    const deleteButtons = screen.getAllByRole('button', { name: /^Delete$/ });
+    expect(deleteButtons).toHaveLength(1);
+    fireEvent.click(deleteButtons[0]);
+
+    await waitFor(() => expect(mockRemove).toHaveBeenCalledWith('finance'));
+    // `handleRemove` re-runs `load()` rather than patching state locally, so a
+    // reset built-in comes back with its server-side defaults.
+    await waitFor(() => expect(mockList).toHaveBeenCalledTimes(2));
+  });
+
+  it('resets a built-in agent through the same remove endpoint', async () => {
+    // Built-ins are not deleted — the panel labels the action "Reset to
+    // default" but routes it through `remove`, which restores the shipped
+    // definition. Worth pinning: the label and the call diverge on purpose.
+    mockRemove.mockResolvedValue(true);
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('Researcher')).toBeInTheDocument());
+
+    const resetButtons = screen.getAllByRole('button', { name: /Reset to default/ });
+    // orchestrator + researcher are both built-in.
+    expect(resetButtons).toHaveLength(2);
+    fireEvent.click(resetButtons[1]);
+
+    await waitFor(() => expect(mockRemove).toHaveBeenCalledWith('researcher'));
+  });
+
+  it('shows an error and stops reloading when a delete fails', async () => {
+    mockRemove.mockRejectedValueOnce(new Error('agent is in use'));
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('Finance')).toBeInTheDocument());
+
+    fireEvent.click(screen.getAllByRole('button', { name: /^Delete$/ })[0]);
+
+    await waitFor(() => expect(screen.getByText('agent is in use')).toBeInTheDocument());
+    // A failed remove must NOT reload: reloading would redraw the row as if
+    // nothing happened and drop the error the user needs to read.
+    expect(mockList).toHaveBeenCalledTimes(1);
+  });
+
+  it('never calls setEnabled for the orchestrator', async () => {
+    // `handleToggle` early-returns on ORCHESTRATOR_ID (line 56) *and* the row
+    // renders its switch disabled. Asserting only `toBeDisabled()` would pass
+    // if the guard were deleted, so drive the handler directly too.
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('Orchestrator')).toBeInTheDocument());
+
+    const orchestratorSwitch = screen.getAllByRole('switch')[0];
+    expect(orchestratorSwitch).toBeDisabled();
+    fireEvent.click(orchestratorSwitch);
+
+    await waitFor(() => expect(screen.getByText('Researcher')).toBeInTheDocument());
+    expect(mockSetEnabled).not.toHaveBeenCalled();
   });
 });

--- a/app/src/components/settings/panels/__tests__/CoreConnectionPanel.urlValidation.test.tsx
+++ b/app/src/components/settings/panels/__tests__/CoreConnectionPanel.urlValidation.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * CoreConnectionPanel — remote-URL validation, and the plain-HTTP warning.
+ *
+ * The sibling spec drives the save flow with a well-formed
+ * `https://core.example.com/rpc` every time, so `validate()`'s rejection arms
+ * were never executed (CoreConnectionPanel.tsx lines 195-208) and neither was
+ * the public-HTTP warning (225-231). That is most of why the panel sat at
+ * 80.18% branch coverage.
+ *
+ * One of those arms is a credential-leak guard, and it is the reason this file
+ * exists. The panel's own comment:
+ *
+ *   > The separate token field is the only credential path; a
+ *   > `user:pass@host` URL would be persisted and echoed back in the
+ *   > active-URL description, leaking a secret. Reject it.
+ *
+ * A regression there does not throw — it persists the password to local
+ * storage and renders it back on the settings page. That is exactly the shape
+ * of defect a test should hold in place, and it had none.
+ */
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { renderWithProviders } from '../../../../test/test-utils';
+
+const hoisted = vi.hoisted(() => ({
+  testCoreRpcConnection: vi.fn(),
+  clearCoreRpcUrlCache: vi.fn(),
+  clearCoreRpcTokenCache: vi.fn(),
+  restartApp: vi.fn(),
+  isTauriEnvironment: vi.fn(() => true),
+  invoke: vi.fn(async () => 'http://127.0.0.1:7788/rpc'),
+}));
+
+vi.mock('../../../../services/coreRpcClient', () => ({
+  testCoreRpcConnection: hoisted.testCoreRpcConnection,
+  clearCoreRpcUrlCache: hoisted.clearCoreRpcUrlCache,
+  clearCoreRpcTokenCache: hoisted.clearCoreRpcTokenCache,
+}));
+
+vi.mock('../../../../utils/tauriCommands/core', () => ({ restartApp: hoisted.restartApp }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: hoisted.invoke }));
+
+vi.mock('../../../../utils/configPersistence', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../../utils/configPersistence')>();
+  return { ...actual, isTauriEnvironment: hoisted.isTauriEnvironment };
+});
+
+function okResponse() {
+  return { ok: true, status: 200, json: async () => ({ jsonrpc: '2.0', id: 1, result: {} }) };
+}
+
+async function importPanel() {
+  const mod = await import('../CoreConnectionPanel');
+  return mod.default;
+}
+
+const URL_ERROR = 'The URL needs to start with http:// or https://';
+const INVALID_URL = "That doesn't look like a valid URL (try https://core.example.com/rpc)";
+const HTTP_WARNING =
+  'This is a plain HTTP URL on a public host: traffic will not be encrypted. Use HTTPS unless you trust this network.';
+
+/** Mount in local mode, flip the remote toggle on, and fill the form. */
+async function openRemoteForm(url: string, token = 'remote-token-xyz') {
+  hoisted.testCoreRpcConnection.mockResolvedValue(okResponse());
+  const Panel = await importPanel();
+  const rendered = renderWithProviders(<Panel />, {
+    preloadedState: { coreMode: { mode: { kind: 'local' } } },
+  });
+  await waitFor(() => expect(screen.getByText('Connected to local core')).toBeInTheDocument());
+
+  fireEvent.click(screen.getByTestId('core-use-remote-toggle'));
+  fireEvent.change(screen.getByLabelText(/Runtime URL/i), { target: { value: url } });
+  fireEvent.change(screen.getByLabelText(/Auth Token/i), { target: { value: token } });
+  return rendered;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  hoisted.testCoreRpcConnection.mockReset();
+  hoisted.clearCoreRpcUrlCache.mockReset();
+  hoisted.clearCoreRpcTokenCache.mockReset();
+  hoisted.restartApp.mockReset();
+  hoisted.restartApp.mockResolvedValue(undefined);
+  hoisted.isTauriEnvironment.mockReset();
+  hoisted.isTauriEnvironment.mockReturnValue(true);
+  hoisted.invoke.mockReset();
+  hoisted.invoke.mockResolvedValue('http://127.0.0.1:7788/rpc');
+  localStorage.clear();
+});
+
+describe('CoreConnectionPanel remote URL validation', () => {
+  test('rejects a URL carrying credentials rather than persisting the secret', async () => {
+    // The guard that matters. Saving must be refused, nothing may reach Redux,
+    // and — the part a coverage number would not tell you — the password must
+    // not appear anywhere in the rendered page.
+    const { store } = await openRemoteForm('https://admin:hunter2@core.example.com/rpc');
+
+    fireEvent.click(screen.getByTestId('core-save-btn'));
+
+    await waitFor(() => expect(screen.getByText(INVALID_URL)).toBeInTheDocument());
+    expect(hoisted.restartApp).not.toHaveBeenCalled();
+    expect(store.getState().coreMode.mode.kind).toBe('local');
+    expect(document.body.textContent).not.toContain('hunter2');
+  });
+
+  test('rejects a URL with a username but no password', async () => {
+    // `parsed.username || parsed.password` — the username-only half of the
+    // guard. Checked separately because a refactor to `&&` would still pass
+    // the case above.
+    const { store } = await openRemoteForm('https://admin@core.example.com/rpc');
+
+    fireEvent.click(screen.getByTestId('core-save-btn'));
+
+    await waitFor(() => expect(screen.getByText(INVALID_URL)).toBeInTheDocument());
+    expect(store.getState().coreMode.mode.kind).toBe('local');
+  });
+
+  test('rejects a non-HTTP protocol with the protocol-specific message', async () => {
+    // A parseable URL that is not http(s) takes the protocol arm, which has
+    // its own copy — asserting the exact string keeps the two arms distinct.
+    await openRemoteForm('ftp://core.example.com/rpc');
+
+    fireEvent.click(screen.getByTestId('core-save-btn'));
+
+    await waitFor(() => expect(screen.getByText(URL_ERROR)).toBeInTheDocument());
+    expect(hoisted.restartApp).not.toHaveBeenCalled();
+  });
+
+  test('rejects an unparseable URL', async () => {
+    // The `catch` around `new URL(...)`.
+    await openRemoteForm('http://[not a url');
+
+    fireEvent.click(screen.getByTestId('core-save-btn'));
+
+    await waitFor(() => expect(screen.getByText(INVALID_URL)).toBeInTheDocument());
+    expect(hoisted.restartApp).not.toHaveBeenCalled();
+  });
+
+  test('warns about plain HTTP to a public host', async () => {
+    // Advisory, not blocking — the warning renders as you type, before any
+    // save. It exists so a user does not silently ship an unencrypted link.
+    await openRemoteForm('http://core.example.com/rpc');
+
+    await waitFor(() => expect(screen.getByText(HTTP_WARNING)).toBeInTheDocument());
+  });
+
+  test('does not warn about plain HTTP to localhost', async () => {
+    // The whole point of `isLocalOrPrivateNetworkHost`: the common, correct
+    // case must stay quiet, or the warning becomes noise people learn to skip.
+    await openRemoteForm('http://127.0.0.1:7788/rpc');
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Runtime URL/i)).toHaveValue('http://127.0.0.1:7788/rpc')
+    );
+    expect(screen.queryByText(HTTP_WARNING)).not.toBeInTheDocument();
+  });
+
+  test('does not warn about plain HTTP to a private-network host', async () => {
+    await openRemoteForm('http://192.168.1.50:7788/rpc');
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Runtime URL/i)).toHaveValue('http://192.168.1.50:7788/rpc')
+    );
+    expect(screen.queryByText(HTTP_WARNING)).not.toBeInTheDocument();
+  });
+
+  test('does not warn about HTTPS to a public host', async () => {
+    await openRemoteForm('https://core.example.com/rpc');
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(/Runtime URL/i)).toHaveValue('https://core.example.com/rpc')
+    );
+    expect(screen.queryByText(HTTP_WARNING)).not.toBeInTheDocument();
+  });
+});

--- a/app/src/components/settings/panels/__tests__/EventLogPanel.sseConfig.test.tsx
+++ b/app/src/components/settings/panels/__tests__/EventLogPanel.sseConfig.test.tsx
@@ -50,11 +50,15 @@ function mockFetchRaw(body: string) {
   global.fetch = vi.fn().mockResolvedValue({ ok: true, body: stream });
 }
 
+// SSE frames are terminated by a BLANK line, not a single newline. The panel's
+// parser splits on '\n' and tolerates the shorter form, but a fixture that is
+// not wire-shaped would keep passing if that parser were tightened — so emit
+// real frames.
 const evt = (event: string, domain = 'tool') =>
-  `data:${JSON.stringify({ domain, event, timestamp: '12:00:00' })}\n`;
+  `data:${JSON.stringify({ domain, event, timestamp: '12:00:00' })}\n\n`;
 
 const config = (payload: Record<string, unknown>) =>
-  `event: config\ndata:${JSON.stringify(payload)}\n`;
+  `event: config\ndata:${JSON.stringify(payload)}\n\n`;
 
 /** Every rendered event label, in DOM order — nothing filtered out. */
 function allRenderedRows(): string[] {

--- a/app/src/components/settings/panels/__tests__/EventLogPanel.sseConfig.test.tsx
+++ b/app/src/components/settings/panels/__tests__/EventLogPanel.sseConfig.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * EventLogPanel — the SSE config protocol.
+ *
+ * Before the stream sends events it may send a config frame, and that frame
+ * decides two things about how the log behaves for the rest of the session:
+ * `max_entries` caps the in-memory buffer, and `new_entries` ('top' | 'bottom')
+ * decides whether arrivals prepend or append — which in turn decides which end
+ * is trimmed when the cap is hit, and where the panel scrolls.
+ *
+ * The sibling spec's `mockFetchSSE` helper only ever emits plain `data:` event
+ * lines, so none of that protocol was executed: `EventLogPanel.tsx` lines
+ * 114-117 (the `event: config` frame) and 127-131 (the config payload) were
+ * the panel's uncovered region and the reason it sat at 70.23% branch coverage.
+ *
+ * This is worth testing rather than assuming, because every failure mode here
+ * is silent. A dropped `new_entries` makes the newest event appear at the wrong
+ * end; a dropped `max_entries` lets the buffer grow past the server's cap; and
+ * trimming the wrong end throws away the events the user is actually watching.
+ * Nothing errors in any of those cases.
+ */
+import { screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from '../../../../test/test-utils';
+import EventLogPanel from '../EventLogPanel';
+
+vi.mock('../../../../services/coreRpcClient', () => ({
+  getCoreHttpBaseUrl: vi.fn().mockResolvedValue('http://localhost:9999'),
+  getCoreRpcToken: vi.fn().mockResolvedValue('test-token'),
+}));
+
+vi.mock('../../hooks/useSettingsNavigation', () => ({
+  useSettingsNavigation: () => ({ navigateBack: vi.fn(), breadcrumbs: [] }),
+}));
+
+vi.mock('../../../../lib/i18n/I18nContext', () => ({ useT: () => ({ t: (k: string) => k }) }));
+
+/**
+ * Feed the panel raw SSE text, so a test can emit config frames as well as
+ * events. The sibling helper builds `data:` lines only and cannot express this.
+ */
+function mockFetchRaw(body: string) {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(body));
+      controller.close();
+    },
+  });
+  global.fetch = vi.fn().mockResolvedValue({ ok: true, body: stream });
+}
+
+const evt = (event: string, domain = 'tool') =>
+  `data:${JSON.stringify({ domain, event, timestamp: '12:00:00' })}\n`;
+
+const config = (payload: Record<string, unknown>) =>
+  `event: config\ndata:${JSON.stringify(payload)}\n`;
+
+/** Every rendered event label, in DOM order — nothing filtered out. */
+function allRenderedRows(): string[] {
+  return Array.from(document.querySelectorAll('span.text-xs.text-content.truncate')).map(
+    el => el.textContent ?? ''
+  );
+}
+
+/**
+ * Rendered event labels restricted to the names a test seeded. Convenient for
+ * order assertions, but blind to EXTRA rows — use `allRenderedRows` whenever
+ * the point of the test is that something was not rendered.
+ */
+function renderedEvents(names: string[]): string[] {
+  return allRenderedRows().filter(text => names.includes(text));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('EventLogPanel SSE config frame', () => {
+  it('defaults to newest-first when no config frame is sent', async () => {
+    // The baseline the other cases are measured against: `newEntriesRef`
+    // starts at 'top', so B (sent second) renders above A.
+    mockFetchRaw(evt('AlphaEvent') + evt('BetaEvent'));
+    renderWithProviders(<EventLogPanel />);
+
+    await waitFor(() => expect(screen.getByText('BetaEvent')).toBeTruthy());
+    expect(renderedEvents(['AlphaEvent', 'BetaEvent'])).toEqual(['BetaEvent', 'AlphaEvent']);
+  });
+
+  it("appends newest-last when the config frame asks for new_entries 'bottom'", async () => {
+    // The whole point of the frame: the server decides the direction. With
+    // 'bottom' the order must invert relative to the case above.
+    mockFetchRaw(
+      config({ max_entries: 100, new_entries: 'bottom' }) + evt('AlphaEvent') + evt('BetaEvent')
+    );
+    renderWithProviders(<EventLogPanel />);
+
+    await waitFor(() => expect(screen.getByText('BetaEvent')).toBeTruthy());
+    expect(renderedEvents(['AlphaEvent', 'BetaEvent'])).toEqual(['AlphaEvent', 'BetaEvent']);
+  });
+
+  it('caps the buffer at max_entries, dropping the oldest when newest-first', async () => {
+    // Cap of 2 with three arrivals in 'top' mode: the list keeps the first two
+    // of [C, B, A] — so C and B survive and A, the oldest, is dropped.
+    mockFetchRaw(
+      config({ max_entries: 2, new_entries: 'top' }) +
+        evt('AlphaEvent') +
+        evt('BetaEvent') +
+        evt('GammaEvent')
+    );
+    renderWithProviders(<EventLogPanel />);
+
+    await waitFor(() => expect(screen.getByText('GammaEvent')).toBeTruthy());
+    expect(renderedEvents(['AlphaEvent', 'BetaEvent', 'GammaEvent'])).toEqual([
+      'GammaEvent',
+      'BetaEvent',
+    ]);
+    expect(screen.queryByText('AlphaEvent')).toBeNull();
+  });
+
+  it('caps the buffer from the other end when newest-last', async () => {
+    // Same cap, opposite direction: the list is [A, B, C] and must keep the
+    // LAST two. Trimming the wrong end here would silently discard the newest
+    // events instead of the oldest — which is why both directions are pinned.
+    mockFetchRaw(
+      config({ max_entries: 2, new_entries: 'bottom' }) +
+        evt('AlphaEvent') +
+        evt('BetaEvent') +
+        evt('GammaEvent')
+    );
+    renderWithProviders(<EventLogPanel />);
+
+    await waitFor(() => expect(screen.getByText('GammaEvent')).toBeTruthy());
+    expect(renderedEvents(['AlphaEvent', 'BetaEvent', 'GammaEvent'])).toEqual([
+      'BetaEvent',
+      'GammaEvent',
+    ]);
+    expect(screen.queryByText('AlphaEvent')).toBeNull();
+  });
+
+  it('ignores an out-of-range new_entries value and keeps the default', async () => {
+    // The guard is `=== 'top' || === 'bottom'`. A server sending anything else
+    // must leave the direction alone rather than assigning it through.
+    mockFetchRaw(
+      config({ max_entries: 100, new_entries: 'sideways' }) + evt('AlphaEvent') + evt('BetaEvent')
+    );
+    renderWithProviders(<EventLogPanel />);
+
+    await waitFor(() => expect(screen.getByText('BetaEvent')).toBeTruthy());
+    expect(renderedEvents(['AlphaEvent', 'BetaEvent'])).toEqual(['BetaEvent', 'AlphaEvent']);
+  });
+
+  it('consumes the config frame instead of rendering it as an event row', async () => {
+    // The frame is recognised by `max_entries !== undefined` and consumed. If
+    // that check regressed, the config payload would fall through and be shown
+    // as a row with no event name and domain 'unknown' — which this panel
+    // renders as the uppercased domain (see the sibling spec's
+    // "renders unknown domain as uppercase text").
+    //
+    // NOTE: this must count ALL rendered rows. An earlier draft asserted on a
+    // name-filtered list and on a `badge.unknown` key that this panel never
+    // emits, so it passed even with the config check disabled — the extra row
+    // was simply filtered out of the comparison.
+    mockFetchRaw(config({ max_entries: 50, new_entries: 'top' }) + evt('AlphaEvent'));
+    renderWithProviders(<EventLogPanel />);
+
+    await waitFor(() => expect(screen.getByText('AlphaEvent')).toBeTruthy());
+    expect(allRenderedRows()).toEqual(['AlphaEvent']);
+    expect(screen.queryByText('UNKNOWN')).toBeNull();
+  });
+});

--- a/app/src/components/settings/panels/__tests__/McpServerPanel.osPaths.test.tsx
+++ b/app/src/components/settings/panels/__tests__/McpServerPanel.osPaths.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * McpServerPanel — the per-OS config-file path table, and the embedded render.
+ *
+ * The sibling `McpServerPanel.test.tsx` runs every case on macOS
+ * (`DEFAULT_BINARY_INFO = { os: 'macos' }`), so `configFilePathFor`'s Windows
+ * and Linux branches were unexecuted — lines 59-64 and 67-68, the reason the
+ * panel sat at 68.18% branch coverage. Line 269, the `embedded` wrapper, was
+ * unreached for the same reason: nothing rendered the panel with the prop.
+ *
+ * These paths are worth pinning rather than eyeballing. The path is what the
+ * "Open config file" row shows and what a user is told to edit by hand; a wrong
+ * one sends them to a file that does not exist, and nothing errors — the string
+ * is just displayed. `configFilePathFor` is a pure `switch` with no test, and
+ * three of its four clients branch on OS in different shapes: `claude-desktop`
+ * and `zed` have three arms each, `cursor` has two, `codex` has one.
+ */
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { renderWithProviders } from '../../../../test/test-utils';
+
+const hoisted = vi.hoisted(() => ({ invoke: vi.fn(), isTauri: vi.fn(() => true) }));
+
+vi.mock('../../../../utils/tauriCommands/common', () => ({
+  isTauri: hoisted.isTauri,
+  safeInvoke: (...args: unknown[]) => hoisted.invoke(...args),
+}));
+
+vi.mock('../../hooks/useSettingsNavigation', () => ({
+  useSettingsNavigation: () => ({
+    navigateBack: vi.fn(),
+    navigateToSettings: vi.fn(),
+    breadcrumbs: [],
+  }),
+}));
+
+const BINARY_PATH = '/usr/local/bin/openhuman-core';
+
+async function importPanel() {
+  const mod = await import('../McpServerPanel');
+  return mod.default;
+}
+
+/** Render with the resolver reporting a given OS, then wait for first paint. */
+async function renderForOs(os: string, props: { embedded?: boolean } = {}) {
+  hoisted.invoke.mockResolvedValue({ path: BINARY_PATH, os });
+  const Panel = await importPanel();
+  renderWithProviders(<Panel {...props} />);
+  await waitFor(() =>
+    expect(screen.getByRole('tab', { name: /Claude Desktop/i })).toBeInTheDocument()
+  );
+}
+
+/** Switch to a client tab and read back the config path the panel displays. */
+async function pathForClient(name: RegExp): Promise<string> {
+  const tab = screen.getByRole('tab', { name });
+  tab.click();
+  await waitFor(() => expect(tab).toHaveAttribute('aria-selected', 'true'));
+  // Anchor on the "Config file:" label and read its sibling, rather than a CSS
+  // class — the panel renders several font-mono spans (tool names, the JSON
+  // snippet) and a class-based selector picks up the first of them.
+  const label = screen.getByText('Config file:');
+  const value = label.nextElementSibling;
+  expect(value, 'the config path should sit beside its label').not.toBeNull();
+  return value!.textContent ?? '';
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  hoisted.invoke.mockReset();
+  hoisted.isTauri.mockReset();
+  hoisted.isTauri.mockReturnValue(true);
+});
+
+describe('<McpServerPanel /> config paths per OS', () => {
+  test('macOS uses the Application Support locations', async () => {
+    await renderForOs('macos');
+    expect(await pathForClient(/Claude Desktop/i)).toBe(
+      '~/Library/Application Support/Claude/claude_desktop_config.json'
+    );
+    expect(await pathForClient(/Zed/i)).toBe('~/Library/Application Support/Zed/settings.json');
+  });
+
+  test('Windows uses %APPDATA% / %USERPROFILE% with backslashes', async () => {
+    // The Windows arms are the ones the macOS-only sibling never reached. Note
+    // these are backslash paths — asserting the exact string is the point,
+    // since a forward-slash regression would still "look like a path".
+    await renderForOs('windows');
+    expect(await pathForClient(/Claude Desktop/i)).toBe(
+      '%APPDATA%\\Claude\\claude_desktop_config.json'
+    );
+    expect(await pathForClient(/Cursor/i)).toBe('%USERPROFILE%\\.cursor\\mcp.json');
+    expect(await pathForClient(/Zed/i)).toBe('%APPDATA%\\Zed\\settings.json');
+  });
+
+  test('Linux falls through to the XDG-style ~/.config locations', async () => {
+    // Linux is the `return` after both guards — reached by any os that is
+    // neither 'macos' nor 'windows'.
+    await renderForOs('linux');
+    expect(await pathForClient(/Claude Desktop/i)).toBe(
+      '~/.config/Claude/claude_desktop_config.json'
+    );
+    expect(await pathForClient(/Cursor/i)).toBe('~/.cursor/mcp.json');
+    expect(await pathForClient(/Zed/i)).toBe('~/.config/zed/settings.json');
+  });
+
+  test('codex is OS-independent', async () => {
+    // The one client with a single arm: its path must not vary with the OS.
+    // Pinning this stops a future edit from "helpfully" adding branches that
+    // disagree with where codex actually reads its config.
+    await renderForOs('windows');
+    expect(await pathForClient(/Codex/i)).toBe('~/.codex/config.json');
+
+    // Tear the first tree down before mounting the second — otherwise both
+    // panels are in the document and the label lookup matches two nodes.
+    cleanup();
+    vi.resetModules();
+    await renderForOs('linux');
+    expect(await pathForClient(/Codex/i)).toBe('~/.codex/config.json');
+  });
+
+  test('an unrecognised OS is treated as Linux rather than blank', async () => {
+    // `configFilePathFor` has no default arm per OS — anything not macOS and
+    // not Windows takes the final return. A future refactor that returned
+    // undefined here would render an empty path with no error.
+    await renderForOs('freebsd');
+    expect(await pathForClient(/Claude Desktop/i)).toBe(
+      '~/.config/Claude/claude_desktop_config.json'
+    );
+  });
+
+  test('renders the settings description normally but omits it when embedded', async () => {
+    // Line 269 — the Connections surface embeds this panel. Both directions
+    // are asserted on purpose: an earlier draft only checked that the
+    // description was ABSENT when embedded, which passed even with the
+    // `embedded` branch deleted, because the string it looked for was wrong
+    // and so never present in either mode. A negative assertion alone cannot
+    // tell "correctly hidden" from "never rendered".
+    const DESCRIPTION = 'Configure external MCP clients to connect to OpenHuman';
+
+    await renderForOs('macos');
+    expect(
+      screen.getByText(DESCRIPTION),
+      'the settings scaffold renders the panel description'
+    ).toBeInTheDocument();
+
+    cleanup();
+    vi.resetModules();
+
+    await renderForOs('macos', { embedded: true });
+    expect(screen.getByRole('tab', { name: /Claude Desktop/i })).toBeInTheDocument();
+    expect(
+      screen.queryByText(DESCRIPTION),
+      'embedded mode uses PanelPage, which must not repeat the settings subtitle'
+    ).not.toBeInTheDocument();
+  });
+});

--- a/app/src/components/settings/panels/__tests__/SystemDiagnostics.errorPaths.test.tsx
+++ b/app/src/components/settings/panels/__tests__/SystemDiagnostics.errorPaths.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * SystemDiagnostics — the failure paths.
+ *
+ * The sibling `SystemDiagnostics.test.tsx` covers the happy paths: the Sentry
+ * row's visibility per environment, a successful send, the restart-tour row,
+ * and the resolved logs-folder path. It leaves every *error* branch
+ * unexecuted — measured at 79.48% statements / 57.69% branches, with
+ * `SystemDiagnostics.tsx` lines 32, 36-40 and 88 uncovered:
+ *
+ *   - `:32`    the `logs_folder_path` rejection handler,
+ *   - `:36-40` the whole "Open logs folder" click handler, success and failure,
+ *   - `:88`    the Sentry send rejection handler.
+ *
+ * All three surface an operator-facing message, and this panel is the one a
+ * user is sent to when something is already broken — so a silent failure here
+ * is worse than elsewhere. A new file rather than an edit to the sibling:
+ * these need `invoke` to reject per-command, which the sibling's
+ * `mockResolvedValue(null)` default would fight.
+ */
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { renderWithProviders } from '../../../../test/test-utils';
+
+const hoisted = vi.hoisted(() => ({
+  trigger: vi.fn(),
+  appEnvironment: 'production' as 'staging' | 'production' | 'development',
+  invoke: vi.fn(),
+  isTauri: vi.fn(() => true),
+  navigate: vi.fn(),
+  resetWalkthrough: vi.fn(),
+}));
+
+vi.mock('../../../../utils/tauriCommands/common', () => ({
+  isTauri: hoisted.isTauri,
+  safeInvoke: (...args: unknown[]) => hoisted.invoke(...args),
+}));
+
+vi.mock('../../../../services/analytics', () => ({ triggerSentryTestEvent: hoisted.trigger }));
+
+vi.mock('../../../../utils/config', () => ({
+  APP_BINARY_VERSION: '0.0.0-test',
+  get APP_ENVIRONMENT() {
+    return hoisted.appEnvironment;
+  },
+  APP_VERSION: '0.0.0-test',
+  BUILD_SHA: 'test',
+  CORE_CARGO_VERSION: '0.0.0-test',
+  GA_MEASUREMENT_ID: undefined,
+  IS_DEV: true,
+  OPENPANEL_API_URL: 'https://panel.tinyhumans.ai/api',
+  OPENPANEL_CLIENT_ID: undefined,
+  SENTRY_DSN: undefined,
+  SENTRY_RELEASE: 'openhuman@test',
+  SENTRY_SMOKE_TEST: false,
+  TAURI_CARGO_VERSION: '0.0.0-test',
+  CORE_RPC_URL: 'http://127.0.0.1:7788/rpc',
+  BACKEND_URL: 'http://localhost:5005',
+  E2E_DEFAULT_CORE_MODE: '',
+}));
+
+vi.mock('../../../walkthrough/AppWalkthrough', () => ({
+  resetWalkthrough: hoisted.resetWalkthrough,
+  setWalkthroughPending: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async importOriginal => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => hoisted.navigate };
+});
+
+async function importPanel() {
+  const mod = await import('../SystemDiagnostics');
+  return mod.default;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  hoisted.invoke.mockReset();
+  hoisted.invoke.mockResolvedValue(null);
+  hoisted.isTauri.mockReset();
+  hoisted.isTauri.mockReturnValue(true);
+  hoisted.trigger.mockReset();
+  hoisted.navigate.mockReset();
+  hoisted.resetWalkthrough.mockReset();
+  hoisted.appEnvironment = 'production';
+});
+
+describe('<SystemDiagnostics /> failure paths', () => {
+  test('surfaces the reason when the logs folder path cannot be resolved', async () => {
+    // `:32` — the effect's catch. Without it the row renders with no path and
+    // no explanation, which reads as "there are no logs" rather than "we could
+    // not look them up".
+    hoisted.invoke.mockImplementation((cmd: string) =>
+      cmd === 'logs_folder_path'
+        ? Promise.reject(new Error('log dir is not readable'))
+        : Promise.resolve()
+    );
+    const Panel = await importPanel();
+    renderWithProviders(<Panel />);
+
+    await waitFor(() => expect(screen.getByText('log dir is not readable')).toBeInTheDocument());
+    // The row itself must survive the failure — it still offers the button.
+    expect(screen.getByRole('button', { name: 'Open logs folder' })).toBeInTheDocument();
+  });
+
+  test('stringifies a non-Error rejection from the logs path lookup', async () => {
+    // `err instanceof Error ? err.message : String(err)` — a bare string
+    // rejection must not render "undefined" into the status line.
+    hoisted.invoke.mockImplementation((cmd: string) =>
+      cmd === 'logs_folder_path' ? Promise.reject('permission denied') : Promise.resolve()
+    );
+    const Panel = await importPanel();
+    renderWithProviders(<Panel />);
+
+    await waitFor(() => expect(screen.getByText('permission denied')).toBeInTheDocument());
+  });
+
+  test('invokes reveal_logs_folder when the open button is clicked', async () => {
+    // `:36-40` — the click handler had no test at all.
+    hoisted.invoke.mockImplementation((cmd: string) =>
+      cmd === 'logs_folder_path' ? Promise.resolve('/tmp/openhuman/logs') : Promise.resolve()
+    );
+    const Panel = await importPanel();
+    renderWithProviders(<Panel />);
+    await waitFor(() => expect(screen.getByText('/tmp/openhuman/logs')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open logs folder' }));
+
+    await waitFor(() => expect(hoisted.invoke).toHaveBeenCalledWith('reveal_logs_folder'));
+  });
+
+  test('surfaces the reason when revealing the logs folder fails', async () => {
+    hoisted.invoke.mockImplementation((cmd: string) => {
+      if (cmd === 'logs_folder_path') return Promise.resolve('/tmp/openhuman/logs');
+      if (cmd === 'reveal_logs_folder') return Promise.reject(new Error('no file manager'));
+      return Promise.resolve();
+    });
+    const Panel = await importPanel();
+    renderWithProviders(<Panel />);
+    await waitFor(() => expect(screen.getByText('/tmp/openhuman/logs')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open logs folder' }));
+
+    await waitFor(() => expect(screen.getByText('no file manager')).toBeInTheDocument());
+  });
+
+  test('clears a previous reveal error when the button is clicked again', async () => {
+    // `setError(null)` is the first line of the handler. Without it a retry
+    // that succeeds still shows the stale failure, so the user cannot tell
+    // whether the second attempt worked.
+    let attempt = 0;
+    hoisted.invoke.mockImplementation((cmd: string) => {
+      if (cmd === 'logs_folder_path') return Promise.resolve('/tmp/openhuman/logs');
+      if (cmd === 'reveal_logs_folder') {
+        attempt += 1;
+        return attempt === 1 ? Promise.reject(new Error('transient')) : Promise.resolve();
+      }
+      return Promise.resolve();
+    });
+    const Panel = await importPanel();
+    renderWithProviders(<Panel />);
+    await waitFor(() => expect(screen.getByText('/tmp/openhuman/logs')).toBeInTheDocument());
+
+    const button = screen.getByRole('button', { name: 'Open logs folder' });
+    fireEvent.click(button);
+    await waitFor(() => expect(screen.getByText('transient')).toBeInTheDocument());
+
+    fireEvent.click(button);
+    await waitFor(() => expect(screen.queryByText('transient')).not.toBeInTheDocument());
+  });
+
+  test('reports a failed Sentry test event instead of claiming it sent', async () => {
+    // `:88` — the send's catch. The success path is covered by the sibling
+    // file; a rejection previously left the row on its "sending" label with no
+    // indication anything went wrong.
+    hoisted.appEnvironment = 'staging';
+    hoisted.trigger.mockRejectedValue(new Error('DSN rejected the event'));
+    const Panel = await importPanel();
+    renderWithProviders(<Panel />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send test event' }));
+
+    await waitFor(() => expect(screen.getByText(/DSN rejected the event/)).toBeInTheDocument());
+    expect(screen.queryByText(/Event sent/)).not.toBeInTheDocument();
+  });
+
+  test('stringifies a non-Error Sentry rejection', async () => {
+    hoisted.appEnvironment = 'staging';
+    hoisted.trigger.mockRejectedValue('network down');
+    const Panel = await importPanel();
+    renderWithProviders(<Panel />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Send test event' }));
+
+    await waitFor(() => expect(screen.getByText(/network down/)).toBeInTheDocument());
+  });
+});

--- a/app/src/components/settings/panels/__tests__/UsagePanel.loadFailure.test.tsx
+++ b/app/src/components/settings/panels/__tests__/UsagePanel.loadFailure.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * UsagePanel — the Background tab's snapshot-load failure, for a rejection
+ * that is not an `Error`.
+ *
+ * The sibling spec covers a rejected `new Error('rpc down')`, which exercises
+ * the true arm of `err instanceof Error ? err.message : String(err)`
+ * (UsagePanel.tsx:87). The false arm was unexecuted — one of the three
+ * branches keeping the panel at 78.57% despite 100% statement and line
+ * coverage.
+ *
+ * It is worth an assertion because the failure is silent-ish: a bare string or
+ * an object rejection is a normal shape for an RPC layer to produce, and
+ * without the `String(err)` fallback the panel renders "undefined" where the
+ * reason should be — which reads as a bug in the panel rather than a failure
+ * of the call behind it.
+ *
+ * # What this file deliberately does NOT test
+ *
+ * The other two uncovered branches are the `if (!cancelled)` guards at :84 and
+ * :87, which suppress a state write when the effect is torn down before the
+ * promise settles. Under React 18 a setState on an unmounted component is a
+ * silent no-op — no warning, no thrown error, no rendered difference — so
+ * removing either guard changes nothing a test at this level can observe. Any
+ * test I wrote for them would pass with the guard deleted, which is exactly
+ * the vacuous shape this suite is meant to avoid, so they are left uncovered
+ * and called out here instead.
+ */
+import { screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { loadAISettings } from '../../../../services/api/aiSettingsApi';
+import { renderWithProviders } from '../../../../test/test-utils';
+import UsagePanel from '../UsagePanel';
+
+vi.mock('../../../dashboard/CostDashboardPanel', () => ({
+  default: () => <div data-testid="stub-cost-dashboard" />,
+}));
+
+vi.mock('../AIPanel', () => ({
+  BackgroundLoopControls: () => <div data-testid="stub-background-loops" />,
+}));
+
+vi.mock('../TokenUsagePanel', () => ({ default: () => <div data-testid="stub-token-usage" /> }));
+
+vi.mock('../../../../services/api/aiSettingsApi', async () => {
+  const actual = await vi.importActual<typeof import('../../../../services/api/aiSettingsApi')>(
+    '../../../../services/api/aiSettingsApi'
+  );
+  return { ...actual, loadAISettings: vi.fn() };
+});
+
+vi.mock('../../hooks/useSettingsNavigation', () => ({
+  useSettingsNavigation: () => ({
+    navigateBack: vi.fn(),
+    navigateToSettings: vi.fn(),
+    breadcrumbs: [],
+  }),
+}));
+
+const mockLoad = vi.mocked(loadAISettings);
+
+beforeEach(() => {
+  mockLoad.mockReset();
+});
+
+describe('UsagePanel background snapshot failures', () => {
+  test('stringifies a bare string rejection instead of rendering undefined', async () => {
+    mockLoad.mockRejectedValue('core offline');
+    renderWithProviders(<UsagePanel />, { initialEntries: ['/settings/usage#background'] });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('usage-background-tab')).toHaveTextContent(/core offline/)
+    );
+    expect(screen.getByTestId('usage-background-tab')).not.toHaveTextContent(/undefined/);
+    // The controls must stay hidden — a failed snapshot means there is nothing
+    // safe to edit, and rendering them would offer writes against unknown state.
+    expect(screen.queryByTestId('stub-background-loops')).not.toBeInTheDocument();
+  });
+
+  test('stringifies a non-Error object rejection', async () => {
+    // An RPC layer rejecting with a plain object is the other common shape.
+    // `String({})` is "[object Object]" — not useful, but it is what the code
+    // promises, and it is not "undefined". Pinning it stops a refactor from
+    // silently dropping to `err.message` on a value that has none.
+    mockLoad.mockRejectedValue({ code: 500 });
+    renderWithProviders(<UsagePanel />, { initialEntries: ['/settings/usage#background'] });
+
+    await waitFor(() =>
+      expect(screen.getByTestId('usage-background-tab')).toHaveTextContent(/\[object Object\]/)
+    );
+    expect(screen.getByTestId('usage-background-tab')).not.toHaveTextContent(/undefined/);
+  });
+});

--- a/app/test/playwright/specs/chat-composer-attachment-gate.spec.ts
+++ b/app/test/playwright/specs/chat-composer-attachment-gate.spec.ts
@@ -72,10 +72,47 @@ const stopButton = (page: Page): Locator => page.getByTestId('stop-generation-bu
 const attachButton = (page: Page): Locator => page.getByRole('button', { name: 'Attach file' });
 const fileInput = (page: Page): Locator => page.locator('input[type="file"]');
 
+/**
+ * Attach a file through the app's own hidden `input[type=file]`, retrying until
+ * the chip appears.
+ *
+ * The retry closes a race in the TEST, not a product bug.
+ * `ComposerAddAttachment` is a `useCallback` whose identity changes with
+ * `attachmentInteractionBlocked`, `attachments.length` and `maxAttachments`
+ * (`AssistantUiChat.tsx:160-185`), so early on a fresh page the input can be
+ * replaced between `setInputFiles` and React binding its `onChange`, and the
+ * change event lands on a detached node. Seen once in fifteen runs, always on
+ * the first case of the file; the screenshot showed a fully rendered, idle
+ * composer with `[+]` enabled and no chip.
+ *
+ * A retry is only acceptable if the case still dies under fault injection —
+ * otherwise it is a way of passing regardless. If ingest is genuinely broken
+ * the chip never appears and this poll exhausts. Re-verified against fault A3
+ * (`onAttachFiles` handed an empty `FileList`): the cases still fail.
+ */
 async function attach(page: Page, name: string, body = 'attached by the picker'): Promise<void> {
-  await fileInput(page)
-    .first()
-    .setInputFiles({ name, mimeType: 'text/plain', buffer: Buffer.from(body) });
+  await expect
+    .poll(
+      async () => {
+        if (
+          await page
+            .getByText(name)
+            .isVisible()
+            .catch(() => false)
+        ) {
+          return true;
+        }
+        await fileInput(page)
+          .first()
+          .setInputFiles({ name, mimeType: 'text/plain', buffer: Buffer.from(body) });
+        return page
+          .getByText(name)
+          .isVisible({ timeout: 2_000 })
+          .catch(() => false);
+      },
+      { timeout: 15_000, message: `attachment chip for ${name} never appeared` }
+    )
+    .toBe(true);
 }
 
 async function beginStreamingTurn(page: Page, prompt: string): Promise<void> {
@@ -101,7 +138,9 @@ test.describe('Chat composer attachment gate', () => {
 
     await attach(page, 'picker-notes.txt');
 
-    await expect(page.getByText('picker-notes.txt')).toBeVisible({ timeout: 10_000 });
+    // `attach` already waits for the chip; assert it here too so this case
+    // fails on its own terms rather than inside a helper.
+    await expect(page.getByText('picker-notes.txt')).toBeVisible();
   });
 
   test('an attached file can be removed again', async ({ page }) => {

--- a/app/test/playwright/specs/chat-composer-attachment-gate.spec.ts
+++ b/app/test/playwright/specs/chat-composer-attachment-gate.spec.ts
@@ -35,7 +35,7 @@ import { expect, type Locator, type Page, test } from '@playwright/test';
 
 import { bootAuthenticatedPage, dismissWalkthroughIfPresent } from '../helpers/core-rpc';
 
-const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18402'}`;
+const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18473'}`;
 const USER_ID = 'pw-chat-attach-gate';
 
 const SLOW_STREAM = [
@@ -105,10 +105,17 @@ async function attach(page: Page, name: string, body = 'attached by the picker')
         await fileInput(page)
           .first()
           .setInputFiles({ name, mimeType: 'text/plain', buffer: Buffer.from(body) });
-        return page
-          .getByText(name)
-          .isVisible({ timeout: 2_000 })
-          .catch(() => false);
+        // `Locator.isVisible()` returns IMMEDIATELY — it does not honour a
+        // timeout — so the previous form could fire a second `setInputFiles`
+        // while the first ingest was still in flight. `handleAttachFiles`
+        // appends without deduplication, so that would have produced two chips
+        // for one file. `expect(...).toBeVisible()` actually waits.
+        return expect(page.getByText(name))
+          .toBeVisible({ timeout: 2_000 })
+          .then(
+            () => true,
+            () => false
+          );
       },
       { timeout: 15_000, message: `attachment chip for ${name} never appeared` }
     )
@@ -122,6 +129,24 @@ async function beginStreamingTurn(page: Page, prompt: string): Promise<void> {
   await sendButton(page).click();
   await expect(stopButton(page)).toBeVisible({ timeout: 20_000 });
 }
+
+/**
+ * These are browser specs against a freshly built bundle, and the first few to
+ * run pay the app's cold start: a fresh `dist-web` plus a just-rebuilt core
+ * means first paint can take most of a minute, while every subsequent test in
+ * the same session settles at ~1s.
+ *
+ * Measured on this suite: cases 1-4 of the first spec failed at ~60s with a
+ * blank `#root`, case 5 of the SAME file passed at 25.3s, and all 13 cases
+ * after it passed in ~1s. Nothing about the app was wrong — the per-test budget
+ * (60s locally, `playwright.config.ts:10`) was simply consumed by warm-up.
+ *
+ * Raising the budget for this describe rather than editing the shared config:
+ * it is a statement about these tests, it masks nothing (the assertions are
+ * unchanged and a genuinely broken app still fails), and whichever spec happens
+ * to sort first should not be the one that flakes.
+ */
+test.describe.configure({ timeout: 120_000 });
 
 test.describe('Chat composer attachment gate', () => {
   test.beforeEach(async () => {

--- a/app/test/playwright/specs/chat-composer-attachment-gate.spec.ts
+++ b/app/test/playwright/specs/chat-composer-attachment-gate.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Chat composer — the attachment gate on the composer the product ships.
+ *
+ * # Scope, and what was cut from it after probing
+ *
+ * The task framed this as a bypass risk: drag-drop and paste might skip the
+ * gate the `[+]` button enforces. That framing belongs to the LEGACY composer
+ * (`ChatComposer.tsx:288-317`), which implements `handleDrop` / `handlePaste`
+ * and gates both on `attachDisabled`. `/chat` does not render that file
+ * (`Conversations.tsx:2539`, default `composer = 'text'`).
+ *
+ * The live composer supplies only a `[+]` button and a hidden
+ * `input[type=file]` (`AssistantUiChat.tsx:160-185`); neither it nor
+ * `assistant-ui/thread.tsx` defines `onDrop`, `onPaste` or `onDragOver`.
+ * Probed against the running app, dispatching `dragover` + `drop` with a
+ * populated `DataTransfer` on **every ancestor** of the input — including the
+ * element carrying `data-[dragging=true]:border-ring`, assistant-ui's own
+ * `AttachmentDropzone` — attached nothing, while `setInputFiles` in the same
+ * run attached fine.
+ *
+ * **So there is no drop/paste spec here, on purpose.** "Dropping a file while
+ * streaming does not attach" would pass because dropping never attaches in any
+ * state; it cannot distinguish a working gate from a dead gesture, and writing
+ * it would put a green test over a probable regression. The finding is in
+ * `~/tinyhuman/bugs/W2-ui-bugs.md` as BUG-W2-UI-1 for a human to confirm with a
+ * real drag.
+ *
+ * What IS real and falsifiable is the gate on the control that does ingest:
+ * `disabled={attachmentInteractionBlocked || attachments.length >= maxAttachments}`
+ * (`AssistantUiChat.tsx:178`), where `attachmentInteractionBlocked` is
+ * `composerInteractionBlocked || isSending` (`Conversations.tsx:2522`). This
+ * file covers that, end to end, through the UI.
+ */
+import { expect, type Locator, type Page, test } from '@playwright/test';
+
+import { bootAuthenticatedPage, dismissWalkthroughIfPresent } from '../helpers/core-rpc';
+
+const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18402'}`;
+const USER_ID = 'pw-chat-attach-gate';
+
+const SLOW_STREAM = [
+  ...Array.from({ length: 24 }, (_, i) => ({ text: `chunk${i + 1} `, delayMs: 1000 })),
+  { finish: 'stop' },
+];
+
+async function resetMock(): Promise<void> {
+  await fetch(`${MOCK_ADMIN_BASE}/__admin/reset`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+}
+
+async function setMockBehavior(key: string, value: string): Promise<void> {
+  await fetch(`${MOCK_ADMIN_BASE}/__admin/behavior`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ key, value }),
+  });
+}
+
+async function openChat(page: Page): Promise<void> {
+  await bootAuthenticatedPage(page, USER_ID, '/chat');
+  await dismissWalkthroughIfPresent(page);
+  await expect(page.getByTestId('chat-message-input')).toBeVisible({ timeout: 30_000 });
+}
+
+const composer = (page: Page): Locator => page.getByTestId('chat-message-input');
+const sendButton = (page: Page): Locator => page.getByTestId('send-message-button');
+const stopButton = (page: Page): Locator => page.getByTestId('stop-generation-button');
+/** The `[+]` control carries no testid — it is found by its accessible name. */
+const attachButton = (page: Page): Locator => page.getByRole('button', { name: 'Attach file' });
+const fileInput = (page: Page): Locator => page.locator('input[type="file"]');
+
+async function attach(page: Page, name: string, body = 'attached by the picker'): Promise<void> {
+  await fileInput(page)
+    .first()
+    .setInputFiles({ name, mimeType: 'text/plain', buffer: Buffer.from(body) });
+}
+
+async function beginStreamingTurn(page: Page, prompt: string): Promise<void> {
+  await composer(page).click();
+  await page.keyboard.type(prompt);
+  await expect(sendButton(page)).toBeVisible();
+  await sendButton(page).click();
+  await expect(stopButton(page)).toBeVisible({ timeout: 20_000 });
+}
+
+test.describe('Chat composer attachment gate', () => {
+  test.beforeEach(async () => {
+    await resetMock();
+    await setMockBehavior('llmStreamScript', JSON.stringify(SLOW_STREAM));
+    await setMockBehavior('llmStreamChunkDelayMs', '1000');
+  });
+
+  test('the picker attaches a file and the chip names it', async ({ page }) => {
+    // The control case for everything below: if this stops working, a
+    // "nothing attached" assertion elsewhere means nothing.
+    await openChat(page);
+    await expect(attachButton(page)).toBeEnabled();
+
+    await attach(page, 'picker-notes.txt');
+
+    await expect(page.getByText('picker-notes.txt')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('an attached file can be removed again', async ({ page }) => {
+    await openChat(page);
+    await attach(page, 'removable.txt');
+    await expect(page.getByText('removable.txt')).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole('button', { name: /Remove removable\.txt/ }).click();
+
+    await expect(page.getByText('removable.txt')).toHaveCount(0);
+  });
+
+  test('the [+] button is disabled while a turn streams', async ({ page }) => {
+    // The gate itself: `attachmentInteractionBlocked = composerInteractionBlocked
+    // || isSending`. Enabled before, disabled during — both halves asserted, so
+    // the test cannot pass against a button that is simply always disabled.
+    await openChat(page);
+    await expect(attachButton(page)).toBeEnabled();
+
+    await beginStreamingTurn(page, 'Count slowly for me');
+
+    await expect(
+      attachButton(page),
+      'a turn in flight must close the attach affordance'
+    ).toBeDisabled();
+  });
+
+  test('the [+] button becomes usable again once the turn is stopped', async ({ page }) => {
+    // Without this, "disabled during a turn" could be satisfied by a button
+    // that never recovers — which would be a worse bug than the one being
+    // guarded against.
+    await openChat(page);
+    await beginStreamingTurn(page, 'Count slowly for me');
+    await expect(attachButton(page)).toBeDisabled();
+
+    await stopButton(page).click();
+    await expect(stopButton(page)).toHaveCount(0, { timeout: 20_000 });
+
+    await expect(attachButton(page)).toBeEnabled({ timeout: 20_000 });
+  });
+
+  test('an attachment keeps the Send affordance even with no typed text', async ({ page }) => {
+    // `showIdleAction` requires `!hasComposerAttachments` (thread.tsx:494-495),
+    // so an attachment alone must hand the slot to Send — otherwise a user who
+    // attaches a file and types nothing has no way to send it.
+    await openChat(page);
+    await expect(page.getByTestId('composer-human-mode')).toBeVisible();
+
+    await attach(page, 'send-me.txt');
+    await expect(page.getByText('send-me.txt')).toBeVisible({ timeout: 10_000 });
+
+    await expect(sendButton(page)).toBeVisible();
+    await expect(page.getByTestId('composer-human-mode')).toHaveCount(0);
+  });
+});

--- a/app/test/playwright/specs/chat-composer-primary-slot.spec.ts
+++ b/app/test/playwright/specs/chat-composer-primary-slot.spec.ts
@@ -42,7 +42,7 @@ import { expect, type Locator, type Page, test } from '@playwright/test';
 
 import { bootAuthenticatedPage, dismissWalkthroughIfPresent } from '../helpers/core-rpc';
 
-const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18402'}`;
+const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18473'}`;
 const USER_ID = 'pw-chat-primary-slot';
 
 /**
@@ -106,6 +106,24 @@ async function beginStreamingTurn(page: Page, prompt: string): Promise<void> {
   await sendButton(page).click();
   await expect(stopButton(page)).toBeVisible({ timeout: 20_000 });
 }
+
+/**
+ * These are browser specs against a freshly built bundle, and the first few to
+ * run pay the app's cold start: a fresh `dist-web` plus a just-rebuilt core
+ * means first paint can take most of a minute, while every subsequent test in
+ * the same session settles at ~1s.
+ *
+ * Measured on this suite: cases 1-4 of the first spec failed at ~60s with a
+ * blank `#root`, case 5 of the SAME file passed at 25.3s, and all 13 cases
+ * after it passed in ~1s. Nothing about the app was wrong — the per-test budget
+ * (60s locally, `playwright.config.ts:10`) was simply consumed by warm-up.
+ *
+ * Raising the budget for this describe rather than editing the shared config:
+ * it is a statement about these tests, it masks nothing (the assertions are
+ * unchanged and a genuinely broken app still fails), and whichever spec happens
+ * to sort first should not be the one that flakes.
+ */
+test.describe.configure({ timeout: 120_000 });
 
 test.describe('Chat composer primary slot', () => {
   test.beforeEach(async () => {

--- a/app/test/playwright/specs/chat-composer-primary-slot.spec.ts
+++ b/app/test/playwright/specs/chat-composer-primary-slot.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * Chat composer — the primary-slot state machine, on the composer the product
+ * actually ships.
+ *
+ * # Which composer this is, and why that needed establishing
+ *
+ * `Conversations.tsx:2539` picks `composer === 'mic-cloud' ? legacyMainPanel :
+ * assistantUiMainPanel`, and `composer` defaults to `'text'`
+ * (`:255`), so `/chat` renders the **assistant-ui** composer. `ChatComposer.tsx`
+ * is the legacy one. A DOM probe against the running app confirms it: the page
+ * contains `composer-human-mode` (`AssistantUiChat.tsx:204`) and **not**
+ * `human-mode-button` (`ChatComposer.tsx:494`), and `chat-message-input` is a
+ * Lexical `[contenteditable]` (`thread.tsx:346`), not a `<textarea>`.
+ *
+ * That distinction is the whole reason this file exists rather than a spec
+ * against `ChatComposer`: the two composers do not behave the same.
+ *
+ * # The live rule
+ *
+ *   <AuiIf condition={s => !s.thread.isRunning}>
+ *     {showIdleAction ? <ComposerIdleAction/> : <Send/>}     thread.tsx:548-594
+ *   </AuiIf>
+ *   <AuiIf condition={s => s.thread.isRunning}>
+ *     <Stop/>                                                thread.tsx:596-608
+ *   </AuiIf>
+ *
+ *   showIdleAction = !!ComposerIdleAction
+ *                 && composerText.trim().length === 0
+ *                 && !hasComposerAttachments                 thread.tsx:494-495
+ *
+ * Note what is NOT there: the live Stop condition has **no typed-content
+ * term**. The legacy composer reverts Stop to Send once a follow-up is typed
+ * (`ChatComposer.tsx:252-253`); the shipped one does not. This spec asserts the
+ * shipped behaviour, and says so, so a future reader does not "fix" the test
+ * toward the legacy rule.
+ *
+ * Assertions are on which control is mounted and on the contenteditable's
+ * rendered text — never on a mock call. `toHaveValue()` is unusable here: the
+ * input is a contenteditable, and an earlier draft failed in 1.3s learning that.
+ */
+import { expect, type Locator, type Page, test } from '@playwright/test';
+
+import { bootAuthenticatedPage, dismissWalkthroughIfPresent } from '../helpers/core-rpc';
+
+const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18402'}`;
+const USER_ID = 'pw-chat-primary-slot';
+
+/**
+ * `safeDelayMs` (`scripts/mock-api/routes/llm.mjs:200-210`) CLAMPS any delay to
+ * 1000ms, so a stream is made long by adding chunks, not by asking for a bigger
+ * delay. 24 chunks ≈ 24s of open stream, inside the 60s test timeout.
+ */
+const SLOW_STREAM = [
+  ...Array.from({ length: 24 }, (_, i) => ({ text: `chunk${i + 1} `, delayMs: 1000 })),
+  { finish: 'stop' },
+];
+
+async function resetMock(): Promise<void> {
+  await fetch(`${MOCK_ADMIN_BASE}/__admin/reset`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+}
+
+async function setMockBehavior(key: string, value: string): Promise<void> {
+  await fetch(`${MOCK_ADMIN_BASE}/__admin/behavior`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ key, value }),
+  });
+}
+
+/**
+ * `bootAuthenticatedPage(.., '/chat')` already navigates to #/chat and runs
+ * `waitForAppReady`. The sibling chat specs then repeat both, which re-navigates
+ * the app mid-boot; under a loaded machine that left the first tests of a file
+ * on a blank `#root` until the 60s timeout. One navigation.
+ */
+async function openChat(page: Page): Promise<void> {
+  await bootAuthenticatedPage(page, USER_ID, '/chat');
+  await dismissWalkthroughIfPresent(page);
+  await expect(page.getByTestId('chat-message-input')).toBeVisible({ timeout: 30_000 });
+}
+
+const composer = (page: Page): Locator => page.getByTestId('chat-message-input');
+const sendButton = (page: Page): Locator => page.getByTestId('send-message-button');
+const stopButton = (page: Page): Locator => page.getByTestId('stop-generation-button');
+const idleAction = (page: Page): Locator => page.getByTestId('composer-human-mode');
+
+/** Type into the Lexical surface — `fill()` does not apply to contenteditable. */
+async function typeIntoComposer(page: Page, text: string): Promise<void> {
+  await composer(page).click();
+  await page.keyboard.type(text);
+}
+
+async function clearComposer(page: Page): Promise<void> {
+  await composer(page).click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.press('Backspace');
+}
+
+async function beginStreamingTurn(page: Page, prompt: string): Promise<void> {
+  await typeIntoComposer(page, prompt);
+  await expect(sendButton(page)).toBeVisible();
+  await sendButton(page).click();
+  await expect(stopButton(page)).toBeVisible({ timeout: 20_000 });
+}
+
+test.describe('Chat composer primary slot', () => {
+  test.beforeEach(async () => {
+    await resetMock();
+    await setMockBehavior('llmStreamScript', JSON.stringify(SLOW_STREAM));
+    await setMockBehavior('llmStreamChunkDelayMs', '1000');
+  });
+
+  test('an idle empty composer offers the mascot action, not a dead Send arrow', async ({
+    page,
+  }) => {
+    await openChat(page);
+
+    await expect(idleAction(page)).toBeVisible();
+    await expect(sendButton(page)).toHaveCount(0);
+    await expect(stopButton(page)).toHaveCount(0);
+  });
+
+  test('the first typed character hands the slot to Send, and clearing hands it back', async ({
+    page,
+  }) => {
+    // `showIdleAction` keys off `composerText.trim().length === 0`, so this is
+    // the live equivalent of the legacy `hasTypedContent` swap — and the trim
+    // matters: whitespace alone must not count as content.
+    await openChat(page);
+    await expect(idleAction(page)).toBeVisible();
+
+    await typeIntoComposer(page, 'h');
+    await expect(sendButton(page)).toBeVisible();
+    await expect(idleAction(page)).toHaveCount(0);
+
+    await clearComposer(page);
+    await expect(idleAction(page)).toBeVisible();
+    await expect(sendButton(page)).toHaveCount(0);
+  });
+
+  test('whitespace alone is not typed content', async ({ page }) => {
+    await openChat(page);
+    await typeIntoComposer(page, '   ');
+
+    await expect(
+      idleAction(page),
+      'a composer holding only spaces is still empty for slot purposes'
+    ).toBeVisible();
+    await expect(sendButton(page)).toHaveCount(0);
+  });
+
+  test('a running turn shows Stop and hides both idle and Send', async ({ page }) => {
+    await openChat(page);
+    await beginStreamingTurn(page, 'Count slowly for me');
+
+    await expect(stopButton(page)).toBeVisible();
+    await expect(sendButton(page)).toHaveCount(0);
+    await expect(idleAction(page)).toHaveCount(0);
+  });
+
+  test('Stop stays mounted while a follow-up is typed mid-stream', async ({ page }) => {
+    // The behavioural difference from the legacy composer, pinned deliberately.
+    // `ChatComposer.tsx:252-253` reverts Stop to Send once `hasTypedContent`;
+    // the shipped composer's Stop is `AuiIf(isRunning)` with no typed-content
+    // term, so typing must NOT disarm it. If this ever starts failing, the app
+    // has adopted the legacy rule — which may be desirable, but is a product
+    // change and should not be absorbed by editing this expectation quietly.
+    await openChat(page);
+    await beginStreamingTurn(page, 'Count slowly for me');
+
+    await typeIntoComposer(page, 'and then summarise it');
+
+    await expect(stopButton(page)).toBeVisible();
+    await expect(sendButton(page)).toHaveCount(0);
+  });
+
+  test('Stop ends the turn and the slot returns to the idle action', async ({ page }) => {
+    await openChat(page);
+    await beginStreamingTurn(page, 'Count slowly for me');
+
+    await stopButton(page).click();
+
+    await expect(stopButton(page)).toHaveCount(0, { timeout: 20_000 });
+    await expect(idleAction(page)).toBeVisible({ timeout: 20_000 });
+    await expect(composer(page)).toBeVisible();
+  });
+});

--- a/app/test/playwright/specs/chat-model-override.spec.ts
+++ b/app/test/playwright/specs/chat-model-override.spec.ts
@@ -67,6 +67,24 @@ const modelChip = (page: Page): Locator =>
   page.locator('[data-analytics-id="chat-model-selector"]');
 const pickerTitle = (page: Page): Locator => page.getByText('Choose provider and model');
 
+/**
+ * These are browser specs against a freshly built bundle, and the first few to
+ * run pay the app's cold start: a fresh `dist-web` plus a just-rebuilt core
+ * means first paint can take most of a minute, while every subsequent test in
+ * the same session settles at ~1s.
+ *
+ * Measured on this suite: cases 1-4 of the first spec failed at ~60s with a
+ * blank `#root`, case 5 of the SAME file passed at 25.3s, and all 13 cases
+ * after it passed in ~1s. Nothing about the app was wrong — the per-test budget
+ * (60s locally, `playwright.config.ts:10`) was simply consumed by warm-up.
+ *
+ * Raising the budget for this describe rather than editing the shared config:
+ * it is a statement about these tests, it masks nothing (the assertions are
+ * unchanged and a genuinely broken app still fails), and whichever spec happens
+ * to sort first should not be the one that flakes.
+ */
+test.describe.configure({ timeout: 120_000 });
+
 test.describe('Chat composer model override', () => {
   test.beforeEach(async () => {
     await resetMock();
@@ -96,6 +114,10 @@ test.describe('Chat composer model override', () => {
 
     const chip = modelChip(page);
     const before = (await chip.textContent())?.trim() ?? '';
+    // Without this the case is vacuous: if the chip rendered no label, `before`
+    // and the post-cancel read are both '' and the comparison passes while
+    // proving nothing.
+    expect(before, 'the model chip must name the current model').not.toBe('');
 
     await chip.click();
     await expect(pickerTitle(page)).toBeVisible({ timeout: 10_000 });

--- a/app/test/playwright/specs/chat-model-override.spec.ts
+++ b/app/test/playwright/specs/chat-model-override.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * Chat composer — the model chip opens the provider/model picker, and the
+ * choice sticks for the next turn.
+ *
+ * Zero browser coverage today: no spec in `app/test/playwright/specs` mentions
+ * the model selector at all. The chip is the only text-labelled control in the
+ * composer footer, and it is what tells a user which model their next message
+ * will go to — so a picker that opens but does not change the label, or a label
+ * that resets on the next send, is a silent correctness problem.
+ *
+ * `ChatComposer.tsx:453` calls it a "Read-only model chip". It is not: it
+ * renders a `Button` that opens `ProviderModelPickerDialog`
+ * (`ModelQualityPill.tsx:104-121`), disabled only when `!onValueChange ||
+ * loading`. The comment is stale; the control is live.
+ *
+ * # Environment dependency, stated plainly
+ *
+ * Which providers appear in the picker comes from core config, and the e2e
+ * fixture does not seed a cloud provider. The always-available option is the
+ * managed tier ("Managed by OpenHuman"), which the dialog deliberately lets you
+ * pick with no model id (`ProviderModelPickerDialog.tsx:189-196`). Where a case
+ * needs a provider this fixture does not have, it skips with a reason rather
+ * than asserting something weaker — per the lane rules, a case that cannot be
+ * driven in the browser is skipped, not quietly downgraded.
+ */
+import { expect, type Locator, type Page, test } from '@playwright/test';
+
+import { bootAuthenticatedPage, dismissWalkthroughIfPresent } from '../helpers/core-rpc';
+
+const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18473'}`;
+const USER_ID = 'pw-chat-model-override';
+
+async function resetMock(): Promise<void> {
+  await fetch(`${MOCK_ADMIN_BASE}/__admin/reset`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+}
+
+async function setMockBehavior(key: string, value: string): Promise<void> {
+  await fetch(`${MOCK_ADMIN_BASE}/__admin/behavior`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ key, value }),
+  });
+}
+
+async function openChat(page: Page): Promise<void> {
+  // `bootAuthenticatedPage(.., '/chat')` already navigates to #/chat and runs
+  // `waitForAppReady`. The sibling chat specs then repeat both; doing so races
+  // the app's own boot and, under a loaded machine, left the first tests of a
+  // file staring at a blank #root until the 60s test timeout. One navigation.
+  await bootAuthenticatedPage(page, USER_ID, '/chat');
+  await dismissWalkthroughIfPresent(page);
+  await expect(page.getByTestId('chat-message-input')).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * The model chip, by its analytics id rather than its accessible name.
+ * `getByRole('button', { name: 'Model' })` is ambiguous once a thread exists:
+ * sidebar thread rows are also `role="button"`, and a thread titled from a
+ * prompt about models matches the same name — a strict-mode violation that only
+ * appears after the first turn is sent.
+ */
+const modelChip = (page: Page): Locator =>
+  page.locator('[data-analytics-id="chat-model-selector"]');
+const pickerTitle = (page: Page): Locator => page.getByText('Choose provider and model');
+
+test.describe('Chat composer model override', () => {
+  test.beforeEach(async () => {
+    await resetMock();
+    await setMockBehavior(
+      'llmForcedResponses',
+      JSON.stringify([{ content: 'Reply after the model override.' }])
+    );
+    await setMockBehavior('llmStreamChunkDelayMs', '5');
+  });
+
+  test('the model chip is an interactive control that opens the picker', async ({ page }) => {
+    await openChat(page);
+
+    const chip = modelChip(page);
+    await expect(chip).toBeVisible();
+    await expect(
+      chip,
+      'the chip is enabled whenever an onValueChange handler is wired and the catalog is loaded'
+    ).toBeEnabled();
+
+    await chip.click();
+    await expect(pickerTitle(page)).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('cancelling the picker leaves the current model untouched', async ({ page }) => {
+    await openChat(page);
+
+    const chip = modelChip(page);
+    const before = (await chip.textContent())?.trim() ?? '';
+
+    await chip.click();
+    await expect(pickerTitle(page)).toBeVisible({ timeout: 10_000 });
+    await page.getByRole('button', { name: 'Cancel' }).click();
+
+    await expect(pickerTitle(page)).toHaveCount(0);
+    expect((await chip.textContent())?.trim() ?? '').toBe(before);
+  });
+
+  /*
+   * REMOVED — 'choosing a provider updates the chip label and survives the next
+   * turn'.
+   *
+   * It passed with the pill's `onValueChange` replaced by a no-op, which means
+   * it never verified that choosing anything took effect. Reading it back, the
+   * assertions were: capture the label AFTER selecting, assert it is non-empty,
+   * then assert it is unchanged by a turn. Nothing compared it to the label
+   * BEFORE, so a handler that discards the selection satisfies every line.
+   *
+   * The obvious repair — assert the label CHANGED — cannot be made honest with
+   * this fixture. The only selectable provider here is the managed tier
+   * (`ProviderModelPickerDialog.tsx:189-196` lets it be picked with no model
+   * id), and that is already the active model, so a correct selection is
+   * legitimately a no-op with nothing observable to assert. Driving a real
+   * change needs a second, seeded cloud provider, which the e2e core config
+   * does not create.
+   *
+   * Deleted rather than weakened or left green: a test that cannot distinguish
+   * a working picker from a discarded selection is worse than no test, because
+   * it reports coverage of exactly the behaviour it fails to check.
+   */
+});

--- a/app/test/playwright/specs/chat-scroll-stick.spec.ts
+++ b/app/test/playwright/specs/chat-scroll-stick.spec.ts
@@ -1,0 +1,244 @@
+/**
+ * Chat transcript — does an arriving message yank a reader back to the bottom?
+ *
+ * This is the classic transcript bug and it had no browser test. The existing
+ * `chat-harness-scroll-render.spec.ts` proves that scrolling up *releases* the
+ * bottom-stick, then stops — it never sends another message afterwards, so the
+ * behaviour that actually bites a user (reading scrollback while the assistant
+ * keeps streaming) was never exercised.
+ *
+ * The contract, from `src/hooks/useStickToBottom.ts`:
+ *
+ *   const STICK_THRESHOLD_PX = 80;
+ *   isNearBottom = scrollHeight - scrollTop - clientHeight <= thresholdPx
+ *
+ *   > If the user manually scrolls up past the threshold we stop sticking, so
+ *   > they [keep their place] … scrolling up always disengages it.
+ *
+ * So: scrolled up past 80px → new content must NOT move the viewport. Parked
+ * within 80px of the bottom → new content SHOULD follow. Both halves are here,
+ * because a spec that only asserted "does not jump" would also pass against a
+ * transcript that never auto-scrolls at all — which would be a different, and
+ * equally real, bug.
+ *
+ * Everything is measured from the live scroll container, not from mock calls.
+ *
+ * **The container has no testid on the shipped path.** `chat-messages-scroll`
+ * belongs to `ChatThreadView` (the legacy composer's transcript);
+ * `Conversations.tsx:2539` renders the assistant-ui panel by default, whose
+ * viewport is `thread.tsx:226` — `relative flex flex-1 flex-col
+ * overflow-x-auto overflow-y-scroll scroll-smooth`, with no testid. Rather
+ * than pin a Tailwind string, this walks up from the composer input and takes
+ * the first ancestor that actually scrolls, and throws if there is none — so a
+ * class rename fails loudly instead of silently measuring `document`.
+ */
+import { expect, type Page, test } from '@playwright/test';
+
+import { bootAuthenticatedPage, dismissWalkthroughIfPresent } from '../helpers/core-rpc';
+
+const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18473'}`;
+const USER_ID = 'pw-chat-scroll-stick';
+
+/** A long reply, so the transcript overflows and there is somewhere to scroll. */
+const LONG_REPLY = Array.from(
+  { length: 40 },
+  (_, i) => `Line ${i + 1}: the transcript needs enough height to actually overflow the viewport. `
+).join('\n\n');
+
+async function resetMock(): Promise<void> {
+  await fetch(`${MOCK_ADMIN_BASE}/__admin/reset`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+}
+
+async function setMockBehavior(key: string, value: string): Promise<void> {
+  await fetch(`${MOCK_ADMIN_BASE}/__admin/behavior`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ key, value }),
+  });
+}
+
+async function openChat(page: Page): Promise<void> {
+  // `bootAuthenticatedPage(.., '/chat')` already navigates to #/chat and runs
+  // `waitForAppReady`. The sibling chat specs then repeat both; doing so races
+  // the app's own boot and, under a loaded machine, left the first tests of a
+  // file staring at a blank #root until the 60s test timeout. One navigation.
+  await bootAuthenticatedPage(page, USER_ID, '/chat');
+  await dismissWalkthroughIfPresent(page);
+  await expect(page.getByTestId('chat-message-input')).toBeVisible({ timeout: 30_000 });
+}
+
+interface ScrollState {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  distanceFromBottom: number;
+}
+
+/**
+ * The transcript viewport, by its stable slot attribute
+ * (`assistant-ui/thread.tsx:225`). An earlier draft walked up from the composer
+ * taking the first scrolling ancestor; that is not deterministic, because which
+ * ancestor overflows changes as the transcript grows, so two reads in one test
+ * could measure two different elements.
+ */
+const FIND_VIEWPORT = `document.querySelector('[data-slot="aui_thread-viewport"]')`;
+
+async function scrollState(page: Page): Promise<ScrollState> {
+  return page.evaluate(`(() => {
+    const el = ${FIND_VIEWPORT};
+    if (!el) throw new Error('transcript viewport [data-slot=aui_thread-viewport] not found');
+    return {
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+      distanceFromBottom: el.scrollHeight - el.scrollTop - el.clientHeight,
+    };
+  })()`);
+}
+
+/**
+ * Scroll the viewport and WAIT FOR IT TO SETTLE.
+ *
+ * The viewport carries `scroll-smooth` (`thread.tsx:226`), so an assignment to
+ * `scrollTop` animates. An earlier draft read the position back immediately and
+ * saw a mid-animation value — it parked at the bottom, measured 1312px from the
+ * bottom, and failed its own setup step. `behavior: 'instant'` overrides the CSS
+ * for this one call; the poll is belt-and-braces for the layout settling.
+ */
+async function scrollTo(page: Page, top: number): Promise<void> {
+  await page.evaluate(`(() => {
+    const el = ${FIND_VIEWPORT};
+    if (!el) throw new Error('transcript viewport [data-slot=aui_thread-viewport] not found');
+    el.scrollTo({ top: ${top}, behavior: 'instant' });
+    el.dispatchEvent(new Event('scroll', { bubbles: true }));
+  })()`);
+  await expect
+    .poll(
+      async () => {
+        const a = await page.evaluate(`(${FIND_VIEWPORT}).scrollTop`);
+        await new Promise(resolve => setTimeout(resolve, 120));
+        const b = await page.evaluate(`(${FIND_VIEWPORT}).scrollTop`);
+        return a === b;
+      },
+      { timeout: 5_000 }
+    )
+    .toBe(true);
+}
+
+async function sendMessage(page: Page, prompt: string): Promise<void> {
+  await dismissWalkthroughIfPresent(page);
+  // The live input is a Lexical contenteditable, not a textarea — `fill()` and
+  // `toHaveValue()` do not apply to it.
+  await page.getByTestId('chat-message-input').click();
+  await page.keyboard.type(prompt);
+  await expect(page.getByTestId('send-message-button')).toBeVisible();
+  await page.getByTestId('send-message-button').click();
+}
+
+/** Send one turn and wait for the whole reply to land. */
+async function completeTurn(page: Page, prompt: string, marker: string): Promise<void> {
+  await sendMessage(page, prompt);
+  await expect(page.getByText(marker, { exact: false }).last()).toBeVisible({ timeout: 40_000 });
+  await expect(page.getByTestId('composer-human-mode')).toBeVisible({ timeout: 40_000 });
+}
+
+test.describe('Chat transcript stick-to-bottom', () => {
+  test.beforeEach(async () => {
+    await resetMock();
+    await setMockBehavior('llmStreamChunkDelayMs', '5');
+  });
+
+  test('a new message does NOT yank a reader who has scrolled up', async ({ page }) => {
+    await setMockBehavior(
+      'llmForcedResponses',
+      JSON.stringify([
+        { content: `${LONG_REPLY}\n\nFIRST-REPLY-END` },
+        { content: `${LONG_REPLY}\n\nSECOND-REPLY-END` },
+      ])
+    );
+    await openChat(page);
+
+    await completeTurn(page, 'First long answer please', 'FIRST-REPLY-END');
+
+    const overflowing = await scrollState(page);
+    test.skip(
+      overflowing.scrollHeight <= overflowing.clientHeight + 200,
+      'transcript did not overflow enough to scroll — viewport too tall for this fixture'
+    );
+
+    // Park the reader well above the bottom, past the 80px stick threshold.
+    const parkedTop = Math.max(0, overflowing.scrollHeight - overflowing.clientHeight - 600);
+    await scrollTo(page, parkedTop);
+    const parked = await scrollState(page);
+    expect(
+      parked.distanceFromBottom,
+      'the fixture must actually park the reader past the 80px stick threshold'
+    ).toBeGreaterThan(80);
+
+    // Now a second turn arrives and grows the transcript underneath them.
+    await completeTurn(page, 'Second long answer please', 'SECOND-REPLY-END');
+
+    const after = await scrollState(page);
+
+    // The assertion that matters: the viewport did not jump to the bottom.
+    expect(
+      after.distanceFromBottom,
+      'a message arriving while the reader is scrolled up must not snap the transcript to the bottom'
+    ).toBeGreaterThan(80);
+
+    // Deliberately NOT asserting `scrollTop` stayed put. New content changes the
+    // container's height, so `scrollTop` legitimately shifts without the view
+    // moving relative to what the reader is looking at. `distanceFromBottom`
+    // above is the actual definition of "was I yanked to the bottom", and it is
+    // the falsifiable one: forcing a scroll-to-bottom drives it to ~0.
+  });
+
+  test('a new turn is anchored into view for a reader parked at the bottom', async ({ page }) => {
+    // The positive half — without it, the case above would also pass against a
+    // transcript that never moves at all, which is its own bug.
+    //
+    // NOTE the contract being asserted. An earlier draft expected the reader to
+    // be left AT the bottom (`distanceFromBottom <= 80`), modelled on
+    // `useStickToBottom`'s `STICK_THRESHOLD_PX = 80`. That hook belongs to
+    // `ChatThreadView` — the LEGACY transcript. The shipped viewport is
+    // `ThreadPrimitive.Viewport turnAnchor="top"` (`thread.tsx:223-226`), which
+    // deliberately scrolls the START of a new turn to the top and lets it grow
+    // downward. Measured, that leaves ~1448px below the fold, so the old
+    // expectation failed on a UI that was behaving correctly.
+    //
+    // What the user actually needs is that the new turn is brought into view,
+    // and that is what this asserts.
+    await setMockBehavior(
+      'llmForcedResponses',
+      JSON.stringify([
+        { content: `${LONG_REPLY}\n\nFIRST-REPLY-END` },
+        { content: `${LONG_REPLY}\n\nSECOND-REPLY-END` },
+      ])
+    );
+    await openChat(page);
+
+    await completeTurn(page, 'First long answer please', 'FIRST-REPLY-END');
+
+    const first = await scrollState(page);
+    test.skip(
+      first.scrollHeight <= first.clientHeight + 200,
+      'transcript did not overflow enough to scroll — viewport too tall for this fixture'
+    );
+
+    await scrollTo(page, first.scrollHeight);
+    expect((await scrollState(page)).distanceFromBottom).toBeLessThanOrEqual(80);
+
+    const SECOND_PROMPT = 'Second long answer please';
+    await completeTurn(page, SECOND_PROMPT, 'SECOND-REPLY-END');
+
+    // The new turn's own prompt must be on screen, not scrolled past.
+    await expect(
+      page.getByText(SECOND_PROMPT, { exact: false }).last(),
+      'a reader at the bottom must have the new turn brought into view'
+    ).toBeInViewport({ timeout: 15_000 });
+  });
+});

--- a/app/test/playwright/specs/chat-scroll-stick.spec.ts
+++ b/app/test/playwright/specs/chat-scroll-stick.spec.ts
@@ -109,6 +109,20 @@ async function scrollState(page: Page): Promise<ScrollState> {
  * bottom, and failed its own setup step. `behavior: 'instant'` overrides the CSS
  * for this one call; the poll is belt-and-braces for the layout settling.
  */
+/**
+ * Viewport-relative Y of a stable piece of already-rendered content.
+ *
+ * `distanceFromBottom` alone only rejects a scroll that lands NEAR the bottom;
+ * a partial auto-scroll could drag the reader some distance and still leave
+ * more than the 80px threshold below. Watching a fixed element's position is
+ * what actually says "the view did not move under me" — raised in review.
+ */
+async function anchorY(page: Page, text: string): Promise<number> {
+  const box = await page.getByText(text, { exact: false }).last().boundingBox();
+  if (!box) throw new Error(`anchor "${text}" has no bounding box`);
+  return box.y;
+}
+
 async function scrollTo(page: Page, top: number): Promise<void> {
   await page.evaluate(`(() => {
     const el = ${FIND_VIEWPORT};
@@ -146,6 +160,24 @@ async function completeTurn(page: Page, prompt: string, marker: string): Promise
   await expect(page.getByTestId('composer-human-mode')).toBeVisible({ timeout: 40_000 });
 }
 
+/**
+ * These are browser specs against a freshly built bundle, and the first few to
+ * run pay the app's cold start: a fresh `dist-web` plus a just-rebuilt core
+ * means first paint can take most of a minute, while every subsequent test in
+ * the same session settles at ~1s.
+ *
+ * Measured on this suite: cases 1-4 of the first spec failed at ~60s with a
+ * blank `#root`, case 5 of the SAME file passed at 25.3s, and all 13 cases
+ * after it passed in ~1s. Nothing about the app was wrong — the per-test budget
+ * (60s locally, `playwright.config.ts:10`) was simply consumed by warm-up.
+ *
+ * Raising the budget for this describe rather than editing the shared config:
+ * it is a statement about these tests, it masks nothing (the assertions are
+ * unchanged and a genuinely broken app still fails), and whichever spec happens
+ * to sort first should not be the one that flakes.
+ */
+test.describe.configure({ timeout: 120_000 });
+
 test.describe('Chat transcript stick-to-bottom', () => {
   test.beforeEach(async () => {
     await resetMock();
@@ -179,10 +211,13 @@ test.describe('Chat transcript stick-to-bottom', () => {
       'the fixture must actually park the reader past the 80px stick threshold'
     ).toBeGreaterThan(80);
 
+    const beforeAnchor = await anchorY(page, 'FIRST-REPLY-END');
+
     // Now a second turn arrives and grows the transcript underneath them.
     await completeTurn(page, 'Second long answer please', 'SECOND-REPLY-END');
 
     const after = await scrollState(page);
+    const afterAnchor = await anchorY(page, 'FIRST-REPLY-END');
 
     // The assertion that matters: the viewport did not jump to the bottom.
     expect(
@@ -190,11 +225,18 @@ test.describe('Chat transcript stick-to-bottom', () => {
       'a message arriving while the reader is scrolled up must not snap the transcript to the bottom'
     ).toBeGreaterThan(80);
 
-    // Deliberately NOT asserting `scrollTop` stayed put. New content changes the
-    // container's height, so `scrollTop` legitimately shifts without the view
-    // moving relative to what the reader is looking at. `distanceFromBottom`
-    // above is the actual definition of "was I yanked to the bottom", and it is
-    // the falsifiable one: forcing a scroll-to-bottom drives it to ~0.
+    // And the stronger half, from review: `distanceFromBottom` rejects a jump to
+    // the bottom, but a PARTIAL auto-scroll could move the reader and still sit
+    // more than 80px above it. Watching a fixed piece of the first reply says
+    // the view did not shift under them at all.
+    //
+    // Still deliberately NOT asserting `scrollTop` stayed put: appending a turn
+    // changes the container's height, so `scrollTop` legitimately moves while
+    // the rendered content does not. The anchor measures what the reader sees.
+    expect(
+      Math.abs(afterAnchor - beforeAnchor),
+      'content the reader was looking at must not shift when a new turn arrives'
+    ).toBeLessThan(40);
   });
 
   test('a new turn is anchored into view for a reader parked at the bottom', async ({ page }) => {

--- a/app/test/playwright/specs/chat-thread-isolation.spec.ts
+++ b/app/test/playwright/specs/chat-thread-isolation.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * Thread isolation — a turn streaming on one conversation must stay attributed
+ * to it while the user reads or starts another.
+ *
+ * The app models this per-thread: `activeThreadIds`, `processingByThread` and
+ * `queuedFollowupsByThread` are all maps keyed by thread id
+ * (`Conversations.tsx:271-282`), and `selectedThreadActive` is
+ * `selectedThreadId && activeThreadIds[selectedThreadId]`. Nothing in the
+ * browser suite exercised the switch, though: thread coverage was one
+ * history-persistence case (`chat-conversation-history`) and one rename/delete
+ * case (`chat-management-functional`).
+ *
+ * The failure this guards against is bleed — the new thread showing the old
+ * thread's tokens, or offering a Stop button that would cancel a turn the user
+ * is no longer looking at. Both are silent: nothing errors, the transcript just
+ * shows the wrong conversation.
+ *
+ * Behaviour was observed on the running app before these assertions were
+ * written, not inferred from the source. Recorded in
+ * `~/tinyhuman/bugs/W2-ui-bugs.md` as OBS-13.
+ *
+ * NOT asserted here, deliberately: the composer draft carries across a switch
+ * (`inputValue` is one global `useState`, not a per-thread map). That is
+ * BUG-W2-UI-2, a product decision rather than a broken contract — pinning it
+ * would entrench behaviour that may be wrong, and whoever fixes it would have
+ * to delete the test.
+ */
+import { expect, type Locator, type Page, test } from '@playwright/test';
+
+import { bootAuthenticatedPage, dismissWalkthroughIfPresent } from '../helpers/core-rpc';
+
+const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18402'}`;
+const USER_ID = 'pw-chat-thread-isolation';
+
+/** `safeDelayMs` clamps to 1000ms, so length comes from chunk count. ~24s. */
+const SLOW_STREAM = [
+  ...Array.from({ length: 24 }, (_, i) => ({ text: `tokenA${i} `, delayMs: 1000 })),
+  { finish: 'stop' },
+];
+
+const A_PROMPT = 'ALPHA-THREAD-PROMPT';
+
+async function resetMock(): Promise<void> {
+  await fetch(`${MOCK_ADMIN_BASE}/__admin/reset`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+}
+
+async function setMockBehavior(key: string, value: string): Promise<void> {
+  await fetch(`${MOCK_ADMIN_BASE}/__admin/behavior`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ key, value }),
+  });
+}
+
+async function openChat(page: Page): Promise<void> {
+  await bootAuthenticatedPage(page, USER_ID, '/chat');
+  await dismissWalkthroughIfPresent(page);
+  await expect(page.getByTestId('chat-message-input')).toBeVisible({ timeout: 30_000 });
+}
+
+const composer = (page: Page): Locator => page.getByTestId('chat-message-input');
+const stopButton = (page: Page): Locator => page.getByTestId('stop-generation-button');
+
+/** The selected thread id, read from the live store. */
+async function selectedThreadId(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const store = (
+      window as unknown as {
+        __OPENHUMAN_STORE__?: {
+          getState?: () => { thread?: { selectedThreadId?: string | null } };
+        };
+      }
+    ).__OPENHUMAN_STORE__;
+    return store?.getState?.().thread?.selectedThreadId ?? null;
+  });
+}
+
+async function startNewThread(page: Page): Promise<void> {
+  await dismissWalkthroughIfPresent(page);
+  const sidebar = page.getByTestId('new-thread-sidebar-button');
+  if (await sidebar.isVisible().catch(() => false)) {
+    await sidebar.click({ force: true });
+  } else {
+    await page.getByTestId('new-thread-button').click({ force: true });
+  }
+}
+
+/** Send on the current thread and leave the turn streaming. */
+async function streamOnCurrentThread(page: Page, prompt: string): Promise<string> {
+  await composer(page).click();
+  await page.keyboard.type(prompt);
+  await page.keyboard.press('Enter');
+  await expect(stopButton(page)).toBeVisible({ timeout: 20_000 });
+  const id = await selectedThreadId(page);
+  expect(id, 'a thread id must exist once a turn is in flight').not.toBeNull();
+  return id as string;
+}
+
+test.describe('Chat thread isolation during a stream', () => {
+  test.beforeEach(async () => {
+    await resetMock();
+    await setMockBehavior('llmStreamScript', JSON.stringify(SLOW_STREAM));
+    await setMockBehavior('llmStreamChunkDelayMs', '1000');
+  });
+
+  /*
+   * REMOVED — 'a turn keeps running on its own thread after the user starts
+   * another'.
+   *
+   * It asserted `activeThreadIds` from the Redux store, which is an internals
+   * assertion, not something a user can see — and it is redundant: the
+   * "switching back" case below proves the same property through the UI, by
+   * showing that A's Stop control is still live when you return to it. A turn
+   * that had been cancelled by navigation could not do that.
+   *
+   * Dropped rather than kept as a cheap extra green: two assertions of one
+   * property, one of them reaching past the UI, is not more coverage.
+   */
+
+  test('the new thread offers no Stop control for the other thread’s turn', async ({ page }) => {
+    // The bleed that matters most: a Stop button on B would cancel A's turn,
+    // which the user is no longer looking at and did not ask to stop.
+    await openChat(page);
+    const threadA = await streamOnCurrentThread(page, A_PROMPT);
+
+    await startNewThread(page);
+    await expect.poll(async () => selectedThreadId(page), { timeout: 15_000 }).not.toBe(threadA);
+
+    await expect(
+      stopButton(page),
+      'the in-flight turn belongs to the other thread and must not be stoppable from here'
+    ).toHaveCount(0);
+  });
+
+  test('the new thread’s transcript shows none of the streaming thread’s content', async ({
+    page,
+  }) => {
+    await openChat(page);
+    const threadA = await streamOnCurrentThread(page, A_PROMPT);
+    // Wait for real streamed tokens, so this is not merely a race with an empty
+    // transcript — there is something that COULD bleed by the time we switch.
+    await expect(page.getByText('tokenA0', { exact: false }).last()).toBeVisible({
+      timeout: 20_000,
+    });
+
+    await startNewThread(page);
+    await expect.poll(async () => selectedThreadId(page), { timeout: 15_000 }).not.toBe(threadA);
+
+    await expect(page.getByText(A_PROMPT, { exact: false })).toHaveCount(0);
+    await expect(page.getByText('tokenA0', { exact: false })).toHaveCount(0);
+  });
+
+  test('switching back restores the original thread and its in-flight turn', async ({ page }) => {
+    // The other half: isolation must not mean the turn is orphaned. Coming
+    // back has to show A's transcript again, with its Stop control live.
+    await openChat(page);
+    const threadA = await streamOnCurrentThread(page, A_PROMPT);
+
+    await startNewThread(page);
+    await expect.poll(async () => selectedThreadId(page), { timeout: 15_000 }).not.toBe(threadA);
+    // NOT asserting a row count. `bootAuthenticatedPage` resets the session but
+    // not the thread list, so threads accumulate across the cases in this file
+    // for the same user id — an earlier draft expected 2 and found 5, which is
+    // a fact about test ordering rather than about isolation. What matters is
+    // that A's own row is there and selects A.
+    const rowA = page.getByTestId(`thread-row-${threadA}`);
+    await expect(rowA).toBeVisible({ timeout: 15_000 });
+    await rowA.click({ force: true });
+
+    await expect.poll(async () => selectedThreadId(page), { timeout: 15_000 }).toBe(threadA);
+    await expect(page.getByText(A_PROMPT, { exact: false }).last()).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      stopButton(page),
+      'returning to a streaming thread must show its Stop control again'
+    ).toBeVisible({ timeout: 15_000 });
+  });
+});

--- a/app/test/playwright/specs/chat-thread-isolation.spec.ts
+++ b/app/test/playwright/specs/chat-thread-isolation.spec.ts
@@ -29,7 +29,7 @@ import { expect, type Locator, type Page, test } from '@playwright/test';
 
 import { bootAuthenticatedPage, dismissWalkthroughIfPresent } from '../helpers/core-rpc';
 
-const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18402'}`;
+const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18473'}`;
 const USER_ID = 'pw-chat-thread-isolation';
 
 /** `safeDelayMs` clamps to 1000ms, so length comes from chunk count. ~24s. */
@@ -99,6 +99,24 @@ async function streamOnCurrentThread(page: Page, prompt: string): Promise<string
   expect(id, 'a thread id must exist once a turn is in flight').not.toBeNull();
   return id as string;
 }
+
+/**
+ * These are browser specs against a freshly built bundle, and the first few to
+ * run pay the app's cold start: a fresh `dist-web` plus a just-rebuilt core
+ * means first paint can take most of a minute, while every subsequent test in
+ * the same session settles at ~1s.
+ *
+ * Measured on this suite: cases 1-4 of the first spec failed at ~60s with a
+ * blank `#root`, case 5 of the SAME file passed at 25.3s, and all 13 cases
+ * after it passed in ~1s. Nothing about the app was wrong — the per-test budget
+ * (60s locally, `playwright.config.ts:10`) was simply consumed by warm-up.
+ *
+ * Raising the budget for this describe rather than editing the shared config:
+ * it is a statement about these tests, it masks nothing (the assertions are
+ * unchanged and a genuinely broken app still fails), and whichever spec happens
+ * to sort first should not be the one that flakes.
+ */
+test.describe.configure({ timeout: 120_000 });
 
 test.describe('Chat thread isolation during a stream', () => {
   test.beforeEach(async () => {

--- a/scripts/test-rust-e2e.sh
+++ b/scripts/test-rust-e2e.sh
@@ -31,6 +31,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Tests guarded by `#[ignore]` stay skipped unless the caller passes
 # `-- --ignored`.
 ALL_E2E_SUITES=(
+  agent_approval_memory_coverage_e2e
   agent_retrieval_e2e
   calendar_grounding_e2e
   config_auth_app_state_connectivity_e2e

--- a/tests/agent_approval_memory_coverage_e2e.rs
+++ b/tests/agent_approval_memory_coverage_e2e.rs
@@ -706,10 +706,13 @@ async fn agent_graph_topologies_exports_structure_without_run_state() {
     let body = payload(&response, "agent_graph_topologies");
 
     // `is_some()` would accept `null` or a scalar, so a schema regression that
-    // dropped the object could still pass. Require the object itself.
+    // dropped the field could still pass. Require the array itself — the handler
+    // builds `graphs` as a `Vec<Value>` and returns
+    // `json!({ "graphs": graphs, "agents": agents })`
+    // (`src/openhuman/agent/schemas.rs:486`), so it is an array, not an object.
     body.get("graphs")
-        .and_then(Value::as_object)
-        .unwrap_or_else(|| panic!("graph_topologies must return a `graphs` object: {body}"));
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("graph_topologies must return a `graphs` array: {body}"));
 
     let serialized = body.to_string();
     for leaked in ["system_prompt", "prompt_text", "api_key", "tool_arguments"] {

--- a/tests/agent_approval_memory_coverage_e2e.rs
+++ b/tests/agent_approval_memory_coverage_e2e.rs
@@ -1,0 +1,906 @@
+//! Wire-level e2e coverage for the agent / approval / memory RPC controllers
+//! that `scripts/check-domain-e2e-coverage.mjs` reported as uncovered.
+//!
+//! # Why a new file rather than extending an existing one
+//!
+//! The eight controllers here span three families whose existing raw-coverage
+//! files are already 2–4k lines each, and several of these tests need a
+//! *clean* process-global approval gate. Sharing a file with
+//! `tool_registry_approval_raw_coverage_e2e.rs` would make them order-dependent
+//! on whether a sibling test already installed the gate — the exact reason that
+//! file documents for skipping `preauthorize_flow`'s success path
+//! (see its `approval_schema_handlers_validate_params_and_surface_empty_gate_state`).
+//!
+//! # What "covered" means here, and what the checker actually measures
+//!
+//! `check-domain-e2e-coverage.mjs` marks a controller covered when the string
+//! literal `"openhuman.<method>"` appears anywhere in a `tests/**/*_e2e.rs`
+//! file. It does not verify the method is invoked or asserted on — a comment
+//! scores 100%. Every method named below is therefore driven over the real
+//! JSON-RPC router (`build_core_http_router`) and asserted on, so the number the
+//! gate reports and the coverage that exists are the same thing.
+
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+use axum::http::header::AUTHORIZATION;
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+use tempfile::{tempdir, TempDir};
+
+use openhuman_core::core::auth::{init_rpc_token, CORE_TOKEN_ENV_VAR};
+use openhuman_core::core::jsonrpc::build_core_http_router;
+
+const TEST_RPC_TOKEN: &str = "agent-approval-memory-coverage-e2e-token";
+
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+static AUTH_INIT: OnceLock<()> = OnceLock::new();
+
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Restores an environment variable to its prior value on drop so a harness
+/// cannot leak `HOME` into a sibling test in the same binary.
+struct EnvVarGuard {
+    key: String,
+    previous: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &str, value: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::set_var(key, value);
+        Self {
+            key: key.to_string(),
+            previous,
+        }
+    }
+
+    fn set_to_path(key: &str, value: &Path) -> Self {
+        Self::set(key, &value.to_string_lossy())
+    }
+
+    fn unset(key: &str) -> Self {
+        let previous = std::env::var(key).ok();
+        std::env::remove_var(key);
+        Self {
+            key: key.to_string(),
+            previous,
+        }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        match self.previous.take() {
+            Some(value) => std::env::set_var(&self.key, value),
+            None => std::env::remove_var(&self.key),
+        }
+    }
+}
+
+struct TestHarness {
+    _tmp: TempDir,
+    _guards: Vec<EnvVarGuard>,
+    rpc_base: String,
+    _rpc_join: tokio::task::JoinHandle<Result<(), std::io::Error>>,
+}
+
+fn ensure_rpc_auth() {
+    AUTH_INIT.get_or_init(|| {
+        std::env::set_var(CORE_TOKEN_ENV_VAR, TEST_RPC_TOKEN);
+        let token_dir = std::env::temp_dir().join("openhuman-agent-approval-memory-e2e-auth");
+        init_rpc_token(&token_dir).expect("init rpc auth token");
+    });
+}
+
+async fn serve_rpc() -> (
+    std::net::SocketAddr,
+    tokio::task::JoinHandle<Result<(), std::io::Error>>,
+) {
+    ensure_rpc_auth();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind rpc listener");
+    let addr = listener.local_addr().expect("rpc listener addr");
+    let router = build_core_http_router(false);
+    let join = tokio::spawn(async move { axum::serve(listener, router).await });
+    (addr, join)
+}
+
+fn write_config(openhuman_dir: &Path) {
+    std::fs::create_dir_all(openhuman_dir).expect("create .openhuman");
+    // `provider = "none"` binds the null memory driver. That is deliberate for
+    // `memory_provider_status`: the null driver still reports the three
+    // MANDATORY capability families, which is what makes the assertion below a
+    // real check rather than a shape check.
+    let cfg = r#"api_url = "http://127.0.0.1:9"
+default_model = "e2e-model"
+default_temperature = 0.2
+
+[secrets]
+encrypt = false
+
+[local_ai]
+enabled = false
+
+[memory]
+provider = "none"
+embedding_provider = "none"
+embedding_model = "none"
+embedding_dimensions = 0
+
+[memory_tree]
+embedding_strict = false
+
+[autonomy]
+level = "supervised"
+workspace_only = false
+max_actions_per_hour = 17
+require_approval_for_medium_risk = false
+block_high_risk_commands = false
+auto_approve = []
+"#;
+    std::fs::write(openhuman_dir.join("config.toml"), cfg).expect("write config.toml");
+}
+
+async fn setup() -> TestHarness {
+    let tmp = tempdir().expect("tempdir");
+    let home = tmp.path();
+    let workspace = home.join("openhuman-workspace");
+    write_config(&workspace);
+    write_config(&home.join(".openhuman"));
+
+    let guards = vec![
+        EnvVarGuard::set_to_path("HOME", home),
+        EnvVarGuard::set_to_path("OPENHUMAN_WORKSPACE", &workspace),
+        EnvVarGuard::unset("BACKEND_URL"),
+        EnvVarGuard::unset("VITE_BACKEND_URL"),
+        EnvVarGuard::unset("OPENHUMAN_API_URL"),
+        EnvVarGuard::set("OPENHUMAN_KEYRING_BACKEND", "file"),
+        EnvVarGuard::set("OPENHUMAN_MEMORY_EMBED_STRICT", "false"),
+        EnvVarGuard::set("OPENHUMAN_MEMORY_EMBED_ENDPOINT", ""),
+        EnvVarGuard::set("OPENHUMAN_MEMORY_EMBED_MODEL", ""),
+    ];
+
+    let (addr, rpc_join) = serve_rpc().await;
+    TestHarness {
+        _tmp: tmp,
+        _guards: guards,
+        rpc_base: format!("http://{addr}"),
+        _rpc_join: rpc_join,
+    }
+}
+
+async fn rpc(rpc_base: &str, id: i64, method: &str, params: Value) -> Value {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("client");
+    let url = format!("{}/rpc", rpc_base.trim_end_matches('/'));
+    let response = client
+        .post(&url)
+        .header(AUTHORIZATION, format!("Bearer {TEST_RPC_TOKEN}"))
+        .json(&json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        }))
+        .send()
+        .await
+        .unwrap_or_else(|err| panic!("POST {url} {method}: {err}"));
+    assert_eq!(response.status(), StatusCode::OK, "{method} HTTP status");
+    response
+        .json::<Value>()
+        .await
+        .unwrap_or_else(|err| panic!("json for {method}: {err}"))
+}
+
+fn ok<'a>(value: &'a Value, context: &str) -> &'a Value {
+    if let Some(error) = value.get("error") {
+        panic!("{context}: unexpected JSON-RPC error: {error}");
+    }
+    value
+        .get("result")
+        .unwrap_or_else(|| panic!("{context}: missing result: {value}"))
+}
+
+/// Peel the conditional `RpcOutcome` envelope. A handler that emits no log
+/// lines returns the bare value; one that emits any returns
+/// `{ result, logs }`. Both shapes are valid for the same method, so every
+/// consumer has to tolerate both — see `src/rpc/mod.rs`.
+fn payload<'a>(value: &'a Value, context: &str) -> &'a Value {
+    let result = ok(value, context);
+    result.get("result").unwrap_or(result)
+}
+
+fn error_message<'a>(value: &'a Value, context: &str) -> &'a str {
+    value
+        .get("error")
+        .and_then(|error| error.get("message"))
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("{context}: error missing message: {value}"))
+}
+
+// ---------------------------------------------------------------------------
+// approval.get_gate_state
+// ---------------------------------------------------------------------------
+
+/// `openhuman.approval_get_gate_state` answers over the wire and the boot-state
+/// snapshot is internally consistent.
+///
+/// The three booleans are not independent, and that is the part worth pinning:
+/// `disabled_by_env` (the override was honoured, gate OFF) and
+/// `override_ignored` (the override was seen and suppressed because the host is
+/// the desktop shell) are mutually exclusive by construction, and an honoured
+/// disable cannot coexist with `installed`. A regression that made the RPC
+/// report both would render two contradictory banners in the UI.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_get_gate_state_returns_a_consistent_boot_snapshot() {
+    let _lock = env_lock();
+    let harness = setup().await;
+
+    let response = rpc(
+        &harness.rpc_base,
+        1,
+        "openhuman.approval_get_gate_state",
+        json!({}),
+    )
+    .await;
+    let state = payload(&response, "approval_get_gate_state");
+
+    // NOTE the wire casing: `ApprovalGateBootState` is
+    // `#[serde(rename_all = "camelCase")]` (`gate.rs:154`), so the RPC emits
+    // `disabledByEnv` / `overrideIgnored` even though the Rust fields are
+    // snake_case. Asserting the snake_case names would silently pass on
+    // `Option::None` rather than fail, so read them explicitly.
+    let installed = state
+        .get("installed")
+        .and_then(Value::as_bool)
+        .unwrap_or_else(|| panic!("installed must be a bool: {state}"));
+    let disabled_by_env = state
+        .get("disabledByEnv")
+        .and_then(Value::as_bool)
+        .unwrap_or_else(|| panic!("disabledByEnv must be a bool: {state}"));
+    let override_ignored = state
+        .get("overrideIgnored")
+        .and_then(Value::as_bool)
+        .unwrap_or_else(|| panic!("overrideIgnored must be a bool: {state}"));
+    let host = state
+        .get("host")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("host must be a string: {state}"));
+
+    assert!(
+        !(disabled_by_env && override_ignored),
+        "disabled_by_env and override_ignored are mutually exclusive, got both in {state}"
+    );
+    assert!(
+        !(installed && disabled_by_env),
+        "an env-disabled gate cannot also be installed: {state}"
+    );
+    // `host` is a pinned string downstream consumers may switch on, so an
+    // unrecognised tag is a contract break even though it is "just a string".
+    //
+    // Four values are reachable, not three. The struct's own doc comment
+    // (`gate.rs:167-169`) enumerates only `tauri-shell` / `cli` / `docker`, but
+    // `approval_get_gate_state` falls back to `host: "unknown"` when boot state
+    // was never recorded (`approval/rpc.rs:30-35`) — any host that did not go
+    // through `bootstrap_core_runtime`, which includes this harness. The
+    // frontend already knows this (`approvalApi.ts:171` documents all four and
+    // types `host` as a plain `string`); only the Rust doc comment is stale.
+    assert!(
+        matches!(host, "tauri-shell" | "cli" | "docker" | "unknown"),
+        "host must be one of the pinned tags (tauri-shell|cli|docker|unknown), \
+         got {host:?} in {state}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// approval.preauthorize_flow
+// ---------------------------------------------------------------------------
+
+/// `openhuman.approval_preauthorize_flow` honours its gate-absent contract:
+/// it **succeeds** with `gate_installed: false` rather than erroring, and does
+/// so identically on a repeat call.
+///
+/// # Scope — what this proves, and what it deliberately does not
+///
+/// No `ApprovalGate` is installed in this harness, so the handler takes the
+/// documented gate-absent branch (`approval/rpc.rs:125-139`). That branch is a
+/// real contract worth pinning — the schema states it in as many words
+/// ("Succeeds with gate_installed=false when the approval gate is disabled"),
+/// and a flow-save path that started erroring when the gate is off would break
+/// every CLI and headless host. Mutating that branch to return an error turns
+/// this test red, so the assertion is live.
+///
+/// It does **not** prove grant idempotency. An earlier draft claimed to, by
+/// comparing `granted` counts across two calls; mutation testing showed that
+/// was vacuous — with no gate installed both calls return `granted: []`, so
+/// `0 <= 0` held no matter what the grant logic did.
+///
+/// Exercising the real grant path needs `ApprovalGate::init_global`, which
+/// installs a **process-global** `OnceLock`. Doing that here would change what
+/// `approval_get_gate_state_returns_a_consistent_boot_snapshot` observes in the
+/// same binary, making the pair order-dependent — the identical reason
+/// `tool_registry_approval_raw_coverage_e2e.rs` gives for skipping this path.
+/// Grant idempotency ("already-trusted tools are reported, not re-granted") is
+/// covered by the unit tests in `approval::rpc` / `approval::store`, which own
+/// the gate lifecycle.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_preauthorize_flow_succeeds_without_a_gate_installed() {
+    let _lock = env_lock();
+    let harness = setup().await;
+
+    let flow_id = format!("flow-{}", uuid::Uuid::new_v4());
+    let args = json!({
+        "flow_id": flow_id,
+        "tool_names": ["slack_post_message", "gmail_send_email"],
+    });
+
+    let first = rpc(
+        &harness.rpc_base,
+        2,
+        "openhuman.approval_preauthorize_flow",
+        args.clone(),
+    )
+    .await;
+    let first_payload = payload(&first, "approval_preauthorize_flow first call");
+
+    assert_eq!(
+        first_payload.get("gate_installed"),
+        Some(&Value::Bool(false)),
+        "with no gate installed the call must succeed reporting gate_installed=false, \
+         not error and not claim a gate: {first_payload}"
+    );
+    assert_eq!(
+        first_payload.get("granted").and_then(Value::as_array),
+        Some(&vec![]),
+        "no gate means nothing can be granted: {first_payload}"
+    );
+    assert_eq!(
+        first_payload.get("flow_id").and_then(Value::as_str),
+        Some(flow_id.as_str()),
+        "the response must echo the flow_id it was asked about: {first_payload}"
+    );
+
+    // Repeating the call must not change the answer — the gate-absent branch
+    // persists nothing, so there is no state for a second call to trip over.
+    let second = rpc(
+        &harness.rpc_base,
+        3,
+        "openhuman.approval_preauthorize_flow",
+        args,
+    )
+    .await;
+    let second_payload = payload(&second, "approval_preauthorize_flow repeat call");
+    assert_eq!(
+        first_payload, second_payload,
+        "a repeat call with no gate installed must be byte-identical: \
+         {first_payload} then {second_payload}"
+    );
+}
+
+/// Required params are enforced at the wire boundary, not merely at the
+/// handler. Registering a controller without wiring its param validation into
+/// dispatch would leave these calls panicking or succeeding with defaults.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_preauthorize_flow_rejects_malformed_params_over_the_wire() {
+    let _lock = env_lock();
+    let harness = setup().await;
+
+    let missing_flow = rpc(
+        &harness.rpc_base,
+        4,
+        "openhuman.approval_preauthorize_flow",
+        json!({}),
+    )
+    .await;
+    assert!(
+        error_message(&missing_flow, "missing flow_id").contains("flow_id"),
+        "missing flow_id must name the param, got {missing_flow}"
+    );
+
+    let missing_tools = rpc(
+        &harness.rpc_base,
+        5,
+        "openhuman.approval_preauthorize_flow",
+        json!({ "flow_id": "flow-1" }),
+    )
+    .await;
+    assert!(
+        error_message(&missing_tools, "missing tool_names").contains("tool_names"),
+        "missing tool_names must name the param, got {missing_tools}"
+    );
+
+    let scalar_tools = rpc(
+        &harness.rpc_base,
+        6,
+        "openhuman.approval_preauthorize_flow",
+        json!({ "flow_id": "flow-1", "tool_names": "slack_post_message" }),
+    )
+    .await;
+    assert!(
+        scalar_tools.get("error").is_some(),
+        "a scalar tool_names must be rejected, not coerced: {scalar_tools}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// The approval gate's classification contract (openhuman#5862)
+// ---------------------------------------------------------------------------
+
+/// **This test reproduces openhuman#5862 and FAILS on `main` today. That is its
+/// purpose.** It is `#[ignore]`d so it does not turn the shared lane red;
+/// run it with `cargo test --test agent_approval_memory_coverage_e2e -- --ignored`.
+/// Un-ignore it when #5863 (or an equivalent fix) lands — at that point it
+/// becomes the regression guard.
+///
+/// # What is broken
+///
+/// `ApprovalSecurityMiddleware` decides whether to park a call on exactly one
+/// predicate — `Tool::external_effect_with_args`
+/// (`agent/tinyagents/middleware_part_02.rs:267-296`). The Composio tools
+/// (`ComposioExecuteTool`, `ComposioActionTool`) declare
+/// `permission_level() == PermissionLevel::Write` but never override
+/// `external_effect*`, so they inherit the trait default of `false`
+/// (`tinytools/src/tool/types.rs:147-158`). Agent-initiated Composio writes —
+/// `GMAIL_SEND_EMAIL` and friends — therefore run with no approval card, no
+/// audit row, and no denial path.
+///
+/// Three defences were checked and none applies:
+/// 1. There is no compensating manual gate. The only `ApprovalGate` intercept
+///    in `integrations/composio/` is `ComposioConnectTool`'s, whose
+///    `external_effect = false` *is* deliberate and documented.
+/// 2. The alternative gate adapter (`host/security_gate.rs:573`) keys off the
+///    same predicate, so which gate is installed makes no difference.
+/// 3. It is not that the codebase does not know how: the legacy
+///    `ComposioTool` (`integrations/composio/tools/direct_part_03.rs:66-80`)
+///    classifies *correctly* and arg-aware — `action: "execute"` is an external
+///    effect, `list` and `connect` are not. That tool is **not** an agent tool
+///    (it is an internal client, built only in `client_part_02.rs`). The
+///    classification was simply not carried over when the surface was split
+///    into per-purpose tools, which is what makes this a migration regression
+///    rather than an oversight in a single file.
+///
+/// Both unclassified tools are on the live agent path:
+/// `ComposioExecuteTool` via `all_composio_agent_tools`
+/// (`tools_part_03.rs:339`), and `ComposioActionTool` via the subagent runner
+/// (`agent/harness/subagent_runner/ops/provider.rs:193`, `runner.rs:1100`).
+///
+/// # Why it is written as a classification assertion
+///
+/// Driving a live Composio write end-to-end would need provider credentials and
+/// would actually send mail. The classification *is* the bug — the gate is a
+/// pure function of it — so asserting the classification tests the real defect
+/// without a network round-trip, and it cannot pass vacuously: it reads the
+/// same method the middleware reads.
+#[test]
+#[ignore = "reproduces openhuman#5862: Composio write tools bypass the approval gate; \
+            un-ignore when #5863 or an equivalent classification fix lands"]
+fn composio_write_tools_declare_an_external_effect_so_the_approval_gate_parks_them() {
+    use std::sync::Arc;
+
+    use openhuman_core::openhuman::config::Config;
+    use openhuman_core::openhuman::integrations::composio::tools::ComposioExecuteTool;
+    use openhuman_core::openhuman::tools::traits::Tool;
+
+    let tool = ComposioExecuteTool::new(Arc::new(Config::default()));
+
+    // A write to a third-party SaaS is the canonical external effect: it is not
+    // reversible inside the user's own machine, which is the line the trait
+    // documents (`types.rs:144-146`).
+    let send_email = json!({
+        "tool": "GMAIL_SEND_EMAIL",
+        "arguments": { "recipient_email": "someone@example.com", "body": "sent by the agent" },
+    });
+
+    assert!(
+        tool.external_effect_with_args(&send_email),
+        "composio_execute(GMAIL_SEND_EMAIL) reports external_effect_with_args=false, so \
+         ApprovalSecurityMiddleware never parks it and the write runs unprompted. \
+         The tool already classifies itself as PermissionLevel::{:?}; the approval gate \
+         reads external_effect*, not permission_level. See openhuman#5862.",
+        tool.permission_level()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// agent.run_events / agent.run_status / agent.runs_active
+// ---------------------------------------------------------------------------
+
+/// The three replay controllers are read-only projections over the durable
+/// tinyagents journal. An unknown `run_id` is a normal, expected query (the UI
+/// polls before a run has written anything), so it must return an empty page
+/// rather than erroring — and `next_offset` must be `null`, meaning "drained",
+/// not `0`, which a paging client would follow forever.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn agent_run_events_returns_a_drained_empty_page_for_an_unknown_run() {
+    let _lock = env_lock();
+    let harness = setup().await;
+
+    let response = rpc(
+        &harness.rpc_base,
+        10,
+        "openhuman.agent_run_events",
+        json!({ "run_id": "run-that-was-never-started" }),
+    )
+    .await;
+    let page = payload(&response, "agent_run_events unknown run");
+
+    let events = page
+        .get("events")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("events must be an array: {page}"));
+    assert!(
+        events.is_empty(),
+        "an unknown run must yield no events, got {events:?}"
+    );
+    assert_eq!(
+        page.get("next_offset"),
+        Some(&Value::Null),
+        "a drained stream must report next_offset=null, not 0 — a client that follows \
+         a 0 cursor would page forever: {page}"
+    );
+}
+
+/// `run_id` is the one required param; omitting it must be rejected by the
+/// **schema validator** at the wire boundary, before the handler runs.
+///
+/// # Why the assertion is on the exact validator string
+///
+/// An earlier draft asserted only `.contains("run_id")`. Mutation testing
+/// showed that was vacuous: when the required-param check is defeated, the
+/// handler proceeds with an empty id and fails downstream with
+/// `"read run events failed: … run_id=: validation error: store namespace and
+/// key must not be empty"` — which *also* contains `"run_id"`, because the
+/// handler embeds `run_id=` as a debug label in its own error text. The loose
+/// assertion could not tell "rejected the missing param" from "accepted it and
+/// failed later", so it passed under both.
+///
+/// Matching `missing required param 'run_id'` — the exact format emitted by
+/// `validate_params` (`src/core/all.rs:1339-1343`) — pins the layer that is
+/// actually supposed to reject this.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn agent_run_events_rejects_a_missing_run_id() {
+    let _lock = env_lock();
+    let harness = setup().await;
+
+    let response = rpc(
+        &harness.rpc_base,
+        11,
+        "openhuman.agent_run_events",
+        json!({}),
+    )
+    .await;
+    assert!(
+        error_message(&response, "missing run_id").contains("missing required param 'run_id'"),
+        "a missing run_id must be rejected by the schema validator before the handler runs; \
+         a downstream failure that merely mentions run_id is not the same thing: {response}"
+    );
+}
+
+/// An over-large `limit` is **accepted and clamped**, not rejected.
+///
+/// # What this test does and does not prove
+///
+/// It proves the *tolerance* half: an absurd `limit` must not become a param
+/// error, because a paging client that guesses high should degrade to the
+/// maximum page rather than fail. That is a real, falsifiable behaviour —
+/// making the handler reject `limit > MAX_EVENTS_LIMIT` turns this test red.
+///
+/// It deliberately does **not** assert `events.len() <= MAX_EVENTS_LIMIT`. An
+/// earlier draft did, and mutation testing showed the assertion was vacuous:
+/// this harness queries an unknown run, so `events` is always empty and
+/// `0 <= 1000` holds no matter what the clamp does. Proving the clamp itself
+/// needs a journal seeded with more than 1000 events, which belongs in a
+/// fixture-backed test rather than here. The clamp is pinned instead by
+/// `replay::ops` (`limit.clamp(1, MAX_EVENTS_LIMIT)`, `ops.rs:56`) and by the
+/// handler's own `.min(MAX_EVENTS_LIMIT)` (`replay/schemas.rs:248`) — note
+/// there are two independent clamps, so removing either alone changes nothing
+/// observable.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn agent_run_events_accepts_an_oversized_limit_without_erroring() {
+    let _lock = env_lock();
+    let harness = setup().await;
+
+    let response = rpc(
+        &harness.rpc_base,
+        12,
+        "openhuman.agent_run_events",
+        json!({ "run_id": "run-unknown", "offset": 0, "limit": 1_000_000 }),
+    )
+    .await;
+
+    assert!(
+        response.get("error").is_none(),
+        "an oversized limit must be clamped and served, not rejected: {response}"
+    );
+    let page = payload(&response, "agent_run_events oversized limit");
+    assert!(
+        page.get("events").and_then(Value::as_array).is_some(),
+        "an oversized limit must still return a well-formed page: {page}"
+    );
+}
+
+/// An unknown run has no status snapshot. `null` is the documented answer —
+/// distinct from an error, which the UI would surface as a failure.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn agent_run_status_returns_null_for_an_unknown_run() {
+    let _lock = env_lock();
+    let harness = setup().await;
+
+    let response = rpc(
+        &harness.rpc_base,
+        13,
+        "openhuman.agent_run_status",
+        json!({ "run_id": "run-that-was-never-started" }),
+    )
+    .await;
+    assert!(
+        response.get("error").is_none(),
+        "an unknown run is a normal query, not an error: {response}"
+    );
+    assert_eq!(
+        payload(&response, "agent_run_status unknown run"),
+        &Value::Null,
+        "an unknown run must report null status"
+    );
+}
+
+/// `agent_runs_active` takes two optional filters and must accept the
+/// unfiltered call, both filters, and either alone — always returning a `runs`
+/// array. A filter that was wired as required would break the UI's default
+/// unfiltered poll.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn agent_runs_active_accepts_every_filter_combination() {
+    let _lock = env_lock();
+    let harness = setup().await;
+
+    for (id, params, label) in [
+        (14, json!({}), "no filter"),
+        (15, json!({ "thread_id": "thread-1" }), "thread only"),
+        (16, json!({ "root_run_id": "root-1" }), "root only"),
+        (
+            17,
+            json!({ "thread_id": "thread-1", "root_run_id": "root-1" }),
+            "both filters",
+        ),
+    ] {
+        let response = rpc(&harness.rpc_base, id, "openhuman.agent_runs_active", params).await;
+        let body = payload(&response, &format!("agent_runs_active ({label})"));
+        assert!(
+            body.get("runs").and_then(Value::as_array).is_some(),
+            "runs must be an array for {label}: {body}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// agent.graph_topologies / agent.registry_snapshot
+// ---------------------------------------------------------------------------
+
+/// `agent_graph_topologies` exports structure only. The contract in its own
+/// schema is explicit — "never closure bodies or run state" — so this asserts
+/// the negative as well as the positive: a topology export that started leaking
+/// prompt text or run state would be a privacy regression that a
+/// shape-only check would not catch.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn agent_graph_topologies_exports_structure_without_run_state() {
+    let _lock = env_lock();
+    let harness = setup().await;
+
+    let response = rpc(
+        &harness.rpc_base,
+        18,
+        "openhuman.agent_graph_topologies",
+        json!({}),
+    )
+    .await;
+    let body = payload(&response, "agent_graph_topologies");
+
+    assert!(
+        body.get("graphs").is_some(),
+        "graph_topologies must return a `graphs` object: {body}"
+    );
+
+    let serialized = body.to_string();
+    for leaked in ["system_prompt", "prompt_text", "api_key", "tool_arguments"] {
+        assert!(
+            !serialized.contains(leaked),
+            "graph topology export is structure-only but contained {leaked:?}"
+        );
+    }
+}
+
+/// `agent_registry_snapshot` projects the capability registry as metadata only.
+/// `counts` must agree with the length of `components` — they are derived from
+/// the same inventory, so a mismatch means one of the two was assembled from a
+/// stale or partial source.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn agent_registry_snapshot_counts_agree_with_the_component_inventory() {
+    let _lock = env_lock();
+    let harness = setup().await;
+
+    let response = rpc(
+        &harness.rpc_base,
+        19,
+        "openhuman.agent_registry_snapshot",
+        json!({}),
+    )
+    .await;
+    let body = payload(&response, "agent_registry_snapshot");
+
+    let components = body
+        .get("components")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("components must be an array: {body}"));
+
+    // `counts` carries the per-kind entries AND a `total` key
+    // (`agent/schemas.rs:643-649`), so summing every value double-counts.
+    // Check the two claims separately — that is stronger than one sum anyway,
+    // because it catches `total` and the per-kind breakdown disagreeing with
+    // each other as well as with `components`.
+    if let Some(counts) = body.get("counts").and_then(Value::as_object) {
+        let per_kind: u64 = counts
+            .iter()
+            .filter(|(key, _)| key.as_str() != "total")
+            .filter_map(|(_, value)| value.as_u64())
+            .sum();
+        assert_eq!(
+            per_kind,
+            components.len() as u64,
+            "per-kind counts ({per_kind}) must sum to the component inventory ({}); \
+             a mismatch means counts and components came from different sources",
+            components.len()
+        );
+        assert_eq!(
+            counts.get("total").and_then(Value::as_u64),
+            Some(components.len() as u64),
+            "counts.total must equal the component inventory ({}): {body}",
+            components.len()
+        );
+    }
+
+    // Metadata only — the schema is explicit that live per-run handles and run
+    // state are excluded.
+    for component in components {
+        assert!(
+            component.get("id").is_some(),
+            "every component carries an id: {component}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// memory.provider_status
+// ---------------------------------------------------------------------------
+
+/// `openhuman.memory_provider_status` is the RPC that *reports* the bound
+/// driver's capability set, and it is deliberately the one memory controller
+/// that is never capability-gated (`core/all.rs:775-780`: "Gating it on a
+/// capability would be self-referential and would hide the explanation for
+/// every other absence in this block").
+///
+/// # The capability assertion is conditional, deliberately
+///
+/// An unresolved slot (no workspace context) reports `class="null"`,
+/// `health="down"`, **empty** capabilities and a `last_error` — pinned by
+/// `memory::ops::provider_tests::status_without_a_context_reports_an_unresolved_slot`.
+/// A bound driver reports its advertised families. Asserting the MANDATORY
+/// three unconditionally would therefore be wrong, not strict: it would fail on
+/// the legitimate unresolved path.
+///
+/// So this asserts the *invariant that holds either way* — a driver that
+/// reports itself healthy must advertise the three MANDATORY families
+/// (`Capabilities::validate` refuses to bind one that does not), and a driver
+/// that advertises nothing must say why. That pairing is what a regression
+/// would break: a driver going silently capability-less while still reporting
+/// `ready` is exactly the shape of openhuman#5598, where `memory_tree` methods
+/// answered `UnknownMethod` on staging with no visible explanation.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn memory_provider_status_reports_the_bound_driver_and_its_mandatory_families() {
+    let _lock = env_lock();
+    let harness = setup().await;
+
+    let response = rpc(
+        &harness.rpc_base,
+        20,
+        "openhuman.memory_provider_status",
+        json!({}),
+    )
+    .await;
+    let status = payload(&response, "memory_provider_status");
+
+    assert_eq!(
+        status.get("slot").and_then(Value::as_str),
+        Some("memory"),
+        "slot is always \"memory\" for this controller: {status}"
+    );
+
+    let class = status
+        .get("class")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("class must be a string: {status}"));
+    assert!(
+        matches!(class, "embedded" | "external" | "module" | "null"),
+        "class must be one of the documented DriverClass tags, got {class:?} in {status}"
+    );
+
+    let health = status
+        .get("health")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("health must be a string: {status}"));
+    assert!(
+        matches!(health, "ready" | "degraded" | "down"),
+        "health must be ready|degraded|down, got {health:?} in {status}"
+    );
+
+    // `health_reason` is documented as null when ready — an operator-facing
+    // reason attached to a healthy driver would be a contradiction the UI
+    // renders as a warning banner on a working system.
+    if health == "ready" {
+        assert!(
+            status
+                .get("health_reason")
+                .map(|reason| reason.is_null())
+                .unwrap_or(true),
+            "a ready driver must carry no health_reason: {status}"
+        );
+    }
+
+    let contract_version = status
+        .get("contract_version")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| panic!("contract_version must be a string: {status}"));
+    let mut parts = contract_version.split('.');
+    let (major, minor, extra) = (parts.next(), parts.next(), parts.next());
+    assert!(
+        major.is_some_and(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
+            && minor.is_some_and(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
+            && extra.is_none(),
+        "contract_version must be exactly \"<major>.<minor>\", got {contract_version:?}"
+    );
+
+    let capabilities: Vec<&str> = status
+        .get("capabilities")
+        .and_then(Value::as_array)
+        .unwrap_or_else(|| panic!("capabilities must be an array: {status}"))
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+
+    if capabilities.is_empty() {
+        // Nothing bound. That is a legitimate state, but it must be explained:
+        // a silently capability-less driver is indistinguishable from a broken
+        // one, which is the whole reason this RPC is never capability-gated.
+        assert_ne!(
+            health, "ready",
+            "a driver advertising no capabilities must not report itself ready: {status}"
+        );
+        assert!(
+            status
+                .get("last_error")
+                .is_some_and(|error| !error.is_null()),
+            "an unresolved memory slot must report last_error explaining why nothing bound: \
+             {status}"
+        );
+    } else {
+        // Something bound and is serving. `Capabilities::validate` refuses to
+        // bind a driver missing any MANDATORY family, so their presence is a
+        // structural guarantee, not a property of the pinned artifact.
+        for mandatory in ["core", "recall", "portability"] {
+            assert!(
+                capabilities.contains(&mandatory),
+                "a bound driver must advertise the MANDATORY family {mandatory:?}; \
+                 got {capabilities:?} in {status}"
+            );
+        }
+    }
+}

--- a/tests/agent_approval_memory_coverage_e2e.rs
+++ b/tests/agent_approval_memory_coverage_e2e.rs
@@ -705,10 +705,11 @@ async fn agent_graph_topologies_exports_structure_without_run_state() {
     .await;
     let body = payload(&response, "agent_graph_topologies");
 
-    assert!(
-        body.get("graphs").is_some(),
-        "graph_topologies must return a `graphs` object: {body}"
-    );
+    // `is_some()` would accept `null` or a scalar, so a schema regression that
+    // dropped the object could still pass. Require the object itself.
+    body.get("graphs")
+        .and_then(Value::as_object)
+        .unwrap_or_else(|| panic!("graph_topologies must return a `graphs` object: {body}"));
 
     let serialized = body.to_string();
     for leaked in ["system_prompt", "prompt_text", "api_key", "tool_arguments"] {
@@ -747,7 +748,14 @@ async fn agent_registry_snapshot_counts_agree_with_the_component_inventory() {
     // Check the two claims separately — that is stronger than one sum anyway,
     // because it catches `total` and the per-kind breakdown disagreeing with
     // each other as well as with `components`.
-    if let Some(counts) = body.get("counts").and_then(Value::as_object) {
+    // NOT `if let`: a missing or non-object `counts` would silently skip every
+    // assertion below and the case would still pass on `components` alone,
+    // which is precisely the agreement this test exists to pin.
+    {
+        let counts = body
+            .get("counts")
+            .and_then(Value::as_object)
+            .unwrap_or_else(|| panic!("registry_snapshot must return a `counts` object: {body}"));
         let per_kind: u64 = counts
             .iter()
             .filter(|(key, _)| key.as_str() != "total")


### PR DESCRIPTION
## Summary

- Adds Rust e2e coverage for the **eight** uncovered agent / approval / memory controllers the coverage gate named.
- Adds six settings-panel suites for panels in the same area that had thin or no coverage.
- 7 files, +1,794 lines. No product code touched.

> **Test lane:** 1 Rust e2e target (real handler dispatch) + 6 vitest component suites (jsdom, mocked transport). No browser-level tests.

## Problem

`scripts/check-domain-e2e-coverage.mjs` reported agent 7/12, approval 3/5, memory 34/35 — eight controllers with no e2e coverage.

While covering them, two facts emerged worth recording:

- **Five of the eight have no frontend consumer at all.** `agent_run_events`, `agent_run_status`, `agent_runs_active`, `agent_graph_topologies` and `memory_provider_status` are registered and wire-reachable but nothing in the product calls them. They are covered here either way; whether the replay trio is awaiting a UI or is surface to retire is a maintainer decision, not a test one.
- **The approval pair sits on the gate that openhuman#5862 reports as bypassable**, so those tests were written to discriminate rather than merely execute.

## Solution

Real handler dispatch against mocks for all eight controllers, plus six settings suites.

**Three drafts were killed by the revert-proof and rewritten** — they are the reason to trust the rest:

1. An oversized-limit assertion compared `0 <= 1000` against an always-empty list; worse, **two independent clamps** exist, so removing either alone changes nothing observable. Rewritten to the falsifiable half, with the limitation stated in the test.
2. A missing-`run_id` assertion matched `.contains("run_id")`, which also matches the *downstream* failure because the handler embeds `run_id=` as a debug label — it passed whether the check fired or not. Now matches the exact `validate_params` format.
3. A preauthorize "idempotency" test compared two empty lists.

Also closes a security-relevant coverage gap: `CoreConnectionPanel.validate()` rejects a `user:pass@host` remote-core URL to stop a secret being persisted and echoed back, and that guard had **no test**. It now has two, and the credential case asserts the password appears nowhere in the rendered page.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — this PR *is* the tests. Every case was revert-proofed: the covered behaviour was broken, the test confirmed to fail naming its own assertion, then restored. Drafts that still passed with the fault injected were rewritten or dropped rather than kept.
- [x] **Diff coverage ≥ 80%** — `N/A: the changed lines are test files`, executed by the suites they belong to; there is no product code in this diff for diff-cover to measure.
- [x] Coverage matrix updated — `N/A: behaviour-only change` — no feature rows added, removed or renamed; this covers behaviour that already ships.
- [x] All affected feature IDs from the matrix are listed — `N/A: no feature IDs affected`.
- [x] No new external network dependencies introduced — mocks and fixtures only; no test reaches a live service.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no product surface changes`, test-only.
- [x] Linked issue closed via `Closes #NNN` — `N/A: no linked issue`; this is coverage work, not a fix.

## Impact

- **Platform:** none at runtime. Test-only.
- **Security:** adds regression cover for the remote-core credential-leak guard, and for the approval gate's parking behaviour.
- **Risk:** none to product behaviour.

## Related

- Closes:
- Related, and deliberately **not** addressed here: openhuman#5862 (Composio writes bypass the approval gate) — this PR adds cover around the gate; the bypass itself needs a product fix.
- Follow-up PR(s)/TODOs: maintainer decision on the five consumer-less controllers.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `test/agent-approval-memory-e2e`
- Commit SHA: see head of this PR

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — prettier clean on the six new `.tsx` files.
- [x] `pnpm typecheck` — `tsc --noEmit`, 0 errors.
- [x] Focused tests: the six vitest suites pass; the Rust target compiles and runs in the root world.
- [x] Rust fmt/check (if changed): `cargo fmt` clean; `tests/agent_approval_memory_coverage_e2e.rs` builds and runs.
- [x] Tauri fmt/check (if changed): `N/A: app/src-tauri not touched.`

### Validation Blocked

- `command:` the 91-spec WebdriverIO desktop suite
- `error:` `cargo metadata --manifest-path app/src-tauri/Cargo.toml` exits 101 — "found a virtual manifest at vendor/tinyagents/Cargo.toml"
- `impact:` those specs cannot build on `main` today, independent of this PR (fixed separately in #5874). This work targets the lanes that do run: vitest, Playwright web, and the root Rust world.

### Behavior Changes

- Intended behavior change: none. Test-only.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: yes — no product code is touched; these pin behaviour that already ships.
- Guard/fallback/dispatch parity checks: every test was proven to fail when the behaviour it pins is broken, so it discriminates rather than merely executing.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none — the six coverage branches in this batch touch disjoint files (verified across all 31).
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded settings-panel coverage for agent management, connection validation, event logs, platform-specific paths, diagnostics, and usage failures.
  * Added end-to-end coverage for approval flows, agent runs, memory status, registry projections, and related API validation.
  * Added browser tests for chat attachments, composer controls, model selection, transcript scrolling, and thread isolation during streaming.
  * Included the new agent, approval, and memory integration suite in the default Rust end-to-end test run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->