### PR TITLE
test(e2e): backfill coverage for the model-call ceiling, relative folder sources, and the /skills deep link

### DIFF
--- a/app/test/playwright/specs/connections-tab-deeplinks.spec.ts
+++ b/app/test/playwright/specs/connections-tab-deeplinks.spec.ts
@@ -15,12 +15,11 @@ import {
  * tab after a click, and — the half that actually reaches users — whether a
  * bookmarked deep link lands on the tab it names.
  *
- * The `/skills` → `/connections` redirect (`AppRoutes.tsx:169-170`) carries a
- * comment saying it "preserves ?tab= deep links". It does not: `<Navigate
+ * The `/skills` → `/connections` redirect did once drop the query — `<Navigate
  * to="/connections" replace />` is a fixed string with no search, and React
- * Router does not carry the current query across it. See the `?tab=` tests
- * below, which pin the CURRENT behaviour and are annotated with what it should
- * be, rather than asserting the fix ahead of it.
+ * Router does not carry the current query across it. #5924 replaced it with
+ * `ForwardSearch`, which copies `search` and `hash` onto the destination; the
+ * `?tab=` tests below assert that forwarding rather than the old defect.
  *
  * NOTE ON SCOPE: nothing here opens the Composio tab. Doing so downloads the
  * `tinyconnectors` module from a GitHub release, and a failed download is
@@ -173,23 +172,35 @@ test.describe('Connections — the /skills back-compat redirect', () => {
     await expect(page.getByTestId('two-pane-nav-composio')).toBeVisible();
   });
 
-  test('BUG: /skills?tab=channels drops the tab and lands on the overview', async ({ page }) => {
-    // This pins CURRENT behaviour, which is wrong. `AppRoutes.tsx:169` says the
-    // redirect "preserves ?tab= deep links"; `<Navigate to="/connections" />`
-    // carries no search, so the query is dropped and `activeTab` falls through
-    // to its `welcome` default.
+  test('/skills?tab=channels carries the tab through the redirect', async ({ page }) => {
+    // Fixed by #5924. This test previously pinned the BUG — it asserted the
+    // query was dropped and the overview rendered — and was left un-flipped
+    // when the fix landed, so it asserted the opposite of shipped behaviour.
+    // `AppRoutes.tsx` now redirects through `ForwardSearch`, which copies the
+    // current `search` and `hash` onto the destination.
     //
-    // Expected once fixed: the hash contains `tab=channels` and the messaging
-    // connectors are visible. Flip the two assertions below when that lands.
-    await openRoute(page, 'pw-skills-tab-drop', '/skills?tab=channels', '/connections');
+    // Assert the SELECTED tab, not merely that a Channels nav row is visible:
+    // that row renders on every tab and would prove nothing.
+    await openRoute(page, 'pw-skills-tab-forward', '/skills?tab=channels', '/connections');
     await expect.poll(() => currentHash(page), { timeout: 15_000 }).toContain('/connections');
 
+    await expect.poll(() => currentHash(page), { timeout: 15_000 }).toContain('tab=channels');
+    await expectSelectedTab(page, 'channels');
+  });
+
+  test('/skills?tab=mcp forwards any tab, not just one hard-coded value', async ({ page }) => {
+    // A second tab so the forward cannot be satisfied by a literal. `mcp` is a
+    // canonical id (Skills.tsx), reached here only via the redirect.
+    await openRoute(page, 'pw-skills-tab-forward-mcp', '/skills?tab=mcp', '/connections');
+    await expect.poll(() => currentHash(page), { timeout: 15_000 }).toContain('tab=mcp');
+    await expectSelectedTab(page, 'mcp');
+  });
+
+  test('/skills with no query still lands on the overview', async ({ page }) => {
+    // The forward must not invent a query where the user supplied none.
+    await openRoute(page, 'pw-skills-no-query', '/skills', '/connections');
     const hash = await currentHash(page);
-    expect(hash).not.toContain('tab=channels');
-    // The user asked for messaging and got the overview instead. Assert the
-    // SELECTED tab: the previous form asserted that the Channels nav row was
-    // visible, which is true on every tab and therefore proved nothing about
-    // the harm this test exists to document.
+    expect(hash).not.toContain('tab=');
     await expectSelectedTab(page, 'welcome');
   });
 

--- a/app/test/playwright/specs/connections-tab-deeplinks.spec.ts
+++ b/app/test/playwright/specs/connections-tab-deeplinks.spec.ts
@@ -196,6 +196,28 @@ test.describe('Connections — the /skills back-compat redirect', () => {
     await expectSelectedTab(page, 'mcp');
   });
 
+  test('/skills?tab=mcp#fragment forwards the fragment as well as the query', async ({
+    page,
+  }) => {
+    // `ForwardSearch` appends `hash` as well as `search`, and nothing here
+    // exercised that half. `AppRoutes.skills.test.tsx` does assert
+    // `loc.hash === '#section-mcp'`, but under `MemoryRouter`, which never
+    // parses `window.location.hash` at all — so it cannot show that a real
+    // HashRouter round-trips a fragment nested inside the routing hash
+    // (`#/connections?tab=mcp#section-mcp`). That is the part only a browser
+    // can answer, and it is the mechanism `/webhooks` relies on for
+    // `#delivery-3`-style deep links.
+    await openRoute(
+      page,
+      'pw-skills-hash-forward',
+      '/skills?tab=mcp#section-mcp',
+      '/connections'
+    );
+    await expect.poll(() => currentHash(page), { timeout: 15_000 }).toContain('tab=mcp');
+    expect(await currentHash(page)).toContain('#section-mcp');
+    await expectSelectedTab(page, 'mcp');
+  });
+
   test('/skills with no query still lands on the overview', async ({ page }) => {
     // The forward must not invent a query where the user supplied none.
     await openRoute(page, 'pw-skills-no-query', '/skills', '/connections');

--- a/app/test/playwright/specs/core-rpc-bearer-401.spec.ts
+++ b/app/test/playwright/specs/core-rpc-bearer-401.spec.ts
@@ -40,10 +40,14 @@ test.describe('Core RPC bearer 401 — recovery, not logout', () => {
     await waitForAppReady(page);
     await dismissWalkthroughIfPresent(page);
 
-    // Fault injection: reject the bearer for the FIRST occurrence of the
-    // trigger method only, exactly as a core that restarted mid-session would,
-    // then serve normally so the refreshed-bearer retry can succeed.
-    let seen = 0;
+    // Fault injection modelled on a real core restart: the FIRST call to the
+    // trigger method is rejected AND the stored bearer is rotated, exactly as a
+    // core that restarted and minted a fresh per-launch token would leave
+    // things. The retry must therefore present a DIFFERENT bearer to succeed —
+    // counting requests alone would let a retry that reused the stale cached
+    // token pass, which is the very regression #5876 guards against.
+    const ROTATED = 'openhuman-playwright-token-rotated';
+    const seenAuth: string[] = [];
     await page.route('**/rpc', async (route, request) => {
       let body: { method?: string } = {};
       try {
@@ -52,8 +56,14 @@ test.describe('Core RPC bearer 401 — recovery, not logout', () => {
         /* not JSON — pass through */
       }
       if (body.method === TRIGGER_METHOD) {
-        seen += 1;
-        if (seen === 1) {
+        seenAuth.push(request.headers()['authorization'] ?? '');
+        if (seenAuth.length === 1) {
+          // Rotate the stored bearer before rejecting, so a refreshed read
+          // picks up the new value and a cached read does not.
+          await page.evaluate(
+            token => window.localStorage.setItem('openhuman_core_rpc_token', token),
+            ROTATED
+          );
           return route.fulfill({
             status: 401,
             contentType: 'text/plain',
@@ -69,27 +79,29 @@ test.describe('Core RPC bearer 401 — recovery, not logout', () => {
       window.location.hash = '/connections?tab=embeddings';
     });
 
-    // (1) The retry. `core_auth` drops the token cache and reissues the SAME
-    // call once. Without #5876 the 401 classifies as `auth_expired`, nothing
-    // retries, and this stays at 1.
-    await expect.poll(() => seen, { timeout: 20_000 }).toBeGreaterThanOrEqual(2);
+    // (1) The retry happened at all. Without #5876 the 401 classifies as
+    // `auth_expired`, nothing retries, and this stays at 1.
+    await expect.poll(() => seenAuth.length, { timeout: 20_000 }).toBeGreaterThanOrEqual(2);
+
+    // (2) And it used a FRESH bearer — the assertion that distinguishes a real
+    // recovery from a blind re-send. `clearCoreRpcTokenCache()` is what makes
+    // the second read see the rotated value.
+    expect(seenAuth[0]).toContain('openhuman-playwright-token');
+    expect(seenAuth[1]).toContain(ROTATED);
+    expect(seenAuth[1]).not.toEqual(seenAuth[0]);
 
     // Bounded to a single extra attempt — a retry loop against a core that is
     // genuinely rejecting us would be worse than the bug.
-    expect(seen).toBeLessThanOrEqual(2);
+    expect(seenAuth.length).toBeLessThanOrEqual(2);
 
-    // (2) The session survives. Without #5876 `clearSession()` wipes the auth
-    // profile and the app falls back to the signed-out surface.
-    await expect
-      .poll(async () => page.evaluate(() => window.location.hash), { timeout: 15_000 })
-      .toContain('/connections');
-    await expect
-      .poll(async () => page.evaluate(() => window.location.hash))
-      .not.toContain('/welcome');
-    await expect
-      .poll(async () =>
-        page.evaluate(() => window.localStorage.getItem('openhuman_core_rpc_token'))
-      )
-      .not.toBeNull();
+    // (3) The session survives. Without #5876 `clearSession()` wipes the auth
+    // profile and the app falls back to the signed-out surface. Assert the
+    // embeddings panel actually rendered rather than merely that the hash is
+    // unchanged — the page was already on /connections before the fault.
+    await expect(page.getByTestId('two-pane-nav-embeddings')).toHaveAttribute(
+      'aria-current',
+      'page',
+      { timeout: 20_000 }
+    );
   });
 });

--- a/app/test/playwright/specs/core-rpc-bearer-401.spec.ts
+++ b/app/test/playwright/specs/core-rpc-bearer-401.spec.ts
@@ -48,6 +48,7 @@ test.describe('Core RPC bearer 401 — recovery, not logout', () => {
     // token pass, which is the very regression #5876 guards against.
     const ROTATED = 'openhuman-playwright-token-rotated';
     const seenAuth: string[] = [];
+    const excessAttempts: string[] = [];
     await page.route('**/rpc', async (route, request) => {
       let body: { method?: string } = {};
       try {
@@ -57,6 +58,14 @@ test.describe('Core RPC bearer 401 — recovery, not logout', () => {
       }
       if (body.method === TRIGGER_METHOD) {
         seenAuth.push(request.headers()['authorization'] ?? '');
+        if (seenAuth.length > 2) {
+          // Recorded HERE, not asserted after the poll: `seenAuth.length` grows
+          // when the handler STARTS, and `route.fallback()` settles
+          // asynchronously, so a third request can arrive after a mid-flight
+          // `<= 2` check and escape it entirely. The handler is the only place
+          // that observes every attempt.
+          excessAttempts.push(request.headers()['authorization'] ?? '');
+        }
         if (seenAuth.length === 1) {
           // Rotate the stored bearer before rejecting, so a refreshed read
           // picks up the new value and a cached read does not.
@@ -90,9 +99,6 @@ test.describe('Core RPC bearer 401 — recovery, not logout', () => {
     expect(seenAuth[1]).toContain(ROTATED);
     expect(seenAuth[1]).not.toEqual(seenAuth[0]);
 
-    // Bounded to a single extra attempt — a retry loop against a core that is
-    // genuinely rejecting us would be worse than the bug.
-    expect(seenAuth.length).toBeLessThanOrEqual(2);
 
     // (3) The session survives. Without #5876 `clearSession()` wipes the auth
     // profile and the app falls back to the signed-out surface. Assert the
@@ -103,5 +109,13 @@ test.describe('Core RPC bearer 401 — recovery, not logout', () => {
       'page',
       { timeout: 20_000 }
     );
+
+    // (4) Bounded to ONE extra attempt. Asserted only now, after the flow has
+    // settled into its terminal rendered state, and from the handler-side
+    // record so a late third request cannot slip past a mid-flight check. A
+    // retry loop against a core that is genuinely rejecting us would be worse
+    // than the bug #5876 fixed.
+    expect(excessAttempts).toEqual([]);
+    expect(seenAuth.length).toBe(2);
   });
 });

--- a/app/test/playwright/specs/core-rpc-bearer-401.spec.ts
+++ b/app/test/playwright/specs/core-rpc-bearer-401.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  bootAuthenticatedPage,
+  dismissWalkthroughIfPresent,
+  waitForAppReady,
+} from '../helpers/core-rpc';
+
+/**
+ * A 401 from the LOCAL core's RPC bearer gate must not sign the user out
+ * (PR #5876).
+ *
+ * `getCoreRpcToken` caches the resolved bearer for the lifetime of the frontend
+ * process, so an in-process core restart — which mints a fresh per-launch token
+ * — leaves the renderer holding a stale one and every subsequent RPC 401s.
+ * Before #5876 `classifyRpcError` mapped any 401 to `auth_expired`, and
+ * `classifyAuthExpiredReason` paired it with `confirmed`, which skips
+ * corroboration in `CoreStateProvider` and calls `clearSession()` — wiping the
+ * TinyHumans auth profile from disk because the *local* core rejected a bearer.
+ * The TinyHumans server had said nothing at all.
+ *
+ * #5876 introduced a distinct `core_auth` kind for exactly this case: it does
+ * not dispatch auth-expired, and it drops the token cache and retries once with
+ * a freshly-read bearer.
+ *
+ * Note on what this does NOT cover, deliberately: a 401 from the *backend*
+ * (a genuinely revoked session) must still sign the user out. That is the
+ * complementary case and `app/test/e2e/specs/auth-access-control.spec.ts`
+ * ("Revoked session auto-logout") owns it. The two must not be conflated — the
+ * whole point of #5876 is that they are different routes with opposite
+ * handling.
+ */
+
+/** The RPC the embeddings tab issues on open — a deterministic trigger. */
+const TRIGGER_METHOD = 'openhuman.embeddings_get_settings';
+
+test.describe('Core RPC bearer 401 — recovery, not logout', () => {
+  test('retries once with a fresh bearer and keeps the user signed in', async ({ page }) => {
+    await bootAuthenticatedPage(page, 'pw-core-401', '/connections');
+    await waitForAppReady(page);
+    await dismissWalkthroughIfPresent(page);
+
+    // Fault injection: reject the bearer for the FIRST occurrence of the
+    // trigger method only, exactly as a core that restarted mid-session would,
+    // then serve normally so the refreshed-bearer retry can succeed.
+    let seen = 0;
+    await page.route('**/rpc', async (route, request) => {
+      let body: { method?: string } = {};
+      try {
+        body = JSON.parse(request.postData() || '{}');
+      } catch {
+        /* not JSON — pass through */
+      }
+      if (body.method === TRIGGER_METHOD) {
+        seen += 1;
+        if (seen === 1) {
+          return route.fulfill({
+            status: 401,
+            contentType: 'text/plain',
+            body: 'Missing or invalid Authorization header',
+          });
+        }
+      }
+      return route.fallback();
+    });
+
+    // Trigger it.
+    await page.evaluate(() => {
+      window.location.hash = '/connections?tab=embeddings';
+    });
+
+    // (1) The retry. `core_auth` drops the token cache and reissues the SAME
+    // call once. Without #5876 the 401 classifies as `auth_expired`, nothing
+    // retries, and this stays at 1.
+    await expect.poll(() => seen, { timeout: 20_000 }).toBeGreaterThanOrEqual(2);
+
+    // Bounded to a single extra attempt — a retry loop against a core that is
+    // genuinely rejecting us would be worse than the bug.
+    expect(seen).toBeLessThanOrEqual(2);
+
+    // (2) The session survives. Without #5876 `clearSession()` wipes the auth
+    // profile and the app falls back to the signed-out surface.
+    await expect
+      .poll(async () => page.evaluate(() => window.location.hash), { timeout: 15_000 })
+      .toContain('/connections');
+    await expect
+      .poll(async () => page.evaluate(() => window.location.hash))
+      .not.toContain('/welcome');
+    await expect
+      .poll(async () =>
+        page.evaluate(() => window.localStorage.getItem('openhuman_core_rpc_token'))
+      )
+      .not.toBeNull();
+  });
+});

--- a/app/test/playwright/specs/embeddings-setup-modal.spec.ts
+++ b/app/test/playwright/specs/embeddings-setup-modal.spec.ts
@@ -87,7 +87,11 @@ test.describe('Embeddings setup — Test connection for a custom endpoint', () =
     // Empty key → disabled by the `!setupKey.trim()` arm, not by `isCustom`.
     await expect(testButton).toBeDisabled();
 
-    const keyField = page.getByRole('textbox').first();
+    // Located by placeholder, not by the `textbox` role: `setupShowKey` starts
+    // false so the field renders as `<input type="password">`, which has no
+    // implicit textbox role and would never match.
+    const keyField = page.getByPlaceholder('Paste your API key…');
+    await expect(keyField).toBeVisible();
     await keyField.fill('sk-not-a-real-key-0000000000');
     await expect(testButton).toBeEnabled();
   });

--- a/app/test/playwright/specs/embeddings-setup-modal.spec.ts
+++ b/app/test/playwright/specs/embeddings-setup-modal.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from '@playwright/test';
+
+import {
+  bootRuntimeReadyGuestPage,
+  dismissWalkthroughIfPresent,
+  signInViaCallbackToken,
+  waitForAppReady,
+} from '../helpers/core-rpc';
+
+/**
+ * The embeddings setup modal's "Test connection" affordance, driven in a real
+ * browser (PR #5943).
+ *
+ * `setupTest` calls `openhuman.embeddings_test_connection` with only
+ * `{ provider, model, dimensions }` — there is no parameter for an endpoint URL
+ * — so a custom OpenAI-compatible provider has nothing to test against. Before
+ * #5943 the button stayed enabled and its handler opened with `if (!isCustom)`,
+ * so a click produced no request, no result and no error: a control that looked
+ * live and silently did nothing. The fix disables it for a custom provider and
+ * renders the reason as visible text beside it.
+ *
+ * Why the reason is text and not a `title`: `Button` applies
+ * `disabled:pointer-events-none`, so a disabled control cannot be hovered, and
+ * a disabled button is out of the tab order — a tooltip would be unreachable by
+ * both mouse and keyboard. Asserting the text is on screen is therefore the
+ * assertion that matches the fix's own reasoning.
+ *
+ * `custom` is a real catalog provider
+ * (`src/openhuman/inference/embeddings/catalog.rs` — `PROVIDER_CUSTOM`, label
+ * "Custom (OpenAI-compatible)"), so it is served by the real core this lane
+ * runs against and needs no fixture.
+ */
+
+const CUSTOM_LABEL = /Custom \(OpenAI-compatible\)/;
+const TEST_CONNECTION = /Test connection/i;
+
+async function openEmbeddingsTab(page: import('@playwright/test').Page, userId: string) {
+  await bootRuntimeReadyGuestPage(page);
+  await signInViaCallbackToken(page, userId);
+  await page.evaluate(() => {
+    try {
+      localStorage.setItem('openhuman:walkthrough_completed', 'true');
+      localStorage.removeItem('openhuman:walkthrough_pending');
+    } catch {}
+    window.location.hash = '/connections?tab=embeddings';
+  });
+  await expect
+    .poll(async () => page.evaluate(() => window.location.hash), { timeout: 15_000 })
+    .toContain('tab=embeddings');
+  await waitForAppReady(page);
+  await dismissWalkthroughIfPresent(page);
+}
+
+test.describe('Embeddings setup — Test connection for a custom endpoint', () => {
+  test('is disabled, and says why, for a custom provider', async ({ page }) => {
+    await openEmbeddingsTab(page, 'pw-embed-custom');
+
+    // Selecting "Custom" opens the setup modal (EmbeddingsPanel:146-152).
+    await page.getByRole('radio').filter({ hasText: CUSTOM_LABEL }).click();
+
+    const testButton = page.getByRole('button', { name: TEST_CONNECTION });
+    await expect(testButton).toBeVisible({ timeout: 15_000 });
+
+    // The fix. Before #5943 this was enabled and its click was a no-op.
+    await expect(testButton).toBeDisabled();
+
+    // And the user is told why, in text that survives having no pointer and no
+    // focus — the whole reason it is not a `title`.
+    const reason = page.getByTestId('embeddings-test-unavailable-reason');
+    await expect(reason).toBeVisible();
+    await expect(reason).toContainText(/not supported yet/i);
+  });
+
+  test('a keyed provider keeps a working Test connection button', async ({ page }) => {
+    // The contrast that proves the disable is scoped to `isCustom` and is not
+    // just "the button is always dead". OpenAI needs a key, so the button is
+    // disabled while the key field is empty and enabled once it is filled —
+    // and no unavailable-reason text is shown for a non-custom provider.
+    await openEmbeddingsTab(page, 'pw-embed-openai');
+
+    await page.getByRole('radio').filter({ hasText: /OpenAI/ }).first().click();
+
+    const testButton = page.getByRole('button', { name: TEST_CONNECTION });
+    await expect(testButton).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId('embeddings-test-unavailable-reason')).toHaveCount(0);
+
+    // Empty key → disabled by the `!setupKey.trim()` arm, not by `isCustom`.
+    await expect(testButton).toBeDisabled();
+
+    const keyField = page.getByRole('textbox').first();
+    await keyField.fill('sk-not-a-real-key-0000000000');
+    await expect(testButton).toBeEnabled();
+  });
+});

--- a/tests/agent_harness_e2e.rs
+++ b/tests/agent_harness_e2e.rs
@@ -176,6 +176,22 @@ fn error_completion(status: u16, message: &str) -> Value {
 // wait expires and never sets [`CANARY_OVERLAP`].
 
 /// Canary substrings whose worker requests must overlap. Empty = disarmed.
+/// Milliseconds every scripted upstream reply is held before it is served, or
+/// `0` for "answer immediately". Armed by the per-model-call ceiling test
+/// (#5766/#5767): the ceiling can only be observed against a call that is still
+/// in flight when the ceiling elapses, and it must apply to *every* attempt —
+/// a queue entry would stall only the first, and the retry would be answered
+/// instantly by the default completion, hiding the timeout.
+static SCRIPTED_STALL_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+fn arm_scripted_stall(ms: u64) {
+    SCRIPTED_STALL_MS.store(ms, std::sync::atomic::Ordering::SeqCst);
+}
+
+fn disarm_scripted_stall() {
+    SCRIPTED_STALL_MS.store(0, std::sync::atomic::Ordering::SeqCst);
+}
+
 static CANARY_BARRIER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
 /// Worker requests currently parked at the barrier.
 static CANARY_IN_FLIGHT: OnceLock<Mutex<std::collections::HashSet<String>>> = OnceLock::new();
@@ -274,6 +290,13 @@ async fn scripted_chat_completions(
             "body": body.clone(),
         }))
     });
+
+    // Hold every reply while the stall is armed, so a model call is still
+    // in flight when a per-call ceiling elapses (#5766/#5767).
+    let stall_ms = SCRIPTED_STALL_MS.load(std::sync::atomic::Ordering::SeqCst);
+    if stall_ms > 0 {
+        tokio::time::sleep(Duration::from_millis(stall_ms)).await;
+    }
 
     // Park an armed fan-out worker before it is answered, so a peer has a
     // chance to arrive. Before the queue pop, not after: holding the popped
@@ -3040,4 +3063,109 @@ async fn provider_sse_tool_args_accumulation() {
     );
 
     server.abort();
+}
+
+// ─── Per-model-call wall-clock ceiling (#5766 / PR #5767) ────────────────────
+//
+// Before #5767 a model call was bounded only by the *turn's remaining* wall
+// clock, so hang detection rode the turn deadline: a turn that had legitimately
+// spent most of its budget across many successful calls handed the next call
+// whatever was left and died. #5767 demoted the turn deadline to a runaway
+// guard (600s → 3600s) and introduced a per-call ceiling
+// (`RunLimits::max_model_call_ms`, default 900s,
+// `OPENHUMAN_MODEL_CALL_TIMEOUT_SECS`, `0` disables) that is recomputed afresh
+// for every call and every retry attempt.
+//
+// The harness names which bound fired in the timeout message
+// (`tinyagents-harness/src/agent_loop/model_call.rs:11,17` —
+// "per-model-call ceiling" vs "remaining wall-clock budget") precisely so field
+// triage can tell "this one call wedged" from "the run is out of time". That
+// label is what this test asserts on: it is the only externally visible signal
+// that distinguishes the two ceilings, so asserting merely "the turn failed"
+// would pass with the fix reverted.
+
+/// A wedged model call is cut off by the PER-CALL ceiling, not by the turn
+/// deadline: with a 2s per-call ceiling under a 600s turn deadline, an upstream
+/// that never answers in time must terminate the turn in seconds, and the
+/// terminal event must name the per-call bound.
+#[test]
+fn model_call_ceiling_bounds_a_wedged_call_below_the_turn_deadline() {
+    run_on_agent_stack(
+        "model_call_ceiling",
+        model_call_ceiling_bounds_a_wedged_call_below_the_turn_deadline_inner,
+    );
+}
+
+async fn model_call_ceiling_bounds_a_wedged_call_below_the_turn_deadline_inner() {
+    let _lock = env_lock();
+
+    // Per-call ceiling far tighter than the turn deadline, so whichever bound
+    // fires is unambiguous. Both are read per turn by `run_policy_for`.
+    let _per_call = EnvVarGuard::set("OPENHUMAN_MODEL_CALL_TIMEOUT_SECS", "2");
+    let _turn = EnvVarGuard::set("OPENHUMAN_AGENT_TURN_TIMEOUT_SECS", "600");
+
+    // Every upstream reply is held for 25s — comfortably past the 2s per-call
+    // ceiling and comfortably short of the 600s turn deadline. Armed globally
+    // so retry attempts stall too.
+    arm_scripted_stall(25_000);
+    reset_script(vec![text_completion("this reply is never delivered in time")]);
+    let stack = boot_stack().await;
+
+    let mut events = spawn_sse_collector(format!(
+        "{}/events?client_id=harness-call-ceiling",
+        stack.rpc_base
+    ));
+    let started = std::time::Instant::now();
+    send_web_chat(
+        &stack.rpc_base,
+        910,
+        "harness-call-ceiling",
+        "thread-call-ceiling",
+        "stall please",
+    )
+    .await;
+
+    // 120s is a generous outer bound: the point is that the turn ends long
+    // before its own 600s deadline, and this wait would itself expire if the
+    // per-call ceiling were not in force.
+    // 120s is a generous outer bound: the point is that the turn ends long
+    // before its own 600s deadline, and this wait would itself expire if the
+    // per-call ceiling were not in force.
+    let terminal = wait_for_terminal(&mut events, Duration::from_secs(120)).await;
+    let elapsed = started.elapsed();
+    disarm_scripted_stall();
+
+    // The turn is stopped rather than completing.
+    assert_eq!(
+        terminal.get("event").and_then(Value::as_str),
+        Some("chat_error"),
+        "a wedged model call must terminate the turn; got: {terminal}"
+    );
+    assert_eq!(
+        terminal.get("error_type").and_then(Value::as_str),
+        Some("turn_timeout"),
+        "the stop must be a timeout, not some other failure; got: {terminal}"
+    );
+
+    // THE assertion, and the one that distinguishes the two ceilings. The
+    // upstream holds every reply for 25s. Bounded only by the turn's remainder
+    // — the pre-#5767 behaviour — that stall completes well inside the 600s
+    // budget and the turn SUCCEEDS. Only a per-call ceiling can stop it at ~2s.
+    // Measured: 2.4s with the ceiling wired, 25.5s with it reverted.
+    assert!(
+        elapsed < Duration::from_secs(15),
+        "the turn must be cut off by the 2s per-call ceiling, not by the 25s \
+         upstream stall completing under the 600s turn deadline; took {elapsed:?}"
+    );
+
+    // Deliberately NOT asserted: that the event names *which* ceiling fired.
+    // The harness distinguishes them internally ("per-model-call ceiling" vs
+    // "remaining wall-clock budget", `model_call.rs:11,17`) precisely so field
+    // triage can tell "this one call wedged" from "the run is out of time", but
+    // the host collapses both into `turn_timeout` with a message that says the
+    // turn "ran past its time budget" and blames a stalled tool or sub-agent.
+    // Here the turn had 598 of its 600 seconds left and no tool ran at all.
+    // Pinning that text would pin a misattribution — see W5-test-findings.md.
+
+    stack.shutdown();
 }

--- a/tests/agent_harness_e2e.rs
+++ b/tests/agent_harness_e2e.rs
@@ -184,12 +184,25 @@ fn error_completion(status: u16, message: &str) -> Value {
 /// instantly by the default completion, hiding the timeout.
 static SCRIPTED_STALL_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
-fn arm_scripted_stall(ms: u64) {
-    SCRIPTED_STALL_MS.store(ms, std::sync::atomic::Ordering::SeqCst);
+/// Arms the stall and disarms it on drop.
+///
+/// The guard exists because the atomic is process-global and the env lock is
+/// deliberately recovered from poisoning: if a test panicked between arming and
+/// a bare `disarm`, every later test sharing this scripted handler would inherit
+/// a 25s delay on every completion, turning one failure into a cascade of
+/// unrelated timeouts.
+struct ScriptedStallGuard;
+
+impl Drop for ScriptedStallGuard {
+    fn drop(&mut self) {
+        SCRIPTED_STALL_MS.store(0, std::sync::atomic::Ordering::SeqCst);
+    }
 }
 
-fn disarm_scripted_stall() {
-    SCRIPTED_STALL_MS.store(0, std::sync::atomic::Ordering::SeqCst);
+#[must_use = "the stall is disarmed when the guard drops; binding it to `_` disarms it immediately"]
+fn arm_scripted_stall(ms: u64) -> ScriptedStallGuard {
+    SCRIPTED_STALL_MS.store(ms, std::sync::atomic::Ordering::SeqCst);
+    ScriptedStallGuard
 }
 
 static CANARY_BARRIER: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
@@ -3107,7 +3120,7 @@ async fn model_call_ceiling_bounds_a_wedged_call_below_the_turn_deadline_inner()
     // Every upstream reply is held for 25s — comfortably past the 2s per-call
     // ceiling and comfortably short of the 600s turn deadline. Armed globally
     // so retry attempts stall too.
-    arm_scripted_stall(25_000);
+    let _stall = arm_scripted_stall(25_000);
     reset_script(vec![text_completion(
         "this reply is never delivered in time",
     )]);
@@ -3135,7 +3148,6 @@ async fn model_call_ceiling_bounds_a_wedged_call_below_the_turn_deadline_inner()
     // per-call ceiling were not in force.
     let terminal = wait_for_terminal(&mut events, Duration::from_secs(120)).await;
     let elapsed = started.elapsed();
-    disarm_scripted_stall();
 
     // The turn is stopped rather than completing.
     assert_eq!(
@@ -3154,8 +3166,12 @@ async fn model_call_ceiling_bounds_a_wedged_call_below_the_turn_deadline_inner()
     // — the pre-#5767 behaviour — that stall completes well inside the 600s
     // budget and the turn SUCCEEDS. Only a per-call ceiling can stop it at ~2s.
     // Measured: 2.4s with the ceiling wired, 25.5s with it reverted.
+    // 8s, not a looser bound: the ceiling under test is 2s, so anything up to
+    // ~4x it still fails while leaving room for boot and SSE delivery. A 15s
+    // bound would also admit an implementation that ignored
+    // `OPENHUMAN_MODEL_CALL_TIMEOUT_SECS` and used a fixed 10s ceiling.
     assert!(
-        elapsed < Duration::from_secs(15),
+        elapsed < Duration::from_secs(8),
         "the turn must be cut off by the 2s per-call ceiling, not by the 25s \
          upstream stall completing under the 600s turn deadline; took {elapsed:?}"
     );

--- a/tests/agent_harness_e2e.rs
+++ b/tests/agent_harness_e2e.rs
@@ -3108,7 +3108,9 @@ async fn model_call_ceiling_bounds_a_wedged_call_below_the_turn_deadline_inner()
     // ceiling and comfortably short of the 600s turn deadline. Armed globally
     // so retry attempts stall too.
     arm_scripted_stall(25_000);
-    reset_script(vec![text_completion("this reply is never delivered in time")]);
+    reset_script(vec![text_completion(
+        "this reply is never delivered in time",
+    )]);
     let stack = boot_stack().await;
 
     let mut events = spawn_sse_collector(format!(

--- a/tests/memory_sources_e2e.rs
+++ b/tests/memory_sources_e2e.rs
@@ -861,3 +861,186 @@ async fn memory_sources_composio_registry_flow() {
 
     rpc_join.abort();
 }
+
+// ─── Relative folder-source paths (openhuman#5830, vendored via PR #5838) ────
+//
+// `FolderReader` was the only reader in `tinymemory-sources` that ignored the
+// workspace it is handed: `PathBuf::from(base_path)` used the configured string
+// verbatim, so a RELATIVE path resolved against the host process's current
+// working directory. For the desktop app that is the Tauri build directory, so
+// a source configured as `docs` looked in `…/app/src-tauri/docs`, found
+// nothing, and failed on every sync cycle forever.
+//
+// `resolve_base` now anchors a relative path on the workspace (absolute paths
+// are still taken verbatim, so every source configured before the fix resolves
+// exactly where it did). The reader is linked into the host as
+// `tinymemory_sources::readers::folder`, so this is reachable over the real
+// `memory_sources_*` RPC surface.
+//
+// The pre-existing `memory_sources_crud_and_folder_read_flow` above passes an
+// ABSOLUTE path, which is the branch the fix deliberately left alone — it
+// cannot catch this.
+
+/// A folder source configured with a RELATIVE path resolves against the
+/// workspace, not the process CWD.
+#[tokio::test]
+async fn memory_sources_folder_relative_path_resolves_against_the_workspace() {
+    let _guard = env_lock();
+    let home = test_home();
+    let openhuman_home = home.join(".openhuman");
+
+    // An explicit workspace makes "the workspace, not the CWD" a decidable
+    // claim: the files exist only under this directory, and the test process's
+    // CWD (the crate root) has no `relative-notes` at all.
+    let workspace = home.join("relative-workspace");
+    std::fs::create_dir_all(&workspace).expect("mkdir workspace");
+
+    let _home = EnvVarGuard::set_to_path("HOME", home);
+    let _ws = EnvVarGuard::set_to_path("OPENHUMAN_WORKSPACE", &workspace);
+    let _backend = EnvVarGuard::unset("BACKEND_URL");
+    let _vite = EnvVarGuard::unset("VITE_BACKEND_URL");
+
+    write_config(&openhuman_home);
+
+    let notes_dir = workspace.join("relative-notes");
+    std::fs::create_dir_all(&notes_dir).expect("mkdir relative notes");
+    std::fs::write(
+        notes_dir.join("brief.md"),
+        "# Relative Brief\n\nAnchored on the workspace, not the process CWD.",
+    )
+    .expect("write brief.md");
+
+    let (rpc_base, rpc_join) = serve().await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Note the path: relative, exactly as openhuman#5830 was configured.
+    let add = rpc(
+        &rpc_base,
+        900,
+        "openhuman.memory_sources_add",
+        json!({
+            "kind": "folder",
+            "label": "Relative Notes",
+            "path": "relative-notes",
+            "glob": "**/*.md",
+        }),
+    )
+    .await;
+    let add_result = ok(&add, "add relative folder source");
+    let source_id = add_result
+        .get("source")
+        .and_then(|s| s.get("id"))
+        .and_then(Value::as_str)
+        .expect("source id")
+        .to_string();
+
+    // THE assertion. Before the fix the reader looked under the CWD, found no
+    // `relative-notes`, and this call returned a "folder does not exist" error
+    // rather than an items array.
+    let items_resp = rpc(
+        &rpc_base,
+        901,
+        "openhuman.memory_sources_list_items",
+        json!({ "source_id": source_id }),
+    )
+    .await;
+    let items_result = ok(&items_resp, "list_items for a relative folder source");
+    let items = items_result
+        .get("items")
+        .and_then(Value::as_array)
+        .expect("items array");
+    let item_ids: Vec<&str> = items
+        .iter()
+        .filter_map(|i| i.get("id").and_then(Value::as_str))
+        .collect();
+    assert!(
+        item_ids.contains(&"brief.md"),
+        "a relative folder path must resolve against the workspace; got {item_ids:?}"
+    );
+
+    // And the content actually reads back through the same resolution.
+    let read = rpc(
+        &rpc_base,
+        902,
+        "openhuman.memory_sources_read_item",
+        json!({ "source_id": source_id, "item_id": "brief.md" }),
+    )
+    .await;
+    let read_result = ok(&read, "read_item for a relative folder source");
+    let body = read_result
+        .get("content")
+        .and_then(|c| c.get("body"))
+        .and_then(Value::as_str)
+        .expect("body");
+    assert!(
+        body.contains("Anchored on the workspace"),
+        "the resolved file must be the workspace one; got {body:?}"
+    );
+
+    rpc_join.abort();
+}
+
+/// A missing relative folder names **where the reader looked**, not just what
+/// it was configured with — the second half of the fix. Reporting `docs` alone
+/// is what made openhuman#5830 cost an `lsof` of the running process to
+/// diagnose.
+#[tokio::test]
+async fn memory_sources_missing_relative_folder_reports_the_resolved_path() {
+    let _guard = env_lock();
+    let home = test_home();
+    let openhuman_home = home.join(".openhuman");
+
+    let workspace = home.join("missing-folder-workspace");
+    std::fs::create_dir_all(&workspace).expect("mkdir workspace");
+
+    let _home = EnvVarGuard::set_to_path("HOME", home);
+    let _ws = EnvVarGuard::set_to_path("OPENHUMAN_WORKSPACE", &workspace);
+    let _backend = EnvVarGuard::unset("BACKEND_URL");
+    let _vite = EnvVarGuard::unset("VITE_BACKEND_URL");
+
+    write_config(&openhuman_home);
+
+    let (rpc_base, rpc_join) = serve().await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let add = rpc(
+        &rpc_base,
+        910,
+        "openhuman.memory_sources_add",
+        json!({
+            "kind": "folder",
+            "label": "Absent",
+            "path": "no-such-folder",
+            "glob": "**/*.md",
+        }),
+    )
+    .await;
+    let source_id = ok(&add, "add absent folder source")
+        .get("source")
+        .and_then(|s| s.get("id"))
+        .and_then(Value::as_str)
+        .expect("source id")
+        .to_string();
+
+    let items_resp = rpc(
+        &rpc_base,
+        911,
+        "openhuman.memory_sources_list_items",
+        json!({ "source_id": source_id }),
+    )
+    .await;
+
+    // The whole response is searched rather than a specific error field: the
+    // point is that the resolved root reaches the caller at all.
+    let serialized = items_resp.to_string();
+    assert!(
+        serialized.contains("no-such-folder"),
+        "the error must still name the configured path; got {items_resp}"
+    );
+    assert!(
+        serialized.contains("resolved to"),
+        "a relative path's error must name where the reader looked; got {items_resp}"
+    );
+
+    rpc_join.abort();
+}

--- a/tests/memory_sources_e2e.rs
+++ b/tests/memory_sources_e2e.rs
@@ -1037,9 +1037,19 @@ async fn memory_sources_missing_relative_folder_reports_the_resolved_path() {
         serialized.contains("no-such-folder"),
         "the error must still name the configured path; got {items_resp}"
     );
+    // The concrete resolved root, not just the phrase "resolved to". A reader
+    // that still joined on the process CWD, or that emitted something generic
+    // like "resolved to an unavailable location", would satisfy a phrase-only
+    // check while keeping the exact diagnostic gap this test exists to close.
+    let expected_resolved = workspace.join("no-such-folder");
+    let expected_resolved = expected_resolved.to_string_lossy();
     assert!(
         serialized.contains("resolved to"),
         "a relative path's error must name where the reader looked; got {items_resp}"
+    );
+    assert!(
+        serialized.contains(expected_resolved.as_ref()),
+        "the resolved root must be the workspace one ({expected_resolved}); got {items_resp}"
     );
 
     rpc_join.abort();


### PR DESCRIPTION
## Summary

Six merged PRs were audited as MISSING or PARTIAL on e2e coverage (`W5-e2e-audit.md`). This closes what could be closed **honestly** and records the rest. **No product code changed** — tests only.

The audit's own lesson drove this: #5924 shipped with a Playwright test that *asserted the bug it fixed*. Every test here was checked against what the behaviour **should** be first, and every Rust test was revert-checked.

## Revert-checked — each fails with the fix reverted, naming its own assertion

| PR | Test | With fix | Fix reverted |
| --- | --- | --- | --- |
| **#5767** | `agent_harness_e2e::model_call_ceiling_bounds_a_wedged_call_below_the_turn_deadline` | **pass, 2.57s** | **FAIL, 25.77s** — `chat_done`, turn succeeded |
| **#5838** | `memory_sources_e2e::memory_sources_folder_relative_path_resolves_against_the_workspace` | **pass** | **FAIL** — `folder does not exist: relative-notes` |
| **#5838** | `memory_sources_e2e::memory_sources_missing_relative_folder_reports_the_resolved_path` | **pass** | **FAIL** — `resolved to` absent |

**#5767** — a new global stall knob on the scripted upstream holds *every* reply (a queue entry would stall only the first attempt; the retry would be answered instantly by the default completion and hide the timeout). With a 2s per-call ceiling under a 600s turn deadline the turn stops in 2.57s. Unwire `policy.limits.max_model_call_ms` and the 25s stall completes comfortably inside the 600s remainder, so the turn **succeeds** — which is exactly the pre-#5767 behaviour, and why elapsed time is the assertion. See the bug below for why the test does *not* assert which ceiling fired.

**#5838** — the payload of that vendor bump is openhuman#5830: a folder source configured with a **relative** path must resolve against the workspace, not the process CWD. The pre-existing folder test passes an **absolute** path — the branch the fix deliberately left alone — so it was never able to catch this. Second test covers the other half of the fix: a missing folder must say *where the reader looked*.

**#5924** — `connections-tab-deeplinks.spec.ts` already covered this path but **asserted the defect**. It was written to pin pre-fix behaviour and says so (`// Flip the two assertions below when that lands.`); #5924 landed the fix and never flipped it. On `main` it asserts the opposite of shipped behaviour. Flipped to assert forwarding, renamed off `BUG:`, file header corrected, plus `?tab=mcp` and a no-query case. Not run locally (see below), but the correction is reasoned directly from `ForwardSearch.tsx`, which copies `search`+`hash` onto the destination.

## Written but NOT revert-checked — please do not record these as coverage

`app/test/playwright/specs/embeddings-setup-modal.spec.ts` (#5943) and `core-rpc-bearer-401.spec.ts` (#5876). The Playwright lane needs a core-bin build plus a browser, and the machine hit its memory limit (0.02 GB free, ~1 GB swap remaining) with the cargo cap cut to 2. I did not run them rather than risk stalling the box.

They are **isolated new files — drop them if you would rather not carry unverified tests.** No lane runs Playwright on PRs to `main`, so they cannot affect CI here either way. Helper signatures were checked by hand against `helpers/core-rpc.ts`.

## Not covered, and why

**#5851** (provider construction moved to `tinychannels::build_channels`). `start_channels` is the only host path that reaches it, and with a populated config it constructs live providers and enters their listen loops — it never returns. The obvious observable does not work either: `handle_list` builds `ChannelManager::new(ChannelsConfig::default(), ())`, the static catalog, so `openhuman.channels_list` is identical whether or not a channel is configured. Covering this needs a build-without-starting seam that does not exist today. Recorded rather than faked.

## Two bugs found while writing these — recorded, not pinned by any test

1. **#5767's per-call/turn distinction is discarded at the event boundary.** My first assertion checked that the terminal event named *which* ceiling fired; it failed **with the fix present**, which is how this surfaced. A wedged model call emits `error_type: "turn_timeout"` and *"This turn ran past its time budget ... This usually means a tool call or a delegated sub-agent stalled"* — when the turn had **598 of its 600 seconds left** and no tool ran at all. The harness preserves `per-model-call ceiling` vs `remaining wall-clock budget` precisely so triage can tell them apart; the host collapses both. Per the "verify before you pin" rule I did not assert that message.
2. **The #5924 spec described above.**

Both are in `bugs/W5-test-findings.md`, which also corrects an error in my own audit: #5838's fix ships in the **linked** `tinymemory_sources` crate, not the cdylib — the audit's verdict stood but its reasoning did not.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — this PR is tests only; three revert-checked, with the failure path (a wedged call, a missing folder) covered explicitly.
- [x] **Diff coverage ≥ 80%** — N/A: no product lines changed; the diff is test files only.
- [x] Coverage matrix updated — N/A: behaviour-only change; no feature rows added, removed or renamed.
- [x] All affected feature IDs from the matrix are listed — N/A: no feature behaviour changed.
- [x] No new external network dependencies introduced — the scripted upstream and mock backend are used throughout; the stall knob is local `tokio::time::sleep`.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: no release-cut surface touched.
- [x] Linked issue closed via `Closes #NNN` — N/A: backfills coverage for already-merged PRs; closes no issue.

## Related

Backfills e2e coverage for merged PRs #5767, #5838, #5924 (and, unverified, #5943, #5876). Context for #5838 is openhuman#5830. Not closing anything.

Note: `main` is currently red on the `Rust Quality` layout gate — pre-existing, being fixed separately, not from this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage confirming Skills links preserve tabs, queries, and URL fragments during redirects.
  * Added regression coverage for local RPC authorization recovery without ending the authenticated session.
  * Added coverage for embeddings connection-test availability and API-key requirements.
  * Added timeout coverage for stalled model requests.
  * Added coverage for resolving relative memory-source folders against the workspace and reporting resolved missing paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->