### PR TITLE
fix(routing): forward ?tab= query params through the /skills redirect

### DIFF
--- a/app/src/AppRoutes.skills.test.tsx
+++ b/app/src/AppRoutes.skills.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from '@testing-library/react';
+import type React from 'react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('./lib/platform', () => ({ getIsMobile: () => false }));
+
+vi.mock('./components/PublicRoute', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('./components/ProtectedRoute', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('./components/DefaultRedirect', () => ({
+  default: () => <div data-testid="default-redirect" />,
+}));
+
+vi.mock('./pages/WebCallbackPage', () => ({
+  default: ({ callbackKind }: { callbackKind?: string }) => (
+    <div data-testid="web-callback">{callbackKind ?? 'route-param'}</div>
+  ),
+}));
+
+vi.mock('./AppRoutesIOS', () => ({ default: () => <div /> }));
+vi.mock('./features/human/HumanPage', () => ({ default: () => <div /> }));
+vi.mock('./pages/Accounts', () => ({ default: () => <div /> }));
+vi.mock('./pages/Brain', () => ({ default: () => <div /> }));
+vi.mock('./pages/dev/AgentInsightsPreview', () => ({ default: () => <div /> }));
+vi.mock('./pages/dev/UiGallery', () => ({ default: () => <div /> }));
+vi.mock('./pages/Invites', () => ({ default: () => <div /> }));
+vi.mock('./pages/Notifications', () => ({ default: () => <div /> }));
+vi.mock('./pages/onboarding/Onboarding', () => ({ default: () => <div /> }));
+vi.mock('./pages/PttOverlayPage', () => ({ PttOverlayPage: () => <div /> }));
+vi.mock('./pages/Rewards', () => ({ default: () => <div /> }));
+vi.mock('./pages/Settings', () => ({ default: () => <div /> }));
+vi.mock('./pages/Skills', () => ({ default: () => <div data-testid="skills-page" /> }));
+vi.mock('./pages/Welcome', () => ({ default: () => <div /> }));
+vi.mock('./pages/WorkflowsRun', () => ({ default: () => <div /> }));
+
+// Reads the ambient router location and passes it to a callback. Rendered as a
+// sibling of AppRoutes so it sees the settled location after any Navigate fires.
+function LocationSpy({
+  onCapture,
+}: {
+  onCapture: (loc: { pathname: string; search: string }) => void;
+}) {
+  const { pathname, search } = useLocation();
+  onCapture({ pathname, search });
+  return null;
+}
+
+const AppRoutes = (await import('./AppRoutes')).default;
+
+describe('/skills back-compat redirect', () => {
+  it('redirects /skills to /connections (Skills page renders)', () => {
+    render(
+      <MemoryRouter initialEntries={['/skills']}>
+        <AppRoutes />
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('skills-page')).toBeInTheDocument();
+  });
+
+  it('forwards ?tab= query params from /skills to /connections', () => {
+    // Object.assign so the last render-pass wins (initial /skills is overwritten
+    // by the settled /connections after Navigate fires via useLayoutEffect).
+    const loc = { pathname: '', search: '' };
+    render(
+      <MemoryRouter initialEntries={['/skills?tab=mcp']}>
+        <AppRoutes />
+        <LocationSpy onCapture={l => Object.assign(loc, l)} />
+      </MemoryRouter>
+    );
+    expect(loc.pathname).toBe('/connections');
+    expect(loc.search).toBe('?tab=mcp');
+  });
+
+  it('produces an empty search when /skills has no query string', () => {
+    const loc = { pathname: '', search: '(init)' };
+    render(
+      <MemoryRouter initialEntries={['/skills']}>
+        <AppRoutes />
+        <LocationSpy onCapture={l => Object.assign(loc, l)} />
+      </MemoryRouter>
+    );
+    expect(loc.pathname).toBe('/connections');
+    expect(loc.search).toBe('');
+  });
+});

--- a/app/src/AppRoutes.skills.test.tsx
+++ b/app/src/AppRoutes.skills.test.tsx
@@ -42,10 +42,10 @@ vi.mock('./pages/WorkflowsRun', () => ({ default: () => <div /> }));
 function LocationSpy({
   onCapture,
 }: {
-  onCapture: (loc: { pathname: string; search: string }) => void;
+  onCapture: (loc: { pathname: string; search: string; hash: string }) => void;
 }) {
-  const { pathname, search } = useLocation();
-  onCapture({ pathname, search });
+  const { pathname, search, hash } = useLocation();
+  onCapture({ pathname, search, hash });
   return null;
 }
 
@@ -64,7 +64,7 @@ describe('/skills back-compat redirect', () => {
   it('forwards ?tab= query params from /skills to /connections', () => {
     // Object.assign so the last render-pass wins (initial /skills is overwritten
     // by the settled /connections after Navigate fires via useLayoutEffect).
-    const loc = { pathname: '', search: '' };
+    const loc = { pathname: '', search: '', hash: '' };
     render(
       <MemoryRouter initialEntries={['/skills?tab=mcp']}>
         <AppRoutes />
@@ -75,8 +75,20 @@ describe('/skills back-compat redirect', () => {
     expect(loc.search).toBe('?tab=mcp');
   });
 
+  it('forwards a hash fragment from /skills to /connections', () => {
+    const loc = { pathname: '', search: '', hash: '' };
+    render(
+      <MemoryRouter initialEntries={['/skills#section-mcp']}>
+        <AppRoutes />
+        <LocationSpy onCapture={l => Object.assign(loc, l)} />
+      </MemoryRouter>
+    );
+    expect(loc.pathname).toBe('/connections');
+    expect(loc.hash).toBe('#section-mcp');
+  });
+
   it('produces an empty search when /skills has no query string', () => {
-    const loc = { pathname: '', search: '(init)' };
+    const loc = { pathname: '', search: '(init)', hash: '' };
     render(
       <MemoryRouter initialEntries={['/skills']}>
         <AppRoutes />

--- a/app/src/AppRoutes.tsx
+++ b/app/src/AppRoutes.tsx
@@ -26,8 +26,8 @@ import Welcome from './pages/Welcome';
 import WorkflowsRun from './pages/WorkflowsRun';
 
 function ForwardSearch({ to }: { to: string }) {
-  const { search } = useLocation();
-  return <Navigate to={`${to}${search}`} replace />;
+  const { search, hash } = useLocation();
+  return <Navigate to={`${to}${search}${hash}`} replace />;
 }
 
 interface AppRoutesProps {

--- a/app/src/AppRoutes.tsx
+++ b/app/src/AppRoutes.tsx
@@ -1,4 +1,4 @@
-import { type Location, Navigate, Route, Routes } from 'react-router-dom';
+import { type Location, Navigate, Route, Routes, useLocation } from 'react-router-dom';
 
 import AppRoutesIOS from './AppRoutesIOS';
 import DefaultRedirect from './components/DefaultRedirect';
@@ -24,6 +24,11 @@ import Skills from './pages/Skills';
 import WebCallbackPage from './pages/WebCallbackPage';
 import Welcome from './pages/Welcome';
 import WorkflowsRun from './pages/WorkflowsRun';
+
+function ForwardSearch({ to }: { to: string }) {
+  const { search } = useLocation();
+  return <Navigate to={`${to}${search}`} replace />;
+}
 
 interface AppRoutesProps {
   /**
@@ -143,9 +148,9 @@ const AppRoutes = ({ location }: AppRoutesProps = {}) => {
 
       {/* Connections page lives at /connections (Phase 2 rename from /skills).
           The old /skills path is kept as a back-compat redirect so bookmarks
-          and deep links continue to work.  `?tab=` query params are preserved
-          by Navigate (replace) so existing deep links still land on the right
-          sub-tab. */}
+          and deep links continue to work.  ForwardSearch copies the current
+          ?tab= (and any other query params) to the destination so existing
+          deep links still land on the right sub-tab. */}
       {/* `/workflows/run` is the single-purpose Skill runner page — the live
           destination of the Run button in the Automations tab (WorkflowsTab). */}
       <Route
@@ -167,7 +172,7 @@ const AppRoutes = ({ location }: AppRoutesProps = {}) => {
       />
 
       {/* Back-compat: /skills → /connections (preserves ?tab= deep links). */}
-      <Route path="/skills" element={<Navigate to="/connections" replace />} />
+      <Route path="/skills" element={<ForwardSearch to="/connections" />} />
 
       {/* Unified chat = agent + connected web apps. Replaces the old
           /conversations and /accounts routes. */}


### PR DESCRIPTION
## Summary

- The `/skills` → `/connections` redirect used a static `<Navigate to="/connections" replace />` which drops `location.search` entirely.
- Any deep-link carrying `?tab=` (or any other query param) would arrive at `/connections` with a bare URL, silently discarding the intended tab state.
- Fix: a `ForwardSearch` helper component reads `useLocation().search` and appends it, so `/skills?tab=mcp` correctly redirects to `/connections?tab=mcp`.

## Problem

- Back-compat `/skills` redirect was introduced when the route was renamed to `/connections`. Any bookmark or external link that included a query string (e.g. `?tab=mcp`, `?tab=installed`) lost the param on redirect.
- React Router v6 `<Navigate>` with a static `to` string does not preserve the current location's search string.

## Solution

- Introduced `ForwardSearch` (a small standalone component) that composes `useLocation()` with `<Navigate>`:

  ```tsx
  function ForwardSearch({ to }: { to: string }) {
    const { search } = useLocation();
    return <Navigate to={`${to}${search}`} replace />;
  }
  ```

- Extracted as a standalone component (not inline in `AppRoutes`) to avoid a hooks-before-early-return ESLint violation — `AppRoutes` has an early `return <AppRoutesIOS />` for mobile.
- Also corrected a stale comment that falsely claimed the previous `<Navigate>` preserved query params.

## Submission Checklist

- [x] Tests added or updated — `AppRoutes.skills.test.tsx`: 3 tests covering redirect to /connections, ?tab= forwarding, and empty-search case.
- [x] **Diff coverage ≥ 80%** — `ForwardSearch` (lines 28–30) fully covered by the new tests.
- [x] Coverage matrix updated — N/A: behaviour-only routing fix, no new feature row.
- [x] All affected feature IDs from the matrix are listed — N/A: no matrix row covers the /skills back-compat redirect.
- [x] No new external network dependencies introduced — N/A: no dependencies added.
- [x] Manual smoke checklist updated — N/A: redirect path is not a release-cut surface.
- [x] Linked issue closed via `Closes #NNN` — Closes #5903 in the Related section below.

## Impact

- Web and desktop: affects all platforms with a React Router shell.
- No performance or security implications.

## Related

- Closes #5903

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/skills-query-forward-5903
- Commit SHA: a5682aeb0

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `pnpm exec vitest run --config test/vitest.config.ts src/AppRoutes.skills.test.tsx` — 3/3 pass
- [x] Rust fmt/check (if changed): N/A
- [x] Tauri fmt/check (if changed): N/A

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: `/skills?tab=X` now redirects to `/connections?tab=X` instead of `/connections`.
- User-visible effect: deep-links and bookmarks with query params are no longer silently broken by the redirect.

### Parity Contract

- Legacy behavior preserved: redirect still uses `replace` (no extra history entry); the target `/connections` is unchanged.
- Guard/fallback/dispatch parity checks: N/A.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A
- Canonical PR: this PR
- Resolution: N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the legacy Skills route to redirect to Connections while preserving query parameters and URL hash fragments.
  * Ensured redirects without query parameters produce a clean destination URL.

* **Tests**
  * Added coverage for legacy route redirection, including query parameters, hash fragments, and destination URL handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->