### PR TITLE
fix(test): run agent_retrieval_e2e, and point it at the shipped ingest path

### DIFF
--- a/tests/agent_retrieval_e2e.rs
+++ b/tests/agent_retrieval_e2e.rs
@@ -427,11 +427,27 @@ async fn fetch_leaves_hydrates_source_ref_for_cited_chunks() {
     // List the ingested chunks through the host read RPC. Not the engine's
     // `store::chunks::store::list_chunks`: ingest went through the bound
     // driver, so this reads the same surface the product reads.
-    let chunks = read_rpc::list_chunks_rpc(&cfg, ChunkFilter::default())
-        .await
-        .expect("list_chunks must not error")
-        .value
-        .chunks;
+    let chunks = read_rpc::list_chunks_rpc(
+        &cfg,
+        ChunkFilter {
+            // Scoped to the thread this test ingested. An unfiltered listing
+            // returns whatever else the store holds, and taking its first two
+            // rows fetched chunks this test never wrote — which is how the
+            // provenance assertion below came to pass on somebody else's
+            // `agent://session/...` segments.
+            source_ids: Some(vec!["gmail:thread-provenance-1".to_string()]),
+            ..ChunkFilter::default()
+        },
+    )
+    .await
+    .expect("list_chunks must not error")
+    .value
+    .chunks;
+
+    assert!(
+        !chunks.is_empty(),
+        "the ingested thread must be listable under its own source id"
+    );
 
     assert!(!chunks.is_empty(), "ingest must produce at least one chunk");
 
@@ -467,17 +483,21 @@ async fn fetch_leaves_hydrates_source_ref_for_cited_chunks() {
         "fetch_leaves must hydrate at least one chunk"
     );
 
-    // Every leaf that has a source_ref at the ingest level must preserve it.
-    // The email thread had explicit source_refs on both messages — at least one
-    // leaf should carry provenance.
-    let with_source_ref = leaves
+    // The point of the test is that the ref set at INGEST reaches the citation,
+    // so assert the value, not merely that the field is inhabited. Asserting
+    // presence alone passed even with `email_items` dropping `source_ref`
+    // outright, because something further down still populates the field —
+    // which is exactly the shape of a provenance test that proves nothing.
+    let refs: Vec<&str> = leaves
         .iter()
-        .filter(|l| l.get("source_ref").and_then(|v| v.as_str()).is_some())
-        .count();
+        .filter_map(|l| l.get("source_ref").and_then(|v| v.as_str()))
+        .collect();
     assert!(
-        with_source_ref >= 1,
-        "fetch_leaves must return at least one leaf with source_ref populated \
-         (provenance chain for citation); got leaves: {fetched:#}"
+        refs.iter()
+            .any(|r| r.contains("q3-roadmap-1@example.com")
+                || r.contains("q3-roadmap-2@example.com")),
+        "fetch_leaves must carry the source_ref set at ingest so a citation \
+         points at the message it came from; got refs {refs:?} in leaves: {fetched:#}"
     );
 
     // Verify content round-trips.

--- a/tests/agent_retrieval_e2e.rs
+++ b/tests/agent_retrieval_e2e.rs
@@ -21,6 +21,9 @@
 
 use chrono::{TimeZone, Utc};
 use openhuman_core::openhuman::config::Config;
+use openhuman_core::openhuman::memory::read_rpc::{self, ChunkFilter};
+use openhuman_core::openhuman::memory::tree::tree::canonicalize_types::IngestRequest;
+use openhuman_core::openhuman::memory::tree::tree::rpc::ingest_rpc;
 use openhuman_core::openhuman::tools::{
     MemoryTreeFetchLeavesTool, MemoryTreeSearchEntitiesTool, Tool,
 };
@@ -28,7 +31,7 @@ use serde_json::{json, Value};
 use tempfile::TempDir;
 use tinycortex::memory::ingest::canonicalize::chat::{ChatBatch, ChatMessage};
 use tinycortex::memory::ingest::canonicalize::email::{EmailMessage, EmailThread};
-use tinymemory_core::ingest_pipeline::{ingest_chat, ingest_email};
+use tinymemory_api::chunks::SourceKind;
 use tinymemory_core::queue::drain_until_idle;
 
 /// Install the host seams the memory subsystem needs.
@@ -241,9 +244,6 @@ fn orchestrator_reaches_memory_agent_on_demand() {
 /// (issue#1505): the retrieval tool must be able to surface facts from a
 /// channel the current conversation did not originate in.
 #[tokio::test]
-#[ignore = "needs a released tinymemory module serving the Retrieval family: \
-             the port routes these tools through the module driver, and the \
-             currently pinned artifact predates SearchEntities/RetrieveLeaves"]
 async fn cross_chat_entity_index_spans_source_boundaries() {
     ensure_memory_seams();
     let (tmp, cfg) = test_config();
@@ -261,9 +261,18 @@ async fn cross_chat_entity_index_spans_source_boundaries() {
             source_ref: Some("slack://eng/1".into()),
         }],
     };
-    ingest_chat(&cfg, "slack:#eng", "alice", vec![], chat_a)
-        .await
-        .expect("ingest chat A should succeed");
+    ingest_rpc(
+        &cfg,
+        IngestRequest {
+            source_kind: SourceKind::Chat,
+            source_id: "slack:#eng".into(),
+            owner: "alice".into(),
+            tags: vec![],
+            payload: serde_json::to_value(chat_a).expect("chat batch serialises"),
+        },
+    )
+    .await
+    .expect("ingest chat A should succeed");
 
     // Chat B — a separate channel with no overlap with chat A
     let chat_b = ChatBatch {
@@ -276,9 +285,18 @@ async fn cross_chat_entity_index_spans_source_boundaries() {
             source_ref: Some("slack://ops/1".into()),
         }],
     };
-    ingest_chat(&cfg, "slack:#ops", "carol", vec![], chat_b)
-        .await
-        .expect("ingest chat B should succeed");
+    ingest_rpc(
+        &cfg,
+        IngestRequest {
+            source_kind: SourceKind::Chat,
+            source_id: "slack:#ops".into(),
+            owner: "carol".into(),
+            tags: vec![],
+            payload: serde_json::to_value(chat_b).expect("chat batch serialises"),
+        },
+    )
+    .await
+    .expect("ingest chat B should succeed");
 
     drain_until_idle(&cfg)
         .await
@@ -356,61 +374,64 @@ async fn cross_chat_entity_index_spans_source_boundaries() {
 /// fetch_leaves and each returned leaf must carry `source_ref` when one was
 /// set at ingest time.
 #[tokio::test]
-#[ignore = "needs a released tinymemory module serving the Retrieval family: \
-             the port routes these tools through the module driver, and the \
-             currently pinned artifact predates SearchEntities/RetrieveLeaves"]
 async fn fetch_leaves_hydrates_source_ref_for_cited_chunks() {
     ensure_memory_seams();
     let (tmp, cfg) = test_config();
 
     // Ingest an email thread with explicit source_refs on every message.
-    ingest_email(
+    ingest_rpc(
         &cfg,
-        "gmail:thread-provenance-1",
-        "alice",
-        vec![],
-        EmailThread {
-            provider: "gmail".into(),
-            thread_subject: "Q3 roadmap decision".into(),
-            messages: vec![
-                EmailMessage {
-                    from: "pm@example.com".into(),
-                    to: vec!["alice@example.com".into()],
-                    cc: vec![],
-                    subject: "Q3 roadmap decision".into(),
-                    sent_at: Utc.timestamp_millis_opt(1_710_000_000_000).unwrap(),
-                    body: "We are committing to the Q3 roadmap with Phoenix as the \
+        IngestRequest {
+            source_kind: SourceKind::Email,
+            source_id: "gmail:thread-provenance-1".into(),
+            owner: "alice".into(),
+            tags: vec![],
+            payload: serde_json::to_value(EmailThread {
+                provider: "gmail".into(),
+                thread_subject: "Q3 roadmap decision".into(),
+                messages: vec![
+                    EmailMessage {
+                        from: "pm@example.com".into(),
+                        to: vec!["alice@example.com".into()],
+                        cc: vec![],
+                        subject: "Q3 roadmap decision".into(),
+                        sent_at: Utc.timestamp_millis_opt(1_710_000_000_000).unwrap(),
+                        body: "We are committing to the Q3 roadmap with Phoenix as the \
                            flagship feature. pm@example.com signed off."
-                        .into(),
-                    source_ref: Some("<q3-roadmap-1@example.com>".into()),
-                    list_unsubscribe: None,
-                },
-                EmailMessage {
-                    from: "alice@example.com".into(),
-                    to: vec!["pm@example.com".into()],
-                    cc: vec![],
-                    subject: "Re: Q3 roadmap decision".into(),
-                    sent_at: Utc.timestamp_millis_opt(1_710_000_060_000).unwrap(),
-                    body: "Confirmed. alice@example.com will own the Phoenix delivery.".into(),
-                    source_ref: Some("<q3-roadmap-2@example.com>".into()),
-                    list_unsubscribe: None,
-                },
-            ],
+                            .into(),
+                        source_ref: Some("<q3-roadmap-1@example.com>".into()),
+                        list_unsubscribe: None,
+                    },
+                    EmailMessage {
+                        from: "alice@example.com".into(),
+                        to: vec!["pm@example.com".into()],
+                        cc: vec![],
+                        subject: "Re: Q3 roadmap decision".into(),
+                        sent_at: Utc.timestamp_millis_opt(1_710_000_060_000).unwrap(),
+                        body: "Confirmed. alice@example.com will own the Phoenix delivery.".into(),
+                        source_ref: Some("<q3-roadmap-2@example.com>".into()),
+                        list_unsubscribe: None,
+                    },
+                ],
+            })
+            .expect("email thread serialises"),
         },
     )
     .await
-    .expect("ingest_email must succeed");
+    .expect("ingest_rpc(email) must succeed");
 
     drain_until_idle(&cfg).await.expect("queue must drain");
 
     let _ws_guard = set_workspace_env(&tmp);
 
-    // List the ingested chunks directly to get leaf chunk ids with their refs.
-    let chunks = tinymemory_core::store::chunks::store::list_chunks(
-        &cfg,
-        &tinymemory_core::store::chunks::store::ListChunksQuery::default(),
-    )
-    .expect("list_chunks must not error");
+    // List the ingested chunks through the host read RPC. Not the engine's
+    // `store::chunks::store::list_chunks`: ingest went through the bound
+    // driver, so this reads the same surface the product reads.
+    let chunks = read_rpc::list_chunks_rpc(&cfg, ChunkFilter::default())
+        .await
+        .expect("list_chunks must not error")
+        .value
+        .chunks;
 
     assert!(!chunks.is_empty(), "ingest must produce at least one chunk");
 


### PR DESCRIPTION
## Summary

- `tests/agent_retrieval_e2e.rs` had two defects at once: both of its async tests carried `#[ignore]`, so neither ran; and both ingested through `tinymemory_core::ingest_pipeline::{ingest_chat, ingest_email}` — the in-process engine call that #5560/#5779 replaced — so if they had run they would have exercised a path the product no longer takes.
- Both are fixed: the `#[ignore]`s are gone and ingest goes through `memory::tree::tree::rpc::ingest_rpc`, the handler behind `openhuman.memory_tree_ingest`.
- Un-ignoring then exposed two further defects **inside** the provenance test, which are also fixed here. Neither was visible while the test was skipped.
- All three tests in the file now run and pass, and both async tests are mutation-checked.

## Problem

`#[ignore]` gave the reason *"the currently pinned artifact predates SearchEntities/RetrieveLeaves"*. That is no longer true — the file's own `ensure_memory_seams` binds the module driver, and the tests pass against the pinned artifact.

Meanwhile the file read as coverage of the ingest route to a grep and to the string-match domain gate, while running nothing.

What surfaced once it ran:

**The provenance test was fetching chunks it never wrote.** It listed chunks with no filter and took the first two rows. Those were not its emails — the leaves came back as:

```
["agent://session/phase1-flush-test/segment/seg-18cdb8ff55cafe88c4a6eeb9#ep1-3",
 "agent://session/phase1-recap-test/segment/seg-18cdb8ff55ed6338909210e5#ep1-3"]
```

rows belonging to something else entirely.

**And its assertion could not tell the difference.** It only checked that a `source_ref` field was *inhabited*, which those foreign chunks satisfied. Measured: with `email_items` dropping `source_ref` outright, the test still passed. A provenance test that passes when provenance is deleted is not a provenance test.

## Solution

- `#[ignore]` removed from both tests. No replacement suppression.
- Ingest via `ingest_rpc` (`SourceKind::Chat` / `SourceKind::Email`), which is payload → `chat_items` / `email_items` → the bound driver's Ingest family.
- The chunk listing moves to `read_rpc::list_chunks_rpc`, **scoped to the thread's own `source_id`**. Reading the engine's in-process store directly would not be reading what the product reads, and reading it unfiltered is what fetched somebody else's rows.
- The provenance assertion now requires the message-id set at ingest to reach the citation, rather than requiring the field to be non-null.

## Mutation checks

Each async test was checked against a mutation of the behaviour it pins; both fail naming their own assertion, and both pass again when restored.

| test | mutation | result |
|---|---|---|
| `cross_chat_entity_index_spans_source_boundaries` | `chat_items` emits empty content | **FAILED** at the cross-source entity assertion |
| `fetch_leaves_hydrates_source_ref_for_cited_chunks` | `email_items` sets `source_ref: None` | **FAILED** — `got refs []` |

Restored: `3 passed; 0 failed; 0 ignored`.

**One negative result worth recording.** Reverting *only* the path change — putting the direct-engine `ingest_chat` / `ingest_email` calls back while keeping the host-side read — left all three tests passing. The two ingest routes converge on the same store at this level, so this file cannot serve as a regression guard for *which* route is taken. It is still correct for it to drive the shipped one — that is what makes the `email_items` mutation above visible at all — but the path change is not itself pinned by an assertion, and I would rather say so than let the green be read as proof.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — two previously-dead tests now run, both mutation-checked
- [x] **Diff coverage ≥ 80%** — `N/A: no production lines changed; the diff is one test file`
- [x] Coverage matrix updated — `N/A: no feature rows added, removed or renamed`
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — `N/A: no coverage-matrix feature IDs affected`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — no new dependency of any kind
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: test-only change, no release-cut surface touched`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — `N/A: fixes a test defect found during a coverage audit; no issue filed`

## Impact

No runtime, platform, security or migration impact — one test file, no production code. CI gains two tests that previously did not execute. The `agent_retrieval_e2e` target runs in ~5s.

## Related

- Follows the coverage audit behind #5965; this is the item recorded there as "an `#[ignore]`d lane that also tests the wrong path".
- Follow-up worth a maintainer's eye, **not fixed here**: an unfiltered `list_chunks_rpc` in a fresh temp workspace returned `agent://session/phase1-*` rows this test never wrote. Scoping the filter is the right fix for *this* test either way, but it does not explain where those rows came from, and if workspace isolation is leaking between tests that is worth knowing independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded end-to-end retrieval coverage for chat and email sources.
  - Retrieval tests now run as part of the standard test suite.
  - Improved validation that cited chunks preserve accurate source references.
  - Added coverage for retrieving chunks within the correct ingested source scope and across source boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->