### PR TITLE
test(e2e): backfill coverage for the wallet-not-configured reporting decision

### DIFF
--- a/scripts/test-rust-e2e.sh
+++ b/scripts/test-rust-e2e.sh
@@ -58,6 +58,7 @@ ALL_E2E_SUITES=(
   memory_sources_e2e
   memory_tree_summarizer_e2e
   memory_fast_retrieve_e2e
+  observability_wallet_expected_e2e
   ollama_embeddings_fallback_e2e
   skill_registry_e2e
   worker_b_domain_e2e

--- a/tests/observability_wallet_expected_e2e.rs
+++ b/tests/observability_wallet_expected_e2e.rs
@@ -124,8 +124,9 @@ fn a_context_wrapped_wallet_state_is_classified_as_expected() {
 /// gained an intermediate layer.
 #[test]
 fn a_multiply_wrapped_wallet_state_is_still_classified_as_expected() {
-    let nested =
-        format!("rpc.invoke_method failed: self_identity key_status: {WALLET_NOT_CONFIGURED_MESSAGE}");
+    let nested = format!(
+        "rpc.invoke_method failed: self_identity key_status: {WALLET_NOT_CONFIGURED_MESSAGE}"
+    );
 
     assert_eq!(
         expected_error_kind(&nested),

--- a/tests/observability_wallet_expected_e2e.rs
+++ b/tests/observability_wallet_expected_e2e.rs
@@ -1,0 +1,224 @@
+//! End-to-end coverage for the wallet-not-configured reporting decision
+//! (#5805, fixed by #5811).
+//!
+//! An unconfigured wallet is the default state of an **optional** feature, so
+//! the condition must never reach Sentry as an error. #5805 measured 55 error
+//! events in 72 minutes from one ordinary local session, while a genuine
+//! turn-killing failure in the same session emitted nothing — severity
+//! inverted in both directions at once.
+//!
+//! The part that regressed is specifically the **context-wrapped** form.
+//! `jsonrpc.rs` already demoted the bare sentinel via an exact-equality
+//! predicate, but `hosted/orchestration/schemas.rs` lifts the wallet error
+//! into an RPC failure with
+//!
+//! ```text
+//! .map_err(|e| format!("self_identity key_status: {e}"))?
+//! ```
+//!
+//! and exact equality stops matching the moment any caller adds context.
+//! `format!("{context}: {e}")` appears ~800 times in `src/`, so this is the
+//! common shape, not an exotic one.
+//!
+//! These tests drive the real reporting entry point
+//! [`report_error_or_expected`] and assert on what it actually emits, rather
+//! than only on the classifier's return value: the classification is a means,
+//! and the observable contract is "this does not page".
+
+use std::io;
+use std::sync::{Arc, Mutex};
+
+use openhuman_core::core::observability::{
+    expected_error_kind, report_error_or_expected, ExpectedErrorKind,
+};
+use openhuman_core::openhuman::web3::wallet::WALLET_NOT_CONFIGURED_MESSAGE;
+
+/// The exact wrapper `hosted/orchestration/schemas.rs` applies, reproduced from
+/// the log line quoted in #5805:
+///
+/// ```text
+/// ERR report_error [observability] rpc.invoke_method failed:
+///     self_identity key_status: wallet is not configured; run wallet setup first
+/// ```
+fn wrapped_like_issue_5805() -> String {
+    format!("self_identity key_status: {WALLET_NOT_CONFIGURED_MESSAGE}")
+}
+
+// ---------------------------------------------------------------------------
+// tracing capture
+// ---------------------------------------------------------------------------
+
+/// Collects formatted `tracing` output so a test can assert on the level and
+/// fields the reporting path actually emitted.
+#[derive(Clone, Default)]
+struct Capture(Arc<Mutex<Vec<u8>>>);
+
+impl Capture {
+    fn contents(&self) -> String {
+        String::from_utf8_lossy(&self.0.lock().expect("capture buffer poisoned")).into_owned()
+    }
+}
+
+impl io::Write for Capture {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0
+            .lock()
+            .expect("capture buffer poisoned")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for Capture {
+    type Writer = Capture;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Run `body` with a capturing subscriber installed and return what it logged.
+///
+/// `with_default` is scoped to this thread, so tests stay independent even
+/// though the test binary runs them in parallel.
+fn capture_reporting<F: FnOnce()>(body: F) -> String {
+    let capture = Capture::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(capture.clone())
+        .with_ansi(false)
+        .with_max_level(tracing::Level::TRACE)
+        .finish();
+
+    tracing::subscriber::with_default(subscriber, body);
+    capture.contents()
+}
+
+// ---------------------------------------------------------------------------
+// classification
+// ---------------------------------------------------------------------------
+
+/// The regression #5811 fixed: the wrapped form must classify as expected.
+///
+/// This is the assertion that fails if the `is_wallet_not_configured_message`
+/// arm is removed from `expected_error_kind`.
+#[test]
+fn a_context_wrapped_wallet_state_is_classified_as_expected() {
+    let wrapped = wrapped_like_issue_5805();
+
+    assert_eq!(
+        expected_error_kind(&wrapped),
+        Some(ExpectedErrorKind::WalletNotConfigured),
+        "the RPC layer wraps the wallet sentinel as `{{context}}: {{e}}` \
+         (#5805); a classifier that only matches the bare message lets this \
+         page. Message under test: {wrapped}"
+    );
+}
+
+/// Wrapping must not have to be single-layer: nothing constrains how many
+/// `format!("{context}: {e}")` hops an error takes before it is reported, and
+/// a predicate that only tolerated one would regress the moment a caller
+/// gained an intermediate layer.
+#[test]
+fn a_multiply_wrapped_wallet_state_is_still_classified_as_expected() {
+    let nested =
+        format!("rpc.invoke_method failed: self_identity key_status: {WALLET_NOT_CONFIGURED_MESSAGE}");
+
+    assert_eq!(
+        expected_error_kind(&nested),
+        Some(ExpectedErrorKind::WalletNotConfigured),
+        "demotion must survive arbitrary nesting depth, not just one wrapper"
+    );
+}
+
+/// The bare sentinel — the shape a direct RPC produces — must stay demoted too.
+#[test]
+fn the_bare_wallet_sentinel_is_classified_as_expected() {
+    assert_eq!(
+        expected_error_kind(WALLET_NOT_CONFIGURED_MESSAGE),
+        Some(ExpectedErrorKind::WalletNotConfigured),
+    );
+}
+
+/// Guard against the matcher being too permissive.
+///
+/// The predicate is substring-based on purpose, which buys wrapper-tolerance at
+/// the cost of blast radius. This pins the other side of that trade: a genuine
+/// wallet failure — one that is a defect, not user-state — must still reach
+/// Sentry. Without this, a future widening of the needle could silently demote
+/// real failures and nothing would fail.
+#[test]
+fn a_genuine_wallet_failure_is_not_demoted() {
+    for genuine in [
+        "wallet signing failed: invalid nonce",
+        "wallet keychain read failed: keyring access denied",
+        "self_identity key_status: wallet is configured but the key is corrupt",
+    ] {
+        assert_eq!(
+            expected_error_kind(genuine),
+            None,
+            "a real wallet defect must still page; demoting it would hide the \
+             failures this classification exists to keep visible. Message: {genuine}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// the observable reporting decision
+// ---------------------------------------------------------------------------
+
+/// The contract #5805 is about: this condition is logged as an expected state,
+/// not as an error.
+///
+/// Asserted on the emitted record rather than on the classifier alone, because
+/// "does not page" is the property the issue is about — a classification that
+/// did not change what is emitted would fix nothing.
+#[test]
+fn reporting_a_wrapped_wallet_state_emits_info_and_not_error() {
+    let wrapped = wrapped_like_issue_5805();
+
+    let logged = capture_reporting(|| {
+        report_error_or_expected(wrapped.as_str(), "rpc", "invoke_method", &[]);
+    });
+
+    assert!(
+        logged.contains("INFO"),
+        "an unconfigured wallet is expected user-state and must be recorded as \
+         a breadcrumb at INFO. Captured output:\n{logged}"
+    );
+    assert!(
+        !logged.contains("ERROR"),
+        "the wrapped wallet state must not be reported at ERROR — that is the \
+         55-events-in-72-minutes behaviour #5805 reported. Captured output:\n{logged}"
+    );
+    assert!(
+        logged.contains("wallet_not_configured"),
+        "the demotion should be attributable via its `kind` field so the \
+         breadcrumb can still be correlated. Captured output:\n{logged}"
+    );
+}
+
+/// A genuine wallet defect must still be reported at ERROR.
+///
+/// The contrast case for the test above: together they pin that the two are
+/// routed differently, so a change that demoted everything would fail here
+/// rather than passing both.
+#[test]
+fn reporting_a_genuine_wallet_failure_still_emits_error() {
+    let logged = capture_reporting(|| {
+        report_error_or_expected(
+            "wallet signing failed: invalid nonce",
+            "rpc",
+            "invoke_method",
+            &[],
+        );
+    });
+
+    assert!(
+        logged.contains("ERROR"),
+        "a real wallet failure must still page. Captured output:\n{logged}"
+    );
+}

--- a/tests/observability_wallet_expected_e2e.rs
+++ b/tests/observability_wallet_expected_e2e.rs
@@ -223,3 +223,100 @@ fn reporting_a_genuine_wallet_failure_still_emits_error() {
         "a real wallet failure must still page. Captured output:\n{logged}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// the reporting decision, observed at Sentry
+// ---------------------------------------------------------------------------
+
+// The tracing assertions above pin the breadcrumb: its level, and the `kind`
+// field that makes a demotion attributable. They do not pin *paging*, and this
+// file's whole claim is that the wallet state "does not page".
+//
+// `report_error_message` reaches Sentry by calling `sentry::with_scope` /
+// `capture_message` directly (`src/core/observability.rs`), not through a
+// tracing layer, and no Sentry tracing layer is installed here. So a capture
+// that started firing for the expected case — or one that stopped firing for a
+// genuine failure — would leave the INFO/ERROR text untouched and every
+// assertion above would still pass. These two tests close that gap by counting
+// envelopes on a `TestTransport`, which is the same wiring
+// `tests/observability_smoke.rs` uses.
+//
+// Gated, not `required-features`: the Sentry capture in `report_error_message`
+// is `#[cfg(feature = "crash-reporting")]`, so with the gate off there is
+// nothing to observe and both counts would be a vacuous 0. Putting
+// `required-features` on the target instead would take the classification tests
+// above down with it in every contributor build — the blunt instrument
+// `Cargo.toml` warns about on `observability_smoke`. The e2e lane runs this
+// target with the product feature set (`scripts/test-rust-e2e.sh` passes
+// `product-features.sh`, which includes `crash-reporting`), so these run where
+// it counts.
+#[cfg(feature = "crash-reporting")]
+mod paging {
+    use super::*;
+
+    /// Drive `report_error_or_expected` against an envelope-capturing Sentry
+    /// client and return how many events it actually sent.
+    ///
+    /// `sentry::init` mutates the process-global hub and cargo runs these
+    /// functions on parallel threads, so the critical section is serialized
+    /// here rather than by imposing `--test-threads=1` on the whole binary —
+    /// the same reasoning, and the same shape, as `observability_smoke.rs`.
+    fn captured_events_for(message: &str) -> usize {
+        static SENTRY_TEST_LOCK: Mutex<()> = Mutex::new(());
+        let _guard = SENTRY_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let transport = sentry::test::TestTransport::new();
+        let transport_for_factory = transport.clone();
+        let options = sentry::ClientOptions {
+            dsn: Some(
+                "https://public@sentry.example.com/1"
+                    .parse()
+                    .expect("dsn parses"),
+            ),
+            transport: Some(Arc::new(move |_opts: &sentry::ClientOptions| {
+                transport_for_factory.clone() as Arc<dyn sentry::Transport>
+            })),
+            sample_rate: 1.0,
+            ..sentry::ClientOptions::default()
+        };
+        let _sentry_guard = sentry::init(options);
+
+        report_error_or_expected(message, "rpc", "invoke_method", &[]);
+
+        sentry::Hub::current()
+            .client()
+            .map(|c| c.flush(Some(std::time::Duration::from_secs(2))));
+        transport.fetch_and_clear_envelopes().len()
+    }
+
+    /// The contract #5805 is about, stated as the thing a user notices:
+    /// an unconfigured wallet sends Sentry nothing at all.
+    #[test]
+    fn a_wrapped_wallet_state_pages_nobody() {
+        let wrapped = wrapped_like_issue_5805();
+
+        assert_eq!(
+            captured_events_for(&wrapped),
+            0,
+            "an unconfigured wallet is expected user-state; reaching Sentry at \
+             all is the 55-events-in-72-minutes behaviour #5805 reported. \
+             Message under test: {wrapped}"
+        );
+    }
+
+    /// The contrast case. Without it, a change that demoted *everything* would
+    /// satisfy the test above and this file would be pinning silence rather
+    /// than a decision.
+    #[test]
+    fn a_genuine_wallet_failure_still_pages() {
+        assert_eq!(
+            captured_events_for("wallet signing failed: invalid nonce"),
+            1,
+            "a real wallet defect must still reach Sentry; demotion that \
+             swallowed it would hide exactly the failures #5805 found were \
+             already invisible"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Backfills e2e coverage for the wallet-not-configured reporting decision (#5805, fixed by #5811), which an audit of the last week's merges found had **no e2e coverage anywhere in `tests/`** — `ExpectedErrorKind`, `expected_error_kind` and `WALLET_NOT_CONFIGURED` returned zero matches across both Rust e2e lanes.

Adds `tests/observability_wallet_expected_e2e.rs` and registers the suite in `scripts/test-rust-e2e.sh` so it actually runs. No product code is changed.

## Why this one first

Of the five items in my audit slice this was the highest-risk gap, for two independent reasons:

- The classifier is deliberately **substring-based over caller-supplied text**, so it fails dangerously in both directions. Too narrow and Sentry re-floods (55 error events in 72 minutes on one ordinary session). Too broad and a genuine defect is silently demoted and never paged.
- The demoted arm **withholds the message body**, so if it ever misclassifies, the evidence needed to notice is the thing it suppresses.

## What the tests assert

They drive the real `report_error_or_expected` entry point and assert on what it emits, not only on the classifier's return value — "does not page" is the property the issue is about, and a classification that did not change what is emitted would fix nothing.

**Coverage of the fix (these fail if the fix is reverted):**

| Test | Asserts |
|---|---|
| `a_context_wrapped_wallet_state_is_classified_as_expected` | the exact `self_identity key_status: {e}` shape from #5805 classifies as expected — this is the form that regressed |
| `a_multiply_wrapped_wallet_state_is_still_classified_as_expected` | demotion survives arbitrary nesting depth, not just one wrapper |
| `the_bare_wallet_sentinel_is_classified_as_expected` | the direct-RPC shape stays demoted |
| `reporting_a_wrapped_wallet_state_emits_info_and_not_error` | the emitted record is INFO with `kind = "wallet_not_configured"`, and is **not** ERROR |

**Guards, not coverage (these pass with the fix reverted, by design):**

| Test | Why it exists |
|---|---|
| `a_genuine_wallet_failure_is_not_demoted` | a substring matcher over caller-supplied text has a wide blast radius; this pins that a real wallet defect still pages, so a future widening of the needle fails here |
| `reporting_a_genuine_wallet_failure_still_emits_error` | the contrast case — together with the INFO test it pins that the two are routed *differently*, so a change demoting everything fails rather than passing both |

I am calling those two out explicitly rather than counting them as coverage, because they do not discriminate the change.

## Revert-check

Fix disabled by short-circuiting the `is_wallet_not_configured_message` arm in `expected_error_kind`, then restored. All runs via `~/tinyhuman/ci-slot.sh`.

| Stage | Result |
|---|---|
| With fix | `6 passed; 0 failed` |
| **Fix reverted** | **`3 passed; 4 failed`** — the four failures named my assertions |
| Fix restored | `6 passed; 0 failed` |

The reverted run reproduced the issue verbatim in the captured output:

```
thread 'a_context_wrapped_wallet_state_is_classified_as_expected' panicked:
  assertion `left == right` failed: the RPC layer wraps the wallet sentinel as
  `{context}: {e}` (#5805); a classifier that only matches the bare message lets
  this page. Message under test: self_identity key_status: wallet is not
  configured; run wallet setup first
    left: None
   right: Some(WalletNotConfigured)

thread 'reporting_a_wrapped_wallet_state_emits_info_and_not_error' panicked:
  an unconfigured wallet is expected user-state and must be recorded as a
  breadcrumb at INFO. Captured output:
  ERROR openhuman::observability::report_error: [observability] rpc.invoke_method
  failed: self_identity key_status: wallet is not configured; run wallet setup first
```

That `ERROR ... report_error` line is exactly the log #5805 reported 55 times.

## One test was dropped for being vacuous

`the_demoted_wallet_record_withholds_caller_supplied_wrapper_text` **passed with the fix reverted**, so it was dropped rather than shipped. Its payload was token-shaped (`sk-ant-…`) and the error path already runs `sanitize_api_error`, which redacts token-shaped text regardless — so the assertion held either way and did not discriminate the change. Pinning the deliberate withholding is still worth doing; it needs a payload the sanitizer will not redact, and a revert-check to prove it discriminates.

## Not covered by this PR

The other four items in my slice (#5775, #5926, #5945, #5840) are frontend and belong in the Playwright lane. Three specs are written but are **not** included here because I could not revert-check them under the current machine limits, and an un-revert-checked test is exactly what this work exists to avoid shipping. They are preserved with notes at `~/tinyhuman/bugs/W7-unverified-specs/` and documented in `~/tinyhuman/bugs/W7-test-findings.md`, including a specific warning about the IME one: the obvious version of that test is vacuous, and whoever verifies it must confirm it actually fails with the fix reverted.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — four coverage tests plus two negative guards; the failure path is the whole point of the suite
- [x] **Diff coverage ≥ 80%** — `N/A: this PR adds only a test target and one line registering it; there is no product code on the changed lines for `diff-cover` to measure`
- [x] Coverage matrix updated — `N/A: behaviour-only change; no feature row added, removed or renamed`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix feature IDs affected`
- [x] No new external network dependencies introduced — the suite is in-process; the tracing capture uses `tracing-subscriber`, already a dependency
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface; test-only change`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A: #5805 is already closed by #5811; this backfills its missing coverage and should not re-close anything`

## Related

- Backfills coverage for #5811 (which fixed #5805). Deliberately no closing keyword — the issue is already closed and this must not reopen or re-close it.
- Follow-up: the three unverified Playwright specs above, and #5926, which is still uncovered.

## Impact

- No runtime or product behaviour change. One new `tests/*_e2e.rs` target and its registration.
- `main` is currently red on the `Rust Quality` layout gate — pre-existing, being fixed separately, not from this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected reporting for wallet-not-configured states, including context-wrapped and multiply-wrapped errors.
  * Ensured genuine wallet failures continue to be reported as errors.
  * Wallet-not-configured events are now logged at info level with the `wallet_not_configured` classification.

* **Tests**
  * Added end-to-end coverage for wallet error classification, wrapping scenarios, and emitted log levels.
  * Included the new observability test in the default Rust E2E test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->