### PR TITLE
fix(core): dispatch loadAgentProfiles on identity established at boot

### DIFF
--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -29,6 +29,7 @@ import {
 import { daemonHealthService } from '../services/daemonHealthService';
 import { socketService } from '../services/socketService';
 import { store } from '../store';
+import { loadAgentProfiles } from '../store/agentProfileSlice';
 import { resetUserScopedState } from '../store/resetActions';
 import { loadThreads, resetThreadCachesPreservingSelection } from '../store/threadSlice';
 import { getActiveUserId, setActiveUserId } from '../store/userScopedStorage';
@@ -416,6 +417,19 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
             return;
           }
           log('post-identity thread reload failed: %O', sanitizeError(err));
+        });
+      // Seed the active agent profile from the backend at the earliest safe
+      // moment — before any chat request can fire with a stale 'default' id.
+      // Without this, activeProfileId resets to 'default' on every reboot
+      // because the agentProfile slice is not persisted (#5872).
+      void store
+        .dispatch(loadAgentProfiles())
+        .unwrap()
+        .catch(err => {
+          if (threadReloadRequestId !== snapshotRequestIdRef.current) {
+            return;
+          }
+          log('post-identity agent profiles load failed: %O', sanitizeError(err));
         });
     }
 

--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -418,15 +418,27 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
           }
           log('post-identity thread reload failed: %O', sanitizeError(err));
         });
-      // Seed the active agent profile from the backend at the earliest safe
-      // moment — before any chat request can fire with a stale 'default' id.
-      // Without this, activeProfileId resets to 'default' on every reboot
-      // because the agentProfile slice is not persisted (#5872).
+    }
+
+    // Seed the active agent profile at the earliest safe moment so no chat
+    // request can fire with a stale 'default' id (#5872). Intentionally not
+    // gated on !isFlip: on Tauri a flip triggers restartApp() so the provider
+    // remounts with undefined previousIdentity and profiles load on the boot
+    // poll; on web restartApp() is a no-op and by the next poll
+    // previousIdentity === nextIdentity, making shouldClearScopedCaches false
+    // — so we must dispatch here while it is still true.
+    if (
+      requestId === snapshotRequestIdRef.current &&
+      shouldClearScopedCaches &&
+      nextIdentity &&
+      !isLogout
+    ) {
+      const profileReloadRequestId = requestId;
       void store
         .dispatch(loadAgentProfiles())
         .unwrap()
         .catch(err => {
-          if (threadReloadRequestId !== snapshotRequestIdRef.current) {
+          if (profileReloadRequestId !== snapshotRequestIdRef.current) {
             return;
           }
           log('post-identity agent profiles load failed: %O', sanitizeError(err));

--- a/app/src/providers/CoreStateProvider.tsx
+++ b/app/src/providers/CoreStateProvider.tsx
@@ -420,8 +420,14 @@ export default function CoreStateProvider({ children }: { children: ReactNode })
         });
     }
 
-    // Seed the active agent profile at the earliest safe moment so no chat
-    // request can fire with a stale 'default' id (#5872). Intentionally not
+    // Seed the active agent profile at the earliest safe moment, so the window
+    // in which a chat request could carry the stale 'default' id is as short as
+    // the snapshot allows (#5872). It is a narrowing, NOT a guarantee: this
+    // dispatch is deliberately not awaited, so a send issued before it resolves
+    // still reads 'default' from the slice. Closing that window for good means
+    // omitting `profileId` while the slice is still loading — the core keeps
+    // its own authoritative `active_profile_id` and resolves an absent id
+    // against it — which belongs in the send path, not here. Intentionally not
     // gated on !isFlip: on Tauri a flip triggers restartApp() so the provider
     // remounts with undefined previousIdentity and profiles load on the boot
     // poll; on web restartApp() is a no-op and by the next poll

--- a/app/src/providers/__tests__/CoreStateProvider.test.tsx
+++ b/app/src/providers/__tests__/CoreStateProvider.test.tsx
@@ -2,6 +2,7 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import { useEffect } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import * as agentProfilesModule from '../../services/api/agentProfilesApi';
 import * as coreStateApi from '../../services/coreStateApi';
 import * as tauriCommands from '../../utils/tauriCommands';
 import { __resetForTests as resetConfigRecoveryNotice } from '../../lib/configRecoveryNotice';
@@ -17,6 +18,9 @@ import CoreStateProvider, {
 
 vi.mock('../../services/coreStateApi');
 vi.mock('../../services/analytics', () => ({ syncAnalyticsConsent: vi.fn() }));
+vi.mock('../../services/api/agentProfilesApi', () => ({
+  agentProfilesApi: { list: vi.fn(), select: vi.fn(), upsert: vi.fn(), delete: vi.fn() },
+}));
 
 type Snapshot = Awaited<ReturnType<typeof coreStateApi.fetchCoreAppSnapshot>>;
 
@@ -120,11 +124,15 @@ describe('CoreStateProvider — identity-change cache clearing', () => {
   const getTeamMembers = vi.mocked(coreStateApi.getTeamMembers);
   const getTeamInvites = vi.mocked(coreStateApi.getTeamInvites);
 
+  const listProfiles = vi.mocked(agentProfilesModule.agentProfilesApi.list);
+
   beforeEach(() => {
     fetchSnapshot.mockReset();
     listTeams.mockReset();
     getTeamMembers.mockReset();
     getTeamInvites.mockReset();
+    listProfiles.mockReset();
+    listProfiles.mockResolvedValue({ profiles: [], activeProfileId: 'default' } as never);
     resetCoreStateStore();
     setActiveUserId(null);
   });
@@ -941,6 +949,30 @@ describe('CoreStateProvider — identity-change cache clearing', () => {
     });
 
     expect(vi.mocked(tauriCommands.storeSession)).toHaveBeenCalled();
+  });
+
+  // Regression for #5872: the active agent profile must be fetched from the
+  // backend immediately when identity is established so the first chat request
+  // carries the correct profileId rather than the 'default' initialState value.
+  it('dispatches loadAgentProfiles when identity is established (#5872)', async () => {
+    // Returning user: seed matches snapshot userId so isFlip = false.
+    // First snapshot transitions previousIdentity (null) → nextIdentity ('u1'),
+    // which sets shouldClearScopedCaches = true and fires the !isFlip block.
+    setActiveUserId('u1');
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'u1', sessionToken: 'tok1' }));
+    listTeams.mockResolvedValue([]);
+
+    render(
+      <CoreStateProvider>
+        <Consumer />
+      </CoreStateProvider>
+    );
+
+    await waitFor(() => expect(screen.getByTestId('ready').textContent).toBe('ready'));
+    // Flush micro-tasks so the void-dispatched promise chain completes.
+    await act(async () => {});
+
+    expect(listProfiles).toHaveBeenCalled();
   });
 });
 

--- a/app/src/providers/__tests__/CoreStateProvider.test.tsx
+++ b/app/src/providers/__tests__/CoreStateProvider.test.tsx
@@ -974,6 +974,47 @@ describe('CoreStateProvider — identity-change cache clearing', () => {
 
     expect(listProfiles).toHaveBeenCalled();
   });
+
+  // The isFlip = TRUE half, which is the whole reason the guard above omits
+  // `!isFlip` (the neighbouring loadThreads block does gate on it). Without
+  // this, a future refactor "tidying" `!isFlip` back in to match its neighbour
+  // would pass every test in this file and silently break the web path, where
+  // restartApp() is a no-op and the next poll has shouldClearScopedCaches
+  // false — so this dispatch would never fire again.
+  it('still dispatches loadAgentProfiles when the identity FLIPS (#5872)', async () => {
+    // u1 established first; `tok*` is not a local session token
+    // (isLocalSessionToken requires a 3-part `….local` shape), so the
+    // subsequent change to u2 gives seedUserId !== nextIdentity && !isLocalSession
+    // => isFlip === true.
+    setActiveUserId('u1');
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'u1', sessionToken: 'tok1' }));
+    listTeams.mockResolvedValue([]);
+
+    let ctx: CoreStateContextValue | undefined;
+    render(
+      <CoreStateProvider>
+        <Consumer
+          captureCtx={next => {
+            ctx = next;
+          }}
+        />
+      </CoreStateProvider>
+    );
+    await waitFor(() => expect(screen.getByTestId('ready').textContent).toBe('ready'));
+    await act(async () => {});
+
+    // Ignore the establish-time load; we are asserting on the flip itself.
+    listProfiles.mockClear();
+
+    fetchSnapshot.mockResolvedValue(makeSnapshot({ userId: 'u2', sessionToken: 'tok2' }));
+    await act(async () => {
+      await ctx!.refresh();
+    });
+    await waitFor(() => expect(screen.getByTestId('user').textContent).toBe('u2'));
+    await act(async () => {});
+
+    expect(listProfiles).toHaveBeenCalled();
+  });
 });
 
 describe('coreStatePollFailureWarningMessage', () => {


### PR DESCRIPTION
## Summary

- Added a `loadAgentProfiles()` dispatch in `CoreStateProvider` in its own identity-established block, next to (but **not** inside) the existing `loadThreads()` block — the guards differ, see Solution
- Regression tests cover both the returning-user boot path (`isFlip = false`) and the identity flip (`isFlip = true`)

## Problem

`agentProfileSlice` is not wrapped in `persistReducer`, so it always starts from `initialState` (empty profiles list) on every process restart. `CoreStateProvider` dispatched `loadThreads()` when a returning user's identity was established for the first time in the current process, but omitted `loadAgentProfiles()`. The profiles list remained empty until the user navigated to a view that independently triggered a reload, causing the agent profile selector to show no profiles after every reboot.

## Solution

The new block fires when `shouldClearScopedCaches = true`, `nextIdentity` is set, and `!isLogout` — the moment a returning user's snapshot is committed and non-persisted slices need re-hydrating. It reuses `loadThreads()`'s stale-request guard and error-logging shape.

**It is deliberately NOT gated on `!isFlip`, unlike the neighbouring `loadThreads()` block.** On Tauri a flip triggers `restartApp()`, so the provider remounts with an undefined `previousIdentity` and profiles load on the boot poll. On web `restartApp()` is a no-op, so by the next poll `previousIdentity === nextIdentity` and `shouldClearScopedCaches` is already `false` — a `!isFlip`-gated dispatch would never fire there. That difference is the point of the block, so it is covered by its own test.

This narrows, but does not eliminate, the window in which a send can carry the stale `'default'` id: the dispatch is not awaited. Closing it fully means omitting `profileId` while the slice is still loading (the core resolves an absent `profile_id` against its own authoritative `active_profile_id`), which belongs in the send path — tracked separately, see the open review thread.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — changed lines (Vitest + cargo-llvm-cov merged via `diff-cover`) meet the gate enforced by [`.github/workflows/ci-lite.yml`](../.github/workflows/ci-lite.yml). Run `pnpm test:coverage` and `pnpm test:rust` locally; PRs below 80% on changed lines will not merge.
- [x] Coverage matrix updated — N/A: behaviour-only change, no matrix rows added/removed
- N/A: All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy))
- N/A: Manual smoke checklist updated if this touches release-cut surfaces
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- Agent profiles are now populated immediately after boot for returning users, eliminating the empty-profile-list state visible between reboot and first navigation
- Applies to first-time logins and identity flips too (`isFlip = true`) — that is intentional and is what makes the web path work. Logout flows are unaffected (`!isLogout` guard).

## Related

- Closes #5872
- Follow-up PR(s)/TODOs: None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Agent profiles now load reliably when establishing or switching identities, helping ensure chats use the correct active profile.
  - Improved local-session authentication handling prevents pending session updates or stale checks from incorrectly signing users out or overwriting the active session.
  - Authentication refresh behavior is more reliable while session credentials are being stored.
- **Tests**
  - Added regression coverage for identity changes, agent-profile loading, and local-session race conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
