### PR TITLE
fix(lint): compare the prose skip against a posix path

### DIFF
--- a/app/scripts/lint-undefined-scales.mjs
+++ b/app/scripts/lint-undefined-scales.mjs
@@ -354,10 +354,16 @@ function* walk(dir) {
  * is loose enough to trip on those, so only it skips them.
  */
 function holdsProseNotClasses(relative) {
+  // `path.relative` yields the platform separator, so on Windows these paths
+  // arrive as `src\\lib\\i18n\\en.ts` and every `/`-spelled test below misses.
+  // The skip then never fires and the catalogues are scanned as class lists:
+  // "text-to-speech" is read as `text-` + an undefined token.
+  const posix = relative.split(path.sep).join('/');
+
   return (
-    relative.startsWith('src/lib/i18n/') ||
-    relative.includes('/__tests__/') ||
-    /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(relative)
+    posix.startsWith('src/lib/i18n/') ||
+    posix.includes('/__tests__/') ||
+    /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(posix)
   );
 }
 


### PR DESCRIPTION
## The defect

On a Windows checkout `pnpm lint:ui-tokens` fails with 15 violations, and every one of them is English prose out of a translation catalogue:

```
lint:ui-tokens: 15 Tailwind utility/utilities name a scale or token that the Tailwind v4 theme does not define.
These emit NO CSS and render uncoloured:

  src\lib\i18n\en.ts:237:  text-to-speech  (to-speech is not a token this theme defines)
  src\lib\i18n\en.ts:690:  to-dos          (dos is not a token this theme defines)
  src\lib\i18n\en.ts:1135: text-based      (based is not a token this theme defines)
  src\lib\i18n\it.ts:818:  to-do           (do is not a token this theme defines)
  … 11 more, all in en/fr/id/it
```

`scripts/lint-undefined-scales.mjs` already has a guard for exactly this, and its doc comment names these exact strings:

> `- prose. The shadeless pass skips `src/lib/i18n/` and test files, where "text-to-speech", "to-do" and fixture strings like `bg-noise` are English and test data, not class lists.`

The guard never fires on Windows:

```js
function holdsProseNotClasses(relative) {
  return (
    relative.startsWith('src/lib/i18n/') ||   // relative is 'src\lib\i18n\en.ts'
    relative.includes('/__tests__/') ||       // and this one too
    /\.(test|spec)\.(ts|tsx|js|jsx)$/.test(relative)
  );
}
```

`relative` comes from `path.relative`, which yields the platform separator. Both `/`-spelled comparisons miss, the catalogues are scanned as class lists, and `text-to-speech` parses as the `text-` utility plus an undefined token `to-speech`. Only the extension regex, which has no separator in it, still works.

## Why it matters beyond a noisy lint

The gate runs from `.husky/pre-push`, so on Windows it blocks **every push**, on a failure the author cannot have caused and cannot act on — the remedy the script prints ("choose a defined semantic token — do NOT add a scale only to silence this lint") does not apply to a `to-do` in a sentence. The only ways past are `--no-verify` or editing someone else's translations.

It also hides real findings: the 15 false positives are the entire output, so a genuine undefined scale introduced on a Windows machine is indistinguishable from the noise.

## The fix

Normalise to `/` once, then compare. Nothing else in the script is separator-sensitive — the same `walk()` hands platform paths to every other check, and those are separator-blind.

## Verification

On this host (Windows 11, Git Bash), against `main`:

| | `node scripts/lint-undefined-scales.mjs` |
| --- | --- |
| before | 15 violations, all in `src\lib\i18n\` |
| after | `no undefined colour scales or tokens (30 shade-bearing scales, 68 shadeless colours, 18 shadows)` |
| after, with the two comparisons reverted to `relative` | the same 15 come back |

The reverted-comparison run is the part worth stating: it pins the cause on the separator rather than on anything else that moved.

I did not add a unit test — `lint-undefined-scales.mjs` executes its scan at import time against a hard-coded `appRoot/src`, so testing `holdsProseNotClasses` would mean extracting it, which is a larger change than the bug warrants. Happy to do that separately if you would rather have the seam.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prose-file detection on Windows by ensuring path checks work consistently across operating systems.
  * Prevented unintended lint warnings for matching internationalization test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->