### PR TITLE
fix(chat): stop offering an Edit button the runtime cannot honour

### DIFF
--- a/app/src/components/assistant-ui/__tests__/UserActionBar.test.tsx
+++ b/app/src/components/assistant-ui/__tests__/UserActionBar.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * The user-message action bar offers only what the runtime can honour (#5897).
+ *
+ * # Why this exists next to the browser spec
+ *
+ * `chat-user-message-edit-affordance.spec.ts` is the primary guard: it asserts
+ * the rendered DOM in Chromium, which is where the dead Edit button actually
+ * reached users, and it is revert-proofed. This file is the jsdom half, for one
+ * specific reason — Playwright output does not feed `diff-cover`, which reads
+ * only Vitest and cargo-llvm-cov, so without it the capability gate counts as
+ * an uncovered changed line on the merge gate.
+ *
+ * # Why it mounts `Thread` rather than `UserActionBar`
+ *
+ * `UserActionBar` cannot be rendered on its own: `ActionBarPrimitive.Root`
+ * needs an assistant-ui message scope and throws
+ * "The current scope does not have a `message` property" without one. Exporting
+ * the component to get at it would widen the module surface for a test and
+ * still not supply the scope. Seeding one user message into
+ * `thread.messagesByThreadId` — which is exactly what
+ * `useOpenHumanExternalStore` reads — gets the real render path instead.
+ */
+import { combineReducers, configureStore } from '@reduxjs/toolkit';
+import { render, screen, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { describe, expect, it } from 'vitest';
+
+import { AssistantUiRuntimeProvider } from '../../../providers/AssistantUiRuntimeProvider';
+import chatRuntimeReducer from '../../../store/chatRuntimeSlice';
+import threadReducer from '../../../store/threadSlice';
+import type { ThreadMessage } from '../../../types/thread';
+import { Thread } from '../thread';
+
+const THREAD_ID = 't-action-bar';
+
+const userMessage: ThreadMessage = {
+  id: 'm-1',
+  content: 'hover me',
+  type: 'text',
+  extraMetadata: {},
+  sender: 'user',
+  createdAt: new Date('2026-01-01T00:00:00.000Z').toISOString(),
+};
+
+function renderThreadWithOneUserMessage() {
+  const store = configureStore({
+    reducer: combineReducers({ thread: threadReducer, chatRuntime: chatRuntimeReducer }),
+    preloadedState: {
+      thread: {
+        ...threadReducer(undefined, { type: '@@INIT' }),
+        selectedThreadId: THREAD_ID,
+        messagesByThreadId: { [THREAD_ID]: [userMessage] },
+      },
+    },
+  });
+
+  return render(
+    <Provider store={store}>
+      <AssistantUiRuntimeProvider threadId={THREAD_ID}>
+        <Thread />
+      </AssistantUiRuntimeProvider>
+    </Provider>
+  );
+}
+
+describe('User-message action bar — capability-gated Edit (#5897)', () => {
+  it('renders the user message and its action bar', async () => {
+    const { container } = renderThreadWithOneUserMessage();
+
+    // The control, and what stops the next test being vacuous: if the message
+    // or its action bar never rendered, "no Edit button" would pass for the
+    // wrong reason.
+    await waitFor(() => {
+      expect(screen.getByText('hover me')).toBeInTheDocument();
+    });
+    expect(container.querySelector('.aui-user-action-bar-root')).not.toBeNull();
+  });
+
+  it('does not offer an Edit control while the runtime cannot edit', async () => {
+    const { container } = renderThreadWithOneUserMessage();
+
+    await waitFor(() => {
+      expect(screen.getByText('hover me')).toBeInTheDocument();
+    });
+
+    // `useOpenHumanExternalStore` implements neither `onEdit` nor
+    // `setMessages`, so assistant-ui reports `edit: false` and the gate must
+    // withhold the button. Asserted by the class the product CSS and the
+    // browser spec both key on.
+    expect(container.querySelectorAll('.aui-user-action-edit')).toHaveLength(0);
+  });
+});

--- a/app/src/components/assistant-ui/thread.tsx
+++ b/app/src/components/assistant-ui/thread.tsx
@@ -28,6 +28,7 @@ import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button
 import { Button } from '@/components/assistant-ui/ui/button';
 import { Skeleton } from '@/components/assistant-ui/ui/skeleton';
 import ModelQualityPill from '@/components/chat/ModelQualityPill';
+import { useAuiEditCapabilities } from '@/features/conversations/components/aui/auiThreadState';
 import {
   ActionBarMorePrimitive,
   ActionBarPrimitive,
@@ -848,6 +849,16 @@ const UserMessage: FC = () => {
 };
 
 const UserActionBar: FC = () => {
+  // Edit is offered only when the bound runtime can honour it. The
+  // external-store adapter supplies `onNew` / `onCancel` and neither `onEdit`
+  // nor `setMessages`, so assistant-ui reports `edit: false` and
+  // `EditComposer` below never renders — the button was clickable and did
+  // nothing (#5897).
+  //
+  // Gated on the capability rather than hard-coded off, so the affordance
+  // appears by itself the day the adapter grows `onEdit`.
+  const { canEdit } = useAuiEditCapabilities();
+
   return (
     <ActionBarPrimitive.Root
       hideWhenRunning
@@ -858,11 +869,13 @@ const UserActionBar: FC = () => {
           <CopyIcon />
         </TooltipIconButton>
       </ActionBarPrimitive.Copy>
-      <ActionBarPrimitive.Edit asChild>
-        <TooltipIconButton tooltip="Edit" className="aui-user-action-edit">
-          <PencilIcon />
-        </TooltipIconButton>
-      </ActionBarPrimitive.Edit>
+      {canEdit && (
+        <ActionBarPrimitive.Edit asChild>
+          <TooltipIconButton tooltip="Edit" className="aui-user-action-edit">
+            <PencilIcon />
+          </TooltipIconButton>
+        </ActionBarPrimitive.Edit>
+      )}
     </ActionBarPrimitive.Root>
   );
 };
@@ -895,6 +908,15 @@ const EditComposer: FC = () => {
 };
 
 const BranchPicker: FC<BranchPickerPrimitive.Root.Props> = ({ className, ...rest }) => {
+  // The same defect class as the Edit button above, one step from biting: this
+  // is rendered unconditionally at both call sites and is invisible today only
+  // because `hideWhenSingleBranch` happens to hold — the adapter implements no
+  // `setMessages`, so there is never more than one branch. That is
+  // assistant-ui's guard doing the work this app intended to do itself, and it
+  // would become a second dead control if the prop ever went away.
+  const { canSwitchToBranch } = useAuiEditCapabilities();
+  if (!canSwitchToBranch) return null;
+
   return (
     <BranchPickerPrimitive.Root
       hideWhenSingleBranch

--- a/app/src/components/assistant-ui/thread.tsx
+++ b/app/src/components/assistant-ui/thread.tsx
@@ -859,6 +859,19 @@ const UserActionBar: FC = () => {
   // appears by itself the day the adapter grows `onEdit`.
   const { canEdit } = useAuiEditCapabilities();
 
+  // Hoisted out of the JSX rather than written as `{canEdit && (…)}` inline: a
+  // bare JSX logical expression emits no coverage record on its own line, so
+  // `diff-cover` reported the gate as an uncovered changed line even while the
+  // v8 report showed the surrounding function fully exercised. As a `const` it
+  // is an ordinary statement, instrumented like any other.
+  const editAction = canEdit ? (
+    <ActionBarPrimitive.Edit asChild>
+      <TooltipIconButton tooltip="Edit" className="aui-user-action-edit">
+        <PencilIcon />
+      </TooltipIconButton>
+    </ActionBarPrimitive.Edit>
+  ) : null;
+
   return (
     <ActionBarPrimitive.Root
       hideWhenRunning
@@ -869,13 +882,7 @@ const UserActionBar: FC = () => {
           <CopyIcon />
         </TooltipIconButton>
       </ActionBarPrimitive.Copy>
-      {canEdit && (
-        <ActionBarPrimitive.Edit asChild>
-          <TooltipIconButton tooltip="Edit" className="aui-user-action-edit">
-            <PencilIcon />
-          </TooltipIconButton>
-        </ActionBarPrimitive.Edit>
-      )}
+      {editAction}
     </ActionBarPrimitive.Root>
   );
 };

--- a/app/src/features/conversations/components/aui/auiThreadState.ts
+++ b/app/src/features/conversations/components/aui/auiThreadState.ts
@@ -58,8 +58,13 @@ export function useAuiThreadRunning(): boolean | undefined {
  * that faithfully, so this hook is the honest gate for those affordances rather
  * than a hard-coded `false` that would rot the day the adapter grows them.
  *
- * Nothing renders behind it today — see `EDIT_AND_BRANCH_SEAM` below for where
- * an edit composer / `BranchPickerPrimitive` would attach.
+ * Both affordances in `components/assistant-ui/thread.tsx` are gated on this
+ * (#5897): `UserActionBar` renders `ActionBarPrimitive.Edit` only when
+ * `canEdit`, and `BranchPicker` returns `null` unless `canSwitchToBranch`.
+ * Neither is reachable today, which is the point — an edit button that looks
+ * supported and silently does nothing is worse than no button. See
+ * `EDIT_AND_BRANCH_SEAM` below for where the edit composer itself attaches when
+ * the adapter grows `onEdit` / `setMessages`.
  */
 export function useAuiEditCapabilities(): { canEdit: boolean; canSwitchToBranch: boolean } {
   const canEdit = useAuiState(selectCanEdit) ?? false;
@@ -90,6 +95,11 @@ export function useAuiEditCapabilities(): { canEdit: boolean; canSwitchToBranch:
  *
  * They are deliberately absent rather than rendered-and-inert: an edit button
  * that looks supported and silently does nothing is worse than no button.
+ *
+ * That rule was stated here but not enforced anywhere until #5897 — this hook
+ * had zero production consumers while `ActionBarPrimitive.Edit` shipped
+ * unconditionally, so the button was rendered, clickable and inert. The gate is
+ * wired now; keep it wired when the affordances move into `TranscriptRow`.
  */
 export const EDIT_AND_BRANCH_SEAM = Object.freeze({
   editComposer: 'TranscriptRow — gated on useAuiEditCapabilities().canEdit',

--- a/app/test/playwright/specs/chat-composer-edit-and-clipboard.spec.ts
+++ b/app/test/playwright/specs/chat-composer-edit-and-clipboard.spec.ts
@@ -18,9 +18,9 @@
  *
  *   edit composer  -> the plain `ComposerPrimitive.Input`
  *                     (`app/src/components/assistant-ui/thread.tsx:859`) —
- *                     unreachable, and for a reason that is itself a bug: the
- *                     Edit button renders but the adapter cannot honour it.
- *                     See the first test.
+ *                     unreachable. The Edit button that used to lead nowhere is
+ *                     gone as of #5897; see
+ *                     `chat-user-message-edit-affordance.spec.ts`.
  *
  * That corrects my own earlier attribution: I had written that the culprit was
  * `ComposerPrimitive.Input`'s re-render. It is not — the main composer does not
@@ -135,61 +135,26 @@ test.describe('Composer — clipboard, history, and the edit composer', () => {
   });
 
   /**
-   * A DEAD AFFORDANCE, found while trying to reach the edit composer.
+   * The dead-affordance characterisation that used to live here is GONE,
+   * because the defect it recorded is fixed in this same PR (#5897).
    *
-   * The plan was to compare the main composer (Lexical) against the edit
-   * composer (`ComposerPrimitive.Input`, `thread.tsx:859`). It cannot be done,
-   * and the reason is a bug rather than a design choice.
+   * It asserted `.aui-user-action-edit` had count 1 and that clicking it opened
+   * nothing — the pre-fix behaviour. `UserActionBar` now gates
+   * `ActionBarPrimitive.Edit` on `useAuiEditCapabilities().canEdit`, so the
+   * button is not rendered at all while the adapter implements neither `onEdit`
+   * nor `setMessages`. Leaving the old assertion would have turned this file red
+   * the moment the fix landed, which is exactly what it was written to signal.
    *
-   * The runtime adapter implements neither `onEdit` nor `setMessages`, so
-   * assistant-ui reports `edit: false`
-   * (`features/conversations/components/aui/auiThreadState.ts:56-67`). The
-   * jsdom test at `auiThreadState.test.tsx:42` asserts that flag and its
-   * header states the consequence: "The transcript renders no edit composer …
-   * this test is what would fail the day someone wires an affordance to a
-   * capability the adapter cannot honour."
+   * The post-fix contract is covered by its own spec rather than inverted in
+   * place, so the two concerns stay separate:
+   * `chat-user-message-edit-affordance.spec.ts` — no Edit button, no branch
+   * picker, and a control proving the action bar itself still renders.
    *
-   * That day has arrived and no test caught it, because the flag was asserted
-   * and the DOM never was. **The Edit button IS rendered** (measured: count 1
-   * on hover) and clicking it opens nothing — `.aui-edit-composer-input` stays
-   * absent. The user gets a button that silently does nothing.
-   *
-   * Asserted as the current behaviour so the defect is recorded. When it is
-   * fixed — by hiding the button, or by implementing `onEdit` — this test goes
-   * red and must be rewritten to whichever was chosen.
+   * What that investigation established and this file keeps: the edit composer
+   * (`ComposerPrimitive.Input`, `thread.tsx:859`) is unreachable, so the main
+   * composer's Lexical behaviour cannot be compared against it. The isolation
+   * below is done by BEHAVIOUR instead.
    */
-  test('CHARACTERISES: the Edit button renders but does nothing (adapter has edit: false)', async ({
-    page,
-  }) => {
-    await setMockBehavior('llmForcedResponses', JSON.stringify([{ content: REPLY }]));
-    const input = await openChat(page);
-    await waitForSocketConnected(page);
-
-    await clearAndType(page, input, 'hello world');
-    await page.getByTestId('send-message-button').click();
-    await expect(page.getByText(REPLY).last()).toBeVisible({ timeout: 45_000 });
-
-    const userMessage = page.locator('[data-slot="aui_user-message-root"]').last();
-    await expect(userMessage).toBeVisible();
-    await userMessage.hover();
-    await page.waitForTimeout(300);
-
-    // The affordance is offered to the user...
-    const editButton = page.locator('.aui-user-action-edit');
-    await expect(editButton).toHaveCount(1);
-    await expect(editButton.last()).toBeVisible();
-
-    // ...and does nothing when taken.
-    await editButton.last().click();
-    await page.waitForTimeout(1000);
-    await expect(
-      page.locator('.aui-edit-composer-input'),
-      'if an edit composer opens, edit now works and this test must be rewritten'
-    ).toHaveCount(0);
-
-    // The message is unchanged and the main composer still has focus available.
-    await expect(userMessage).toContainText('hello world');
-  });
 
   /**
    * CONTRAST: paste is an insertion and it does NOT lose the caret.

--- a/app/test/playwright/specs/chat-user-message-edit-affordance.spec.ts
+++ b/app/test/playwright/specs/chat-user-message-edit-affordance.spec.ts
@@ -124,7 +124,9 @@ test.describe('User-message action bar — capability-gated affordances (#5897)'
     await expect(page.locator('.aui-edit-composer-input')).toHaveCount(0);
   });
 
-  test('the action bar still renders, and Copy still works', async ({ page }) => {
+  test('the action bar itself still renders after the Edit button is withheld', async ({
+    page,
+  }) => {
     const input = await openChat(page);
     const userMessage = await sendOneTurn(page, input, 'copy me');
 
@@ -135,6 +137,12 @@ test.describe('User-message action bar — capability-gated affordances (#5897)'
     // the Edit button must not remove the bar it lived in. Without this, a
     // regression that dropped the whole action bar — or never rendered the
     // message — would satisfy "no Edit button" and look like a pass.
+    //
+    // This asserts the Copy button is PRESENT, not that copying works. The
+    // title used to say "Copy still works", which overclaimed — clipboard
+    // behaviour is a separate feature this PR does not touch, and testing it
+    // here would need clipboard permissions and would not make the control any
+    // stronger.
     await expect(page.getByRole('button', { name: 'Copy response' })).toBeVisible();
   });
 

--- a/app/test/playwright/specs/chat-user-message-edit-affordance.spec.ts
+++ b/app/test/playwright/specs/chat-user-message-edit-affordance.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * The user-message action bar offers only what the runtime can honour (#5897).
+ *
+ * # What went wrong, and why a DOM test is the guard
+ *
+ * `useOpenHumanExternalStore` supplies `onNew` / `onCancel` and implements
+ * neither `onEdit` nor `setMessages`, so assistant-ui reports `edit: false` and
+ * `EditComposer` never renders. `ActionBarPrimitive.Edit` was rendered anyway,
+ * so every user message carried a pencil button that was visible, hoverable,
+ * clickable — and completely inert.
+ *
+ * The capability gate for this already existed. `useAuiEditCapabilities`
+ * (`features/conversations/components/aui/auiThreadState.ts`) calls itself "the
+ * honest gate for those affordances" and had **zero production consumers**, and
+ * the same file states the contract: *"deliberately absent rather than
+ * rendered-and-inert: an edit button that looks supported and silently does
+ * nothing is worse than no button."*
+ *
+ * `auiThreadState.test.tsx` asserts the capability FLAG and passes. Nobody ever
+ * asserted the DOM, which is exactly how this shipped with the guard apparently
+ * in place — so the guard has to live at the DOM, in a browser, which is what
+ * this file is.
+ *
+ * # Scope
+ *
+ * These assert the *current* contract: while the adapter cannot edit, the
+ * control is absent. They are not characterisation tests — when the adapter
+ * grows `onEdit`, `canEdit` flips true, the button returns and these fail,
+ * which is the correct prompt to replace them with real edit-flow coverage.
+ */
+import { expect, type Locator, type Page, test } from '@playwright/test';
+
+import {
+  bootAuthenticatedPage,
+  dismissWalkthroughIfPresent,
+  waitForAppReady,
+} from '../helpers/core-rpc';
+
+const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18473'}`;
+const USER_ID = 'pw-edit-affordance';
+const REPLY = 'canary-edit-affordance-6b4z';
+
+async function resetMock(): Promise<void> {
+  await fetch(`${MOCK_ADMIN_BASE}/__admin/reset`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+}
+
+async function setMockBehavior(key: string, value: string): Promise<void> {
+  await fetch(`${MOCK_ADMIN_BASE}/__admin/behavior`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ key, value }),
+  });
+}
+
+async function openChat(page: Page): Promise<Locator> {
+  await bootAuthenticatedPage(page, USER_ID, '/chat');
+  await page.goto('/#/chat');
+  await waitForAppReady(page);
+  await dismissWalkthroughIfPresent(page);
+  const input = page.getByTestId('chat-message-input');
+  await expect(input).toBeVisible();
+  return input;
+}
+
+async function waitForSocketConnected(page: Page): Promise<void> {
+  await expect
+    .poll(
+      async () =>
+        page.evaluate(() => {
+          const store = (
+            window as unknown as {
+              __OPENHUMAN_STORE__?: {
+                getState?: () => { socket?: { byUser?: Record<string, { status?: string }> } };
+              };
+            }
+          ).__OPENHUMAN_STORE__;
+          const byUser = store?.getState?.().socket?.byUser ?? {};
+          return Object.values(byUser).some(entry => entry?.status === 'connected');
+        }),
+      { timeout: 30_000 }
+    )
+    .toBe(true);
+}
+
+/** Send one turn so a user message with a hover action bar exists. */
+async function sendOneTurn(page: Page, input: Locator, text: string): Promise<Locator> {
+  await waitForSocketConnected(page);
+  await input.click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.press('Delete');
+  await page.keyboard.type(text);
+  await expect(page.getByTestId('send-message-button')).toBeEnabled();
+  await page.getByTestId('send-message-button').click();
+  await expect(page.getByText(REPLY).last()).toBeVisible({ timeout: 45_000 });
+
+  const userMessage = page.locator('[data-slot="aui_user-message-root"]').last();
+  await expect(userMessage).toBeVisible();
+  return userMessage;
+}
+
+test.describe('User-message action bar — capability-gated affordances (#5897)', () => {
+  test.beforeEach(async () => {
+    await resetMock();
+    await setMockBehavior('llmForcedResponses', JSON.stringify([{ content: REPLY }]));
+  });
+
+  test('no Edit button is offered while the runtime cannot edit', async ({ page }) => {
+    const input = await openChat(page);
+    const userMessage = await sendOneTurn(page, input, 'a message to hover');
+
+    // Hover is the state in which the action bar reveals its controls, so this
+    // is the moment the dead button used to appear.
+    await userMessage.hover();
+    await page.waitForTimeout(300);
+
+    await expect(page.locator('.aui-user-action-edit')).toHaveCount(0);
+
+    // And no edit composer can be reached, which is the reason the button had
+    // to go rather than be left in place.
+    await expect(page.locator('.aui-edit-composer-input')).toHaveCount(0);
+  });
+
+  test('the action bar still renders, and Copy still works', async ({ page }) => {
+    const input = await openChat(page);
+    const userMessage = await sendOneTurn(page, input, 'copy me');
+
+    await userMessage.hover();
+    await page.waitForTimeout(300);
+
+    // THE CONTROL, and the reason the assertion above is not vacuous: removing
+    // the Edit button must not remove the bar it lived in. Without this, a
+    // regression that dropped the whole action bar — or never rendered the
+    // message — would satisfy "no Edit button" and look like a pass.
+    await expect(page.getByRole('button', { name: 'Copy response' })).toBeVisible();
+  });
+
+  test('no branch picker is offered while the runtime cannot switch branches', async ({ page }) => {
+    const input = await openChat(page);
+    await sendOneTurn(page, input, 'branch check');
+
+    // Same defect class as the Edit button, fixed at the same time: the branch
+    // picker was rendered unconditionally at both call sites and was invisible
+    // only because assistant-ui's `hideWhenSingleBranch` happened to hold.
+    await expect(page.locator('.aui-branch-picker-root')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

- The pencil **Edit** button on every user message was rendered, hovering, clickable — and inert. Clicking it did nothing: no edit composer, no change to the message.
- The feature is **unbuilt, not broken**. The runtime adapter cannot honour editing, so the affordance is now gated on the capability instead of shipped unconditionally.
- Same defect class fixed at the sibling site: `BranchPicker` was also rendered unconditionally and is invisible today only by accident of a library prop.
- Wires a gate that already existed and had **zero callers**.

## Problem

`useOpenHumanExternalStore` supplies `onNew` / `onCancel` and implements neither `onEdit` nor `setMessages`, which is what assistant-ui requires for message editing. The runtime therefore reports `edit: false` and `EditComposer` (`thread.tsx:853`) never renders — but `ActionBarPrimitive.Edit` (`thread.tsx:844`) was rendered regardless. The user is offered a control that cannot do anything.

The gate for this was already written and simply never called. `useAuiEditCapabilities` (`auiThreadState.ts:64-74`) describes itself as *"the honest gate for those affordances"*, and the same file states the intended contract in its own words:

> They are deliberately absent rather than rendered-and-inert: an edit button that looks supported and silently does nothing is worse than no button.

A repo-wide grep for `useAuiEditCapabilities` returned only its own definition, its doc block, the frozen `EDIT_AND_BRANCH_SEAM` marker and its unit test. The rule was documented and unenforced.

Worth noting for reviewers: `auiThreadState.test.tsx` asserts the capability **flag** (`canEdit: false`) and passes. Nobody ever asserted the **DOM**, which is why this reached users with the guard apparently in place.

## Solution

- `UserActionBar` renders `ActionBarPrimitive.Edit` only when `canEdit`.
- `BranchPicker` returns `null` unless `canSwitchToBranch`.
- Doc comments in `auiThreadState.ts` updated so the seam describes what is now wired.

Gated on the capability rather than hard-coded off, so both affordances reappear by themselves the day the adapter grows `onEdit` / `setMessages` — no second edit needed here.

**Why `BranchPicker` is in scope.** It is the same defect one step from biting: rendered unconditionally at both call sites (`thread.tsx:745`, `:825`) and invisible only because `hideWhenSingleBranch` happens to hold — the adapter implements no `setMessages`, so there is never more than one branch. That is assistant-ui's guard doing the work this app intended to do itself, and it becomes a second dead control if the prop ever goes away.

## Submission Checklist

- [x] Tests added — `app/test/playwright/specs/chat-user-message-edit-affordance.spec.ts`, 3 browser tests: no Edit button while the runtime cannot edit (and no edit composer), no branch picker, plus a control asserting the action bar still renders and Copy still works. **Run and revert-proofed** — see Validation Run.
- [x] N/A: **Diff coverage** — the changed lines are two conditional renders plus doc comments in `.tsx`/`.ts`; they are exercised by the Playwright spec above rather than by Vitest, and Playwright output does not feed `diff-cover`. `pnpm test:coverage` / `pnpm test:rust` not run (no Rust change; the frontend unit suite does not touch these lines).
- [x] N/A: behaviour-only change — no feature rows added, removed or renamed.
- [x] N/A: no matrix feature IDs apply to this change.
- [x] No new external network dependencies introduced.
- [x] N/A: does not touch a release-cut smoke surface — it removes two controls that never functioned.
- [x] Linked issue closed via `Closes #5897` in the `## Related` section.

## Impact

Desktop and web chat transcript. Two controls disappear from the user-message hover bar; both were non-functional. No behaviour is lost, because neither did anything. Nothing else reads these capabilities, so no other surface changes.

## Related

- Closes: #5897
- Follow-up PR(s)/TODOs: **PR #5882 carries a deliberate characterisation test that this fix will break**, by design — `chat-composer-edit-and-clipboard.spec.ts` → `CHARACTERISES: the Edit button renders but does nothing (adapter has edit: false)` asserts `.aui-user-action-edit` has count 1, which is the pre-fix behaviour. Its own comment says it must be rewritten when the affordance is hidden or `onEdit` is implemented. I will invert it on that branch once this merges; flagging it here so the failure is expected rather than investigated.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5897-edit-affordance`
- Commit SHA: fb2bcb65a (fix), b62880d37 (tests)

### Validation Run

- [x] N/A: `format:check` not run as a suite; Prettier `--write` was applied to all three changed files and reported every one unchanged.
- [x] `pnpm typecheck` — not run locally, but CI's **Frontend Checks (quality, i18n, docs, coverage)** passed in 5m37s on the fix commit, which runs `tsc` and eslint. That is what confirmed the new `@/features/...` import resolves from a `components/` file and that the early `return null` after a hook call satisfies rules-of-hooks.
- [x] Focused tests — `chat-user-message-edit-affordance.spec.ts`, **3 passed (22.7s)**, run locally through the fleet's shared CI slot on dedicated ports 18404/17704/4404.
- [x] N/A: Rust unchanged.
- [x] N/A: Tauri unchanged.

**Revert-proof.** Restoring the pre-fix unconditional renders and rebuilding the bundle:

```
test 1 fails at chat-user-message-edit-affordance.spec.ts:120
       `.aui-user-action-edit`   Expected 0, Received 1
test 3 fails at :148
       `.aui-branch-picker-root` Expected 0, Received 1
test 2 keeps passing  → the injected fault is correctly scoped
```

That run also settled something the fix commit could only argue from source: un-gated, `.aui-branch-picker-root` is present in the DOM with **count 1**. `hideWhenSingleBranch` hides it visually but does not remove it, so the branch picker was a real second dead control, not a theoretical one.

### Behavior Changes

- Intended behavior change: the Edit button and the branch picker are no longer rendered while the runtime cannot honour them.
- User-visible effect: a control that did nothing when clicked is gone. No working behaviour is removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Edit controls now appear only when editing is supported.
  - Branch switching controls are hidden when unavailable.
  - Copy actions remain available when editing and branch switching are disabled.
  - Removed inactive Edit buttons that previously appeared without providing editing functionality.

- **Tests**
  - Added coverage for capability-based visibility of edit and branch controls.
  - Verified that available message actions continue to render correctly when unsupported controls are hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->