### PR TITLE
test(e2e): backfill coverage for the credential store, voice dry run and the e2e coverage gate

### DIFF
--- a/scripts/__tests__/domain-e2e-coverage-gate.test.mjs
+++ b/scripts/__tests__/domain-e2e-coverage-gate.test.mjs
@@ -1,0 +1,137 @@
+// Behavioural cover for `scripts/check-domain-e2e-coverage.mjs` (#5936).
+//
+// The sibling `coverage-script-help.test.mjs` only asserts `--help` and
+// argument rejection, so all three defects #5936 fixed were unpinned: the gate
+// could go back to measuring a seventh of the surface and every test would stay
+// green. That is the failure mode this file exists to make loud.
+//
+// Each test drives the real script against a fixture tree — the script keys off
+// `process.cwd()`, so a temp dir with `src/openhuman/**` and `tests/**` is a
+// complete world — and asserts on the specific defect, not on the exit code
+// alone. Exit status is deliberately NOT the assertion where it cannot
+// discriminate: an incomplete fixture trips the `declaredButMissing` guard, so
+// several of these runs exit non-zero for more than one reason.
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = resolve(HERE, '..', 'check-domain-e2e-coverage.mjs');
+
+function write(root, relative, contents) {
+  const full = join(root, relative);
+  fs.mkdirSync(dirname(full), { recursive: true });
+  fs.writeFileSync(full, contents);
+}
+
+/** A minimal `ControllerSchema` literal in the shape the scanner matches. */
+function controller(namespace, fn) {
+  return `
+pub const SCHEMA: ControllerSchema = ControllerSchema {
+    namespace: "${namespace}",
+    function: "${fn}",
+};
+`;
+}
+
+function runGate(root, threshold = '90') {
+  return spawnSync(process.execPath, [SCRIPT], {
+    cwd: root,
+    encoding: 'utf8',
+    env: { ...process.env, DOMAIN_E2E_COVERAGE_THRESHOLD: threshold },
+  });
+}
+
+function fixture(t) {
+  const root = fs.mkdtempSync(join(tmpdir(), 'domain-e2e-gate-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  return root;
+}
+
+// Defect (a): discovery used to read only files whose path matched
+// `/(^|\/)schemas?(\.rs|\/)/`. The #5856/#5857 `include!` split moved
+// `ControllerSchema` literals into `*_part_NN.rs` siblings, which that pattern
+// does not match — 180 controllers across 12 namespaces went invisible in one
+// commit and the gate simply reported a smaller world.
+test('discovers controllers declared in an include!-split part file', (t) => {
+  const root = fixture(t);
+  // The filename is the point: `schemas_part_01.rs` does NOT match the old
+  // path filter, because `schemas` is followed by `_` rather than `.rs` or `/`.
+  write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+  write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
+
+  const result = runGate(root);
+
+  assert.match(
+    result.stdout,
+    /Discovered 1 controllers across 1 namespaces/,
+    `the part file's controller must be discovered; got:\n${result.stdout}`,
+  );
+  assert.match(
+    result.stdout,
+    /\| widgets \| widgets \| 1\/1 \| 100\.0% \|/,
+    `widgets must be measured at 1/1; got:\n${result.stdout}`,
+  );
+});
+
+// Defect (b): `percent = expected.size === 0 ? 100 : …` meant a namespace whose
+// controllers had all become invisible scored 100% — indistinguishable in the
+// gate's own output from genuinely full coverage. Four namespaces were doing
+// exactly that. A namespace MODULES names but discovery cannot see is now a
+// hard failure, because nothing was measured.
+test('fails loudly when a declared namespace discovers no controllers', (t) => {
+  const root = fixture(t);
+  write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+  write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
+
+  const result = runGate(root);
+
+  assert.equal(result.status, 1, `an unmeasurable namespace must fail the gate; got:\n${result.stdout}`);
+  assert.match(
+    result.stderr,
+    /namespace\(s\) with no discovered controllers/,
+    `the failure must say nothing was measured; got:\n${result.stderr}`,
+  );
+  // `config` is a MODULES entry with no controller in this fixture. Scoring it
+  // 100% is the bug; naming it as unmeasured is the fix.
+  assert.match(result.stderr, /\bconfig\b/, `the unmeasured namespace must be named; got:\n${result.stderr}`);
+  assert.doesNotMatch(
+    result.stdout,
+    /\| config \|.*100\.0% \|/,
+    `an unmeasured namespace must never be reported as 100% covered; got:\n${result.stdout}`,
+  );
+});
+
+// Defect (c): MODULES used to be the *scope* of the check, so ~50 namespaces
+// were never measured at any threshold simply because nobody added a line.
+// MODULES is now presentational; every discovered namespace is measured.
+test('measures a discovered namespace that MODULES does not name', (t) => {
+  const root = fixture(t);
+  // `widgets` appears nowhere in MODULES.
+  write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+  write(root, 'src/openhuman/widgets/schemas_part_02.rs', controller('widgets', 'purge'));
+  // Only one of the two is named by an e2e target: 1/2 = 50%, under the 90% bar.
+  write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
+
+  const result = runGate(root);
+
+  assert.match(
+    result.stdout,
+    /\| widgets \| widgets \| 1\/2 \| 50\.0% \|/,
+    `an unlisted namespace must still be measured; got:\n${result.stdout}`,
+  );
+  assert.match(
+    result.stderr,
+    /widgets \(1\/2, 50\.0%\)/,
+    `an unlisted namespace below the threshold must fail the gate by name; got:\n${result.stderr}`,
+  );
+  assert.match(
+    result.stdout,
+    /openhuman\.widgets_purge/,
+    `the uncovered controller must be reported as missing; got:\n${result.stdout}`,
+  );
+});

--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -14164,3 +14164,226 @@ async fn json_rpc_memory_diff_surface_is_gone_and_memory_still_answers() {
 
     rpc_join.abort();
 }
+
+// ── Backfilled e2e cover (#5795, #5947) ──────────────────────────────────────
+//
+// Both of these drive the JSON-RPC surface rather than the library type the
+// fix lives on, so a future refactor that swaps the write path or the dispatch
+// arm is caught even though the inner unit tests keep passing.
+
+/// Set on the re-exec below so the child runs the test body instead of
+/// spawning another child.
+#[cfg(unix)]
+const OWNER_ONLY_CHILD_ENV: &str = "OPENHUMAN_E2E_OWNER_ONLY_CHILD";
+#[cfg(unix)]
+const OWNER_ONLY_TEST_NAME: &str =
+    "auth_store_provider_credentials_writes_an_owner_only_store_file";
+
+/// Find `auth-profiles.json` beneath a temp `HOME`.
+///
+/// `cfg(unix)` to match its only caller: the mode assertion below has nothing
+/// to check on a platform without permission bits, and an uncalled helper
+/// would be dead code there.
+///
+/// Searched rather than hard-coded: the state dir is resolved from config and
+/// user scope, and pinning that layout here would make this test fail for a
+/// reason that has nothing to do with file modes.
+#[cfg(unix)]
+fn find_auth_profiles_store(root: &Path) -> Option<PathBuf> {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.file_name() == Some(std::ffi::OsStr::new("auth-profiles.json")) {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+/// #5795 — the credential store must not be group/world readable.
+///
+/// `fs::write` creates at `0o666 & ~umask` (0644 under the usual 022) and
+/// `fs::rename` carries the source mode onto the destination, so before the fix
+/// every save left OAuth-token ciphertext readable by any UID on the box.
+///
+/// Driven through `auth.store_provider_credentials` — the RPC a user hits when
+/// they paste a provider key — because the existing unit cover calls
+/// `AuthProfilesStore` directly and would not notice the RPC path acquiring a
+/// different writer.
+#[cfg(unix)]
+#[tokio::test]
+async fn auth_store_provider_credentials_writes_an_owner_only_store_file() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    // Re-exec this one test under a known-permissive umask before doing
+    // anything else.
+    //
+    // umask is process-global and libtest runs tests as threads, so it cannot
+    // be set in-process without racing every other test in this binary. It has
+    // to be controlled, though: a reverted `fs::write` creates at
+    // `0o666 & ~umask`, which is 0644 under the usual 022 but ALSO 0600 under a
+    // hardened 077 — and under 077 an owner-only assertion passes whether or not
+    // the fix is present. Skipping in that case is not a way out either: libtest
+    // records an early `return` as a PASS, so on a hardened runner this
+    // security regression test would go green having checked nothing.
+    if std::env::var(OWNER_ONLY_CHILD_ENV).is_err() {
+        let exe = std::env::current_exe().expect("current_exe");
+        let status = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(format!(
+                "umask 022 && exec '{}' --exact {} --nocapture --test-threads=1",
+                exe.display(),
+                OWNER_ONLY_TEST_NAME
+            ))
+            .env(OWNER_ONLY_CHILD_ENV, "1")
+            .status()
+            .expect("re-exec the owner-only test under umask 022");
+        assert!(
+            status.success(),
+            "the owner-only credential-store check failed under umask 022 (see child output above)"
+        );
+        return;
+    }
+
+    let _env_lock = json_rpc_e2e_env_lock();
+    let tmp = tempdir().expect("tempdir");
+    let home = tmp.path();
+    let openhuman_home = home.join(".openhuman");
+
+    let _home_guard = EnvVarGuard::set_to_path("HOME", home);
+    let _workspace_guard = EnvVarGuard::unset("OPENHUMAN_WORKSPACE");
+    let _backend_url_guard = EnvVarGuard::unset("BACKEND_URL");
+    let _vite_backend_guard = EnvVarGuard::unset("VITE_BACKEND_URL");
+
+    // Precondition, asserted rather than skipped: with umask 022 an ordinary
+    // create must land group/world-readable. If it does not, the umask did not
+    // take and the assertion below could not tell the fix from its absence —
+    // that is a failure, not a pass.
+    let probe = home.join("umask-probe");
+    std::fs::write(&probe, b"probe").expect("write probe");
+    let probe_mode = std::fs::metadata(&probe)
+        .expect("probe metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_ne!(
+        probe_mode & 0o077,
+        0,
+        "umask 022 should leave a plain create group-readable, got {probe_mode:#o}; \
+         without that this test cannot distinguish the owner-only fix from its absence"
+    );
+
+    let (mock_addr, mock_join) = serve_on_ephemeral(mock_upstream_router()).await;
+    let mock_origin = format!("http://{}", mock_addr);
+    write_min_config(&openhuman_home, &mock_origin);
+
+    let (rpc_addr, rpc_join) = serve_on_ephemeral(build_core_http_router(false)).await;
+    let rpc_base = format!("http://{}", rpc_addr);
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let stored = post_json_rpc(
+        &rpc_base,
+        9_795,
+        "openhuman.auth_store_provider_credentials",
+        json!({
+            "provider": "provider:openai",
+            "profile": "default",
+            "token": "sk-owner-only-e2e",
+            "setActive": true
+        }),
+    )
+    .await;
+    assert_no_jsonrpc_error(&stored, "auth_store_provider_credentials");
+
+    let store_path =
+        find_auth_profiles_store(home).expect("the save must have produced an auth-profiles.json");
+    let mode = std::fs::metadata(&store_path)
+        .expect("store metadata")
+        .permissions()
+        .mode()
+        & 0o777;
+
+    assert_eq!(
+        mode,
+        0o600,
+        "the credential store at {} must be owner-only, got {mode:#o} \
+         (a plain create in this environment yields {probe_mode:#o})",
+        store_path.display()
+    );
+
+    mock_join.abort();
+    rpc_join.abort();
+}
+
+/// #5947 — `validate_only` is a dry run for **stt**, not only for tts.
+///
+/// It used to be checked inside the `"tts"` arm alone. Every provider the
+/// settings modal can reach maps to `"stt"`, so the modal's dry-run request
+/// fell through to a live transcription — the opposite of what "Test Key"
+/// promises. A reserved slug is used because it is the one dry-run answer that
+/// is fully determined with no network: there is no user-held key to check, so
+/// the handler reports success without calling a provider.
+#[tokio::test]
+async fn voice_test_provider_honours_validate_only_for_the_stt_workload() {
+    let _env_lock = json_rpc_e2e_env_lock();
+    let tmp = tempdir().expect("tempdir");
+    let home = tmp.path();
+    let openhuman_home = home.join(".openhuman");
+
+    let _home_guard = EnvVarGuard::set_to_path("HOME", home);
+    let _workspace_guard = EnvVarGuard::unset("OPENHUMAN_WORKSPACE");
+    let _backend_url_guard = EnvVarGuard::unset("BACKEND_URL");
+    let _vite_backend_guard = EnvVarGuard::unset("VITE_BACKEND_URL");
+    let _piper_guard = EnvVarGuard::unset("PIPER_BIN");
+
+    let (mock_addr, mock_join) = serve_on_ephemeral(mock_upstream_router()).await;
+    let mock_origin = format!("http://{}", mock_addr);
+    write_min_config(&openhuman_home, &mock_origin);
+
+    let (rpc_addr, rpc_join) = serve_on_ephemeral(build_core_http_router(false)).await;
+    let rpc_base = format!("http://{}", rpc_addr);
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let dry_run = post_json_rpc(
+        &rpc_base,
+        9_947,
+        "openhuman.voice_test_provider",
+        json!({ "workload": "stt", "provider": "cloud", "validate_only": true }),
+    )
+    .await;
+    // Asserted on the whole envelope rather than through
+    // `assert_no_jsonrpc_error` so that BOTH shapes a regression can take —
+    // an error response from `create_stt_provider`, or an ok response
+    // carrying a live-transcription verdict — fail on this assertion and say
+    // why, instead of tripping a generic harness helper first.
+    let detail = dry_run
+        .get("result")
+        .and_then(|r| r.get("detail"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        detail.contains("managed by OpenHuman"),
+        "validate_only must short-circuit an stt request before any provider call: \
+         expected a managed-provider answer, got detail {detail:?} in {dry_run}. \
+         An error here, or an \"STT test …\" verdict, means validate_only was \
+         ignored for the stt workload (#5947)."
+    );
+    assert_eq!(
+        dry_run
+            .get("result")
+            .and_then(|r| r.get("ok"))
+            .and_then(Value::as_bool),
+        Some(true),
+        "a managed provider has no key to check, which is not a failed check: {dry_run}"
+    );
+
+    mock_join.abort();
+    rpc_join.abort();
+}

--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -14235,13 +14235,20 @@ async fn auth_store_provider_credentials_writes_an_owner_only_store_file() {
     // security regression test would go green having checked nothing.
     if std::env::var(OWNER_ONLY_CHILD_ENV).is_err() {
         let exe = std::env::current_exe().expect("current_exe");
+        // The exe path and the test name go in as POSITIONAL PARAMETERS rather
+        // than interpolated into the command string. A repository or
+        // CARGO_TARGET_DIR containing a single quote (`/home/o'connor/openhuman`)
+        // would close the literal `'...'` early and hand `sh` invalid syntax, so
+        // this test would fail before its child ever started — on exactly the
+        // machines whose paths are least likely to be noticed. `$0` is the
+        // conventional placeholder slot for `sh -c`, so the real arguments start
+        // at `$1`.
         let status = std::process::Command::new("sh")
             .arg("-c")
-            .arg(format!(
-                "umask 022 && exec '{}' --exact {} --nocapture --test-threads=1",
-                exe.display(),
-                OWNER_ONLY_TEST_NAME
-            ))
+            .arg("umask 022 && exec \"$1\" --exact \"$2\" --nocapture --test-threads=1")
+            .arg("sh")
+            .arg(&exe)
+            .arg(OWNER_ONLY_TEST_NAME)
             .env(OWNER_ONLY_CHILD_ENV, "1")
             .status()
             .expect("re-exec the owner-only test under umask 022");


### PR DESCRIPTION
## Summary

- Backfills e2e cover for three behaviours merged in the last week that had **no test which would fail if the fix were reverted**. Found by an audit of the last 7 days of merges; this PR closes the gaps that audit named.
- Every test here was revert-checked against the specific hunk it covers — the fix was reverted locally, the test observed to fail *naming its own assertion*, and the fix restored. Results are tabulated below.
- One item in the audited slice (#5842) turned out to need **no test**, for a reason worth reading: see "What is deliberately not covered".
- Test-only. No product code touched.

## Problem

The repo's domain e2e gate is a string match — it counts a literal appearing anywhere in `tests/**/*_e2e.rs`. A "pass" is therefore not evidence of coverage, and for these three changes it was not:

- **#5795** (auth profile store written owner-only) — `0o600` appeared nowhere under `tests/`. `tests/config_auth_app_state_connectivity_e2e.rs` contains *both* `AuthProfilesStore` and `PermissionsExt`, so a name-based search scores it covered; that `PermissionsExt` use chmods the **state directory** for an app-state quarantine test and never reads the credential file's mode.
- **#5947** (`validate_only` is a dry run for stt, not only tts) — `voice_test_provider` and `validate_only` matched **zero** files under `tests/`.
- **#5936** (the coverage gate itself) — its only test asserted `--help` output and argument rejection. All three defects it fixed were unpinned. The one `*_e2e.rs` file matching `check-domain-e2e-coverage` matches it in two `//!` comments.

## Solution

Each test drives the changed code path through the surface a user or caller actually reaches, not the library type the fix happens to live on.

**`tests/json_rpc_e2e.rs`** (+2 tests) — this target already declares `required-features = ["voice"]`, so both run in the product lane.

- `auth_store_provider_credentials_writes_an_owner_only_store_file` — drives `openhuman.auth_store_provider_credentials` over the real JSON-RPC router, locates the resulting `auth-profiles.json` and asserts its mode is `0600`. Going through the RPC (rather than `AuthProfilesStore`, which the existing unit test uses) means a future refactor that gives the RPC path a different writer is caught too.
- `voice_test_provider_honours_validate_only_for_the_stt_workload` — asserts an `stt` dry run short-circuits before any provider call. A reserved slug (`cloud`) is used because it is the one dry-run answer fully determined with no network.

**`scripts/__tests__/domain-e2e-coverage-gate.test.mjs`** (new, 3 tests) — fixture-driven, one test per defect #5936 fixed: discovery of `ControllerSchema` literals in `include!`-split `*_part_NN.rs` files, the hard failure when a declared namespace discovers nothing (it used to score 100%), and measuring a namespace `MODULES` does not name.

### Revert-check results

| Test | Fix reverted | Result |
|---|---|---|
| `auth_store_provider_credentials_writes_an_owner_only_store_file` | `write_owner_only(&tmp_path, …)` → `fs::write(&tmp_path, …)` | ✅ failed on `assert_eq!(mode, 0o600)` — `got 0o644 (a plain create in this environment yields 0o644)` |
| `voice_test_provider_honours_validate_only_for_the_stt_workload` | `if p.validate_only {` → `if p.validate_only && p.workload == "tts" {` | ✅ failed on the short-circuit assertion — `got detail "STT test failed: no backend session token; sign in first"` |
| gate: part-file discovery | restored the `/(^\|\/)schemas?(\.rs\|\/)/` path filter | ✅ failed on `the part file's controller must be discovered` |
| gate: unmeasurable namespace fails | disabled the `declaredButMissing` hard failure | ✅ failed on `an unmeasurable namespace must fail the gate` — and **only** that test |
| gate: namespace outside `MODULES` measured | `continue`d namespaces absent from `MODULES` | ✅ failed on `an unlisted namespace must still be measured` |



> **`Rust Core Coverage` is skipping on this PR, and not because of anything here.** Its
> gate is `needs.changes.outputs['rust-core'] == 'true' && needs['rust-quality'].result ==
> 'success'`. `Rust Quality` fails on the pre-existing layout gate (an inline test module in
> `agent/harness/session/turn/context.rs`, and `tools/impl/filesystem/git_operations{,_tests}.rs`
> over the 750-line limit — none of them touched here), so the coverage lane never starts.
> The consequence is worth someone's attention independently of this PR: **while that gate is
> red, no Rust test in the repository runs in CI on any pull request.** PR #5958 shows the
> same `fail` / `skipping` pair; #5947 and #5932, merged before the breakage, show `pass` /
> `pass`.

**Baseline**: all five pass with the fixes in place. **Restore**: verified clean (`git diff --stat` empty on both reverted source files; the gate suite back to 3/3).

Two details worth noting from the run. The `#5795` baseline reports the test twice — that is the parent and the `umask 022` child re-exec, so the child mechanism is confirmed working, and on revert the parent correctly propagates (`the owner-only credential-store check failed under umask 022`). And gate revert **B** fails *exactly one* test, the one written for that defect; reverts **A** and **C** each fail two, because a fixture that cannot be discovered at all also cannot be measured — the discovery defect subsumes the scoping one.

### What is deliberately not covered

**#5842** (`chore(tauri): remove obsolete provider webview bridge`) gets no test, because there is no behaviour to pin. The audit flagged that `clearAllAppData` had stopped calling `scheduleCefProfilePurge`; on investigation, the Tauri command behind it had not existed for three weeks:

```
$ git show 1843706c3 --stat | grep cef_profile
 app/src-tauri/src/cef_profile.rs | 671 ----------------
$ git show 1843706c3 | grep -n "schedule_cef_profile_purge"
5141:-async fn schedule_cef_profile_purge(user_id: Option<String>) -> Result<String, String> {
5524:-            schedule_cef_profile_purge,
```

`1843706c3` ("replace CEF runtime with upstream Wry") deleted the command and its `invoke_handler` registration, leaving the frontend wrapper, its unit tests, the Tauri permission entry and the docs orphaned. #5842 removed the orphaned caller — correct cleanup of a call that had been failing into a `catch` and a `console.warn`. A test asserting either the presence or the absence of that purge would be pinning an accident.

Two related notes are recorded for an owner rather than guessed at here: the removed unit tests asserted `expect(mockInvoke).toHaveBeenCalledWith('schedule_cef_profile_purge', …)` against a mocked bridge and so stayed green across the command's deletion; and since `1843706c3` nothing purges per-user browser profile data on "Clear App Data" while the dialog still promises "All other local data".

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — 5 tests; the gate suite is entirely failure-path (two of its three assert the gate *fails*), and each test was revert-checked
- [x] **Diff coverage ≥ 80%** — N/A: test-only change, no product lines added
- [x] Coverage matrix updated — N/A: no feature rows added, removed or renamed; this adds tests for behaviour already shipped
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature rows affected
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — the RPC tests use the existing in-repo mock upstream; the gate tests use temp-dir fixtures
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: no release-cut surface changed
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: no issue; this backfills cover for already-merged PRs, referenced below

## Impact

- Test-only: no runtime, platform, performance, security or compatibility impact.
- CI cost: two more tests in the existing `json_rpc_e2e` target (already built by the product lane) and one new `node:test` file in the scripts self-test lane, which runs in ~0.3s.
- `main` is currently red on the `Rust Quality` layout gate, which is pre-existing and unrelated — that gate scans `src/openhuman` only, and this PR touches `tests/` and `scripts/`.

## Related

- Backfills e2e cover for #5795, #5947 and #5936.
- Records why #5842 needs none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for domain coverage validation, including split schemas, missing controllers, and undeclared namespaces.
  * Added Unix-specific coverage confirming credential stores use owner-only permissions.
  * Added validation-only speech-to-text coverage, confirming managed providers can be validated without starting transcription.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->