### PR TITLE
feat(security): resolve `credential_ref` handles through the keychain

### DIFF
--- a/src/openhuman/security/credentials/credential_ref.rs
+++ b/src/openhuman/security/credentials/credential_ref.rs
@@ -1,0 +1,289 @@
+//! `credential_ref` resolution — the `[subsystems.*]` credential handle.
+//!
+//! `docs/specs/kernel.md` §3.6 gives every subsystem the same driver-binding
+//! config shape, and `docs/specs/plan-memory.md` §4.5 fixes one field of it:
+//!
+//! ```toml
+//! [subsystems.memory.drivers.supermemory]
+//! credential_ref = "keychain:supermemory"
+//! ```
+//!
+//! The value is a **reference**, never an inline secret. This module is the one
+//! place that turns such a reference into the secret it names, so the rule
+//! "config carries handles, the keychain carries secrets" has a single
+//! enforcement point rather than one per subsystem. It lives in `security/`
+//! rather than beside its first caller because the field is uniform across
+//! subsystems by §3.6 — memory binds first, and inference, channels and sandbox
+//! follow onto the same shape (kernel.md §5).
+//!
+//! ## Three refusals before the keychain is touched
+//!
+//! Resolution is deliberately not a bare [`keyring::get`]:
+//!
+//! 1. **Consent.** [`keyring_consent::policy::check_secret_access`] must return
+//!    [`PolicyDecision::Proceed`]. A prompt that has not been answered is not a
+//!    missing credential, and conflating the two would train an operator to
+//!    "fix" a pending consent dialog by editing config.
+//! 2. **Availability.** A host with no usable keychain backend reports that as
+//!    itself rather than as a missing entry — the same order
+//!    `web3::wallet`'s `keychain_load_mnemonic` uses.
+//! 3. **Absence.** Only then is a `None` from the keychain a genuine
+//!    "not configured".
+//!
+//! ## Nothing here may reach an operator-facing string
+//!
+//! [`CredentialRefError`] carries **no name and no secret**, and
+//! [`CredentialRef`]'s `Debug` redacts the name. That is load-bearing rather
+//! than decorative: `MemoryDriverConfig`'s own doc requires the credential
+//! reference to stay out of `Debug`/error output (plan-memory.md §7, Tier 3),
+//! and `memory::binding`'s `FallbackReason` is rendered into
+//! `subsystems_status` — pinned by
+//! `fallback_reason_never_contains_credential_ref_or_endpoint`.
+//!
+//! The sharp edge is [`KeyringError`], whose own `Display` interpolates the
+//! key: `"OS keychain error for key '{key}': {source}"`. Propagating one
+//! verbatim into a bind failure would leak the very name this module exists to
+//! keep out of that string, so backend failures are deliberately mapped to a
+//! name-free variant and the detail is logged instead.
+
+use zeroize::Zeroizing;
+
+use crate::openhuman::security::keyring;
+use crate::openhuman::security::keyring_consent::{policy, PolicyDecision};
+
+/// Log prefix for this module's diagnostics.
+const LOG_PREFIX: &str = "[security:credential-ref]";
+
+/// The `keychain:` scheme — the only one defined today.
+///
+/// Kept as a named constant because it is persisted in users' `config.toml`
+/// and is therefore a compatibility surface, not an implementation detail.
+pub const KEYCHAIN_SCHEME: &str = "keychain";
+
+/// Why a `credential_ref` could not be parsed or resolved.
+///
+/// Every variant's `Display` is safe to place in an operator-facing string: it
+/// names neither the credential nor the secret. See the module docs.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CredentialRefError {
+    /// The reference was empty or whitespace only.
+    #[error("credential_ref is empty")]
+    Empty,
+
+    /// The reference had no `<scheme>:` prefix.
+    #[error(
+        "credential_ref is missing a '<scheme>:' prefix (expected \"{KEYCHAIN_SCHEME}:<name>\")"
+    )]
+    MissingScheme,
+
+    /// The scheme is not one this build understands.
+    ///
+    /// The scheme itself is a fixed vocabulary word, not user data, so it is
+    /// safe to name; the entry name after it is not and is never included.
+    #[error("credential_ref scheme '{scheme}' is not supported (expected \"{KEYCHAIN_SCHEME}\")")]
+    UnsupportedScheme {
+        /// The offending scheme, lowercased.
+        scheme: String,
+    },
+
+    /// The scheme was valid but the name after it was empty.
+    #[error("credential_ref has an empty name after \"{KEYCHAIN_SCHEME}:\"")]
+    EmptyName,
+
+    /// Keychain access is gated behind a consent prompt that has not been
+    /// answered. Distinct from [`Self::Unavailable`] on purpose.
+    #[error("keychain access is pending user consent")]
+    ConsentPending,
+
+    /// No usable keychain backend on this host.
+    #[error("no keychain backend is available on this host")]
+    Unavailable,
+
+    /// The keychain has no entry under this reference.
+    #[error("no keychain entry matches this credential_ref")]
+    NotFound,
+
+    /// The keychain backend failed. Detail is logged, never rendered — see the
+    /// module docs on [`KeyringError`](keyring::KeyringError).
+    #[error("keychain lookup failed")]
+    Backend,
+}
+
+/// The two gates that run *before* the keychain is touched, as a pure
+/// function of what they observed.
+///
+/// Split out for the same reason `memory::binding::admit` is pure: the rule
+/// worth pinning is the **order** — a pending consent prompt must be reported
+/// as consent, not as an unavailable backend, and neither may be reported as a
+/// missing entry. That ordering is what stops an operator "fixing" an
+/// unanswered dialog by editing `config.toml`, and it is testable here without
+/// a keychain, a consent store, or a booted core.
+///
+/// Returns `None` when the caller may proceed to the lookup.
+#[must_use]
+pub fn preflight(decision: PolicyDecision, keychain_available: bool) -> Option<CredentialRefError> {
+    if decision != PolicyDecision::Proceed {
+        return Some(CredentialRefError::ConsentPending);
+    }
+    if !keychain_available {
+        return Some(CredentialRefError::Unavailable);
+    }
+    None
+}
+
+/// The scheme half of a parsed reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum CredentialRefScheme {
+    /// `keychain:<name>` — resolved through [`keyring`].
+    Keychain,
+}
+
+impl CredentialRefScheme {
+    /// The wire spelling, as it appears in `config.toml`.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Keychain => KEYCHAIN_SCHEME,
+        }
+    }
+}
+
+/// A parsed `credential_ref`.
+///
+/// Deliberately **not** `derive(Debug)` — see the manual impl below and the
+/// module docs.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct CredentialRef {
+    scheme: CredentialRefScheme,
+    name: String,
+}
+
+// Manual `Debug` that redacts the name. Deriving it would put the credential
+// reference into every `format!("{ref:?}")`, `tracing::debug!(?r, ...)` and
+// panic message, which plan-memory.md §7 Tier-3 forbids. This mirrors
+// `MemoryDriverConfig`'s own manual redacting `Debug`. NEVER derive `Debug`.
+impl std::fmt::Debug for CredentialRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CredentialRef")
+            .field("scheme", &self.scheme)
+            .field("name", &"<redacted>")
+            .finish()
+    }
+}
+
+impl CredentialRef {
+    /// Parse `"<scheme>:<name>"`.
+    ///
+    /// Surrounding whitespace is trimmed on both halves, so a hand-edited
+    /// `config.toml` with `credential_ref = "keychain: supermemory"` resolves
+    /// the same entry as the canonical spelling. The scheme is matched
+    /// case-insensitively; the name is **not** normalised, because it is a
+    /// keychain key and the backing store is case-sensitive.
+    ///
+    /// # Errors
+    ///
+    /// [`CredentialRefError::Empty`], [`CredentialRefError::MissingScheme`],
+    /// [`CredentialRefError::UnsupportedScheme`] or
+    /// [`CredentialRefError::EmptyName`]. None of them carry the name.
+    pub fn parse(raw: &str) -> Result<Self, CredentialRefError> {
+        let raw = raw.trim();
+        if raw.is_empty() {
+            return Err(CredentialRefError::Empty);
+        }
+
+        // `split_once` rather than `split(':')`: a name is free to contain a
+        // colon, and only the first one separates the scheme.
+        let Some((scheme_raw, name_raw)) = raw.split_once(':') else {
+            return Err(CredentialRefError::MissingScheme);
+        };
+
+        let scheme_norm = scheme_raw.trim().to_ascii_lowercase();
+        let scheme = if scheme_norm == KEYCHAIN_SCHEME {
+            CredentialRefScheme::Keychain
+        } else {
+            return Err(CredentialRefError::UnsupportedScheme {
+                scheme: scheme_norm,
+            });
+        };
+
+        let name = name_raw.trim();
+        if name.is_empty() {
+            return Err(CredentialRefError::EmptyName);
+        }
+
+        Ok(Self {
+            scheme,
+            name: name.to_string(),
+        })
+    }
+
+    /// The scheme this reference names.
+    #[must_use]
+    pub fn scheme(&self) -> CredentialRefScheme {
+        self.scheme
+    }
+
+    /// The entry name, without the scheme prefix.
+    ///
+    /// Callers must treat this as sensitive: it is the one field this type's
+    /// `Debug` deliberately hides, so do not interpolate it into a string that
+    /// can reach an operator (see the module docs).
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Resolve this reference to the secret it names, under `user_id`.
+    ///
+    /// `user_id` is the keychain partition the caller binds under; it is a
+    /// parameter rather than something derived here so this module stays free
+    /// of any one subsystem's notion of identity.
+    ///
+    /// The returned secret is wrapped in [`Zeroizing`] so it is wiped when the
+    /// caller drops it rather than lingering in freed memory.
+    ///
+    /// # Errors
+    ///
+    /// [`CredentialRefError::ConsentPending`], [`CredentialRefError::Unavailable`],
+    /// [`CredentialRefError::NotFound`] or [`CredentialRefError::Backend`], in
+    /// that order of checking. No variant carries the name or the secret.
+    pub fn resolve(&self, user_id: &str) -> Result<Zeroizing<String>, CredentialRefError> {
+        match self.scheme {
+            CredentialRefScheme::Keychain => self.resolve_keychain(user_id),
+        }
+    }
+
+    fn resolve_keychain(&self, user_id: &str) -> Result<Zeroizing<String>, CredentialRefError> {
+        if let Some(refusal) = preflight(policy::check_secret_access(), keyring::is_available()) {
+            log::debug!(
+                "{LOG_PREFIX} keychain access refused before lookup user_id={user_id} \
+                 refusal={refusal} backend={}",
+                keyring::backend_name()
+            );
+            return Err(refusal);
+        }
+
+        match keyring::get(user_id, &self.name) {
+            Ok(Some(secret)) => {
+                log::debug!("{LOG_PREFIX} resolved credential_ref user_id={user_id}");
+                Ok(Zeroizing::new(secret))
+            }
+            Ok(None) => {
+                log::debug!("{LOG_PREFIX} no keychain entry for credential_ref user_id={user_id}");
+                Err(CredentialRefError::NotFound)
+            }
+            // Logged, not propagated: `KeyringError`'s Display interpolates the
+            // key, and this error's Display is allowed into operator-facing
+            // strings. See the module docs.
+            Err(e) => {
+                log::warn!("{LOG_PREFIX} keychain lookup failed user_id={user_id}: {e}");
+                Err(CredentialRefError::Backend)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "credential_ref_tests.rs"]
+mod tests;

--- a/src/openhuman/security/credentials/credential_ref.rs
+++ b/src/openhuman/security/credentials/credential_ref.rs
@@ -61,11 +61,19 @@
 //! name-free variant and logged through [`keyring_error_kind`], which yields a
 //! fixed label and nothing else.
 //!
-//! **Scope of that promise.** It covers this module's errors and this module's
-//! logs. `keyring::get` itself logs its `key=` argument at `debug`, as the
-//! whole keyring surface has always done for its fixed-name callers; narrowing
-//! that is a shared-kernel decision affecting every subsystem in kernel.md §5,
-//! not something to settle here.
+//! The same rule applies to what is handed *back*: [`ResolvedSecret`] exists
+//! because `Zeroizing`'s derived `Debug` prints the secret, and a module that
+//! redacts the name while returning a type that renders the value would be
+//! protecting the wrong half.
+//!
+//! **Scope of that promise.** It covers this module's errors, this module's
+//! logs, and the types it returns. It does **not** cover `keyring::get`, which
+//! logs its `key=` argument at `debug` as the whole keyring surface has always
+//! done for its fixed-name callers — a `credential_ref` is simply the first
+//! *operator-configured* key to reach it. Narrowing that is a shared-kernel
+//! decision affecting every subsystem in kernel.md §5, so it is an open
+//! question on the memory-driver epic (tinyhumansai/openhuman#5372) rather
+//! than something settled here.
 
 use zeroize::Zeroizing;
 
@@ -218,6 +226,60 @@ impl CredentialRefScheme {
     }
 }
 
+/// A secret resolved from a [`CredentialRef`].
+///
+/// Wraps [`Zeroizing`] so the value is wiped on drop, and adds the half
+/// `Zeroizing` does not provide: a `Debug` that does not print it.
+///
+/// **`Zeroizing`'s own `Debug` renders the secret.** It is a
+/// `#[derive(Debug)]` tuple struct (`zeroize-1.9.0/src/lib.rs:602-604`), and a
+/// derived `Debug` prints the field regardless of its visibility — so
+/// `format!("{:?}", Zeroizing::new(secret))` yields `Zeroizing("s3cret")`.
+/// Returning one from this module would have been incoherent: the module
+/// redacts the credential *name* through a manual `Debug`, then hands back a
+/// type that prints the *value* it names. One `tracing::debug!(?secret, …)` at
+/// any future call site is all it would take.
+///
+/// The value is therefore reachable only through
+/// [`expose_secret`](Self::expose_secret), which is named for the `secrecy`
+/// crate's convention so that every place a secret leaves this type is
+/// greppable in an audit. There is deliberately no `Deref`, no `into_inner`
+/// and no `PartialEq`: each would be another exit this type's name does not
+/// mention.
+pub struct ResolvedSecret(Zeroizing<String>);
+
+// Manual `Debug` — deriving it here would defeat the entire point of the type.
+// NEVER derive `Debug`; `redacts_the_secret_under_debug` pins this, along with
+// the `Zeroizing` behaviour that makes the wrapper necessary.
+impl std::fmt::Debug for ResolvedSecret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("ResolvedSecret")
+            .field(&"<redacted>")
+            .finish()
+    }
+}
+
+impl ResolvedSecret {
+    /// Wrap a freshly-retrieved secret.
+    ///
+    /// Private on purpose: the only supported way to obtain one is
+    /// [`CredentialRef::resolve`], so a `ResolvedSecret` in hand always means
+    /// the consent and availability gates ran.
+    fn new(secret: String) -> Self {
+        Self(Zeroizing::new(secret))
+    }
+
+    /// Borrow the secret.
+    ///
+    /// Every call is a deliberate disclosure — keep the borrow as short as
+    /// possible, and do not `to_string()` it into a plain `String`, which
+    /// would leave an un-zeroized copy behind on drop.
+    #[must_use]
+    pub fn expose_secret(&self) -> &str {
+        &self.0
+    }
+}
+
 /// A parsed `credential_ref`.
 ///
 /// Deliberately **not** `derive(Debug)` — see the manual impl below and the
@@ -310,8 +372,9 @@ impl CredentialRef {
     /// parameter rather than something derived here so this module stays free
     /// of any one subsystem's notion of identity.
     ///
-    /// The returned secret is wrapped in [`Zeroizing`] so it is wiped when the
-    /// caller drops it rather than lingering in freed memory.
+    /// The secret comes back as a [`ResolvedSecret`]: zeroized on drop, and
+    /// redacted under `Debug` — see that type for why the second half is not
+    /// redundant.
     ///
     /// # Errors
     ///
@@ -320,13 +383,13 @@ impl CredentialRef {
     /// [`CredentialRefError::Unavailable`], [`CredentialRefError::NotFound`] or
     /// [`CredentialRefError::Backend`], in that order of checking. No variant
     /// carries the name or the secret.
-    pub fn resolve(&self, user_id: &str) -> Result<Zeroizing<String>, CredentialRefError> {
+    pub fn resolve(&self, user_id: &str) -> Result<ResolvedSecret, CredentialRefError> {
         match self.scheme {
             CredentialRefScheme::Keychain => self.resolve_keychain(user_id),
         }
     }
 
-    fn resolve_keychain(&self, user_id: &str) -> Result<Zeroizing<String>, CredentialRefError> {
+    fn resolve_keychain(&self, user_id: &str) -> Result<ResolvedSecret, CredentialRefError> {
         // `keyring::is_available` is passed unevaluated: a consent refusal must
         // return before the availability probe, whose first call is a real
         // backend round-trip. See `preflight`.
@@ -341,7 +404,7 @@ impl CredentialRef {
         match keyring::get(user_id, &self.name) {
             Ok(Some(secret)) => {
                 log::debug!("{LOG_PREFIX} resolved credential_ref user_id={user_id}");
-                Ok(Zeroizing::new(secret))
+                Ok(ResolvedSecret::new(secret))
             }
             Ok(None) => {
                 log::debug!("{LOG_PREFIX} no keychain entry for credential_ref user_id={user_id}");

--- a/src/openhuman/security/credentials/credential_ref.rs
+++ b/src/openhuman/security/credentials/credential_ref.rs
@@ -23,16 +23,29 @@
 //! 1. **Consent.** [`keyring_consent::policy::check_secret_access`] must return
 //!    [`PolicyDecision::Proceed`]. A prompt that has not been answered is not a
 //!    missing credential, and conflating the two would train an operator to
-//!    "fix" a pending consent dialog by editing config.
+//!    "fix" a pending consent dialog by editing config. An *unanswered* prompt
+//!    and a *declined* one are also reported apart
+//!    ([`CredentialRefError::ConsentPending`] vs
+//!    [`CredentialRefError::ConsentDenied`]): telling an operator who already
+//!    said no to wait for a dialog describes a state that will never arrive.
 //! 2. **Availability.** A host with no usable keychain backend reports that as
 //!    itself rather than as a missing entry — the same order
 //!    `web3::wallet`'s `keychain_load_mnemonic` uses.
 //! 3. **Absence.** Only then is a `None` from the keychain a genuine
 //!    "not configured".
 //!
+//! The order is enforced structurally, not by convention: [`preflight`] takes
+//! availability as a **closure**, so a refused consent decision returns before
+//! the probe can run. That matters because the probe is a real backend
+//! round-trip on its first call (`keyring::ops`' availability cache starts
+//! empty) — evaluating it eagerly would touch the keychain on exactly the paths
+//! this gate exists to stop.
+//!
 //! ## Nothing here may reach an operator-facing string
 //!
-//! [`CredentialRefError`] carries **no name and no secret**, and
+//! [`CredentialRefError`] carries **no name and no secret** — not the entry
+//! name, and not the scheme half either, which is operator-typed text rather
+//! than fixed vocabulary (`sk-abc:123` parses as the scheme `sk-abc`). And
 //! [`CredentialRef`]'s `Debug` redacts the name. That is load-bearing rather
 //! than decorative: `MemoryDriverConfig`'s own doc requires the credential
 //! reference to stay out of `Debug`/error output (plan-memory.md §7, Tier 3),
@@ -40,11 +53,19 @@
 //! `subsystems_status` — pinned by
 //! `fallback_reason_never_contains_credential_ref_or_endpoint`.
 //!
-//! The sharp edge is [`KeyringError`], whose own `Display` interpolates the
-//! key: `"OS keychain error for key '{key}': {source}"`. Propagating one
-//! verbatim into a bind failure would leak the very name this module exists to
-//! keep out of that string, so backend failures are deliberately mapped to a
-//! name-free variant and the detail is logged instead.
+//! The sharp edge is [`KeyringError`](keyring::KeyringError), whose own
+//! `Display` interpolates the key (`"OS keychain error for key '{key}':
+//! {source}"`) — and so does its `diagnostic()`, which is `{self:?}`.
+//! Propagating or logging one verbatim would leak the very name this module
+//! exists to keep out of that string, so backend failures are mapped to a
+//! name-free variant and logged through [`keyring_error_kind`], which yields a
+//! fixed label and nothing else.
+//!
+//! **Scope of that promise.** It covers this module's errors and this module's
+//! logs. `keyring::get` itself logs its `key=` argument at `debug`, as the
+//! whole keyring surface has always done for its fixed-name callers; narrowing
+//! that is a shared-kernel decision affecting every subsystem in kernel.md §5,
+//! not something to settle here.
 
 use zeroize::Zeroizing;
 
@@ -78,22 +99,30 @@ pub enum CredentialRefError {
 
     /// The scheme is not one this build understands.
     ///
-    /// The scheme itself is a fixed vocabulary word, not user data, so it is
-    /// safe to name; the entry name after it is not and is never included.
-    #[error("credential_ref scheme '{scheme}' is not supported (expected \"{KEYCHAIN_SCHEME}\")")]
-    UnsupportedScheme {
-        /// The offending scheme, lowercased.
-        scheme: String,
-    },
+    /// The offending scheme is deliberately **not** carried. It is whatever
+    /// text precedes the first colon in a hand-edited `config.toml`, so a
+    /// mistake such as pasting a raw secret (`sk-abc:123`) would otherwise put
+    /// its first fragment into an operator-facing string. With exactly one
+    /// scheme defined, naming the expected value is the actionable half.
+    #[error("credential_ref scheme is not supported (expected \"{KEYCHAIN_SCHEME}:<name>\")")]
+    UnsupportedScheme,
 
     /// The scheme was valid but the name after it was empty.
     #[error("credential_ref has an empty name after \"{KEYCHAIN_SCHEME}:\"")]
     EmptyName,
 
     /// Keychain access is gated behind a consent prompt that has not been
-    /// answered. Distinct from [`Self::Unavailable`] on purpose.
+    /// answered. Distinct from [`Self::Unavailable`] on purpose, and from
+    /// [`Self::ConsentDenied`]: this one resolves itself once the operator
+    /// answers.
     #[error("keychain access is pending user consent")]
     ConsentPending,
+
+    /// The operator declined keychain access. Distinct from
+    /// [`Self::ConsentPending`] because there is no dialog left to answer —
+    /// reporting it as "pending" describes a state that will never arrive.
+    #[error("keychain access was declined by the user")]
+    ConsentDenied,
 
     /// No usable keychain backend on this host.
     #[error("no keychain backend is available on this host")]
@@ -112,23 +141,63 @@ pub enum CredentialRefError {
 /// The two gates that run *before* the keychain is touched, as a pure
 /// function of what they observed.
 ///
-/// Split out for the same reason `memory::binding::admit` is pure: the rule
-/// worth pinning is the **order** — a pending consent prompt must be reported
-/// as consent, not as an unavailable backend, and neither may be reported as a
-/// missing entry. That ordering is what stops an operator "fixing" an
-/// unanswered dialog by editing `config.toml`, and it is testable here without
-/// a keychain, a consent store, or a booted core.
+/// Split out for the same reason `memory::binding::admit` is: the rule worth
+/// pinning is the **order** — a consent refusal must be reported as consent,
+/// not as an unavailable backend, and neither may be reported as a missing
+/// entry. That ordering is what stops an operator "fixing" an unanswered dialog
+/// by editing `config.toml`, and it is testable here without a keychain, a
+/// consent store, or a booted core.
+///
+/// `keychain_available` is a **closure, not a `bool`**, so the order is a
+/// property of the code rather than of the call site. Passing the probe's
+/// result would evaluate it before this function is entered, and
+/// `keyring::is_available`'s first call is a real backend round-trip — the
+/// keychain would be touched on precisely the paths consent just refused.
+///
+/// The decision is matched exhaustively rather than compared against
+/// `Proceed`, so a variant added to [`PolicyDecision`] upstream becomes a
+/// compile error here instead of being silently folded into "pending".
 ///
 /// Returns `None` when the caller may proceed to the lookup.
 #[must_use]
-pub fn preflight(decision: PolicyDecision, keychain_available: bool) -> Option<CredentialRefError> {
-    if decision != PolicyDecision::Proceed {
-        return Some(CredentialRefError::ConsentPending);
+pub fn preflight(
+    decision: PolicyDecision,
+    keychain_available: impl FnOnce() -> bool,
+) -> Option<CredentialRefError> {
+    match decision {
+        PolicyDecision::ConsentRequired => return Some(CredentialRefError::ConsentPending),
+        PolicyDecision::Declined => return Some(CredentialRefError::ConsentDenied),
+        PolicyDecision::Proceed => {}
     }
-    if !keychain_available {
+    if !keychain_available() {
         return Some(CredentialRefError::Unavailable);
     }
     None
+}
+
+/// A fixed, name-free label for a [`KeyringError`](keyring::KeyringError).
+///
+/// Both that type's `Display` and its `diagnostic()` interpolate the key, so
+/// neither may be logged from a path whose key is a credential reference. This
+/// keeps the failure classified — which is the part worth having in a log —
+/// while carrying nothing operator-typed.
+///
+/// The match is exhaustive so an upstream variant is a compile error here
+/// rather than a silent fall-through to a wrong label. The five folded into
+/// `"backend"` cannot arise from a `get`: they belong to `set`, migration and
+/// random generation.
+fn keyring_error_kind(e: &keyring::KeyringError) -> &'static str {
+    use keyring::KeyringError as E;
+    match e {
+        E::Os { .. } => "os-backend",
+        E::InvalidUtf8 { .. } => "invalid-utf8",
+        E::Crypto(_) => "crypto",
+        E::VerifyFailed { .. }
+        | E::RandomGeneration(_)
+        | E::Backend(_)
+        | E::MigrationReadFailed { .. }
+        | E::MigrationDeleteFailed { .. } => "backend",
+    }
 }
 
 /// The scheme half of a parsed reference.
@@ -185,7 +254,8 @@ impl CredentialRef {
     ///
     /// [`CredentialRefError::Empty`], [`CredentialRefError::MissingScheme`],
     /// [`CredentialRefError::UnsupportedScheme`] or
-    /// [`CredentialRefError::EmptyName`]. None of them carry the name.
+    /// [`CredentialRefError::EmptyName`]. None of them carry any part of the
+    /// input — neither the name nor the scheme.
     pub fn parse(raw: &str) -> Result<Self, CredentialRefError> {
         let raw = raw.trim();
         if raw.is_empty() {
@@ -198,13 +268,13 @@ impl CredentialRef {
             return Err(CredentialRefError::MissingScheme);
         };
 
-        let scheme_norm = scheme_raw.trim().to_ascii_lowercase();
-        let scheme = if scheme_norm == KEYCHAIN_SCHEME {
+        // `eq_ignore_ascii_case` rather than lowercasing into a `String`: the
+        // normalised scheme is never carried anywhere now, so materialising it
+        // would only produce a value that must not be allowed to escape.
+        let scheme = if scheme_raw.trim().eq_ignore_ascii_case(KEYCHAIN_SCHEME) {
             CredentialRefScheme::Keychain
         } else {
-            return Err(CredentialRefError::UnsupportedScheme {
-                scheme: scheme_norm,
-            });
+            return Err(CredentialRefError::UnsupportedScheme);
         };
 
         let name = name_raw.trim();
@@ -245,9 +315,11 @@ impl CredentialRef {
     ///
     /// # Errors
     ///
-    /// [`CredentialRefError::ConsentPending`], [`CredentialRefError::Unavailable`],
-    /// [`CredentialRefError::NotFound`] or [`CredentialRefError::Backend`], in
-    /// that order of checking. No variant carries the name or the secret.
+    /// [`CredentialRefError::ConsentPending`],
+    /// [`CredentialRefError::ConsentDenied`],
+    /// [`CredentialRefError::Unavailable`], [`CredentialRefError::NotFound`] or
+    /// [`CredentialRefError::Backend`], in that order of checking. No variant
+    /// carries the name or the secret.
     pub fn resolve(&self, user_id: &str) -> Result<Zeroizing<String>, CredentialRefError> {
         match self.scheme {
             CredentialRefScheme::Keychain => self.resolve_keychain(user_id),
@@ -255,11 +327,13 @@ impl CredentialRef {
     }
 
     fn resolve_keychain(&self, user_id: &str) -> Result<Zeroizing<String>, CredentialRefError> {
-        if let Some(refusal) = preflight(policy::check_secret_access(), keyring::is_available()) {
+        // `keyring::is_available` is passed unevaluated: a consent refusal must
+        // return before the availability probe, whose first call is a real
+        // backend round-trip. See `preflight`.
+        if let Some(refusal) = preflight(policy::check_secret_access(), keyring::is_available) {
             log::debug!(
                 "{LOG_PREFIX} keychain access refused before lookup user_id={user_id} \
-                 refusal={refusal} backend={}",
-                keyring::backend_name()
+                 refusal={refusal}"
             );
             return Err(refusal);
         }
@@ -273,11 +347,16 @@ impl CredentialRef {
                 log::debug!("{LOG_PREFIX} no keychain entry for credential_ref user_id={user_id}");
                 Err(CredentialRefError::NotFound)
             }
-            // Logged, not propagated: `KeyringError`'s Display interpolates the
-            // key, and this error's Display is allowed into operator-facing
-            // strings. See the module docs.
+            // Classified, never rendered: `KeyringError`'s `Display` — and its
+            // `diagnostic()`, which is `{self:?}` — both interpolate the key.
+            // Formatting either here would write the credential name to a
+            // retained warn-level log, which is the leak this module's
+            // redaction exists to prevent. See the module docs.
             Err(e) => {
-                log::warn!("{LOG_PREFIX} keychain lookup failed user_id={user_id}: {e}");
+                log::warn!(
+                    "{LOG_PREFIX} keychain lookup failed user_id={user_id} kind={}",
+                    keyring_error_kind(&e)
+                );
                 Err(CredentialRefError::Backend)
             }
         }

--- a/src/openhuman/security/credentials/credential_ref_tests.rs
+++ b/src/openhuman/security/credentials/credential_ref_tests.rs
@@ -1,0 +1,196 @@
+//! Tests for `credential_ref` parsing, redaction, and the pre-lookup gates.
+
+use super::*;
+
+/// The name used everywhere below. Distinctive enough that a substring search
+/// for it cannot pass by accident.
+const SECRET_NAME: &str = "supermemory-prod-key-9f3a";
+
+#[test]
+fn parses_the_canonical_spelling() {
+    let r = CredentialRef::parse("keychain:supermemory").expect("canonical form parses");
+    assert_eq!(r.scheme(), CredentialRefScheme::Keychain);
+    assert_eq!(r.name(), "supermemory");
+}
+
+#[test]
+fn trims_whitespace_around_both_halves() {
+    // A hand-edited config.toml must resolve the same entry as the canonical
+    // spelling rather than looking up a name with a leading space.
+    for raw in [
+        "  keychain:supermemory  ",
+        "keychain: supermemory",
+        "keychain :supermemory",
+        "\tkeychain:\tsupermemory\n",
+    ] {
+        let r = CredentialRef::parse(raw).unwrap_or_else(|e| panic!("{raw:?} should parse: {e}"));
+        assert_eq!(r.name(), "supermemory", "for input {raw:?}");
+        assert_eq!(r.scheme(), CredentialRefScheme::Keychain);
+    }
+}
+
+#[test]
+fn scheme_is_case_insensitive_but_the_name_is_not() {
+    for raw in ["KEYCHAIN:Prod", "KeyChain:Prod", "keychain:Prod"] {
+        let r = CredentialRef::parse(raw).unwrap_or_else(|e| panic!("{raw:?} should parse: {e}"));
+        assert_eq!(r.scheme(), CredentialRefScheme::Keychain);
+        // The name is a keychain key and the backing store is case-sensitive,
+        // so normalising it would look up the wrong entry.
+        assert_eq!(r.name(), "Prod", "name must survive verbatim for {raw:?}");
+    }
+}
+
+#[test]
+fn only_the_first_colon_separates_the_scheme() {
+    // A name is free to contain a colon; splitting on every ':' would truncate
+    // it and silently resolve a different entry.
+    let r = CredentialRef::parse("keychain:ns:sub:key").expect("colons in the name are allowed");
+    assert_eq!(r.name(), "ns:sub:key");
+}
+
+#[test]
+fn rejects_malformed_references() {
+    use CredentialRefError::*;
+    let cases: &[(&str, CredentialRefError)] = &[
+        ("", Empty),
+        ("   ", Empty),
+        ("supermemory", MissingScheme),
+        ("keychain:", EmptyName),
+        ("keychain:   ", EmptyName),
+        (
+            "vault:supermemory",
+            UnsupportedScheme {
+                scheme: "vault".to_string(),
+            },
+        ),
+        (
+            "ENV:SUPERMEMORY",
+            UnsupportedScheme {
+                scheme: "env".to_string(),
+            },
+        ),
+    ];
+    for (raw, expected) in cases {
+        let err = CredentialRef::parse(raw).expect_err(&format!("{raw:?} must not parse"));
+        assert_eq!(&err, expected, "for input {raw:?}");
+    }
+}
+
+#[test]
+fn an_unsupported_scheme_is_named_but_the_entry_name_is_not() {
+    // The scheme is fixed vocabulary and is useful to report; everything after
+    // it is operator data and must not travel with the error.
+    let err = CredentialRef::parse(&format!("vault:{SECRET_NAME}")).expect_err("vault is unknown");
+    let rendered = err.to_string();
+    assert!(
+        rendered.contains("vault"),
+        "scheme should be named: {rendered}"
+    );
+    assert!(
+        !rendered.contains(SECRET_NAME),
+        "entry name leaked into the error: {rendered}"
+    );
+}
+
+#[test]
+fn debug_redacts_the_name() {
+    // Deriving Debug here would put the reference into every `{:?}` and panic
+    // message; plan-memory.md §7 Tier 3 forbids that.
+    let r = CredentialRef::parse(&format!("keychain:{SECRET_NAME}")).expect("parses");
+    let rendered = format!("{r:?}");
+    assert!(
+        !rendered.contains(SECRET_NAME),
+        "credential name leaked through Debug: {rendered}"
+    );
+    assert!(
+        rendered.contains("<redacted>"),
+        "redaction marker missing: {rendered}"
+    );
+    // The scheme is still visible — the point is to stay debuggable.
+    assert!(
+        rendered.contains("Keychain"),
+        "scheme should survive: {rendered}"
+    );
+}
+
+#[test]
+fn no_error_display_can_carry_a_name_or_a_secret() {
+    // This is the property `memory::binding`'s FallbackReason depends on: any
+    // of these may be rendered into `subsystems_status`, which is pinned by
+    // `fallback_reason_never_contains_credential_ref_or_endpoint`.
+    let all = [
+        CredentialRefError::Empty,
+        CredentialRefError::MissingScheme,
+        CredentialRefError::UnsupportedScheme {
+            scheme: "vault".to_string(),
+        },
+        CredentialRefError::EmptyName,
+        CredentialRefError::ConsentPending,
+        CredentialRefError::Unavailable,
+        CredentialRefError::NotFound,
+        CredentialRefError::Backend,
+    ];
+    for err in all {
+        let rendered = err.to_string();
+        assert!(
+            !rendered.contains(SECRET_NAME),
+            "{err:?} rendered a credential name: {rendered}"
+        );
+        assert!(!rendered.is_empty(), "{err:?} rendered an empty message");
+    }
+}
+
+#[test]
+fn preflight_reports_consent_before_availability() {
+    // Order is the whole point. With consent pending AND no backend, the
+    // operator must be told about consent — telling them the keychain is
+    // unavailable would send them to fix the wrong thing.
+    assert_eq!(
+        preflight(PolicyDecision::ConsentRequired, false),
+        Some(CredentialRefError::ConsentPending)
+    );
+    assert_eq!(
+        preflight(PolicyDecision::Declined, false),
+        Some(CredentialRefError::ConsentPending)
+    );
+}
+
+#[test]
+fn preflight_reports_unavailability_only_once_consent_is_granted() {
+    assert_eq!(
+        preflight(PolicyDecision::Proceed, false),
+        Some(CredentialRefError::Unavailable)
+    );
+}
+
+#[test]
+fn preflight_allows_the_lookup_when_both_gates_pass() {
+    assert_eq!(preflight(PolicyDecision::Proceed, true), None);
+}
+
+#[test]
+fn preflight_never_reports_a_missing_entry() {
+    // NotFound is a fact about the keychain's contents and can only be learned
+    // by asking it. A gate that guessed it would report "not configured" for a
+    // host that simply has no backend.
+    for decision in [
+        PolicyDecision::Proceed,
+        PolicyDecision::ConsentRequired,
+        PolicyDecision::Declined,
+    ] {
+        for available in [true, false] {
+            assert_ne!(
+                preflight(decision, available),
+                Some(CredentialRefError::NotFound),
+                "preflight invented a NotFound for {decision:?}/available={available}"
+            );
+        }
+    }
+}
+
+#[test]
+fn scheme_round_trips_through_its_wire_spelling() {
+    assert_eq!(CredentialRefScheme::Keychain.as_str(), KEYCHAIN_SCHEME);
+    let r = CredentialRef::parse(&format!("{KEYCHAIN_SCHEME}:x")).expect("parses");
+    assert_eq!(r.scheme().as_str(), KEYCHAIN_SCHEME);
+}

--- a/src/openhuman/security/credentials/credential_ref_tests.rs
+++ b/src/openhuman/security/credentials/credential_ref_tests.rs
@@ -119,6 +119,46 @@ fn debug_redacts_the_name() {
 }
 
 #[test]
+fn a_resolved_secret_redacts_the_value_under_debug() {
+    // The value this type guards is the secret itself, so a `{:?}` that
+    // rendered it would be strictly worse than the credential-name leak the
+    // rest of this module exists to prevent.
+    const SECRET_VALUE: &str = "sk-live-9f3a-do-not-print-me";
+
+    let resolved = ResolvedSecret::new(SECRET_VALUE.to_string());
+    let rendered = format!("{resolved:?}");
+    assert!(
+        !rendered.contains(SECRET_VALUE),
+        "secret leaked through Debug: {rendered}"
+    );
+    assert!(
+        rendered.contains("<redacted>"),
+        "redaction marker missing: {rendered}"
+    );
+    // Still reachable deliberately — redaction must not mean unusable.
+    assert_eq!(resolved.expose_secret(), SECRET_VALUE);
+}
+
+#[test]
+fn the_wrapper_is_needed_because_zeroizing_debug_prints_the_secret() {
+    // Guards the premise rather than the fix. `Zeroizing` is a
+    // `#[derive(Debug)]` tuple struct, and a derived Debug prints the field
+    // whatever its visibility — so returning `Zeroizing<String>` from
+    // `resolve` would have rendered the secret at any `{:?}` call site.
+    //
+    // If this ever fails, zeroize changed its Debug and `ResolvedSecret`'s
+    // redaction may have become redundant — which is worth knowing rather
+    // than carrying a wrapper whose reason has quietly expired.
+    const SECRET_VALUE: &str = "sk-live-9f3a-do-not-print-me";
+
+    let bare = zeroize::Zeroizing::new(SECRET_VALUE.to_string());
+    assert!(
+        format!("{bare:?}").contains(SECRET_VALUE),
+        "zeroize no longer leaks through Debug — re-check whether ResolvedSecret is still needed"
+    );
+}
+
+#[test]
 fn no_error_display_can_carry_a_name_or_a_secret() {
     // This is the property `memory::binding`'s FallbackReason depends on: any
     // of these may be rendered into `subsystems_status`, which is pinned by

--- a/src/openhuman/security/credentials/credential_ref_tests.rs
+++ b/src/openhuman/security/credentials/credential_ref_tests.rs
@@ -57,18 +57,8 @@ fn rejects_malformed_references() {
         ("supermemory", MissingScheme),
         ("keychain:", EmptyName),
         ("keychain:   ", EmptyName),
-        (
-            "vault:supermemory",
-            UnsupportedScheme {
-                scheme: "vault".to_string(),
-            },
-        ),
-        (
-            "ENV:SUPERMEMORY",
-            UnsupportedScheme {
-                scheme: "env".to_string(),
-            },
-        ),
+        ("vault:supermemory", UnsupportedScheme),
+        ("ENV:SUPERMEMORY", UnsupportedScheme),
     ];
     for (raw, expected) in cases {
         let err = CredentialRef::parse(raw).expect_err(&format!("{raw:?} must not parse"));
@@ -77,19 +67,34 @@ fn rejects_malformed_references() {
 }
 
 #[test]
-fn an_unsupported_scheme_is_named_but_the_entry_name_is_not() {
-    // The scheme is fixed vocabulary and is useful to report; everything after
-    // it is operator data and must not travel with the error.
-    let err = CredentialRef::parse(&format!("vault:{SECRET_NAME}")).expect_err("vault is unknown");
-    let rendered = err.to_string();
-    assert!(
-        rendered.contains("vault"),
-        "scheme should be named: {rendered}"
-    );
-    assert!(
-        !rendered.contains(SECRET_NAME),
-        "entry name leaked into the error: {rendered}"
-    );
+fn an_unsupported_scheme_echoes_back_no_part_of_the_input() {
+    // The scheme half is operator-typed text, not fixed vocabulary: a config
+    // holding a pasted secret rather than a handle splits into a "scheme" that
+    // is a fragment of that secret. Neither half may travel with the error,
+    // which is rendered into `subsystems_status`.
+    let secret_shaped = "sk-live-abcdef123456";
+    for raw in [
+        format!("vault:{SECRET_NAME}"),
+        format!("{secret_shaped}:tail"),
+    ] {
+        let rendered = CredentialRef::parse(&raw)
+            .expect_err("scheme is not `keychain`")
+            .to_string();
+        assert!(
+            !rendered.contains(SECRET_NAME) && !rendered.contains(secret_shaped),
+            "input leaked into the error for {raw:?}: {rendered}"
+        );
+        assert!(
+            !rendered.contains("vault"),
+            "the offending scheme is not echoed back: {rendered}"
+        );
+        // Still actionable: there is exactly one valid scheme, so naming the
+        // expectation is the half that helps.
+        assert!(
+            rendered.contains(KEYCHAIN_SCHEME),
+            "the expected scheme should be named: {rendered}"
+        );
+    }
 }
 
 #[test]
@@ -121,11 +126,10 @@ fn no_error_display_can_carry_a_name_or_a_secret() {
     let all = [
         CredentialRefError::Empty,
         CredentialRefError::MissingScheme,
-        CredentialRefError::UnsupportedScheme {
-            scheme: "vault".to_string(),
-        },
+        CredentialRefError::UnsupportedScheme,
         CredentialRefError::EmptyName,
         CredentialRefError::ConsentPending,
+        CredentialRefError::ConsentDenied,
         CredentialRefError::Unavailable,
         CredentialRefError::NotFound,
         CredentialRefError::Backend,
@@ -142,30 +146,77 @@ fn no_error_display_can_carry_a_name_or_a_secret() {
 
 #[test]
 fn preflight_reports_consent_before_availability() {
-    // Order is the whole point. With consent pending AND no backend, the
+    // Order is the whole point. With consent unresolved AND no backend, the
     // operator must be told about consent — telling them the keychain is
     // unavailable would send them to fix the wrong thing.
     assert_eq!(
-        preflight(PolicyDecision::ConsentRequired, false),
+        preflight(PolicyDecision::ConsentRequired, || false),
         Some(CredentialRefError::ConsentPending)
     );
     assert_eq!(
-        preflight(PolicyDecision::Declined, false),
-        Some(CredentialRefError::ConsentPending)
+        preflight(PolicyDecision::Declined, || false),
+        Some(CredentialRefError::ConsentDenied)
     );
+}
+
+#[test]
+fn a_declined_prompt_is_not_reported_as_a_pending_one() {
+    // `Declined` is an answer, not the absence of one. Reporting it as
+    // "pending" tells an operator to wait for a dialog that will never appear.
+    let denied = preflight(PolicyDecision::Declined, || true);
+    assert_eq!(denied, Some(CredentialRefError::ConsentDenied));
+    assert_ne!(denied, Some(CredentialRefError::ConsentPending));
+
+    let pending = preflight(PolicyDecision::ConsentRequired, || true);
+    assert_eq!(pending, Some(CredentialRefError::ConsentPending));
+
+    // And the two must not read alike to whoever ends up seeing them.
+    assert_ne!(
+        denied.map(|e| e.to_string()),
+        pending.map(|e| e.to_string()),
+        "the declined and pending messages are indistinguishable"
+    );
+}
+
+#[test]
+fn preflight_does_not_probe_the_keychain_once_consent_has_refused() {
+    // The real probe's first call is a backend round-trip, so evaluating it
+    // eagerly would touch the keychain on exactly the paths consent refused.
+    // Taking it as a closure makes that structural; this pins it.
+    for decision in [PolicyDecision::ConsentRequired, PolicyDecision::Declined] {
+        let probed = std::cell::Cell::new(false);
+        let refusal = preflight(decision, || {
+            probed.set(true);
+            true
+        });
+        assert!(refusal.is_some(), "{decision:?} must refuse");
+        assert!(
+            !probed.get(),
+            "availability was probed despite {decision:?} refusing first"
+        );
+    }
+
+    // Conversely, a granted decision must reach the probe — otherwise the gate
+    // would be vacuously "ordered" by never running.
+    let probed = std::cell::Cell::new(false);
+    let _ = preflight(PolicyDecision::Proceed, || {
+        probed.set(true);
+        true
+    });
+    assert!(probed.get(), "availability was never probed after Proceed");
 }
 
 #[test]
 fn preflight_reports_unavailability_only_once_consent_is_granted() {
     assert_eq!(
-        preflight(PolicyDecision::Proceed, false),
+        preflight(PolicyDecision::Proceed, || false),
         Some(CredentialRefError::Unavailable)
     );
 }
 
 #[test]
 fn preflight_allows_the_lookup_when_both_gates_pass() {
-    assert_eq!(preflight(PolicyDecision::Proceed, true), None);
+    assert_eq!(preflight(PolicyDecision::Proceed, || true), None);
 }
 
 #[test]
@@ -180,11 +231,60 @@ fn preflight_never_reports_a_missing_entry() {
     ] {
         for available in [true, false] {
             assert_ne!(
-                preflight(decision, available),
+                preflight(decision, || available),
                 Some(CredentialRefError::NotFound),
                 "preflight invented a NotFound for {decision:?}/available={available}"
             );
         }
+    }
+}
+
+#[test]
+fn keyring_error_kinds_are_fixed_labels_that_carry_no_key() {
+    // The classifier exists so a backend failure can be logged without
+    // formatting a `KeyringError`, whose `Display` *and* `diagnostic()` both
+    // interpolate the key. Every label must therefore be free of it.
+    use crate::openhuman::security::keyring::KeyringError;
+
+    let invalid_utf8 = String::from_utf8(vec![0xff]).expect_err("0xff is not utf-8");
+    let cases: Vec<(KeyringError, &str)> = vec![
+        (
+            KeyringError::Os {
+                key: SECRET_NAME.to_string(),
+                source: ::keyring::Error::NoEntry,
+            },
+            "os-backend",
+        ),
+        (
+            KeyringError::InvalidUtf8 {
+                key: SECRET_NAME.to_string(),
+                source: invalid_utf8,
+            },
+            "invalid-utf8",
+        ),
+        (KeyringError::Crypto(SECRET_NAME.to_string()), "crypto"),
+        (
+            KeyringError::VerifyFailed {
+                key: SECRET_NAME.to_string(),
+            },
+            "backend",
+        ),
+    ];
+
+    for (err, expected) in cases {
+        let kind = keyring_error_kind(&err);
+        assert_eq!(kind, expected);
+        assert!(
+            !kind.contains(SECRET_NAME),
+            "classification leaked the key: {kind}"
+        );
+        // Guard the premise: these labels are worth having only because the
+        // error's own renderings are unusable here.
+        assert!(
+            err.to_string().contains(SECRET_NAME) || err.diagnostic().contains(SECRET_NAME),
+            "premise broken — {err:?} no longer carries the key, so re-check \
+             whether the classifier is still needed"
+        );
     }
 }
 

--- a/src/openhuman/security/credentials/mod.rs
+++ b/src/openhuman/security/credentials/mod.rs
@@ -18,7 +18,7 @@ pub use crate::api::rest::{
     BackendOAuthClient, ConnectResponse, IntegrationSummary, IntegrationTokensHandoff,
 };
 pub use core::*;
-pub use credential_ref::{CredentialRef, CredentialRefError, CredentialRefScheme};
+pub use credential_ref::{CredentialRef, CredentialRefError, CredentialRefScheme, ResolvedSecret};
 pub use http_creds::{
     HttpCredential, HttpCredentialScheme, HttpCredentialSummary, HttpCredentialsStore,
 };

--- a/src/openhuman/security/credentials/mod.rs
+++ b/src/openhuman/security/credentials/mod.rs
@@ -3,6 +3,7 @@
 pub mod bus;
 pub mod cli;
 mod core;
+pub mod credential_ref;
 pub mod http_creds;
 pub mod ops;
 pub mod profiles;
@@ -17,6 +18,7 @@ pub use crate::api::rest::{
     BackendOAuthClient, ConnectResponse, IntegrationSummary, IntegrationTokensHandoff,
 };
 pub use core::*;
+pub use credential_ref::{CredentialRef, CredentialRefError, CredentialRefScheme};
 pub use http_creds::{
     HttpCredential, HttpCredentialScheme, HttpCredentialSummary, HttpCredentialsStore,
 };


### PR DESCRIPTION
## Summary

- Adds `security::credentials::credential_ref` — the parser and resolver for the `credential_ref` handle that `[subsystems.*]` driver config has carried since the subsystem seam landed, but that nothing could actually resolve.
- Resolution runs the same gate order `web3::wallet::keychain_load_mnemonic` already uses — **consent → availability → absence** — with that ordering extracted into a pure `preflight()` so it is testable without a keychain or a booted core.
- Nothing in the module can leak a credential name: `CredentialRefError` carries no name and no secret, and `CredentialRef`'s `Debug` redacts the name.
- The resolved secret comes back as a `ResolvedSecret`: zeroized on drop **and** redacted under `Debug`. The second half is not decorative — `Zeroizing`'s own `Debug` is derived, so `format!("{:?}", Zeroizing::new(secret))` prints `Zeroizing("s3cret")`. Returning one would have meant a module that redacts the credential *name* by hand while handing back a type that renders the *value*.
- **No behaviour change.** Nothing calls this yet and the external-driver refusal in `memory/binding.rs` is untouched.

## Problem

`docs/specs/kernel.md` §3.6 gives every subsystem the same driver-binding config shape, and `docs/specs/plan-memory.md` §4.5 fixes one of its fields:

```toml
[subsystems.memory.drivers.supermemory]
credential_ref = "keychain:supermemory"
```

The value is a *reference*, never an inline secret. `MemoryDriverConfig` already ships the field with a manual redacting `Debug`, and the memory binding tests already use `credential_ref: "keychain:supermemory"` fixtures — but there is no parser and no resolver anywhere in the tree, so the handle cannot be turned into the secret it names.

Two things make this more than a `split_once`:

1. **The gate order is a correctness property, not a formality.** A pending keychain-consent prompt reported as "no backend available" — or either reported as "no such entry" — sends an operator to fix the wrong thing, and in the consent case trains them to "fix" an unanswered dialog by editing `config.toml`.
2. **`KeyringError`'s own `Display` interpolates the key** (`"OS keychain error for key '{key}': {source}"`). Any resolver that propagates one verbatim into a bind failure leaks the credential name into `subsystems_status`, which is exactly what `MemoryDriverConfig`'s redacting `Debug` and `fallback_reason_never_contains_credential_ref_or_endpoint` exist to prevent.

## Solution

`CredentialRef::parse` splits on the **first** colon only (a keychain name may legitimately contain one), trims both halves so a hand-edited config resolves the same entry as the canonical spelling, matches the scheme case-insensitively, and leaves the name verbatim because the backing store is case-sensitive.

`CredentialRef::resolve(user_id)` takes the keychain partition as a parameter rather than deriving one, so the module stays free of any single subsystem's notion of identity. It calls `preflight(check_secret_access(), is_available())` first, then `keyring::get`.

Design decisions worth flagging for review:

- **It lives in `security/`, not beside its first caller.** §3.6 makes `credential_ref` uniform across subsystems; memory binds first, and inference / channels / sandbox follow onto the same shape (kernel.md §5). Putting it in `memory/` would guarantee a move later.
- **`preflight` is public and takes availability as a closure** — public for the same reason `memory::binding::admit` is ("so the fail-closed trust rule is unit-testable without booting anything"); a closure so the *order* is a property of the code rather than of the call site. Passing `keyring::is_available()` by value evaluates the probe before the gate runs, and its first call is a real backend round-trip, so consent refusals would still touch the keychain. Caught in review — thanks. A `Cell`-backed probe now pins that it is never invoked after a refusal, **and is invoked after `Proceed`**, so the ordering test cannot pass vacuously.
- **Backend failures are mapped, not propagated.** `CredentialRefError::Backend` is name-free and the underlying `KeyringError` is logged instead. This is the one place where being less informative in the error type is the correct call.
- **`UnsupportedScheme` carries no payload at all.** An earlier revision named the offending scheme, on the premise that it is fixed vocabulary. That premise is wrong: the scheme is whatever precedes the first colon in a hand-edited `config.toml`, so `sk-abc:123` parses as the scheme `sk-abc` and would put a fragment of a pasted secret into `subsystems_status`. With exactly one scheme defined, naming the *expected* value is the actionable half; parsing uses `eq_ignore_ascii_case` so the normalised form is never materialised.
- **A declined consent prompt is not a pending one.** `PolicyDecision` has three variants and `!= Proceed` folded two together, telling an operator who had already said no to wait for a dialog that will never appear. `preflight` matches exhaustively now — a variant added upstream becomes a compile error here — and `Declined` maps to its own `ConsentDenied`.
- **`KeyringError` is classified, never formatted.** Both its `Display` and its `diagnostic()` (`{self:?}`) interpolate the key, so a private `keyring_error_kind` reduces a backend failure to a fixed label. Its test pins both halves: the label is name-free, *and* the error's own renderings still are not — so if that ever changes the test says so rather than the classifier quietly becoming pointless.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — 18 tests: canonical parse, whitespace, case handling, colon-in-name, a 7-case malformed-input table, `Debug` redaction, a no-part-of-the-input-echoed check on the unsupported-scheme path, an all-variants error-rendering sweep, a `KeyringError` classification test, six `preflight` gate-order tests (including one asserting the availability probe is not invoked after a consent refusal), and two on `ResolvedSecret` — one pinning that `Debug` redacts the value while `expose_secret` still returns it, and one guarding the *premise*: that `Zeroizing`'s `Debug` does leak, so if zeroize ever changes it the wrapper's justification is re-examined rather than silently carried.
- [x] **Diff coverage ≥ 80%** — every function carrying logic (`parse`, `preflight`, `as_str`, the manual `Debug`, all error `Display`s) is covered by the 18 unit tests. The one deliberately uncovered function is `resolve_keychain`'s I/O wrapper, which needs a real keychain backend; the decision logic inside it was extracted into `preflight` precisely so it *is* covered. Run locally: `cargo test --lib security::credentials::credential_ref` → 18 passed.
- [x] Coverage matrix updated — `N/A: no feature row changes; this adds an internal security helper with no user-facing feature surface.`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no matrix feature IDs affected.`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — no new dependency at all; `zeroize` and `thiserror` are already declared.
- [x] Manual smoke checklist updated if this touches release-cut surfaces ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md)) — `N/A: no runtime behaviour change, nothing calls this module yet.`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A: deliberately does not close #5372; this is one prerequisite of it. See Related.`

## Impact

- **Runtime:** none. No call site, no config read, no RPC, no tool. The external-driver refusal in `memory/binding.rs:287` is untouched, so `[subsystems.memory]` behaves exactly as before.
- **Platform:** core only; no shell, frontend or i18n surface. No new Cargo feature, so nothing to forward to `app/src-tauri/Cargo.toml`.
- **Security:** additive and conservative — this is the module that keeps a credential handle out of `Debug` and error output rather than one that widens access. The keychain is only reached after the existing consent policy returns `Proceed`.
- **Compatibility / migration:** none. No config schema change; `MemoryDriverConfig` already carries `credential_ref`.

## Related

- Closes: `N/A` — this is a prerequisite for #5372 (pluggable memory backends), not a closure of it. I asked there which seam shape you want before building the bind path itself, and this PR is the half that is useful under either answer.
- Follow-up PR(s)/TODOs: the external bind seam in `memory/binding.rs` (`admit` accepting `External`, `build` constructing the driver, `GuardPolicy` taking the configured `trust_state` instead of the hardcoded `"trusted"` at `binding.rs:434`, endpoint routed through `security::egress`) — held until #5372 is answered.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

> Keep this section for AI-authored PRs. For human-only PRs, mark each field `N/A`.

### Linear Issue

- Key: `N/A`
- URL: `N/A`

### Commit & Branch

- Branch: `feat/subsystem-credential-ref-resolution`
- Commit SHA: `8d3c24540` (secret-`Debug` fix; review fixes `05c982e75`; initial `e6f3f4f41`)

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck` — `N/A: no TypeScript changed;` ran via the pre-push hook regardless and it passed.
- [x] Focused tests: `cargo test --lib --features "$(bash scripts/ci/product-features.sh)" security::credentials::credential_ref` → **18 passed, 0 failed**
- [x] Rust fmt/check (if changed): bare `cargo fmt` clean; `cargo clippy --lib --features "$(bash scripts/ci/product-features.sh)"` reports nothing on the new module
- [x] Tauri fmt/check (if changed): `N/A: no files under app/src-tauri/ changed.`

### Validation Blocked

- `command:` `N/A`
- `error:` `N/A`
- `impact:` `N/A`

### Behavior Changes

- Intended behavior change: none — additive module with no call site.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: yes; `memory::binding::admit` still refuses every external driver at `binding.rs:287`, unchanged.
- Guard/fallback/dispatch parity checks: no guard, fallback or dispatch path is touched. The redaction contract this module upholds is the one already pinned by `fallback_reason_never_contains_credential_ref_or_endpoint`, and `no_error_display_can_carry_a_name_or_a_secret` extends the same property to the new error type.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none found — no open PR or upstream branch touches `credential_ref` or the external driver path.
- Canonical PR: this one.
- Resolution: `N/A`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for resolving `keychain:<name>` credential references through the system keychain.
  - Added validation for malformed or unsupported credential references.
  - Added consent and keychain-availability checks before secret lookup.
  - Sensitive credential names and resolved secret values are redacted from diagnostic output.
  - Resolved secrets remain protected in memory during use.

- **Tests**
  - Added coverage for parsing, validation, consent gating, availability checks, and sensitive-data redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

