### PR TITLE
fix(ci): the domain e2e coverage gate was measuring a seventh of the surface

### DIFF
--- a/scripts/check-domain-e2e-coverage.mjs
+++ b/scripts/check-domain-e2e-coverage.mjs
@@ -29,6 +29,21 @@ if (!Number.isFinite(THRESHOLD) || THRESHOLD < 0 || THRESHOLD > 100) {
   process.exit(2);
 }
 
+// Curated labels for namespaces that read better grouped, plus the namespaces
+// this gate was originally written to watch. This list is now PRESENTATIONAL
+// and a safety net, not the scope of the check: every namespace discovered in
+// the source is measured whether or not it appears here (see `rows` below).
+//
+// It used to be the scope, and that was the bug. Fifty-odd namespaces —
+// `flows`, `skills`, `skill_runtime`, `webhooks`, `cron`, `subagent`,
+// `mcp_setup`, `workflow_run`, `voice`, `billing`, `team`, … — were never
+// measured at any threshold simply because nobody added a line here, and
+// nothing made that visible. A list you must remember to extend is a list that
+// silently stops covering things.
+//
+// A namespace named here that no longer exists in the source is a hard failure:
+// it means either the namespace was deleted (drop the line) or discovery has
+// stopped seeing it (fix discovery). Both are worth a red lane.
 const MODULES = [
   { label: 'config', namespaces: ['config'] },
   { label: 'credentials', namespaces: ['auth'] },
@@ -49,7 +64,22 @@ const MODULES = [
   { label: 'threads', namespaces: ['threads'] },
 ];
 
-const TARGET_NAMESPACES = new Set(MODULES.flatMap((module) => module.namespaces));
+// Where `ControllerSchema` literals live.
+//
+// `src/openhuman` is the bulk. The second root is not optional: the `channels`
+// namespace's 20 controllers are declared in the vendored TinyChannels *bus*
+// crate as `ChannelControllerSchema` literals, and openhuman's
+// `channels/controllers/schemas.rs` only maps them across with
+// `namespace: schema.namespace` — dynamic fields no static scan can read. With
+// only the first root, `channels` discovers zero controllers and (before the
+// fix below) scored a vacuous 100%.
+//
+// `app/src/services/__tests__/rpcMethods.test.ts` already reaches into the same
+// vendored crate for the same reason.
+const SCHEMA_ROOTS = [
+  path.join(ROOT, 'src', 'openhuman'),
+  path.join(ROOT, 'vendor', 'tinychannels', 'crates', 'tinychannels-bus', 'src', 'controllers'),
+];
 
 function walk(dir, predicate, out = []) {
   if (!fs.existsSync(dir)) return out;
@@ -68,6 +98,27 @@ function read(file) {
   return fs.readFileSync(file, 'utf8');
 }
 
+/**
+ * Every `"openhuman.x_y"` string literal appearing in a `tests/**\/*_e2e.rs`.
+ *
+ * KNOWN LIMITATION, left in place deliberately. This is a text match, so a
+ * method named anywhere in such a file counts as covered — including in a
+ * schema-catalog assertion list that never calls it.
+ *
+ * Two tightenings were measured before deciding to leave it:
+ *
+ *  - Ignoring comments: **zero** methods are credited by a comment alone today
+ *    (390 found with comments, 390 without), so stripping them is a no-op that
+ *    would only add a regex able to mangle a string literal containing `//`.
+ *  - Ignoring bare list entries: not separable by line shape. rustfmt puts a
+ *    long call's method argument on its own line, so an invocation and a list
+ *    element look identical (`"openhuman.flows_create",` is a list entry by
+ *    shape and a real `post_json_rpc` argument at `json_rpc_e2e.rs:11049`).
+ *    Telling them apart needs an AST, which is a different tool than this.
+ *
+ * So: a method credited here is *named* by an e2e target, not provably invoked
+ * by one. Read the percentages with that in mind.
+ */
 function collectInvokedMethods() {
   const methods = new Set();
   const testsDir = path.join(ROOT, 'tests');
@@ -83,24 +134,38 @@ function collectInvokedMethods() {
   return methods;
 }
 
+/**
+ * Every controller declared anywhere under `SCHEMA_ROOTS`, keyed by namespace.
+ *
+ * This reads EVERY `.rs` file under those roots. It used to read only files
+ * whose path matched `/(^|\/)schemas?(\.rs|\/)/`, which stopped working on
+ * 2026-08-30: the `include!` split (#5856/#5857) moved `ControllerSchema`
+ * literals out of `schemas.rs` into `*_part_NN.rs` siblings that the pattern
+ * does not match, and out of `flows/schemas.rs` into `flows_schema_part_*.rs`
+ * entirely. Thirteen files and 180 controllers went invisible in one commit,
+ * with no signal — the gate simply reported a smaller world.
+ *
+ * The path filter bought nothing a content match does not: a file with no
+ * `ControllerSchema` literal contributes nothing either way. Dropping it means
+ * the next refactor that moves a declaration cannot repeat this.
+ */
 function collectSchemaMethods() {
-  const methodsByNamespace = new Map([...TARGET_NAMESPACES].map((namespace) => [namespace, new Set()]));
-  const files = walk(path.join(ROOT, 'src', 'openhuman'), (file) => {
-    const normalized = file.split(path.sep).join('/');
-    return file.endsWith('.rs') && /(^|\/)schemas?(\.rs|\/)/.test(normalized);
-  });
+  const methodsByNamespace = new Map();
 
-  for (const file of files) {
-    const text = read(file);
-    const constNamespace = text.match(/const\s+NAMESPACE:\s*&str\s*=\s*"([a-z_]+)"/)?.[1];
-    for (const match of text.matchAll(/ControllerSchema\s*\{([\s\S]*?)\n\s*\}/g)) {
-      const block = match[1];
-      const namespaceToken = block.match(/namespace:\s*(?:NAMESPACE|"([a-z_]+)")/);
-      const functionName = block.match(/function:\s*"([A-Za-z0-9_]+)"/)?.[1];
-      const namespace = namespaceToken?.[1] ?? (namespaceToken ? constNamespace : undefined);
-      if (!namespace || !functionName || functionName === 'unknown') continue;
-      if (!TARGET_NAMESPACES.has(namespace)) continue;
-      methodsByNamespace.get(namespace).add(`openhuman.${namespace}_${functionName}`);
+  for (const root of SCHEMA_ROOTS) {
+    for (const file of walk(root, (f) => f.endsWith('.rs'))) {
+      const text = read(file);
+      const constNamespace = text.match(/const\s+NAMESPACE:\s*&str\s*=\s*"([a-z_]+)"/)?.[1];
+      // `ChannelControllerSchema` is the vendored bus crate's equivalent shape.
+      for (const match of text.matchAll(/(?:Channel)?ControllerSchema\s*\{([\s\S]*?)\n\s*\}/g)) {
+        const block = match[1];
+        const namespaceToken = block.match(/namespace:\s*(?:NAMESPACE|"([a-z_]+)")/);
+        const functionName = block.match(/function:\s*"([A-Za-z0-9_]+)"/)?.[1];
+        const namespace = namespaceToken?.[1] ?? (namespaceToken ? constNamespace : undefined);
+        if (!namespace || !functionName || functionName === 'unknown') continue;
+        if (!methodsByNamespace.has(namespace)) methodsByNamespace.set(namespace, new Set());
+        methodsByNamespace.get(namespace).add(`openhuman.${namespace}_${functionName}`);
+      }
     }
   }
 
@@ -109,37 +174,83 @@ function collectSchemaMethods() {
 
 const invoked = collectInvokedMethods();
 const schemas = collectSchemaMethods();
+
+const labelForNamespace = new Map();
+for (const module of MODULES) {
+  for (const namespace of module.namespaces) labelForNamespace.set(namespace, module.label);
+}
+
+// A MODULES entry naming a namespace discovery cannot find. Either the
+// namespace is gone (delete the line) or discovery broke (fix it). Reporting
+// this as 0/0 = 100% is exactly the bug this gate had.
+const declaredButMissing = [...labelForNamespace.keys()]
+  .filter((namespace) => !schemas.has(namespace))
+  .sort();
+
+// One row per namespace that actually exists, grouped where MODULES says so.
+const rows = new Map();
+for (const [namespace, methods] of schemas) {
+  const label = labelForNamespace.get(namespace) ?? namespace;
+  if (!rows.has(label)) rows.set(label, { label, namespaces: [], expected: new Set() });
+  const row = rows.get(label);
+  row.namespaces.push(namespace);
+  for (const method of methods) row.expected.add(method);
+}
+
 let failed = false;
+const below = [];
 
 console.log(`Domain Rust E2E controller coverage threshold: ${THRESHOLD}%`);
 console.log('');
 console.log('| Module | Namespace(s) | Covered | Percent | Missing |');
 console.log('| --- | --- | ---: | ---: | --- |');
 
-for (const module of MODULES) {
-  const expected = new Set();
-  const covered = new Set();
-  for (const namespace of module.namespaces) {
-    for (const method of schemas.get(namespace) ?? []) expected.add(method);
-  }
-  for (const method of expected) {
-    if (invoked.has(method)) covered.add(method);
-  }
+for (const row of [...rows.values()].sort((a, b) => a.label.localeCompare(b.label))) {
+  const covered = new Set([...row.expected].filter((method) => invoked.has(method)));
+  const missing = [...row.expected].filter((method) => !covered.has(method)).sort();
 
-  const missing = [...expected].filter((method) => !covered.has(method)).sort();
-  const percent = expected.size === 0 ? 100 : (covered.size / expected.size) * 100;
+  // `expected.size === 0` used to score 100%. It cannot happen here — a row
+  // only exists because discovery found at least one controller for it — and
+  // the case it used to hide is now `declaredButMissing` above.
+  const percent = (covered.size / row.expected.size) * 100;
   const missingText = missing.length === 0 ? '-' : missing.join('<br>');
 
   console.log(
-    `| ${module.label} | ${module.namespaces.join(', ')} | ${covered.size}/${expected.size} | ${percent.toFixed(1)}% | ${missingText} |`,
+    `| ${row.label} | ${row.namespaces.sort().join(', ')} | ${covered.size}/${row.expected.size} | ${percent.toFixed(1)}% | ${missingText} |`,
   );
 
-  if (expected.size > 0 && percent < THRESHOLD) failed = true;
+  if (percent < THRESHOLD) {
+    failed = true;
+    below.push(`${row.label} (${covered.size}/${row.expected.size}, ${percent.toFixed(1)}%)`);
+  }
+}
+
+const totalExpected = [...rows.values()].reduce((sum, row) => sum + row.expected.size, 0);
+const totalCovered = [...rows.values()].reduce(
+  (sum, row) => sum + [...row.expected].filter((method) => invoked.has(method)).length,
+  0,
+);
+console.log('');
+console.log(
+  `Discovered ${totalExpected} controllers across ${rows.size} namespaces; ${totalCovered} invoked by a tests/**/*_e2e.rs target.`,
+);
+
+if (declaredButMissing.length > 0) {
+  failed = true;
+  console.error(
+    `\nMODULES names ${declaredButMissing.length} namespace(s) with no discovered controllers: ${declaredButMissing.join(', ')}.` +
+      '\nEither the namespace was removed (drop it from MODULES) or schema discovery has stopped seeing it (fix SCHEMA_ROOTS / the match).' +
+      '\nThis is NOT a coverage result — nothing was measured.',
+  );
 }
 
 if (failed) {
-  console.error(`\nDomain Rust E2E controller coverage is below ${THRESHOLD}% for one or more modules.`);
+  if (below.length > 0) {
+    console.error(
+      `\nDomain Rust E2E controller coverage is below ${THRESHOLD}% for ${below.length} module(s):\n  ${below.join('\n  ')}`,
+    );
+  }
   process.exit(1);
 }
 
-console.log(`\nAll named modules meet the ${THRESHOLD}% Rust E2E controller coverage threshold.`);
+console.log(`\nAll ${rows.size} namespaces meet the ${THRESHOLD}% Rust E2E controller coverage threshold.`);


### PR DESCRIPTION
## Summary

- Fixes three independent defects in `scripts/check-domain-e2e-coverage.mjs`, the gate that guards Rust e2e controller coverage.
- The gate was measuring roughly a seventh of the surface and reporting the rest as clean.
- 1 file. No product code touched.

## Problem

Three separate holes, each of which alone makes the gate unreliable:

**(a) It cannot see most controllers.** `collectSchemaMethods()` only reads files matching `/(^|\/)schemas?(\.rs|\/)/`. The #5856/#5857 `include!` split moved `ControllerSchema` literals into `*_part_NN.rs` siblings that do not match, hiding **180 controllers across 12 namespaces**.

**(b) Measuring nothing scores 100%.** `percent = expected.size === 0 ? 100 : …` means a namespace whose controllers all became invisible reports **100%** — indistinguishable in the gate's own output from genuinely full coverage. Four namespaces were doing exactly that: `composio` 0/23, `threads` 0/20, `memory_sources` 0/17, `tools` 0/6.

**(c) `MODULES` omits most of the product.** ~50 namespaces are not listed at all, so they are never measured at any threshold — `webhooks` 0/13, `skill_runtime` 0/6, `subagent` 0/2, `mcp_setup` 0/6, `voice` 2/17, `flows` 19/36.

## Solution

Discovery over the same roots the gate already means to cover, an explicit failure when a namespace discovers zero controllers, and a `MODULES` extension.

**The honest post-fix numbers are much worse than the pre-fix ones, and that is the point:** **359/625 controllers = 57.4% across 83 namespaces** (up from 17 namespaces visible). 62 namespaces fall below the unchanged 90% threshold, **39 of them at exactly 0%**.

**The threshold is untouched and no ratchet was added.** Making the gate green today is the failure mode being removed. It should stay red and honest until the coverage is real — how to stage that is a maintainer decision, and the repo's own precedent (`scripts/kernel-floor.limits`, "only goes DOWN") is the obvious tool if one is wanted.

Also measured and deliberately **not** changed: comment-only credit is a provable no-op today (390 methods found with comments, 390 without), and separating bare-list-entry credit from real invocations needs an AST — rustfmt puts a long call's method argument on its own line, so `"openhuman.flows_create",` is indistinguishable from a list element by regex.

## Submission Checklist

- [x] Tests added or updated — `N/A: this changes a CI script`, not product code; its behaviour is verified by the measured before/after controller counts in the Problem section.
- [x] **Diff coverage ≥ 80%** — `N/A: CI script`, not covered by the product coverage lanes.
- [x] Coverage matrix updated — `N/A: behaviour-only change`, no feature rows affected.
- [x] All affected feature IDs listed — `N/A: no feature IDs affected`.
- [x] No new external network dependencies introduced — none; the script reads the repo only.
- [x] Manual smoke checklist updated — `N/A: no product surface changes`.
- [x] Linked issue closed via `Closes #NNN` — `N/A: intentionally not auto-closing`; see Related.

## Impact

- **CI:** this gate will report far lower coverage than before. That is a correction, not a regression — the previous numbers were measuring a subset and scoring the invisible remainder as perfect.
- **Risk:** confined to a reporting script. It cannot affect the product.

## Related

- Addresses the defect described in openhuman#5911. Deliberately no closing keyword — the issue also covers the honest-coverage question, which this PR measures but does not resolve.
- Sibling: `fix/rpc-methods-drift-guard` fixes the same blindness in `app/src/services/__tests__/rpcMethods.test.ts`.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/domain-e2e-coverage-gate`
- Commit SHA: see head of this PR

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no app/ files changed.`
- [x] `pnpm typecheck` — `N/A: no TypeScript changed` (the script is `.mjs`).
- [x] Focused tests: the script was run against the repo before and after; the controller counts quoted above are its own output.
- [x] Rust fmt/check (if changed): `N/A: no .rs files changed.`
- [x] Tauri fmt/check (if changed): `N/A: app/src-tauri not touched.`

### Validation Blocked

- `command:` re-running the gate after the most recent rebase
- `error:` not attempted — local CI runs are disabled by standing instruction
- `impact:` the numbers quoted were measured before the rebase onto current main; the script's logic is unchanged since, so they should hold, but CI is the authority.

### Behavior Changes

- Intended behavior change: the gate now measures the whole controller surface and fails a namespace that discovers zero controllers.
- User-visible effect: none. CI reporting only.

### Parity Contract

- Legacy behavior preserved: no, deliberately — the previous behaviour was the defect.
- Guard/fallback/dispatch parity checks: a namespace with zero discovered controllers now fails instead of scoring 100%.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end domain coverage checks to include additional controller sources and Rust files.
  * Added support for multiple controller schema formats.
  * Coverage reporting now includes detailed row-level failures and aggregate totals.
  * Configured namespaces missing from discovery are now reported as distinct failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->