### PR TITLE
fix(tools): name the config key when git_operations refuses, not "not a repo"

### DIFF
--- a/src/openhuman/tools/impl/filesystem/git_operations.rs
+++ b/src/openhuman/tools/impl/filesystem/git_operations.rs
@@ -95,14 +95,7 @@ impl GitOperationsTool {
                 "[git_operations] refusing to run git: dir={}, disallowed_config_key={key}",
                 cwd.display()
             );
-            anyhow::bail!(
-                "refusing to run git in {}: its repository config sets `{key}`, which is \
-                 not on the allowlist of configuration this tool will run under. \
-                 Several git config keys name a command git then executes, and this \
-                 directory is agent-writable, so unrecognised configuration is treated \
-                 as untrusted rather than honoured.",
-                cwd.display()
-            )
+            anyhow::bail!("{}", untrusted_repo_config_refusal(cwd, &key))
         }
 
         let output = hardened_git(cwd).args(args).output().await?;
@@ -648,6 +641,24 @@ fn normalise_config_key(key: &str) -> String {
     }
 }
 
+/// The refusal reported when a repository's own config sets a key this tool
+/// will not run under.
+///
+/// Shared by the two sites that refuse — [`GitOperationsTool::run_git_command_in`],
+/// at the moment it would spawn `git`, and `execute_in_context`, which refuses
+/// before its worktree probe — so the two can never drift into describing the
+/// same condition differently.
+fn untrusted_repo_config_refusal(dir: &Path, key: &str) -> String {
+    format!(
+        "refusing to run git in {}: its repository config sets `{key}`, which is \
+         not on the allowlist of configuration this tool will run under. \
+         Several git config keys name a command git then executes, and this \
+         directory is agent-writable, so unrecognised configuration is treated \
+         as untrusted rather than honoured.",
+        dir.display()
+    )
+}
+
 /// Returns the first repository config key at `dir` that is not on
 /// [`ALLOWED_REPO_CONFIG`], or `None` if every key it sets is recognised.
 ///
@@ -673,11 +684,13 @@ fn normalise_config_key(key: &str) -> String {
 /// inspection step does not have the property it is checking for.
 ///
 /// A non-zero exit here is treated as a refusal, not as "nothing to
-/// distrust": by the time this runs, the caller (`execute_in_context`) has
-/// already confirmed `dir` — or one of its parents — contains a `.git`, so
-/// `git config --list` failing means the config could not be read, not that
-/// there is none. Proceeding to run the real command against config this step
-/// never actually inspected would defeat the point of inspecting it first.
+/// distrust": `git config --list` failing means the config could not be read,
+/// not that there is none. Proceeding to run the real command against config
+/// this step never actually inspected would defeat the point of inspecting it
+/// first. `execute_in_context` calls this before it establishes whether `dir`
+/// is a work tree at all, so "not a repository" also surfaces here as a
+/// refusal rather than as an empty config — which is the correct direction to
+/// fail in.
 async fn first_disallowed_repo_config_key(dir: &Path) -> anyhow::Result<Option<String>> {
     let mut cmd = tokio::process::Command::new("git");
     suppress_ambient_git_config(&mut cmd).current_dir(dir);
@@ -814,6 +827,27 @@ impl GitOperationsTool {
         };
 
         let effective_dir = self.effective_action_dir_for_context(context);
+
+        // Repository-config refusal comes first, and the ordering is the point.
+        // The worktree probe below is itself a `run_git_command_in` call, which
+        // refuses when the config names a command git would execute — and its
+        // `is_ok_and` flattened that refusal into `false`, so the operation
+        // answered "Not in a git repository": untrue of a directory that plainly
+        // is one, and it discarded the key that caused the refusal. Both
+        // orderings return before anything runs under the untrusted config, so
+        // what this restores is the diagnostic, not the guard.
+        if let Some(key) = first_disallowed_repo_config_key(&effective_dir).await? {
+            tracing::debug!(
+                "[git_operations] refusing operation: dir={}, operation={operation}, \
+                 disallowed_config_key={key}",
+                effective_dir.display()
+            );
+            return Ok(ToolResult::error(untrusted_repo_config_refusal(
+                &effective_dir,
+                &key,
+            )));
+        }
+
         // Validate the repository instead of trusting the presence of a `.git`
         // path. This handles linked-worktree gitfiles and rejects malformed
         // ancestor markers that Git itself cannot open.


### PR DESCRIPTION
## The security question first

**The #5672 guard is NOT bypassed on `main`. It still refuses, and nothing runs under an untrusted repository config.** This is a **diagnostic** regression, not an exploitable one: the refusal is reported as `Not in a git repository` instead of naming the key that caused it.

Neither of the two obvious readings is right. It is not a broken fixture, and repo detection does not short-circuit *ahead of* the config check — the detection call **is** a config-checked call, so the key is reached and acted on; only its message is lost.

Evidence, from the failing runs themselves rather than from reading the code:

1. **The planted program did not execute.** `repository_config_naming_a_command_does_not_get_to_run_it` plants a `core.fsmonitor` hook that `touch`es a marker, then asserts `!marker.exists()` — *"this tool is a code-execution primitive"* — **before** it asserts the message. `assert!` aborts on first failure, and the panic is at the *next* assertion (`git_operations_tests_part_02_tests.rs:32`, the `msg.contains("fsmonitor")` one). Reaching line 32 proves line 27 passed: **git never ran the hook.**
2. **The tool refused in every one of the six.** Five go through `error_text`, whose first statement is `assert!(r.is_error, "expected a tool-error ToolResult")`. That assertion passes in all five. The sixth (`refusal_also_covers_write_operations`) asserts `result.is_error && …contains("credential.helper")`; the `is_error` half holds.
3. **Mechanically it fails closed on every path.** `execute_in_context` → `run_git_command_in(["rev-parse", "--is-inside-work-tree"])` → `first_disallowed_repo_config_key` finds the key → `bail!` → `.is_ok_and(…)` is `false` → early `return Ok(ToolResult::error(…))`. The operation is never reached.

So: no agent-reachable code execution, in shipped builds or anywhere else. What was lost is the operator-facing reason — and the message is also simply false about a directory that plainly *is* a repository.

## How it broke

A semantic merge conflict between two independently-green changes.

At #5672's own CI (2026-08-23, green — `repository_config_naming_a_command_does_not_get_to_run_it … ok`) the repository check was a filesystem walk that never invoked git:

```rust
if !effective_dir.join(".git").exists() {
    // …walk parents looking for .git…
    if !found_git { return Ok(ToolResult::error("Not in a git repository")); }
}
```

It was replaced on `main` with a `rev-parse` probe routed through `run_git_command_in`, and #5672 merged on 2026-09-02 against that ten-day-old green. Neither PR's CI could see the interaction. `CI Lite` scopes its libtest filter to changed modules, so no push to `main` since has re-run these tests — the coverage job's scoped pass reports `0 passed; 0 failed; 10977 filtered out`.

## The fix

Check the repository-config allowlist **before** the worktree probe, and report the refusal that names the key. Three lines of ordering plus a shared message.

The ordering is load-bearing in both directions, and I checked the edge cases against real `git` rather than assuming:

| case | `git config --list --null` | `git rev-parse --is-inside-work-tree` | result |
|---|---|---|---|
| ordinary repo | exit 0, allowlisted keys | `true` | proceeds, unchanged |
| disallowed key | exit 0, key found | (not reached) | **refusal naming the key** |
| not a repository | **exit 0**, empty listing | exit 128 | falls through to `Not in a git repository` — unchanged |
| unreadable `.git/config` | exit 128 | exit 128 | `could not inspect its repository config` |

The third row is why the config check can safely go first: outside a repository `git config --list` succeeds with an empty listing, so it yields `Ok(None)` rather than a spurious refusal, and `not_in_git_repo_returns_error` (which `.unwrap()`s an `Ok`) keeps its message.

The refusal text moved into `untrusted_repo_config_refusal(dir, key)`, shared by `run_git_command_in` and `execute_in_context`, so the two sites cannot drift into describing the same condition differently.

One stale doc line went with it: `first_disallowed_repo_config_key`'s comment claimed *"by the time this runs, the caller (`execute_in_context`) has already confirmed `dir` — or one of its parents — contains a `.git`"*. That described the deleted `.git` walk and is load-bearing for the "a non-zero exit is a refusal" argument, so it is corrected to match the new ordering. Not a drive-by: this change is what makes it wrong.

## Tests

**No test was added, removed, weakened, or rewritten.** The six (seven on macOS) failing tests already encode the intended contract; they now pass because the product does what they say again.

## Submission Checklist

- [x] Tests added or updated — the seven pre-existing tests in `git_operations_tests.rs` that assert this contract go from failing to passing; not one assertion was touched. The failure path is what they test.
- [x] **N/A: no coverage-relevant new lines** — the change is an ordering fix plus an extracted message; every added line is executed by the seven tests above.
- [x] **N/A: behaviour-only change** — no feature row added, removed or renamed in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] **N/A: no matrix feature IDs affected** — see `## Related`.
- [x] No new external network dependencies introduced.
- [x] **N/A: no release-cut surface touched** — an agent tool's error message; no user-facing workflow changed.
- [x] **N/A: no tracking issue** — surfaced by #5954's CI; see `## Related`.

## Impact

- **Desktop / CLI, `git_operations` agent tool only.** A repository carrying a non-allowlisted config key now gets the refusal that names the key, instead of a false `Not in a git repository`.
- **No security-posture change.** The tool refused before and refuses now; this restores the reason.
- Cost: one extra `git config --list` per operation on the refusal path. The existing defence-in-depth check inside `run_git_command_in` is deliberately kept — the module's own docs explain why the inspection and the real command being two invocations matters.

## Related

- Closes: N/A — no tracking issue. Surfaced by the `Rust Core Coverage` failure on #5954 (run [`33618878810`](https://github.com/tinyhumansai/openhuman/actions/runs/33618878810)); root-cause analysis is in [that PR's thread](https://github.com/tinyhumansai/openhuman/pull/5954#issuecomment-5508534978).
- Regressed the guard added in #5672.
- **Ordering with #5954:** both touch `git_operations.rs` and will conflict textually, so they are not order-independent. #5954 is a pure layout split (it is what makes the `Rust Quality` gate pass on `main`); this one is behaviour. Whichever lands second needs a small rebase — after #5954 these hunks land in `git_operations_part_01.rs` (`run_git_command_in`) and `git_operations_part_02.rs` (the helper and `execute_in_context`). Note **neither PR is green alone**: #5954 fixes the layout gate but trips these tests, and this one fixes the tests while `git_operations.rs` stays over the line limit. Landing #5954 first and rebasing this one clears both.
- Follow-up PR(s)/TODOs: worth a separate look at whether `CI Lite`'s changed-module scoping should periodically run the full suite on `main` — this regression sat green for ten days because nothing touched the module.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/git-config-refusal-message`
- Base: `upstream/main` @ `61d25fe2170318109d85b77c94ebed76ba20bb0f`

### Validation Run

- [x] **N/A: no frontend files touched** — Rust-only diff.
- [x] **N/A: no TypeScript touched.**
- [x] Focused tests: `cargo test -p openhuman --lib -- openhuman::tools::implementations::filesystem::git_operations` — see the run output in the PR thread.
- [x] Rust fmt/check: `cargo fmt --all -- --check` clean.
- [x] **N/A: Tauri shell not touched.**

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: a repository-config refusal now names the offending key instead of reporting `Not in a git repository`.
- User-visible effect: an accurate, actionable error where there was a misleading one. No change to what is allowed to run.

### Parity Contract

- Legacy behavior preserved: the ordinary-repository path, the genuine not-a-repository path and the unreadable-config path all keep their existing messages — verified case by case against real `git` exit codes (table above).
- Guard/fallback/dispatch parity checks: the tool refuses in exactly the same set of cases as before; only the reported reason changes.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None.
- Canonical PR: This one.
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Git operation error handling when a repository contains unsupported or disallowed configuration settings.
  - Errors now identify the specific configuration key involved, including when the target directory is not recognized as a Git repository, instead of displaying a misleading repository-status message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->