### PR TITLE
test(connections): pin the route table and ?tab= resolution against the app's own routes

### DIFF
--- a/app/src/AppRoutes.connections-flows.test.tsx
+++ b/app/src/AppRoutes.connections-flows.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * Route-table coverage for the connections / channels / flows / automation
+ * surfaces.
+ *
+ * WHY THIS FILE EXISTS, given `pages/__tests__/Connections.redirects.test.tsx`
+ * already claims to cover two of these redirects:
+ *
+ * That file declares its **own** local `<TestRoutes>` copy of three routes and
+ * renders that, so it asserts React Router's `<Navigate>` works rather than
+ * asserting anything about this app's route table. Deleting `/skills` from
+ * `AppRoutes.tsx` leaves it green. It also never inspects the landing URL,
+ * which is the entire payload of the `/channels` redirect.
+ *
+ * This file mounts the REAL `AppRoutes` (same mocking pattern as
+ * `AppRoutes.auth.test.tsx`) and asserts the landing `pathname + search`, so a
+ * change to the route table is what makes it fail.
+ */
+import { render, screen } from '@testing-library/react';
+import type React from 'react';
+import { MemoryRouter, useLocation, useParams } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./lib/platform', () => ({ getIsMobile: () => false }));
+
+vi.mock('./components/PublicRoute', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('./components/ProtectedRoute', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('./components/DefaultRedirect', () => ({
+  default: () => <div data-testid="default-redirect" />,
+}));
+
+vi.mock('./AppRoutesIOS', () => ({ default: () => <div /> }));
+vi.mock('./features/human/HumanPage', () => ({ default: () => <div /> }));
+vi.mock('./pages/Accounts', () => ({ default: () => <div /> }));
+vi.mock('./pages/Brain', () => ({ default: () => <div /> }));
+vi.mock('./pages/dev/AgentInsightsPreview', () => ({ default: () => <div /> }));
+vi.mock('./pages/dev/assistant-ui-demo', () => ({ default: () => <div /> }));
+vi.mock('./pages/dev/UiGallery', () => ({ default: () => <div /> }));
+vi.mock('./pages/Invites', () => ({ default: () => <div /> }));
+vi.mock('./pages/Notifications', () => ({ default: () => <div /> }));
+vi.mock('./pages/onboarding/Onboarding', () => ({ default: () => <div /> }));
+vi.mock('./pages/PttOverlayPage', () => ({ PttOverlayPage: () => <div /> }));
+vi.mock('./pages/Rewards', () => ({ default: () => <div /> }));
+vi.mock('./pages/Settings', () => ({ default: () => <div /> }));
+vi.mock('./pages/Welcome', () => ({ default: () => <div /> }));
+vi.mock('./pages/WebCallbackPage', () => ({ default: () => <div /> }));
+
+// The pages this file actually asserts on. Each renders a probe that reports
+// the landing location, so an assertion failure names the URL we landed on.
+vi.mock('./pages/Skills', () => ({
+  default: () => <div data-testid="page">connections</div>,
+}));
+vi.mock('./pages/FlowsPage', () => ({
+  default: () => <div data-testid="page">flows</div>,
+}));
+vi.mock('./pages/Activity', () => ({
+  default: () => <div data-testid="page">activity</div>,
+}));
+vi.mock('./pages/WorkflowsRun', () => ({
+  default: () => <div data-testid="page">workflows-run</div>,
+}));
+vi.mock('./pages/FlowCanvasPage', () => ({
+  default: () => {
+    const { id } = useParams();
+    return <div data-testid="page">{`flow-canvas:${id ?? ''}`}</div>;
+  },
+  FlowCanvasDraftPage: () => <div data-testid="page">flow-canvas-draft</div>,
+}));
+
+const AppRoutes = (await import('./AppRoutes')).default;
+
+/** Reports the live location so assertions can name the URL we landed on. */
+function LocationProbe() {
+  const loc = useLocation();
+  return <span data-testid="href">{loc.pathname + loc.search}</span>;
+}
+
+function renderAt(entry: string) {
+  render(
+    <MemoryRouter initialEntries={[entry]}>
+      <LocationProbe />
+      <AppRoutes />
+    </MemoryRouter>
+  );
+  return {
+    href: () => screen.getByTestId('href').textContent,
+    page: () => screen.queryByTestId('page')?.textContent,
+  };
+}
+
+describe('connections / channels back-compat redirects (real route table)', () => {
+  it('/skills lands on /connections and renders the Connections page', () => {
+    const at = renderAt('/skills');
+    expect(at.href()).toBe('/connections');
+    expect(at.page()).toBe('connections');
+  });
+
+  it('/channels lands on /connections?tab=messaging, preserving the tab selector', () => {
+    // The whole point of this redirect: `/channels` was an orphaned standalone
+    // page, and the messaging tab of Connections replaced it. Landing on bare
+    // `/connections` would drop the user on the Welcome tab instead — which is
+    // exactly what `Connections.redirects.test.tsx` cannot distinguish, because
+    // it only asserts that the page rendered.
+    const at = renderAt('/channels');
+    expect(at.href()).toBe('/connections?tab=messaging');
+    expect(at.page()).toBe('connections');
+  });
+
+  it('PINS A KNOWN BUG: /skills drops its ?tab= query on the way to /connections', () => {
+    // `AppRoutes.tsx` claims twice — at the block comment above the
+    // `/connections` route and again on the `/skills` line itself — that this
+    // redirect "preserves ?tab= deep links". It does not: `<Navigate to="…" />`
+    // is given an absolute path *string* with no search component, so the
+    // incoming query is discarded.
+    //
+    // The knock-on is that `pages/Skills.tsx`'s legacy alias table
+    // (`apps`→`composio`, `messaging`→`channels`, `tools`→`mcp`,
+    // `explorer`→`skills`), whose own comment says it exists "so that e.g.
+    // `/skills?tab=composio` still works after the redirect", is unreachable
+    // from that route — `activeTab` always falls through to 'welcome'.
+    //
+    // This assertion pins the CURRENT (wrong) behaviour deliberately, so the
+    // bug cannot deepen unnoticed. When it is fixed — `<Navigate to={{ pathname:
+    // '/connections', search: location.search }} />` or equivalent — this test
+    // MUST be flipped to expect '/connections?tab=messaging' and the two source
+    // comments left alone, because they will finally be true.
+    const at = renderAt('/skills?tab=messaging');
+    expect(at.href()).toBe('/connections');
+    expect(at.href()).not.toBe('/connections?tab=messaging');
+  });
+});
+
+describe('automation route slugs', () => {
+  it('/routines redirects to /flows', () => {
+    const at = renderAt('/routines');
+    expect(at.href()).toBe('/flows');
+    expect(at.page()).toBe('flows');
+  });
+
+  it('/webhooks redirects to the Integrations settings page', () => {
+    // Webhooks were retired from the UI; the route survives only to keep old
+    // deep links from 404-ing.
+    const at = renderAt('/webhooks');
+    expect(at.href()).toBe('/settings/integrations');
+  });
+
+  it('/workflows is NOT a redirect — it renders the legacy SKILL.md hub', () => {
+    // Guards against the stale claim in `AppRoutes.tsx`'s own `/flows` block
+    // comment, which says "the bare `/workflows` and `/routines` slugs now
+    // redirect here (to `/flows`)". Only `/routines` does. `/workflows` renders
+    // Activity, per the comment directly above its own route.
+    const at = renderAt('/workflows');
+    expect(at.href()).toBe('/workflows');
+    expect(at.page()).toBe('activity');
+  });
+
+  it('/workflows/run renders the single-purpose Skill runner, not the hub', () => {
+    const at = renderAt('/workflows/run');
+    expect(at.href()).toBe('/workflows/run');
+    expect(at.page()).toBe('workflows-run');
+  });
+});
+
+describe('/flows canvas route ranking', () => {
+  it('/flows renders the flows list hub', () => {
+    expect(renderAt('/flows').page()).toBe('flows');
+  });
+
+  it('/flows/draft resolves to the draft canvas, not to /flows/:id', () => {
+    // `AppRoutes.tsx` warns that if `:id` won this match, the canvas would call
+    // `flows_get('draft')` for a flow that does not exist. Pin the resolution
+    // so a reorder or a rename of either route is caught here.
+    const at = renderAt('/flows/draft');
+    expect(at.page()).toBe('flow-canvas-draft');
+    expect(at.page()).not.toBe('flow-canvas:draft');
+  });
+
+  it('/flows/:id resolves to the canvas and hands it the id', () => {
+    expect(renderAt('/flows/flow_abc123').page()).toBe('flow-canvas:flow_abc123');
+  });
+});

--- a/app/src/AppRoutes.connections-flows.test.tsx
+++ b/app/src/AppRoutes.connections-flows.test.tsx
@@ -50,15 +50,9 @@ vi.mock('./pages/WebCallbackPage', () => ({ default: () => <div /> }));
 
 // The pages this file actually asserts on. Each renders a probe that reports
 // the landing location, so an assertion failure names the URL we landed on.
-vi.mock('./pages/Skills', () => ({
-  default: () => <div data-testid="page">connections</div>,
-}));
-vi.mock('./pages/FlowsPage', () => ({
-  default: () => <div data-testid="page">flows</div>,
-}));
-vi.mock('./pages/Activity', () => ({
-  default: () => <div data-testid="page">activity</div>,
-}));
+vi.mock('./pages/Skills', () => ({ default: () => <div data-testid="page">connections</div> }));
+vi.mock('./pages/FlowsPage', () => ({ default: () => <div data-testid="page">flows</div> }));
+vi.mock('./pages/Activity', () => ({ default: () => <div data-testid="page">activity</div> }));
 vi.mock('./pages/WorkflowsRun', () => ({
   default: () => <div data-testid="page">workflows-run</div>,
 }));

--- a/app/src/AppRoutes.connections-flows.test.tsx
+++ b/app/src/AppRoutes.connections-flows.test.tsx
@@ -72,7 +72,13 @@ const AppRoutes = (await import('./AppRoutes')).default;
 /** Reports the live location so assertions can name the URL we landed on. */
 function LocationProbe() {
   const loc = useLocation();
-  return <span data-testid="href">{loc.pathname + loc.search}</span>;
+  // `hash` included deliberately. Without it the probe reports only
+  // `pathname + search`, so a route whose destination carries a fragment —
+  // AGENTS.md:175 specifies `/webhooks` -> `/settings/integrations#webhooks` —
+  // could lose that fragment and every assertion here would stay green
+  // (#5883, Codex). This is a HashRouter, so `loc.hash` is the fragment WITHIN
+  // the routed path, not the leading `#/` of the URL.
+  return <span data-testid="href">{loc.pathname + loc.search + loc.hash}</span>;
 }
 
 function renderAt(entry: string) {
@@ -124,14 +130,25 @@ describe('connections / channels back-compat redirects (real route table)', () =
     // '/connections', search: location.search }} />` or equivalent — this test
     // MUST be flipped to expect '/connections?tab=messaging' and the two source
     // comments left alone, because they will finally be true.
+    //
+    // One assertion, not two. A second `.not.toBe('/connections?tab=messaging')`
+    // was strictly implied by the line below it and could never fire
+    // independently — and it encoded "the fixed value must not appear" as a
+    // separate contract, so whoever fixes the redirect would hit two failures
+    // and have to work out whether the negative one was deliberate
+    // (#5883, YellowSnnowmann).
     const at = renderAt('/skills?tab=messaging');
     expect(at.href()).toBe('/connections');
-    expect(at.href()).not.toBe('/connections?tab=messaging');
   });
 });
 
 describe('automation route slugs', () => {
   it('/routines redirects to /flows', () => {
+    // `AGENTS.md:175` documents `/routines` -> `/settings/automations`. The two
+    // agree on where the user ends up: `/settings/automations` is itself
+    // `<Navigate to="/flows">` (settingsRouteElements.tsx:164), so the code
+    // short-circuits one hop of the documented chain and lands in the same
+    // place. `/workflows` is the real divergence — see the test below.
     const at = renderAt('/routines');
     expect(at.href()).toBe('/flows');
     expect(at.page()).toBe('flows');
@@ -140,11 +157,23 @@ describe('automation route slugs', () => {
   it('/webhooks redirects to the Integrations settings page', () => {
     // Webhooks were retired from the UI; the route survives only to keep old
     // deep links from 404-ing.
+    //
+    // ⚠️ CONTRACT DIVERGENCE. `AGENTS.md:175` is the authoritative route table
+    // and specifies `/webhooks` -> `/settings/integrations#webhooks`. The code
+    // (`AppRoutes.tsx`) emits no fragment, so the Webhooks section is not
+    // selected on arrival. This asserts what the app DOES; changing it to the
+    // documented destination would be a knowingly-failing test. The fix is a
+    // source change and someone has to decide which side moves — see W5 BUG-13.
     const at = renderAt('/webhooks');
     expect(at.href()).toBe('/settings/integrations');
   });
 
   it('/workflows is NOT a redirect — it renders the legacy SKILL.md hub', () => {
+    // ⚠️ CONTRACT DIVERGENCE, and a three-way one. `AGENTS.md:175` says
+    // `/workflows` -> `/settings/automations`; `AppRoutes.tsx`'s own `/flows`
+    // block comment says it redirects to `/flows`; the code renders <Activity/>
+    // and stays put. Three statements, three destinations. This pins the code.
+    // See W5 BUG-13 (#5883, Codex).
     // Guards against the stale claim in `AppRoutes.tsx`'s own `/flows` block
     // comment, which says "the bare `/workflows` and `/routines` slugs now
     // redirect here (to `/flows`)". Only `/routines` does. `/workflows` renders

--- a/app/src/AppRoutes.connections-flows.test.tsx
+++ b/app/src/AppRoutes.connections-flows.test.tsx
@@ -57,7 +57,10 @@ vi.mock('./pages/WorkflowsRun', () => ({
   default: () => <div data-testid="page">workflows-run</div>,
 }));
 vi.mock('./pages/FlowCanvasPage', () => ({
-  default: () => {
+  // Named + capitalised so eslint's rules-of-hooks recognises it as a component;
+  // an anonymous arrow assigned to `default` is not, and `useParams` then trips
+  // "called in function 'default' that is neither a component nor a custom Hook".
+  default: function FlowCanvasPageMock() {
     const { id } = useParams();
     return <div data-testid="page">{`flow-canvas:${id ?? ''}`}</div>;
   },

--- a/app/src/AppRoutes.connections-flows.test.tsx
+++ b/app/src/AppRoutes.connections-flows.test.tsx
@@ -131,46 +131,6 @@ describe('connections / channels back-compat redirects (real route table)', () =
     const at = renderAt('/skills?tab=messaging');
     expect(at.href()).toBe('/connections?tab=messaging');
   });
-
-  it('/channels lands on /connections?tab=messaging, preserving the tab selector', () => {
-    // The whole point of this redirect: `/channels` was an orphaned standalone
-    // page, and the messaging tab of Connections replaced it. Landing on bare
-    // `/connections` would drop the user on the Welcome tab instead — which is
-    // exactly what `Connections.redirects.test.tsx` cannot distinguish, because
-    // it only asserts that the page rendered.
-    const at = renderAt('/channels');
-    expect(at.href()).toBe('/connections?tab=messaging');
-    expect(at.page()).toBe('connections');
-  });
-
-  it('PINS A KNOWN BUG: /skills drops its ?tab= query on the way to /connections', () => {
-    // `AppRoutes.tsx` claims twice — at the block comment above the
-    // `/connections` route and again on the `/skills` line itself — that this
-    // redirect "preserves ?tab= deep links". It does not: `<Navigate to="…" />`
-    // is given an absolute path *string* with no search component, so the
-    // incoming query is discarded.
-    //
-    // The knock-on is that `pages/Skills.tsx`'s legacy alias table
-    // (`apps`→`composio`, `messaging`→`channels`, `tools`→`mcp`,
-    // `explorer`→`skills`), whose own comment says it exists "so that e.g.
-    // `/skills?tab=composio` still works after the redirect", is unreachable
-    // from that route — `activeTab` always falls through to 'welcome'.
-    //
-    // This assertion pins the CURRENT (wrong) behaviour deliberately, so the
-    // bug cannot deepen unnoticed. When it is fixed — `<Navigate to={{ pathname:
-    // '/connections', search: location.search }} />` or equivalent — this test
-    // MUST be flipped to expect '/connections?tab=messaging' and the two source
-    // comments left alone, because they will finally be true.
-    //
-    // One assertion, not two. A second `.not.toBe('/connections?tab=messaging')`
-    // was strictly implied by the line below it and could never fire
-    // independently — and it encoded "the fixed value must not appear" as a
-    // separate contract, so whoever fixes the redirect would hit two failures
-    // and have to work out whether the negative one was deliberate
-    // (#5883, YellowSnnowmann).
-    const at = renderAt('/skills?tab=messaging');
-    expect(at.href()).toBe('/connections');
-  });
 });
 
 describe('automation route slugs', () => {

--- a/app/src/AppRoutes.connections-flows.test.tsx
+++ b/app/src/AppRoutes.connections-flows.test.tsx
@@ -112,6 +112,37 @@ describe('connections / channels back-compat redirects (real route table)', () =
     expect(at.page()).toBe('connections');
   });
 
+  it('/skills forwards its ?tab= query through to /connections', () => {
+    // This used to pin the opposite: `<Navigate to="/connections" />` was given
+    // an absolute path *string* with no search component, so the incoming query
+    // was discarded — while `AppRoutes.tsx` claimed twice that the redirect
+    // "preserves ?tab= deep links".
+    //
+    // openhuman#5924 replaced it with `<ForwardSearch to="/connections" />`,
+    // which reads `useLocation()` and copies both `search` and `hash` onto the
+    // destination. The two source comments are now true, so they were left
+    // alone exactly as the previous revision of this test asked.
+    //
+    // The knock-on matters more than the redirect: `pages/Skills.tsx`'s legacy
+    // alias table (`apps`→`composio`, `messaging`→`channels`, `tools`→`mcp`,
+    // `explorer`→`skills`) exists "so that e.g. `/skills?tab=composio` still
+    // works after the redirect". While the query was dropped it was unreachable
+    // dead code; this assertion is what proves the route can reach it at all.
+    const at = renderAt('/skills?tab=messaging');
+    expect(at.href()).toBe('/connections?tab=messaging');
+  });
+
+  it('/channels lands on /connections?tab=messaging, preserving the tab selector', () => {
+    // The whole point of this redirect: `/channels` was an orphaned standalone
+    // page, and the messaging tab of Connections replaced it. Landing on bare
+    // `/connections` would drop the user on the Welcome tab instead — which is
+    // exactly what `Connections.redirects.test.tsx` cannot distinguish, because
+    // it only asserts that the page rendered.
+    const at = renderAt('/channels');
+    expect(at.href()).toBe('/connections?tab=messaging');
+    expect(at.page()).toBe('connections');
+  });
+
   it('PINS A KNOWN BUG: /skills drops its ?tab= query on the way to /connections', () => {
     // `AppRoutes.tsx` claims twice — at the block comment above the
     // `/connections` route and again on the `/skills` line itself — that this

--- a/app/src/pages/__tests__/Skills.tab-resolution.test.tsx
+++ b/app/src/pages/__tests__/Skills.tab-resolution.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * `?tab=` resolution on the Connections page (`Skills.tsx:517-542`).
+ *
+ * `Skills.intelligence-tabs.test.tsx` covers six canonical values
+ * (llm / voice / embeddings / search / usage / composio-key). This file covers
+ * the rest of that `useMemo`, which had none:
+ *
+ *   - the four LEGACY aliases (`apps`, `messaging`, `tools`, `explorer`), whose
+ *     own source comment says they exist "so that e.g. `/skills?tab=composio`
+ *     still works after the redirect";
+ *   - the default landing tab when no `?tab=` is supplied — the branch every
+ *     first visit takes;
+ *   - an unrecognised value, which must fall back rather than render nothing.
+ *
+ * Worth knowing while reading: the aliases are currently unreachable by the
+ * route they were written for. `/skills` redirects with
+ * `<Navigate to="/connections" replace />`, a bare path string, so the query is
+ * dropped before the page ever sees it — see the pinned case in
+ * `AppRoutes.connections-flows.test.tsx`. They ARE reachable by a direct
+ * `/connections?tab=apps`, which is what this file exercises, so the branches
+ * are live code and not dead weight.
+ */
+import { screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import '../../test/mockDefaultSkillStatusHooks';
+import { renderWithProviders } from '../../test/test-utils';
+import type { ChannelDefinition } from '../../types/channels';
+import Skills from '../Skills';
+
+// A non-empty definition list is what makes the channels group render at all.
+const webDef: ChannelDefinition = {
+  id: 'web',
+  display_name: 'Web',
+  description: 'Chat via the built-in web UI.',
+  icon: 'web',
+  auth_modes: [],
+  capabilities: [],
+};
+
+vi.mock('../../hooks/useChannelDefinitions', () => ({
+  useChannelDefinitions: () => ({ definitions: [webDef], loading: false, error: null }),
+}));
+
+// Stub the two heavy tab bodies so the branch is observable without its tree.
+vi.mock('../../components/skills/SkillsExplorerTab', () => ({
+  default: () => <div data-testid="tab-body-skills-explorer" />,
+}));
+vi.mock('../../components/channels/mcp/McpServersTab', () => ({
+  default: () => <div data-testid="tab-body-mcp-servers" />,
+}));
+
+vi.mock('../../lib/skills/skillsApi', () => ({
+  installSkill: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../../lib/skills/hooks', () => ({
+  useAvailableSkills: () => ({ skills: [], loading: false, refresh: vi.fn() }),
+}));
+vi.mock('../../lib/composio/hooks', () => ({
+  useComposioIntegrations: () => ({
+    toolkits: [],
+    connectionByToolkit: new Map(),
+    connectionsByToolkit: new Map(),
+    refresh: vi.fn(),
+    loading: false,
+    error: null,
+  }),
+  useAgentReadyComposioToolkits: () => ({
+    agentReady: new Set<string>(),
+    loading: true,
+    error: null,
+  }),
+}));
+vi.mock('../../lib/coreState/store', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/coreState/store')>(
+    '../../lib/coreState/store'
+  );
+  return { ...actual, getCoreStateSnapshot: () => ({ snapshot: { sessionToken: 'jwt-abc' } }) };
+});
+vi.mock('../../utils/tauriCommands', async () => {
+  const actual = await vi.importActual<typeof import('../../utils/tauriCommands')>(
+    '../../utils/tauriCommands'
+  );
+  return {
+    ...actual,
+    openhumanComposioGetMode: vi.fn(async () => ({
+      result: { mode: 'backend', api_key_set: true },
+      logs: [],
+    })),
+  };
+});
+
+const renderAt = (search: string) =>
+  renderWithProviders(<Skills />, { initialEntries: [`/connections${search}`] });
+
+/**
+ * Which tab the page resolved to, read off the two-pane nav.
+ *
+ * `TwoPaneNav` marks exactly one row `aria-current="page"`
+ * (`components/layout/TwoPaneNav.tsx:97-98`), which is a direct read of
+ * `activeTab` and does not depend on whether that tab's body has data to show.
+ * Asserting the body instead would couple every case to whatever mocks its
+ * panel happens to need.
+ */
+async function selectedTab(): Promise<string> {
+  const row = await waitFor(() => {
+    const current = document.querySelector('[data-testid^="two-pane-nav-"][aria-current="page"]');
+    expect(current).not.toBeNull();
+    return current as HTMLElement;
+  });
+  return (row.dataset.testid ?? '').replace('two-pane-nav-', '');
+}
+
+describe('Connections ?tab= resolution — legacy aliases', () => {
+  // Each of these four has a canonical successor. `Skills.tsx:537-540` maps
+  // them, per its own comment, "so that e.g. `/skills?tab=composio` still works
+  // after the redirect". None had a test.
+  it.each([
+    ['apps', 'composio'],
+    ['messaging', 'channels'],
+    ['tools', 'mcp'],
+    ['explorer', 'skills'],
+  ])('?tab=%s resolves to the %s tab', async (alias, canonical) => {
+    renderAt(`?tab=${alias}`);
+    expect(await selectedTab()).toBe(canonical);
+  });
+
+  it('a legacy alias does NOT silently fall through to Welcome', async () => {
+    // The failure this guards is invisible: drop the alias table and every one
+    // of the four still renders a perfectly good page — the wrong one.
+    renderAt('?tab=apps');
+    expect(await selectedTab()).toBe('composio');
+    expect(screen.queryByTestId('connections-welcome')).not.toBeInTheDocument();
+  });
+
+  it('the Composio apps tab actually renders its body, not just the nav state', async () => {
+    renderAt('?tab=apps');
+    await waitFor(() => {
+      expect(screen.getByTestId('composio-integrations-card')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Connections ?tab= resolution — canonical values', () => {
+  it.each([['composio'], ['channels'], ['mcp'], ['skills'], ['wallet']])(
+    '?tab=%s passes through unchanged',
+    async tab => {
+      renderAt(`?tab=${tab}`);
+      expect(await selectedTab()).toBe(tab);
+    }
+  );
+
+  it('?tab=welcome renders the landing overview', async () => {
+    // `welcome` is the one value with no nav row of its own -- it is the
+    // page's landing overview, rendered by `PageWelcome` at Skills.tsx:1037.
+    renderAt('?tab=welcome');
+    await waitFor(() => {
+      expect(screen.getByTestId('connections-welcome')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Connections ?tab= resolution — default and fallback', () => {
+  it.each([
+    ['', 'no ?tab= at all'],
+    ['?tab=definitely-not-a-tab', 'an unrecognised value'],
+    ['?tab=', 'an empty value'],
+    ['?tab=Composio', 'a value with the wrong case'],
+  ])('%s lands on Welcome', async search => {
+    renderAt(search);
+    await waitFor(() => {
+      expect(screen.getByTestId('connections-welcome')).toBeInTheDocument();
+    });
+    // ...and specifically NOT on some other tab that happened to also render.
+    const current = document.querySelector('[data-testid^="two-pane-nav-"][aria-current="page"]');
+    expect(current).toBeNull();
+  });
+});

--- a/app/src/pages/__tests__/Skills.tab-resolution.test.tsx
+++ b/app/src/pages/__tests__/Skills.tab-resolution.test.tsx
@@ -29,14 +29,24 @@ import type { ChannelDefinition } from '../../types/channels';
 import Skills from '../Skills';
 
 // A non-empty definition list is what makes the channels group render at all.
-const webDef: ChannelDefinition = {
-  id: 'web',
-  display_name: 'Web',
-  description: 'Chat via the built-in web UI.',
-  icon: 'web',
-  auth_modes: [],
-  capabilities: [],
-};
+//
+// Declared through `vi.hoisted` rather than as a plain top-level `const`:
+// `vi.mock` is hoisted above every declaration in the file, so a factory that
+// closes over an ordinary const reads it before initialisation if the mocked
+// module is pulled in during the import phase. It happens to work here — the
+// hook is only called during render, inside the test body — but it is the
+// documented hazard and `vi.hoisted` is the supported way to share a value
+// with a factory (#5883, CodeRabbit).
+const { webDef } = vi.hoisted(() => ({
+  webDef: {
+    id: 'web',
+    display_name: 'Web',
+    description: 'Chat via the built-in web UI.',
+    icon: 'web',
+    auth_modes: [],
+    capabilities: [],
+  } as ChannelDefinition,
+}));
 
 vi.mock('../../hooks/useChannelDefinitions', () => ({
   useChannelDefinitions: () => ({ definitions: [webDef], loading: false, error: null }),


### PR DESCRIPTION
## Summary

- Adds coverage for the connections / skills / flows route table and for `?tab=` resolution on the Connections page.
- 2 files, +362 lines. No product code touched.

> **Test lane:** 2 vitest component suites (jsdom). **Not** browser e2e.

## Problem

Two holes, one of which hid a live defect:

- **`Connections.redirects.test.tsx` is vacuous.** It declares its own `<TestRoutes>` component reproducing three routes by hand and renders *that* — it never imports `AppRoutes.tsx`. Deleting or changing `/skills` or `/channels` in the real route table leaves all three tests green. It asserts that React Router's `<Navigate>` works, which is not this repo's code.
- **The `?tab=` resolution `useMemo` was almost entirely uncovered.** An existing suite covers six canonical tab values; all four legacy aliases (`apps`, `messaging`, `tools`, `explorer`), the default landing tab, and unknown/empty values had **zero** coverage between them.

Because of the first hole, a real bug is live on `main` with a green suite over it: `/skills?tab=…` silently drops the query string, since `<Navigate to="/connections">` carries no search component. That makes the four legacy aliases unreachable from the route they were written for — and two source comments state the opposite behaviour.

## Solution

A route-table suite that imports the app's own `AppRoutes.tsx` and asserts the **resolved location**, not merely that a page rendered — which is what the vacuous test could never do.

The `?tab=` suite asserts the resolved tab off the nav's `aria-current` rather than each tab's body, so no case depends on whatever mocks its panel needs. A first attempt asserting bodies had three cases fail on mock-path and data-shape problems; reading `activeTab` off the nav is both more robust and a more direct read of the thing under test.

Revert-proven with four mutations: deleting the alias table fails 6 cases; mis-mapping `messaging` fails exactly 1; changing the default fails the 4 fallback cases.

The existing vacuous file is **left in place** — replacing it touches a file outside this branch's scope, and is recommended rather than done here.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — this PR *is* the tests. Every case was revert-proofed: the covered behaviour was broken, the test confirmed to fail naming its own assertion, then restored. Drafts that still passed with the fault injected were rewritten or dropped rather than kept.
- [x] **Diff coverage ≥ 80%** — `N/A: the changed lines are test files`, executed by the suites they belong to; there is no product code in this diff for diff-cover to measure.
- [x] Coverage matrix updated — `N/A: behaviour-only change` — no feature rows added, removed or renamed; this covers behaviour that already ships.
- [x] All affected feature IDs from the matrix are listed — `N/A: no feature IDs affected`.
- [x] No new external network dependencies introduced — mocks and fixtures only; no test reaches a live service.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no product surface changes`, test-only.
- [x] Linked issue closed via `Closes #NNN` — `N/A: no linked issue`; this is coverage work, not a fix.

## Impact

- **Platform:** none at runtime. Test-only.
- **Risk:** none to product behaviour.
- **Note:** this coverage will fail on `main` for the `/skills?tab=` cases if written against intended behaviour, so the suite pins **actual** behaviour and the defect is reported separately.

## Related

- Closes:
- Follow-up PR(s)/TODOs: (a) the `/skills?tab=` query-drop defect and the two source comments that contradict it; (b) replacing `Connections.redirects.test.tsx`, which is structurally incapable of catching it.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `test/e2e-connections-flows`
- Commit SHA: see head of this PR

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — prettier clean on both new files.
- [x] `pnpm typecheck` — `tsc --noEmit`, 0 errors.
- [x] Focused tests: both suites pass (16 cases in the tab-resolution suite alone), each revert-proofed by the four mutations described above.
- [x] Rust fmt/check (if changed): `N/A: no .rs files changed.`
- [x] Tauri fmt/check (if changed): `N/A: app/src-tauri not touched.`

### Validation Blocked

- `command:` the 91-spec WebdriverIO desktop suite
- `error:` `cargo metadata --manifest-path app/src-tauri/Cargo.toml` exits 101 — "found a virtual manifest at vendor/tinyagents/Cargo.toml"
- `impact:` those specs cannot build on `main` today, independent of this PR (fixed separately in #5874). This work targets the lanes that do run: vitest, Playwright web, and the root Rust world.

### Behavior Changes

- Intended behavior change: none. Test-only.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: yes — no product code is touched; these pin behaviour that already ships.
- Guard/fallback/dispatch parity checks: every test was proven to fail when the behaviour it pins is broken, so it discriminates rather than merely executing.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none — the six coverage branches in this batch touch disjoint files (verified across all 31).
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added route coverage for connections, channels, automation, flows, routines, webhooks, and workflows.
  * Verified redirects and query-parameter handling across key navigation paths.
  * Added coverage for connection tab aliases, canonical values, the welcome state, and invalid or missing tab values.
  * Confirmed routing for flow drafts, individual flows, and workflow execution pages.
  * Covered legacy navigation links and their mapping to current Connections tabs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->