### PR TITLE
fix(test): pin the candidate-key precedence in voice_test_provider

### DIFF
--- a/src/openhuman/voice/schemas_tests.rs
+++ b/src/openhuman/voice/schemas_tests.rs
@@ -583,3 +583,66 @@ fn set_providers_params_all_optional() {
     assert!(parsed.stt_model.is_none());
     assert!(parsed.tts_voice.is_none());
 }
+
+// ── `validate_provider_key`: the candidate-key half of #5947 ────────────────
+//
+// `validate_provider_key` had no test caller at all — the only references in
+// the tree were its definition and the one handler call site. What that left
+// unpinned is the branch the "Test Key" button exists for: a key the user has
+// just typed, for a provider they have not saved yet, must be the key that
+// gets validated. Invert the two match arms and the modal silently validates
+// whatever was already stored (or reports "no API key configured" for a key the
+// user is looking at), while still answering `ok` — a wrong answer about a
+// credential, which is the worst shape this code can fail in.
+//
+// `127.0.0.1:1` is the observation trick: it refuses immediately, so "the
+// validator got past the key check and tried to reach the provider" is
+// distinguishable from "the validator stopped at the key check" with no mock
+// server, no network and no wall-clock cost.
+
+fn candidate_precedence_config(slug: &str) -> crate::openhuman::config::Config {
+    use crate::openhuman::config::schema::voice_providers::VoiceProviderCreds;
+
+    let mut config = crate::openhuman::config::Config::default();
+    config.voice_providers.push(VoiceProviderCreds {
+        slug: slug.to_string(),
+        endpoint: "http://127.0.0.1:1".to_string(),
+        ..Default::default()
+    });
+    config
+}
+
+/// A candidate key must win over an absent stored key (#5947, #5896).
+#[tokio::test]
+async fn validate_provider_key_prefers_the_candidate_over_an_absent_stored_key() {
+    let slug = "e2e-candidate-precedence";
+    let config = candidate_precedence_config(slug);
+
+    // Nothing stored, no candidate: the validator must stop at the key check.
+    // This is the control — it proves the slug resolves and that the "no key"
+    // answer is what the absent-key path produces.
+    let without = super::helpers::validate_provider_key(slug, &config, None)
+        .await
+        .expect_err("no key anywhere cannot be a valid provider");
+    assert!(
+        without.contains("no API key configured"),
+        "control: with nothing stored and no candidate the validator must stop \
+         at the key check, got {without:?}"
+    );
+
+    // Same config, same absent stored key — only a candidate is added.
+    let with =
+        super::helpers::validate_provider_key(slug, &config, Some("candidate-not-yet-saved"))
+            .await
+            .expect_err("127.0.0.1:1 refuses, so the request cannot succeed");
+    assert!(
+        !with.contains("no API key configured"),
+        "a candidate key must be used when nothing is stored for the slug; \
+         got {with:?}, which means the candidate was ignored and the absent \
+         stored key won — the modal would report on a key the user never typed"
+    );
+    assert!(
+        with.contains("request failed"),
+        "the candidate must carry the validator through to the provider request, got {with:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds the one test `validate_provider_key` never had: a candidate API key typed into the provider-enable modal must be the key that gets validated, for a provider the user has not saved yet.
- The function had **zero test callers** — the only references in the tree were its definition and its single call site — so the branch the "Test Key" button exists for was unenforced.
- Test-only. No product code touched.

## Problem

This was assigned as "the `api_key` field is silently dropped in deserialization, so that half of the provider config is unenforceable and untestable". **Checked first, and that is not what the code does** — so nothing about the serde handling has been changed. `api_key` survives, end to end:

| Link | Evidence |
|---|---|
| struct | `params.rs:167` — `#[serde(default)] pub(super) api_key: Option<String>`; no `rename`, no `skip`, no struct-level `rename_all` |
| wire | `voiceSettingsApi.ts:251` — `...(apiKey?.trim() ? { api_key: apiKey.trim() } : {})`; the camelCase `apiKey` is only the TS parameter name, the payload key is snake_case and matches |
| handler | `provider_server.rs:344` — `validate_provider_key(trimmed, &config, p.api_key.as_deref())` |
| validator | `helpers.rs` — the candidate is preferred over `lookup_key_for_slug` |

It is also already tested on both sides: `schemas_tests.rs::deserialize_voice_test_provider_params_accepts_candidate_key` asserts the field parses from a map keyed `"api_key"` (so a rename or `rename_all` breaks it — exactly the silent-drop class), and `voiceSettingsApi.test.ts` asserts the request body carries `api_key` when a candidate is supplied and omits it entirely when not.

**What *was* missing** is the behaviour those two tests do not reach: that the candidate is the key actually used. Nothing pinned it.

## Solution

`validate_provider_key_prefers_the_candidate_over_an_absent_stored_key` in `src/openhuman/voice/schemas_tests.rs`.

The observation trick is the endpoint: `http://127.0.0.1:1` refuses immediately, so *"got past the key check and tried to reach the provider"* (`request failed: …`) is distinguishable from *"stopped at the key check"* (`no API key configured`) with **no mock server, no network and no wall-clock cost**. The test asserts the control first (nothing stored, no candidate → stops at the key check), then adds only a candidate to the same config and asserts the validator gets through.

Why it matters beyond coverage: with the candidate ignored, the modal reports on whatever was already stored — or says "no API key configured" about a key the user is looking at — while still answering through the normal `ok` envelope. A wrong answer about a credential is the worst shape this code can fail in.

### Revert-check

| Test | Revert applied | Result |
|---|---|---|
| `validate_provider_key_prefers_the_candidate_over_an_absent_stored_key` | validator ignores `candidate_key` (its pre-#5947 shape) | ✅ **FAILED as required**, naming my assertion: `a candidate key must be used when nothing is stored for the slug; got "no API key configured for this provider", which means the candidate was ignored and the absent stored key won` (`schemas_tests.rs:638`) |

**Baseline**: passes in 0.01s (`test result: ok. 1 passed`). **Restore**: verified clean (`git diff --stat` empty on `helpers.rs`). The whole check ran on the narrow `cargo test -p openhuman --features voice --lib -- <filter>` lane, not a full build.

### A second test I wrote and deleted

I also wrote one pinning the `!k.is_empty()` guard, so a whitespace-only field is not forwarded as a credential. It is **vacuous by construction**: without the guard `api_key` becomes `""`, and the next statement is `if api_key.is_empty() { return Err("no API key configured for this provider") }` — the same error either way, so the test cannot fail against a revert of the behaviour it claims to pin. Deleted rather than shipped.

The guard is not redundant in general — it changes behaviour when a stored key *exists* — but pinning that needs a populated `AuthProfilesStore` and the config wiring `lookup_key_for_slug` resolves through. Left as a known, deliberately-unpinned branch rather than covered by a test that proves nothing.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — one test, both branches asserted (control: no key anywhere; subject: candidate only), revert-checked
- [x] **Diff coverage ≥ 80%** — N/A: test-only change, no product lines added
- [x] Coverage matrix updated — N/A: no feature rows added, removed or renamed
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature rows affected
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — the test deliberately uses `127.0.0.1:1`, which refuses locally; no server and no egress
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: no release-cut surface changed
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: no issue; this backfills cover for already-merged #5947

## Impact

- Test-only: no runtime, platform, performance, security or compatibility impact.
- CI cost: one `#[tokio::test]` in the existing lib test target; it performs a single refused local connection and returns in milliseconds.

## Related

- Pins the candidate-key half of #5947 (#5896).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming that a supplied provider key takes precedence when no stored key is available.
  * Added validation for the resulting error behavior, distinguishing missing credentials from provider request failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->