### PR TITLE
fix(drag): stop blur listener leak on sidebar and shell drag gestures

### DIFF
--- a/app/src/components/layout/shell/RootShellLayout.test.tsx
+++ b/app/src/components/layout/shell/RootShellLayout.test.tsx
@@ -127,6 +127,19 @@ describe('RootShellLayout — redux-controlled geometry', () => {
     expect(panel(store).sidebarWidth).toBe(340);
   });
 
+  it('detaches drag listeners when the window loses focus mid-drag', () => {
+    renderShell({}, withLayout(true, 300));
+    const divider = screen.getByTestId('root-shell-divider');
+
+    fireEvent.pointerDown(divider, { clientX: 500 });
+    // Window loses focus before the pointer is released.
+    fireEvent.blur(window);
+    // Subsequent pointer moves must not affect layout — listeners are detached.
+    fireEvent.pointerMove(window, { clientX: 580 });
+
+    expect(screen.getByTestId('root-shell-sidebar').style.width).toBe('300px');
+  });
+
   it('narrows the column to the icon width when collapsed, rather than unmounting it', () => {
     const { store } = renderShell({}, withLayout(false, 300));
 

--- a/app/src/components/layout/shell/RootShellLayout.tsx
+++ b/app/src/components/layout/shell/RootShellLayout.tsx
@@ -182,7 +182,7 @@ export default function RootShellLayout({ sidebar, children, unframed }: RootShe
     function detach() {
       window.removeEventListener('pointerup', stop);
       window.removeEventListener('pointercancel', stop);
-      window.removeEventListener('blur-sm', stop);
+      window.removeEventListener('blur', stop);
       document.body.style.removeProperty('cursor');
       document.body.style.removeProperty('user-select');
       draggingRef.current = false;

--- a/app/src/components/ui/Sidebar.tsx
+++ b/app/src/components/ui/Sidebar.tsx
@@ -280,7 +280,7 @@ export const SidebarRail = forwardRef<HTMLDivElement, SidebarRailProps>(
           window.removeEventListener('pointermove', handleMove);
           window.removeEventListener('pointerup', detach);
           window.removeEventListener('pointercancel', detach);
-          window.removeEventListener('blur-sm', detach);
+          window.removeEventListener('blur', detach);
           detachRef.current = null;
         };
 


### PR DESCRIPTION
## Summary

- Two `removeEventListener('blur-sm', ...)` calls were corrupted by a Tailwind codemod that renamed the CSS class `blur` → `blur-sm`; the event name strings were incorrectly renamed along with the class names.
- The paired `addEventListener('blur', ...)` still used the correct name, so the window blur listener was registered but never removed — leaking on every drag that ended via window blur.
- Fix: restore both event name strings to `'blur'` in `Sidebar.tsx` and `RootShellLayout.tsx`.

## Problem

- Every drag gesture on the sidebar or shell resize rail that ends via window losing focus (e.g. cmd-tab, window focus change) leaves a dangling `blur` listener on `window`.
- Over a session with many such gestures, these accumulate and fire on every subsequent window blur event — re-triggering `stop`/`detach` logic on stale drag state.

## Solution

- Corrected the event name in `window.removeEventListener` from `'blur-sm'` back to `'blur'` in the two affected `detach` functions.
- No logic changes; purely a string literal fix.

## Submission Checklist

- [x] Tests added or updated — N/A: event-listener string literals are not exercisable in jsdom; the fix is verified by code inspection against the symmetric `addEventListener('blur', ...)` call.
- [x] **Diff coverage ≥ 80%** — N/A: no new code paths; correcting a string literal.
- [x] Coverage matrix updated — N/A: behaviour-only correction, no new or removed feature rows.
- [x] All affected feature IDs from the matrix are listed — N/A: no matrix row covers drag-blur listener cleanup.
- [x] No new external network dependencies introduced — N/A: no dependencies added.
- [x] Manual smoke checklist updated — N/A: drag-blur is not a release-cut surface.
- [x] Linked issue closed via `Closes #NNN` — Closes #5898 in the Related section below.

## Impact

- Desktop only (drag gestures are desktop UI).
- No performance or security implications; fixes a listener accumulation / memory leak.

## Related

- Closes #5898

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/blur-listener-leak-5898
- Commit SHA: 4903e9be7

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: N/A (string literal fix — no exercisable paths in jsdom)
- [x] Rust fmt/check (if changed): N/A
- [x] Tauri fmt/check (if changed): N/A

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: blur listener is now correctly removed after every drag ends.
- User-visible effect: eliminates listener accumulation over long sessions; no visible UX change.

### Parity Contract

- Legacy behavior preserved: drag start/stop/cancel paths unchanged.
- Guard/fallback/dispatch parity checks: symmetric addEventListener/removeEventListener pair now uses matching event name.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar dragging cleanup when the browser window loses focus.
  * Prevented stale event handling that could affect subsequent sidebar interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->