### PR TITLE
test(e2e): backfill coverage for the memory module-dispatch and maintenance-contract hops

### DIFF
--- a/tests/memory_sources_e2e.rs
+++ b/tests/memory_sources_e2e.rs
@@ -1054,3 +1054,212 @@ async fn memory_sources_missing_relative_folder_reports_the_resolved_path() {
 
     rpc_join.abort();
 }
+
+/// Regression for #5801, fixed by #5808: `MemorySourceSync::run_source_sync` is
+/// a **defaulted** contract member whose default body answers
+/// `Unsupported(SourceSync)`. `ModuleMemoryProvider` inherited that default
+/// instead of bridging the call, so the user's "Sync now" button reported
+/// `unsupported capability: source_sync` on a build whose module could sync
+/// perfectly well — while the module's own scheduler, which never crosses this
+/// bridge, kept syncing fine.
+///
+/// A defaulted member that was never bridged is indistinguishable from a
+/// bridged one at compile time, which is exactly why the bug shipped. So this
+/// asserts on the **runtime** answer.
+///
+/// The discriminator: `binding::build` binds `module_provider` — i.e.
+/// `ModuleMemoryProvider` — whenever the `modules` feature is on, which it is by
+/// default, so this RPC really does reach the bridged member. No module artifact
+/// is installed in a test run, so a **bridged** member fails while trying to
+/// reach the module (a transport/availability failure), whereas an **unbridged**
+/// one refuses the capability outright before any transport is attempted. Those
+/// two failures are distinguishable in the message, and only the second is the
+/// regression.
+///
+/// Deliberately not asserted: that the sync *succeeds*. That would need a live
+/// module artifact and a network fetch, which this lane must not depend on.
+/// The bug was never "sync returns the wrong data" — it was "the call is
+/// refused before it is attempted", and that is what this pins.
+#[tokio::test]
+async fn sources_sync_dispatches_to_the_module_rather_than_refusing_the_capability() {
+    let _guard = env_lock();
+    let home = test_home();
+    let openhuman_home = home.join(".openhuman");
+
+    let _home = EnvVarGuard::set_to_path("HOME", home);
+    let _ws = EnvVarGuard::unset("OPENHUMAN_WORKSPACE");
+    let _backend = EnvVarGuard::unset("BACKEND_URL");
+    let _vite = EnvVarGuard::unset("VITE_BACKEND_URL");
+
+    write_config(&openhuman_home);
+
+    let notes_dir = home.join("sync-dispatch-notes");
+    std::fs::create_dir_all(&notes_dir).expect("mkdir sync-dispatch-notes");
+    std::fs::write(notes_dir.join("note.md"), "# Note\n\nBody.\n").expect("write note.md");
+
+    let (rpc_base, rpc_join) = serve().await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let add = rpc(
+        &rpc_base,
+        901,
+        "openhuman.memory_sources_add",
+        json!({
+            "kind": "folder",
+            "label": "Sync Dispatch Fixture",
+            "path": notes_dir.to_string_lossy(),
+            "glob": "**/*.md",
+        }),
+    )
+    .await;
+    let source = ok(&add, "add sync-dispatch source");
+    let source = source.get("source").expect("source in add response");
+    let source_id = source
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("source id")
+        .to_string();
+    // The enabled gate in `sync_rpc` returns before the driver is ever asked, so
+    // a disabled source would make this test vacuous.
+    assert_eq!(
+        source.get("enabled"),
+        Some(&json!(true)),
+        "fixture must be enabled or sync_rpc short-circuits before reaching the driver"
+    );
+
+    let sync = rpc(
+        &rpc_base,
+        902,
+        "openhuman.memory_sources_sync",
+        json!({ "source_id": source_id }),
+    )
+    .await;
+
+    let message = sync
+        .get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+
+    assert!(
+        !message.contains("unsupported capability"),
+        "memory_sources_sync refused the capability instead of dispatching to the module \
+         — `run_source_sync` is inheriting its defaulted `Unsupported` body again (#5801). \
+         Got: {message}"
+    );
+    // Pin the specific family too, so a future unrelated `Unsupported` cannot
+    // satisfy the assertion above by accident.
+    assert!(
+        !message.contains("source_sync"),
+        "memory_sources_sync named the source_sync capability as unsupported (#5801). \
+         Got: {message}"
+    );
+    // The OTHER way the call can be refused before dispatch, and the one the two
+    // assertions above cannot see. `sync_rpc` resolves
+    // `binding.provider().as_source_sync()` and bails with
+    //
+    //     the bound memory driver '<id>' does not serve source sync
+    //
+    // (`memory/sources/rpc_part_01.rs:560-564`) when the capability is absent.
+    // That string carries "source sync" with a SPACE — so it contains neither
+    // "unsupported capability" nor the underscored "source_sync", and both
+    // assertions above pass while `run_source_sync` was never reached. Codex
+    // caught this on #5973; without it the test is green for the exact
+    // regression it exists to catch, one layer up from the defaulted body.
+    assert!(
+        !message.contains("does not serve source sync"),
+        "memory_sources_sync was refused host-side: the bound provider does not expose \
+         SourceSync at all, so the bridged member was never reached. This is the same \
+         class of failure as #5801, one layer up. Got: {message}"
+    );
+
+    let _ = rpc(
+        &rpc_base,
+        903,
+        "openhuman.memory_sources_remove",
+        json!({ "id": source_id }),
+    )
+    .await;
+
+    rpc_join.abort();
+}
+
+/// #5725 routed `reset_tree` and `flush_now` through the `MemoryProvider`
+/// contract (`Maintenance::reset_derived_index` / `flush_pending`) instead of
+/// reaching into the engine. Nothing exercised either afterwards: in the
+/// raw-coverage lane `"flush_now"` and `"reset_tree"` appear only as string
+/// literals fed to `memory::schema::schemas(...)` — a schema lookup — and in
+/// `worker_c_modules_e2e.rs` they sit in a 68-method loop whose helper
+/// (`assert_rpc_completed`) passes on an error response. So both paths could
+/// stop reaching a driver entirely and every lane would stay green.
+///
+/// This drives both RPCs for real and pins the routing: the bound driver must
+/// SERVE Maintenance and the call must reach it.
+///
+/// What is asserted is the host-side refusal, not success. `reset_tree_rpc` and
+/// `flush_now_rpc` each resolve `binding.provider().as_maintenance()` and bail
+/// with `"driver '<id>' does not serve Maintenance"` when the capability is
+/// absent — that message is produced *before* any driver call, so it is the one
+/// failure that proves the contract hop did not happen. A driver-side failure
+/// (no module artifact in this lane) is a different message and is fine here:
+/// it means the call was dispatched, which is the thing under test.
+///
+/// Deliberately NOT asserted: that rows were deleted or a flush was enqueued.
+/// Those need a live module artifact and a network fetch (see FINDING 1 in
+/// W3-test-findings.md), and a lane that must not depend on the network cannot
+/// honestly pin them.
+#[tokio::test]
+async fn tree_reset_and_flush_route_through_the_maintenance_contract() {
+    let _guard = env_lock();
+    let home = test_home();
+    let openhuman_home = home.join(".openhuman");
+
+    let _home = EnvVarGuard::set_to_path("HOME", home);
+    let _ws = EnvVarGuard::unset("OPENHUMAN_WORKSPACE");
+    let _backend = EnvVarGuard::unset("BACKEND_URL");
+    let _vite = EnvVarGuard::unset("VITE_BACKEND_URL");
+
+    write_config(&openhuman_home);
+
+    let (rpc_base, rpc_join) = serve().await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    for (id, method) in [
+        (921_i64, "openhuman.memory_tree_flush_now"),
+        (922, "openhuman.memory_tree_reset_tree"),
+    ] {
+        let resp = rpc(&rpc_base, id, method, json!({})).await;
+        let message = resp
+            .get("error")
+            .and_then(|e| e.get("message"))
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+
+        assert!(
+            !message.contains("does not serve Maintenance"),
+            "{method} never reached a driver: the bound provider does not serve the \
+             Maintenance capability, so the contract hop #5725 introduced is not happening. \
+             Got: {message}"
+        );
+        // A renamed or removed RPC must not read as success. The assertion above
+        // only excludes one string, so an unknown method — whose message is
+        // `unknown method: <name>` and contains no "does not serve Maintenance" —
+        // would satisfy it while nothing was dispatched at all (Codex, #5973).
+        assert!(
+            !message.contains("unknown method"),
+            "{method} is not a registered RPC any more, so this test was asserting \
+             against a method that no longer exists. Got: {message}"
+        );
+        // And the response has to be one of the two shapes a dispatched call can
+        // produce: a result, or a driver-side error. Anything else means the
+        // request did not complete.
+        assert!(
+            resp.get("result").is_some() || resp.get("error").is_some(),
+            "{method} returned neither a result nor an error, so nothing was dispatched: {resp}"
+        );
+    }
+
+    rpc_join.abort();
+}


### PR DESCRIPTION
## Summary

- Backfills e2e coverage for two paths found uncovered in an audit of recently merged PRs: **#5808** (the bridged `run_source_sync` module member) and **#5725** (`reset_tree` / `flush_now` routed through the Maintenance contract).
- Both tests are **revert-checked** — each fails, at its own assertion, with the fix removed. Evidence below.
- No production code is touched. Two tests added to `tests/memory_sources_e2e.rs`.
- Four items in the audited slice are **not** covered here; the reason is the same for three of them and is written up rather than papered over — see `## Related`.

## Problem

Both paths could break completely today and no lane would go red.

**#5808 / #5801.** `MemorySourceSync::run_source_sync` is a **defaulted** contract member. `ModuleMemoryProvider` inherited its `Unsupported` body instead of bridging it, so "Sync now" answered `unsupported capability: source_sync` while the module's own scheduler kept syncing fine. A defaulted member that was never bridged is indistinguishable from a bridged one at compile time — which is exactly why the bug shipped.

**#5725.** `reset_tree` and `flush_now` were routed through `Maintenance::reset_derived_index` / `flush_pending`. Nothing exercised either afterwards. In the raw-coverage lane both names appear only as **string literals fed to `memory::schema::schemas(...)`** — a schema lookup, not an invocation (`memory_threads_raw_coverage_e2e.rs:1153-1158`). In `worker_c_modules_e2e.rs` they sit in a 68-method loop whose helper `assert_rpc_completed` passes if the response contains *either* `result` *or* `error`. Both satisfy a grep and the domain e2e gate while asserting nothing.

## Solution

Because the compile-time signal is exactly what is missing in both cases, both tests assert the **runtime** answer, and each keys on a message produced on a specific side of the seam.

**`sources_sync_dispatches_to_the_module_rather_than_refusing_the_capability`** — `binding::build` binds `module_provider` whenever the `modules` feature is on, so `openhuman.memory_sources_sync` really does reach the bridged member. An **unbridged** member refuses the capability *before* any transport is attempted; a **bridged** one gets as far as the module. Those two failures differ in the message. The test adds an enabled folder source (asserting `enabled` first, since the enabled gate in `sync_rpc` returns before the driver is ever asked) and requires that the answer is not an `unsupported capability` refusal.

**`tree_reset_and_flush_route_through_the_maintenance_contract`** — both RPCs resolve `binding.provider().as_maintenance()` and bail with `"driver '<id>' does not serve Maintenance"` *before* any driver call. That message is therefore the one failure that proves the contract hop did not happen, and it is what the test forbids.

**Neither test asserts success**, deliberately. Success needs a live module artifact fetched over the network, and this lane must not depend on that. The bugs being pinned were never "wrong data" — they were "the call is refused before it is attempted", and that is what these assert.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — this PR *is* the tests; each pins the failure path it was written for, and both are revert-checked.
- [x] **Diff coverage ≥ 80%** — N/A: the diff is test code only; no production line is added or changed, so there are no changed lines for `diff-cover` to score.
- [x] Coverage matrix updated — N/A: no feature row added, removed or renamed; this adds coverage for existing behaviour.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature row applies.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — neither new test requires the network. Note that the *existing* lane does; that is reported, not introduced, in `## Related`.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: test-only change, no user-facing surface.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: backfills coverage for already-merged PRs; there is no open issue to close.

## Impact

- Test-only. No runtime, platform, performance, security, migration or compatibility impact.
- Both tests live in the existing `memory_sources_e2e` target, so no new link step.

## Related

- Covers: #5808, #5725
- Not covered here, with reasons: **#5837**, **#5849**, **#5875** all require a **loaded module** to drive the behaviour end to end, and the only way this lane obtains one today is a live GitHub-release download at test time. Pinning them would mean either shipping a network-dependent test or asserting something weaker than the behaviour. **#5942** is a Playwright change; a spec is written but I could not run it under the current machine limits, and an unverified test is not worth the risk of a red lane — it is held back rather than shipped blind.
- Findings written up (no issues opened): `~/tinyhuman/bugs/W3-test-findings.md` — most notably that `flows/.../composio_tests.rs::backend_dispatch_forwards_the_workflow_connection_id` is a non-`#[ignore]`d test that can only pass by downloading a module over the network, which contradicts the mock policy and will fail on an isolated runner.
- Follow-up PR(s)/TODOs: give `assert_rpc_completed` a real assertion; make the `raw_coverage_all` feature gating fail loudly instead of skipping silently.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A — no Linear issue; this is a coverage backfill from an internal audit.
- URL: N/A

### Commit & Branch

- Branch: `test/e2e-backfill-w3`
- Commit SHA: `4490739d2`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend file is touched.
- [x] `pnpm typecheck` — N/A: no TypeScript is touched.
- [x] Focused tests: `cargo test --test memory_sources_e2e sources_sync_dispatches_to_the_module` and `... tree_reset_and_flush_route_through` — both pass; both revert-checked (table below).
- [x] Rust fmt/check (if changed): `cargo fmt -- --check` — clean.
- [x] Tauri fmt/check (if changed): N/A: the Tauri shell is not touched.

### Validation Blocked

- `command:` the Playwright spec for #5942, and any test that drives a real module for #5837 / #5849 / #5875
- `error:` no module artifact is available without a network download; the host was at its memory and slot limits, so a Playwright app build was not run
- `impact:` those four items are reported as not covered rather than shipped unverified

### Behavior Changes

- Intended behavior change: none — test-only.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: N/A — no production code changed.
- Guard/fallback/dispatch parity checks: both tests assert the dispatch seam itself; the revert-checks below show each failing when its seam is removed.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A

---

### Revert-check evidence

| Test | Fix reverted | Result |
|---|---|---|
| `sources_sync_dispatches_to_the_module_rather_than_refusing_the_capability` | `run_source_sync` bridge removed from `modules/memory_part_02.rs` so the trait default applies | **FAILED** at `memory_sources_e2e.rs:952` — `Got: unsupported capability: source_sync` (the #5801 string verbatim) |
| `tree_reset_and_flush_route_through_the_maintenance_contract` | `as_maintenance()` returns `None` in `modules/memory_part_01.rs` | **FAILED** at `memory_sources_e2e.rs:1029` — `Got: flush_now: driver 'tinymemory' does not serve Maintenance` |

Both fixes restored afterwards; `git diff` against `main` for both files is empty.

> `main` is currently red on the `Rust Quality` layout gate (`git_operations.rs` at 949 lines against a 750 limit, from #5672). That is pre-existing and unrelated to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end regression coverage for resolving relative folder-source paths against the workspace location.
  * Added validation that missing-folder diagnostics include the resolved workspace path.
  * Added coverage confirming memory source synchronization requests are dispatched successfully without unsupported-capability or host-side refusal errors.
  * Added validation for memory tree flush and reset operations, ensuring requests route through maintenance handling without unknown-method failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->