### PR TITLE
fix(sidebar): lift the resize rail above the content card so its hit area works

### DIFF
--- a/app/src/components/ui/Sidebar.tsx
+++ b/app/src/components/ui/Sidebar.tsx
@@ -327,7 +327,17 @@ export const SidebarRail = forwardRef<HTMLDivElement, SidebarRailProps>(
           // wider than its other three by exactly that much. The seam is drawn
           // by the absolutely-positioned indicator below instead, which costs
           // no width — and it only paints on hover/focus anyway.
-          'group relative w-0 flex-none cursor-col-resize select-none self-stretch',
+          //
+          // `z-20` is load-bearing, not decoration. `SidebarInset` — the content
+          // card, rendered AFTER this element by `RootShellLayout` — carries
+          // `relative z-10`, and the hit area below carried `z-10` too. Equal
+          // z-index means DOM order decides, so the card painted over the half
+          // of the hit area that overhangs it and pointer events never reached
+          // the rail there: `elementFromPoint` at the rail's own centre returned
+          // the content viewport, not this element (#5906). Raising the rail
+          // itself rather than the child lifts BOTH the hit area and the 1px
+          // seam, which share the cause.
+          'group relative z-20 w-0 flex-none cursor-col-resize select-none self-stretch',
           'bg-transparent focus:outline-hidden',
           className
         )}

--- a/app/test/playwright/specs/app-shell-sidebar-resize.spec.ts
+++ b/app/test/playwright/specs/app-shell-sidebar-resize.spec.ts
@@ -51,13 +51,18 @@ const widthOf = (page: Page) =>
  * So: point at the hit area, read colour off the seam, and assert the rail's
  * presence by count rather than by visibility.
  *
- * And point at its LEFT half specifically. Measured with `elementFromPoint`
- * (sidebar right edge at x=224, hit area x=220..228):
+ * The LEFT-half-only caveat this comment used to carry is FIXED (#5906). It
+ * read: measured with `elementFromPoint` at a 224px sidebar edge, x=221 and
+ * x=222 reached the rail while x=224 and x=227 reached the content viewport —
+ * so half the widened hit area was dead and aiming at the element's centre
+ * (what `hover()` and `boundingBox()` centre do) landed on the dead side.
  *
- *     x=221  -> SPAN.absolute inset-y-0 -left-1 -right-1   (the rail)
- *     x=222  -> SPAN                                        (the rail)
- *     x=224  -> DIV.relative flex flex-1 ...                (content viewport)
- *     x=227  -> DIV                                         (content viewport)
+ * Cause: `SidebarInset` carries `relative z-10` and is rendered AFTER the rail,
+ * and the hit area carried `z-10` too, so equal z-index let DOM order decide.
+ * `SidebarRail` now carries `z-20`, which lifts the hit area and the seam
+ * together. `railPoint` below still aims at the sidebar edge — that is where a
+ * user's cursor is when the resize cursor appears — and the new test at the end
+ * of this file asserts the formerly dead half now receives events.
  *
  * The content surface is painted over the `-right-1` half despite the hit
  * area's `z-10`, so only x 220..223 actually reaches the rail. Aiming at the
@@ -138,6 +143,44 @@ test.describe('App shell — sidebar resize (#5676 AC-4)', () => {
     // And specifically NOT back at the default — the assertion above would also
     // hold if `resized` happened to equal the default width.
     expect(resized).not.toBe(before);
+  });
+
+  test('the full width of the hit area receives pointer events (#5906)', async ({ page }) => {
+    // The regression guard for the stacking fix. Before it, the content card
+    // (`SidebarInset`, `relative z-10`, rendered after the rail) painted over
+    // the half of the hit area that overhangs it, so `elementFromPoint` there
+    // returned the content viewport and a drag started on nothing.
+    //
+    // Walks the hit area's real box and asserts every sampled x resolves to a
+    // node inside the rail. Sampling rather than one point: the failure was
+    // exactly that one half worked and the other did not, so a single probe at
+    // the wrong offset reports the wrong answer either way.
+    const box = await hitArea(page).boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeGreaterThan(0);
+
+    const y = box!.y + box!.height / 2;
+    const offsets = [1, box!.width / 4, box!.width / 2, (box!.width * 3) / 4, box!.width - 1];
+
+    const owners = await page.evaluate(
+      ({ xs, yy }) =>
+        xs.map(x => {
+          const el = document.elementFromPoint(x, yy);
+          const railEl = document.querySelector('[data-testid="root-shell-divider"]');
+          return {
+            x: Math.round(x),
+            insideRail: Boolean(railEl && el && (el === railEl || railEl.contains(el))),
+            tag: el ? el.tagName : 'null',
+          };
+        }),
+      { xs: offsets.map(o => box!.x + o), yy: y }
+    );
+
+    const dead = owners.filter(o => !o.insideRail);
+    expect(
+      dead,
+      `these x positions do not reach the rail: ${dead.map(d => `${d.x} -> ${d.tag}`).join(', ')}`
+    ).toEqual([]);
   });
 
   test('the rail is absent while collapsed — the icon column is fixed, not draggable', async ({


### PR DESCRIPTION
## Summary

Half the sidebar resize rail's widened pointer target never received events. Raising `SidebarRail` to `z-20` fixes it.

## Problem

`SidebarRail` is `w-0` with an absolutely-positioned hit area that overhangs it by 4px each side (`-left-1 -right-1`, `Sidebar.tsx:336`), so the grab target should be 8px. It was 4px.

This is a stacking problem, not a sizing one — the widths were already right. The hit area carried `z-10`. So does `SidebarInset`, the content card (`relative z-10`, `Sidebar.tsx:408`), and `RootShellLayout` renders the card **after** the rail (`RootShellLayout.tsx:256-277`). Equal `z-index` means DOM order decides, so the card painted over the overhanging half.

Measured with `elementFromPoint` at a 224px sidebar edge, hit area spanning x=220..228:

| x | element returned |
|---:|---|
| 221 | `SPAN` — the rail |
| 222 | `SPAN` — the rail |
| **224** | `DIV` — content viewport |
| **227** | `DIV` — content viewport |

The dead half is the one a cursor naturally lands on: `hover()` and `boundingBox()` centre both target the element's midpoint, which is exactly the boundary.

## Solution

`z-20` on the `SidebarRail` root rather than on the hit-area child.

The 1px seam indicator has the same cause — it sits at the rail's `left-0` with no `z-index` of its own, and `SidebarInset` butts against the sidebar with no left margin, so it was under the card too. Lifting the rail lifts both children together, which is why this is one class rather than two.

`SidebarInset`'s own `after:z-20` content-edge shadow cannot compete: `relative z-10` makes it a stacking context, so that pseudo-element is scoped inside it.

Nothing new is drawn over the content — the rail is 8px of transparent hit area plus a 1px seam that only paints on hover/focus.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — `app-shell-sidebar-resize.spec.ts` gains a regression guard that samples five x positions across the hit area's real box and asserts each resolves inside the rail. It samples rather than probing once because the failure was precisely that one half worked and the other did not, so a single probe reports the wrong answer either way. The file's header comment recorded the dead half as a standing caveat; that is corrected to describe the fix.
- [x] **Diff coverage ≥ 80%** — N/A as a local measurement: builds and test runs are prohibited for this worker in the current phase, so `pnpm test:coverage` / `pnpm test:rust` were NOT run. The changed lines are one CSS class in `Sidebar.tsx` plus the new spec, and the CI coverage gate is the check.
- [x] Coverage matrix updated — `N/A: behaviour-only change`. No feature row added, removed or renamed.
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature IDs affected`.
- [x] No new external network dependencies introduced — none; the change is a CSS class and a DOM assertion.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: does not touch a release-cut surface`. The rail is app-shell chrome, not covered by `RELEASE-MANUAL-SMOKE.md`.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

The sidebar resize grab area becomes the 8px it was written to be, instead of 4px. The hover/focus seam becomes visible along its full length rather than only where it overhangs the sidebar side.

No layout change: the rail still has zero layout width, so the content card's left gutter is unaffected.

## Related

Closes #5906

Found during the fleet e2e coverage pass; the measurement above comes from that work. The two specs that cover this surface (`app-shell-sidebar-resize.spec.ts`, `app-shell-responsive.spec.ts`) landed in #5887.

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: `N/A` — tracked as GitHub issue #5906, not Linear.
- URL: `N/A`

### Commit & Branch

- Branch: `fix/5906-rail-hit-area-stacking`
- Commit SHA: `a6bf97103`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — ran `prettier --write` on the touched spec; reports unchanged (already clean).
- [x] `pnpm typecheck` — ran `tsc --noEmit`; zero errors in the touched files.
- [x] Focused tests: `N/A — NOT RUN.` Local test execution is prohibited for this worker in the current phase. The new assertion is reasoned from source, not executed. CI is the check.
- [x] Rust fmt/check (if changed): `N/A: no Rust changed.`
- [x] Tauri fmt/check (if changed): `N/A: no Tauri code changed.`

### Validation Blocked

- `command:` `pnpm --filter openhuman-app test:e2e:web:build` and `playwright test`
- `error:` not attempted — a standing instruction prohibits local builds and test runs for this worker in this phase (concurrent workers exhausted machine memory).
- `impact:` the fix and its new assertion are verified by reading `Sidebar.tsx:330/336/408` and `RootShellLayout.tsx:256-277`, and by the `elementFromPoint` measurement taken before the prohibition. Neither has been executed since. CI is the verification.

### Behavior Changes

- Intended behavior change: the full 8px width of the resize rail's hit area receives pointer events; the 1px seam is no longer occluded by the content card.
- User-visible effect: dragging the sidebar edge works when aiming at the visible resize cursor, rather than only when aiming 2px to its left.

### Parity Contract

- Legacy behavior preserved: yes — no change to layout width, drag arithmetic, arrow-key steps, persistence, or the collapsed rail. Only paint order changes.
- Guard/fallback/dispatch parity checks: the rail is still rendered only while expanded (`RootShellLayout.tsx`, `isOpen &&`), so the collapsed icon column remains non-draggable.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): `N/A`
- Canonical PR: this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar resizing so the entire rail hit area responds to pointer interactions.
  * Improved layering at the sidebar seam to prevent the content surface from blocking rail interactions.

* **Tests**
  * Added regression coverage to verify pointer detection across the rail’s full hit area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->