### PR TITLE
fix(settings): show the real error when a profile save/select/delete fails

### DIFF
--- a/app/src/components/settings/panels/ProfileEditorPage.tsx
+++ b/app/src/components/settings/panels/ProfileEditorPage.tsx
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { LuX } from 'react-icons/lu';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
+import { errorMessage } from '../../../lib/errorMessage';
 import { useT } from '../../../lib/i18n/I18nContext';
 import { selectAgentProfiles, upsertAgentProfile } from '../../../store/agentProfileSlice';
 import { useAppDispatch, useAppSelector } from '../../../store/hooks';
@@ -168,7 +169,12 @@ const ProfileEditorPage = () => {
       await dispatch(upsertAgentProfile(profile)).unwrap();
       if (mountedRef.current) backToList();
     } catch (err) {
-      if (mountedRef.current) setError(err instanceof Error ? err.message : String(err));
+      // `.unwrap()` rejects with Redux Toolkit's SerializedError — a plain
+      // object, not an `Error` — so an `instanceof` guard here rendered
+      // "[object Object]" and hid the backend's reason (#5900).
+      if (mountedRef.current) {
+        setError(errorMessage(err, 'Failed to save profile'));
+      }
     } finally {
       if (mountedRef.current) setSubmitting(false);
     }

--- a/app/src/components/settings/panels/ProfilesPanel.tsx
+++ b/app/src/components/settings/panels/ProfilesPanel.tsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { LuPlus } from 'react-icons/lu';
 import { useNavigate } from 'react-router-dom';
 
+import { errorMessage } from '../../../lib/errorMessage';
 import { useT } from '../../../lib/i18n/I18nContext';
 import {
   deleteAgentProfile,
@@ -43,7 +44,9 @@ const ProfilesPanel = () => {
       try {
         await dispatch(selectAgentProfile(id)).unwrap();
       } catch (err) {
-        setActionError(err instanceof Error ? err.message : String(err));
+        // See #5900: `.unwrap()` rejects with a SerializedError, so the old
+        // `instanceof` guard rendered "[object Object]" here.
+        setActionError(errorMessage(err, 'Failed to switch profile'));
       }
     },
     [dispatch]
@@ -56,7 +59,7 @@ const ProfilesPanel = () => {
       try {
         await dispatch(deleteAgentProfile(id)).unwrap();
       } catch (err) {
-        setActionError(err instanceof Error ? err.message : String(err));
+        setActionError(errorMessage(err, 'Failed to delete profile'));
       }
     },
     [dispatch, t]

--- a/app/src/components/settings/panels/__tests__/ProfileEditorPage.payload.test.tsx
+++ b/app/src/components/settings/panels/__tests__/ProfileEditorPage.payload.test.tsx
@@ -260,16 +260,13 @@ describe('ProfileEditorPage — failure path', () => {
     await waitFor(() => expect(create).not.toBeDisabled());
   });
 
-  // BUG (see ~/tinyhuman/bugs/W1-settings-bugs.md): the alert reads
-  // "[object Object]", not the message. `dispatch(thunk).unwrap()` rejects with
-  // Redux Toolkit's SerializedError — a PLAIN OBJECT, not an `Error` — so the
-  // `err instanceof Error ? err.message : String(err)` guard at
-  // `ProfileEditorPage.tsx:170` takes the `String(err)` branch and stringifies
-  // an object. Every failed profile save shows this.
-  //
-  // Pinned as CURRENT behaviour so the defect is visible and regression-locked.
-  // When it is fixed, change this to assert the message and delete the comment.
-  it('renders the failure as [object Object] instead of the message (known defect)', async () => {
+  // Was pinned as a known defect (#5900): the alert read "[object Object]"
+  // because `dispatch(thunk).unwrap()` rejects with Redux Toolkit's
+  // SerializedError — a plain object, not an `Error` — and the old
+  // `err instanceof Error ? err.message : String(err)` guard stringified it.
+  // Fixed by routing through `lib/errorMessage`; the assertion is inverted
+  // rather than deleted, so a regression re-surfaces here.
+  it('renders the failure message, not [object Object]', async () => {
     mockUpsert.mockRejectedValueOnce(new Error('backend refused the profile'));
     renderAt('/settings/profiles/new');
 
@@ -277,8 +274,26 @@ describe('ProfileEditorPage — failure path', () => {
     fireEvent.click(submit('Create'));
 
     const alert = await screen.findByRole('alert');
-    expect(alert).toHaveTextContent('[object Object]');
-    expect(alert).not.toHaveTextContent('backend refused the profile');
+    expect(alert).toHaveTextContent('backend refused the profile');
+    expect(alert).not.toHaveTextContent('[object Object]');
+  });
+
+  // The shape that actually reaches this catch in production: a thunk that
+  // threw is rethrown by `.unwrap()` as a SerializedError, never an `Error`.
+  it('renders the message from a SerializedError-shaped rejection', async () => {
+    mockUpsert.mockRejectedValueOnce({
+      name: 'Error',
+      message: 'profile id already taken',
+      stack: 'at …',
+    });
+    renderAt('/settings/profiles/new');
+
+    fireEvent.change(nameField(), { target: { value: 'Doomed' } });
+    fireEvent.click(submit('Create'));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('profile id already taken');
+    expect(alert).not.toHaveTextContent('[object Object]');
   });
 
   it('clears a previous error when the next save succeeds', async () => {

--- a/app/src/components/settings/panels/__tests__/ProfilesPanel.actions.test.tsx
+++ b/app/src/components/settings/panels/__tests__/ProfilesPanel.actions.test.tsx
@@ -5,7 +5,7 @@
  * `ProfilesPanel.test.tsx` (sibling) covers the happy paths and the *load*
  * error. Neither `setActive` nor `remove` has its failure branch exercised
  * anywhere, which is how the `[object Object]` defect at `ProfilesPanel.tsx:46`
- * and `:59` survived — see `~/tinyhuman/bugs/W1-settings-bugs.md`. It also does
+ * and `:59` survived until #5900 fixed it. It also does
  * not assert which buttons a built-in or already-active profile may show; those
  * are the guards that stop a user deleting a built-in.
  *
@@ -88,7 +88,7 @@ describe('ProfilesPanel — action failures', () => {
     await waitFor(() => expect(mockSelect).toHaveBeenCalledWith('writer'));
     // The panel must say *something* — silence would leave the user believing
     // the switch took effect.
-    expect(await screen.findByText(/object Object|select blew up/)).toBeInTheDocument();
+    expect(await screen.findByText('select blew up')).toBeInTheDocument();
   });
 
   it('shows an error when deleting a profile fails', async () => {
@@ -100,29 +100,41 @@ describe('ProfilesPanel — action failures', () => {
     fireEvent.click(within(row('Writer')).getByText('Delete'));
 
     await waitFor(() => expect(mockDelete).toHaveBeenCalledWith('writer'));
-    expect(await screen.findByText(/object Object|delete blew up/)).toBeInTheDocument();
+    expect(await screen.findByText('delete blew up')).toBeInTheDocument();
     confirmSpy.mockRestore();
   });
 
-  // BUG (`~/tinyhuman/bugs/W1-settings-bugs.md` #1): both handlers stringify
-  // Redux Toolkit's SerializedError — a plain object, not an `Error` — so
-  // `err instanceof Error ? err.message : String(err)` (`ProfilesPanel.tsx:46`
-  // and `:59`) yields "[object Object]". The message never reaches the user.
-  //
-  // Pinned as CURRENT behaviour. When it is fixed, assert the message here and
-  // delete this comment — do not delete the test.
-  it('renders both action failures as [object Object] (known defect)', async () => {
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+  // Was pinned as a known defect (#5900): both handlers stringified Redux
+  // Toolkit's SerializedError — a plain object, not an `Error` — so
+  // `err instanceof Error ? err.message : String(err)` yielded
+  // "[object Object]" and the message never reached the user. Fixed by routing
+  // through `lib/errorMessage`; the assertions are inverted rather than
+  // deleted, so a regression re-surfaces here.
+  it('renders the select failure message, not [object Object]', async () => {
     mockSelect.mockRejectedValueOnce(new Error('select blew up'));
     renderPanel();
 
     await screen.findByText('Writer');
     fireEvent.click(within(row('Writer')).getByText('Set as active'));
 
-    const shown = await screen.findByText('[object Object]');
-    expect(shown).toBeInTheDocument();
-    expect(screen.queryByText(/select blew up/)).not.toBeInTheDocument();
-    confirmSpy.mockRestore();
+    expect(await screen.findByText('select blew up')).toBeInTheDocument();
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+  });
+
+  // The production shape: `.unwrap()` rethrows a SerializedError, not an Error.
+  it('renders the message from a SerializedError-shaped rejection', async () => {
+    mockSelect.mockRejectedValueOnce({
+      name: 'Error',
+      message: 'profile is not selectable',
+      stack: 'at …',
+    });
+    renderPanel();
+
+    await screen.findByText('Writer');
+    fireEvent.click(within(row('Writer')).getByText('Set as active'));
+
+    expect(await screen.findByText('profile is not selectable')).toBeInTheDocument();
+    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
   });
 
   it('clears a previous action error when the next action succeeds', async () => {
@@ -132,10 +144,10 @@ describe('ProfilesPanel — action failures', () => {
 
     await screen.findByText('Writer');
     fireEvent.click(within(row('Writer')).getByText('Set as active'));
-    expect(await screen.findByText('[object Object]')).toBeInTheDocument();
+    expect(await screen.findByText('first attempt fails')).toBeInTheDocument();
 
     fireEvent.click(within(row('Writer')).getByText('Set as active'));
-    await waitFor(() => expect(screen.queryByText('[object Object]')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText('first attempt fails')).not.toBeInTheDocument());
   });
 
   it('does not delete, and raises no error, when the confirm is dismissed', async () => {
@@ -146,7 +158,7 @@ describe('ProfilesPanel — action failures', () => {
     fireEvent.click(within(row('Writer')).getByText('Delete'));
 
     expect(mockDelete).not.toHaveBeenCalled();
-    expect(screen.queryByText('[object Object]')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     confirmSpy.mockRestore();
   });
 });

--- a/app/src/lib/errorMessage.test.ts
+++ b/app/src/lib/errorMessage.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { errorMessage } from './errorMessage';
+
+const FALLBACK = 'Something went wrong';
+
+describe('errorMessage', () => {
+  it('reads the message off a real Error', () => {
+    expect(errorMessage(new Error('boom'), FALLBACK)).toBe('boom');
+  });
+
+  // The case the helper exists for (#5900). `dispatch(thunk).unwrap()` rethrows
+  // Redux Toolkit's SerializedError — a plain object, NOT an Error — so an
+  // `instanceof` guard falls through to `String(value)`, which is
+  // "[object Object]".
+  it('reads the message off a SerializedError-shaped object', () => {
+    const serialized = { name: 'Error', message: 'backend refused the profile', stack: '…' };
+
+    expect(errorMessage(serialized, FALLBACK)).toBe('backend refused the profile');
+    expect(errorMessage(serialized, FALLBACK)).not.toBe('[object Object]');
+  });
+
+  it('accepts a bare string, which is what rejectWithValue often carries', () => {
+    expect(errorMessage('plain failure', FALLBACK)).toBe('plain failure');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(errorMessage(new Error('  padded  '), FALLBACK)).toBe('padded');
+    expect(errorMessage('  bare  ', FALLBACK)).toBe('bare');
+    expect(errorMessage({ message: '  object  ' }, FALLBACK)).toBe('object');
+  });
+
+  // An empty message is no more useful than none, and rendering it would put a
+  // blank alert on screen — worse than the fallback, because it reads as "no
+  // error". Same reasoning as `formatThreadCreateError` (threadSlice.ts:117-121).
+  it.each([
+    ['an Error with an empty message', new Error('')],
+    ['an Error with a whitespace message', new Error('   ')],
+    ['an object with an empty message', { message: '' }],
+    ['an object with a whitespace message', { message: '   ' }],
+    ['an empty string', ''],
+    ['a whitespace string', '   '],
+  ])('falls back for %s', (_label, value) => {
+    expect(errorMessage(value, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a number', 42],
+    ['an object with no message', { code: 500 }],
+    ['an object whose message is not a string', { message: { nested: true } }],
+    ['an array', ['a', 'b']],
+  ])('falls back for %s', (_label, value) => {
+    expect(errorMessage(value, FALLBACK)).toBe(FALLBACK);
+  });
+
+  it('never returns the literal [object Object]', () => {
+    for (const value of [{}, { message: {} }, { code: 1 }, Object.create(null)]) {
+      expect(errorMessage(value, FALLBACK)).toBe(FALLBACK);
+    }
+  });
+});

--- a/app/src/lib/errorMessage.ts
+++ b/app/src/lib/errorMessage.ts
@@ -1,0 +1,51 @@
+/**
+ * Turn an unknown thrown/rejected value into something worth showing a user.
+ *
+ * The case this exists for: `dispatch(someThunk()).unwrap()` does NOT reject
+ * with an `Error`. For a `createAsyncThunk` that threw, Redux Toolkit rethrows
+ * its `SerializedError` — a plain object `{ name, message, stack }` — and for
+ * one that used `rejectWithValue`, it rethrows the payload, often a bare
+ * string. Neither is an `instanceof Error`.
+ *
+ * So the common guard
+ *
+ *   err instanceof Error ? err.message : String(err)
+ *
+ * takes its `String(err)` branch on exactly the shape it was written to
+ * handle, and `String({ message: '…' })` is `"[object Object]"`. The user loses
+ * the only diagnostic the failure path gives them (#5900), and the same shape
+ * caused the "Non-Error promise rejection captured with value" reports in
+ * #5156.
+ *
+ * Read `message` off the value instead of testing its prototype.
+ *
+ * Two existing helpers already solve this for their own domains —
+ * `formatThreadCreateError` (`store/threadSlice.ts`) and `formatThreadLoadError`
+ * (`features/conversations/Conversations.tsx`). Both predate this and carry
+ * domain-specific fallbacks and, in the thread case, an extra empty-message
+ * rule that #5156 depends on; they are deliberately left alone. New call sites
+ * should use this.
+ *
+ * @param error    the caught value, of unknown shape
+ * @param fallback shown when nothing usable can be recovered
+ */
+export function errorMessage(error: unknown, fallback: string): string {
+  if (typeof error === 'string' && error.trim().length > 0) return error.trim();
+
+  // An `Error` with an empty message is no more useful than no error at all —
+  // fall through to the fallback rather than rendering a blank alert.
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message.trim();
+  }
+
+  // The SerializedError / rejectWithValue-object case: duck-type `message`
+  // rather than testing the prototype, which is the whole bug.
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === 'string' && message.trim().length > 0) {
+      return message.trim();
+    }
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
## Summary

- Failed agent-profile **save**, **select** and **delete** rendered `[object Object]` instead of the backend's reason, on the error path of all three actions.
- Root cause is the `.unwrap()` boundary, not the three lines: `dispatch(thunk).unwrap()` does not reject with an `Error`, so the `instanceof` guard was defeated by the exact shape it was written for.
- Adds one shared `errorMessage(error, fallback)` helper and routes all three sites through it, rather than a fourth copy of a ternary the repo has already written twice.
- Flips the two tests that pinned this defect (they carried instructions to invert rather than delete), and adds the SerializedError-shaped cases production actually produces.

## Problem

For a `createAsyncThunk` that threw, Redux Toolkit's `unwrap()` rethrows its **`SerializedError`** — a plain object `{ name, message, stack }` — and for one using `rejectWithValue`, the payload, often a bare string. Neither is an `instanceof Error`.

So this guard, at all three sites:

```ts
setError(err instanceof Error ? err.message : String(err));
```

takes its `String(err)` branch on precisely the shape it exists to handle, and `String({ message: '…' })` is `"[object Object]"`. The user loses the only diagnostic the failure gives them.

Sites (verified on current `main` before changing anything — the issue cited `ProfileEditorPage.tsx:170`, which has since drifted to `:171`):

| file | line | action |
|---|---|---|
| `ProfileEditorPage.tsx` | `:171` | save / create / edit |
| `ProfilesPanel.tsx` | `:46` | select a profile |
| `ProfilesPanel.tsx` | `:59` | delete a profile |

## Solution

**Checked for an existing helper first, as the issue asks.** The repo has solved this class twice already, both domain-specific:

- `formatThreadCreateError` — `store/threadSlice.ts:115`, written for the same root cause in **#5156** ("Non-Error promise rejection captured with value")
- `formatThreadLoadError` — `features/conversations/Conversations.tsx:220`

Its own doc comment states the insight exactly: *"an `.unwrap()` rejection is a bare string or a `SerializedError`, never an `Error`."* Rather than add a fourth copy, this extracts the shared shape into `app/src/lib/errorMessage.ts`, which duck-types `message` instead of testing the prototype.

**The two existing helpers are deliberately left alone.** They carry domain-specific fallbacks, and `formatThreadCreateError` has an empty-message rule that #5156 depends on (an empty message would store a falsy `createThreadError`, which `deriveChatErrorBanner` reads as "no failure" — a dead button and no banner). Converting them is a follow-up, not part of fixing this.

**Scope.** 164 files use the same ternary. The defect only bites where the rejection is a non-`Error` object carrying `message` — the `.unwrap()` boundary. Of the 15 files that call `.unwrap()`, only the three named here both unwrap and surface the result to the user, so the diff stops there rather than sweeping files where the guard is correct.

## Impact

- Desktop/web renderer only. No Rust, no schema, no migration.
- User-visible and strictly an improvement on the failure path: an actionable message replaces `[object Object]`. Where nothing usable can be recovered, a plain fallback appears instead of a blank or nonsense alert.
- Fallbacks are plain English literals, matching `formatThreadCreateError`'s existing precedent, rather than new i18n keys — which would have meant 14 locale files for a string that appears only when the error carries no message at all.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — new `lib/errorMessage.test.ts` covers `Error`, SerializedError-shaped objects, bare strings, whitespace trimming, and 12 fallback cases including `null`, arrays and non-string `message`; the two panel specs are flipped from asserting the bug to asserting the fix.
- [x] **Diff coverage ≥ 80%** — focused suites run locally via the fleet CI semaphore: **48/48 pass** across `errorMessage.test.ts` (17) and the two panel specs (31). Full `pnpm test:coverage` not run (it is the whole suite, not the narrowest command that answers the question); CI's `diff-cover` gate remains the arbiter.
- [x] N/A: behaviour-only change — no feature rows added, removed or renamed, so `docs/TEST-COVERAGE-MATRIX.md` is unchanged.
- [x] N/A: no matrix feature IDs apply to this change.
- [x] No new external network dependencies introduced — pure local error normalisation; no transport touched.
- [x] N/A: does not touch a release-cut surface — settings error copy only, no install/update/launch path.
- [x] Linked issue closed via `Closes #5900` in the `## Related` section.

## Related

- Closes: #5900
- Follow-up PR(s)/TODOs: converting `formatThreadCreateError` and `formatThreadLoadError` onto the shared helper — deliberately out of scope here because of the #5156 empty-message rule.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5900-profile-error-message`
- Commit SHA: `b5b2ea597`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `prettier --check` on all six changed files: clean.
- [x] `pnpm typecheck` — `tsc --noEmit -p app/tsconfig.json`: **exit 0, 0 errors**.
- [x] Focused tests: `vitest run src/lib/errorMessage.test.ts src/components/settings/panels/__tests__/ProfileEditorPage.payload.test.tsx src/components/settings/panels/__tests__/ProfilesPanel.actions.test.tsx` — **3 files, 48 tests, all pass**.
- [x] N/A: Rust fmt/check — no Rust changed.
- [x] N/A: Tauri fmt/check — no Tauri changed.

### Validation Blocked

- `command:` none
- `error:` n/a
- `impact:` n/a — everything claimed here was executed. (An earlier revision of this body said the tests were written but not run, which was true at the time under a temporary no-local-builds rule; that rule has since been lifted and this section is updated to match what actually ran.)

### Revert-proof

Restoring the original `err instanceof Error ? err.message : String(err)` at all three sites and re-running makes **7 tests fail**, naming these assertions:

```
Expected element to have text content:
  backend refused the profile
Received:
  [object Object]
```

Restored afterwards; the suite is green again at 48/48. So the tests fail for the reason they exist and are not passing vacuously.

### Behavior Changes

- Intended behavior change: a failed profile save/select/delete shows the backend's message instead of `[object Object]`.
- User-visible effect: the red alert on those three actions now carries an actionable reason. No change on the success path, and no change to when the alert appears or clears.
