### PR TITLE
test(app): pin the nine redirect contracts, auth guards and the embedding-state warning

### DIFF
--- a/app/src/AppRoutes.guards.test.tsx
+++ b/app/src/AppRoutes.guards.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * Which desktop routes require authentication, and which deliberately do not.
+ *
+ * A route silently losing its `<ProtectedRoute>` wrapper exposes a surface — and
+ * the RPC calls it makes on mount — to an unauthenticated session. A route
+ * gaining one locks out a flow that has to work signed-out: the OAuth callback
+ * that *establishes* the session, and the push-to-talk overlay window.
+ * Both directions are one-line edits in a 260-line JSX table, and nothing
+ * asserted either.
+ *
+ * `test/playwright/specs/auth-access-control.spec.ts` covers the session
+ * *lifecycle* (sign-in, logout, expiry) with a booted authenticated page; it
+ * never varies the guard on a route. This is the complementary half: the
+ * classification itself.
+ *
+ * Two layers, deliberately:
+ *  1. Render assertions for the routes this file owns — the page renders AND
+ *     the expected guard wrapped it.
+ *  2. A source-level classification guard over the WHOLE route table, so a
+ *     route added or re-guarded anywhere in `AppRoutes.tsx` fails here even
+ *     though its page is another spec's business.
+ */
+import { render, screen } from '@testing-library/react';
+import type React from 'react';
+import { MemoryRouter, useParams } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./lib/platform', () => ({ getIsMobile: () => false }));
+
+// The guards are replaced by markers that record that they wrapped something,
+// rather than being stubbed away as passthroughs. That is the whole point here.
+vi.mock('./components/PublicRoute', () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="guard-public">{children}</div>
+  ),
+}));
+vi.mock('./components/ProtectedRoute', () => ({
+  default: ({ children, requireAuth }: { children: React.ReactNode; requireAuth?: boolean }) => (
+    <div data-testid="guard-protected" data-require-auth={String(requireAuth)}>
+      {children}
+    </div>
+  ),
+}));
+vi.mock('./components/DefaultRedirect', () => ({
+  default: () => <div data-testid="default-redirect" />,
+}));
+
+// Echo the route params so the `:kind` / `:status` plumbing is observable.
+vi.mock('./pages/WebCallbackPage', () => {
+  const WebCallbackProbe = ({ callbackKind }: { callbackKind?: string }) => {
+    const { kind, status } = useParams();
+    return (
+      <div data-testid="page-web-callback">
+        <span data-testid="callback-kind">{callbackKind ?? kind ?? ''}</span>
+        <span data-testid="callback-status">{status ?? ''}</span>
+      </div>
+    );
+  };
+  return { default: WebCallbackProbe };
+});
+
+vi.mock('./AppRoutesIOS', () => ({ default: () => <div /> }));
+vi.mock('./features/human/HumanPage', () => ({ default: () => <div /> }));
+vi.mock('./pages/Accounts', () => ({ default: () => <div /> }));
+vi.mock('./pages/Brain', () => ({ default: () => <div /> }));
+vi.mock('./pages/dev/AgentInsightsPreview', () => ({ default: () => <div /> }));
+vi.mock('./pages/dev/UiGallery', () => ({ default: () => <div data-testid="page-ui-gallery" /> }));
+vi.mock('./pages/Invites', () => ({ default: () => <div data-testid="page-invites" /> }));
+vi.mock('./pages/Notifications', () => ({
+  default: () => <div data-testid="page-notifications" />,
+}));
+vi.mock('./pages/onboarding/Onboarding', () => ({
+  default: () => <div data-testid="page-onboarding" />,
+}));
+vi.mock('./pages/PttOverlayPage', () => ({
+  PttOverlayPage: () => <div data-testid="page-ptt-overlay" />,
+}));
+vi.mock('./pages/Rewards', () => ({ default: () => <div data-testid="page-rewards" /> }));
+vi.mock('./pages/Settings', () => ({ default: () => <div /> }));
+vi.mock('./pages/Skills', () => ({ default: () => <div /> }));
+vi.mock('./pages/Welcome', () => ({ default: () => <div data-testid="page-welcome" /> }));
+vi.mock('./pages/WorkflowsRun', () => ({ default: () => <div /> }));
+
+const AppRoutes = (await import('./AppRoutes')).default;
+
+function visit(entry: string) {
+  render(
+    <MemoryRouter initialEntries={[entry]}>
+      <AppRoutes />
+    </MemoryRouter>
+  );
+}
+
+type Guard = 'protected' | 'public' | 'none';
+/** `protected-but-open` = wrapped in ProtectedRoute but with the check disabled. */
+type TableGuard = Guard | 'redirect' | 'protected-but-open';
+
+/** The route, the page it must render, and the guard that must wrap it. */
+const OWNED: Array<{ path: string; page: string; guard: Guard }> = [
+  { path: '/', page: 'page-welcome', guard: 'public' },
+  { path: '/onboarding/profile', page: 'page-onboarding', guard: 'protected' },
+  { path: '/invites', page: 'page-invites', guard: 'protected' },
+  { path: '/notifications', page: 'page-notifications', guard: 'protected' },
+  { path: '/rewards', page: 'page-rewards', guard: 'protected' },
+  { path: '/ptt-overlay', page: 'page-ptt-overlay', guard: 'none' },
+  { path: '/dev/ui', page: 'page-ui-gallery', guard: 'none' },
+];
+
+describe('AppRoutes — each route renders its page behind the right guard', () => {
+  for (const { path, page, guard } of OWNED) {
+    it(`${path} renders ${page} with guard=${guard}`, () => {
+      visit(path);
+
+      expect(screen.getByTestId(page)).toBeInTheDocument();
+      // The catch-all must not have swallowed the route.
+      expect(screen.queryByTestId('default-redirect')).not.toBeInTheDocument();
+
+      expect(!!screen.queryByTestId('guard-protected')).toBe(guard === 'protected');
+      expect(!!screen.queryByTestId('guard-public')).toBe(guard === 'public');
+    });
+  }
+
+  it('never disables the check on a route it wraps', () => {
+    // `requireAuth` DEFAULTS to true (ProtectedRoute.tsx:18), so omitting it is
+    // harmless and this deliberately does not assert the prop is spelled out —
+    // that would fail on a harmless tidy-up and catch no real defect. What is
+    // dangerous is `requireAuth={false}`: the wrapper is still there, so the
+    // route reads as protected in review while the check is off. The route
+    // table below classifies that separately, so it cannot pass unnoticed.
+    visit('/rewards');
+    expect(screen.getByTestId('guard-protected')).not.toHaveAttribute('data-require-auth', 'false');
+  });
+});
+
+describe('AppRoutes — the OAuth callback family is reachable signed-out', () => {
+  // These routes ESTABLISH the session. Wrapping them in ProtectedRoute would
+  // make sign-in impossible while every signed-in test still passed.
+  it('/auth is unguarded and pins its kind from the prop', () => {
+    visit('/auth?token=jwt');
+
+    expect(screen.getByTestId('callback-kind')).toHaveTextContent('auth');
+    expect(screen.queryByTestId('guard-protected')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('guard-public')).not.toBeInTheDocument();
+  });
+
+  it('/callback/:kind takes its kind from the path', () => {
+    visit('/callback/composio');
+
+    expect(screen.getByTestId('callback-kind')).toHaveTextContent('composio');
+    expect(screen.getByTestId('callback-status')).toBeEmptyDOMElement();
+    expect(screen.queryByTestId('guard-protected')).not.toBeInTheDocument();
+  });
+
+  it('/callback/:kind/:status carries both segments', () => {
+    // The two-segment form is a distinct <Route>. A provider redirecting to
+    // `/callback/gmail/success` must not fall through to the catch-all.
+    visit('/callback/gmail/success');
+
+    expect(screen.getByTestId('callback-kind')).toHaveTextContent('gmail');
+    expect(screen.getByTestId('callback-status')).toHaveTextContent('success');
+    expect(screen.queryByTestId('default-redirect')).not.toBeInTheDocument();
+  });
+
+  it('routes a failure status to the same handler rather than the catch-all', () => {
+    visit('/callback/gmail/error');
+
+    expect(screen.getByTestId('callback-status')).toHaveTextContent('error');
+    expect(screen.queryByTestId('default-redirect')).not.toBeInTheDocument();
+  });
+});
+
+describe('AppRoutes — the whole route table stays classified', () => {
+  // Source-level, so it covers routes whose pages are other specs' business.
+  // A new route, or a changed guard on any existing one, fails here.
+  const EXPECTED: Record<string, TableGuard> = {
+    '/': 'public',
+    '/auth': 'none',
+    '/callback/:kind': 'none',
+    '/callback/:kind/:status': 'none',
+    '/onboarding/*': 'protected',
+    '/home': 'redirect',
+    '/human': 'protected',
+    '/brain': 'protected',
+    '/flows': 'protected',
+    '/flows/draft': 'protected',
+    '/flows/:id': 'protected',
+    '/activity': 'redirect',
+    '/intelligence': 'redirect',
+    '/workflows/run': 'protected',
+    '/connections': 'protected',
+    '/skills': 'redirect',
+    '/chat/:threadId?': 'protected',
+    '/accounts': 'redirect',
+    '/channels': 'redirect',
+    '/invites': 'protected',
+    '/feedback': 'redirect',
+    '/notifications': 'protected',
+    '/routines': 'redirect',
+    '/rewards': 'protected',
+    '/workflows': 'protected',
+    '/webhooks': 'redirect',
+    '/settings/*': 'protected',
+    '/ptt-overlay': 'none',
+    '/dev/agent-insights': 'none',
+    '/dev/ui': 'none',
+    '/dev/assistant-ui': 'none',
+    '*': 'none',
+  };
+
+  function classifyRouteTable(): Record<string, TableGuard> {
+    const fs = require('node:fs') as typeof import('node:fs');
+    const path = require('node:path') as typeof import('node:path');
+    const source = fs.readFileSync(path.resolve('src/AppRoutes.tsx'), 'utf8');
+
+    const out: Record<string, TableGuard> = {};
+    // Each `<Route path="X"` up to the start of the next one is that route's body.
+    const starts = [...source.matchAll(/<Route\s+path="([^"]+)"/g)];
+    starts.forEach((match, index) => {
+      const from = match.index ?? 0;
+      const to =
+        index + 1 < starts.length ? (starts[index + 1].index ?? source.length) : source.length;
+      const body = source.slice(from, to);
+      if (/<Navigate\b/.test(body)) out[match[1]] = 'redirect';
+      else if (/<ProtectedRoute\b[^>]*requireAuth=\{false\}/.test(body))
+        out[match[1]] = 'protected-but-open';
+      else if (/<ProtectedRoute\b/.test(body)) out[match[1]] = 'protected';
+      else if (/<PublicRoute\b/.test(body)) out[match[1]] = 'public';
+      else out[match[1]] = 'none';
+    });
+    return out;
+  }
+
+  it('every route carries the guard this table expects', () => {
+    expect(classifyRouteTable()).toEqual(EXPECTED);
+  });
+});

--- a/app/src/AppRoutes.guards.test.tsx
+++ b/app/src/AppRoutes.guards.test.tsx
@@ -220,7 +220,11 @@ describe('AppRoutes — the whole route table stays classified', () => {
       const to =
         index + 1 < starts.length ? (starts[index + 1].index ?? source.length) : source.length;
       const body = source.slice(from, to);
-      if (/<Navigate\b/.test(body)) out[match[1]] = 'redirect';
+      // `ForwardSearch` (added by #5924) is a redirect too: it renders a
+      // `<Navigate>` internally after copying the query string and hash, so the
+      // route body never contains the literal `<Navigate`. Matching only that
+      // classified `/skills` as 'none' and silently dropped it from this table.
+      if (/<(?:Navigate|ForwardSearch)\b/.test(body)) out[match[1]] = 'redirect';
       else if (/<ProtectedRoute\b[^>]*requireAuth=\{false\}/.test(body))
         out[match[1]] = 'protected-but-open';
       else if (/<ProtectedRoute\b/.test(body)) out[match[1]] = 'protected';

--- a/app/src/AppRoutes.redirects.test.tsx
+++ b/app/src/AppRoutes.redirects.test.tsx
@@ -127,7 +127,10 @@ describe('AppRoutes back-compat redirects', () => {
         const from = match.index ?? 0;
         const to =
           index + 1 < starts.length ? (starts[index + 1].index ?? source.length) : source.length;
-        return /<Navigate\b/.test(source.slice(from, to));
+        // `ForwardSearch` (#5924) renders `<Navigate>` internally after copying
+        // the query string and hash, so the route body has no literal
+        // `<Navigate`. Matching only that dropped `/skills` from this list.
+        return /<(?:Navigate|ForwardSearch)\b/.test(source.slice(from, to));
       })
       .map(match => match[1]);
 

--- a/app/src/AppRoutes.redirects.test.tsx
+++ b/app/src/AppRoutes.redirects.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Back-compat redirect contracts for the desktop route table.
+ *
+ * Every `<Navigate>` in `AppRoutes.tsx` is a promise to somebody's bookmark: a
+ * route that used to be top-level and now lives somewhere else. Breaking one is
+ * silent — the app still renders *a* page, just not the one the link meant.
+ *
+ * This asserts a different contract from `test/playwright/specs/navigation.spec.ts`,
+ * which covers four of these at the browser layer. That spec asserts the hash
+ * *begins with* the landing path, which cannot tell `/connections` apart from
+ * `/connections?tab=messaging`, and says nothing about `replace`. Here the whole
+ * resolved location is compared exactly, and the `replace` semantics — the thing
+ * that stops the Back button bouncing a user into a redirect loop — are asserted
+ * on their own.
+ *
+ * Mocks mirror `AppRoutes.auth.test.tsx`: every leaf page is stubbed so this
+ * exercises the router and nothing else.
+ */
+import { render, screen } from '@testing-library/react';
+import type React from 'react';
+import { MemoryRouter, useLocation, useNavigationType } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./lib/platform', () => ({ getIsMobile: () => false }));
+
+vi.mock('./components/PublicRoute', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('./components/ProtectedRoute', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('./components/DefaultRedirect', () => ({
+  default: () => <div data-testid="default-redirect" />,
+}));
+
+vi.mock('./pages/WebCallbackPage', () => ({ default: () => <div /> }));
+vi.mock('./AppRoutesIOS', () => ({ default: () => <div /> }));
+vi.mock('./features/human/HumanPage', () => ({ default: () => <div /> }));
+vi.mock('./pages/Accounts', () => ({ default: () => <div /> }));
+vi.mock('./pages/Brain', () => ({ default: () => <div /> }));
+vi.mock('./pages/dev/AgentInsightsPreview', () => ({ default: () => <div /> }));
+vi.mock('./pages/dev/UiGallery', () => ({ default: () => <div /> }));
+vi.mock('./pages/Invites', () => ({ default: () => <div /> }));
+vi.mock('./pages/Notifications', () => ({ default: () => <div /> }));
+vi.mock('./pages/onboarding/Onboarding', () => ({ default: () => <div /> }));
+vi.mock('./pages/PttOverlayPage', () => ({ PttOverlayPage: () => <div /> }));
+vi.mock('./pages/Rewards', () => ({ default: () => <div /> }));
+vi.mock('./pages/Settings', () => ({ default: () => <div /> }));
+vi.mock('./pages/Skills', () => ({ default: () => <div /> }));
+vi.mock('./pages/Welcome', () => ({ default: () => <div /> }));
+vi.mock('./pages/WorkflowsRun', () => ({ default: () => <div /> }));
+
+const AppRoutes = (await import('./AppRoutes')).default;
+
+/** Reports the router's resolved location, so a redirect is observed rather than inferred. */
+function LocationProbe() {
+  const location = useLocation();
+  return (
+    <>
+      <div data-testid="pathname">{location.pathname}</div>
+      <div data-testid="search">{location.search}</div>
+    </>
+  );
+}
+
+/** Reports the router's last navigation action, so `replace` is observed rather than assumed. */
+function ActionProbe() {
+  return <div data-testid="nav-type">{useNavigationType()}</div>;
+}
+
+function landingFor(entry: string) {
+  render(
+    <MemoryRouter initialEntries={[entry]}>
+      <AppRoutes />
+      <LocationProbe />
+    </MemoryRouter>
+  );
+  return {
+    pathname: screen.getByTestId('pathname').textContent,
+    search: screen.getByTestId('search').textContent,
+  };
+}
+
+// Every `<Navigate>` in AppRoutes.tsx, read off the route table. If a redirect
+// is added there and not here, `every redirect in the route table is covered`
+// below fails — the list cannot silently fall behind the code.
+const REDIRECTS: Array<{ from: string; pathname: string; search: string }> = [
+  { from: '/home', pathname: '/chat', search: '' },
+  { from: '/activity', pathname: '/settings/notifications', search: '' },
+  { from: '/intelligence', pathname: '/settings/notifications', search: '' },
+  { from: '/skills', pathname: '/connections', search: '' },
+  { from: '/accounts', pathname: '/chat', search: '' },
+  { from: '/channels', pathname: '/connections', search: '?tab=messaging' },
+  { from: '/feedback', pathname: '/settings/feedback', search: '' },
+  { from: '/routines', pathname: '/flows', search: '' },
+  { from: '/webhooks', pathname: '/settings/integrations', search: '' },
+];
+
+describe('AppRoutes back-compat redirects', () => {
+  for (const { from, pathname, search } of REDIRECTS) {
+    it(`sends ${from} to ${pathname}${search}`, () => {
+      expect(landingFor(from)).toEqual({ pathname, search });
+    });
+  }
+
+  it('carries the messaging tab through the /channels redirect', () => {
+    // Singled out because it is the only redirect whose contract is a query
+    // string. A prefix match on the path alone passes even when `?tab=messaging`
+    // is dropped, which lands the user on the wrong Connections tab.
+    expect(landingFor('/channels').search).toBe('?tab=messaging');
+  });
+
+  it('every redirect in the route table is covered by this spec', async () => {
+    const [fs, path] = await Promise.all([import('node:fs'), import('node:path')]);
+    // vitest runs with `app/` as cwd (test/vitest.config.ts sets the root).
+    const source = fs.readFileSync(path.resolve('src/AppRoutes.tsx'), 'utf8');
+    const routed = [...source.matchAll(/<Route path="([^"]+)" element={<Navigate /g)].map(
+      match => match[1]
+    );
+    expect(routed.sort()).toEqual(REDIRECTS.map(r => r.from).sort());
+  });
+});
+
+describe('AppRoutes redirects replace rather than push', () => {
+  // A redirect that pushes leaves the retired path on the history stack, so
+  // Back returns to it and is immediately redirected forward again — the user
+  // cannot leave. `replace` is what prevents that. Nothing else asserts it, and
+  // dropping `replace` from a `<Navigate>` is a one-word edit that every other
+  // test in the tree still passes.
+  for (const { from } of REDIRECTS) {
+    it(`${from} navigates by REPLACE, not PUSH`, () => {
+      render(
+        <MemoryRouter initialEntries={[from]}>
+          <AppRoutes />
+          <ActionProbe />
+        </MemoryRouter>
+      );
+      expect(screen.getByTestId('nav-type')).toHaveTextContent('REPLACE');
+    });
+  }
+});

--- a/app/src/AppRoutes.redirects.test.tsx
+++ b/app/src/AppRoutes.redirects.test.tsx
@@ -114,9 +114,23 @@ describe('AppRoutes back-compat redirects', () => {
     const [fs, path] = await Promise.all([import('node:fs'), import('node:path')]);
     // vitest runs with `app/` as cwd (test/vitest.config.ts sets the root).
     const source = fs.readFileSync(path.resolve('src/AppRoutes.tsx'), 'utf8');
-    const routed = [...source.matchAll(/<Route path="([^"]+)" element={<Navigate /g)].map(
-      match => match[1]
-    );
+
+    // Each route's body is the slice up to the next `<Route path=`, and the body
+    // is searched for `<Navigate`. Deliberately NOT a single-line regex like
+    // `/<Route path="…" element={<Navigate /`: Prettier wraps a `<Route>` across
+    // lines as soon as its props exceed the print width, and a one-line pattern
+    // then silently skips that redirect — the list stays unchanged and this test
+    // still claims full coverage. A guard that stops guarding is worse than none.
+    const starts = [...source.matchAll(/<Route\s+path="([^"]+)"/g)];
+    const routed = starts
+      .filter((match, index) => {
+        const from = match.index ?? 0;
+        const to =
+          index + 1 < starts.length ? (starts[index + 1].index ?? source.length) : source.length;
+        return /<Navigate\b/.test(source.slice(from, to));
+      })
+      .map(match => match[1]);
+
     expect(routed.sort()).toEqual(REDIRECTS.map(r => r.from).sort());
   });
 });

--- a/app/src/AppRoutesIOS.pairing.test.tsx
+++ b/app/src/AppRoutesIOS.pairing.test.tsx
@@ -21,13 +21,24 @@
  * `pages/ios/PairScreen.test.tsx`. Not repeated here.
  */
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useParams } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('./features/human/HumanPage', () => ({
   default: () => <div data-testid="page-human">human</div>,
 }));
-vi.mock('./pages/Accounts', () => ({ default: () => <div data-testid="page-chat">chat</div> }));
+// Renders the route param back out. A stub that discards params makes
+// `/chat/thread-abc`, `/chat/anything` and a route that dropped the
+// `:threadId` segment entirely produce identical DOM — so the deep-link test
+// below would pass without observing the thread id at all. Mirrors the
+// technique already used in `AppRoutes.connections-flows.test.tsx`.
+vi.mock('./pages/Accounts', () => {
+  const ChatProbe = () => {
+    const { threadId } = useParams();
+    return <div data-testid="page-chat">{`chat:${threadId ?? ''}`}</div>;
+  };
+  return { default: ChatProbe };
+});
 vi.mock('./pages/Settings', () => ({
   default: () => <div data-testid="page-settings">settings</div>,
 }));
@@ -103,7 +114,9 @@ describe('AppRoutesIOS — deep links a paired phone must honour', () => {
 
     renderAt('/chat/thread-abc');
 
-    expect(screen.getByTestId('page-chat')).toBeInTheDocument();
+    // The segment must survive to the page, not merely match the route: this is
+    // the half a notification deep link depends on.
+    expect(screen.getByTestId('page-chat')).toHaveTextContent('chat:thread-abc');
     expect(screen.getByTestId('mobile-tab-bar')).toBeInTheDocument();
     expect(screen.queryByTestId('page-human')).not.toBeInTheDocument();
   });

--- a/app/src/AppRoutesIOS.pairing.test.tsx
+++ b/app/src/AppRoutesIOS.pairing.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * `/pair` must stay reachable — including from an already-paired phone.
+ *
+ * openhuman#5479 ("Cannot Pair iPhone") is a wire-contract failure on the
+ * desktop side: `[devices/tunnel] parse tunnel:register ack failed: missing
+ * field 'channelId'`. Nothing in this file can fix that — it is Rust, in
+ * `src/openhuman/security/devices/tunnel_client.rs`. What this file protects is
+ * the thing that turns that bug from "retry it" into "the phone is bricked":
+ * the route that lets a user pair again.
+ *
+ * `/pair` is the ONLY mobile route not wrapped in `RequirePairing`
+ * (`AppRoutesIOS.tsx:57`). That is deliberate and load-bearing — a phone whose
+ * saved profile points at a core it can no longer reach is "paired" as far as
+ * `isPaired()` is concerned (`listProfiles().length > 0`), so wrapping `/pair`
+ * or letting the catch-all swallow it would strand exactly the user who most
+ * needs to re-pair. `AppRoutesIOS.test.tsx` covers `/pair` while UNPAIRED; this
+ * covers the paired case, which is the one that regresses silently.
+ *
+ * The pairing screen's own behaviour (QR happy path, expiry, bad URL, missing
+ * fields, transport unhealthy, camera errors, retry) is already covered by
+ * `pages/ios/PairScreen.test.tsx`. Not repeated here.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./features/human/HumanPage', () => ({
+  default: () => <div data-testid="page-human">human</div>,
+}));
+vi.mock('./pages/Accounts', () => ({ default: () => <div data-testid="page-chat">chat</div> }));
+vi.mock('./pages/Settings', () => ({
+  default: () => <div data-testid="page-settings">settings</div>,
+}));
+vi.mock('./pages/ios/PairScreen', () => ({
+  PairScreen: () => <div data-testid="page-pair">pair</div>,
+}));
+vi.mock('./components/ios/MobileTabBar', () => ({
+  default: () => <nav data-testid="mobile-tab-bar">tabs</nav>,
+}));
+
+const listProfiles = vi.fn();
+vi.mock('./services/transport/profileStore', () => ({ listProfiles: () => listProfiles() }));
+
+const AppRoutesIOS = (await import('./AppRoutesIOS')).default;
+
+const renderAt = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <AppRoutesIOS />
+    </MemoryRouter>
+  );
+
+/** A saved profile is all `isPaired()` looks at — not whether the core answers. */
+const SAVED_PROFILE = [{ id: 'profile-1', label: 'Desk' }];
+
+describe('AppRoutesIOS — re-pairing escape hatch', () => {
+  beforeEach(() => listProfiles.mockReset());
+  afterEach(() => vi.clearAllMocks());
+
+  it('serves /pair to an already-paired phone rather than bouncing it to /human', () => {
+    listProfiles.mockReturnValue(SAVED_PROFILE);
+
+    renderAt('/pair');
+
+    expect(screen.getByTestId('page-pair')).toBeInTheDocument();
+    expect(screen.queryByTestId('page-human')).not.toBeInTheDocument();
+  });
+
+  it('still serves /pair when the saved profile is stale or broken', () => {
+    // `isPaired()` is `listProfiles().length > 0` (AppRoutesIOS.tsx:29) — it
+    // never asks whether the core is reachable. A phone holding a profile for a
+    // desktop that is gone is indistinguishable from a healthy one here, and it
+    // is precisely the phone that must be able to re-scan a QR code.
+    listProfiles.mockReturnValue([{ id: 'dead-core', label: 'Old laptop' }]);
+
+    renderAt('/pair');
+
+    expect(screen.getByTestId('page-pair')).toBeInTheDocument();
+  });
+
+  it('shows no tab bar on /pair, paired or not', () => {
+    // The tab bar navigates to paired-only surfaces. Rendering it over the
+    // pairing screen offers exits that bounce straight back to /pair.
+    for (const profiles of [[], SAVED_PROFILE]) {
+      listProfiles.mockReturnValue(profiles);
+      const { unmount } = renderAt('/pair');
+      expect(screen.getByTestId('page-pair')).toBeInTheDocument();
+      expect(screen.queryByTestId('mobile-tab-bar')).not.toBeInTheDocument();
+      unmount();
+    }
+  });
+});
+
+describe('AppRoutesIOS — deep links a paired phone must honour', () => {
+  beforeEach(() => listProfiles.mockReset());
+  afterEach(() => vi.clearAllMocks());
+
+  it('opens a specific thread at /chat/:threadId', () => {
+    // The bare /chat form is covered by AppRoutesIOS.test.tsx; the optional
+    // `:threadId` segment is what a notification deep link actually carries,
+    // and a mismatch there lands the user on the catch-all instead.
+    listProfiles.mockReturnValue(SAVED_PROFILE);
+
+    renderAt('/chat/thread-abc');
+
+    expect(screen.getByTestId('page-chat')).toBeInTheDocument();
+    expect(screen.getByTestId('mobile-tab-bar')).toBeInTheDocument();
+    expect(screen.queryByTestId('page-human')).not.toBeInTheDocument();
+  });
+
+  it('bounces a thread deep link to /pair when the phone is unpaired', () => {
+    listProfiles.mockReturnValue([]);
+
+    renderAt('/chat/thread-abc');
+
+    expect(screen.getByTestId('page-pair')).toBeInTheDocument();
+    expect(screen.queryByTestId('page-chat')).not.toBeInTheDocument();
+  });
+});

--- a/app/src/components/intelligence/MemorySourceRow.pipelineWarning.test.tsx
+++ b/app/src/components/intelligence/MemorySourceRow.pipelineWarning.test.tsx
@@ -145,27 +145,34 @@ describe('MemorySourceRow — what suppresses the warning', () => {
     expect(warning()).not.toBeInTheDocument();
   });
 
-  it('ALSO stays hidden after a sync has finished, for as long as the result chip lives', () => {
-    // Pinned because it is surprising and load-bearing, not because it is right.
-    //
-    // `settled = !progress && !result` (MemorySourceRow.tsx:100). `result` is the
-    // terminal success/failure chip, and MemorySourcesRegistry only clears it
-    // when the NEXT sync starts (`:213`, `:358`) — nothing else drops it. So
-    // after any completed sync the "stored without vectors" warning is hidden
-    // indefinitely, which is exactly the shape of the incident this file exists
-    // for: chunks synced, none embedded, and no indicator anywhere.
-    //
-    // Recorded as a bug in ~/tinyhuman/bugs/W6-ui-bugs.md rather than asserted
-    // as correct. If someone narrows the suppression to `progress` alone, this
-    // test fails and should be updated to expect the warning — that failure is
-    // the fix landing, not a regression.
+  // Skipped, not deleted, and it asserts the DESIRED behaviour rather than the
+  // current one — which is the only framing that satisfies both reviews on this
+  // thread.
+  //
+  // The bug: `settled = !progress && !result` (MemorySourceRow.tsx:100), and
+  // MemorySourcesRegistry clears `result` only when the NEXT sync starts
+  // (`:213`, `:358`). Nothing else drops it. So after any completed or failed
+  // sync the "stored without vectors" warning is suppressed indefinitely —
+  // exactly the incident this file exists for.
+  //
+  // Asserting the suppression as correct would make the bug a required
+  // contract, so a genuine fix would turn this red (CodeRabbit's objection, and
+  // it is right). Deleting the case would leave it invisible again, which is
+  // how it hid in the first place (Codex's objection, also right). Defining the
+  // expected behaviour and skipping until it holds does neither: it is a
+  // written-down spec for the fix, and it goes green the moment the fix lands.
+  //
+  // UNSKIP when the suppression is narrowed to `!progress`, or when the
+  // registry clears `syncResults` once the row's status refreshes post-sync.
+  // Tracked in ~/tinyhuman/bugs/W6-ui-bugs.md #14.
+  it.skip('should still warn after a sync finishes while chunks remain unembedded', () => {
     renderRow({
       status: storedWithoutVectors(),
       progress: null,
       result: { ok: true } as unknown as React.ComponentProps<typeof MemorySourceRow>['result'],
     });
 
-    expect(warning()).not.toBeInTheDocument();
+    expect(warning()).toBeInTheDocument();
   });
 
   it('reports the truth again once the sync has settled', () => {

--- a/app/src/components/intelligence/MemorySourceRow.pipelineWarning.test.tsx
+++ b/app/src/components/intelligence/MemorySourceRow.pipelineWarning.test.tsx
@@ -129,7 +129,7 @@ describe('MemorySourceRow — the row tells the truth about embedding state', ()
   });
 });
 
-describe('MemorySourceRow — the warning is suppressed only while a sync is in flight', () => {
+describe('MemorySourceRow — what suppresses the warning', () => {
   // `settled = !progress && !result` in MemorySourceRow.tsx. This suppression is
   // correct (mid-sync `chunks_pending` is legitimately transient) and is also the
   // most plausible way for the indicator to never appear: a source wedged in a
@@ -140,6 +140,29 @@ describe('MemorySourceRow — the warning is suppressed only while a sync is in 
       progress: { processed: 10, total: 2581 } as unknown as React.ComponentProps<
         typeof MemorySourceRow
       >['progress'],
+    });
+
+    expect(warning()).not.toBeInTheDocument();
+  });
+
+  it('ALSO stays hidden after a sync has finished, for as long as the result chip lives', () => {
+    // Pinned because it is surprising and load-bearing, not because it is right.
+    //
+    // `settled = !progress && !result` (MemorySourceRow.tsx:100). `result` is the
+    // terminal success/failure chip, and MemorySourcesRegistry only clears it
+    // when the NEXT sync starts (`:213`, `:358`) — nothing else drops it. So
+    // after any completed sync the "stored without vectors" warning is hidden
+    // indefinitely, which is exactly the shape of the incident this file exists
+    // for: chunks synced, none embedded, and no indicator anywhere.
+    //
+    // Recorded as a bug in ~/tinyhuman/bugs/W6-ui-bugs.md rather than asserted
+    // as correct. If someone narrows the suppression to `progress` alone, this
+    // test fails and should be updated to expect the warning — that failure is
+    // the fix landing, not a regression.
+    renderRow({
+      status: storedWithoutVectors(),
+      progress: null,
+      result: { ok: true } as unknown as React.ComponentProps<typeof MemorySourceRow>['result'],
     });
 
     expect(warning()).not.toBeInTheDocument();

--- a/app/src/components/intelligence/MemorySourceRow.pipelineWarning.test.tsx
+++ b/app/src/components/intelligence/MemorySourceRow.pipelineWarning.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * The "stored without vectors" warning must actually reach the screen.
+ *
+ * Motivating incident: a workspace sat with 2,581 chunks synced and 0 embedded,
+ * and no degraded indicator appeared anywhere in the UI. The user's semantic
+ * search was silently returning nothing findable, while every surface reported
+ * a healthy sync.
+ *
+ * The *verdict* behind that warning — `deriveSourcePipelineHealth` — is already
+ * exhaustively covered by `sourcePipelineStatus.test.ts` (14 cases, every
+ * branch). What was NOT covered is whether the verdict is ever rendered:
+ * `MemorySourceRow.test.tsx` only exercises the settings disclosure. Deleting
+ * the whole `{ingestedOnly && …}` block from `MemorySourceRow.tsx` leaves every
+ * other test in the repo green — a correct verdict computed into a void, which
+ * is exactly the shape of the reported incident.
+ *
+ * These tests therefore assert the *rendered* contract, not the derivation:
+ * the warning appears when chunks are stored without vectors, it carries the
+ * message the user needs, and — the easy thing to get wrong — it is suppressed
+ * only while a sync is genuinely in flight.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { MemorySourceEntry, SourceStatus } from '../../services/memorySourcesService';
+import { MemorySourceRow } from './MemorySourceRow';
+
+vi.mock('../../lib/i18n/I18nContext', () => ({ useT: () => ({ t: (k: string) => k }) }));
+
+const SOURCE_ID = 'src_brain_1';
+
+function makeSource(overrides: Partial<MemorySourceEntry> = {}): MemorySourceEntry {
+  return {
+    id: SOURCE_ID,
+    kind: 'github_repo',
+    label: 'My Repo',
+    enabled: true,
+    url: 'https://github.com/org/repo',
+    ...overrides,
+  };
+}
+
+/** The incident's shape: everything ingested, nothing embedded. */
+function storedWithoutVectors(overrides: Partial<SourceStatus> = {}): SourceStatus {
+  return {
+    source_id: SOURCE_ID,
+    chunks_synced: 2581,
+    chunks_pending: 2581,
+    last_chunk_at_ms: Date.now(),
+    freshness: 'recent',
+    ...overrides,
+  } as SourceStatus;
+}
+
+function renderRow(overrides: Partial<React.ComponentProps<typeof MemorySourceRow>> = {}) {
+  const props: React.ComponentProps<typeof MemorySourceRow> = {
+    source: makeSource(),
+    status: null,
+    pipeline: null,
+    isAuthenticated: true,
+    isSyncing: false,
+    isBuilding: false,
+    progress: null,
+    result: null,
+    settingsExpanded: false,
+    onToggle: vi.fn(),
+    onRemove: vi.fn(),
+    onSync: vi.fn(),
+    onBuild: vi.fn(),
+    onToggleSettings: vi.fn(),
+    onSettingsSaved: vi.fn(),
+    onViewHealth: vi.fn(),
+    onSignIn: vi.fn(),
+    ...overrides,
+  };
+  render(
+    <ul>
+      <MemorySourceRow {...props} />
+    </ul>
+  );
+}
+
+const warning = () => screen.queryByTestId(`memory-source-pipeline-warning-${SOURCE_ID}`);
+
+describe('MemorySourceRow — the row tells the truth about embedding state', () => {
+  it('shows the pipeline warning when every synced chunk is unembedded', () => {
+    renderRow({ status: storedWithoutVectors() });
+
+    const banner = warning();
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveTextContent('sync.pipeline.storedWithoutVectors');
+  });
+
+  it('shows the warning for a single unembedded chunk, not just a large backlog', () => {
+    // There is no threshold in the contract: one chunk that semantic search
+    // cannot reach is still a source that is not retrieval-ready.
+    renderRow({ status: storedWithoutVectors({ chunks_synced: 10, chunks_pending: 1 }) });
+
+    expect(warning()).toBeInTheDocument();
+  });
+
+  it('stays silent when every chunk is embedded', () => {
+    renderRow({ status: storedWithoutVectors({ chunks_pending: 0 }) });
+
+    expect(warning()).not.toBeInTheDocument();
+  });
+
+  it('stays silent before anything has been ingested', () => {
+    // A brand-new source has no chunks and therefore nothing to warn about;
+    // warning here would train users to ignore the banner.
+    renderRow({ status: storedWithoutVectors({ chunks_synced: 0, chunks_pending: 0 }) });
+
+    expect(warning()).not.toBeInTheDocument();
+  });
+
+  it('surfaces the warning from the global semantic-recall latch with no pending chunks', () => {
+    // The per-source count can be 0 while the process-wide embeddings provider
+    // is down; the row still is not retrieval-ready.
+    renderRow({
+      status: storedWithoutVectors({ chunks_pending: 0 }),
+      pipeline: {
+        status: 'degraded',
+        degraded: { semantic_recall: true },
+      } as unknown as React.ComponentProps<typeof MemorySourceRow>['pipeline'],
+    });
+
+    expect(warning()).toBeInTheDocument();
+    expect(warning()).toHaveTextContent('sync.pipeline.storedWithoutVectors');
+  });
+});
+
+describe('MemorySourceRow — the warning is suppressed only while a sync is in flight', () => {
+  // `settled = !progress && !result` in MemorySourceRow.tsx. This suppression is
+  // correct (mid-sync `chunks_pending` is legitimately transient) and is also the
+  // most plausible way for the indicator to never appear: a source wedged in a
+  // progress state would warn about nothing forever. Both directions are pinned.
+  it('hides the warning while a sync is actively reporting progress', () => {
+    renderRow({
+      status: storedWithoutVectors(),
+      progress: { processed: 10, total: 2581 } as unknown as React.ComponentProps<
+        typeof MemorySourceRow
+      >['progress'],
+    });
+
+    expect(warning()).not.toBeInTheDocument();
+  });
+
+  it('reports the truth again once the sync has settled', () => {
+    renderRow({ status: storedWithoutVectors(), progress: null, result: null });
+
+    expect(warning()).toBeInTheDocument();
+  });
+
+  it('offers sign-in only when the failure is a missing backend session', () => {
+    renderRow({
+      isAuthenticated: false,
+      status: storedWithoutVectors(),
+      pipeline: {
+        status: 'degraded',
+        first_blocking_cause: { code: 'auth_missing' },
+      } as unknown as React.ComponentProps<typeof MemorySourceRow>['pipeline'],
+    });
+
+    expect(screen.getByTestId(`memory-source-signin-${SOURCE_ID}`)).toBeInTheDocument();
+  });
+
+  it('does not offer sign-in for a non-auth embeddings failure', () => {
+    renderRow({
+      isAuthenticated: false,
+      status: storedWithoutVectors(),
+      pipeline: {
+        status: 'degraded',
+        first_blocking_cause: { code: 'provider_unreachable' },
+      } as unknown as React.ComponentProps<typeof MemorySourceRow>['pipeline'],
+    });
+
+    expect(warning()).toBeInTheDocument();
+    expect(screen.queryByTestId(`memory-source-signin-${SOURCE_ID}`)).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Pins the **nine** back-compat route redirects as contracts — including `replace` semantics, which nothing asserted.
- Pins route auth guards, the iOS re-pairing escape hatch, and the memory embedding-state warning.
- 4 files, +676 lines. No product code touched.

> **Test lane:** 4 vitest component suites (jsdom). **Not** browser e2e.

## Problem

Three untested contracts, each cheap to break by accident:

- **`replace` semantics on all nine `<Navigate>` redirects had no cover at all.** Dropping `replace` from any one of them leaves the retired path on the history stack, so Back returns to it and is redirected forward again — the user cannot navigate back out. A one-word edit produces that, and the whole suite stayed green.
- **The `/accounts` redirect was unguarded.** Its existing test asserts only that the `Accounts` component rendered — but `Accounts` is *also* the element for `/chat/:threadId?`, so the assertion held whether or not the redirect existed. Verified by deleting the redirect entirely: the old test still passed.
- **The embedding-state warning could stop rendering silently.** `deriveSourcePipelineHealth` is covered exhaustively (14 cases), but the JSX that *renders* its verdict was not. Neutering `{ingestedOnly && (…)}` to `{false && (…)}` left the entire repo green — a correct verdict computed into a void, which is precisely the shape of the incident where 2,581 chunks sat with 0 embedded and no indicator appeared.

## Solution

Four suites asserting resolved locations and history actions rather than what rendered.

Proven by mutation throughout: removing `replace` from `/feedback` fails with `expected 'PUSH' to be 'REPLACE'`; deleting the `/accounts` redirect fails 3 cases where the old test passed; the embedding warning has 9 cases proven by three separate mutations.

**Two of my own drafts were dropped rather than kept:** one pinned a style convention (a prop whose removal changed no behaviour) and one restated an assertion already made elsewhere. A check of the mobile default redirect found it already covered by `AppRoutesIOS.test.tsx`, so nothing was added there.

On **openhuman#5479 ("Cannot Pair iPhone")**: the root cause was located — `tunnel_client.rs:74-92` parses the ack into a struct whose three fields are all required with no `Option`, default, or untagged fallback, so *any* non-conforming response (error envelope, wrapped success, timeout) surfaces as `missing field 'channelId'` instead of the backend's actual reason. **No test was written for it**, because a Rust test target could not be compiled here and shipping an unprovable test is worse than shipping none. What *is* covered is the recovery path: `/pair` staying reachable, which is what stops the bug bricking a phone rather than merely blocking a retry.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — this PR *is* the tests. Every case was revert-proofed: the covered behaviour was broken, the test confirmed to fail naming its own assertion, then restored. Drafts that still passed with the fault injected were rewritten or dropped rather than kept.
- [x] **Diff coverage ≥ 80%** — `N/A: the changed lines are test files`, executed by the suites they belong to; there is no product code in this diff for diff-cover to measure.
- [x] Coverage matrix updated — `N/A: behaviour-only change` — no feature rows added, removed or renamed; this covers behaviour that already ships.
- [x] All affected feature IDs from the matrix are listed — `N/A: no feature IDs affected`.
- [x] No new external network dependencies introduced — mocks and fixtures only; no test reaches a live service.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no product surface changes`, test-only.
- [x] Linked issue closed via `Closes #NNN` — `N/A: no linked issue`; this is coverage work, not a fix.

## Impact

- **Platform:** none at runtime. Test-only.
- **UX:** the `replace` contracts guard against a back-button trap that a one-word edit would reintroduce.
- **Risk:** none to product behaviour.

## Related

- Closes:
- Related, and deliberately **not** addressed here: openhuman#5479 — root cause identified above; the serde fix belongs in a product PR.
- Follow-up PR(s)/TODOs: an untagged-enum ack type for `TunnelRegisterResponse` so the backend's real error reaches the user.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `test/routes-redirect-contracts`
- Commit SHA: see head of this PR

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — prettier clean on all four new files.
- [x] `pnpm typecheck` — `tsc --noEmit`, 0 errors; eslint clean on all four.
- [x] Focused tests: full run of the affected area — **80 tests / 9 files green**, including all pre-existing route and pipeline specs.
- [x] Rust fmt/check (if changed): `N/A: no .rs files changed.`
- [x] Tauri fmt/check (if changed): `N/A: app/src-tauri not touched.`

### Validation Blocked

- `command:` the 91-spec WebdriverIO desktop suite
- `error:` `cargo metadata --manifest-path app/src-tauri/Cargo.toml` exits 101 — "found a virtual manifest at vendor/tinyagents/Cargo.toml"
- `impact:` those specs cannot build on `main` today, independent of this PR (fixed separately in #5874). This work targets the lanes that do run: vitest, Playwright web, and the root Rust world.

### Behavior Changes

- Intended behavior change: none. Test-only.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: yes — no product code is touched; these pin behaviour that already ships.
- Guard/fallback/dispatch parity checks: every test was proven to fail when the behaviour it pins is broken, so it discriminates rather than merely executing.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none — the six coverage branches in this batch touch disjoint files (verified across all 31).
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added comprehensive coverage for route access rules, including public, protected, and unrestricted pages.
  - Verified OAuth callback routes remain accessible when signed out.
  - Added coverage for legacy redirects and confirmed they replace browser history correctly.
  - Tested iOS pairing and deep-link behavior for paired and unpaired states.
  - Added coverage for memory pipeline warnings, embedding status, sync progress, and sign-in prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->