### PR TITLE
fix(test): assert the shipped /skills redirect, and make the TinyBus peel reachable

### DIFF
--- a/app/test/playwright/specs/route-redirect-history.spec.ts
+++ b/app/test/playwright/specs/route-redirect-history.spec.ts
@@ -111,20 +111,25 @@ test.describe('The /channels redirect carries its tab selector through a real na
     await expect.poll(() => hash(page)).toContain('tab=messaging');
   });
 
-  test('/skills?tab=… currently DROPS the query — pinned, see W5 BUG-1', async ({ page }) => {
-    // `AppRoutes.tsx` claims twice that this redirect "preserves ?tab= deep
-    // links". It does not: `<Navigate to="/connections" replace />` takes a
-    // bare path string with no search component. The knock-on is that the
-    // legacy alias table in `pages/Skills.tsx` — written, per its own comment,
-    // so `/skills?tab=composio` keeps working after the redirect — is
-    // unreachable from this route.
+  test('/skills?tab=… carries the deep link through the redirect', async ({ page }) => {
+    // `AppRoutes.tsx` says this redirect "preserves ?tab= deep links", and as of
+    // `d434f1e0f` it does: `/skills` is `<ForwardSearch to="/connections" />`,
+    // which copies `search` and `hash` onto the target rather than dropping them
+    // the way a bare `<Navigate to="/connections" />` did.
     //
-    // Pinned as CURRENT behaviour so it cannot deepen unnoticed. When it is
-    // fixed, flip this to expect `tab=messaging` and delete the note.
+    // This assertion used to be inverted — it pinned the pre-fix behaviour
+    // (`not.toContain('tab=messaging')`) and was written 94 minutes AFTER the
+    // fix landed, so it passed only while the bug was present and would have
+    // gone green through the exact regression it names. Asserting the shipped
+    // behaviour is what makes it a regression test.
+    //
+    // `messaging` is a legacy alias that `Skills.tsx` maps to the `channels`
+    // tab, so the URL keeping the raw value is the contract under test here;
+    // `connections-tab-aliases.spec.ts` covers what it then resolves to.
     await page.goto('/#/skills?tab=messaging');
     await waitForAppReady(page);
 
     await expect.poll(() => hash(page)).toMatch(/^#\/connections/);
-    await expect.poll(() => hash(page)).not.toContain('tab=messaging');
+    await expect.poll(() => hash(page)).toContain('tab=messaging');
   });
 });

--- a/src/openhuman/integrations/composio/module_client.rs
+++ b/src/openhuman/integrations/composio/module_client.rs
@@ -38,11 +38,26 @@ pub fn is_unsupported_by_route(error: &str) -> bool {
 
 /// Keep the structured Composio classification at the start of the error.
 ///
-/// TinyBus prefixes member failures twice — the member name (`Execute: `) and,
-/// since the module extraction, the wire error name
-/// (`ai.tinyhumans.tinybus.Error.Failed: `) — but the frontend parser
-/// intentionally requires the classification at byte zero. Both layers are
-/// peeled before checking; other errors retain their full context unchanged.
+/// TinyBus prefixes a member failure with the member name (`Execute: `) and,
+/// since the module extraction, with its wire error name
+/// (`ai.tinyhumans.tinybus.Error.<Kind>: `) — but the frontend parser
+/// intentionally requires the classification at byte zero, so every transport
+/// layer is peeled before checking. Errors that are not classified retain their
+/// full context unchanged.
+///
+/// # Why the wire layer is peeled in a loop
+///
+/// It used to be peeled once, with a second `strip_prefix` afterwards as a
+/// fallback for `Error.Failed: ` specifically. That fallback could not fire for
+/// the shape its comment described: the single peel above it already consumed
+/// `Error.Failed: `, so the branch was reachable only by a *doubly* wire-wrapped
+/// error — which nothing documented, and which the fallback's own comment did
+/// not claim to handle. Nesting depth is a property of the transport, not
+/// something this function should hardcode a guess at, so it now strips as many
+/// layers as are present. Output is unchanged for every shape the old form
+/// handled, including the double wrap the fallback did catch; a triple or deeper
+/// wrap, which the old form silently passed through unnormalised (and so
+/// reported to the user as an unclassified outage), now normalises too.
 fn normalize_error(member: &str, error: String) -> String {
     const CLASSIFIED: &str = "[composio:error:";
     const WIRE_ERROR_PREFIX: &str = "ai.tinyhumans.tinybus.Error.";
@@ -50,28 +65,20 @@ fn normalize_error(member: &str, error: String) -> String {
         .strip_prefix(member)
         .and_then(|remainder| remainder.strip_prefix(": "))
     {
-        // Optionally peel the bus wire-name layer: `ai.tinyhumans.tinybus.
-        // Error.<Kind>: `. `<Kind>` is a bare identifier, so the next `: `
-        // ends it; anything shaped differently is left alone.
-        let module_error = remainder
+        // Peel each `ai.tinyhumans.tinybus.Error.<Kind>: ` layer. `<Kind>` is a
+        // bare identifier, so the next `: ` ends it; anything shaped differently
+        // stops the loop and is left alone. An embedded marker that does NOT
+        // follow a wire prefix is never promoted — the `starts_with` below is
+        // what decides, and it runs on the fully-peeled remainder only.
+        let mut module_error = remainder;
+        while let Some(tail) = module_error
             .strip_prefix(WIRE_ERROR_PREFIX)
             .and_then(|rest| rest.split_once(": ").map(|(_, tail)| tail))
-            .unwrap_or(remainder);
+        {
+            module_error = tail;
+        }
         if module_error.starts_with(CLASSIFIED) {
             return module_error.to_string();
-        }
-        // Recent TinyBus versions wrap member failures in their wire error
-        // name before preserving the module's message:
-        // `Execute: ai.tinyhumans.tinybus.Error.Failed: [composio:error:…]`.
-        // That wrapper is transport context, not provider text, so retain the
-        // frontend's byte-zero classification contract exactly as for the
-        // older unwrapped shape. Do not promote an arbitrary embedded marker:
-        // it must follow this known TinyBus failure prefix.
-        const TINYBUS_FAILED: &str = "ai.tinyhumans.tinybus.Error.Failed: ";
-        if let Some(classified) = module_error.strip_prefix(TINYBUS_FAILED) {
-            if classified.starts_with(CLASSIFIED) {
-                return classified.to_string();
-            }
         }
     }
     error

--- a/src/openhuman/integrations/composio/module_client_tests.rs
+++ b/src/openhuman/integrations/composio/module_client_tests.rs
@@ -24,6 +24,30 @@ fn classified_errors_stay_at_byte_zero_after_tinybus_failure_wrapping() {
     );
 }
 
+/// The depth the previous single-peel-plus-fallback form could not reach.
+///
+/// That form peeled one `Error.<Kind>: ` layer and had one `Error.Failed: `
+/// fallback, so it topped out at **two** wire layers. This case carries three,
+/// which the old form passed through unnormalised — reaching the frontend as an
+/// unclassified outage ("the provider is down") instead of the classified
+/// reason ("reconnect your account"). Nesting depth belongs to the transport,
+/// not to a hardcoded guess here, so the peel now loops.
+///
+/// Three layers, not two, is deliberate: at two the old fallback still fired,
+/// so a two-layer case passes against the pre-change code and proves nothing.
+#[test]
+fn classification_survives_however_many_wire_layers_tinybus_adds() {
+    assert_eq!(
+        super::normalize_error(
+            methods::EXECUTE,
+            "Execute: ai.tinyhumans.tinybus.Error.A: ai.tinyhumans.tinybus.Error.B: \
+             ai.tinyhumans.tinybus.Error.Failed: [composio:error:rate_limited] Please retry later"
+                .to_string()
+        ),
+        "[composio:error:rate_limited] Please retry later"
+    );
+}
+
 #[test]
 fn unclassified_errors_keep_the_member_context() {
     assert_eq!(


### PR DESCRIPTION
## Summary

- Two Playwright specs asserted the **pre-fix** `/skills` redirect behaviour — that a
  `?tab=` deep link is dropped. `d434f1e0f` fixed that, so in their existing form the fix
  is what would have turned them red, not a regression. Both now assert shipped behaviour.
- `module_client::normalize_error` carried a `TINYBUS_FAILED` fallback that could not fire
  for the shape its own comment described. The wire-name peel now loops, which makes the
  handling reachable at any depth and closes a latent case the old form got wrong.
- Both changes revert-checked. One of my own new tests turned out vacuous on the first
  attempt; that is described below rather than quietly fixed.

## Problem — the specs

`AppRoutes.tsx:171` became `<ForwardSearch to="/connections" />` in `d434f1e0f`
(2026-09-01 13:41), which copies `search` and `hash` onto the redirect target. Two specs
still pinned the behaviour it replaced:

| spec | assertion | committed |
|---|---|---|
| `route-redirect-history.spec.ts:114` | `not.toContain('tab=messaging')` | 15:15 — **94 min after the fix** |
| `connections-tab-deeplinks.spec.ts:176` | `not.toContain('tab=channels')` + `expectSelectedTab('welcome')` | before the fix, never updated |

Both carried a "flip this when it lands" note that was never actioned. A test in that
shape passes only while the bug exists — it is a regression test pointed backwards.

## Problem — `normalize_error`

```rust
let module_error = remainder
    .strip_prefix(WIRE_ERROR_PREFIX)               // "ai.tinyhumans.tinybus.Error."
    .and_then(|rest| rest.split_once(": ").map(|(_, tail)| tail))
    .unwrap_or(remainder);
if module_error.starts_with(CLASSIFIED) { return module_error.to_string(); }

const TINYBUS_FAILED: &str = "ai.tinyhumans.tinybus.Error.Failed: ";
if let Some(classified) = module_error.strip_prefix(TINYBUS_FAILED) { … }   // ← could not fire
```

The peel above already consumes `Error.Failed: `, so the fallback was reachable only by a
**doubly** wire-wrapped error — a shape nothing documents and which its comment does not
claim. Confirmed rather than argued: with the fallback removed,
`classified_errors_stay_at_byte_zero_after_tinybus_failure_wrapping` — which asserts
exactly the documented shape — still passes.

## Solution

Deleting the fallback outright would have regressed the two-layer case it *did* catch, so
the peel loops instead. Output is identical for every shape the old form handled. A
three-layer wrap, which the old form passed through unnormalised — reaching the frontend
as an unclassified outage ("the provider is down") rather than the classified reason
("reconnect your account") — now normalises too, and that depth is pinned by a new test.

## Revert-check

**Playwright** — `/skills` reverted to a bare `<Navigate to="/connections" replace />`,
`dist-web` rebuilt (the session serves the prebuilt bundle; without the rebuild the proof
is vacuous). Only the `/skills` route was reverted so `ForwardSearch` stays in use by
`/webhooks` — an unused import fails the TS build, and a failed build leaves `dist-web`
stale and silently re-tests the old bundle.

| spec | corrected | reverted | restored |
|---|---|---|---|
| `route-redirect-history.spec.ts` | pass | **FAIL** `:133` `toContain('tab=messaging')`, received `"#/connections"` | pass |
| `connections-tab-deeplinks.spec.ts` | pass | **FAIL** `:194` `toContain('tab=channels')`, received `"#/connections"` | pass |

**Rust** — loop reverted to single-peel-plus-fallback:

```
classification_survives_however_many_wire_layers_tinybus_adds ... FAILED
  left:  "Execute: …Error.A: …Error.B: …Error.Failed: [composio:error:rate_limited] …"
  right: "[composio:error:rate_limited] Please retry later"
test result: FAILED. 7 passed; 1 failed      →  restored →  ok. 8 passed
```

**A vacuous test I caught and fixed.** The first version of that depth test used *two*
wire layers and **passed against the reverted code** — the old fallback still fires at
exactly that depth, so it proved nothing. It carries three layers now, which is the first
depth the old form cannot reach. Worth stating plainly: that is the same defect class as
the specs this PR fixes, and only the revert-check surfaced it.

## What was executed locally

The Playwright lane does not run on PRs to `main` (`ci-lite.yml` has no Playwright;
`ci-full.yml` is `release`-only; `e2e-playwright.yml` is `workflow_dispatch`), so CI will
not exercise these specs on this PR. Everything below was run locally on dedicated ports:

- `e2e-web-session.sh test/playwright/specs/route-redirect-history.spec.ts -g "carries the deep link"` → 1 passed
- `e2e-web-session.sh test/playwright/specs/connections-tab-deeplinks.spec.ts -g "keeps the tab through the redirect"` → 1 passed
- both specs, `-g "through the redirect"`, against the faulted bundle → 2 failed (above)
- both specs again after restore + rebuild → 2 passed
- `cargo test -p openhuman --lib module_client` → 8 passed (and 7 passed / 1 failed under revert)

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — two corrected assertions plus one new depth test, each revert-checked.
- [x] **Diff coverage ≥ 80%** — N/A: the only production change is `normalize_error`, whose every branch is exercised by the eight `module_client` tests; the rest of the diff is test code.
- [x] Coverage matrix updated — N/A: no feature rows added, removed or renamed.
- [x] All affected feature IDs from the matrix are listed under `## Related` — N/A: no feature IDs affected.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: no shipped surface changes; the routing behaviour is unchanged, only its tests.
- [x] Linked issue closed via `Closes #NNN` — N/A: these are findings from a test audit, not filed issues.

## Impact

- Runtime/platform impact: `normalize_error` only. Identical output for every previously
  handled shape; a three-or-more-layer wrap is now classified instead of surfacing as an
  unclassified outage.
- No routing behaviour changes — `AppRoutes.tsx` is untouched in the final diff.

## Related

- Corrects specs pinning the pre-fix behaviour of `d434f1e0f`.
- `main` may still be red on unrelated pre-existing failures; nothing here touches them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Redirects from skills links now preserve query parameters, keeping deep-link context when navigating to Connections.
  - Improved integration error handling now correctly classifies errors even when they include multiple layers of wrapping.
  - Prevented deeply nested wrapped errors from appearing as unclassified outages.

- **Tests**
  - Added coverage for query-parameter preservation during redirects.
  - Added coverage for error classification across multiple wrapping layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->