### PR TITLE
test(e2e): backfill coverage for the per-model-call ceiling and the per-config MCP failure lookups

### DIFF
--- a/tests/agent_harness_e2e.rs
+++ b/tests/agent_harness_e2e.rs
@@ -3116,6 +3116,16 @@ async fn model_call_ceiling_bounds_a_wedged_call_below_the_turn_deadline_inner()
     // fires is unambiguous. Both are read per turn by `run_policy_for`.
     let _per_call = EnvVarGuard::set("OPENHUMAN_MODEL_CALL_TIMEOUT_SECS", "2");
     let _turn = EnvVarGuard::set("OPENHUMAN_AGENT_TURN_TIMEOUT_SECS", "600");
+    // There is a THIRD wall clock, and pinning only the two above leaves this
+    // test's conclusion resting on the ambient environment. `web_turn_deadline()`
+    // (`web_chat/ops_part_01.rs:79`) applies its own backstop from
+    // `OPENHUMAN_WEB_TURN_TIMEOUT_SECS`, and the web layer maps every harness
+    // `Timeout` onto the same generic `turn_timeout` copy — so an inherited
+    // value below the 8s bound asserted here would fire first, produce an
+    // identical terminal, and let the whole test pass with the per-call ceiling
+    // unwired. Cleared, not set, so it falls back to its 900s default and can
+    // play no part in the outcome.
+    let _web_backstop = EnvVarGuard::unset("OPENHUMAN_WEB_TURN_TIMEOUT_SECS");
 
     // Every upstream reply is held for 25s — comfortably past the 2s per-call
     // ceiling and comfortably short of the 600s turn deadline. Armed globally

--- a/tests/mcp_registry_e2e.rs
+++ b/tests/mcp_registry_e2e.rs
@@ -850,3 +850,113 @@ fn supervisor_default_probe_window_stays_eight_seconds() {
          regression b44b958d reverted"
     );
 }
+
+/// An HTTP-remote install pointed at `url`.
+///
+/// The stdio fixture above cannot reach the auth path at all: a 401 is an HTTP
+/// fact, so the credential hints only exist for this transport.
+fn make_http_remote_server(url: &str) -> InstalledServer {
+    InstalledServer {
+        server_id: format!("test-http-{}", uuid::Uuid::new_v4()),
+        qualified_name: "@openhuman-test/remote".to_string(),
+        display_name: "Test Remote".to_string(),
+        description: Some("Stub HTTP-remote MCP server used by mcp_registry_e2e tests.".into()),
+        icon_url: None,
+        // Carried but unread for this transport — callers route off `transport`.
+        command_kind: CommandKind::Binary,
+        command: String::new(),
+        args: Vec::new(),
+        env_keys: Vec::new(),
+        config: None,
+        installed_at: 0,
+        last_connected_at: None,
+        transport: Transport::HttpRemote {
+            url: url.to_string(),
+        },
+        enabled: true,
+    }
+}
+
+/// The failure side of the per-config lookups (#5701).
+///
+/// `per_config_lookups_see_a_per_config_connection` covers the success side and
+/// asserts `last_error_for_config` is `None` after a clean connect. That leaves
+/// the half that matters for diagnosis untested: `auth_hint_for_config` had no
+/// reference in any e2e lane at all, and nothing anywhere asserted that a real
+/// failure is actually *surfaced* rather than folded into the same `None` a
+/// missing workspace returns.
+///
+/// The two-workspace precondition is what makes this discriminate. With two
+/// hosts open and no default, `host::try_service()` refuses to guess, so the
+/// ambient forms answer `None` for a server that genuinely has both a hint and
+/// an error recorded — which is exactly the confusion #5701 was filed about.
+#[tokio::test]
+async fn per_config_failure_lookups_surface_the_reason() {
+    use openhuman_core::openhuman::mcp::host;
+    use openhuman_core::openhuman::mcp::registry::connections;
+    use wiremock::matchers::any;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // A server that refuses everything for want of credentials.
+    let upstream = MockServer::start().await;
+    Mock::given(any())
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&upstream)
+        .await;
+
+    let (_tmp_a, cfg_a) = fresh_workspace_config();
+    let (_tmp_b, cfg_b) = fresh_workspace_config();
+    let _host_b = host(&cfg_b);
+
+    let h = host(&cfg_a);
+    let server = make_http_remote_server(&upstream.uri());
+    h.dynamic()
+        .store()
+        .insert_server(&server)
+        .expect("insert installed server");
+
+    let outcome = connections::connect(&cfg_a, &server).await;
+    assert!(
+        outcome.is_err(),
+        "a 401 from the endpoint must fail the connect, not report success"
+    );
+
+    assert!(
+        host::try_service().is_none(),
+        "two workspaces open and no default: the ambient service must refuse to guess, \
+         which is what makes the per-config forms the only correct ones here"
+    );
+
+    let hint = connections::auth_hint_for_config(&cfg_a, &server.server_id).await;
+    assert_eq!(
+        hint,
+        Some("credential_required"),
+        "the workspace that attempted the connect must see why its 401 happened"
+    );
+
+    let last_error = connections::last_error_for_config(&cfg_a, &server.server_id).await;
+    // Non-empty after trimming, not merely `Some`: the contract this pins is a
+    // *readable* reason, and `Some(String::new())` satisfies `is_some()` while
+    // telling a caller polling status precisely nothing.
+    assert!(
+        last_error
+            .as_deref()
+            .is_some_and(|error| !error.trim().is_empty()),
+        "a failed attempt must leave a readable reason behind — `connect`'s own contract \
+         is that a caller polling status sees it without re-attempting; got {last_error:?}"
+    );
+
+    // A failure belongs to the workspace that hit it, not to every workspace.
+    assert!(
+        connections::auth_hint_for_config(&cfg_b, &server.server_id)
+            .await
+            .is_none(),
+        "an auth hint must not leak across workspaces"
+    );
+    assert!(
+        connections::last_error_for_config(&cfg_b, &server.server_id)
+            .await
+            .is_none(),
+        "a failure must not leak across workspaces"
+    );
+}


### PR DESCRIPTION
## Summary

- Backfills e2e coverage for two behaviours that merged in the last week with none: the **per-model-call wall-clock ceiling** (#5766, armed by the #5796 vendor bump) and the **failure side of the per-config MCP lookups** (#5817).
- Two tests, both revert-checked. **No production code is touched** — the diff is two test files.
- Adds a `delay_ms` entry to `agent_harness_e2e`'s scripted upstream so a completion can be withheld; a call that outlives its budget is the only way to observe a ceiling.
- Reports three things this work found but does **not** fix, below — including one test I wrote, could not make fail, and deliberately dropped.

## Problem

An audit of merged PRs against the three e2e lanes found these two uncovered.

**#5796 / #5766 — the ceiling was never exercised.** `RunLimits::max_model_call_ms` bounds each individual model call so one wedged provider call cannot hold a turn. The only assertion that existed is a unit test (`agent/tinyagents/tinyagents_tests.rs`) pinning that the number is *copied into the policy* — which the wiring line satisfies whether or not any call is ever bounded. It is a safety limit whose failure mode is silent: if it stopped firing, runs would simply hang against a stalled provider until a coarser timeout caught them.

**#5817 — only the success side was covered.** `per_config_lookups_see_a_per_config_connection` covers a clean connect and asserts `last_error_for_config` is `None` afterwards. That left the half that matters for diagnosis untested: `auth_hint_for_config` had no reference in **any** e2e lane, and nothing asserted a real failure is *surfaced* rather than folded into the same `None` a missing workspace returns — which is the confusion #5701 was filed about.

## Solution

**`tests/agent_harness_e2e.rs` — `model_call_exceeding_the_per_call_ceiling_is_cut_off`**
Sets `OPENHUMAN_MODEL_CALL_TIMEOUT_SECS=1`, scripts four 4s stalls (one per possible attempt, so no attempt can fall through to the handler's un-stalled default), and asserts the turn ends in `chat_error` / `turn_timeout` **within seconds**.

The elapsed-time assertion is the load-bearing one and needs explaining. The obvious test — assert the failure names the bound that fired — does not work: the harness *does* label its timeout `per-model-call ceiling` vs `remaining wall-clock budget` (`agent_loop/model_call.rs:11,17`), but the web layer maps both onto one generic `turn_timeout` copy and discards the label. So the discriminator has to be the clock: the turn budget is left at its default hour, so a turn that dies in seconds can only have died on the per-call bound.

**`tests/mcp_registry_e2e.rs` — `per_config_failure_lookups_surface_the_reason`**
Points an HTTP-remote install at a wiremock endpoint that 401s everything, opens a second workspace so `host::try_service()` refuses to guess (the precondition that makes the per-config forms the only correct ones), and asserts `auth_hint_for_config` returns `credential_required`, `last_error_for_config` returns the reason, and neither leaks to the second workspace.

### Revert-check

| test | revert applied | result |
|---|---|---|
| `model_call_exceeding_the_per_call_ceiling_is_cut_off` | `policy.limits.max_model_call_ms = None` in `agent/tinyagents/mod_part_01.rs:214` | **FAILED** as required — `assertion left == right failed: a model call that outruns the per-call ceiling must end the turn; left: Some("chat_done") right: Some("chat_error")`, with `full_response: "UNREACHED_AFTER_CEILING"` proving the stall was awaited to completion |
| `per_config_failure_lookups_surface_the_reason` | both lookups routed back through `host::try_service()` in `mcp/registry/mod.rs` | **FAILED** as required — `assertion left == right failed: the workspace that attempted the connect must see why its 401 happened; left: None right: Some("credential_required")` |

Both restored afterwards; final run of the two binaries in full is **17 passed / 18 passed, 0 failed**.

### One test written, proven vacuous, and dropped

The ceiling has a second half: tool calls are **exempt** from it and stay on the run remainder alone, because a sub-agent delegation is a tool call wrapping an entire child run. I wrote `tool_call_exceeding_the_per_call_ceiling_is_exempt` for it and could not make it fail — it passed both with the ceiling unwired *and* with the exemption removed from `call_budget` outright (fault injected into the vendored `tinyagents-harness`, confirmed recompiled, then restored). A blocking delegation does not appear to be bounded by the parent's tool-call budget in the way the test assumed, so the fault it existed to catch was invisible to it.

Rather than ship a test that proves nothing, it is dropped and the gap is recorded in a comment above the surviving test. **This half remains uncovered.**

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — both added tests *are* failure-path tests; each is revert-checked and shown failing on its own assertion above.
- [x] **Diff coverage ≥ 80%** — `N/A: the diff is test code only; no production lines changed, so there are no changed lines for diff-cover to measure.`
- [x] Coverage matrix updated — `N/A: behaviour-only change; no feature rows added, removed or renamed.`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix feature IDs affected.`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — both tests are hermetic: the existing in-test scripted upstream, and `wiremock` (already a dev-dependency) on localhost.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface changed; test-only.`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A: backfills coverage for already-merged PRs; closes no issue.`

## Impact

- Test-only. No runtime, platform, performance, security, migration or compatibility impact.
- `agent_harness_e2e`'s scripted upstream gains an optional `delay_ms` on a queue entry. Existing entries are unaffected — the handler's fast path is one `get("delay_ms")` miss — and the full binary passes unchanged (17/17).

## Findings this PR does not fix

Recorded here so they are not lost; no issues were opened.

1. **#5701 is not closed by #5817.** The five per-config lookups landed, but **no production caller uses them** — `connections::connected_overview()` (ambient) is still what `agent/harness/session/turn/core_turn.rs:137,210` and `agent/registry/agents/orchestrator/prompt.rs:170` call, and none of the six lookups has any other caller in `src/`. `try_service()` resolves the `init()` workspace first, so a normally booted desktop process still answers — but it answers **from the default workspace**, so a process serving more than one can hand the orchestrator another workspace's MCP servers; an embedder that only ever used `for_config` gets `Vec::new()`. The capability moved, the callers did not.

2. **The `turn_timeout` copy blames the wrong thing.** `web_chat/web_errors_part_02.rs:107-113` tells the user *"This usually means a tool call or a delegated sub-agent stalled."* That branch now also catches the per-model-call ceiling, which fires **only** on model calls and from which tool calls are explicitly exempt — so in the case #5766 was built to detect, the message names the one cause it cannot be. My first attempt at the test asserted against this and got the misleading copy back verbatim.

3. **`error_type` cannot distinguish the two bounds.** Both the per-call ceiling and the turn deadline surface as `turn_timeout` with the label discarded, so no client, log line, or test can tell "this one call wedged" from "the run is out of time". That is why the test above has to discriminate on elapsed time.

## Related

- Closes:
- Follow-up PR(s)/TODOs: the tool-call exemption half of the ceiling remains uncovered (see above); the three findings above are unfiled by instruction.

## Note on CI

`main` is currently red on the `Rust Quality` layout gate — pre-existing and being fixed separately. Expect it here; every other check should be green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage confirming stalled model calls terminate within the configured timeout and report a turn-timeout error.
  * Added coverage confirming incomplete timed-out responses do not appear in chat history.
  * Added coverage for remote connection failures, including credential-required guidance and workspace-specific error visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->