### PR TITLE
fix(chat): remove doubled gap under assistant messages

### DIFF
--- a/app/src/components/assistant-ui/thread.actionBarSpacing.test.tsx
+++ b/app/src/components/assistant-ui/thread.actionBarSpacing.test.tsx
@@ -1,0 +1,81 @@
+import {
+  AssistantRuntimeProvider,
+  type ThreadMessageLike,
+  useExternalStoreRuntime,
+} from '@assistant-ui/react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Thread } from './thread';
+
+/**
+ * The assistant action bar reserves its own height (`min-h-*`) so that a bar
+ * revealed on hover does not shift the transcript, and immediately cancels that
+ * reservation with a matching negative bottom margin (`-mb-*`) so it costs
+ * nothing in flow — inter-message spacing stays whatever the message group's
+ * `gap-y-*` says.
+ *
+ * The pair is only self-cancelling while both halves sit on the same element.
+ * They were separated once: the `-mb` drifted onto the message root, where it
+ * merely cancelled that element's own paint-box `pb`, leaving the footer's
+ * reservation uncompensated and adding a dead 30px band under every assistant
+ * turn — a doubled gap between consecutive replies.
+ *
+ * jsdom does no layout, so the class pair is the only observable for this, and
+ * it is asserted as an invariant (reserved === compensated) rather than as a
+ * literal value: retuning the bar's height stays free, decoupling the halves
+ * does not.
+ */
+
+const messages: ThreadMessageLike[] = [
+  { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+  { role: 'assistant', content: [{ type: 'text', text: 'first reply' }] },
+  { role: 'assistant', content: [{ type: 'text', text: 'second reply' }] },
+];
+
+function Harness() {
+  const runtime = useExternalStoreRuntime({
+    messages,
+    isRunning: false,
+    convertMessage: (m: ThreadMessageLike) => m,
+    onNew: async () => {},
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  );
+}
+
+/** The `n` in `min-h-<n>` / `-mb-<n>`, or `null` when the utility is absent. */
+function spacingStep(classNames: string, prefix: string): string | null {
+  const match = classNames
+    .split(/\s+/)
+    .find(cls => cls.startsWith(`${prefix}-`))
+    ?.slice(prefix.length + 1);
+  return match ?? null;
+}
+
+describe('assistant message action bar spacing', () => {
+  it('cancels its reserved height on the same element that reserves it', () => {
+    render(<Harness />);
+
+    const footers = screen.getAllByTestId('agent-message').map(root => {
+      const footer = root.querySelector('[data-slot="aui_assistant-message-footer"]');
+      expect(footer).not.toBeNull();
+      return footer as HTMLElement;
+    });
+
+    expect(footers.length).toBeGreaterThan(0);
+
+    for (const footer of footers) {
+      const reserved = spacingStep(footer.className, 'min-h');
+      const compensated = spacingStep(footer.className, '-mb');
+
+      // Reserving height without compensating it on the same element is the
+      // regression this test exists for.
+      expect(reserved).not.toBeNull();
+      expect(compensated).toBe(reserved);
+    }
+  });
+});

--- a/app/src/components/assistant-ui/thread.actionBarSpacing.test.tsx
+++ b/app/src/components/assistant-ui/thread.actionBarSpacing.test.tsx
@@ -9,22 +9,26 @@ import { describe, expect, it } from 'vitest';
 import { Thread } from './thread';
 
 /**
- * The assistant action bar reserves its own height (`min-h-*`) so that a bar
- * revealed on hover does not shift the transcript, and immediately cancels that
- * reservation with a matching negative bottom margin (`-mb-*`) so it costs
- * nothing in flow — inter-message spacing stays whatever the message group's
- * `gap-y-*` says.
+ * The assistant action bar reserves its own height (`min-h-*`) so a bar revealed
+ * on hover does not shift the transcript, then hands most of that reservation
+ * back with a negative bottom margin (`-mb-*`) so it is drawn *inside* the gap
+ * the message group already provides rather than stacking on top of it.
  *
- * The pair is only self-cancelling while both halves sit on the same element.
- * They were separated once: the `-mb` drifted onto the message root, where it
- * merely cancelled that element's own paint-box `pb`, leaving the footer's
- * reservation uncompensated and adding a dead 30px band under every assistant
- * turn — a doubled gap between consecutive replies.
+ * The amount handed back has to be exactly the message group's `gap-y-*`, and
+ * both failure directions have shipped or been caught in review:
  *
- * jsdom does no layout, so the class pair is the only observable for this, and
- * it is asserted as an invariant (reserved === compensated) rather than as a
- * literal value: retuning the bar's height stays free, decoupling the halves
- * does not.
+ * - Give back nothing (the `-mb` had drifted onto the message root, where it
+ *   only cancelled that element's own paint-box `pb`) and the full reservation
+ *   becomes dead space: a 30px band under every assistant turn, on top of the
+ *   gap — consecutive replies ~54px apart instead of 30px.
+ * - Give back the whole reservation and the bar is pulled deeper than the gap
+ *   is tall, so its tail paints over the following message's first line, at the
+ *   same left inset (`ms-2` on the bar, `px-2` on the content).
+ *
+ * jsdom performs no layout, so the utilities are the only observable here. They
+ * are read as an invariant relating two elements — pulled === available gap —
+ * rather than asserted as literals, so retuning either stays free while
+ * breaking their correspondence does not.
  */
 
 const messages: ThreadMessageLike[] = [
@@ -47,35 +51,48 @@ function Harness() {
   );
 }
 
-/** The `n` in `min-h-<n>` / `-mb-<n>`, or `null` when the utility is absent. */
-function spacingStep(classNames: string, prefix: string): string | null {
-  const match = classNames
-    .split(/\s+/)
-    .find(cls => cls.startsWith(`${prefix}-`))
-    ?.slice(prefix.length + 1);
-  return match ?? null;
+/**
+ * The numeric step of a Tailwind spacing utility — the `6` in `gap-y-6`, the
+ * `7.5` in `min-h-7.5` — or `null` when the element does not carry one.
+ */
+function spacingStep(el: HTMLElement, prefix: string): number | null {
+  const token = el.className.split(/\s+/).find(cls => cls.startsWith(`${prefix}-`));
+  if (!token) return null;
+  const step = Number(token.slice(prefix.length + 1));
+  return Number.isFinite(step) ? step : null;
 }
 
 describe('assistant message action bar spacing', () => {
-  it('cancels its reserved height on the same element that reserves it', () => {
-    render(<Harness />);
+  it('draws the action bar inside the inter-message gap, filling it exactly', () => {
+    const { container } = render(<Harness />);
+
+    const group = container.querySelector<HTMLElement>('[data-slot="aui_message-group"]');
+    expect(group).not.toBeNull();
+    const gap = spacingStep(group as HTMLElement, 'gap-y');
+    expect(gap).not.toBeNull();
 
     const footers = screen.getAllByTestId('agent-message').map(root => {
-      const footer = root.querySelector('[data-slot="aui_assistant-message-footer"]');
+      const footer = root.querySelector<HTMLElement>('[data-slot="aui_assistant-message-footer"]');
       expect(footer).not.toBeNull();
       return footer as HTMLElement;
     });
-
     expect(footers.length).toBeGreaterThan(0);
 
     for (const footer of footers) {
-      const reserved = spacingStep(footer.className, 'min-h');
-      const compensated = spacingStep(footer.className, '-mb');
+      const reserved = spacingStep(footer, 'min-h');
+      const pulled = spacingStep(footer, '-mb');
 
-      // Reserving height without compensating it on the same element is the
-      // regression this test exists for.
+      // Reserving the bar's height is what keeps a hover-revealed bar from
+      // shifting the transcript, so the reservation itself must be present.
       expect(reserved).not.toBeNull();
-      expect(compensated).toBe(reserved);
+
+      // Pulling back less than the gap leaves dead space under every turn;
+      // pulling back more paints the bar over the next message's first line.
+      expect(pulled).toBe(gap);
+
+      // The bar is drawn into the gap, so it must not be taller than the space
+      // the pull actually buys it.
+      expect(reserved as number).toBeLessThanOrEqual((pulled as number) + (gap as number));
     }
   });
 });

--- a/app/src/components/assistant-ui/thread.tsx
+++ b/app/src/components/assistant-ui/thread.tsx
@@ -630,19 +630,25 @@ const AssistantMessage: FC = () => {
   } = useContext(ThreadComponentsContext);
 
   const ACTION_BAR_PT = 'pt-1.5';
-  // `min-h` reserves the bar's height so an autohidden bar appearing on hover
-  // does not shift the transcript; the matching `-mb` immediately compensates
-  // it so the reservation costs nothing in flow and message spacing stays the
-  // `gap-y-6` the message group sets. The two MUST stay on the same element —
-  // separating them (the `-mb` had drifted onto the root, where it merely
-  // cancelled that element's own `pb`) leaves the reservation uncompensated and
-  // adds a dead 30px band under every assistant turn.
-  // For `pt-[n]` use `-mb-[n + 6]` and `min-h-[n + 6]` to preserve compensation.
-  const ACTION_BAR_HEIGHT = `-mb-7.5 min-h-7.5 ${ACTION_BAR_PT}`;
+  // `min-h` reserves the bar's height (`pt-1.5` + a `size-6` button = 7.5) so a
+  // bar revealed on hover does not shift the transcript, and `-mb` gives that
+  // reservation back to the flow so it does not stack on top of the spacing the
+  // message group already provides. Both MUST sit on this one element: the `-mb`
+  // had drifted onto the root, where it only cancelled that element's own `pb`,
+  // leaving the reservation uncompensated — a dead 30px band under every turn.
+  //
+  // The `-mb` step is `gap-y-6` from the message group, NOT the full `min-h`.
+  // The bar is pulled into the inter-message gap and must stay inside it: give
+  // back more than the gap and the bar's tail paints over the next message's
+  // first line, which sits at the same left inset (`ms-2` here, `px-2` there).
+  // So the bar occupies the gap exactly and the turns end up 7.5 apart.
+  // Keep this in step with `aui_message-group`'s `gap-y-*`; the pairing is
+  // asserted in `thread.actionBarSpacing.test.tsx`.
+  const ACTION_BAR_HEIGHT = `-mb-6 min-h-7.5 ${ACTION_BAR_PT}`;
   // The root's own `-mb-7.5 pb-7.5` pair below is PAINT-ONLY and unrelated to
-  // that compensation: `content-visibility:auto` implies `contain: paint`, so
-  // `pb` widens the paint box to cover the bar the footer's `-mb` pulls past
-  // the content box, and the root's `-mb` cancels that padding in flow.
+  // the above: `content-visibility:auto` implies `contain: paint`, so `pb`
+  // widens the paint box to cover the bar that `-mb` pulls past the content
+  // box, and the root's `-mb` cancels that padding again in flow.
 
   return (
     <MessagePrimitive.Root

--- a/app/src/components/assistant-ui/thread.tsx
+++ b/app/src/components/assistant-ui/thread.tsx
@@ -630,8 +630,19 @@ const AssistantMessage: FC = () => {
   } = useContext(ThreadComponentsContext);
 
   const ACTION_BAR_PT = 'pt-1.5';
-  // Keep the action bar inside the contained root's paint box, then cancel its reserved space in flow.
-  const ACTION_BAR_HEIGHT = `min-h-7.5 ${ACTION_BAR_PT}`;
+  // `min-h` reserves the bar's height so an autohidden bar appearing on hover
+  // does not shift the transcript; the matching `-mb` immediately compensates
+  // it so the reservation costs nothing in flow and message spacing stays the
+  // `gap-y-6` the message group sets. The two MUST stay on the same element —
+  // separating them (the `-mb` had drifted onto the root, where it merely
+  // cancelled that element's own `pb`) leaves the reservation uncompensated and
+  // adds a dead 30px band under every assistant turn.
+  // For `pt-[n]` use `-mb-[n + 6]` and `min-h-[n + 6]` to preserve compensation.
+  const ACTION_BAR_HEIGHT = `-mb-7.5 min-h-7.5 ${ACTION_BAR_PT}`;
+  // The root's own `-mb-7.5 pb-7.5` pair below is PAINT-ONLY and unrelated to
+  // that compensation: `content-visibility:auto` implies `contain: paint`, so
+  // `pb` widens the paint box to cover the bar the footer's `-mb` pulls past
+  // the content box, and the root's `-mb` cancels that padding in flow.
 
   return (
     <MessagePrimitive.Root


### PR DESCRIPTION
## Summary

- Consecutive assistant messages in chat sat ~54px apart, because the action bar's height reservation lost the negative margin that hands it back to the flow.
- Restores that `-mb` onto the footer that carries `min-h-7.5`, sized to the message group's gap so the bar is drawn *inside* the gap instead of stacking on top of it. Assistant turns go from ~54px apart to 30px.
- Adds a regression test pinning the relationship (amount pulled back === the group's `gap-y-*`), which fails in both directions.
- No change to the action bar's own appearance, and none to user-message spacing.

## Problem

`AssistantMessage` reserves the action bar's height with `min-h-7.5` so a bar revealed on hover does not shift the transcript. That reservation is meant to be cancelled immediately by a matching `-mb-7.5` on the same element, so it costs nothing in flow — the pattern is still intact in `pages/dev/assistant-ui-demo/BaseDemo.tsx:599`, comment included:

```
// reserves space for action bar and compensates with `-mb` for consistent msg spacing
const ACTION_BAR_HEIGHT = `-mb-7.5 min-h-7.5 ${ACTION_BAR_PT}`;
```

In `thread.tsx` the two halves had drifted apart. `-mb-7.5` ended up on the message root, paired with a `pb-7.5` added so `content-visibility: auto` (which implies `contain: paint`) would not clip the bar. On the root those two simply cancel each other and reclaim nothing, leaving the footer's `min-h-7.5` uncompensated:

| | Reserved | Compensated | Net flow cost |
| --- | --- | --- | --- |
| `BaseDemo.tsx` footer | `min-h-7.5` | `-mb-7.5` | 0px |
| `thread.tsx` footer (before) | `min-h-7.5` | — | **30px** |
| `thread.tsx` root | `pb-7.5` | `-mb-7.5` | 0px (paint-only) |

Result: 30px of dead space under every assistant turn, stacked on the message group's `gap-y-6` (24px) — so ~54px between consecutive replies, and the same band between a reply and a following tool group.

## Solution

Put the compensation back on the element that reserves the height, sized to the gap it is being pulled into:

```diff
-const ACTION_BAR_HEIGHT = `min-h-7.5 ${ACTION_BAR_PT}`;
+const ACTION_BAR_HEIGHT = `-mb-6 min-h-7.5 ${ACTION_BAR_PT}`;
```

Assistant turns now sit **30px** apart, down from ~54px.

**Why `-mb-6` and not the full `-mb-7.5`.** Full compensation is what upstream prescribes (`BaseDemo.tsx:599`, "for `pt-[n]` use `-mb-[n + 6]`"), and it was the first form of this fix — Codex caught it in review. The bar is `pt-1.5` plus a `size-6` button, so it is exactly 30px, while `gap-y-6` makes the gap only 24px. Pulling back all 30px drags the bar 6px deeper than the gap is tall, and the bar (`ms-2`) and the next message's content (`px-2`) share an 8px left inset — so the tail lands on the following reply's first line rather than beside it. Handing back the gap instead makes the bar fill it exactly:

| `-mb` step | Flow cost | Turn spacing | Bar vs. gap |
| --- | --- | --- | --- |
| absent (before) | 30px | ~54px | fits, but 30px is wasted below it |
| `-mb-7.5` (full) | 0px | 24px | 6px overflow onto the next message |
| `-mb-6` (this PR) | 6px | 30px | fills the gap exactly |

Notes on what deliberately did **not** change:

- **The root's `-mb-7.5 pb-7.5` stays.** It is paint-only and is load-bearing again: with the footer's `-mb` restored the bar paints past the root's content box, and `contain: paint` would clip it without that padding. Both pairs are now commented so a future reader does not conflate the paint allowance with the spacing compensation.
- **`gap-y-6` is untouched.** It also governs user↔assistant spacing, so retuning it is a separate design call rather than part of this fix.
- **The bar still reserves its height,** so a hover-revealed bar does not shift the transcript. This restores the intended behaviour rather than trading it away.

The test reads the `-mb-*` step off the footer and the `gap-y-*` step off `aui_message-group` and asserts they match, so it pins the relationship rather than either literal — retuning either stays free, breaking their correspondence does not. Verified non-vacuous in both directions before landing: no `-mb` fails with `expected null to be 6`, and `-mb-7.5` fails with `expected 7.5 to be 6`.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `thread.actionBarSpacing.test.tsx`, covering both failure directions (no compensation → dead band; over-compensation → overlap), each confirmed failing before landing. jsdom performs no layout, so the utilities are the only observable; they are read as a relationship between two elements rather than asserted as class-string literals.
- [x] **Diff coverage ≥ 80%** — the one changed executable line (the `ACTION_BAR_HEIGHT` assignment) is hit by the new test; `thread.tsx` went from 0% to ~67% statements. The rest of the diff is comments.
- [x] Coverage matrix updated — `N/A: behaviour-only change`, no feature row added, removed or renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix feature IDs affected`.
- [x] No new external network dependencies introduced — none added; the test renders against an in-memory `useExternalStoreRuntime`.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: CSS-only spacing fix, no release-cut surface changed`.
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue; reported directly`.

## Impact

- **Platform**: desktop chat UI only. No core, RPC, or Tauri change.
- **Visual**: consecutive assistant messages tighten from ~54px to 30px, with the action bar sitting flush in the gap. User-message spacing is unchanged.
- **Performance / security / migration**: none.

## Related

- Closes: N/A — no tracking issue; reported directly.
- Follow-up PR(s)/TODOs: `gap-y-6` at `thread.tsx:248` is the remaining knob if 30px still reads loose — note it now sets both the turn spacing and the space the action bar is drawn into, and it also moves user↔assistant spacing, so it is left as a separate design call. `BaseDemo.tsx:599` still carries the fully-compensated form and the same latent overlap; left alone as it is a dev-only demo page.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/assistant-message-action-bar-spacing`
- Commit SHA: 4dae492d7 (review fix) on 884d66db3

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — prettier clean on both touched files; eslint clean.
- [x] `pnpm typecheck`
- [x] Focused tests: `vitest run src/components/assistant-ui/ src/features/conversations/components/` — 27 files, 248 tests passed.
- [x] Rust fmt/check (if changed): N/A — no Rust changed.
- [x] Tauri fmt/check (if changed): N/A — no Tauri changed.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: the assistant action bar's height reservation is drawn into the existing inter-message gap instead of stacking on top of it.
- User-visible effect: the gap between consecutive assistant messages drops from ~54px to 30px.

### Parity Contract

- Legacy behavior preserved: the bar still reserves its height, so a hover-revealed bar does not shift the transcript; the root's paint-box padding still prevents `contain: paint` from clipping it; the bar stays clear of neighbouring messages.
- Guard/fallback/dispatch parity checks: N/A — no guards, fallbacks or dispatch involved.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary blank space beneath assistant messages when action controls are displayed.
  * Improved spacing and visual alignment between assistant responses.
  * Ensured action bar spacing integrates cleanly with the surrounding message layout.

* **Tests**
  * Added automated coverage to verify consistent footer spacing and action bar alignment across assistant messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->