### PR TITLE
fix(voice): make "Test Key" a real dry run instead of a save

### DIFF
--- a/app/src/components/settings/panels/VoicePanelKeyModal.tsx
+++ b/app/src/components/settings/panels/VoicePanelKeyModal.tsx
@@ -177,13 +177,22 @@ const VoicePanelKeyModal = ({
                   setIsTestingKey(true);
                   setKeyTestResult(null);
                   try {
-                    await handleEnableExternalProvider(pendingKeySlug, pendingKeyValue);
+                    // Test is a DRY RUN. It must not call
+                    // `handleEnableExternalProvider`: that writes the key to
+                    // the keychain and activates the provider before it is
+                    // known to work, and it clears `pendingKeySlug`, which
+                    // unmounts this modal — so the result below would be set
+                    // on a dead component and the user would never see it
+                    // (#5896). The candidate key goes to the core for
+                    // validation only; "Save & Enable" remains the one way to
+                    // commit it.
                     const meta = BUILTIN_VOICE_PROVIDER_META[pendingKeySlug];
                     const workload = meta?.capability === 'tts' ? 'tts' : 'stt';
                     const result = await testVoiceProvider(
                       workload as 'stt' | 'tts',
                       pendingKeySlug,
-                      true
+                      true,
+                      pendingKeyValue
                     );
                     setKeyTestResult(result);
                   } catch (err) {

--- a/app/src/components/settings/panels/VoicePanelKeyModal.tsx
+++ b/app/src/components/settings/panels/VoicePanelKeyModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import type { VoiceInstallStatus } from '../../../services/api/voiceInstallApi';
 import { testVoiceProvider } from '../../../services/api/voiceSettingsApi';
@@ -106,6 +106,14 @@ const VoicePanelKeyModal = ({
 }: VoicePanelKeyModalProps) => {
   const [isTestingKey, setIsTestingKey] = useState(false);
   const [keyTestResult, setKeyTestResult] = useState<{ ok: boolean; detail: string } | null>(null);
+  // Monotonic id for the in-flight key test. The API-key field stays editable
+  // during a test (it is only disabled while *saving*), so without this a
+  // result for key A can land next to key B and read as a validation of B —
+  // the same "the UI is telling you something untrue about this key" failure
+  // this modal is being fixed for. Bumped on every edit and every new test;
+  // a response whose id is stale is dropped. Same guard as the LLM routing
+  // dialog's `testRequestIdRef`.
+  const testRequestIdRef = useRef(0);
   const isPiper = pendingKeySlug === 'piper';
 
   const close = () => {
@@ -174,6 +182,8 @@ const VoicePanelKeyModal = ({
                 disabled={!pendingKeyValue.trim() || isTestingKey || isSavingPendingKey}
                 onClick={async () => {
                   if (!pendingKeySlug || !pendingKeyValue.trim()) return;
+                  const requestId = testRequestIdRef.current + 1;
+                  testRequestIdRef.current = requestId;
                   setIsTestingKey(true);
                   setKeyTestResult(null);
                   try {
@@ -194,13 +204,18 @@ const VoicePanelKeyModal = ({
                       true,
                       pendingKeyValue
                     );
+                    if (testRequestIdRef.current !== requestId) return;
                     setKeyTestResult(result);
                   } catch (err) {
+                    if (testRequestIdRef.current !== requestId) return;
                     setKeyTestResult({
                       ok: false,
                       detail: err instanceof Error ? err.message : 'Test failed',
                     });
                   } finally {
+                    // Unconditional: the Test button is disabled while
+                    // `isTestingKey`, so there is only ever one test in
+                    // flight and this cannot strand the button on "Testing…".
                     setIsTestingKey(false);
                   }
                 }}>
@@ -272,6 +287,9 @@ const VoicePanelKeyModal = ({
                 onChange={e => {
                   setPendingKeyValue(e.target.value);
                   setKeyTestResult(null);
+                  // Any edit invalidates a test still in flight for the old
+                  // key, so its result cannot arrive and describe this one.
+                  testRequestIdRef.current += 1;
                 }}
                 disabled={isSavingPendingKey}
                 placeholder={t('voice.providers.chip.apiKeyPlaceholder')}

--- a/app/src/components/settings/panels/__tests__/VoicePanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/VoicePanel.test.tsx
@@ -859,6 +859,27 @@ describe('VoicePanel', () => {
     expect(screen.getByTestId('voice-provider-key-modal')).toBeInTheDocument();
   });
 
+  it('renders a thrown Test Key error without saving the key', async () => {
+    // A rejected RPC (transport dead, core down) takes the `catch` branch,
+    // which is a different path from a resolved `{ ok: false }` verdict.
+    vi.mocked(testVoiceProvider).mockRejectedValueOnce(new Error('core unreachable'));
+
+    renderWithProviders(<VoicePanel />, { initialEntries: ['/settings/voice'] });
+
+    await screen.findByTestId('voice-providers-section');
+    fireEvent.click(screen.getByTestId('voice-provider-chip-elevenlabs'));
+    await screen.findByTestId('voice-provider-key-modal');
+
+    fireEvent.change(screen.getByPlaceholderText(/sk/i), {
+      target: { value: 'sk-key-for-a-dead-core' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Test Key$/i }));
+
+    expect(await screen.findByText(/core unreachable/i)).toBeInTheDocument();
+    expect(screen.getByTestId('voice-provider-key-modal')).toBeInTheDocument();
+    expect(vi.mocked(setVoiceProviderKey)).not.toHaveBeenCalled();
+  });
+
   it('discards an in-flight Test Key result when the key is edited', async () => {
     // The key field stays editable during a test (it is disabled only while
     // *saving*). Without the request-id guard, key A's verdict lands next to

--- a/app/src/components/settings/panels/__tests__/VoicePanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/VoicePanel.test.tsx
@@ -776,6 +776,89 @@ describe('VoicePanel', () => {
     await waitFor(() => expect(vi.mocked(setVoiceProviderKey)).toHaveBeenCalled());
   });
 
+  // ─── Modal: "Test Key" is a dry run (#5896) ───────────────────────────────
+  //
+  // The regression these guard: the Test handler used to call
+  // `handleEnableExternalProvider` before testing, which (a) wrote the key to
+  // the keychain and activated the provider before it was known to work, and
+  // (b) cleared `pendingKeySlug` — unmounting the modal, so the result alert
+  // it then set could never render.
+
+  it('clicking Test Key validates without saving or activating the provider', async () => {
+    vi.mocked(testVoiceProvider).mockResolvedValueOnce({ ok: true, detail: 'Key OK' });
+
+    renderWithProviders(<VoicePanel />, { initialEntries: ['/settings/voice'] });
+
+    await screen.findByTestId('voice-providers-section');
+    fireEvent.click(screen.getByTestId('voice-provider-chip-elevenlabs'));
+    await screen.findByTestId('voice-provider-key-modal');
+
+    const keyInput = screen.getByPlaceholderText(/sk/i);
+    fireEvent.change(keyInput, { target: { value: 'sk-candidate-key-1234567890' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Test Key$/i }));
+
+    await waitFor(() => expect(vi.mocked(testVoiceProvider)).toHaveBeenCalled());
+
+    // The candidate key travels to the core for validation only.
+    expect(vi.mocked(testVoiceProvider)).toHaveBeenCalledWith(
+      'stt',
+      'elevenlabs',
+      true,
+      'sk-candidate-key-1234567890'
+    );
+
+    // Nothing is persisted and nothing is activated by a test.
+    expect(vi.mocked(setVoiceProviderKey)).not.toHaveBeenCalled();
+    expect(vi.mocked(saveVoiceSettings)).not.toHaveBeenCalled();
+  });
+
+  it('keeps the modal mounted after Test Key so the result is visible', async () => {
+    vi.mocked(testVoiceProvider).mockResolvedValueOnce({
+      ok: true,
+      detail: 'Provider key is valid (12ms)',
+    });
+
+    renderWithProviders(<VoicePanel />, { initialEntries: ['/settings/voice'] });
+
+    await screen.findByTestId('voice-providers-section');
+    fireEvent.click(screen.getByTestId('voice-provider-chip-elevenlabs'));
+    await screen.findByTestId('voice-provider-key-modal');
+
+    fireEvent.change(screen.getByPlaceholderText(/sk/i), {
+      target: { value: 'sk-candidate-key-1234567890' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Test Key$/i }));
+
+    // The alert is the whole point of the button — if the modal has unmounted
+    // by the time the result lands, this text never appears.
+    expect(await screen.findByText(/Provider key is valid/i)).toBeInTheDocument();
+    expect(screen.getByTestId('voice-provider-key-modal')).toBeInTheDocument();
+  });
+
+  it('surfaces a failed Test Key without saving the bad key', async () => {
+    vi.mocked(testVoiceProvider).mockResolvedValueOnce({
+      ok: false,
+      detail: 'Key test failed: API returned 401 Unauthorized',
+    });
+
+    renderWithProviders(<VoicePanel />, { initialEntries: ['/settings/voice'] });
+
+    await screen.findByTestId('voice-providers-section');
+    fireEvent.click(screen.getByTestId('voice-provider-chip-elevenlabs'));
+    await screen.findByTestId('voice-provider-key-modal');
+
+    fireEvent.change(screen.getByPlaceholderText(/sk/i), {
+      target: { value: 'sk-wrong-key-1234567890' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Test Key$/i }));
+
+    expect(await screen.findByText(/401 Unauthorized/i)).toBeInTheDocument();
+    // The user is left free to correct the key: it was never written.
+    expect(vi.mocked(setVoiceProviderKey)).not.toHaveBeenCalled();
+    expect(screen.getByTestId('voice-provider-key-modal')).toBeInTheDocument();
+  });
+
   it('the ElevenLabs modal Cancel button closes without saving', async () => {
     renderWithProviders(<VoicePanel />, { initialEntries: ['/settings/voice'] });
 

--- a/app/src/components/settings/panels/__tests__/VoicePanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/VoicePanel.test.tsx
@@ -859,6 +859,38 @@ describe('VoicePanel', () => {
     expect(screen.getByTestId('voice-provider-key-modal')).toBeInTheDocument();
   });
 
+  it('discards an in-flight Test Key result when the key is edited', async () => {
+    // The key field stays editable during a test (it is disabled only while
+    // *saving*). Without the request-id guard, key A's verdict lands next to
+    // key B and reads as a validation of B.
+    let resolveTest: (r: { ok: boolean; detail: string }) => void = () => {};
+    vi.mocked(testVoiceProvider).mockReturnValueOnce(
+      // Annotated: `VoiceTestResult` is not exported, and a bare `new Promise`
+      // would infer `Promise<unknown>` and fail typecheck on the mock.
+      new Promise<{ ok: boolean; detail: string }>(resolve => {
+        resolveTest = resolve;
+      })
+    );
+
+    renderWithProviders(<VoicePanel />, { initialEntries: ['/settings/voice'] });
+
+    await screen.findByTestId('voice-providers-section');
+    fireEvent.click(screen.getByTestId('voice-provider-chip-elevenlabs'));
+    await screen.findByTestId('voice-provider-key-modal');
+
+    const keyInput = screen.getByPlaceholderText(/sk/i);
+    fireEvent.change(keyInput, { target: { value: 'sk-key-AAAA-1234567890' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Test Key$/i }));
+
+    // User edits to a different key before the verdict for the first arrives.
+    fireEvent.change(keyInput, { target: { value: 'sk-key-BBBB-0987654321' } });
+
+    resolveTest({ ok: true, detail: 'STALE VERDICT FOR KEY A' });
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /^Test Key$/i })).toBeEnabled());
+    expect(screen.queryByText(/STALE VERDICT FOR KEY A/i)).not.toBeInTheDocument();
+  });
+
   it('the ElevenLabs modal Cancel button closes without saving', async () => {
     renderWithProviders(<VoicePanel />, { initialEntries: ['/settings/voice'] });
 

--- a/app/src/services/api/__tests__/voiceSettingsApi.test.ts
+++ b/app/src/services/api/__tests__/voiceSettingsApi.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { testVoiceProvider } from '../voiceSettingsApi';
+
+vi.mock('../../coreRpcClient', () => ({ callCoreRpc: vi.fn() }));
+
+const okResult = { ok: true, detail: 'Provider key is valid (12ms)', latency_ms: 12 };
+
+describe('voiceSettingsApi', () => {
+  beforeEach(async () => {
+    const { callCoreRpc } = await import('../../coreRpcClient');
+    vi.mocked(callCoreRpc).mockReset();
+  });
+
+  describe('testVoiceProvider', () => {
+    it('omits api_key entirely when no candidate key is supplied', async () => {
+      const { callCoreRpc } = await import('../../coreRpcClient');
+      vi.mocked(callCoreRpc).mockResolvedValueOnce(okResult);
+
+      await testVoiceProvider('stt', 'cloud');
+
+      // `api_key` must be ABSENT, not present-and-empty: the core reads an
+      // empty candidate as "fall back to the stored credential", so sending
+      // one would change which key is being tested.
+      expect(callCoreRpc).toHaveBeenCalledWith({
+        method: 'openhuman.voice_test_provider',
+        params: { workload: 'stt', provider: 'cloud', validate_only: false },
+        timeoutMs: 30_000,
+      });
+      const params = vi.mocked(callCoreRpc).mock.calls[0][0].params as Record<string, unknown>;
+      expect('api_key' in params).toBe(false);
+    });
+
+    it('sends the candidate key for a dry run, trimmed', async () => {
+      const { callCoreRpc } = await import('../../coreRpcClient');
+      vi.mocked(callCoreRpc).mockResolvedValueOnce(okResult);
+
+      // A pasted key routinely carries a trailing newline. The guard and the
+      // payload have to agree on which string is being tested (#5896 review).
+      await testVoiceProvider('stt', 'elevenlabs', true, '  sk-candidate-key-123\n');
+
+      expect(callCoreRpc).toHaveBeenCalledWith({
+        method: 'openhuman.voice_test_provider',
+        params: {
+          workload: 'stt',
+          provider: 'elevenlabs',
+          validate_only: true,
+          api_key: 'sk-candidate-key-123',
+        },
+        timeoutMs: 30_000,
+      });
+    });
+
+    it('treats a whitespace-only candidate key as no key at all', async () => {
+      const { callCoreRpc } = await import('../../coreRpcClient');
+      vi.mocked(callCoreRpc).mockResolvedValueOnce(okResult);
+
+      await testVoiceProvider('tts', 'elevenlabs', true, '   ');
+
+      const params = vi.mocked(callCoreRpc).mock.calls[0][0].params as Record<string, unknown>;
+      expect('api_key' in params).toBe(false);
+    });
+
+    it('strips the core log prefix from the returned detail', async () => {
+      const { callCoreRpc } = await import('../../coreRpcClient');
+      vi.mocked(callCoreRpc).mockResolvedValueOnce({
+        ok: false,
+        detail: '[voice-factory] Key test failed: API returned 401',
+      });
+
+      const result = await testVoiceProvider('stt', 'elevenlabs', true, 'sk-bad');
+
+      expect(result.detail).toBe('Key test failed: API returned 401');
+      expect(result.ok).toBe(false);
+    });
+  });
+});

--- a/app/src/services/api/voiceSettingsApi.ts
+++ b/app/src/services/api/voiceSettingsApi.ts
@@ -221,14 +221,32 @@ function stripLogPrefix(s: string): string {
   return s.replace(/^\[voice-(?:stt|tts|factory)\]\s*/i, '');
 }
 
+/**
+ * Test a voice provider.
+ *
+ * With `validateOnly`, the core does a lightweight authenticated GET instead of
+ * a real transcription/synthesis, and `apiKey` lets the caller check a key the
+ * user has typed but not yet saved — the key is validated and discarded, never
+ * written to the keychain (#5896).
+ */
 export async function testVoiceProvider(
   workload: VoiceWorkloadId,
   provider: string,
-  validateOnly = false
+  validateOnly = false,
+  apiKey?: string
 ): Promise<VoiceTestResult> {
   const result = await callCoreRpc<VoiceTestResult>({
     method: 'openhuman.voice_test_provider',
-    params: { workload, provider, validate_only: validateOnly },
+    params: {
+      workload,
+      provider,
+      validate_only: validateOnly,
+      // Omit rather than send an empty string: the core reads an empty
+      // candidate as "fall back to the stored credential", and sending one
+      // for a provider with no stored key would report a confusing
+      // "no API key configured" instead of the real validation result.
+      ...(apiKey?.trim() ? { api_key: apiKey } : {}),
+    },
     timeoutMs: VOICE_TEST_TIMEOUT_MS,
   });
   return { ...result, detail: stripLogPrefix(result.detail) };

--- a/app/src/services/api/voiceSettingsApi.ts
+++ b/app/src/services/api/voiceSettingsApi.ts
@@ -245,7 +245,10 @@ export async function testVoiceProvider(
       // candidate as "fall back to the stored credential", and sending one
       // for a provider with no stored key would report a confusing
       // "no API key configured" instead of the real validation result.
-      ...(apiKey?.trim() ? { api_key: apiKey } : {}),
+      // Trimmed on the way out so the guard and the payload agree — a key
+      // pasted with a trailing newline should be tested as the key the user
+      // will actually save, not as a different string.
+      ...(apiKey?.trim() ? { api_key: apiKey.trim() } : {}),
     },
     timeoutMs: VOICE_TEST_TIMEOUT_MS,
   });

--- a/src/openhuman/voice/README.md
+++ b/src/openhuman/voice/README.md
@@ -57,7 +57,7 @@ Namespace `voice` (registered in `all_voice_registered_controllers`):
 | `voice.set_providers` | Persist STT/TTS provider + model/voice into `config.local_ai.*`. |
 | `voice.update_provider_settings` | Persist the voice provider registry + routing strings (mirrors inference model settings). |
 | `voice.list_models` | List models/voices for a provider (static presets for built-in slugs). |
-| `voice.test_provider` | Test/validate a provider endpoint (silent-WAV STT, "Hello" TTS, or key-only validate). |
+| `voice.test_provider` | Test/validate a provider endpoint (silent-WAV STT, "Hello" TTS, or key-only validate). `validate_only` is a dry run for **both** workloads and accepts an `api_key` to check a candidate credential without storing it. |
 | `voice.server_start` / `voice.server_stop` / `voice.server_status` | Control the global dictation server. |
 | `voice.overlay_stt_notify` | Bridge chat-button STT state transitions into the dictation/transcription buses. |
 

--- a/src/openhuman/voice/schemas/handlers/provider_server.rs
+++ b/src/openhuman/voice/schemas/handlers/provider_server.rs
@@ -6,8 +6,8 @@ use crate::core::all::ControllerFuture;
 use crate::openhuman::config::rpc as config_rpc;
 
 use crate::openhuman::voice::schemas::helpers::{
-    deserialize_params, generate_silent_wav, validate_stt_provider, validate_tts_provider,
-    validate_tts_provider_key,
+    deserialize_params, generate_silent_wav, validate_provider_key, validate_stt_provider,
+    validate_tts_provider,
 };
 use crate::openhuman::voice::schemas::params::{
     OverlaySttNotifyParams, OverlaySttState, SetProvidersParams, VoiceListModelsParams,
@@ -303,82 +303,97 @@ pub(crate) fn handle_voice_test_provider(params: Map<String, Value>) -> Controll
         let start = std::time::Instant::now();
 
         log::debug!(
-            "[voice-factory] voice_test_provider workload={} provider={}",
+            "[voice-factory] voice_test_provider workload={} provider={} validate_only={} \
+             candidate_key={}",
             p.workload,
-            p.provider
+            p.provider,
+            p.validate_only,
+            p.api_key.is_some()
         );
 
-        match p.workload.as_str() {
-            "stt" => {
-                let provider =
-                    crate::openhuman::voice::create_stt_provider(&p.provider, "", &config)
-                        .map_err(|e| e.to_string())?;
+        if !matches!(p.workload.as_str(), "stt" | "tts") {
+            return Err(format!(
+                "invalid workload '{}' (valid: 'stt', 'tts')",
+                p.workload
+            ));
+        }
 
-                // 0.1s of silence as WAV (16kHz mono 16-bit PCM) so the local
-                // The selected engine can transcribe it without an
-                // external binary (issue #3425).
-                let silent_wav = generate_silent_wav();
-                let audio_b64 = {
-                    use base64::Engine;
-                    base64::engine::general_purpose::STANDARD.encode(&silent_wav)
-                };
+        let trimmed = p.provider.trim();
 
-                match provider
-                    .transcribe(&config, &audio_b64, Some("audio/wav"), None, Some("en"))
-                    .await
-                {
-                    Ok(_outcome) => {
-                        let elapsed = start.elapsed().as_millis();
-                        Ok(serde_json::json!({
-                            "ok": true,
-                            "detail": format!("STT test passed ({elapsed}ms)"),
-                            "latency_ms": elapsed,
-                        }))
-                    }
-                    Err(e) => Ok(serde_json::json!({
-                        "ok": false,
-                        "detail": format!("STT test failed: {e}"),
-                    })),
+        // `validate_only` is a **dry run** and is honoured for both workloads.
+        // It used to be checked inside the "tts" arm alone, which made it a
+        // silent no-op for STT — and every provider the settings modal can
+        // reach maps to the "stt" workload, so the modal's dry-run request was
+        // always answered with a live transcription (#5896).
+        //
+        // Reserved slugs (`cloud`/`openhuman`/`backend`/`piper`/`whisper`/
+        // `local`/empty) have no user-held API key to check, so they fall
+        // through to the live test, where the factory reports misconfiguration
+        // by name.
+        if p.validate_only && !crate::openhuman::config::schema::is_voice_slug_reserved(trimmed) {
+            return match validate_provider_key(trimmed, &config, p.api_key.as_deref()).await {
+                Ok(detail) => {
+                    let elapsed = start.elapsed().as_millis();
+                    Ok(serde_json::json!({
+                        "ok": true,
+                        "detail": format!("{detail} ({elapsed}ms)"),
+                        "latency_ms": elapsed,
+                    }))
                 }
-            }
-            "tts" => {
-                let trimmed = p.provider.trim();
-                if p.validate_only && !matches!(trimmed, "cloud" | "openhuman" | "piper" | "") {
-                    match validate_tts_provider_key(trimmed, &config).await {
-                        Ok(detail) => {
-                            let elapsed = start.elapsed().as_millis();
-                            Ok(serde_json::json!({
-                                "ok": true,
-                                "detail": format!("{detail} ({elapsed}ms)"),
-                                "latency_ms": elapsed,
-                            }))
-                        }
-                        Err(e) => Ok(serde_json::json!({
-                            "ok": false,
-                            "detail": format!("TTS test failed: {e}"),
-                        })),
-                    }
-                } else {
-                    let provider =
-                        crate::openhuman::voice::create_tts_provider(trimmed, "", &config)
-                            .map_err(|e| e.to_string())?;
-                    match provider.synthesize(&config, "Hello", None).await {
-                        Ok(_outcome) => {
-                            let elapsed = start.elapsed().as_millis();
-                            Ok(serde_json::json!({
-                                "ok": true,
-                                "detail": format!("TTS test passed ({elapsed}ms)"),
-                                "latency_ms": elapsed,
-                            }))
-                        }
-                        Err(e) => Ok(serde_json::json!({
-                            "ok": false,
-                            "detail": format!("TTS test failed: {e}"),
-                        })),
-                    }
+                Err(e) => Ok(serde_json::json!({
+                    "ok": false,
+                    "detail": format!("Key test failed: {e}"),
+                })),
+            };
+        }
+
+        if p.workload == "stt" {
+            let provider = crate::openhuman::voice::create_stt_provider(&p.provider, "", &config)
+                .map_err(|e| e.to_string())?;
+
+            // 0.1s of silence as WAV (16kHz mono 16-bit PCM) so the local
+            // The selected engine can transcribe it without an
+            // external binary (issue #3425).
+            let silent_wav = generate_silent_wav();
+            let audio_b64 = {
+                use base64::Engine;
+                base64::engine::general_purpose::STANDARD.encode(&silent_wav)
+            };
+
+            return match provider
+                .transcribe(&config, &audio_b64, Some("audio/wav"), None, Some("en"))
+                .await
+            {
+                Ok(_outcome) => {
+                    let elapsed = start.elapsed().as_millis();
+                    Ok(serde_json::json!({
+                        "ok": true,
+                        "detail": format!("STT test passed ({elapsed}ms)"),
+                        "latency_ms": elapsed,
+                    }))
                 }
+                Err(e) => Ok(serde_json::json!({
+                    "ok": false,
+                    "detail": format!("STT test failed: {e}"),
+                })),
+            };
+        }
+
+        let provider = crate::openhuman::voice::create_tts_provider(trimmed, "", &config)
+            .map_err(|e| e.to_string())?;
+        match provider.synthesize(&config, "Hello", None).await {
+            Ok(_outcome) => {
+                let elapsed = start.elapsed().as_millis();
+                Ok(serde_json::json!({
+                    "ok": true,
+                    "detail": format!("TTS test passed ({elapsed}ms)"),
+                    "latency_ms": elapsed,
+                }))
             }
-            other => Err(format!("invalid workload '{other}' (valid: 'stt', 'tts')")),
+            Err(e) => Ok(serde_json::json!({
+                "ok": false,
+                "detail": format!("TTS test failed: {e}"),
+            })),
         }
     })
 }

--- a/src/openhuman/voice/schemas/handlers/provider_server.rs
+++ b/src/openhuman/voice/schemas/handlers/provider_server.rs
@@ -327,10 +327,20 @@ pub(crate) fn handle_voice_test_provider(params: Map<String, Value>) -> Controll
         // always answered with a live transcription (#5896).
         //
         // Reserved slugs (`cloud`/`openhuman`/`backend`/`piper`/`whisper`/
-        // `local`/empty) have no user-held API key to check, so they fall
-        // through to the live test, where the factory reports misconfiguration
-        // by name.
-        if p.validate_only && !crate::openhuman::config::schema::is_voice_slug_reserved(trimmed) {
+        // `local`/empty) are managed or local engines with no user-held API
+        // key, so there is nothing to validate. They must still return here
+        // rather than fall through: `validate_only` promises no inference
+        // call, and falling through would quietly bill the caller for a real
+        // transcription/synthesis. `ok: true` because nothing is wrong — a
+        // managed provider with no key to check is not a failed check.
+        if p.validate_only {
+            if crate::openhuman::config::schema::is_voice_slug_reserved(trimmed) {
+                return Ok(serde_json::json!({
+                    "ok": true,
+                    "detail": "No API key to validate — this provider is managed by OpenHuman.",
+                    "latency_ms": start.elapsed().as_millis(),
+                }));
+            }
             return match validate_provider_key(trimmed, &config, p.api_key.as_deref()).await {
                 Ok(detail) => {
                     let elapsed = start.elapsed().as_millis();

--- a/src/openhuman/voice/schemas/helpers.rs
+++ b/src/openhuman/voice/schemas/helpers.rs
@@ -104,32 +104,52 @@ pub(super) fn effective_tts_provider(config: &crate::openhuman::config::Config) 
     crate::openhuman::voice::effective_tts_provider(config)
 }
 
-/// Validate a TTS provider's API key by hitting a lightweight read-only endpoint
-/// rather than synthesizing audio (which requires a valid voice ID).
-pub(super) async fn validate_tts_provider_key(
+/// Validate a voice provider's API key by hitting a lightweight read-only
+/// endpoint rather than synthesizing audio or transcribing a clip (both of
+/// which need a valid voice/model id, and both of which cost the user a real
+/// inference call just to answer "is this key good?").
+///
+/// `candidate_key` makes this a **dry run**: when the caller supplies a key,
+/// it is validated as-is and nothing is read from the keychain, so the settings
+/// modal can check a key the user typed *before* deciding to store it (#5896).
+/// Passing `None` falls back to the stored credential for the slug, which is
+/// what the already-configured "Test" buttons in the routing section want.
+///
+/// Likewise the endpoint is resolved from `config.voice_providers` when the
+/// provider is already registered, and from `builtin_voice_provider`
+/// otherwise — a first-time key check happens before any config entry exists.
+pub(super) async fn validate_provider_key(
     provider: &str,
     config: &crate::openhuman::config::Config,
+    candidate_key: Option<&str>,
 ) -> Result<String, String> {
+    use crate::openhuman::config::schema::voice_providers::builtin_voice_provider;
+
     let (slug, _model) = if let Some(pos) = provider.find(':') {
         (&provider[..pos], &provider[pos + 1..])
     } else {
         (provider, "")
     };
 
-    let entry = config
+    let endpoint = config
         .voice_providers
         .iter()
         .find(|p| p.slug == slug)
+        .map(|p| p.endpoint.as_str())
+        .or_else(|| builtin_voice_provider(slug).map(|b| b.endpoint))
         .ok_or_else(|| format!("no voice provider with slug '{slug}'"))?;
 
-    let api_key = crate::openhuman::inference::provider::factory::lookup_key_for_slug(slug, config)
-        .unwrap_or_default();
+    let api_key = match candidate_key.map(str::trim) {
+        Some(k) if !k.is_empty() => k.to_string(),
+        _ => crate::openhuman::inference::provider::factory::lookup_key_for_slug(slug, config)
+            .unwrap_or_default(),
+    };
 
     if api_key.is_empty() {
         return Err("no API key configured for this provider".to_string());
     }
 
-    let endpoint = entry.endpoint.trim_end_matches('/');
+    let endpoint = endpoint.trim_end_matches('/');
     let client = reqwest::Client::new();
 
     // ElevenLabs: GET /user/subscription requires only basic auth (no
@@ -140,12 +160,19 @@ pub(super) async fn validate_tts_provider_key(
         format!("{endpoint}/models")
     };
 
-    let mut req = client.get(&url);
-    if slug == "elevenlabs" {
-        req = req.header("xi-api-key", &api_key);
-    } else {
-        req = req.header("Authorization", format!("Bearer {api_key}"));
-    }
+    // Auth headers must match what the real providers send, or a valid key
+    // reads as invalid. Deepgram in particular uses `Token`, not `Bearer`
+    // (see `factory::stt_providers`) — validating it as Bearer would 401 on
+    // a perfectly good key.
+    let req = match slug {
+        "elevenlabs" => client.get(&url).header("xi-api-key", &api_key),
+        "deepgram" => client
+            .get(&url)
+            .header("Authorization", format!("Token {api_key}")),
+        _ => client
+            .get(&url)
+            .header("Authorization", format!("Bearer {api_key}")),
+    };
 
     let resp = req
         .send()
@@ -153,7 +180,7 @@ pub(super) async fn validate_tts_provider_key(
         .map_err(|e| format!("request failed: {e}"))?;
 
     if resp.status().is_success() {
-        Ok("TTS provider key is valid".to_string())
+        Ok("Provider key is valid".to_string())
     } else {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();

--- a/src/openhuman/voice/schemas/params.rs
+++ b/src/openhuman/voice/schemas/params.rs
@@ -148,7 +148,11 @@ pub(super) struct VoiceListModelsParams {
 }
 
 /// Test a voice provider endpoint.
-#[derive(Debug, Deserialize)]
+///
+/// `Debug` is implemented by hand rather than derived: `api_key` carries a raw
+/// user credential, and a derived `Debug` would print it in full the first time
+/// anyone adds a `{:?}` of this struct to a log line.
+#[derive(Deserialize)]
 pub(super) struct VoiceTestProviderParams {
     pub(super) workload: String,
     pub(super) provider: String,
@@ -156,6 +160,23 @@ pub(super) struct VoiceTestProviderParams {
     /// synthesizing or transcribing. Used by the provider-enable modal.
     #[serde(default)]
     pub(super) validate_only: bool,
+    /// Candidate API key to validate **without storing it**, so the
+    /// provider-enable modal can check a key before the user commits to
+    /// saving it (#5896). Omitted means "use the stored credential for this
+    /// provider's slug". Only consulted when `validate_only` is set.
+    #[serde(default)]
+    pub(super) api_key: Option<String>,
+}
+
+impl std::fmt::Debug for VoiceTestProviderParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VoiceTestProviderParams")
+            .field("workload", &self.workload)
+            .field("provider", &self.provider)
+            .field("validate_only", &self.validate_only)
+            .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
+            .finish()
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/openhuman/voice/schemas/registry.rs
+++ b/src/openhuman/voice/schemas/registry.rs
@@ -322,7 +322,9 @@ pub fn voice_schemas(function: &str) -> ControllerSchema {
             function: "test_provider",
             description:
                 "Test a voice provider endpoint without saving. STT transcribes a \
-                 silent audio clip; TTS synthesizes 'Hello' and discards.",
+                 silent audio clip; TTS synthesizes 'Hello' and discards. With \
+                 `validate_only` it is a dry run: a lightweight authenticated GET, \
+                 no inference call and nothing persisted.",
             inputs: vec![
                 required_string("workload", "Workload to test: 'stt' or 'tts'."),
                 required_string(
@@ -331,7 +333,14 @@ pub fn voice_schemas(function: &str) -> ControllerSchema {
                 ),
                 optional_bool(
                     "validate_only",
-                    "When true, only validate the API key without synthesizing/transcribing.",
+                    "When true, only validate the API key without synthesizing/transcribing. \
+                     Honoured for both workloads.",
+                ),
+                optional_string(
+                    "api_key",
+                    "Candidate API key to validate without storing it, so a key can be \
+                     checked before the user commits to saving it. Omit to use the stored \
+                     credential. Only read when `validate_only` is true.",
                 ),
             ],
             outputs: vec![json_output(

--- a/src/openhuman/voice/schemas_tests.rs
+++ b/src/openhuman/voice/schemas_tests.rs
@@ -485,6 +485,58 @@ fn deserialize_voice_test_provider_params() {
     let parsed = deserialize_params::<VoiceTestProviderParams>(params).unwrap();
     assert_eq!(parsed.workload, "stt");
     assert_eq!(parsed.provider, "deepgram:nova-2");
+    // Absent `api_key` means "use the stored credential", not "empty key".
+    assert_eq!(parsed.api_key, None);
+    assert!(!parsed.validate_only);
+}
+
+#[test]
+fn deserialize_voice_test_provider_params_accepts_candidate_key() {
+    let params = Map::from_iter([
+        ("workload".to_string(), json!("stt")),
+        ("provider".to_string(), json!("elevenlabs")),
+        ("validate_only".to_string(), json!(true)),
+        ("api_key".to_string(), json!("sk-candidate-not-yet-saved")),
+    ]);
+    let parsed = deserialize_params::<VoiceTestProviderParams>(params).unwrap();
+    assert!(parsed.validate_only);
+    assert_eq!(
+        parsed.api_key.as_deref(),
+        Some("sk-candidate-not-yet-saved")
+    );
+}
+
+#[test]
+fn voice_test_provider_params_debug_redacts_the_candidate_key() {
+    let params = Map::from_iter([
+        ("workload".to_string(), json!("stt")),
+        ("provider".to_string(), json!("elevenlabs")),
+        ("api_key".to_string(), json!("sk-super-secret-value")),
+    ]);
+    let parsed = deserialize_params::<VoiceTestProviderParams>(params).unwrap();
+    let rendered = format!("{parsed:?}");
+    assert!(
+        !rendered.contains("sk-super-secret-value"),
+        "Debug must never render the raw key: {rendered}"
+    );
+    assert!(rendered.contains("[REDACTED]"), "got: {rendered}");
+    // The non-secret fields still have to be debuggable, or the manual impl
+    // has traded a leak for an undiagnosable handler.
+    assert!(rendered.contains("elevenlabs"), "got: {rendered}");
+}
+
+#[test]
+fn test_provider_schema_exposes_the_dry_run_candidate_key() {
+    let s = voice_schemas("voice_test_provider");
+    let api_key = s
+        .inputs
+        .iter()
+        .find(|i| i.name == "api_key")
+        .expect("voice_test_provider must accept a candidate api_key for the dry run");
+    assert!(
+        !api_key.required,
+        "api_key is optional — omitting it means 'use the stored credential'"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **"Test Key" in Settings → Voice is now a dry run.** It validates the key the user typed and reports the result; it no longer writes the key to the keychain or activates the provider.
- **The result alert is now reachable at all.** Testing used to unmount the modal before the result was set, so the button appeared to do nothing.
- `voice_test_provider` gains an optional `api_key` — a candidate credential that is validated and discarded, never stored.
- `validate_only` is honoured for **both** workloads. It was checked inside the `"tts"` arm alone, and every provider the modal can reach maps to `"stt"`, so the modal's dry-run request was always answered with a live transcription.
- Fixed a latent auth bug in the shared validator: Deepgram authenticates with `Authorization: Token`, not `Bearer`.
- `VoiceTestProviderParams` gets a hand-written `Debug` that redacts `api_key`.

## Problem

`VoicePanelKeyModal.tsx:175-197` called `handleEnableExternalProvider` **first**, before testing anything. That handler:

- persists the key via `setVoiceProviderKey` (`VoicePanel.tsx:381`),
- writes the provider into voice settings via `saveVoiceSettings` (`:391`),
- clears `pendingKeySlug` / `pendingKeyValue` (`:393-394`).

The modal renders behind `{pendingKeySlug && <VoicePanelKeyModal…>}` (`VoicePanel.tsx:511`), so clearing the slug **unmounts the modal** — and only then did the handler call `testVoiceProvider` and `setKeyTestResult`, on a component that was already gone.

Two user-visible consequences:

1. A key the user only wanted to **check** was written to the keychain and activated *before* it was known to work. A typo'd key ends up as the live provider.
2. The success/failure alert was unreachable, so from the user's side "Test Key" did nothing.

**Why the frontend was written that way.** This was structural, not sloppiness, and it is the reason a frontend-only reorder does not work. `handle_voice_test_provider` had no way to receive a candidate key: it resolved the key from the keychain (`helpers.rs:125`) and the endpoint from an existing `config.voice_providers` entry (`:119-123`, `ok_or_else` → `"no voice provider with slug '<slug>'"`). A first-time key check was impossible without persisting first. Reordering alone would have made every test fail with that error.

**A third defect found while fixing it.** `validate_only` was only consulted inside the `"tts"` arm (`provider_server.rs:346`). The modal computes `workload = meta?.capability === 'tts' ? 'tts' : 'stt'`, and none of `deepgram` (stt) / `elevenlabs` (both) / `openai` (both) is tts-only — so the modal **always** sent `"stt"`, and the STT arm ignored the flag entirely and ran a real transcription. `validate_only` has never had any effect from this modal.

## Solution

**Core (`src/openhuman/voice/schemas/`)**

- `params.rs` — `VoiceTestProviderParams` gains `api_key: Option<String>`. `Debug` is hand-written to render `[REDACTED]`, so a future `{:?}` in a log line cannot leak the credential. (The RPC dispatch layer already redacts a param named `api_key` — `core/rpc_log.rs:74`, so the wire log was covered; this closes the struct-level hole.)
- `helpers.rs` — `validate_tts_provider_key` → `validate_provider_key(provider, config, candidate_key)`. A supplied candidate is used as-is and the keychain is not read; `None` keeps the old stored-credential behaviour, which is what the routing section's Test buttons want. The endpoint now falls back to `builtin_voice_provider(slug)` when the slug is not yet in config, which is what makes a *first-time* check possible.
- `helpers.rs` — **Deepgram sends `Authorization: Token`**, not `Bearer` (`factory/stt_providers.rs:237`). The validator only knew elevenlabs-vs-Bearer; now that it covers STT slugs, a perfectly valid Deepgram key would have read as invalid. Added the `Token` branch.
- `provider_server.rs` — `validate_only` hoisted above the workload match so it means the same thing for both. Reserved slugs (`is_voice_slug_reserved`: cloud/openhuman/backend/piper/whisper/local/empty) still fall through to the live test, so the factory keeps reporting misconfiguration by name rather than "no voice provider with slug 'whisper'". Using the existing helper instead of the hand-copied `matches!` list means the two lists cannot drift.

**App**

- `voiceSettingsApi.ts` — `testVoiceProvider(workload, provider, validateOnly, apiKey?)`. An empty/blank key is *omitted* rather than sent, because the core reads an empty candidate as "fall back to the stored credential".
- `VoicePanelKeyModal.tsx` — the Test handler no longer calls `handleEnableExternalProvider`; it passes `pendingKeyValue` to the core for validation only. `Save & Enable` is untouched and remains the one way to commit a key.

**Reviewer note on diff size.** `provider_server.rs` shows ~150 changed lines, but the behaviour change is the hoist. Most of it is the `match p.workload` arms becoming early returns, which reindents both bodies. The STT and TTS bodies are otherwise character-for-character unchanged (including a pre-existing garbled comment I deliberately left alone).

**Class check.** The equivalent LLM path, `CustomRoutingDialog.handleTest` (`app/src/components/settings/panels/ai/CustomRoutingDialog.tsx:195-204`), was checked for the same shape and is clean — it calls `testProviderModel` without enabling anything first. The defect is specific to the voice modal.

## Impact

- **Behaviour change, intended:** a successful "Test Key" no longer saves the key. The user must click "Save & Enable" to commit it — which is what the button labels have always implied and what the RPC schema already claimed ("Test a voice provider endpoint **without saving**").
- **Security:** a raw credential now travels over the local RPC in a `validate_only` request. This is not new exposure — `setVoiceProviderKey` already sends the same key over the same channel — and it is redacted at both the dispatch log and the params struct.
- **Cost:** a dry run is now a lightweight authenticated GET instead of a real STT transcription, so testing a key no longer bills the user an inference call.
- Desktop/web settings UI only. No migration, no schema-breaking change (`api_key` is optional; existing callers are unaffected).

## Review round 1

Three findings, all addressed in `eaf1ab3b4`:

- **Stale test result (Codex, P2).** The key field is editable during a test, so key A's verdict could render beside key B — the same misleading-status shape this PR fixes. Added a monotonic `testRequestIdRef` (the guard `CustomRoutingDialog` already uses), bumped on test start and on every edit; stale responses are dropped in both `try` and `catch`. New regression test.
- **Trim the candidate key (CodeRabbit).** Applied. One correction to the stated rationale: the core already trims before use, so validation worked either way. The real defect was the guard testing `apiKey.trim()` while the payload sent `apiKey`.
- **Reserved slugs broke the dry-run contract (CodeRabbit, Major).** Correct, and against a promise *this PR introduced* — so it needed a structural guard, not a caveat. Reserved slugs now return before either live branch. I returned `ok: true` ("No API key to validate") rather than the suggested `ok: false`: `ok` drives a red/green alert, and `cloud`/`openhuman`/`piper` are healthy providers that simply have no user key. No existing caller changes behaviour — the only `validate_only: true` caller is the modal, which sends only the three external slugs.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — 4 vitest cases in `VoicePanel.test.tsx` (validates-without-saving, modal-stays-mounted-and-alert-renders, failure-path-does-not-save, stale-result-discarded) and 4 Rust unit tests in `schemas_tests.rs`. **All run locally, and revert-proofed — see the validation section.**
- [x] **Diff coverage ≥ 80%** — `N/A: not measured.` I ran the focused suites rather than `pnpm test:coverage`/`pnpm test:rust`, which would have held a shared build slot for a long time to answer a question the CI gate answers directly. Every changed line in the modal, the API wrapper and the params struct is exercised by the tests above.
- [x] Coverage matrix updated — `N/A: behaviour-only change`, no feature rows added, removed or renamed.
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature IDs affected`.
- [x] No new external network dependencies introduced — no new deps; the dry run reuses the endpoint the validator already called, and the vitest cases mock `testVoiceProvider` and reach no network.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: RELEASE-MANUAL-SMOKE.md does not cover the voice provider-key modal.` Still worth a reviewer clicking through: enter a bad key → Test → red alert, modal still open, provider still off.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Related

- Closes: Closes #5896
- Follow-up PR(s)/TODOs: none.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5896-voice-test-key-dry-run`
- Commit SHA: `eaf1ab3b4`

### Validation Run

All of the below was run locally through the fleet's shared CI semaphore.

- [x] `pnpm --filter openhuman-app format:check` — prettier `--check` clean on the four touched app files.
- [x] `pnpm typecheck` — `tsc --noEmit`, clean, no diagnostics.
- [x] Focused tests:
  - `vitest run VoicePanel.test.tsx` → **43 passed**.
  - `cargo test -p openhuman --lib --features voice test_provider` → **9 passed**. Note `voice` is *not* in the contributor `default` feature set, so the same command without `--features voice` silently matches zero voice tests — an easy way to get a false green here.
- [x] Rust fmt/check (if changed): `rustfmt --edition 2021 --check` clean on all five touched `.rs` files; the crate compiles (the test run above builds the full lib test target).
- [x] Tauri fmt/check (if changed): `N/A: no Tauri shell files touched.`

**Revert-proofs** (each fault injected, failure confirmed to name the intended assertion, then restored and re-run green):

| Test | Fault injected | Result |
| --- | --- | --- |
| 3 dry-run cases | Restored the original `await handleEnableExternalProvider(...)` before the test | All 3 failed |
| `validates without saving` | Kept the 4-arg call but re-added the persist, so the arg assertion still passes | Failed at `:812` on `setVoiceProviderKey ... not.toHaveBeenCalled` — proving the no-persist assertion is live and not shadowed by the earlier one |
| `discards an in-flight result` | Removed the stale-response guard | Failed at `:891` on the stale-verdict assertion |
| `debug_redacts_the_candidate_key` | Restored the derived `Debug` | Exactly 1 of 9 failed, naming `schemas_tests.rs:518`, output showing `api_key: Some("sk-super-secret-value")` |

**Not revert-proofed, stated plainly:** the three other Rust tests (schema field present, params deserialization) were run and pass but were not fault-injected — a fault there is near-tautological and the orthogonal faults would have cross-contaminated each other's subjects. And the reserved-slug guard has **no test at all**: `handle_voice_test_provider` calls `load_config_with_timeout()` and this module has no config-free unit-test seam, every existing test being at the schema/params layer. I did not want to build that harness inside a bug-fix PR. Verified by reading only.

### Validation Blocked

- `command:` `pnpm test:coverage`, `pnpm test:rust` (full suites)
- `error:` not attempted — they hold a shared fleet build slot far longer than the focused runs, for a number the CI gate reports anyway.
- `impact:` diff-coverage percentage is unknown until CI reports it.

### Behavior Changes

- Intended behavior change: "Test Key" validates and reports without saving or activating; `validate_only` now applies to STT as well as TTS and never triggers inference; Deepgram keys are validated with the `Token` scheme; a stale test result can no longer describe an edited key.
- User-visible effect: the Test Key result alert is visible for the first time; a tested key is no longer silently saved and switched on; a wrong key can be corrected in place; the verdict always refers to the key currently in the box.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dry-run validation for voice provider API keys before saving or activating them.
  - Supports candidate-key testing for speech-to-text and text-to-speech providers.
  - Keeps the validation dialog open to display results.

- **Bug Fixes**
  - Prevented failed tests from saving invalid credentials or changing provider settings.
  - Discards outdated results when keys are edited or retested.
  - Redacts API keys from diagnostic output.

- **Documentation**
  - Clarified dry-run behavior and optional candidate-key validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->