### PR TITLE
fix(test): make a skipped test target audible and assert RPC reachability

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -121,7 +121,11 @@ fn warn_about_silently_skipped_test_targets(manifest_dir: &Path) {
         return;
     };
 
-    let mut skipped: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    // Per target: what is missing NOW (the diagnostic) and what the target
+    // requires IN FULL (the remediation). They differ whenever a caller has
+    // some of the gates already, and conflating them is what made the
+    // suggested command wrong — see the `all` union below.
+    let mut skipped: BTreeMap<String, (Vec<String>, Vec<String>)> = BTreeMap::new();
     for (target, required) in gated_test_targets(&manifest) {
         let missing: Vec<String> = required
             .iter()
@@ -136,7 +140,7 @@ fn warn_about_silently_skipped_test_targets(manifest_dir: &Path) {
             .cloned()
             .collect();
         if !missing.is_empty() {
-            skipped.insert(target, missing);
+            skipped.insert(target, (missing, required));
         }
     }
     if skipped.is_empty() {
@@ -145,13 +149,21 @@ fn warn_about_silently_skipped_test_targets(manifest_dir: &Path) {
 
     let detail = skipped
         .iter()
-        .map(|(target, missing)| format!("{target} (needs {})", missing.join(" + ")))
+        .map(|(target, (missing, _))| format!("{target} (needs {})", missing.join(" + ")))
         .collect::<Vec<_>>()
         .join(", ");
+    // The union of every skipped target's FULL `required-features`, not just
+    // the subset currently missing. `--features` is the complete set to
+    // activate, not a delta applied to the current one, so a command built from
+    // the missing subset drops the gates the caller already had: with `voice`
+    // on, `raw_coverage_all` is missing only `inference`, and
+    // `--features inference` would silently skip both voice targets again — the
+    // warning would be handing out a command that reproduces the exact failure
+    // it exists to prevent.
     let all: Vec<&str> = {
         let mut features: Vec<&str> = skipped
             .values()
-            .flat_map(|missing| missing.iter().map(String::as_str))
+            .flat_map(|(_, required)| required.iter().map(String::as_str))
             .collect();
         features.sort_unstable();
         features.dedup();

--- a/build.rs
+++ b/build.rs
@@ -12,13 +12,43 @@
 //! We glob the directory at build time (rather than hand-maintaining a `mod`
 //! list) so that any newly added `tests/raw_coverage/*.rs` file is picked up
 //! automatically and cannot be silently skipped.
+//!
+//! # Second job: make an unmet `required-features` skip audible
+//!
+//! Four `tests/*.rs` targets carry `required-features` (see `[[test]]` in
+//! `Cargo.toml`), and every one of those features is default-OFF for
+//! contributors. Cargo treats the two ways of selecting a target differently,
+//! and only one of them is safe:
+//!
+//! - **Naming it** — `cargo test --test json_rpc_e2e` — is a hard error when
+//!   the features are unmet (`target ... requires the features: voice`,
+//!   exit 101). CI names its targets one at a time, so CI cannot lose one this
+//!   way.
+//! - **Globbing** — a bare `cargo test`, or `cargo test --tests` — filters the
+//!   target out **silently and exits 0**. That is what a contributor runs, and
+//!   it reports a green suite having compiled and run none of them.
+//!
+//! `json_rpc_e2e` alone is >12k lines of RPC contract coverage, and
+//! `raw_coverage_all` aggregates ~76 suites. A green run that skipped both
+//! reads exactly like a green run that did not, which is how untested code
+//! comes to look covered.
+//!
+//! So [`warn_about_silently_skipped_test_targets`] emits a `cargo::warning=`
+//! naming what this feature configuration will skip. A build-script warning is
+//! used rather than a failing test on purpose: cargo captures the output of a
+//! *passing* test, so a warning printed there would itself be invisible, while
+//! build-script warnings are shown unconditionally. It warns rather than fails
+//! because a contributor build legitimately omits these gates — the goal is
+//! that the omission is never a surprise, not that it is forbidden.
 
+use std::collections::BTreeMap;
 use std::env;
 use std::fs;
 use std::path::Path;
 
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set");
+    warn_about_silently_skipped_test_targets(Path::new(&manifest_dir));
     let tests_dir = Path::new(&manifest_dir).join("tests");
     let raw_dir = tests_dir.join("raw_coverage");
 
@@ -66,4 +96,128 @@ fn main() {
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR must be set");
     let out_path = Path::new(&out_dir).join("raw_coverage_mods.rs");
     fs::write(&out_path, generated).expect("failed to write raw_coverage_mods.rs");
+}
+
+/// The env var cargo sets for an enabled feature: upper-cased, `-` to `_`.
+fn feature_env_var(feature: &str) -> String {
+    format!(
+        "CARGO_FEATURE_{}",
+        feature.to_uppercase().replace(['-', '.'], "_")
+    )
+}
+
+/// Emit one `cargo::warning=` naming every `[[test]]` target this feature
+/// configuration will silently drop from a globbed `cargo test`.
+///
+/// The manifest is parsed rather than hard-coded so a target added later is
+/// covered without anyone remembering to update this list — the same reason
+/// the module list above is globbed instead of hand-maintained.
+fn warn_about_silently_skipped_test_targets(manifest_dir: &Path) {
+    let manifest_path = manifest_dir.join("Cargo.toml");
+    println!("cargo:rerun-if-changed={}", manifest_path.display());
+    let Ok(manifest) = fs::read_to_string(&manifest_path) else {
+        // A source-only build tree may not ship the manifest we expect; the
+        // module list above already tolerates that shape.
+        return;
+    };
+
+    let mut skipped: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (target, required) in gated_test_targets(&manifest) {
+        let missing: Vec<String> = required
+            .iter()
+            .filter(|feature| {
+                let var = feature_env_var(feature);
+                // Re-run when the feature set changes, so switching profiles
+                // re-emits (or clears) the warning instead of leaving a stale
+                // cached result.
+                println!("cargo:rerun-if-env-changed={var}");
+                env::var_os(&var).is_none()
+            })
+            .cloned()
+            .collect();
+        if !missing.is_empty() {
+            skipped.insert(target, missing);
+        }
+    }
+    if skipped.is_empty() {
+        return;
+    }
+
+    let detail = skipped
+        .iter()
+        .map(|(target, missing)| format!("{target} (needs {})", missing.join(" + ")))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let all: Vec<&str> = {
+        let mut features: Vec<&str> = skipped
+            .values()
+            .flat_map(|missing| missing.iter().map(String::as_str))
+            .collect();
+        features.sort_unstable();
+        features.dedup();
+        features
+    };
+    let features_flag = all.join(",");
+    // One warning rather than one per target: this fires on every build in a
+    // configuration that omits the gates, and four lines of it would train
+    // people to scroll past.
+    println!(
+        "cargo:warning=A globbed `cargo test` SILENTLY SKIPS these targets in this feature \
+         configuration and still exits 0: {detail}. Run them with `--features {features_flag}`, \
+         or use the product set: cargo test --features \"$(bash \
+         scripts/ci/product-features.sh)\". Naming a target explicitly (cargo test --test \
+         json_rpc_e2e) errors instead of skipping — only the globbed form is silent."
+    );
+}
+
+/// Every `[[test]]` target in `manifest` that declares `required-features`.
+///
+/// Deliberately a small hand parse: `build.rs` has no dependencies, and adding
+/// a TOML crate to the build graph to read four lines would cost every build.
+/// The shape it accepts is the shape the manifest uses — `[[test]]`, then
+/// `name = "..."` and `required-features = [...]` before the next table.
+fn gated_test_targets(manifest: &str) -> Vec<(String, Vec<String>)> {
+    let mut found = Vec::new();
+    let mut in_test_table = false;
+    let mut name: Option<String> = None;
+    let mut required: Option<Vec<String>> = None;
+
+    let flush = |name: &mut Option<String>,
+                 required: &mut Option<Vec<String>>,
+                 found: &mut Vec<(String, Vec<String>)>| {
+        if let (Some(name), Some(required)) = (name.take(), required.take()) {
+            found.push((name, required));
+        }
+    };
+
+    for line in manifest.lines() {
+        let line = line.trim();
+        if line.starts_with('[') {
+            // Any new table ends the current `[[test]]` block.
+            flush(&mut name, &mut required, &mut found);
+            in_test_table = line == "[[test]]";
+            continue;
+        }
+        if !in_test_table {
+            continue;
+        }
+        if let Some(value) = line.strip_prefix("name") {
+            if let Some(value) = value.trim_start().strip_prefix('=') {
+                name = Some(value.trim().trim_matches('"').to_string());
+            }
+        } else if let Some(value) = line.strip_prefix("required-features") {
+            if let Some(value) = value.trim_start().strip_prefix('=') {
+                let inner = value.trim().trim_start_matches('[').trim_end_matches(']');
+                required = Some(
+                    inner
+                        .split(',')
+                        .map(|feature| feature.trim().trim_matches('"').to_string())
+                        .filter(|feature| !feature.is_empty())
+                        .collect(),
+                );
+            }
+        }
+    }
+    flush(&mut name, &mut required, &mut found);
+    found
 }

--- a/tests/worker_c_modules_e2e.rs
+++ b/tests/worker_c_modules_e2e.rs
@@ -245,12 +245,24 @@ fn assert_rpc_completed(value: &Value, context: &str) {
         ),
         (None, None) => panic!("{context}: response carries neither result nor error: {value}"),
     };
-    let message = error
-        .get("message")
-        .and_then(Value::as_str)
-        .unwrap_or_default();
+    // Not `unwrap_or_default()`: that turns a missing, null or non-string
+    // `message` into `""`, which then satisfies the check below and lets a
+    // malformed error-only response count as a completed dispatch — the same
+    // vacuous-pass shape this helper was rewritten to remove.
+    let Some(message) = error.get("message").and_then(Value::as_str) else {
+        panic!(
+            "{context}: error response carries no string `message`, so nothing can be \
+             concluded about whether the method dispatched: {value}"
+        );
+    };
+    // `starts_with`, not `contains`: `dispatch.rs:96` builds the string as
+    // `format!("{UNKNOWN_METHOD_PREFIX}{method}")`, so the marker is always at
+    // byte zero — `dispatch.rs:151` reads it back with `strip_prefix` for the
+    // same reason. `contains` would additionally reject a REGISTERED method
+    // whose own validation error quoted the phrase later in the message,
+    // turning a reachable surface into a false failure.
     assert!(
-        !message.contains(UNKNOWN_METHOD_PREFIX),
+        !message.starts_with(UNKNOWN_METHOD_PREFIX),
         "{context}: the core does not serve this method, so the surface is NOT reachable \
          — the registry entry is missing or its namespace was renamed. Got: {message}"
     );

--- a/tests/worker_c_modules_e2e.rs
+++ b/tests/worker_c_modules_e2e.rs
@@ -17,6 +17,7 @@ use serde_json::{json, Value};
 use tempfile::{tempdir, TempDir};
 
 use openhuman_core::core::auth::{init_rpc_token, CORE_TOKEN_ENV_VAR};
+use openhuman_core::core::dispatch::UNKNOWN_METHOD_PREFIX;
 use openhuman_core::core::jsonrpc::build_core_http_router;
 
 const TEST_RPC_TOKEN: &str = "worker-c-modules-e2e-token";
@@ -218,10 +219,40 @@ fn error_message<'a>(value: &'a Value, context: &str) -> &'a str {
         .unwrap_or_else(|| panic!("{context}: expected JSON-RPC error with message: {value}"))
 }
 
+/// Assert that `value` is a JSON-RPC response for a method the core actually
+/// serves.
+///
+/// This used to assert only that the envelope carried `result` **or** `error`,
+/// which every well-formed JSON-RPC response does — including
+/// `unknown method: openhuman.whatever`. The reachability loops below call ~90
+/// methods through this helper, so all of them could have been deleted from the
+/// registry and this file would still have passed.
+///
+/// An error is still tolerated, and deliberately: these loops call each method
+/// with empty params, so a registered method usually answers with a validation
+/// failure. That is a *completed dispatch* — the method resolved, took the
+/// params and rejected them — and it is the strongest thing a probe with no
+/// arguments can honestly assert. What must not happen is the request never
+/// reaching a handler at all, which is exactly what
+/// [`UNKNOWN_METHOD_PREFIX`] marks.
 fn assert_rpc_completed(value: &Value, context: &str) {
+    let error = match (value.get("result"), value.get("error")) {
+        (Some(_), None) => return,
+        (None, Some(error)) => error,
+        (Some(_), Some(_)) => panic!(
+            "{context}: response carries BOTH result and error, which is not a valid \
+             JSON-RPC envelope: {value}"
+        ),
+        (None, None) => panic!("{context}: response carries neither result nor error: {value}"),
+    };
+    let message = error
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
     assert!(
-        value.get("result").is_some() || value.get("error").is_some(),
-        "{context}: expected JSON-RPC result or error envelope: {value}"
+        !message.contains(UNKNOWN_METHOD_PREFIX),
+        "{context}: the core does not serve this method, so the surface is NOT reachable \
+         — the registry entry is missing or its namespace was renamed. Got: {message}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Two findings from the e2e coverage audit, both the same shape: **something reports green having checked nothing.**
- `build.rs` now emits a `cargo::warning=` naming every test target the current feature set will silently skip.
- `assert_rpc_completed` now rejects an `unknown method` response instead of accepting any JSON-RPC envelope.
- Both revert-checked. No production behaviour changes.

## Problem

**1. An unmet `required-features` skip is silent.** Four `tests/*.rs` targets carry `required-features` (`json_rpc_e2e`, `raw_coverage_all`, `observability_smoke`, `x402_twit_sh_live`) and every gate they name is default-OFF for contributors. Cargo treats the two ways of selecting a target differently, and only one is safe — verified rather than assumed:

```
$ cargo test -p openhuman --test json_rpc_e2e -- --list
error: target `json_rpc_e2e` in package `openhuman` requires the features: `voice`
$ echo $?
101
```

Naming a target is a **hard error**. Globbing — a bare `cargo test`, or `--tests` — drops it **silently and exits 0**. That second form is what a contributor runs, and `json_rpc_e2e` alone is >12k lines of RPC contract coverage while `raw_coverage_all` aggregates ~76 suites. A green local run can have executed neither and look identical to one that did.

**2. `assert_rpc_completed` asserted nothing.**

```rust
assert!(value.get("result").is_some() || value.get("error").is_some(), ...);
```

That is true of every well-formed JSON-RPC response, including `unknown method: openhuman.whatever`. Roughly 90 methods across four tests were probed through it — `memory_memory_tree_and_sources_controller_surfaces_are_reachable` alone loops 68 — so the entire registry could have been deleted and this file would still have passed.

## Solution

**build.rs** reads the manifest, compares each target's `required-features` against `CARGO_FEATURE_*`, and emits one consolidated warning:

```
warning: openhuman@0.63.19: A globbed `cargo test` SILENTLY SKIPS these targets in this
feature configuration and still exits 0: json_rpc_e2e (needs voice), observability_smoke
(needs crash-reporting), raw_coverage_all (needs voice + inference), x402_twit_sh_live
(needs web3). Run them with `--features crash-reporting,inference,voice,web3` ...
```

Three deliberate choices: a **build-script warning** rather than a failing test, because cargo captures the output of a *passing* test — a warning printed there would itself be invisible; a **warning** rather than an error, because a contributor build legitimately omits these gates and the goal is that the omission is never a surprise; and the **manifest is parsed**, not hard-coded, so a target added later is covered without anyone remembering this file — the same reasoning as the globbed module list beside it.

**`assert_rpc_completed`** now rejects an error carrying `dispatch::UNKNOWN_METHOD_PREFIX`, imported from the shared constant so the probe cannot drift from the emit site. An error is still tolerated, deliberately: these loops call each method with empty params, so a registered method usually answers with a validation failure — that is a *completed dispatch*, and the strongest thing an argument-less probe can honestly claim.

**Checked, not assumed:** all 10 tests in the file still pass, so **no call site was passing only because the helper was vacuous**. Those ~90 surfaces are genuinely reachable — a clean negative result, and the one worth stating since the task was to find gaps hiding behind it.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — the corrected helper is exercised by all four call-site tests; the revert-check below is its failure path.
- [x] **Diff coverage ≥ 80%** — N/A: the diff is a build script and a test helper. Neither is instrumented by `cargo-llvm-cov`, so there are no product lines for `diff-cover` to score.
- [x] Coverage matrix updated — N/A: no feature row added, removed or renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matrix feature row applies.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — none; `build.rs` gains no dependency (the manifest parse is deliberately hand-rolled to keep the build graph unchanged).
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: build-script warning and test helper only, no user-facing surface.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section — N/A: internal audit findings, no issue filed.

## Impact

- No product code changes. `build.rs` gains a warning path and no dependency; the build graph is unchanged.
- Contributors will now see one warning on builds that omit the gates. That is the point — it names what their green run did not cover.

## Related

- Fixes findings 2 and 4 from `~/tinyhuman/bugs/W3-test-findings.md` (W12 independently hit the same skip as its finding 6).
- Follow-up: nothing blocking. Whether CI should also *run* `json_rpc_e2e` under the product feature set is a lane-owner decision and is not touched here — CI currently names it explicitly, so a misconfiguration there fails loudly rather than skipping.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A — internal audit finding, no Linear issue.
- URL: N/A

### Commit & Branch

- Branch: `fix/loud-skip-and-rpc-assert`
- Commit SHA: `dc743738b`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend file touched.
- [x] `pnpm typecheck` — N/A: no TypeScript touched.
- [x] Focused tests: `cargo test --test worker_c_modules_e2e -- --test-threads=1` — 10 passed, 0 failed, on the exact committed state.
- [x] Rust fmt/check (if changed): `cargo fmt -- --check` — clean.
- [x] Tauri fmt/check (if changed): N/A: the Tauri shell is not touched.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: none at runtime. A build-script warning is added, and a test helper becomes stricter.
- User-visible effect: none for app users; contributors see the new build warning.

### Parity Contract

- Legacy behavior preserved: yes — no product code path is altered.
- Guard/fallback/dispatch parity checks: the helper still tolerates a validation error, so every previously-passing call site still passes; only an unregistered method now fails.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A

---

### Revert-check evidence

| Corrected assertion | Behaviour reverted | Result |
|---|---|---|
| `assert_rpc_completed` | memory_sources controllers unregistered in `core/all.rs` | **FAILED** at `worker_c_modules_e2e.rs:254` — `openhuman.memory_sources_list: the core does not serve this method ... Got: unknown method: openhuman.memory_sources_list`. **The old helper passed that same response**, which is the whole point. |
| build.rs warning | n/a — verified positively: with the gates off the warning lists all four targets and their exact missing features (quoted above); it is absent when they are on. | — |

`core/all.rs` restored afterwards; `git diff` against `main` is empty for it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Developer Experience**
  - Added clearer build-time warnings when test targets are skipped because required features are unavailable.
  - Build configuration changes now trigger appropriate checks when relevant features or manifest settings change.
  - Warnings include the complete feature set needed to enable skipped tests.

- **Tests**
  - Strengthened end-to-end validation for invalid JSON-RPC responses and unknown methods.
  - Reachability checks now reliably detect missing method registrations while preserving valid handler-level error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->