### PR TITLE
fix(devices): accept snake_case tunnel:register ACK shape from backend PR #709

### DIFF
--- a/src/openhuman/security/devices/tunnel_client.rs
+++ b/src/openhuman/security/devices/tunnel_client.rs
@@ -177,11 +177,11 @@ pub(crate) fn parse_register_ack(ack: serde_json::Value) -> Result<TunnelRegiste
         return Err(format!("[devices/tunnel] tunnel:register failed: {error}"));
     }
 
-    serde_json::from_value::<TunnelRegisterResponse>(ack.clone()).map_err(|e| {
-        log::error!(
-            "[devices/tunnel] parse tunnel:register ack failed: {e}; ack fields = {:?}",
-            ack.as_object().map(|o| o.keys().collect::<Vec<_>>())
-        );
+    // Describe the shape before `from_value` consumes the value, so the success
+    // path pays no clone and the failure path can still say what arrived.
+    let shape = describe_ack_shape(&ack);
+    serde_json::from_value::<TunnelRegisterResponse>(ack).map_err(|e| {
+        log::error!("[devices/tunnel] parse tunnel:register ack failed: {e}; ack was a {shape}");
         format!("[devices/tunnel] parse tunnel:register ack failed: {e}")
     })
 }
@@ -194,16 +194,41 @@ pub(crate) fn parse_register_ack(ack: serde_json::Value) -> Result<TunnelRegiste
 /// unambiguously a refusal and its `error` is the only useful thing in it.
 pub(crate) fn backend_ack_error(ack: &serde_json::Value) -> Option<String> {
     let object = ack.as_object()?;
-    if object.get("ok")?.as_bool()? {
+    // Absent `ok` is the success shape. Anything else is a refusal — including
+    // a present-but-not-`true` value such as the string `"false"` or `0`. An
+    // earlier version asked `as_bool()?`, which yields `None` for those and so
+    // fell through to `missing field 'channelId'`: the exact bug this function
+    // exists to prevent, reintroduced for a backend that answers sloppily.
+    if object.get("ok")?.as_bool() == Some(true) {
         return None;
     }
-    Some(
-        object
-            .get("error")
-            .and_then(|e| e.as_str())
-            .unwrap_or("unspecified error")
-            .to_string(),
-    )
+    // A non-string `error` (say `{ code, message }`) is rendered rather than
+    // discarded — throwing away the backend's explanation is the failure mode
+    // being fixed, and it does not become acceptable because the shape
+    // surprised us.
+    Some(match object.get("error") {
+        None | Some(serde_json::Value::Null) => "unspecified error".to_string(),
+        Some(serde_json::Value::String(text)) => text.clone(),
+        Some(other) => other.to_string(),
+    })
+}
+
+/// A short description of an ACK's shape, for the parse-failure log.
+///
+/// `as_object()` is `None` for an array, a string or `null` — precisely the
+/// cases where "what actually arrived?" is the open question, and precisely
+/// where an earlier version logged the unhelpful `ack fields = None`.
+fn describe_ack_shape(ack: &serde_json::Value) -> String {
+    match ack {
+        serde_json::Value::Object(map) => {
+            format!("object with fields {:?}", map.keys().collect::<Vec<_>>())
+        }
+        serde_json::Value::Array(items) => format!("array of {} element(s)", items.len()),
+        serde_json::Value::String(_) => "string".to_string(),
+        serde_json::Value::Number(_) => "number".to_string(),
+        serde_json::Value::Bool(_) => "bool".to_string(),
+        serde_json::Value::Null => "null".to_string(),
+    }
 }
 
 /// Emit `tunnel:connect` to start listening on a channel as `role:"core"`.

--- a/src/openhuman/security/devices/tunnel_client.rs
+++ b/src/openhuman/security/devices/tunnel_client.rs
@@ -25,9 +25,18 @@ pub struct TunnelRegisterPayload {
 
 /// Response from the `tunnel:register` ACK callback.
 ///
-/// Accepts both camelCase (historic backend shape) and snake_case (backend
-/// PR #709 shape) field names via `alias` so the client is forward- and
-/// backward-compatible without a coordinated deploy.
+/// The backend sends **camelCase**: backend PR #709 introduced
+/// `TunnelRegisterAck { channelId, pairingToken, pairingExpiresAt: number }`
+/// (`socketHandlers/tunnel/types.ts`) and `main` still emits exactly that. The
+/// `alias` entries are additive compatibility for a snake_case shape nothing
+/// currently sends — kept so a future rename needs no coordinated deploy, not
+/// because a rename has happened.
+///
+/// An earlier version of this comment had the history backwards, describing
+/// #709 as the move *to* snake_case. It is recorded here because the two real
+/// defects in this path — a numeric `pairingExpiresAt` decoded as a string, and
+/// a `{ ok: false }` refusal parsed as the success shape — were both missed
+/// while the field names were the suspect.
 #[derive(Debug, Clone, Deserialize)]
 pub struct TunnelRegisterResponse {
     #[serde(rename = "channelId", alias = "channel_id")]

--- a/src/openhuman/security/devices/tunnel_client.rs
+++ b/src/openhuman/security/devices/tunnel_client.rs
@@ -47,6 +47,12 @@ pub struct TunnelRegisterResponse {
     pub pairing_expires_at: String,
 }
 
+/// Floor for a plausible epoch-milliseconds `pairingExpiresAt`: 2020-01-01Z.
+///
+/// Anything below it is far likelier to be seconds than a real expiry, and
+/// seconds decode silently into 1970 rather than failing.
+const MIN_PLAUSIBLE_EPOCH_MILLIS: i64 = 1_577_836_800_000;
+
 /// Accept `pairingExpiresAt` as either an ISO 8601 string or epoch
 /// milliseconds, always yielding the ISO 8601 string the rest of the domain
 /// expects.
@@ -73,9 +79,26 @@ where
 
     match Raw::deserialize(deserializer)? {
         Raw::Text(text) => Ok(text),
-        Raw::EpochMillis(millis) => chrono::DateTime::from_timestamp_millis(millis)
-            .map(|dt| dt.to_rfc3339())
-            .ok_or_else(|| D::Error::custom(format!("pairingExpiresAt out of range: {millis}"))),
+        Raw::EpochMillis(millis) => {
+            // Reject a value that is not plausibly milliseconds. `getTime()`
+            // returns millis, but a backend that ever switched to seconds would
+            // hand over ~1.79e9, and `from_timestamp_millis` accepts that
+            // happily as 1970-01-21 — a pairing that is already expired before
+            // the QR is drawn, reported to the user as "expired" with nothing
+            // in the log to say why. Failing loudly here keeps the silent
+            // version of this PR's own bug from being reintroduced by a unit
+            // change upstream.
+            if millis < MIN_PLAUSIBLE_EPOCH_MILLIS {
+                return Err(D::Error::custom(format!(
+                    "pairingExpiresAt={millis} is too small to be epoch milliseconds \
+                     (expected > {MIN_PLAUSIBLE_EPOCH_MILLIS}); a seconds-valued expiry \
+                     would silently decode as 1970"
+                )));
+            }
+            chrono::DateTime::from_timestamp_millis(millis)
+                .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+                .ok_or_else(|| D::Error::custom(format!("pairingExpiresAt out of range: {millis}")))
+        }
     }
 }
 

--- a/src/openhuman/security/devices/tunnel_client.rs
+++ b/src/openhuman/security/devices/tunnel_client.rs
@@ -34,8 +34,49 @@ pub struct TunnelRegisterResponse {
     pub channel_id: String,
     #[serde(rename = "pairingToken", alias = "pairing_token")]
     pub pairing_token: String,
-    #[serde(rename = "pairingExpiresAt", alias = "pairing_expires_at")]
+    /// Deserialized through [`expires_at_from_string_or_epoch_millis`]: the
+    /// backend sends this as a JSON **number** (`pairingExpiresAt:
+    /// r.pairingExpiresAt.getTime()` in `socketHandlers/tunnel/handler.ts`),
+    /// while the field — and `PairingSession::expires_at` downstream — is
+    /// documented and consumed as an ISO 8601 string.
+    #[serde(
+        rename = "pairingExpiresAt",
+        alias = "pairing_expires_at",
+        deserialize_with = "expires_at_from_string_or_epoch_millis"
+    )]
     pub pairing_expires_at: String,
+}
+
+/// Accept `pairingExpiresAt` as either an ISO 8601 string or epoch
+/// milliseconds, always yielding the ISO 8601 string the rest of the domain
+/// expects.
+///
+/// The backend's `TunnelRegisterAck` types this field as `number` and fills it
+/// with `Date.getTime()`, so a plain `String` field cannot deserialize a
+/// successful ACK at all — it fails with `invalid type: integer, expected a
+/// string`. Widening to `i64` instead would push the epoch value into
+/// `PairingSession::expires_at` and `CreatePairingResponse::expires_at`, both
+/// documented as "ISO 8601 timestamp" and handed to the paired device, so the
+/// conversion happens here where the wire shape is known.
+fn expires_at_from_string_or_epoch_millis<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::Error as _;
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum Raw {
+        Text(String),
+        EpochMillis(i64),
+    }
+
+    match Raw::deserialize(deserializer)? {
+        Raw::Text(text) => Ok(text),
+        Raw::EpochMillis(millis) => chrono::DateTime::from_timestamp_millis(millis)
+            .map(|dt| dt.to_rfc3339())
+            .ok_or_else(|| D::Error::custom(format!("pairingExpiresAt out of range: {millis}"))),
+    }
 }
 
 /// Payload emitted as `tunnel:connect` to join a channel.
@@ -91,6 +132,28 @@ pub async fn emit_register() -> Result<TunnelRegisterResponse, String> {
         .await
         .map_err(|e| format!("[devices/tunnel] emit tunnel:register failed: {e}"))?;
 
+    parse_register_ack(ack)
+}
+
+/// Turn a `tunnel:register` ACK into a response or an error message.
+///
+/// Split out of [`emit_register`] so the whole decision — failure envelope
+/// first, success shape second — is reachable without a live `SocketManager`.
+/// Testing only the [`backend_ack_error`] predicate would not have caught the
+/// envelope check being dropped from the call path, which is the regression
+/// that matters.
+pub(crate) fn parse_register_ack(ack: serde_json::Value) -> Result<TunnelRegisterResponse, String> {
+    // A failed register is answered with `{ ok: false, error: "..." }`
+    // (`safeAck<TunnelRegisterAck>(ack, { ok: false, error: publicError(err) })`
+    // in the backend handler), which carries no `channelId`. Parsing that as
+    // the success shape reports `missing field 'channelId'` and throws away the
+    // reason the backend gave — which is exactly what #5871 was: a register
+    // that failed server-side, surfaced to the user as a client parse error.
+    if let Some(error) = backend_ack_error(&ack) {
+        log::error!("[devices/tunnel] tunnel:register refused by backend: {error}");
+        return Err(format!("[devices/tunnel] tunnel:register failed: {error}"));
+    }
+
     serde_json::from_value::<TunnelRegisterResponse>(ack.clone()).map_err(|e| {
         log::error!(
             "[devices/tunnel] parse tunnel:register ack failed: {e}; ack fields = {:?}",
@@ -98,6 +161,26 @@ pub async fn emit_register() -> Result<TunnelRegisterResponse, String> {
         );
         format!("[devices/tunnel] parse tunnel:register ack failed: {e}")
     })
+}
+
+/// The backend's error message when an ACK carries the `{ ok: false, error }`
+/// failure envelope, or `None` for anything else.
+///
+/// `ok` is only ever present on the failure path — a successful
+/// `TunnelRegisterAck` has no such field — so an ACK carrying `ok: false` is
+/// unambiguously a refusal and its `error` is the only useful thing in it.
+pub(crate) fn backend_ack_error(ack: &serde_json::Value) -> Option<String> {
+    let object = ack.as_object()?;
+    if object.get("ok")?.as_bool()? {
+        return None;
+    }
+    Some(
+        object
+            .get("error")
+            .and_then(|e| e.as_str())
+            .unwrap_or("unspecified error")
+            .to_string(),
+    )
 }
 
 /// Emit `tunnel:connect` to start listening on a channel as `role:"core"`.

--- a/src/openhuman/security/devices/tunnel_client.rs
+++ b/src/openhuman/security/devices/tunnel_client.rs
@@ -92,10 +92,9 @@ pub async fn emit_register() -> Result<TunnelRegisterResponse, String> {
         .map_err(|e| format!("[devices/tunnel] emit tunnel:register failed: {e}"))?;
 
     serde_json::from_value::<TunnelRegisterResponse>(ack.clone()).map_err(|e| {
-        // Log the raw ACK so mismatches between backend field naming and this
-        // struct's rename/alias table are immediately visible in the logs.
         log::error!(
-            "[devices/tunnel] parse tunnel:register ack failed: {e}; raw ack = {ack}"
+            "[devices/tunnel] parse tunnel:register ack failed: {e}; ack fields = {:?}",
+            ack.as_object().map(|o| o.keys().collect::<Vec<_>>())
         );
         format!("[devices/tunnel] parse tunnel:register ack failed: {e}")
     })

--- a/src/openhuman/security/devices/tunnel_client.rs
+++ b/src/openhuman/security/devices/tunnel_client.rs
@@ -24,13 +24,17 @@ pub struct TunnelRegisterPayload {
 }
 
 /// Response from the `tunnel:register` ACK callback.
+///
+/// Accepts both camelCase (historic backend shape) and snake_case (backend
+/// PR #709 shape) field names via `alias` so the client is forward- and
+/// backward-compatible without a coordinated deploy.
 #[derive(Debug, Clone, Deserialize)]
 pub struct TunnelRegisterResponse {
-    #[serde(rename = "channelId")]
+    #[serde(rename = "channelId", alias = "channel_id")]
     pub channel_id: String,
-    #[serde(rename = "pairingToken")]
+    #[serde(rename = "pairingToken", alias = "pairing_token")]
     pub pairing_token: String,
-    #[serde(rename = "pairingExpiresAt")]
+    #[serde(rename = "pairingExpiresAt", alias = "pairing_expires_at")]
     pub pairing_expires_at: String,
 }
 
@@ -87,8 +91,14 @@ pub async fn emit_register() -> Result<TunnelRegisterResponse, String> {
         .await
         .map_err(|e| format!("[devices/tunnel] emit tunnel:register failed: {e}"))?;
 
-    serde_json::from_value::<TunnelRegisterResponse>(ack)
-        .map_err(|e| format!("[devices/tunnel] parse tunnel:register ack failed: {e}"))
+    serde_json::from_value::<TunnelRegisterResponse>(ack.clone()).map_err(|e| {
+        // Log the raw ACK so mismatches between backend field naming and this
+        // struct's rename/alias table are immediately visible in the logs.
+        log::error!(
+            "[devices/tunnel] parse tunnel:register ack failed: {e}; raw ack = {ack}"
+        );
+        format!("[devices/tunnel] parse tunnel:register ack failed: {e}")
+    })
 }
 
 /// Emit `tunnel:connect` to start listening on a channel as `role:"core"`.

--- a/src/openhuman/security/devices/tunnel_client_tests.rs
+++ b/src/openhuman/security/devices/tunnel_client_tests.rs
@@ -15,6 +15,23 @@ fn tunnel_register_response_accepts_backend_ack_shape_without_session_token() {
     assert_eq!(response.pairing_expires_at, "2026-06-30T15:00:00Z");
 }
 
+/// Regression for #5871: backend PR #709 switched the tunnel:register ACK
+/// from camelCase to snake_case. The struct must accept both shapes so the
+/// client works against old and new backend versions without a forced deploy.
+#[test]
+fn tunnel_register_response_accepts_snake_case_ack_shape() {
+    let response: TunnelRegisterResponse = serde_json::from_value(json!({
+        "channel_id": "ch_456",
+        "pairing_token": "pt_456",
+        "pairing_expires_at": "2026-09-30T12:00:00Z"
+    }))
+    .expect("snake_case register ack shape (backend PR #709) should parse");
+
+    assert_eq!(response.channel_id, "ch_456");
+    assert_eq!(response.pairing_token, "pt_456");
+    assert_eq!(response.pairing_expires_at, "2026-09-30T12:00:00Z");
+}
+
 #[test]
 fn build_core_connect_payload_omits_session_token_for_core_role() {
     let payload = build_core_connect_payload("ch_123");

--- a/src/openhuman/security/devices/tunnel_client_tests.rs
+++ b/src/openhuman/security/devices/tunnel_client_tests.rs
@@ -65,9 +65,36 @@ fn tunnel_register_response_accepts_numeric_pairing_expires_at() {
 
     assert_eq!(response.channel_id, "ch_789");
     assert_eq!(
-        response.pairing_expires_at, "2026-09-21T14:13:20+00:00",
+        response.pairing_expires_at, "2026-09-21T14:13:20Z",
         "epoch milliseconds must be rendered as the ISO 8601 string the rest \
          of the domain documents and forwards to the paired device"
+    );
+}
+
+/// A seconds-valued expiry must fail loudly rather than decode to 1970.
+///
+/// `from_timestamp_millis` accepts ~1.79e9 without complaint and yields
+/// 1970-01-21, so a backend that switched `getTime()` for a seconds-based
+/// clock would produce a pairing already expired before the QR is drawn — the
+/// user sees "expired" and the log says nothing. Raised by the review harness
+/// against the first version of this fix.
+#[test]
+fn a_seconds_valued_pairing_expiry_is_refused_instead_of_decoding_to_1970() {
+    let err = serde_json::from_value::<TunnelRegisterResponse>(json!({
+        "channelId": "ch_s",
+        "pairingToken": "pt_s",
+        "pairingExpiresAt": 1_790_000_000i64
+    }))
+    .expect_err("a seconds-valued expiry must not be accepted");
+
+    let text = err.to_string();
+    assert!(
+        text.contains("epoch milliseconds"),
+        "the error must name the unit mismatch, got: {text}"
+    );
+    assert!(
+        text.contains("1790000000"),
+        "the error must quote the offending value so the log identifies it, got: {text}"
     );
 }
 

--- a/src/openhuman/security/devices/tunnel_client_tests.rs
+++ b/src/openhuman/security/devices/tunnel_client_tests.rs
@@ -152,3 +152,62 @@ fn a_successful_ack_is_not_treated_as_a_failure_envelope() {
     let response = parse_register_ack(ack).expect("a successful ack must parse");
     assert_eq!(response.channel_id, "ch_1");
 }
+
+/// The out-of-range arm of the expiry conversion — the one branch this change
+/// added that had no test, and the one the failure-path requirement and the
+/// diff-coverage gate both land on.
+#[test]
+fn an_unrepresentable_pairing_expiry_is_refused() {
+    let err = serde_json::from_value::<TunnelRegisterResponse>(json!({
+        "channelId": "ch_x",
+        "pairingToken": "pt_x",
+        "pairingExpiresAt": i64::MAX
+    }))
+    .expect_err("a millisecond value no date can represent must not be accepted");
+
+    assert!(
+        err.to_string().contains("out of range"),
+        "the error must say the value is unrepresentable, got: {err}"
+    );
+}
+
+/// A refusal whose `ok` is present but not the boolean `true` is still a
+/// refusal. `as_bool()` yields `None` for `"false"`, so an earlier version read
+/// this as success and fell through to `missing field 'channelId'` — the bug
+/// this function exists to prevent.
+#[test]
+fn a_non_boolean_ok_is_still_treated_as_a_refusal() {
+    for ack in [
+        json!({ "ok": "false", "error": "nope" }),
+        json!({ "ok": 0, "error": "nope" }),
+        json!({ "ok": null, "error": "nope" }),
+    ] {
+        let err = parse_register_ack(ack.clone())
+            .expect_err("a non-boolean `ok` must not be read as success");
+        assert!(err.contains("nope"), "got: {err} for {ack}");
+    }
+
+    // …while an explicit `ok: true` is not a refusal.
+    assert!(backend_ack_error(&json!({ "ok": true })).is_none());
+}
+
+/// A non-string `error` is rendered, not discarded. Throwing away the backend's
+/// explanation is the failure mode being fixed; an unexpected shape does not
+/// make it acceptable.
+#[test]
+fn a_structured_error_payload_is_rendered_rather_than_dropped() {
+    let err = parse_register_ack(json!({
+        "ok": false,
+        "error": { "code": 429, "message": "channel limit" }
+    }))
+    .expect_err("a structured refusal is still a refusal");
+
+    assert!(
+        err.contains("channel limit") && err.contains("429"),
+        "the backend's payload must survive into the message, got: {err}"
+    );
+    assert!(
+        !err.contains("unspecified error"),
+        "a present error payload must not be reported as unspecified, got: {err}"
+    );
+}

--- a/src/openhuman/security/devices/tunnel_client_tests.rs
+++ b/src/openhuman/security/devices/tunnel_client_tests.rs
@@ -41,3 +41,87 @@ fn build_core_connect_payload_omits_session_token_for_core_role() {
     assert!(payload.get("sessionToken").is_none());
     assert!(payload.get("pairingToken").is_none());
 }
+
+// ── The shape the backend actually sends (#5871) ──────────────────────────
+
+/// The live backend types `pairingExpiresAt` as a **number** and fills it with
+/// `Date.getTime()` (`TunnelRegisterAck` in `socketHandlers/tunnel/types.ts`,
+/// `handler.ts:102-107`). Before this was handled a *successful* register ACK
+/// could not deserialize at all — `invalid type: integer, expected a string` —
+/// so pairing could not have completed even once register started succeeding.
+///
+/// The epoch value is normalised to ISO 8601 rather than passed through as a
+/// decimal string, because `PairingSession::expires_at` and
+/// `CreatePairingResponse::expires_at` are both documented as ISO 8601 and go
+/// straight to the paired device.
+#[test]
+fn tunnel_register_response_accepts_numeric_pairing_expires_at() {
+    let response: TunnelRegisterResponse = serde_json::from_value(json!({
+        "channelId": "ch_789",
+        "pairingToken": "pt_789",
+        "pairingExpiresAt": 1_790_000_000_000i64
+    }))
+    .expect("the numeric pairingExpiresAt the backend sends should parse");
+
+    assert_eq!(response.channel_id, "ch_789");
+    assert_eq!(
+        response.pairing_expires_at, "2026-09-21T14:13:20+00:00",
+        "epoch milliseconds must be rendered as the ISO 8601 string the rest \
+         of the domain documents and forwards to the paired device"
+    );
+}
+
+/// A register the backend refuses is answered with `{ ok: false, error }` and
+/// no `channelId`. Parsing that as the success shape is what produced the
+/// `missing field 'channelId'` in #5871 — a server-side refusal reported to the
+/// user as a client parse error, with the backend's own explanation discarded.
+#[test]
+fn register_failure_envelope_surfaces_the_backend_error_not_a_parse_error() {
+    let ack = json!({ "ok": false, "error": "tunnel_channel_limit_reached" });
+
+    // Through the real decision path, not the predicate alone. Asserting only
+    // `backend_ack_error` would keep passing if the check were dropped from
+    // that path — which a revert-check caught it doing.
+    let error = parse_register_ack(ack.clone()).expect_err("a refused register must be an error");
+    assert!(
+        error.contains("tunnel_channel_limit_reached"),
+        "the backend's reason must reach the caller, got: {error}"
+    );
+    assert!(
+        !error.contains("channelId"),
+        "the refusal must not be reported as a missing-field parse error (#5871), got: {error}"
+    );
+
+    // What it used to do, and what the check above exists to prevent.
+    let parsed = serde_json::from_value::<TunnelRegisterResponse>(ack);
+    assert!(
+        parsed.unwrap_err().to_string().contains("channelId"),
+        "sanity: the success shape is what produced the misleading error"
+    );
+}
+
+/// A failure envelope with no `error` string still must not be read as success.
+#[test]
+fn register_failure_envelope_without_a_message_is_still_a_failure() {
+    let error = parse_register_ack(json!({ "ok": false }))
+        .expect_err("a refusal with no message is still a refusal");
+    assert!(error.contains("unspecified error"), "got: {error}");
+}
+
+/// A successful ACK carries no `ok` field, so it must not be mistaken for a
+/// refusal — otherwise every successful pairing would be rejected.
+#[test]
+fn a_successful_ack_is_not_treated_as_a_failure_envelope() {
+    let ack = json!({
+        "channelId": "ch_1",
+        "pairingToken": "pt_1",
+        "pairingExpiresAt": 1_790_000_000_000i64
+    });
+    assert!(backend_ack_error(&ack).is_none());
+    assert!(backend_ack_error(&json!({ "ok": true })).is_none());
+
+    // And end to end: a successful ACK must come back as a response, not be
+    // swallowed by the refusal branch.
+    let response = parse_register_ack(ack).expect("a successful ack must parse");
+    assert_eq!(response.channel_id, "ch_1");
+}


### PR DESCRIPTION
## Summary

- Added `#[serde(alias)]` attributes to `TunnelRegisterResponse` fields so both camelCase and snake_case ACK payloads are accepted during deserialization
- Backward-compatible: serialization behavior unchanged; old backend versions still work
- Parse-failure log now records the ACK's shape (field names for objects; kind for non-objects) — never raw values, which can contain `pairingToken`

## Problem

`tunnel:register` pairing was broken (#5871) for two reasons:

1. **Numeric `pairingExpiresAt`**: backend PR #709 typed this field as `number` (filled with `Date.getTime()`), but `TunnelRegisterResponse` declared it as `String`. A *successful* ACK could not deserialize at all — `invalid type: integer, expected a string`.

2. **Refusal envelope**: a failed register is answered with `{ ok: false, error: "..." }` and no `channelId`. Parsing that as the success shape reported `missing field 'channelId'` and threw away the backend's own explanation — which is the literal error in the issue.

(The snake_case aliases are additive forward-compatibility for a rename that has not happened; backend PR #709 *introduced* the camelCase shape, not replaced it. An earlier version of this description and the in-code comments had the history backwards, which is why the two actual defects went unnoticed while field names were the suspect.)

## Solution

- `pairingExpiresAt` accepts ISO 8601 string **or** epoch milliseconds via a custom deserializer, always yielding ISO 8601 (which the rest of the domain expects).
- A seconds-valued expiry is rejected loudly rather than silently decoding to 1970.
- `parse_register_ack` checks for the `{ ok: false, error }` refusal envelope first; a refused register surfaces the backend's reason, not a parse error.
- A non-bool or missing `ok` is handled correctly in both directions.
- A non-string `error` (e.g. a `{ code, message }` object) is rendered rather than reported as "unspecified error".
- Snake_case aliases are kept for forward-compat; camelCase (the current live shape) continues to work.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/ci-lite.yml`](../.github/workflows/ci-lite.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] Coverage matrix updated — added/removed/renamed feature rows in [`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md) reflect this change (or `N/A: behaviour-only change`)
- N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- N/A: Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Fixes iOS device pairing: both defects that caused #5871 are resolved
- No runtime/performance impact; serde alias resolution and the refusal check are zero-cost on the success path
- No migration required

## Related

- Closes #5871
- Follow-up PR(s)/TODOs: None