### PR TITLE
test(e2e): browser specs for the settings surface, plus seven panel suites

### DIFF
--- a/app/src/components/settings/panels/__tests__/PermissionsPanel.races.test.tsx
+++ b/app/src/components/settings/panels/__tests__/PermissionsPanel.races.test.tsx
@@ -105,7 +105,7 @@ describe('PermissionsPanel — load-shape defaults', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsTauri.mockReturnValue(true);
-    mockGetPaths.mockResolvedValue({ result: agentPaths() });
+    mockGetPaths.mockResolvedValue({ result: agentPaths(), logs: [] });
   });
 
   // `require_task_plan_approval ?? true` and `trusted_roots ?? []`
@@ -116,8 +116,8 @@ describe('PermissionsPanel — load-shape defaults', () => {
     const partial = autonomy();
     delete (partial as Partial<AutonomySettings>).trusted_roots;
     delete (partial as { require_task_plan_approval?: boolean }).require_task_plan_approval;
-    mockGet.mockResolvedValue({ result: partial as AutonomySettings });
-    mockUpdate.mockResolvedValue({ result: autonomy({ level: 'full' }) });
+    mockGet.mockResolvedValue({ result: partial as AutonomySettings, logs: [] });
+    mockUpdate.mockResolvedValue({ result: {} as never, logs: [] });
 
     renderWithProviders(<PermissionsPanel />);
     await waitFor(() => expect(mockGet).toHaveBeenCalled());
@@ -133,8 +133,9 @@ describe('PermissionsPanel — load-shape defaults', () => {
   it('preserves a false require_task_plan_approval rather than defaulting it on', async () => {
     mockGet.mockResolvedValue({
       result: autonomy({ require_task_plan_approval: false } as Partial<AutonomySettings>),
+      logs: [],
     });
-    mockUpdate.mockResolvedValue({ result: autonomy({ level: 'full' }) });
+    mockUpdate.mockResolvedValue({ result: {} as never, logs: [] });
 
     renderWithProviders(<PermissionsPanel />);
     await waitFor(() => expect(mockGet).toHaveBeenCalled());
@@ -162,8 +163,8 @@ describe('PermissionsPanel — persist sequence guard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsTauri.mockReturnValue(true);
-    mockGet.mockResolvedValue({ result: autonomy() });
-    mockGetPaths.mockResolvedValue({ result: agentPaths() });
+    mockGet.mockResolvedValue({ result: autonomy(), logs: [] });
+    mockGetPaths.mockResolvedValue({ result: agentPaths(), logs: [] });
   });
 
   it('surfaces a save failure', async () => {
@@ -181,9 +182,9 @@ describe('PermissionsPanel — persist sequence guard', () => {
   // outcome once a newer one has started. Without `persistSeqRef` the stale
   // rejection below would paint an error over a save that actually succeeded.
   it('ignores a stale save failure that lands after a newer save', async () => {
-    const stale = deferred<{ result: AutonomySettings }>();
+    const stale = deferred<{ result: never; logs: string[] }>();
     mockUpdate.mockReturnValueOnce(stale.promise);
-    mockUpdate.mockResolvedValueOnce({ result: autonomy({ level: 'readonly' }) });
+    mockUpdate.mockResolvedValueOnce({ result: {} as never, logs: [] });
 
     renderWithProviders(<PermissionsPanel />);
     await waitFor(() => expect(mockGet).toHaveBeenCalled());
@@ -199,7 +200,7 @@ describe('PermissionsPanel — persist sequence guard', () => {
   });
 
   it('ignores a stale save success that lands after a newer failure', async () => {
-    const stale = deferred<{ result: AutonomySettings }>();
+    const stale = deferred<{ result: never; logs: string[] }>();
     mockUpdate.mockReturnValueOnce(stale.promise);
     mockUpdate.mockRejectedValueOnce(new Error('newer save refused'));
 
@@ -211,7 +212,7 @@ describe('PermissionsPanel — persist sequence guard', () => {
 
     expect(await screen.findByText(/newer save refused/)).toBeInTheDocument();
 
-    stale.resolve({ result: autonomy({ level: 'full' }) });
+    stale.resolve({ result: {} as never, logs: [] });
     await flush();
     // The newer failure must still stand — a late success must not clear it...
     expect(screen.getByText(/newer save refused/)).toBeInTheDocument();
@@ -232,8 +233,8 @@ describe('PermissionsPanel — action_dir sequence guard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockIsTauri.mockReturnValue(true);
-    mockGet.mockResolvedValue({ result: autonomy() });
-    mockGetPaths.mockResolvedValue({ result: agentPaths() });
+    mockGet.mockResolvedValue({ result: autonomy(), logs: [] });
+    mockGetPaths.mockResolvedValue({ result: agentPaths(), logs: [] });
   });
 
   const startEditing = async () => {
@@ -244,7 +245,7 @@ describe('PermissionsPanel — action_dir sequence guard', () => {
   };
 
   it('trims the typed path before sending it', async () => {
-    mockUpdatePaths.mockResolvedValue({ result: agentPaths({ action_dir: '/new/dir' }) });
+    mockUpdatePaths.mockResolvedValue({ result: agentPaths({ action_dir: '/new/dir' }), logs: [] });
 
     const input = await startEditing();
     fireEvent.change(input, { target: { value: '   /new/dir   ' } });
@@ -279,7 +280,7 @@ describe('PermissionsPanel — action_dir sequence guard', () => {
   // one is in flight. Assert the guard that actually holds — a second click
   // cannot start a second RPC — rather than a race the user cannot trigger.
   it('disables Save while one is in flight, so a second click cannot double-send', async () => {
-    const inflight = deferred<{ result: AgentPaths }>();
+    const inflight = deferred<{ result: AgentPaths; logs: string[] }>();
     mockUpdatePaths.mockReturnValueOnce(inflight.promise);
 
     const input = await startEditing();
@@ -291,7 +292,7 @@ describe('PermissionsPanel — action_dir sequence guard', () => {
     fireEvent.click(save);
     expect(mockUpdatePaths).toHaveBeenCalledTimes(1);
 
-    inflight.resolve({ result: agentPaths({ action_dir: '/first' }) });
+    inflight.resolve({ result: agentPaths({ action_dir: '/first' }), logs: [] });
     await waitFor(() => expect(screen.getByText('/first')).toBeInTheDocument());
   });
 });

--- a/app/src/components/settings/panels/__tests__/PermissionsPanel.races.test.tsx
+++ b/app/src/components/settings/panels/__tests__/PermissionsPanel.races.test.tsx
@@ -1,0 +1,313 @@
+/**
+ * PermissionsPanel — the sequence guards, the RPC-shape defaults, and the two
+ * save-failure branches.
+ *
+ * `PermissionsPanel.test.tsx` (sibling) covers the three presets, the
+ * action_dir edit flow and the env-locked notice. What it does not reach is the
+ * panel's concurrency machinery: `persistSeqRef` (`PermissionsPanel.tsx:115`)
+ * and `dirSeqRef` (`:166`) exist so a slow in-flight response cannot overwrite
+ * the result of a newer one, and neither guard has a test. Branch coverage sat
+ * at 69.8% with those and the `??` defaults unexercised.
+ *
+ * Separate file rather than an edit to the sibling: three of us are in this
+ * directory.
+ */
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from '../../../../test/test-utils';
+import {
+  type AgentPaths,
+  type AutonomySettings,
+  isTauri,
+  openhumanGetAgentPaths,
+  openhumanGetAutonomySettings,
+  openhumanUpdateAgentPaths,
+  openhumanUpdateAutonomySettings,
+} from '../../../../utils/tauriCommands';
+import PermissionsPanel from '../PermissionsPanel';
+
+const autonomy = (overrides: Partial<AutonomySettings> = {}): AutonomySettings => ({
+  level: 'supervised',
+  workspace_only: false,
+  allowed_commands: [],
+  forbidden_paths: [],
+  trusted_roots: [],
+  allow_tool_install: true,
+  max_actions_per_hour: 0,
+  auto_approve: [],
+  ...overrides,
+});
+
+const agentPaths = (overrides: Partial<AgentPaths> = {}): AgentPaths => ({
+  action_dir: '/home/test/OpenHuman/projects',
+  workspace_dir: '/home/test/.openhuman/users/u1/workspace',
+  projects_dir: '/home/test/OpenHuman/projects',
+  action_dir_source: 'default',
+  ...overrides,
+});
+
+vi.mock('../../hooks/useSettingsNavigation', () => ({
+  useSettingsNavigation: () => ({
+    navigateBack: vi.fn(),
+    navigateToSettings: vi.fn(),
+    breadcrumbs: [],
+  }),
+}));
+
+vi.mock('../../../../utils/tauriCommands', async () => {
+  const actual = await vi.importActual<typeof import('../../../../utils/tauriCommands')>(
+    '../../../../utils/tauriCommands'
+  );
+  return {
+    ...actual,
+    isTauri: vi.fn(() => true),
+    openhumanGetAutonomySettings: vi.fn(),
+    openhumanUpdateAutonomySettings: vi.fn(),
+    openhumanGetAgentPaths: vi.fn(),
+    openhumanUpdateAgentPaths: vi.fn(),
+  };
+});
+
+const mockGet = vi.mocked(openhumanGetAutonomySettings);
+const mockUpdate = vi.mocked(openhumanUpdateAutonomySettings);
+const mockGetPaths = vi.mocked(openhumanGetAgentPaths);
+const mockUpdatePaths = vi.mocked(openhumanUpdateAgentPaths);
+const mockIsTauri = vi.mocked(isTauri);
+
+/** A promise plus the handles to settle it later — lets a test hold one RPC
+ *  in flight while a second one starts and finishes. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Let a settled promise's `.then`/`.catch` chain and React's resulting render
+ *  actually run. A bare `waitFor(() => expect(x).not.toBeInTheDocument())`
+ *  passes on its FIRST tick — before the rejection has been handled — so it
+ *  would hold even with the guard removed. This makes the negative assertions
+ *  below mean something. */
+async function flush() {
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
+}
+
+const preset = (name: RegExp) => screen.getByText(name).closest('button') as HTMLElement;
+
+describe('PermissionsPanel — load-shape defaults', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsTauri.mockReturnValue(true);
+    mockGetPaths.mockResolvedValue({ result: agentPaths() });
+  });
+
+  // `require_task_plan_approval ?? true` and `trusted_roots ?? []`
+  // (`PermissionsPanel.tsx:90-91`) exist because an older core omits both
+  // fields. The defaults matter: they are carried straight back into the next
+  // save, so getting them wrong silently rewrites the user's settings.
+  it('defaults the fields an older core omits, and carries them into a save', async () => {
+    const partial = autonomy();
+    delete (partial as Partial<AutonomySettings>).trusted_roots;
+    delete (partial as { require_task_plan_approval?: boolean }).require_task_plan_approval;
+    mockGet.mockResolvedValue({ result: partial as AutonomySettings });
+    mockUpdate.mockResolvedValue({ result: autonomy({ level: 'full' }) });
+
+    renderWithProviders(<PermissionsPanel />);
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+
+    fireEvent.click(preset(/Full control/i));
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    const sent = mockUpdate.mock.calls[0][0];
+    expect(sent.require_task_plan_approval).toBe(true);
+    expect(sent.trusted_roots).toEqual([]);
+  });
+
+  it('preserves a false require_task_plan_approval rather than defaulting it on', async () => {
+    mockGet.mockResolvedValue({
+      result: autonomy({ require_task_plan_approval: false } as Partial<AutonomySettings>),
+    });
+    mockUpdate.mockResolvedValue({ result: autonomy({ level: 'full' }) });
+
+    renderWithProviders(<PermissionsPanel />);
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+
+    fireEvent.click(preset(/Full control/i));
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    expect(mockUpdate.mock.calls[0][0].require_task_plan_approval).toBe(false);
+  });
+
+  it('reports an autonomy load failure but still renders the folder section', async () => {
+    mockGet.mockRejectedValue(new Error('autonomy rpc down'));
+
+    renderWithProviders(<PermissionsPanel />);
+
+    expect(await screen.findByText(/autonomy rpc down/)).toBeInTheDocument();
+    // The paths RPC is independent — a failed autonomy load must not blank it.
+    await waitFor(() =>
+      expect(screen.getByText('/home/test/OpenHuman/projects')).toBeInTheDocument()
+    );
+  });
+});
+
+describe('PermissionsPanel — persist sequence guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsTauri.mockReturnValue(true);
+    mockGet.mockResolvedValue({ result: autonomy() });
+    mockGetPaths.mockResolvedValue({ result: agentPaths() });
+  });
+
+  it('surfaces a save failure', async () => {
+    mockUpdate.mockRejectedValue(new Error('autonomy save refused'));
+
+    renderWithProviders(<PermissionsPanel />);
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+
+    fireEvent.click(preset(/Full control/i));
+
+    expect(await screen.findByText(/autonomy save refused/)).toBeInTheDocument();
+  });
+
+  // The guard's whole purpose: an older in-flight save must not report its
+  // outcome once a newer one has started. Without `persistSeqRef` the stale
+  // rejection below would paint an error over a save that actually succeeded.
+  it('ignores a stale save failure that lands after a newer save', async () => {
+    const stale = deferred<{ result: AutonomySettings }>();
+    mockUpdate.mockReturnValueOnce(stale.promise);
+    mockUpdate.mockResolvedValueOnce({ result: autonomy({ level: 'readonly' }) });
+
+    renderWithProviders(<PermissionsPanel />);
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+
+    fireEvent.click(preset(/Full control/i));
+    fireEvent.click(preset(/Look, don't touch/i));
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(2));
+
+    // Now let the FIRST call fail, after the second has already finished.
+    stale.reject(new Error('stale failure'));
+    await flush();
+    expect(screen.queryByText(/stale failure/)).not.toBeInTheDocument();
+  });
+
+  it('ignores a stale save success that lands after a newer failure', async () => {
+    const stale = deferred<{ result: AutonomySettings }>();
+    mockUpdate.mockReturnValueOnce(stale.promise);
+    mockUpdate.mockRejectedValueOnce(new Error('newer save refused'));
+
+    renderWithProviders(<PermissionsPanel />);
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+
+    fireEvent.click(preset(/Full control/i));
+    fireEvent.click(preset(/Look, don't touch/i));
+
+    expect(await screen.findByText(/newer save refused/)).toBeInTheDocument();
+
+    stale.resolve({ result: autonomy({ level: 'full' }) });
+    await flush();
+    // The newer failure must still stand — a late success must not clear it...
+    expect(screen.getByText(/newer save refused/)).toBeInTheDocument();
+    // ...and no "Saved" note appears over a save that failed.
+    //
+    // Defence in depth, and worth being precise about: this holds for TWO
+    // independent reasons — `persistSeqRef` drops the stale success before it
+    // reaches state, and `StatusLine` renders error-over-saving-over-saved by
+    // design ("so a failure is never masked by a stale success note",
+    // `ui/StatusLine.tsx:16`). Removing the seq guard alone leaves this green,
+    // which I verified. It fails only if both go, so read it as a guard on the
+    // user-visible outcome, not on `persistSeqRef` specifically.
+    expect(screen.queryByText(/Saved: applies on your next message/)).not.toBeInTheDocument();
+  });
+});
+
+describe('PermissionsPanel — action_dir sequence guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsTauri.mockReturnValue(true);
+    mockGet.mockResolvedValue({ result: autonomy() });
+    mockGetPaths.mockResolvedValue({ result: agentPaths() });
+  });
+
+  const startEditing = async () => {
+    renderWithProviders(<PermissionsPanel />);
+    await waitFor(() => expect(mockGetPaths).toHaveBeenCalled());
+    fireEvent.click(await screen.findByText('Edit'));
+    return screen.getByDisplayValue('/home/test/OpenHuman/projects');
+  };
+
+  it('trims the typed path before sending it', async () => {
+    mockUpdatePaths.mockResolvedValue({ result: agentPaths({ action_dir: '/new/dir' }) });
+
+    const input = await startEditing();
+    fireEvent.change(input, { target: { value: '   /new/dir   ' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => expect(mockUpdatePaths).toHaveBeenCalledWith({ action_dir: '/new/dir' }));
+  });
+
+  it('leaves edit mode open when the save fails', async () => {
+    mockUpdatePaths.mockRejectedValue(new Error('path rejected by core'));
+
+    const input = await startEditing();
+    fireEvent.change(input, { target: { value: '/bad/dir' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    expect(await screen.findByText(/path rejected by core/)).toBeInTheDocument();
+    // Still editing — the user's typed value must not be thrown away.
+    expect(screen.getByDisplayValue('/bad/dir')).toBeInTheDocument();
+  });
+
+  it('discards the edit and restores the original on cancel', async () => {
+    const input = await startEditing();
+    fireEvent.change(input, { target: { value: '/scratch' } });
+    fireEvent.click(screen.getByText('Cancel'));
+
+    expect(screen.queryByDisplayValue('/scratch')).not.toBeInTheDocument();
+    expect(screen.getByText('/home/test/OpenHuman/projects')).toBeInTheDocument();
+  });
+
+  // `dirSeqRef` (`PermissionsPanel.tsx:166`) guards against an overlapping
+  // action_dir save, but the UI makes that unreachable: Save is disabled while
+  // one is in flight. Assert the guard that actually holds — a second click
+  // cannot start a second RPC — rather than a race the user cannot trigger.
+  it('disables Save while one is in flight, so a second click cannot double-send', async () => {
+    const inflight = deferred<{ result: AgentPaths }>();
+    mockUpdatePaths.mockReturnValueOnce(inflight.promise);
+
+    const input = await startEditing();
+    fireEvent.change(input, { target: { value: '/first' } });
+    const save = screen.getByText('Save').closest('button') as HTMLButtonElement;
+    fireEvent.click(save);
+
+    await waitFor(() => expect(save).toBeDisabled());
+    fireEvent.click(save);
+    expect(mockUpdatePaths).toHaveBeenCalledTimes(1);
+
+    inflight.resolve({ result: agentPaths({ action_dir: '/first' }) });
+    await waitFor(() => expect(screen.getByText('/first')).toBeInTheDocument());
+  });
+});
+
+describe('PermissionsPanel — off-Tauri', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsTauri.mockReturnValue(false);
+  });
+
+  it('does not persist a tier change in the browser', async () => {
+    renderWithProviders(<PermissionsPanel />);
+
+    fireEvent.click(preset(/Full control/i));
+
+    await waitFor(() => expect(screen.getByText(/desktop app/i)).toBeInTheDocument());
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/components/settings/panels/__tests__/PrivacyModeSection.status.test.tsx
+++ b/app/src/components/settings/panels/__tests__/PrivacyModeSection.status.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * PrivacyModeSection — the load/save failure branches, the disabled states and
+ * the auto-clearing "saved" note.
+ *
+ * `PrivacyModeSection.test.tsx` (sibling) covers the three options, the loaded
+ * selection and the no-op re-click. Every failure branch and every transient
+ * status was unexercised, which is what held branch coverage at 70.8%. This
+ * matters more here than on most panels: the control sets the data-egress
+ * posture (#4435), so a save that silently fails leaves the user believing they
+ * are in `local_only` when they are not.
+ *
+ * Separate file rather than an edit to the sibling: three of us are in this
+ * directory.
+ */
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from '../../../../test/test-utils';
+import PrivacyModeSection from '../PrivacyModeSection';
+
+const callCoreRpc = vi.fn();
+vi.mock('../../../../services/coreRpcClient', () => ({
+  callCoreRpc: (arg: { method: string; params: unknown }) => callCoreRpc(arg),
+}));
+
+const GET = 'openhuman.config_get_privacy_mode';
+const SET = 'openhuman.config_set_privacy_mode';
+
+/** Load resolves to `mode`; the setter behaviour is supplied per test. */
+function wire(opts: {
+  loadMode?: string;
+  loadError?: unknown;
+  onSet?: (mode?: string) => Promise<unknown>;
+}) {
+  callCoreRpc.mockImplementation((arg: { method: string; params: { mode?: string } }) => {
+    if (arg.method === GET) {
+      return opts.loadError
+        ? Promise.reject(opts.loadError)
+        : Promise.resolve({ result: { mode: opts.loadMode ?? 'standard' } });
+    }
+    if (arg.method === SET) {
+      return opts.onSet
+        ? opts.onSet(arg.params.mode)
+        : Promise.resolve({ result: { mode: arg.params.mode } });
+    }
+    return Promise.reject(new Error(`unexpected method ${arg.method}`));
+  });
+}
+
+const option = (mode: string) => screen.getByTestId(`privacy-mode-option-${mode}`);
+const statusLine = () => document.querySelector('[data-slot="status-line"]') as HTMLElement;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // The panel logs failures through `console.warn`; keep the run readable while
+  // still proving the branch executed via the rendered status line.
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe('PrivacyModeSection — load', () => {
+  it('shows the load failure message and leaves nothing selected', async () => {
+    wire({ loadError: new Error('privacy rpc unavailable') });
+    renderWithProviders(<PrivacyModeSection />);
+
+    expect(await screen.findByText('privacy rpc unavailable')).toBeInTheDocument();
+    // `mode` stays null, so no option may claim to be the current posture.
+    for (const mode of ['local_only', 'standard', 'sensitive']) {
+      expect(option(mode)).not.toBeChecked();
+    }
+  });
+
+  it('stringifies a non-Error load rejection rather than rendering nothing', async () => {
+    wire({ loadError: 'plain string failure' });
+    renderWithProviders(<PrivacyModeSection />);
+
+    expect(await screen.findByText('plain string failure')).toBeInTheDocument();
+  });
+
+  it('disables every option while the current mode is still loading', () => {
+    wire({ onSet: () => new Promise(() => {}) });
+    callCoreRpc.mockImplementation(() => new Promise(() => {}));
+    renderWithProviders(<PrivacyModeSection />);
+
+    for (const mode of ['local_only', 'standard', 'sensitive']) {
+      expect(option(mode)).toBeDisabled();
+    }
+  });
+
+  it('enables the options once the mode has loaded', async () => {
+    wire({ loadMode: 'standard' });
+    renderWithProviders(<PrivacyModeSection />);
+
+    await waitFor(() => expect(option('standard')).toBeChecked());
+    expect(option('local_only')).toBeEnabled();
+  });
+});
+
+describe('PrivacyModeSection — save', () => {
+  it('reports a save failure and keeps the previous selection', async () => {
+    wire({ loadMode: 'standard', onSet: () => Promise.reject(new Error('egress locked')) });
+    renderWithProviders(<PrivacyModeSection />);
+    await waitFor(() => expect(option('standard')).toBeChecked());
+
+    fireEvent.click(option('local_only'));
+
+    expect(await screen.findByText('egress locked')).toBeInTheDocument();
+    // The posture must not appear to have changed when the write failed —
+    // believing you are local-only when you are not is the whole risk here.
+    expect(option('standard')).toBeChecked();
+    expect(option('local_only')).not.toBeChecked();
+  });
+
+  it('adopts the mode the core echoes back, not the one that was clicked', async () => {
+    // The core is authoritative: if it coerces the request, the UI must follow.
+    wire({ loadMode: 'standard', onSet: () => Promise.resolve({ result: { mode: 'sensitive' } }) });
+    renderWithProviders(<PrivacyModeSection />);
+    await waitFor(() => expect(option('standard')).toBeChecked());
+
+    fireEvent.click(option('local_only'));
+
+    await waitFor(() => expect(option('sensitive')).toBeChecked());
+    expect(option('local_only')).not.toBeChecked();
+  });
+
+  it('disables the options while a save is in flight', async () => {
+    let release!: (v: unknown) => void;
+    wire({ loadMode: 'standard', onSet: () => new Promise(resolve => (release = resolve)) });
+    renderWithProviders(<PrivacyModeSection />);
+    await waitFor(() => expect(option('standard')).toBeChecked());
+
+    fireEvent.click(option('local_only'));
+
+    await waitFor(() => expect(option('sensitive')).toBeDisabled());
+    release({ result: { mode: 'local_only' } });
+    await waitFor(() => expect(option('sensitive')).toBeEnabled());
+  });
+
+  it('clears the saved note after the two-second window', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    wire({ loadMode: 'standard' });
+    renderWithProviders(<PrivacyModeSection />);
+    await waitFor(() => expect(option('standard')).toBeChecked());
+
+    fireEvent.click(option('local_only'));
+    await waitFor(() => expect(statusLine()).toHaveTextContent(/saved/i));
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    await waitFor(() => expect(statusLine()).toHaveTextContent(''));
+  });
+
+  it('does not call the setter when the already-selected mode is re-chosen', async () => {
+    wire({ loadMode: 'sensitive' });
+    renderWithProviders(<PrivacyModeSection />);
+    await waitFor(() => expect(option('sensitive')).toBeChecked());
+
+    const before = callCoreRpc.mock.calls.filter(c => c[0].method === SET).length;
+    fireEvent.click(option('sensitive'));
+
+    expect(callCoreRpc.mock.calls.filter(c => c[0].method === SET)).toHaveLength(before);
+  });
+});

--- a/app/src/components/settings/panels/__tests__/PrivacyModeSection.status.test.tsx
+++ b/app/src/components/settings/panels/__tests__/PrivacyModeSection.status.test.tsx
@@ -152,7 +152,11 @@ describe('PrivacyModeSection — save', () => {
     await act(async () => {
       vi.advanceTimersByTime(2000);
     });
-    await waitFor(() => expect(statusLine()).toHaveTextContent(''));
+    // `toHaveTextContent('')` is a false positive: jest-dom treats an empty
+    // expected string as matching anything (it now throws rather than assert),
+    // so it would pass whether or not the note cleared. `toBeEmptyDOMElement`
+    // is the matcher that actually checks emptiness.
+    await waitFor(() => expect(statusLine()).toBeEmptyDOMElement());
   });
 
   it('does not call the setter when the already-selected mode is re-chosen', async () => {

--- a/app/src/components/settings/panels/__tests__/PrivacyPanel.kinds.test.tsx
+++ b/app/src/components/settings/panels/__tests__/PrivacyPanel.kinds.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * PrivacyPanel — the data-kind labels, the empty catalog, and the analytics
+ * toggle's failure path.
+ *
+ * `PrivacyPanel.test.tsx` (sibling) exercises `raw` and `derived` only, so
+ * three of the five `kindLabel` arms (`PrivacyPanel.tsx:36-49`) never ran, and
+ * neither did the "ready but empty" state nor the toggle's `catch`.
+ *
+ * The labels are the point of the panel: it is the screen that tells a user
+ * what leaves their computer, so a capability rendering under the wrong kind —
+ * `credentials` shown as `raw`, say — misinforms them about exactly the thing
+ * they came here to check.
+ *
+ * Separate file rather than an edit to the sibling: three of us are in this
+ * directory.
+ */
+import { fireEvent, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from '../../../../test/test-utils';
+import { type Capability, listCapabilities } from '../../../../utils/tauriCommands/aboutApp';
+import PrivacyPanel from '../PrivacyPanel';
+
+vi.mock('../../../../utils/tauriCommands/aboutApp', () => ({ listCapabilities: vi.fn() }));
+
+const setAnalyticsEnabledMock = vi.fn();
+vi.mock('../../../../providers/CoreStateProvider', () => ({
+  useCoreState: () => ({
+    snapshot: { analyticsEnabled: false },
+    setAnalyticsEnabled: (v: boolean) => setAnalyticsEnabledMock(v),
+  }),
+}));
+
+vi.mock('../../hooks/useSettingsNavigation', () => ({
+  useSettingsNavigation: () => ({ navigateBack: vi.fn(), breadcrumbs: [] }),
+}));
+
+const mockList = vi.mocked(listCapabilities);
+
+type DataKind = 'raw' | 'derived' | 'credentials' | 'diagnostics' | 'metadata';
+
+const cap = (id: string, data_kind: DataKind, over: Partial<Capability> = {}): Capability => ({
+  id,
+  name: `Cap ${id}`,
+  domain: 'test',
+  category: 'test',
+  description: `Description for ${id}`,
+  how_to: 'Somewhere',
+  status: 'stable',
+  privacy: { leaves_device: true, data_kind, destinations: ['Backend'] },
+  ...over,
+});
+
+const row = (id: string) => screen.getByTestId(`privacy-row-${id}`);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('PrivacyPanel — data-kind labels', () => {
+  // Every arm of `kindLabel`. The switch has no default, so a new kind added to
+  // the union without a case here returns undefined and the badge renders
+  // blank — this is what would catch that.
+  it.each([
+    ['raw', 'Raw'],
+    ['derived', 'Derived'],
+    ['credentials', 'Credentials'],
+    ['diagnostics', 'Diagnostics'],
+    ['metadata', 'Metadata'],
+  ] as const)('labels a %s capability as "%s"', async (kind, label) => {
+    mockList.mockResolvedValue([cap(`c-${kind}`, kind)]);
+    renderWithProviders(<PrivacyPanel />);
+
+    await waitFor(() => expect(screen.getByTestId('privacy-capability-list')).toBeInTheDocument());
+    expect(within(row(`c-${kind}`)).getByText(label)).toBeInTheDocument();
+  });
+
+  it('renders all five kinds together, each with its own label', async () => {
+    const kinds: DataKind[] = ['raw', 'derived', 'credentials', 'diagnostics', 'metadata'];
+    mockList.mockResolvedValue(kinds.map(k => cap(`c-${k}`, k)));
+    renderWithProviders(<PrivacyPanel />);
+
+    await waitFor(() => expect(screen.getByTestId('privacy-capability-list')).toBeInTheDocument());
+    for (const label of ['Raw', 'Derived', 'Credentials', 'Diagnostics', 'Metadata']) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+});
+
+describe('PrivacyPanel — leaves-device and destinations', () => {
+  it('distinguishes a capability that leaves the device from one that does not', async () => {
+    mockList.mockResolvedValue([
+      cap('remote', 'derived', {
+        privacy: { leaves_device: true, data_kind: 'derived', destinations: ['Backend'] },
+      }),
+      cap('local', 'raw', {
+        privacy: { leaves_device: false, data_kind: 'raw', destinations: [] },
+      }),
+    ]);
+    renderWithProviders(<PrivacyPanel />);
+
+    await waitFor(() => expect(screen.getByTestId('privacy-capability-list')).toBeInTheDocument());
+    expect(within(row('remote')).getByText('Leaves device')).toBeInTheDocument();
+    expect(within(row('local')).getByText('Stays local')).toBeInTheDocument();
+  });
+
+  it('lists every destination, and omits the line when there are none', async () => {
+    mockList.mockResolvedValue([
+      cap('multi', 'derived', {
+        privacy: { leaves_device: true, data_kind: 'derived', destinations: ['Alpha', 'Beta'] },
+      }),
+      cap('none', 'raw', { privacy: { leaves_device: false, data_kind: 'raw', destinations: [] } }),
+    ]);
+    renderWithProviders(<PrivacyPanel />);
+
+    await waitFor(() => expect(screen.getByTestId('privacy-capability-list')).toBeInTheDocument());
+    expect(within(row('multi')).getByText(/Alpha, Beta/)).toBeInTheDocument();
+    expect(within(row('none')).queryByText(/Sent to/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('PrivacyPanel — catalog states', () => {
+  it('says so when the catalog is empty rather than showing a bare heading', async () => {
+    mockList.mockResolvedValue([]);
+    renderWithProviders(<PrivacyPanel />);
+
+    // Wait for the READY state by its own text. Waiting on
+    // `expect(list).not.toBeInTheDocument()` would pass while still loading and
+    // assert nothing.
+    expect(
+      await screen.findByText('No capabilities currently disclose data movement.')
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('privacy-capability-list')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('privacy-load-error')).not.toBeInTheDocument();
+  });
+
+  it('reaches the empty state when nothing in the catalog is annotated', async () => {
+    // Unannotated entries are filtered out (`PrivacyPanel.tsx:63-65`), so a
+    // full catalog with no privacy metadata is indistinguishable from an empty
+    // one — and must not look like an error.
+    const bare: Capability = {
+      id: 'plain',
+      name: 'Plain',
+      domain: 'test',
+      category: 'test',
+      description: 'No privacy metadata.',
+      how_to: 'Nowhere',
+      status: 'stable',
+    };
+    mockList.mockResolvedValue([bare]);
+    renderWithProviders(<PrivacyPanel />);
+
+    expect(
+      await screen.findByText('No capabilities currently disclose data movement.')
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('privacy-capability-list')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('privacy-load-error')).not.toBeInTheDocument();
+  });
+
+  it('treats a null privacy field as unannotated', async () => {
+    const nulled = { ...cap('nulled', 'raw'), privacy: null } as unknown as Capability;
+    mockList.mockResolvedValue([nulled]);
+    renderWithProviders(<PrivacyPanel />);
+
+    expect(
+      await screen.findByText('No capabilities currently disclose data movement.')
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('privacy-capability-list')).not.toBeInTheDocument();
+  });
+});
+
+describe('PrivacyPanel — analytics toggle', () => {
+  it('does not crash, and keeps the panel usable, when persisting fails', async () => {
+    mockList.mockResolvedValue([cap('c-raw', 'raw')]);
+    setAnalyticsEnabledMock.mockRejectedValueOnce(new Error('config write failed'));
+    renderWithProviders(<PrivacyPanel />);
+
+    await waitFor(() => expect(screen.getByTestId('privacy-capability-list')).toBeInTheDocument());
+
+    const toggle = screen.getByRole('switch');
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(setAnalyticsEnabledMock).toHaveBeenCalledWith(true));
+    // The panel swallows the failure by design (`PrivacyPanel.tsx:81-87`); what
+    // must hold is that it stays rendered rather than tearing down.
+    expect(screen.getByTestId('privacy-capability-list')).toBeInTheDocument();
+    expect(screen.getByRole('switch')).toBeInTheDocument();
+  });
+});

--- a/app/src/components/settings/panels/__tests__/PrivacyPanel.kinds.test.tsx
+++ b/app/src/components/settings/panels/__tests__/PrivacyPanel.kinds.test.tsx
@@ -42,8 +42,8 @@ type DataKind = 'raw' | 'derived' | 'credentials' | 'diagnostics' | 'metadata';
 const cap = (id: string, data_kind: DataKind, over: Partial<Capability> = {}): Capability => ({
   id,
   name: `Cap ${id}`,
-  domain: 'test',
-  category: 'test',
+  domain: 'settings',
+  category: 'settings',
   description: `Description for ${id}`,
   how_to: 'Somewhere',
   status: 'stable',
@@ -144,8 +144,8 @@ describe('PrivacyPanel — catalog states', () => {
     const bare: Capability = {
       id: 'plain',
       name: 'Plain',
-      domain: 'test',
-      category: 'test',
+      domain: 'settings',
+      category: 'settings',
       description: 'No privacy metadata.',
       how_to: 'Nowhere',
       status: 'stable',

--- a/app/src/components/settings/panels/__tests__/ProfileEditorPage.payload.test.tsx
+++ b/app/src/components/settings/panels/__tests__/ProfileEditorPage.payload.test.tsx
@@ -1,0 +1,314 @@
+/**
+ * ProfileEditorPage — the save payload, id stickiness, and the failure path.
+ *
+ * `ProfileEditorPage.test.tsx` (sibling) covers the happy path: slug derivation,
+ * hydration, not-found, the allowlist chips and the toggle rows. It stops at
+ * `expect(sent.id)` / `expect(sent.name)`, so the rest of the object
+ * `handleSubmit` builds is unasserted — and that object is what reaches the RPC
+ * layer. This file covers the normalisation in `handleSubmit`
+ * (`ProfileEditorPage.tsx:137-166`), the `idTouched` latch, and what happens
+ * when the upsert rejects.
+ *
+ * Deliberately a separate file rather than an edit to the sibling: three of us
+ * are working in this directory.
+ */
+import { configureStore } from '@reduxjs/toolkit';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { agentProfilesApi } from '../../../../services/api/agentProfilesApi';
+import agentProfilesReducer from '../../../../store/agentProfileSlice';
+import type { AgentProfile } from '../../../../types/agentProfile';
+import ProfileEditorPage from '../ProfileEditorPage';
+
+vi.mock('../../../../services/api/agentProfilesApi', () => ({
+  agentProfilesApi: { list: vi.fn(), select: vi.fn(), upsert: vi.fn(), delete: vi.fn() },
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async importOriginal => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockUpsert = vi.mocked(agentProfilesApi.upsert);
+
+function profile(overrides: Partial<AgentProfile> = {}): AgentProfile {
+  return {
+    id: 'writer',
+    name: 'Writer',
+    description: 'Drafts copy.',
+    agentId: 'orchestrator',
+    builtIn: false,
+    ...overrides,
+  };
+}
+
+function renderAt(path: string, profiles: AgentProfile[] = []) {
+  const store = configureStore({
+    reducer: { agentProfiles: agentProfilesReducer },
+    preloadedState: {
+      agentProfiles: { profiles, activeProfileId: 'default', status: 'idle' as const, error: null },
+    },
+  });
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/settings/profiles/new" element={<ProfileEditorPage />} />
+          <Route path="/settings/profiles/edit/:id" element={<ProfileEditorPage />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>
+  );
+}
+
+const nameField = () => screen.getByLabelText('Name');
+const idField = () => screen.getByLabelText('ID') as HTMLInputElement;
+const submit = (label: string) => screen.getByText(label).closest('button')!;
+
+async function sentPayload() {
+  await waitFor(() => expect(mockUpsert).toHaveBeenCalled());
+  return mockUpsert.mock.calls[0][0];
+}
+
+describe('ProfileEditorPage — id stickiness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpsert.mockResolvedValue({ profiles: [], activeProfileId: 'default' });
+  });
+
+  // `handleName` re-slugs the id only while the user has not touched it
+  // (`ProfileEditorPage.tsx:125-128`). Without the latch, typing the rest of a
+  // name after choosing an id silently overwrites the chosen id.
+  it('stops re-slugging the id once the user edits it', () => {
+    renderAt('/settings/profiles/new');
+
+    fireEvent.change(nameField(), { target: { value: 'My Research' } });
+    expect(idField().value).toBe('my-research');
+
+    fireEvent.change(idField(), { target: { value: 'custom-id' } });
+    fireEvent.change(nameField(), { target: { value: 'My Research Assistant' } });
+
+    expect(idField().value).toBe('custom-id');
+  });
+
+  it('keeps re-slugging while the id is untouched', () => {
+    renderAt('/settings/profiles/new');
+
+    fireEvent.change(nameField(), { target: { value: 'One' } });
+    expect(idField().value).toBe('one');
+    fireEvent.change(nameField(), { target: { value: 'One Two' } });
+    expect(idField().value).toBe('one-two');
+  });
+
+  it('submits the typed id rather than the slug of the name', async () => {
+    renderAt('/settings/profiles/new');
+
+    fireEvent.change(nameField(), { target: { value: 'My Research' } });
+    fireEvent.change(idField(), { target: { value: '  custom-id  ' } });
+    fireEvent.click(submit('Create'));
+
+    expect((await sentPayload()).id).toBe('custom-id');
+  });
+
+  it('falls back to the slug of the name when the id box is cleared', async () => {
+    renderAt('/settings/profiles/new');
+
+    fireEvent.change(nameField(), { target: { value: 'My Research' } });
+    fireEvent.change(idField(), { target: { value: '' } });
+    // The latch is set, so the id no longer tracks the name — but `resolvedId`
+    // still falls back to the slug rather than submitting an empty id.
+    fireEvent.click(submit('Create'));
+
+    expect((await sentPayload()).id).toBe('my-research');
+  });
+
+  it('does not offer an editable id in edit mode', () => {
+    renderAt('/settings/profiles/edit/writer', [profile()]);
+    expect(screen.queryByLabelText('ID')).not.toBeInTheDocument();
+  });
+});
+
+describe('ProfileEditorPage — save payload normalisation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpsert.mockResolvedValue({ profiles: [], activeProfileId: 'default' });
+  });
+
+  it('trims the name and description', async () => {
+    renderAt('/settings/profiles/new');
+
+    fireEvent.change(nameField(), { target: { value: '  Spaced Name  ' } });
+    fireEvent.change(screen.getByLabelText('Description'), {
+      target: { value: '  padded description  ' },
+    });
+    fireEvent.click(submit('Create'));
+
+    const sent = await sentPayload();
+    expect(sent.name).toBe('Spaced Name');
+    expect(sent.description).toBe('padded description');
+  });
+
+  // `name: name.trim() || id` — a whitespace-only name must not reach the RPC
+  // layer as an empty string; the id stands in for it.
+  it('falls back to the id when the name is only whitespace', async () => {
+    renderAt('/settings/profiles/new');
+
+    fireEvent.change(nameField(), { target: { value: 'Temp' } });
+    fireEvent.change(idField(), { target: { value: 'kept-id' } });
+    fireEvent.change(nameField(), { target: { value: '   ' } });
+    fireEvent.click(submit('Create'));
+
+    const sent = await sentPayload();
+    expect(sent.name).toBe('kept-id');
+  });
+
+  it('sends null rather than an empty string for the optional text fields', async () => {
+    renderAt('/settings/profiles/new');
+
+    fireEvent.change(nameField(), { target: { value: 'Blank Optionals' } });
+    fireEvent.click(submit('Create'));
+
+    const sent = await sentPayload();
+    expect(sent.modelOverride).toBeNull();
+    expect(sent.systemPromptSuffix).toBeNull();
+    expect(sent.soulMd).toBeNull();
+    expect(sent.temperature).toBeNull();
+  });
+
+  it('defaults a blank agent id to orchestrator', async () => {
+    renderAt('/settings/profiles/new');
+
+    fireEvent.change(nameField(), { target: { value: 'Blank Agent' } });
+    const agent = screen.getByLabelText('Base agent');
+    fireEvent.change(agent, { target: { value: '   ' } });
+    fireEvent.click(submit('Create'));
+
+    expect((await sentPayload()).agentId).toBe('orchestrator');
+  });
+
+  it('parses a numeric temperature', async () => {
+    renderAt('/settings/profiles/new');
+
+    fireEvent.change(nameField(), { target: { value: 'Warm' } });
+    fireEvent.change(screen.getByLabelText('Temperature'), { target: { value: '0.7' } });
+    fireEvent.click(submit('Create'));
+
+    expect((await sentPayload()).temperature).toBe(0.7);
+  });
+
+  // `Number('abc')` is NaN, and NaN would serialise as `null` in JSON anyway —
+  // but only after passing through the payload as NaN. The `Number.isFinite`
+  // guard (`ProfileEditorPage.tsx:154`) is what keeps a non-numeric entry from
+  // becoming a NaN temperature.
+  it.each(['abc', '--', 'Infinity'])(
+    'sends null for a non-finite temperature entry %s',
+    async value => {
+      renderAt('/settings/profiles/new');
+
+      fireEvent.change(nameField(), { target: { value: 'Bad Temp' } });
+      fireEvent.change(screen.getByLabelText('Temperature'), { target: { value } });
+      fireEvent.click(submit('Create'));
+
+      const sent = await sentPayload();
+      expect(sent.temperature).toBeNull();
+      expect(Number.isNaN(sent.temperature as unknown as number)).toBe(false);
+    }
+  );
+
+  it('preserves builtIn when editing a built-in profile', async () => {
+    renderAt('/settings/profiles/edit/writer', [profile({ builtIn: true })]);
+
+    fireEvent.change(nameField(), { target: { value: 'Renamed Builtin' } });
+    fireEvent.click(submit('Save'));
+
+    const sent = await sentPayload();
+    expect(sent.builtIn).toBe(true);
+    expect(sent.id).toBe('writer');
+  });
+
+  it('marks a newly created profile as not built-in', async () => {
+    renderAt('/settings/profiles/new');
+
+    fireEvent.change(nameField(), { target: { value: 'Mine' } });
+    fireEvent.click(submit('Create'));
+
+    expect((await sentPayload()).builtIn).toBe(false);
+  });
+});
+
+describe('ProfileEditorPage — failure path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpsert.mockResolvedValue({ profiles: [], activeProfileId: 'default' });
+  });
+
+  it('surfaces an alert, stays on the page, and re-enables the button', async () => {
+    mockUpsert.mockRejectedValueOnce(new Error('backend refused the profile'));
+    renderAt('/settings/profiles/new');
+
+    fireEvent.change(nameField(), { target: { value: 'Doomed' } });
+    const create = submit('Create');
+    fireEvent.click(create);
+
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    // Navigating away on a failed save would lose the user's unsaved form.
+    expect(mockNavigate).not.toHaveBeenCalled();
+    await waitFor(() => expect(create).not.toBeDisabled());
+  });
+
+  // BUG (see ~/tinyhuman/bugs/W1-settings-bugs.md): the alert reads
+  // "[object Object]", not the message. `dispatch(thunk).unwrap()` rejects with
+  // Redux Toolkit's SerializedError — a PLAIN OBJECT, not an `Error` — so the
+  // `err instanceof Error ? err.message : String(err)` guard at
+  // `ProfileEditorPage.tsx:170` takes the `String(err)` branch and stringifies
+  // an object. Every failed profile save shows this.
+  //
+  // Pinned as CURRENT behaviour so the defect is visible and regression-locked.
+  // When it is fixed, change this to assert the message and delete the comment.
+  it('renders the failure as [object Object] instead of the message (known defect)', async () => {
+    mockUpsert.mockRejectedValueOnce(new Error('backend refused the profile'));
+    renderAt('/settings/profiles/new');
+
+    fireEvent.change(nameField(), { target: { value: 'Doomed' } });
+    fireEvent.click(submit('Create'));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('[object Object]');
+    expect(alert).not.toHaveTextContent('backend refused the profile');
+  });
+
+  it('clears a previous error when the next save succeeds', async () => {
+    mockUpsert.mockRejectedValueOnce(new Error('transient failure'));
+    renderAt('/settings/profiles/new');
+
+    fireEvent.change(nameField(), { target: { value: 'Retry' } });
+    fireEvent.click(submit('Create'));
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+
+    fireEvent.click(submit('Create'));
+    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
+    expect(mockNavigate).toHaveBeenCalledWith('/settings/profiles');
+  });
+
+  it('navigates back to the list only after a successful save', async () => {
+    renderAt('/settings/profiles/new');
+
+    fireEvent.change(nameField(), { target: { value: 'Fine' } });
+    expect(mockNavigate).not.toHaveBeenCalled();
+    fireEvent.click(submit('Create'));
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/settings/profiles'));
+  });
+
+  it('does not show not-found while the profile list is still empty', () => {
+    // `notFound` is only set once a list has arrived
+    // (`ProfileEditorPage.tsx:99-102`); flagging it during load would blame the
+    // user for a race.
+    renderAt('/settings/profiles/edit/missing', []);
+    expect(screen.queryByText(/not found/i)).not.toBeInTheDocument();
+  });
+});

--- a/app/src/components/settings/panels/__tests__/ProfilesPanel.actions.test.tsx
+++ b/app/src/components/settings/panels/__tests__/ProfilesPanel.actions.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * ProfilesPanel — the action-error paths, and the built-in/active affordance
+ * rules.
+ *
+ * `ProfilesPanel.test.tsx` (sibling) covers the happy paths and the *load*
+ * error. Neither `setActive` nor `remove` has its failure branch exercised
+ * anywhere, which is how the `[object Object]` defect at `ProfilesPanel.tsx:46`
+ * and `:59` survived — see `~/tinyhuman/bugs/W1-settings-bugs.md`. It also does
+ * not assert which buttons a built-in or already-active profile may show; those
+ * are the guards that stop a user deleting a built-in.
+ *
+ * Separate file rather than an edit to the sibling: three of us are in this
+ * directory.
+ */
+import { configureStore } from '@reduxjs/toolkit';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { agentProfilesApi } from '../../../../services/api/agentProfilesApi';
+import agentProfilesReducer from '../../../../store/agentProfileSlice';
+import type { AgentProfile, AgentProfilesResponse } from '../../../../types/agentProfile';
+import ProfilesPanel from '../ProfilesPanel';
+
+vi.mock('../../../../services/api/agentProfilesApi', () => ({
+  agentProfilesApi: { list: vi.fn(), select: vi.fn(), upsert: vi.fn(), delete: vi.fn() },
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async importOriginal => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockList = vi.mocked(agentProfilesApi.list);
+const mockSelect = vi.mocked(agentProfilesApi.select);
+const mockDelete = vi.mocked(agentProfilesApi.delete);
+
+function profile(overrides: Partial<AgentProfile> = {}): AgentProfile {
+  return {
+    id: 'research',
+    name: 'Research',
+    description: 'Source-grounded research.',
+    agentId: 'researcher',
+    builtIn: true,
+    ...overrides,
+  };
+}
+
+function response(profiles: AgentProfile[], activeProfileId: string): AgentProfilesResponse {
+  return { profiles, activeProfileId };
+}
+
+const PROFILES = [
+  profile({ id: 'default', name: 'Default', builtIn: true }),
+  profile({ id: 'writer', name: 'Writer', description: 'Drafts copy.', builtIn: false }),
+];
+
+function renderPanel() {
+  const store = configureStore({ reducer: { agentProfiles: agentProfilesReducer } });
+  render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <ProfilesPanel />
+      </MemoryRouter>
+    </Provider>
+  );
+  return store;
+}
+
+/** The <li> for a profile, addressed by its visible name. */
+const row = (name: string) => screen.getByText(name).closest('li') as HTMLElement;
+
+describe('ProfilesPanel — action failures', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockList.mockResolvedValue(response(PROFILES, 'default'));
+  });
+
+  it('shows an error when activating a profile fails', async () => {
+    mockSelect.mockRejectedValueOnce(new Error('select blew up'));
+    renderPanel();
+
+    await screen.findByText('Writer');
+    fireEvent.click(within(row('Writer')).getByText('Set as active'));
+
+    await waitFor(() => expect(mockSelect).toHaveBeenCalledWith('writer'));
+    // The panel must say *something* — silence would leave the user believing
+    // the switch took effect.
+    expect(await screen.findByText(/object Object|select blew up/)).toBeInTheDocument();
+  });
+
+  it('shows an error when deleting a profile fails', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockDelete.mockRejectedValueOnce(new Error('delete blew up'));
+    renderPanel();
+
+    await screen.findByText('Writer');
+    fireEvent.click(within(row('Writer')).getByText('Delete'));
+
+    await waitFor(() => expect(mockDelete).toHaveBeenCalledWith('writer'));
+    expect(await screen.findByText(/object Object|delete blew up/)).toBeInTheDocument();
+    confirmSpy.mockRestore();
+  });
+
+  // BUG (`~/tinyhuman/bugs/W1-settings-bugs.md` #1): both handlers stringify
+  // Redux Toolkit's SerializedError — a plain object, not an `Error` — so
+  // `err instanceof Error ? err.message : String(err)` (`ProfilesPanel.tsx:46`
+  // and `:59`) yields "[object Object]". The message never reaches the user.
+  //
+  // Pinned as CURRENT behaviour. When it is fixed, assert the message here and
+  // delete this comment — do not delete the test.
+  it('renders both action failures as [object Object] (known defect)', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockSelect.mockRejectedValueOnce(new Error('select blew up'));
+    renderPanel();
+
+    await screen.findByText('Writer');
+    fireEvent.click(within(row('Writer')).getByText('Set as active'));
+
+    const shown = await screen.findByText('[object Object]');
+    expect(shown).toBeInTheDocument();
+    expect(screen.queryByText(/select blew up/)).not.toBeInTheDocument();
+    confirmSpy.mockRestore();
+  });
+
+  it('clears a previous action error when the next action succeeds', async () => {
+    mockSelect.mockRejectedValueOnce(new Error('first attempt fails'));
+    mockSelect.mockResolvedValueOnce(response(PROFILES, 'writer'));
+    renderPanel();
+
+    await screen.findByText('Writer');
+    fireEvent.click(within(row('Writer')).getByText('Set as active'));
+    expect(await screen.findByText('[object Object]')).toBeInTheDocument();
+
+    fireEvent.click(within(row('Writer')).getByText('Set as active'));
+    await waitFor(() => expect(screen.queryByText('[object Object]')).not.toBeInTheDocument());
+  });
+
+  it('does not delete, and raises no error, when the confirm is dismissed', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    renderPanel();
+
+    await screen.findByText('Writer');
+    fireEvent.click(within(row('Writer')).getByText('Delete'));
+
+    expect(mockDelete).not.toHaveBeenCalled();
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+    confirmSpy.mockRestore();
+  });
+});
+
+describe('ProfilesPanel — affordance rules', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockList.mockResolvedValue(response(PROFILES, 'default'));
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('offers no Delete on a built-in profile', async () => {
+    renderPanel();
+    await screen.findByText('Default');
+
+    // `Default` is builtIn; deleting a shipped profile must not be offered.
+    expect(within(row('Default')).queryByText('Delete')).not.toBeInTheDocument();
+    expect(within(row('Writer')).getByText('Delete')).toBeInTheDocument();
+  });
+
+  it('offers no Set active on the profile that is already active', async () => {
+    renderPanel();
+    await screen.findByText('Default');
+
+    expect(within(row('Default')).queryByText('Set as active')).not.toBeInTheDocument();
+    expect(within(row('Writer')).getByText('Set as active')).toBeInTheDocument();
+  });
+
+  it('always offers Edit, on built-in and custom alike', async () => {
+    renderPanel();
+    await screen.findByText('Default');
+
+    expect(within(row('Default')).getByText('Edit')).toBeInTheDocument();
+    expect(within(row('Writer')).getByText('Edit')).toBeInTheDocument();
+  });
+
+  it('labels the active profile and the built-in/custom source', async () => {
+    renderPanel();
+    await screen.findByText('Default');
+
+    expect(within(row('Default')).getByText('Active')).toBeInTheDocument();
+    expect(within(row('Writer')).queryByText('Active')).not.toBeInTheDocument();
+    expect(within(row('Default')).getByText('Built-in')).toBeInTheDocument();
+    expect(within(row('Writer')).getByText('Custom')).toBeInTheDocument();
+  });
+});

--- a/app/src/components/settings/panels/__tests__/SandboxSettingsPanel.validation.test.tsx
+++ b/app/src/components/settings/panels/__tests__/SandboxSettingsPanel.validation.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * SandboxSettingsPanel — the input the blur handlers must REFUSE, the null
+ * limits on load, and the persist sequence guard.
+ *
+ * `SandboxSettingsPanel.test.tsx` (sibling) covers each field's happy path and
+ * the explicit clear-to-null. What it never does is hand a field something
+ * invalid: `handleMemoryBlur` (`SandboxSettingsPanel.tsx:113-123`) and
+ * `handleCpuBlur` (`:125-135`) both drop non-numeric and non-positive input on
+ * the floor, and `handleDockerImageBlur` (`:107-111`) drops a blank image.
+ * Those three guards were entirely unexercised — branch coverage 71.4%.
+ *
+ * The guards matter: a `0` or negative container limit that reached the core
+ * would be a Docker run argument, and a blank image would replace a working one.
+ *
+ * Separate file rather than an edit to the sibling: three of us are in this
+ * directory.
+ */
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from '../../../../test/test-utils';
+import {
+  isTauri,
+  openhumanGetSandboxSettings,
+  openhumanUpdateSandboxSettings,
+  type SandboxSettings,
+} from '../../../../utils/tauriCommands';
+import SandboxSettingsPanel from '../SandboxSettingsPanel';
+
+const sandboxSettings = (overrides: Partial<SandboxSettings> = {}): SandboxSettings => ({
+  enabled: true,
+  backend: 'auto',
+  docker_image: 'alpine:3.20',
+  docker_memory_limit_mb: 512,
+  docker_cpu_limit: 1.0,
+  docker_available: true,
+  detected_backend: 'seatbelt',
+  env_passthrough: ['PATH', 'HOME', 'TERM'],
+  ...overrides,
+});
+
+vi.mock('../../hooks/useSettingsNavigation', () => ({
+  useSettingsNavigation: () => ({
+    navigateBack: vi.fn(),
+    navigateToSettings: vi.fn(),
+    breadcrumbs: [],
+  }),
+}));
+
+vi.mock('../../../../utils/tauriCommands', async () => {
+  const actual = await vi.importActual<typeof import('../../../../utils/tauriCommands')>(
+    '../../../../utils/tauriCommands'
+  );
+  return {
+    ...actual,
+    isTauri: vi.fn(() => true),
+    openhumanGetSandboxSettings: vi.fn(),
+    openhumanUpdateSandboxSettings: vi.fn(),
+  };
+});
+
+const mockGet = vi.mocked(openhumanGetSandboxSettings);
+const mockUpdate = vi.mocked(openhumanUpdateSandboxSettings);
+const mockIsTauri = vi.mocked(isTauri);
+
+async function renderLoaded(overrides: Partial<SandboxSettings> = {}) {
+  mockGet.mockResolvedValue({ result: sandboxSettings(overrides) });
+  renderWithProviders(<SandboxSettingsPanel />);
+  await waitFor(() => expect(mockGet).toHaveBeenCalled());
+}
+
+/** Blur a field after typing `value`, then report what (if anything) persisted. */
+function blurWith(input: HTMLElement, value: string) {
+  fireEvent.change(input, { target: { value } });
+  fireEvent.blur(input);
+}
+
+const memoryInput = () => screen.getByDisplayValue('512');
+const cpuInput = () => screen.getByDisplayValue('1');
+const imageInput = () => screen.getByDisplayValue('alpine:3.20');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsTauri.mockReturnValue(true);
+  mockUpdate.mockResolvedValue(undefined as never);
+});
+
+describe('SandboxSettingsPanel — memory limit validation', () => {
+  // Only values a `type="number"` field can actually hold. Non-numeric text
+  // ('abc', '!!') is unreachable here: jsdom, like a browser, reports an empty
+  // value for it, which lands on the clear-to-null branch instead. The
+  // `!isNaN(parsed)` half of the guard is therefore dead through the UI — see
+  // the note in the bug list.
+  it.each(['0', '-1', '-512'])('refuses to persist %s', async value => {
+    await renderLoaded();
+    blurWith(memoryInput(), value);
+
+    // A moment for any stray async persist to land.
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('persists a positive integer', async () => {
+    await renderLoaded();
+    blurWith(memoryInput(), '2048');
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith({ docker_memory_limit_mb: 2048 }));
+  });
+
+  it('persists null when the field is cleared to whitespace', async () => {
+    await renderLoaded();
+    blurWith(memoryInput(), '   ');
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith({ docker_memory_limit_mb: null }));
+  });
+});
+
+describe('SandboxSettingsPanel — CPU limit validation', () => {
+  it.each(['0', '-0.5'])('refuses to persist %s', async value => {
+    await renderLoaded();
+    blurWith(cpuInput(), value);
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('persists a fractional limit', async () => {
+    await renderLoaded();
+    blurWith(cpuInput(), '0.25');
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith({ docker_cpu_limit: 0.25 }));
+  });
+
+  it('persists null when the field is cleared to whitespace', async () => {
+    await renderLoaded();
+    blurWith(cpuInput(), '  ');
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith({ docker_cpu_limit: null }));
+  });
+});
+
+describe('SandboxSettingsPanel — docker image validation', () => {
+  it('refuses to persist a blank image, keeping the configured one', async () => {
+    await renderLoaded();
+    blurWith(imageInput(), '   ');
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('trims the image before persisting', async () => {
+    await renderLoaded();
+    blurWith(imageInput(), '  ubuntu:24.04  ');
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith({ docker_image: 'ubuntu:24.04' }));
+  });
+});
+
+describe('SandboxSettingsPanel — load shape', () => {
+  it('renders empty limit fields when the core reports no limits', async () => {
+    await renderLoaded({ docker_memory_limit_mb: null, docker_cpu_limit: null });
+
+    await waitFor(() => expect(screen.queryByDisplayValue('512')).not.toBeInTheDocument());
+    expect(screen.queryByDisplayValue('1')).not.toBeInTheDocument();
+  });
+
+  it('does not call the core at all off-Tauri', async () => {
+    mockIsTauri.mockReturnValue(false);
+    renderWithProviders(<SandboxSettingsPanel />);
+
+    await waitFor(() => expect(screen.getByText(/desktop app/i)).toBeInTheDocument());
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+});
+
+describe('SandboxSettingsPanel — persist sequence guard', () => {
+  /** Let a settled promise's continuation and the resulting render run. A bare
+   *  `waitFor(() => expect(x).not.toBeInTheDocument())` passes on its first
+   *  tick, before the rejection is handled, and would hold with the guard gone. */
+  async function flush() {
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+
+  it('drops a stale persist failure that lands after a newer persist', async () => {
+    let rejectFirst!: (e: unknown) => void;
+    mockUpdate.mockReturnValueOnce(
+      new Promise((_res, rej) => {
+        rejectFirst = rej;
+      }) as never
+    );
+    mockUpdate.mockResolvedValueOnce(undefined as never);
+
+    await renderLoaded();
+    blurWith(memoryInput(), '1024');
+    blurWith(cpuInput(), '2');
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(2));
+
+    rejectFirst(new Error('stale sandbox failure'));
+    await flush();
+
+    expect(screen.queryByText(/stale sandbox failure/)).not.toBeInTheDocument();
+  });
+});

--- a/app/src/components/settings/panels/__tests__/SandboxSettingsPanel.validation.test.tsx
+++ b/app/src/components/settings/panels/__tests__/SandboxSettingsPanel.validation.test.tsx
@@ -64,7 +64,7 @@ const mockUpdate = vi.mocked(openhumanUpdateSandboxSettings);
 const mockIsTauri = vi.mocked(isTauri);
 
 async function renderLoaded(overrides: Partial<SandboxSettings> = {}) {
-  mockGet.mockResolvedValue({ result: sandboxSettings(overrides) });
+  mockGet.mockResolvedValue({ result: sandboxSettings(overrides), logs: [] });
   renderWithProviders(<SandboxSettingsPanel />);
   await waitFor(() => expect(mockGet).toHaveBeenCalled());
 }

--- a/app/src/components/settings/panels/__tests__/SandboxSettingsPanel.validation.test.tsx
+++ b/app/src/components/settings/panels/__tests__/SandboxSettingsPanel.validation.test.tsx
@@ -15,7 +15,7 @@
  * Separate file rather than an edit to the sibling: three of us are in this
  * directory.
  */
-import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { renderWithProviders } from '../../../../test/test-utils';
@@ -69,6 +69,23 @@ async function renderLoaded(overrides: Partial<SandboxSettings> = {}) {
   await waitFor(() => expect(mockGet).toHaveBeenCalled());
 }
 
+/**
+ * Let any queued persist actually run before asserting it did NOT happen.
+ *
+ * `await waitFor(() => expect(mockGet).toHaveBeenCalled())` is NOT a readiness
+ * signal here: `mockGet` fires on mount, so the condition is already true and
+ * `waitFor` resolves on its first tick — before a blur handler's promise chain
+ * has had a chance to reach `mockUpdate`. The negative assertion that follows
+ * would then pass whether or not the guard exists. Two macrotasks is what a
+ * `void persist(...)` needs to get from the handler to the mock.
+ */
+async function flushPersist() {
+  await act(async () => {
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await new Promise(resolve => setTimeout(resolve, 0));
+  });
+}
+
 /** Blur a field after typing `value`, then report what (if anything) persisted. */
 function blurWith(input: HTMLElement, value: string) {
   fireEvent.change(input, { target: { value } });
@@ -95,8 +112,7 @@ describe('SandboxSettingsPanel — memory limit validation', () => {
     await renderLoaded();
     blurWith(memoryInput(), value);
 
-    // A moment for any stray async persist to land.
-    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    await flushPersist();
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
@@ -120,7 +136,7 @@ describe('SandboxSettingsPanel — CPU limit validation', () => {
     await renderLoaded();
     blurWith(cpuInput(), value);
 
-    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    await flushPersist();
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
@@ -144,7 +160,7 @@ describe('SandboxSettingsPanel — docker image validation', () => {
     await renderLoaded();
     blurWith(imageInput(), '   ');
 
-    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    await flushPersist();
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
@@ -160,7 +176,11 @@ describe('SandboxSettingsPanel — load shape', () => {
   it('renders empty limit fields when the core reports no limits', async () => {
     await renderLoaded({ docker_memory_limit_mb: null, docker_cpu_limit: null });
 
-    await waitFor(() => expect(screen.queryByDisplayValue('512')).not.toBeInTheDocument());
+    // Wait for a POSITIVE loaded signal first — the image field is populated
+    // from the same response. Waiting on the absence of '512' would pass while
+    // the panel was still empty because nothing had loaded at all.
+    expect(await screen.findByDisplayValue('alpine:3.20')).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('512')).not.toBeInTheDocument();
     expect(screen.queryByDisplayValue('1')).not.toBeInTheDocument();
   });
 

--- a/app/src/components/settings/panels/__tests__/SecurityPanel.unknownMode.test.tsx
+++ b/app/src/components/settings/panels/__tests__/SecurityPanel.unknownMode.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * SecurityPanel — the unknown-mode fallback.
+ *
+ * `SecurityPanel.test.tsx` (sibling) is thorough: 18 tests, 100% line and
+ * function coverage. One branch survives it — the
+ * `?? MODE_BADGE_VARIANT.consent_pending` fallback at `SecurityPanel.tsx:24-25`,
+ * which only runs when `keyringStatus.activeMode` is a value the UI does not
+ * know.
+ *
+ * That is a version-skew path, not dead code: `activeMode` is typed as a plain
+ * string and arrives from the core, so a core that grows a fifth mode hands this
+ * panel something absent from `MODE_BADGE_VARIANT`.
+ *
+ * **The fallback itself cannot be asserted, and this file does not pretend to.**
+ * `Badge` declares `defaultVariants: { variant: 'neutral' }` (`ui/Badge.tsx:22`)
+ * and `consent_pending` maps to `'neutral'`, so an undefined variant and the
+ * fallback render byte-identical classes. Deleting the `??` changes nothing
+ * observable — I verified that by removing it, and dropped the test that
+ * claimed to cover it rather than keep one that always passes. The `??` is
+ * harmless belt-and-braces; it is not load-bearing.
+ *
+ * What IS asserted below: an unknown mode still renders (no crash, no blank
+ * row), and the four known modes stay visually distinguishable — which is the
+ * signal this row actually carries.
+ */
+import { cleanup } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { renderWithProviders } from '../../../../test/test-utils';
+import SecurityPanel from '../SecurityPanel';
+
+vi.mock('../../../../services/keyringApi', () => ({
+  retryKeyringProbe: vi.fn(),
+  decideKeyringConsent: vi.fn(),
+}));
+
+vi.mock('../../hooks/useSettingsNavigation', () => ({
+  useSettingsNavigation: () => ({ navigateBack: vi.fn(), breadcrumbs: [] }),
+}));
+
+const mockUseCoreState = vi.fn();
+vi.mock('../../../../providers/CoreStateProvider', () => ({
+  useCoreState: () => mockUseCoreState(),
+}));
+
+function render(activeMode: string) {
+  mockUseCoreState.mockReturnValue({
+    snapshot: {
+      keyringStatus: {
+        activeMode,
+        available: true,
+        backendName: 'macOS Keychain',
+        failureReason: null,
+      },
+    },
+  });
+  const { container } = renderWithProviders(<SecurityPanel />);
+  // Scope to THIS mount's container: RTL appends a new one per render, so a
+  // document-wide query would keep returning the first mount's badge.
+  const badge = container.querySelector('[data-slot="badge"]');
+  if (!badge) throw new Error('no badge rendered');
+  return badge;
+}
+
+afterEach(() => cleanup());
+
+describe('SecurityPanel — unknown storage mode', () => {
+  it('still renders the mode the core reported, even when unrecognised', () => {
+    const badge = render('hardware_token_v2');
+
+    // The raw mode reaches the label (via a missing i18n key, so the key shows).
+    expect(badge.textContent).toContain('hardware_token_v2');
+  });
+
+  it('uses a distinct badge styling for each mode it does know', () => {
+    const seen = new Map<string, string>();
+    for (const mode of ['os_keyring', 'local_encrypted', 'consent_pending', 'declined']) {
+      cleanup();
+      seen.set(mode, render(mode).className);
+    }
+
+    // Four modes, four different variants — if two collapsed to the same class
+    // the badge would stop distinguishing "stored in the OS keyring" from
+    // "declined", which is the whole signal this row carries.
+    expect(new Set(seen.values()).size).toBe(4);
+  });
+});

--- a/app/test/playwright/specs/settings-appearance-theme.spec.ts
+++ b/app/test/playwright/specs/settings-appearance-theme.spec.ts
@@ -1,6 +1,10 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 
-import { bootAuthenticatedPage, dismissWalkthroughIfPresent, waitForAppReady } from '../helpers/core-rpc';
+import {
+  bootAuthenticatedPage,
+  dismissWalkthroughIfPresent,
+  waitForAppReady,
+} from '../helpers/core-rpc';
 
 /**
  * Theme switching, asserted where it actually lands: on the document.
@@ -26,8 +30,7 @@ const variant = (page: Page, label: string) =>
   page.getByLabel('Theme variant').getByText(label, { exact: true });
 
 /** A palette family tile in the grid. */
-const family = (page: Page, name: string) =>
-  page.getByRole('button', { name, exact: true });
+const family = (page: Page, name: string) => page.getByRole('button', { name, exact: true });
 
 /** What the document actually holds after a theme is applied. */
 function documentTheme(page: Page) {

--- a/app/test/playwright/specs/settings-appearance-theme.spec.ts
+++ b/app/test/playwright/specs/settings-appearance-theme.spec.ts
@@ -1,0 +1,169 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { bootAuthenticatedPage, dismissWalkthroughIfPresent, waitForAppReady } from '../helpers/core-rpc';
+
+/**
+ * Theme switching, asserted where it actually lands: on the document.
+ *
+ * `ThemeProvider.applyTheme` (`providers/ThemeProvider.tsx:38-60`) does three
+ * separate things — toggles the `dark` class on `<html>`, sets
+ * `style.colorScheme`, and writes the palette as `--*` custom properties. A
+ * jsdom test can observe the class, but the custom properties and the resolved
+ * `color-scheme` are only meaningful in a real engine, and "the theme visibly
+ * applied" means all three moved together.
+ *
+ * `/settings/appearance` hosts the theme studio (the standalone
+ * `/settings/theme` route redirects here). Its two controls are separate and
+ * compose: a VARIANT toggle (Light / Dark / Auto) and a FAMILY grid (Classic,
+ * Ocean, Sepia, Matrix, HAL 9000 — `lib/theme/presets.ts:342`). Choosing
+ * "Dark" is the variant toggle; choosing "HAL 9000" is a family. An earlier
+ * version of this spec looked for a button named "Dark" in the family grid and
+ * timed out, because no such button exists.
+ */
+
+/** The Light / Dark / Auto toggle, scoped so a family name cannot match it. */
+const variant = (page: Page, label: string) =>
+  page.getByLabel('Theme variant').getByText(label, { exact: true });
+
+/** A palette family tile in the grid. */
+const family = (page: Page, name: string) =>
+  page.getByRole('button', { name, exact: true });
+
+/** What the document actually holds after a theme is applied. */
+function documentTheme(page: Page) {
+  return page.evaluate(() => {
+    const root = document.documentElement;
+    const styles = getComputedStyle(root);
+    return {
+      dark: root.classList.contains('dark'),
+      colorScheme: root.style.colorScheme,
+      surface: styles.getPropertyValue('--surface').trim(),
+      content: styles.getPropertyValue('--content').trim(),
+    };
+  });
+}
+
+async function openAppearance(page: Page) {
+  // Navigate explicitly even though beforeEach booted here: on a cold first
+  // test the '/home' -> '/chat' redirect can still be in flight and win the
+  // race, leaving the chat surface behind. Re-navigating settles it.
+  await page.goto('/#/settings/appearance');
+  await waitForAppReady(page);
+  await dismissWalkthroughIfPresent(page);
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Appearance', {
+    timeout: 30_000,
+  });
+}
+
+test.describe('Appearance — theme switching', () => {
+  test.beforeEach(async ({ page }) => {
+    await bootAuthenticatedPage(page, 'pw-w1-theme', '/settings/appearance');
+    await openAppearance(page);
+  });
+
+  test('choosing Dark sets the dark class and color-scheme on <html>', async ({ page }) => {
+    await variant(page, 'Dark').click();
+
+    await expect.poll(async () => (await documentTheme(page)).dark).toBe(true);
+    expect((await documentTheme(page)).colorScheme).toBe('dark');
+  });
+
+  test('choosing Light clears them again', async ({ page }) => {
+    await variant(page, 'Dark').click();
+    await expect.poll(async () => (await documentTheme(page)).dark).toBe(true);
+
+    await variant(page, 'Light').click();
+
+    await expect.poll(async () => (await documentTheme(page)).dark).toBe(false);
+    expect((await documentTheme(page)).colorScheme).toBe('light');
+  });
+
+  // The class alone does not prove the palette applied — a theme that set the
+  // class and no custom properties would look unchanged to the user.
+  test('the palette custom properties change with the theme', async ({ page }) => {
+    await variant(page, 'Light').click();
+    await expect.poll(async () => (await documentTheme(page)).dark).toBe(false);
+    const light = await documentTheme(page);
+
+    await variant(page, 'Dark').click();
+    await expect.poll(async () => (await documentTheme(page)).dark).toBe(true);
+    const dark = await documentTheme(page);
+
+    expect(light.surface).not.toBe('');
+    expect(dark.surface).not.toBe('');
+    expect(dark.surface).not.toBe(light.surface);
+    expect(dark.content).not.toBe(light.content);
+  });
+
+  test('a named palette family applies its own surface, distinct from Classic', async ({
+    page,
+  }) => {
+    await variant(page, 'Dark').click();
+    await family(page, 'Classic').click();
+    await expect.poll(async () => (await documentTheme(page)).dark).toBe(true);
+    const classicDark = await documentTheme(page);
+
+    await family(page, 'HAL 9000').click();
+    await expect
+      .poll(async () => (await documentTheme(page)).surface)
+      .not.toBe(classicDark.surface);
+
+    // The variant is unchanged — the palette moved, not light/dark mode.
+    expect((await documentTheme(page)).dark).toBe(true);
+  });
+
+  test('the chosen family is marked pressed, and only that one', async ({ page }) => {
+    await family(page, 'Ocean').click();
+
+    await expect(family(page, 'Ocean')).toHaveAttribute('aria-pressed', 'true');
+    await expect(family(page, 'Sepia')).toHaveAttribute('aria-pressed', 'false');
+
+    await family(page, 'Sepia').click();
+
+    await expect(family(page, 'Sepia')).toHaveAttribute('aria-pressed', 'true');
+    await expect(family(page, 'Ocean')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  // Variant and family are independent axes: switching palette must not flip
+  // light/dark, and vice versa.
+  test('family and variant compose without overriding each other', async ({ page }) => {
+    await variant(page, 'Dark').click();
+    await expect.poll(async () => (await documentTheme(page)).dark).toBe(true);
+
+    await family(page, 'Ocean').click();
+    const oceanDark = await documentTheme(page);
+    expect(oceanDark.dark).toBe(true);
+
+    await variant(page, 'Light').click();
+    await expect.poll(async () => (await documentTheme(page)).dark).toBe(false);
+
+    // Still Ocean, now light — so the surface must differ from Ocean dark.
+    await expect(family(page, 'Ocean')).toHaveAttribute('aria-pressed', 'true');
+    expect((await documentTheme(page)).surface).not.toBe(oceanDark.surface);
+  });
+
+  test('the theme survives a reload', async ({ page }) => {
+    await variant(page, 'Dark').click();
+    await expect.poll(async () => (await documentTheme(page)).dark).toBe(true);
+    const before = await documentTheme(page);
+
+    await page.reload();
+    await waitForAppReady(page);
+
+    await expect.poll(async () => (await documentTheme(page)).dark).toBe(true);
+    expect((await documentTheme(page)).surface).toBe(before.surface);
+  });
+
+  test('the theme applies outside settings too, not just on this panel', async ({ page }) => {
+    await variant(page, 'Dark').click();
+    await expect.poll(async () => (await documentTheme(page)).dark).toBe(true);
+
+    // The class lives on <html>, so leaving the panel must not drop it — a
+    // theme scoped to the settings subtree would be the bug this catches.
+    await page.goto('/#/settings/privacy');
+    await waitForAppReady(page);
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Privacy');
+
+    expect((await documentTheme(page)).dark).toBe(true);
+  });
+});

--- a/app/test/playwright/specs/settings-form-interaction.spec.ts
+++ b/app/test/playwright/specs/settings-form-interaction.spec.ts
@@ -1,6 +1,10 @@
-import { expect, test, type Locator, type Page } from '@playwright/test';
+import { expect, type Locator, type Page, test } from '@playwright/test';
 
-import { bootAuthenticatedPage, dismissWalkthroughIfPresent, waitForAppReady } from '../helpers/core-rpc';
+import {
+  bootAuthenticatedPage,
+  dismissWalkthroughIfPresent,
+  waitForAppReady,
+} from '../helpers/core-rpc';
 
 /**
  * Real keyboard interaction with settings text fields.

--- a/app/test/playwright/specs/settings-form-interaction.spec.ts
+++ b/app/test/playwright/specs/settings-form-interaction.spec.ts
@@ -1,0 +1,181 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+import { bootAuthenticatedPage, dismissWalkthroughIfPresent, waitForAppReady } from '../helpers/core-rpc';
+
+/**
+ * Real keyboard interaction with settings text fields.
+ *
+ * # Why a browser lane is required for this
+ *
+ * jsdom has no caret. `fireEvent.change(input, { target: { value } })` replaces
+ * the whole value in one step, so a component that re-renders and resets the
+ * selection looks identical to one that does not. Every settings test in
+ * `app/src/**` — including the ones I wrote last round — is blind to it.
+ *
+ * W4 found exactly that defect in the chat composer
+ * (`chat-composer-caret.spec.ts`): typing mid-string moves the caret to the end,
+ * so the second keystroke lands in the wrong place. This spec asks whether any
+ * settings text input shares it.
+ *
+ * The profile editor is the sharpest place to ask. Its ID field is
+ * *programmatically rewritten* while you type the Name
+ * (`ProfileEditorPage.tsx:125-128`), which is the exact shape — a controlled
+ * input whose value is reassigned during render — that produces caret jumps.
+ */
+
+const NEW_PROFILE = '/#/settings/profiles/new';
+
+async function openProfileEditor(page: Page) {
+  await page.goto(NEW_PROFILE);
+  await waitForAppReady(page);
+  await dismissWalkthroughIfPresent(page);
+  await expect(page.getByLabel('Name', { exact: true })).toBeVisible({ timeout: 30_000 });
+}
+
+/** Where the caret sits inside a text input, read from the live DOM. */
+function caret(input: Locator): Promise<number | null> {
+  return input.evaluate(el => (el as HTMLInputElement).selectionStart);
+}
+
+async function placeCaret(input: Locator, offset: number) {
+  await input.evaluate((el, at) => {
+    const field = el as HTMLInputElement;
+    field.focus();
+    field.setSelectionRange(at, at);
+  }, offset);
+}
+
+test.describe('Settings forms — caret behaviour while typing', () => {
+  test.beforeEach(async ({ page }) => {
+    await bootAuthenticatedPage(page, 'pw-w1-forms');
+    await openProfileEditor(page);
+  });
+
+  test('typing at the end leaves the caret at the end', async ({ page }) => {
+    const name = page.getByLabel('Name', { exact: true });
+    await name.click();
+    await page.keyboard.type('Research');
+
+    await expect(name).toHaveValue('Research');
+    expect(await caret(name)).toBe('Research'.length);
+  });
+
+  // The W4 defect, asked of a settings field: type one character into the
+  // middle and the caret must sit immediately after it, not jump to the end.
+  test('typing mid-string leaves the caret after the inserted character', async ({ page }) => {
+    const name = page.getByLabel('Name', { exact: true });
+    await name.click();
+    await page.keyboard.type('Reearch');
+
+    await placeCaret(name, 2);
+    await page.keyboard.type('s');
+
+    await expect(name).toHaveValue('Research');
+    expect(await caret(name)).toBe(3);
+  });
+
+  // The consequence that makes the chat-composer bug user-visible: if the caret
+  // jumps on the first keystroke, the SECOND one lands at the end and the text
+  // comes out scrambled. Two characters is the smallest test that shows it.
+  test('two consecutive mid-string keystrokes both land where they were typed', async ({
+    page,
+  }) => {
+    const name = page.getByLabel('Name', { exact: true });
+    await name.click();
+    await page.keyboard.type('Rearch');
+
+    await placeCaret(name, 2);
+    await page.keyboard.type('s');
+    await page.keyboard.type('e');
+
+    await expect(name).toHaveValue('Research');
+    expect(await caret(name)).toBe(4);
+  });
+
+  test('backspace mid-string keeps the caret at the deletion point', async ({ page }) => {
+    const name = page.getByLabel('Name', { exact: true });
+    await name.click();
+    await page.keyboard.type('Resxearch');
+
+    await placeCaret(name, 4);
+    await page.keyboard.press('Backspace');
+
+    await expect(name).toHaveValue('Research');
+    expect(await caret(name)).toBe(3);
+  });
+
+  // The ID field is rewritten from the Name on every keystroke until it is
+  // touched, so it is the most likely place for a reset-driven caret jump.
+  test('the ID field keeps its caret when edited directly', async ({ page }) => {
+    const id = page.getByLabel('ID', { exact: true });
+    await id.click();
+    await page.keyboard.type('reearch-agent');
+
+    await placeCaret(id, 2);
+    await page.keyboard.type('s');
+
+    await expect(id).toHaveValue('research-agent');
+    expect(await caret(id)).toBe(3);
+  });
+});
+
+test.describe('Settings forms — the Name/ID coupling, driven by keyboard', () => {
+  test.beforeEach(async ({ page }) => {
+    await bootAuthenticatedPage(page, 'pw-w1-forms-coupling');
+    await openProfileEditor(page);
+  });
+
+  test('the ID auto-slugs from the Name as it is typed', async ({ page }) => {
+    await page.getByLabel('Name', { exact: true }).click();
+    await page.keyboard.type('My Research Agent');
+
+    await expect(page.getByLabel('ID', { exact: true })).toHaveValue('my-research-agent');
+  });
+
+  // The `idTouched` latch, in a real browser. My jsdom test of this fires a
+  // synthetic change event; this types, which is what a user does and what
+  // exercises the per-keystroke re-render.
+  test('editing the ID stops the Name from overwriting it', async ({ page }) => {
+    const name = page.getByLabel('Name', { exact: true });
+    const id = page.getByLabel('ID', { exact: true });
+
+    await name.click();
+    await page.keyboard.type('My Research');
+    await expect(id).toHaveValue('my-research');
+
+    await id.click();
+    await id.press('ControlOrMeta+a');
+    await page.keyboard.type('custom-id');
+
+    await name.click();
+    await page.keyboard.press('End');
+    await page.keyboard.type(' Agent');
+
+    await expect(name).toHaveValue('My Research Agent');
+    await expect(id).toHaveValue('custom-id');
+  });
+
+  test('Tab moves from Name to the ID field', async ({ page }) => {
+    const name = page.getByLabel('Name', { exact: true });
+    await name.click();
+    await page.keyboard.type('Tabbed');
+    await page.keyboard.press('Tab');
+
+    // Focus is what a keyboard user actually experiences; jsdom tests assert
+    // values and never this.
+    await expect(page.getByLabel('ID', { exact: true })).toBeFocused();
+  });
+
+  test('the Create button enables only once a usable id exists', async ({ page }) => {
+    const create = page.getByRole('button', { name: 'Create' });
+    await expect(create).toBeDisabled();
+
+    // Punctuation-only slugs to '', so it must stay disabled.
+    await page.getByLabel('Name', { exact: true }).click();
+    await page.keyboard.type('!!!');
+    await expect(create).toBeDisabled();
+
+    await page.keyboard.type('Ok');
+    await expect(create).toBeEnabled();
+  });
+});

--- a/app/test/playwright/specs/settings-navigation-panels.spec.ts
+++ b/app/test/playwright/specs/settings-navigation-panels.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 
 import { bootAuthenticatedPage, waitForAppReady } from '../helpers/core-rpc';
 
@@ -50,10 +50,34 @@ const PANELS = [
   { id: 'appearance', route: 'appearance', heading: 'Appearance', marker: 'font-size-slider' },
   { id: 'privacy', route: 'privacy', heading: 'Privacy', marker: 'privacy-mode-options' },
   { id: 'devices', route: 'devices', heading: 'Devices', marker: null, text: 'Pair iPhone' },
-  { id: 'security', route: 'security', heading: 'Security', marker: null, text: 'Retry keychain detection' },
-  { id: 'notifications', route: 'notifications', heading: 'Notifications', marker: null, text: 'Categories' },
-  { id: 'profiles', route: 'profiles', heading: 'Agent Profiles', marker: null, text: 'New profile' },
-  { id: 'agent-access', route: 'agent-access', heading: 'Agent OS access', marker: null, text: 'View approval history' },
+  {
+    id: 'security',
+    route: 'security',
+    heading: 'Security',
+    marker: null,
+    text: 'Retry keychain detection',
+  },
+  {
+    id: 'notifications',
+    route: 'notifications',
+    heading: 'Notifications',
+    marker: null,
+    text: 'Categories',
+  },
+  {
+    id: 'profiles',
+    route: 'profiles',
+    heading: 'Agent Profiles',
+    marker: null,
+    text: 'New profile',
+  },
+  {
+    id: 'agent-access',
+    route: 'agent-access',
+    heading: 'Agent OS access',
+    marker: null,
+    text: 'View approval history',
+  },
   // Sandbox is a desktop-only panel: in the web lane its body is the
   // desktop-only notice, not the Docker fields. Asserting what this build
   // actually renders, rather than what the Tauri build would.

--- a/app/test/playwright/specs/settings-navigation-panels.spec.ts
+++ b/app/test/playwright/specs/settings-navigation-panels.spec.ts
@@ -1,0 +1,205 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import { bootAuthenticatedPage, waitForAppReady } from '../helpers/core-rpc';
+
+/**
+ * Settings navigation, driven in a real browser.
+ *
+ * # Why this exists alongside `navigation-settings-panels.spec.ts`
+ *
+ * That spec asserts `#root` innerText is longer than 50 characters and that
+ * SOME marker from a list appears. Its markers ('Settings', 'Appearance',
+ * 'Notifications', 'Tools'…) are the settings SIDEBAR's own labels, which are
+ * rendered on every `/settings/*` route — so each of its cases passes whenever
+ * the sidebar renders, whether or not the routed panel does. It cannot
+ * distinguish "the panel opened" from "the chrome around it opened".
+ *
+ * This spec uses two assertions per route, because one is not enough:
+ *
+ * 1. **The `<h1>`.** Every settings page renders exactly one, and the sidebar
+ *    renders none (`SettingsTabbedPage.tsx:70`), so an exact-text assertion
+ *    proves a settings page resolved for that URL — which the marker-OR above
+ *    cannot.
+ *
+ *    But it does NOT prove the right panel mounted. `SettingsPanel.tsx:108`
+ *    resolves the heading as `title ?? t(findEntryById(currentRoute).titleKey)`,
+ *    so for the many panels that pass no explicit `title` the h1 comes from the
+ *    ROUTE registry, not the component. I verified this by wiring
+ *    `/settings/security` to `<MigrationPanel />` and rebuilding: the heading
+ *    still read "Security" and an h1-only spec passed.
+ *
+ * 2. **A body marker unique to that panel** — a control only that panel
+ *    renders. This is what actually pins panel identity, and every marker below
+ *    was read out of the live DOM rather than guessed.
+ *
+ * Both matter: (1) catches a dead or unresolved route, (2) catches a mis-wired
+ * one.
+ *
+ * Selectors come from the route registry, whose `id` is documented as "used as
+ * the React key, test id, and route slug"
+ * (`settingsRouteRegistry.ts:77`) — the sidebar renders each entry with
+ * `data-testid={`settings-nav-${entry.id}`}` (`SettingsSidebar.tsx:50`).
+ */
+
+/**
+ * Registry id → the route's `<h1>` (from the registry `titleKey`) and a marker
+ * that only that panel's BODY renders. Markers were collected from the running
+ * app, not inferred from source.
+ */
+const PANELS = [
+  { id: 'appearance', route: 'appearance', heading: 'Appearance', marker: 'font-size-slider' },
+  { id: 'privacy', route: 'privacy', heading: 'Privacy', marker: 'privacy-mode-options' },
+  { id: 'devices', route: 'devices', heading: 'Devices', marker: null, text: 'Pair iPhone' },
+  { id: 'security', route: 'security', heading: 'Security', marker: null, text: 'Retry keychain detection' },
+  { id: 'notifications', route: 'notifications', heading: 'Notifications', marker: null, text: 'Categories' },
+  { id: 'profiles', route: 'profiles', heading: 'Agent Profiles', marker: null, text: 'New profile' },
+  { id: 'agent-access', route: 'agent-access', heading: 'Agent OS access', marker: null, text: 'View approval history' },
+  // Sandbox is a desktop-only panel: in the web lane its body is the
+  // desktop-only notice, not the Docker fields. Asserting what this build
+  // actually renders, rather than what the Tauri build would.
+  {
+    id: 'sandbox-settings',
+    route: 'sandbox-settings',
+    heading: 'Sandbox execution',
+    marker: null,
+    text: 'only available in the desktop app',
+  },
+  { id: 'about', route: 'about', heading: 'About', marker: 'github-star-cta' },
+] as const;
+
+/** The panel-identity assertion: a control only this panel's body renders. */
+async function expectPanelBody(page: Page, panel: (typeof PANELS)[number]) {
+  if (panel.marker) {
+    await expect(page.getByTestId(panel.marker)).toBeVisible({ timeout: 30_000 });
+  } else {
+    await expect(page.getByText(panel.text!, { exact: false }).first()).toBeVisible({
+      timeout: 30_000,
+    });
+  }
+}
+
+const panelHeading = (page: Page) => page.getByRole('heading', { level: 1 });
+
+async function gotoSettings(page: Page, route: string) {
+  await page.goto(`/#/settings/${route}`);
+  await waitForAppReady(page);
+  // `waitForAppReady` only proves the shell painted; the routed panel mounts a
+  // beat later. Wait for the panel's own heading before asserting on it.
+  await expect(panelHeading(page)).toBeVisible({ timeout: 30_000 });
+}
+
+test.describe('Settings navigation — deep links', () => {
+  test.beforeEach(async ({ page }) => {
+    // Boot directly to a settings route. The helper's default '/home' hash
+    // waits for the chat-shell redirect to settle, which is a slow path this
+    // suite never needs — and it exhausted the 60s test budget in beforeEach.
+    await bootAuthenticatedPage(page, 'pw-w1-settings-nav', '/settings/appearance');
+  });
+
+  for (const panel of PANELS) {
+    test(`deep link /settings/${panel.route} mounts the ${panel.id} panel`, async ({ page }) => {
+      await gotoSettings(page, panel.route);
+
+      // (1) a settings page resolved for this URL — the sidebar has no h1, so
+      // this fails if only the chrome mounted.
+      await expect(panelHeading(page)).toHaveText(panel.heading, { timeout: 30_000 });
+      // (2) and it is THIS panel, not another one wired to the same route.
+      await expectPanelBody(page, panel);
+      expect(await page.evaluate(() => window.location.hash)).toBe(`#/settings/${panel.route}`);
+    });
+  }
+
+  test('the sidebar renders exactly one h1, and it belongs to the panel', async ({ page }) => {
+    await gotoSettings(page, 'privacy');
+
+    // If a future layout change gave the sidebar an h1, every assertion above
+    // would silently weaken. This is the guard on the discriminator itself.
+    await expect(panelHeading(page)).toHaveCount(1);
+    await expect(panelHeading(page)).toHaveText('Privacy', { timeout: 30_000 });
+  });
+});
+
+test.describe('Settings navigation — clicking through the sidebar', () => {
+  test.beforeEach(async ({ page }) => {
+    await bootAuthenticatedPage(page, 'pw-w1-settings-click', '/settings/appearance');
+    await expect(panelHeading(page)).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('clicking a sidebar entry swaps the panel and the URL together', async ({ page }) => {
+    await expect(panelHeading(page)).toHaveText('Appearance', { timeout: 30_000 });
+
+    await page.getByTestId('settings-nav-privacy').click();
+
+    await expect(panelHeading(page)).toHaveText('Privacy', { timeout: 30_000 });
+    await expect(page.getByTestId('privacy-mode-options')).toBeVisible({ timeout: 30_000 });
+    await expect
+      .poll(async () => page.evaluate(() => window.location.hash))
+      .toBe('#/settings/privacy');
+  });
+
+  test('walks three panels in sequence without stale content', async ({ page }) => {
+    for (const step of ['security', 'devices', 'about'] as const) {
+      const expected = PANELS.find(p => p.id === step)!.heading;
+      await page.getByTestId(`settings-nav-${step}`).click();
+      // `toHaveText` retries, so this also proves the PREVIOUS panel's heading
+      // is gone rather than both being present.
+      await expect(panelHeading(page)).toHaveText(expected, { timeout: 30_000 });
+      await expectPanelBody(page, PANELS.find(p => p.id === step)!);
+    }
+  });
+
+  test('marks the open panel as the current page for assistive tech', async ({ page }) => {
+    await page.getByTestId('settings-nav-privacy').click();
+    await expect(panelHeading(page)).toHaveText('Privacy', { timeout: 30_000 });
+
+    const privacyNav = page.getByTestId('settings-nav-privacy');
+    const securityNav = page.getByTestId('settings-nav-security');
+
+    // Whatever the mechanism (aria-current or aria-selected), the open entry
+    // must be distinguishable from a closed one; a sighted user gets the
+    // highlight, and this is the same signal for a screen reader.
+    const current = await privacyNav.evaluate(
+      el => el.getAttribute('aria-current') ?? el.getAttribute('aria-selected')
+    );
+    const other = await securityNav.evaluate(
+      el => el.getAttribute('aria-current') ?? el.getAttribute('aria-selected')
+    );
+    expect(current).not.toBeNull();
+    expect(current).not.toBe(other);
+  });
+});
+
+test.describe('Settings navigation — browser history', () => {
+  test.beforeEach(async ({ page }) => {
+    await bootAuthenticatedPage(page, 'pw-w1-settings-history', '/settings/appearance');
+  });
+
+  test('back returns to the previous panel, forward returns again', async ({ page }) => {
+    await gotoSettings(page, 'appearance');
+    await expect(panelHeading(page)).toHaveText('Appearance', { timeout: 30_000 });
+
+    await page.getByTestId('settings-nav-security').click();
+    await expect(panelHeading(page)).toHaveText('Security', { timeout: 30_000 });
+
+    await page.goBack();
+    await expect(panelHeading(page)).toHaveText('Appearance', { timeout: 30_000 });
+    await expect(page.getByTestId('font-size-slider')).toBeVisible({ timeout: 30_000 });
+    await expect
+      .poll(async () => page.evaluate(() => window.location.hash))
+      .toBe('#/settings/appearance');
+
+    await page.goForward();
+    await expect(panelHeading(page)).toHaveText('Security', { timeout: 30_000 });
+  });
+
+  test('a reload keeps you on the panel you deep-linked to', async ({ page }) => {
+    await gotoSettings(page, 'sandbox-settings');
+    await expect(panelHeading(page)).toHaveText('Sandbox execution', { timeout: 30_000 });
+
+    await page.reload();
+    await waitForAppReady(page);
+
+    await expect(panelHeading(page)).toHaveText('Sandbox execution', { timeout: 30_000 });
+    await expectPanelBody(page, PANELS.find(p => p.id === 'sandbox-settings')!);
+  });
+});

--- a/app/test/playwright/specs/settings-navigation-panels.spec.ts
+++ b/app/test/playwright/specs/settings-navigation-panels.spec.ts
@@ -1,6 +1,10 @@
 import { expect, type Page, test } from '@playwright/test';
 
-import { bootAuthenticatedPage, waitForAppReady } from '../helpers/core-rpc';
+import {
+  bootAuthenticatedPage,
+  dismissWalkthroughIfPresent,
+  waitForAppReady,
+} from '../helpers/core-rpc';
 
 /**
  * Settings navigation, driven in a real browser.
@@ -107,6 +111,11 @@ const panelHeading = (page: Page) => page.getByRole('heading', { level: 1 });
 async function gotoSettings(page: Page, route: string) {
   await page.goto(`/#/settings/${route}`);
   await waitForAppReady(page);
+  // Defence in depth: `seedBrowserCoreMode` already sets
+  // `openhuman:walkthrough_completed`, which is why this suite passed without
+  // it — but if that seed ever changes, an open walkthrough would intercept
+  // the sidebar clicks below rather than failing loudly.
+  await dismissWalkthroughIfPresent(page);
   // `waitForAppReady` only proves the shell painted; the routed panel mounts a
   // beat later. Wait for the panel's own heading before asserting on it.
   await expect(panelHeading(page)).toBeVisible({ timeout: 30_000 });

--- a/app/test/playwright/specs/settings-privacy-mode.spec.ts
+++ b/app/test/playwright/specs/settings-privacy-mode.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 
 import {
   bootAuthenticatedPage,
@@ -148,9 +148,7 @@ test.describe('Privacy mode — selecting a posture reaches the core', () => {
       // false here and would make this assertion vacuous.
       const checked = await page.evaluate(
         () =>
-          Array.from(
-            document.querySelectorAll('[data-testid^="privacy-mode-option-"]')
-          ).filter(
+          Array.from(document.querySelectorAll('[data-testid^="privacy-mode-option-"]')).filter(
             el =>
               el.getAttribute('aria-checked') === 'true' ||
               el.getAttribute('data-state') === 'checked' ||

--- a/app/test/playwright/specs/settings-privacy-mode.spec.ts
+++ b/app/test/playwright/specs/settings-privacy-mode.spec.ts
@@ -1,0 +1,163 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import {
+  bootAuthenticatedPage,
+  callCoreRpc,
+  dismissWalkthroughIfPresent,
+  waitForAppReady,
+} from '../helpers/core-rpc';
+
+/**
+ * Privacy Mode — the data-egress posture, asserted against the CORE.
+ *
+ * This control decides what leaves the user's machine (#4435): `local_only`,
+ * `standard`, or `sensitive`. Believing you are in `local_only` when the core
+ * still has `standard` is the whole risk, and it is not observable from the DOM
+ * — the radio can show the click while the write failed or never happened.
+ *
+ * So every assertion here reads `openhuman.config_get_privacy_mode` back from
+ * the core and compares. `settings-account-preferences.spec.ts` persists the
+ * *analytics* toggle; nothing drives the egress mode, in this lane or any other.
+ */
+
+type PrivacyMode = 'local_only' | 'standard' | 'sensitive';
+
+async function coreMode(): Promise<string | undefined> {
+  const res = await callCoreRpc<{ result?: { mode?: string } }>(
+    'openhuman.config_get_privacy_mode',
+    {}
+  );
+  return res.result?.mode;
+}
+
+async function setCoreMode(mode: PrivacyMode): Promise<void> {
+  await callCoreRpc('openhuman.config_set_privacy_mode', { mode });
+}
+
+/** The radio input — queryable for state, but `sr-only`, so never clicked. */
+const option = (page: Page, mode: PrivacyMode) => page.getByTestId(`privacy-mode-option-${mode}`);
+
+/**
+ * The visible label that wraps each radio. The input itself carries `sr-only`
+ * (`PrivacyModeSection.tsx:120`), so clicking it times out — a user clicks the
+ * card, and the `htmlFor` association is what activates the radio.
+ */
+const choose = (page: Page, mode: PrivacyMode) =>
+  page.locator(`label[for="privacy-mode-option-${mode}-input"]`);
+
+async function openPrivacy(page: Page) {
+  await page.goto('/#/settings/privacy');
+  await waitForAppReady(page);
+  await dismissWalkthroughIfPresent(page);
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Privacy', { timeout: 30_000 });
+  await expect(page.getByTestId('privacy-mode-options')).toBeVisible({ timeout: 30_000 });
+}
+
+test.describe('Privacy mode — the selector reflects the core', () => {
+  test.beforeEach(async ({ page }) => {
+    // Start from a known posture so "it changed" means something.
+    await setCoreMode('standard');
+    await bootAuthenticatedPage(page, 'pw-w1-privacy', '/settings/privacy');
+    await openPrivacy(page);
+  });
+
+  test('loads the mode the core actually holds, not a default', async ({ page }) => {
+    await expect(option(page, 'standard')).toBeChecked();
+    await expect(option(page, 'local_only')).not.toBeChecked();
+    await expect(option(page, 'sensitive')).not.toBeChecked();
+  });
+
+  test('a mode set outside the UI is reflected on next open', async ({ page }) => {
+    await setCoreMode('sensitive');
+
+    // Leave and come back: same hash would be a router no-op, so hop.
+    await page.goto('/#/settings/security');
+    await waitForAppReady(page);
+    await openPrivacy(page);
+
+    await expect(option(page, 'sensitive')).toBeChecked();
+  });
+});
+
+test.describe('Privacy mode — selecting a posture reaches the core', () => {
+  test.beforeEach(async ({ page }) => {
+    await setCoreMode('standard');
+    await bootAuthenticatedPage(page, 'pw-w1-privacy-write', '/settings/privacy');
+    await openPrivacy(page);
+  });
+
+  test('choosing local_only writes local_only to the core', async ({ page }) => {
+    await choose(page, 'local_only').click();
+
+    await expect(option(page, 'local_only')).toBeChecked();
+    // The assertion that matters: the CORE agrees. A UI-only change here would
+    // leave the user believing their data stays on the machine when it does not.
+    await expect.poll(coreMode, { timeout: 20_000 }).toBe('local_only');
+  });
+
+  test('choosing sensitive writes sensitive to the core', async ({ page }) => {
+    await choose(page, 'sensitive').click();
+
+    await expect(option(page, 'sensitive')).toBeChecked();
+    await expect.poll(coreMode, { timeout: 20_000 }).toBe('sensitive');
+  });
+
+  test('switching postures twice leaves the core on the last one', async ({ page }) => {
+    await choose(page, 'local_only').click();
+    await expect.poll(coreMode, { timeout: 20_000 }).toBe('local_only');
+
+    await choose(page, 'sensitive').click();
+    await expect.poll(coreMode, { timeout: 20_000 }).toBe('sensitive');
+
+    await expect(option(page, 'sensitive')).toBeChecked();
+    await expect(option(page, 'local_only')).not.toBeChecked();
+  });
+
+  test('the chosen posture survives a reload', async ({ page }) => {
+    await choose(page, 'local_only').click();
+    await expect.poll(coreMode, { timeout: 20_000 }).toBe('local_only');
+
+    await page.reload();
+    await waitForAppReady(page);
+    await dismissWalkthroughIfPresent(page);
+
+    await expect(option(page, 'local_only')).toBeChecked({ timeout: 30_000 });
+    expect(await coreMode()).toBe('local_only');
+  });
+
+  test('re-selecting the current posture does not disturb it', async ({ page }) => {
+    await choose(page, 'local_only').click();
+    await expect.poll(coreMode, { timeout: 20_000 }).toBe('local_only');
+
+    // The panel short-circuits when the mode is unchanged
+    // (`PrivacyModeSection.tsx:69`). What must hold either way is that the
+    // posture does not flip or clear.
+    await choose(page, 'local_only').click();
+
+    await expect(option(page, 'local_only')).toBeChecked();
+    expect(await coreMode()).toBe('local_only');
+  });
+
+  test('the three postures are mutually exclusive in the DOM', async ({ page }) => {
+    for (const mode of ['local_only', 'standard', 'sensitive'] as const) {
+      await choose(page, mode).click();
+      await expect.poll(coreMode, { timeout: 20_000 }).toBe(mode);
+
+      // The radios are Radix items, so selection is `aria-checked` /
+      // `data-state`, not the native `.checked` property — which is always
+      // false here and would make this assertion vacuous.
+      const checked = await page.evaluate(
+        () =>
+          Array.from(
+            document.querySelectorAll('[data-testid^="privacy-mode-option-"]')
+          ).filter(
+            el =>
+              el.getAttribute('aria-checked') === 'true' ||
+              el.getAttribute('data-state') === 'checked' ||
+              (el as HTMLInputElement).checked === true
+          ).length
+      );
+      expect(checked).toBe(1);
+    }
+  });
+});

--- a/app/test/playwright/specs/settings-profiles-crud.spec.ts
+++ b/app/test/playwright/specs/settings-profiles-crud.spec.ts
@@ -1,0 +1,193 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import {
+  bootAuthenticatedPage,
+  callCoreRpc,
+  dismissWalkthroughIfPresent,
+  waitForAppReady,
+} from '../helpers/core-rpc';
+
+/**
+ * Agent profiles — the full create / activate / delete journey, verified
+ * against the core.
+ *
+ * My jsdom specs (`ProfileEditorPage.payload.test.tsx`,
+ * `ProfilesPanel.actions.test.tsx`) assert the payload the panel BUILDS and the
+ * errors it renders, with the API mocked. What neither can show is that the
+ * profile actually reaches `openhuman.profiles_upsert`, comes back in
+ * `profiles_list`, survives a reload, and disappears on delete. No spec in any
+ * lane does that today.
+ *
+ * Each test therefore reads the core's own profile list over RPC and compares.
+ */
+
+interface Profile {
+  id?: string;
+  name?: string;
+  description?: string;
+  builtIn?: boolean;
+}
+
+/**
+ * NOTE the shape: `profiles_list` returns `{ activeProfileId, profiles }`
+ * DIRECTLY — unlike `wallet_status`, whose payload is nested under a second
+ * `result`. Reading `res.result?.profiles` here silently yields `[]`, so every
+ * core comparison passes vacuously or fails for the wrong reason. Verified
+ * against the live RPC.
+ */
+async function coreProfiles(): Promise<{ profiles: Profile[]; activeId?: string }> {
+  const res = await callCoreRpc<{ profiles?: Profile[]; activeProfileId?: string }>(
+    'openhuman.profiles_list',
+    {}
+  );
+  return { profiles: res.profiles ?? [], activeId: res.activeProfileId };
+}
+
+const coreIds = async () => (await coreProfiles()).profiles.map(p => p.id).filter(Boolean).sort();
+
+async function openProfiles(page: Page) {
+  await page.goto('/#/settings/profiles');
+  await waitForAppReady(page);
+  await dismissWalkthroughIfPresent(page);
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Agent Profiles', {
+    timeout: 30_000,
+  });
+}
+
+/** The list row for a profile, addressed by its visible name. */
+const row = (page: Page, name: string) =>
+  page.locator('li').filter({ hasText: name }).first();
+
+/** Remove a profile directly, so a test's own leftovers cannot leak forward. */
+async function deleteFromCore(id: string) {
+  // The param is snake_case `profile_id` (agentProfilesApi.ts:43) — `profileId`
+  // is accepted by the transport and ignored, so the delete silently no-ops.
+  await callCoreRpc('openhuman.profiles_delete', { profile_id: id }).catch(() => {});
+}
+
+test.describe('Agent profiles — create', () => {
+  const NAME = 'W1 Browser Profile';
+  const ID = 'w1-browser-profile';
+
+  test.beforeEach(async ({ page }) => {
+    await deleteFromCore(ID);
+    await bootAuthenticatedPage(page, 'pw-w1-profiles', '/settings/profiles');
+    await openProfiles(page);
+  });
+
+  test.afterEach(async () => {
+    await deleteFromCore(ID);
+  });
+
+  test('creating a profile persists it to the core and lists it', async ({ page }) => {
+    expect(await coreIds()).not.toContain(ID);
+
+    await page.getByRole('button', { name: 'New profile' }).click();
+    await expect(page.getByLabel('Name', { exact: true })).toBeVisible({ timeout: 30_000 });
+
+    await page.getByLabel('Name', { exact: true }).click();
+    await page.keyboard.type(NAME);
+    await expect(page.getByLabel('ID', { exact: true })).toHaveValue(ID);
+
+    await page.getByRole('button', { name: 'Create' }).click();
+
+    // Back on the list, and the core holds it.
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Agent Profiles', {
+      timeout: 30_000,
+    });
+    await expect.poll(coreIds, { timeout: 20_000 }).toContain(ID);
+    await expect(row(page, NAME)).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('a created profile is custom, not built-in, and offers Delete', async ({ page }) => {
+    await page.getByRole('button', { name: 'New profile' }).click();
+    await page.getByLabel('Name', { exact: true }).click();
+    await page.keyboard.type(NAME);
+    await page.getByRole('button', { name: 'Create' }).click();
+    await expect.poll(coreIds, { timeout: 20_000 }).toContain(ID);
+
+    const created = (await coreProfiles()).profiles.find(p => p.id === ID);
+    expect(created?.builtIn ?? false).toBe(false);
+
+    // Built-ins hide Delete; a custom profile must offer it.
+    await expect(row(page, NAME).getByText('Delete')).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('the created profile survives a reload', async ({ page }) => {
+    await page.getByRole('button', { name: 'New profile' }).click();
+    await page.getByLabel('Name', { exact: true }).click();
+    await page.keyboard.type(NAME);
+    await page.getByRole('button', { name: 'Create' }).click();
+    await expect.poll(coreIds, { timeout: 20_000 }).toContain(ID);
+
+    await page.reload();
+    await waitForAppReady(page);
+    await dismissWalkthroughIfPresent(page);
+
+    await expect(row(page, NAME)).toBeVisible({ timeout: 30_000 });
+  });
+});
+
+test.describe('Agent profiles — activate and delete', () => {
+  const NAME = 'W1 Lifecycle Profile';
+  const ID = 'w1-lifecycle-profile';
+
+  test.beforeEach(async ({ page }) => {
+    await deleteFromCore(ID);
+    await callCoreRpc('openhuman.profiles_upsert', {
+      profile: {
+        id: ID,
+        name: NAME,
+        description: 'Created over RPC so the test starts from a known list.',
+        agentId: 'orchestrator',
+        builtIn: false,
+        includeAgentConversations: true,
+      },
+    }).catch(() => {});
+    await bootAuthenticatedPage(page, 'pw-w1-profiles-life', '/settings/profiles');
+    await openProfiles(page);
+  });
+
+  test.afterEach(async () => {
+    await deleteFromCore(ID);
+  });
+
+  test('Set as active moves the active profile in the core', async ({ page }) => {
+    const before = (await coreProfiles()).activeId;
+    expect(before).not.toBe(ID);
+
+    await row(page, NAME).getByText('Set as active').click();
+
+    await expect.poll(async () => (await coreProfiles()).activeId, { timeout: 20_000 }).toBe(ID);
+    // The row stops offering "Set as active" once it IS active.
+    await expect(row(page, NAME).getByText('Set as active')).toHaveCount(0, { timeout: 30_000 });
+  });
+
+  test('deleting removes it from the core and from the list', async ({ page }) => {
+    page.once('dialog', d => void d.accept());
+
+    await expect(row(page, NAME)).toBeVisible({ timeout: 30_000 });
+    await row(page, NAME).getByText('Delete').click();
+
+    await expect.poll(coreIds, { timeout: 20_000 }).not.toContain(ID);
+    await expect(page.getByText(NAME)).toHaveCount(0, { timeout: 30_000 });
+  });
+
+  test('dismissing the delete confirm keeps the profile', async ({ page }) => {
+    page.once('dialog', d => void d.dismiss());
+
+    await row(page, NAME).getByText('Delete').click();
+
+    // Nothing should have been asked of the core, and the row stays.
+    await expect(row(page, NAME)).toBeVisible();
+    expect(await coreIds()).toContain(ID);
+  });
+
+  test('Edit opens the editor with the profile hydrated from the core', async ({ page }) => {
+    await row(page, NAME).getByText('Edit').click();
+
+    await expect(page.getByLabel('Name', { exact: true })).toHaveValue(NAME, { timeout: 30_000 });
+    // The id is read-only in edit mode — there is no ID field to type into.
+    await expect(page.getByLabel('ID', { exact: true })).toHaveCount(0);
+  });
+});

--- a/app/test/playwright/specs/settings-profiles-crud.spec.ts
+++ b/app/test/playwright/specs/settings-profiles-crud.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 
 import {
   bootAuthenticatedPage,
@@ -43,7 +43,11 @@ async function coreProfiles(): Promise<{ profiles: Profile[]; activeId?: string 
   return { profiles: res.profiles ?? [], activeId: res.activeProfileId };
 }
 
-const coreIds = async () => (await coreProfiles()).profiles.map(p => p.id).filter(Boolean).sort();
+const coreIds = async () =>
+  (await coreProfiles()).profiles
+    .map(p => p.id)
+    .filter(Boolean)
+    .sort();
 
 async function openProfiles(page: Page) {
   await page.goto('/#/settings/profiles');
@@ -55,8 +59,7 @@ async function openProfiles(page: Page) {
 }
 
 /** The list row for a profile, addressed by its visible name. */
-const row = (page: Page, name: string) =>
-  page.locator('li').filter({ hasText: name }).first();
+const row = (page: Page, name: string) => page.locator('li').filter({ hasText: name }).first();
 
 /** Remove a profile directly, so a test's own leftovers cannot leak forward. */
 async function deleteFromCore(id: string) {

--- a/app/test/playwright/specs/settings-profiles-crud.spec.ts
+++ b/app/test/playwright/specs/settings-profiles-crud.spec.ts
@@ -69,6 +69,11 @@ async function deleteFromCore(id: string) {
 }
 
 test.describe('Agent profiles — create', () => {
+  // These tests share one hard-coded profile id against a single core, so they
+  // must not interleave: a parallel worker's afterEach delete can land between
+  // another test's create and its assertion. Serialising the describe is the
+  // fix that keeps the id stable and readable (tinysweeper, test-isolation).
+  test.describe.configure({ mode: 'serial' });
   const NAME = 'W1 Browser Profile';
   const ID = 'w1-browser-profile';
 
@@ -132,6 +137,11 @@ test.describe('Agent profiles — create', () => {
 });
 
 test.describe('Agent profiles — activate and delete', () => {
+  // These tests share one hard-coded profile id against a single core, so they
+  // must not interleave: a parallel worker's afterEach delete can land between
+  // another test's create and its assertion. Serialising the describe is the
+  // fix that keeps the id stable and readable (tinysweeper, test-isolation).
+  test.describe.configure({ mode: 'serial' });
   const NAME = 'W1 Lifecycle Profile';
   const ID = 'w1-lifecycle-profile';
 
@@ -190,7 +200,11 @@ test.describe('Agent profiles — activate and delete', () => {
     await row(page, NAME).getByText('Edit').click();
 
     await expect(page.getByLabel('Name', { exact: true })).toHaveValue(NAME, { timeout: 30_000 });
-    // The id is read-only in edit mode — there is no ID field to type into.
+    // Edit mode renders the id as a non-editable `<code>`, not a read-only input:
+    // `ProfileEditorPage.tsx:224-229` branches on `isCreate` and only the create
+    // branch renders a `SettingsTextField` with an `aria-label`. So there is no
+    // labelled control to find and the count is 0, not 1 (tinysweeper flagged this
+    // as possibly a hidden-but-present field; it is genuinely absent).
     await expect(page.getByLabel('ID', { exact: true })).toHaveCount(0);
   });
 });

--- a/app/test/playwright/specs/settings-recovery-phrase-replace.spec.ts
+++ b/app/test/playwright/specs/settings-recovery-phrase-replace.spec.ts
@@ -1,0 +1,216 @@
+import { expect, test, type Page } from '@playwright/test';
+
+import {
+  bootAuthenticatedPage,
+  callCoreRpc,
+  dismissWalkthroughIfPresent,
+  waitForAppReady,
+} from '../helpers/core-rpc';
+
+/**
+ * RecoveryPhrasePanel — the replace gate, in a real browser.
+ *
+ * # What is already covered, and what is not
+ *
+ * `settings-account-preferences.spec.ts` drives generate → confirm → save and
+ * asserts the wallet ends up configured. Its helper *clicks through* the
+ * replace gate to reach generate mode, but nothing asserts the gate itself:
+ * that a configured wallet cannot reach the generate flow without passing it,
+ * that the warning is shown, and — the part that matters — that backing out
+ * leaves the existing key material untouched.
+ *
+ * This is the highest-stakes flow in the app: confirming replace destroys the
+ * user's only copy of their wallet. A cancel that silently rotated the key
+ * would be unrecoverable, and no jsdom test can prove it did not, because the
+ * proof is in the core's `wallet_status`, not in the DOM.
+ *
+ * Each test therefore reads the wallet's real state over RPC before and after
+ * the interaction, and compares.
+ */
+
+/**
+ * Make `isTauri()` true for the page. The crypto settings surface is
+ * desktop-gated, so without this `/settings/recovery-phrase` never mounts in
+ * the web lane and the router falls through to chat. Copied per-spec, as the
+ * other specs that need it do (`settings-advanced-config.spec.ts:9`,
+ * `chat-harness-wallet-flow.spec.ts:71`) — `helpers/` is shared and off-limits.
+ */
+async function emulateTauriRuntime(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const win = window as typeof window & {
+      isTauri?: boolean;
+      __TAURI_INTERNALS__?: { invoke?: (cmd: string, args?: unknown) => Promise<unknown> };
+    };
+    win.isTauri = true;
+    win.__TAURI_INTERNALS__ = win.__TAURI_INTERNALS__ ?? {};
+    win.__TAURI_INTERNALS__.invoke = win.__TAURI_INTERNALS__.invoke ?? (async () => null);
+  });
+}
+
+interface WalletStatus {
+  configured?: boolean;
+  accounts?: { address?: string }[];
+}
+
+async function walletState(): Promise<{ configured: boolean; addresses: string[] }> {
+  const status = await callCoreRpc<{ result?: WalletStatus }>('openhuman.wallet_status', {});
+  return {
+    configured: Boolean(status.result?.configured),
+    addresses: (status.result?.accounts ?? [])
+      .map(a => a?.address ?? '')
+      .filter(Boolean)
+      .sort(),
+  };
+}
+
+const replaceButton = (page: Page) => page.getByRole('button', { name: 'Replace wallet' });
+const confirmReplace = (page: Page) =>
+  page.getByRole('button', { name: 'I understand, replace my wallet' });
+const importInstead = (page: Page) =>
+  page.getByRole('button', { name: 'I already have a recovery phrase' });
+const cancelButton = (page: Page) => page.getByRole('button', { name: 'Cancel' });
+const copyButton = (page: Page) => page.getByRole('button', { name: 'Copy to Clipboard' });
+
+async function gotoRecoveryPhrase(page: Page) {
+  await page.goto('/#/settings/recovery-phrase');
+  await waitForAppReady(page);
+  // A walkthrough overlay intercepts clicks on a fresh profile; the working
+  // account spec dismisses it the same way before touching this panel.
+  await dismissWalkthroughIfPresent(page);
+  await expect(page.getByRole('heading', { level: 1 })).toHaveText('Recovery phrase', {
+    timeout: 30_000,
+  });
+}
+
+/**
+ * Leave the account with a configured wallet and the panel in `view` mode.
+ *
+ * The wallet's existence is checked over RPC rather than by reading the panel's
+ * mode: `view` vs `generate` is derived from an async status fetch, so a
+ * UI-first check races the first render on a fresh account.
+ */
+async function ensureConfiguredWallet(page: Page) {
+  if (!(await walletState()).configured) {
+    await gotoRecoveryPhrase(page);
+    await expect(copyButton(page)).toBeVisible({ timeout: 30_000 });
+    await page.locator('#mnemonic-confirm-checkbox').check();
+    await page.getByRole('button', { name: 'Save Recovery Phrase' }).click();
+
+    // Wait on the CORE, not the DOM: the saved-note is transient and the panel
+    // re-renders as the wallet lands.
+    await expect
+      .poll(async () => (await walletState()).configured, { timeout: 45_000 })
+      .toBe(true);
+  }
+
+  // Re-enter so the panel reads the now-configured status from a clean mount.
+  // Navigating to the SAME hash is a no-op for the router, so the panel would
+  // keep its post-save state and never re-read the wallet — hop via another
+  // settings route to force a real remount.
+  await page.goto('/#/settings/privacy');
+  await waitForAppReady(page);
+  await gotoRecoveryPhrase(page);
+  await expect(replaceButton(page)).toBeVisible({ timeout: 30_000 });
+}
+
+test.describe('Recovery phrase — the replace gate', () => {
+  test.beforeEach(async ({ page }) => {
+    await bootAuthenticatedPage(page, 'pw-w1-recovery');
+    await emulateTauriRuntime(page);
+    await ensureConfiguredWallet(page);
+  });
+
+  test('a configured wallet shows no phrase and offers no direct regenerate', async ({ page }) => {
+    // View mode must not display the mnemonic until it is explicitly revealed,
+    // and the destructive action must sit behind the gate rather than being a
+    // one-click affordance.
+    await expect(replaceButton(page)).toBeVisible();
+    await expect(confirmReplace(page)).toHaveCount(0);
+    await expect(copyButton(page)).toHaveCount(0);
+  });
+
+  test('clicking Replace wallet shows the gate, not the new phrase', async ({ page }) => {
+    await replaceButton(page).click();
+
+    await expect(confirmReplace(page)).toBeVisible();
+    await expect(importInstead(page)).toBeVisible();
+    await expect(cancelButton(page)).toBeVisible();
+    // The gate must not have already produced a replacement phrase behind it.
+    await expect(copyButton(page)).toHaveCount(0);
+  });
+
+  test('Cancel returns to view mode and leaves the wallet byte-identical', async ({ page }) => {
+    const before = await walletState();
+    expect(before.configured).toBe(true);
+    expect(before.addresses.length).toBeGreaterThan(0);
+
+    await replaceButton(page).click();
+    await expect(confirmReplace(page)).toBeVisible();
+
+    await cancelButton(page).click();
+
+    // Back to view mode...
+    await expect(replaceButton(page)).toBeVisible();
+    await expect(confirmReplace(page)).toHaveCount(0);
+
+    // ...and the core still holds exactly the same key material. This is the
+    // assertion the DOM cannot make on its own.
+    const after = await walletState();
+    expect(after).toEqual(before);
+  });
+
+  test('navigating away from the open gate does not replace the wallet', async ({ page }) => {
+    const before = await walletState();
+
+    await replaceButton(page).click();
+    await expect(confirmReplace(page)).toBeVisible();
+
+    // Abandoning the flow mid-gate is the likeliest real-world exit, and must
+    // be as safe as pressing Cancel.
+    await page.goto('/#/settings/privacy');
+    await waitForAppReady(page);
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Privacy');
+
+    expect(await walletState()).toEqual(before);
+  });
+
+  test('re-entering the panel after Cancel starts from view mode, not the gate', async ({
+    page,
+  }) => {
+    await replaceButton(page).click();
+    await expect(confirmReplace(page)).toBeVisible();
+    await cancelButton(page).click();
+    await expect(replaceButton(page)).toBeVisible();
+
+    await page.goto('/#/settings/privacy');
+    await waitForAppReady(page);
+    await gotoRecoveryPhrase(page);
+
+    // A gate left open across navigation would be a loaded gun on return.
+    await expect(replaceButton(page)).toBeVisible({ timeout: 20_000 });
+    await expect(confirmReplace(page)).toHaveCount(0);
+  });
+
+  test('"I already have a recovery phrase" opens import, and importing nothing changes nothing', async ({
+    page,
+  }) => {
+    const before = await walletState();
+
+    await replaceButton(page).click();
+    await importInstead(page).click();
+
+    // Import mode: word slots, and no generated phrase to copy. The slots are
+    // addressed by their aria-label — they carry no id
+    // (`RecoveryPhraseImportMode.tsx:88`).
+    await expect(page.getByLabel('Recovery phrase word 1', { exact: true })).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(copyButton(page)).toHaveCount(0);
+
+    // Leaving without completing the import must not touch the wallet.
+    await page.goto('/#/settings/privacy');
+    await waitForAppReady(page);
+
+    expect(await walletState()).toEqual(before);
+  });
+});

--- a/app/test/playwright/specs/settings-recovery-phrase-replace.spec.ts
+++ b/app/test/playwright/specs/settings-recovery-phrase-replace.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from '@playwright/test';
+import { expect, type Page, test } from '@playwright/test';
 
 import {
   bootAuthenticatedPage,
@@ -98,9 +98,7 @@ async function ensureConfiguredWallet(page: Page) {
 
     // Wait on the CORE, not the DOM: the saved-note is transient and the panel
     // re-renders as the wallet lands.
-    await expect
-      .poll(async () => (await walletState()).configured, { timeout: 45_000 })
-      .toBe(true);
+    await expect.poll(async () => (await walletState()).configured, { timeout: 45_000 }).toBe(true);
   }
 
   // Re-enter so the panel reads the now-configured status from a clean mount.


### PR DESCRIPTION
## Summary

- **6 Playwright browser specs** for the settings surface, plus 7 vitest suites for panels that had thin coverage.
- 13 files, +2,603 lines. No product code touched.

## Problem

The settings surface is 65 panels and its existing browser coverage could not distinguish a panel from its chrome — `navigation-settings-panels.spec.ts` asserts on an `<h1>` that comes from the **route**, not the panel, so it passes with the wrong panel rendered.

Several things about this surface only became visible in a browser:
* a panel's heading is supplied by the route, so heading-based assertions prove nothing about which panel mounted;
* desktop-gated panels **are** reachable in the web lane via `emulateTauriRuntime`, so "desktop-only" was not a reason to skip them;
* theme is **two independent axes**, not one list of themes;
* re-navigating to the same hash does **not** remount a panel, which invalidates the obvious way to write a navigation test.

## Solution

Six browser specs — panel navigation, form interaction, appearance/theme, privacy mode, profiles CRUD, and the recovery-phrase replace gate — each asserting what the DOM holds after real interaction rather than that a mock was called.

The privacy-mode and profiles specs assert the change **reaches the core**, not merely that a radio flipped. The recovery-phrase spec covers the replace gate, which is the highest-stakes destructive path on the surface.

Seven vitest suites cover panels whose logic is cheaper to exercise in jsdom: PermissionsPanel sequence guards, PrivacyPanel data kinds, PrivacyModeSection status branches, SandboxSettingsPanel validation, SecurityPanel unknown-mode, ProfileEditorPage payload, ProfilesPanel actions.

One product defect was found and is reported rather than fixed: every failed agent-profile save/select/delete renders `[object Object]` (`ProfileEditorPage.tsx:170`, `ProfilesPanel.tsx:46` and `:59`), destroying the only diagnostic the user gets.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — this PR *is* the tests. Every case was revert-proofed: the covered behaviour was broken, the test confirmed to fail naming its own assertion, then restored. Drafts that still passed with the fault injected were rewritten or dropped rather than kept.
- [x] **Diff coverage ≥ 80%** — `N/A: the changed lines are test files`, executed by the suites they belong to; there is no product code in this diff for diff-cover to measure.
- [x] Coverage matrix updated — `N/A: behaviour-only change` — no feature rows added, removed or renamed; this covers behaviour that already ships.
- [x] All affected feature IDs from the matrix are listed — `N/A: no feature IDs affected`.
- [x] No new external network dependencies introduced — mocks and fixtures only; no test reaches a live service.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no product surface changes`, test-only.
- [x] Linked issue closed via `Closes #NNN` — `N/A: no linked issue`; this is coverage work, not a fix.

## Impact

- **Platform:** none at runtime. Test-only.
- **Security:** browser-level cover for the recovery-phrase replace gate and for privacy mode actually reaching the core.
- **Risk:** none to product behaviour.

## Related

- Closes:
- Follow-up PR(s)/TODOs: the `[object Object]` error rendering, and `navigation-settings-panels.spec.ts` asserting on a route-supplied heading.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `test/settings-panels-coverage`
- Commit SHA: see head of this PR

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — prettier clean.
- [x] `pnpm typecheck` — `tsc --noEmit`, 0 errors (one commit is a dedicated typecheck fix for the specs).
- [x] Focused tests: the six Playwright specs run green on the web lane with dedicated ports; the seven vitest suites pass. Revert-proofs re-verified after rebuilding `dist-web` — see Validation Blocked for why that matters.
- [x] Rust fmt/check (if changed): `N/A: no .rs files changed.`
- [x] Tauri fmt/check (if changed): `N/A: app/src-tauri not touched.`

### Validation Blocked

- `command:` the 91-spec WebdriverIO desktop suite
- `error:` `cargo metadata --manifest-path app/src-tauri/Cargo.toml` exits 101 — "found a virtual manifest at vendor/tinyagents/Cargo.toml"
- `impact:` those specs cannot build on `main` today, independent of this PR (fixed separately in #5874). This work targets the lanes that do run: vitest, Playwright web, and the root Rust world.

### Behavior Changes

- Intended behavior change: none. Test-only.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: yes — no product code is touched; these pin behaviour that already ships.
- Guard/fallback/dispatch parity checks: every test was proven to fail when the behaviour it pins is broken, so it discriminates rather than merely executing.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none — the six coverage branches in this batch touch disjoint files (verified across all 31).
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded settings coverage for permissions, privacy, security, sandbox, profiles, and recovery-phrase workflows.
  - Added validation for save failures, stale responses, loading states, unknown modes, input normalization, and persistence.
  - Added end-to-end coverage for themes, navigation, privacy modes, profile management, form interactions, and wallet replacement safeguards.
  - Verified keyboard accessibility, browser history, reload persistence, and core state synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->