### PR TITLE
test(e2e): backfill coverage for the embeddings dimension probe and the flows authoring gates

### DIFF
--- a/tests/embeddings_rpc_e2e.rs
+++ b/tests/embeddings_rpc_e2e.rs
@@ -882,3 +882,79 @@ async fn legacy_alias_inference_embed_resolves() {
         "legacy alias should resolve to embeddings_embed and return vector data: {inner}"
     );
 }
+
+/// #4056 / #5859: a Custom endpoint whose NATIVE vector width differs from the
+/// width the user guessed must still verify, and the width that gets persisted
+/// must be the endpoint's, not the guess.
+///
+/// This is the half of the change no existing test could observe.
+/// `embeddings_embed_with_custom_openai_endpoint_round_trips_vectors_and_api_key`
+/// configures `dimensions: 3` against a mock that returns 3-wide vectors, so
+/// "honoured the guess" and "discovered the native width" produce the same
+/// number and its `dimensions == 3` assertion cannot tell them apart. Here the
+/// two are deliberately different: the guess is the product default (1024) and
+/// the endpoint returns 3.
+///
+/// Before the probe was made dimension-agnostic, the save-time verification
+/// enforced the guessed width, so every reachable, valid endpoint whose native
+/// size was not the guess failed verification — the whole of #4056. After it,
+/// `final_probe_dims` adopts the returned length for any model outside the
+/// `text-embedding-3-*` family (`mock-embedding-model` is one), which is also
+/// what keeps the live embed path's length guard from rejecting later embeds.
+#[tokio::test(flavor = "multi_thread")]
+async fn embeddings_update_settings_adopts_custom_endpoint_native_dimension() {
+    let _lock = embeddings_e2e_env_lock();
+    let (rpc_base, _tmp, _guards, _join) = setup_embeddings_test().await;
+    let (mock_base, _mock_state, mock_join) = serve_mock_embeddings().await;
+
+    let update = post_json_rpc(
+        &rpc_base,
+        90,
+        "openhuman.embeddings_update_settings",
+        json!({
+            "provider": "custom",
+            "custom_endpoint": mock_base,
+            "model": "mock-embedding-model",
+            // The guess. The mock returns 3-wide vectors, so this is wrong on
+            // purpose — it is the product default a user would never edit.
+            "dimensions": 1024,
+            "confirm_wipe": true
+        }),
+    )
+    .await;
+    let update_result = assert_no_rpc_error(&update, "embeddings_update_settings native dims");
+    let update_inner = update_result.get("result").unwrap_or(update_result);
+
+    // 1. The save is NOT rejected. A mismatched guess used to fail verification.
+    assert_eq!(
+        update_inner.get("error").and_then(Value::as_str),
+        None,
+        "a reachable endpoint whose native width differs from the guess must \
+         still verify, not be refused: {update_inner}"
+    );
+    let expected_provider = format!("custom:{mock_base}");
+    assert_eq!(
+        update_inner.get("provider").and_then(Value::as_str),
+        Some(expected_provider.as_str()),
+        "the custom provider must be persisted: {update_inner}"
+    );
+
+    // 2. The width that survives is the endpoint's 3, not the guessed 1024.
+    let after = post_json_rpc(
+        &rpc_base,
+        91,
+        "openhuman.embeddings_get_settings",
+        json!({}),
+    )
+    .await;
+    let after_result = assert_no_rpc_error(&after, "get_settings after native-dim save");
+    let after_inner = after_result.get("result").unwrap_or(after_result);
+    assert_eq!(
+        after_inner.get("dimensions").and_then(Value::as_u64),
+        Some(3),
+        "the probe must adopt the endpoint's native vector width (3), not the \
+         guessed 1024: {after_inner}"
+    );
+
+    mock_join.abort();
+}

--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -14561,6 +14561,19 @@ async fn json_rpc_flows_strict_create_accepts_binding_to_schemaless_agent() {
     .await;
 
     if let Some(refusal) = strict_create_refusal(&create) {
+        // A refusal is expected here and is NOT this gate's doing: the fixture
+        // also carries a Slack node whose `channel` arg binds to an upstream
+        // field that is null under a sandboxed dry run, which strict mode
+        // refuses on its own. Success therefore cannot be asserted.
+        //
+        // But the refusal must still be a *strict-validation* one. Without this
+        // the test would also pass on a transport failure, an unknown-method
+        // error or any other structural break — the false-positive shape a bare
+        // "does not contain" check leaves open.
+        assert!(
+            refusal.starts_with("strict validation failed:"),
+            "expected a strict-validation refusal, not an unrelated failure: {refusal}"
+        );
         assert!(
             !refusal.contains("output_parser.schema"),
             "a schema-less agent must be treated as unverifiable, not refused: {refusal}"
@@ -14593,12 +14606,27 @@ async fn json_rpc_flows_strict_create_accepts_prose_prompt_beside_real_messages(
     )
     .await;
 
-    if let Some(refusal) = strict_create_refusal(&create) {
-        assert!(
-            !refusal.contains("reads as an instruction written as a"),
-            "a `=`-prose prompt beside real messages must not block the save: {refusal}"
-        );
-    }
+    // Asserted as a successful save, not merely "no refusal naming this gate".
+    // This fixture is a trigger plus one agent node — no bindings, no
+    // connections, no external-tool args — so there is no later gate it could
+    // legitimately trip, and a tolerated-error form would have gone green on a
+    // structural error, a transport failure or a renamed diagnostic while
+    // proving nothing. Confirmed against the running stack: the create returns
+    // a flow id.
+    let created = assert_no_jsonrpc_error(&create, "flows_create prose prompt beside messages");
+    let created = peel_logs_envelope(created);
+    assert_eq!(
+        created.get("name").and_then(Value::as_str),
+        Some("prose-prompt-with-messages"),
+        "the saved flow must be the one submitted: {created}"
+    );
+    assert!(
+        created
+            .get("id")
+            .and_then(Value::as_str)
+            .is_some_and(|id| !id.is_empty()),
+        "a saved flow must come back with an id: {created}"
+    );
 
     rpc_join.abort();
     api_join.abort();

--- a/tests/json_rpc_e2e.rs
+++ b/tests/json_rpc_e2e.rs
@@ -14394,3 +14394,244 @@ async fn voice_test_provider_honours_validate_only_for_the_stt_workload() {
     mock_join.abort();
     rpc_join.abort();
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #5846 — the two authoring-gate behaviour changes, driven end-to-end through
+// the real strict-mode create path.
+//
+// `flows_create` with `strict: true` runs `ops::strict_gate`
+// (`flows/schemas_handlers.rs:18`) -> `run_builder_gates`
+// (`flows/ops_part_01.rs:509`) -> `validate_binding_resolvability`
+// (`flows/ops_part_02.rs:433`) -> `tinyflows::gates::failures`, the stack
+// #5846 evicted upstream.
+//
+// `ops_tests_part_06_tests.rs` already pins the gate FUNCTION at unit level.
+// What no test covered is that the evicted gate is still WIRED into the strict
+// RPC path — the eviction moved the implementation out of this repository, so
+// the wiring is exactly the thing that can now rot without a local test failing.
+//
+// A NOTE ON #5846's SUMMARY. The PR body reads "a workflow whose `tool_call`
+// arg binds to a schema-less agent is now refused". Taken literally that is not
+// what the gate does, deliberately: an agent with NO `output_parser.schema` is
+// skipped because "the field may exist, so it is unverifiable rather than
+// guaranteed invalid" (`gates/mod.rs:234-239`). Only a field absent from a
+// schema that EXISTS is refused. These tests pin the implemented contract, and
+// the carve-out gets its own case precisely because the PR wording invites
+// someone to "fix" it away.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A `tool_call` arg reading a field the target agent's declared schema omits.
+#[cfg(feature = "flows")]
+fn graph_binding_to_undeclared_agent_field() -> Value {
+    json!({
+        "name": "undeclared-field",
+        "nodes": [
+            { "id": "t", "kind": "trigger", "name": "Manual" },
+            { "id": "summarize", "kind": "agent", "name": "Summarize",
+              "config": { "prompt": "summarize",
+                "output_parser": { "schema": { "type": "object",
+                  "properties": { "summary": { "type": "string" } } } } } },
+            { "id": "post", "kind": "tool_call", "name": "Post",
+              "config": { "slug": "SLACK_SEND_MESSAGE",
+                "args": { "channel": "=nodes.summarize.item.json.channel" } } }
+        ],
+        "edges": [
+            { "from_node": "t", "to_node": "summarize" },
+            { "from_node": "summarize", "to_node": "post" }
+        ]
+    })
+}
+
+/// The same shape with NO declared schema — the deliberate carve-out.
+#[cfg(feature = "flows")]
+fn graph_binding_to_schemaless_agent() -> Value {
+    json!({
+        "name": "schemaless-agent",
+        "nodes": [
+            { "id": "t", "kind": "trigger", "name": "Manual" },
+            { "id": "summarize", "kind": "agent", "name": "Summarize",
+              "config": { "prompt": "summarize" } },
+            { "id": "post", "kind": "tool_call", "name": "Post",
+              "config": { "slug": "SLACK_SEND_MESSAGE",
+                "args": { "channel": "=nodes.summarize.item.json.channel" } } }
+        ],
+        "edges": [
+            { "from_node": "t", "to_node": "summarize" },
+            { "from_node": "summarize", "to_node": "post" }
+        ]
+    })
+}
+
+/// An instruction written as a `=`-expression beside a real `messages` array.
+#[cfg(feature = "flows")]
+fn graph_prose_prompt_beside_real_messages() -> Value {
+    json!({
+        "name": "prose-prompt-with-messages",
+        "nodes": [
+            { "id": "t", "kind": "trigger", "name": "Manual" },
+            { "id": "writer", "kind": "agent", "name": "Writer",
+              "config": {
+                "prompt": "=Write a short friendly summary of the article above",
+                "messages": [{ "role": "user", "content": "summarise the article" }] } }
+        ],
+        "edges": [{ "from_node": "t", "to_node": "writer" }]
+    })
+}
+
+/// The same prompt with no `messages` to fall through to — still refused.
+#[cfg(feature = "flows")]
+fn graph_prose_prompt_without_messages() -> Value {
+    json!({
+        "name": "prose-prompt-alone",
+        "nodes": [
+            { "id": "t", "kind": "trigger", "name": "Manual" },
+            { "id": "writer", "kind": "agent", "name": "Writer",
+              "config": { "prompt": "=Write a short friendly summary of the article above" } }
+        ],
+        "edges": [{ "from_node": "t", "to_node": "writer" }]
+    })
+}
+
+/// The refusal message from a strict `flows_create`, or `None` when it saved.
+#[cfg(feature = "flows")]
+fn strict_create_refusal(response: &Value) -> Option<String> {
+    response
+        .get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+#[cfg(feature = "flows")]
+#[tokio::test]
+async fn json_rpc_flows_strict_create_refuses_binding_to_undeclared_agent_field() {
+    let _env_lock = json_rpc_e2e_env_lock();
+    let (rpc_base, _tmp, api_join, rpc_join, _guards) = boot_flows_rpc_env().await;
+
+    let create = post_json_rpc(
+        &rpc_base,
+        9801,
+        "openhuman.flows_create",
+        json!({
+            "name": "undeclared-field",
+            "graph": graph_binding_to_undeclared_agent_field(),
+            "strict": true
+        }),
+    )
+    .await;
+
+    let refusal = strict_create_refusal(&create)
+        .unwrap_or_else(|| panic!("strict create must be refused, got: {create}"));
+    assert!(
+        refusal.contains("output_parser.schema"),
+        "the refusal must come from the undeclared-field gate, got: {refusal}"
+    );
+    assert!(
+        refusal.contains("channel"),
+        "the refusal must name the offending field, got: {refusal}"
+    );
+
+    rpc_join.abort();
+    api_join.abort();
+}
+
+/// The carve-out: an agent with no declared schema is unverifiable, not
+/// invalid, so this binding must NOT be refused by the schema gate.
+///
+/// Asserted as "no refusal naming this gate" rather than "the save succeeded",
+/// because a strict create must clear every later gate too and this test is
+/// about one of them. It is still non-vacuous: revert the carve-out and the
+/// refusal names `output_parser.schema`, which is exactly what this forbids.
+#[cfg(feature = "flows")]
+#[tokio::test]
+async fn json_rpc_flows_strict_create_accepts_binding_to_schemaless_agent() {
+    let _env_lock = json_rpc_e2e_env_lock();
+    let (rpc_base, _tmp, api_join, rpc_join, _guards) = boot_flows_rpc_env().await;
+
+    let create = post_json_rpc(
+        &rpc_base,
+        9803,
+        "openhuman.flows_create",
+        json!({
+            "name": "schemaless-agent",
+            "graph": graph_binding_to_schemaless_agent(),
+            "strict": true
+        }),
+    )
+    .await;
+
+    if let Some(refusal) = strict_create_refusal(&create) {
+        assert!(
+            !refusal.contains("output_parser.schema"),
+            "a schema-less agent must be treated as unverifiable, not refused: {refusal}"
+        );
+    }
+
+    rpc_join.abort();
+    api_join.abort();
+}
+
+/// #5846's second behaviour change: a vestigial `=`-prose `prompt` beside real
+/// `messages` no longer blocks the save — the node never runs on `prompt` once
+/// `messages` supply the turn, so refusing it was a refusal with no failure
+/// behind it.
+#[cfg(feature = "flows")]
+#[tokio::test]
+async fn json_rpc_flows_strict_create_accepts_prose_prompt_beside_real_messages() {
+    let _env_lock = json_rpc_e2e_env_lock();
+    let (rpc_base, _tmp, api_join, rpc_join, _guards) = boot_flows_rpc_env().await;
+
+    let create = post_json_rpc(
+        &rpc_base,
+        9804,
+        "openhuman.flows_create",
+        json!({
+            "name": "prose-prompt-with-messages",
+            "graph": graph_prose_prompt_beside_real_messages(),
+            "strict": true
+        }),
+    )
+    .await;
+
+    if let Some(refusal) = strict_create_refusal(&create) {
+        assert!(
+            !refusal.contains("reads as an instruction written as a"),
+            "a `=`-prose prompt beside real messages must not block the save: {refusal}"
+        );
+    }
+
+    rpc_join.abort();
+    api_join.abort();
+}
+
+/// The other side of the same rule: with no `messages` to fall through to, the
+/// `=`-prose prompt is still a hard refusal. #5846 narrowed this rule; it did
+/// not remove it, and pinning that stops the narrowing being widened.
+#[cfg(feature = "flows")]
+#[tokio::test]
+async fn json_rpc_flows_strict_create_still_refuses_prose_prompt_without_messages() {
+    let _env_lock = json_rpc_e2e_env_lock();
+    let (rpc_base, _tmp, api_join, rpc_join, _guards) = boot_flows_rpc_env().await;
+
+    let create = post_json_rpc(
+        &rpc_base,
+        9805,
+        "openhuman.flows_create",
+        json!({
+            "name": "prose-prompt-alone",
+            "graph": graph_prose_prompt_without_messages(),
+            "strict": true
+        }),
+    )
+    .await;
+
+    let refusal = strict_create_refusal(&create)
+        .unwrap_or_else(|| panic!("strict create must be refused, got: {create}"));
+    assert!(
+        refusal.contains("reads as an instruction written as a"),
+        "the refusal must come from the `=`-prose prompt gate, got: {refusal}"
+    );
+
+    rpc_join.abort();
+    api_join.abort();
+}


### PR DESCRIPTION
## Summary

Backfills e2e coverage for two of the five gaps found in a coverage audit of recently-merged PRs. Tests only — no production code, no submodule pin, no gate weakened.

Every assertion here is revert-checked: the fix was reverted locally, the test was confirmed to fail **naming the new assertion**, and the fix restored. Results are in the table below.

## What is covered

### openhuman#5859 — the custom embedding endpoint's native vector width

`tests/embeddings_rpc_e2e.rs::embeddings_update_settings_adopts_custom_endpoint_native_dimension`

Configures `dimensions: 1024` against a mock returning 3-wide vectors, then asserts the save is **not** refused and that `embeddings_get_settings` afterwards reports **3**.

The existing `embeddings_embed_with_custom_openai_endpoint_round_trips_vectors_and_api_key` configures `3` against a 3-wide mock, so "honoured the guess" and "discovered the native width" produce the same number and its `dimensions == 3` assertion cannot separate them. A mismatched guess is precisely the #4056 case the probe was made dimension-agnostic for.

### openhuman#5846 — the two authoring-gate behaviour changes

`tests/json_rpc_e2e.rs`, four cases driving `flows_create` with `strict: true`, which reaches `ops::strict_gate` → `run_builder_gates` → `validate_binding_resolvability` → `tinyflows::gates::failures`.

| test | asserts |
|---|---|
| `…refuses_binding_to_undeclared_agent_field` | a `tool_call` arg reading a field the agent's declared schema omits is refused, naming the field |
| `…accepts_binding_to_schemaless_agent` | an agent with **no** schema is unverifiable, not invalid — the deliberate carve-out |
| `…accepts_prose_prompt_beside_real_messages` | a vestigial `=`-prose `prompt` beside real `messages` no longer blocks the save |
| `…still_refuses_prose_prompt_without_messages` | with no `messages` to fall through to, it is still a hard refusal |

`ops_tests_part_06_tests.rs` already pins the gate *function* at unit level. What nothing covered is that the evicted gate is still **wired into the strict RPC path** — #5846 moved the implementation out of this repository, so the wiring is exactly the thing that can now rot without a local test failing.

**One note on the PR summary of #5846.** It reads *"a workflow whose `tool_call` arg binds to a schema-less agent is now refused"*. The gate deliberately does the opposite: `gates/mod.rs` skips an agent with no `output_parser.schema` because *"the field may exist, so it is unverifiable rather than guaranteed invalid"*, and tinyflows' own `binding_to_agent_without_any_schema_is_unverifiable_not_rejected` pins that. The implementation is the defensible reading — refusing every schema-less agent would reject valid graphs. These tests follow the implemented contract, and the carve-out has its own case precisely so that tightening it to match the prose fails loudly.

## Revert-check results

| revert applied | expected | observed |
|---|---|---|
| `final_probe_dims` forced to keep the guess | the #5859 test fails | **FAILED** — *"the probe must adopt the endpoint's native vector width (3), not the guessed 1024"* |
| both #5846 carve-outs reverted (schema-less refused; `messages` carve-out dropped) | the two acceptance tests fail, the two refusal tests still pass | **2 failed / 2 passed** — *"a schema-less agent must be treated as unverifiable, not refused"*, *"a `=`-prose prompt beside real messages must not block the save"* |
| `agent_prompt_failures` + `agent_schema_failures` unwired from `failures()` | the two refusal tests fail, the two acceptance tests still pass | **2 failed / 2 passed** |

All five pass with the fixes in place (`1 passed` and `4 passed` respectively).

## Not covered, and why

Stated rather than papered over — these are honest gaps, not oversights:

- **#5588 (share-card credential redaction).** Coverable, and worth doing: `ShareCardModal` puts the drafted headline into the `#share-caption` textarea via `buildFallbackHeadline` → `redactSensitive`, so a Playwright spec can assert `[redacted]` reaches a real DOM node. Not attempted here because the Playwright lane needs a full web build, and the machine is under an active memory throttle.
- **#5803 (coding-session import deadline).** The changed value is computed by `ingest_budget` and consumed in `modules::memory`, both `pub(crate)`, so no external test crate can observe it. Proving it end-to-end needs a loaded module whose `IngestCodingSessions` member exceeds 30 s — a real module process and a >30 s test.
- **#5823 (corrupt memory store).** All eight functions in `memory::tree::health::user_error` are `pub(crate)`. The only public seam is `apply_all_in_rpc`, and reaching its aggregation branch needs triggers that actually fail. Worth correcting one thing from the original audit: this is **no longer dormant** — `registry_part_01.rs:178` now pins tinymemory `1.13.7` and `vendor/tinymemory` carries the `corruption` module, so the gap is live rather than deferred.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — five e2e cases, each revert-checked, covering both the accept and refuse sides of every gate touched
- [x] **Diff coverage ≥ 80%** — N/A: this PR is tests only; it adds no production lines for diff-cover to measure
- [x] N/A: no feature row added, removed or renamed — Coverage matrix updated
- [x] N/A: no coverage-matrix feature IDs affected — All affected feature IDs listed under `## Related`
- [x] No new external network dependencies introduced — both tests use the existing in-process axum mocks
- [x] N/A: no release-cut surface touched — Manual smoke checklist updated
- [x] N/A: no tracking issue; this backfills coverage for already-merged PRs — Linked issue closed via a closing keyword

## Related

Backfills coverage for openhuman#5859 and openhuman#5846. Refs openhuman#5588, openhuman#5803, openhuman#5823 for the gaps left open above.

`main` is currently red on the `Rust Quality` layout gate (`git_operations.rs` over the 750-line limit, from #5672). That is pre-existing and unrelated to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added end-to-end coverage confirming custom OpenAI-compatible embedding endpoints retain their native vector dimensions when saved.
  - Added coverage for strict flow creation validation, including invalid tool bindings, schema-less agents, and prompt/message combinations.
  - Verified that invalid configurations are rejected while supported configurations continue to save successfully.
  - Confirmed memory initialization remains available while removed memory-diff methods return appropriate unknown-method errors.
  - Added checks that stored provider credentials use owner-only permissions.
  - Verified validation-only voice provider checks avoid live transcription workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->