### PR TITLE
fix(git_operations): stop `-c diff.external=` from breaking every diff

### DIFF
--- a/src/openhuman/tools/impl/filesystem/git_operations.rs
+++ b/src/openhuman/tools/impl/filesystem/git_operations.rs
@@ -174,7 +174,14 @@ impl GitOperationsTool {
         // Validate files argument against injection patterns
         self.sanitize_git_args(files)?;
 
-        let mut git_args = vec!["diff", "--unified=3"];
+        // `--no-ext-diff` is what actually refuses a repository-set
+        // `diff.external`. It cannot be done with a `-c` override the way the
+        // other command-valued keys are neutralised — an empty value makes git
+        // execute the empty string rather than disable the driver — so the
+        // flag lives here, on the one operation that can run one (#5979).
+        // `git_log` uses `--pretty=format:` and never produces a patch, so it
+        // has no external diff to refuse.
+        let mut git_args = vec!["diff", "--no-ext-diff", "--unified=3"];
         if cached {
             git_args.push("--cached");
         }

--- a/src/openhuman/tools/impl/filesystem/git_operations_config.rs
+++ b/src/openhuman/tools/impl/filesystem/git_operations_config.rs
@@ -120,12 +120,31 @@ pub(super) const ALLOWED_REPO_CONFIG: &[&str] = &[
 ///
 /// `core.hooksPath` and `commit.gpgSign` are handled separately, in
 /// [`hardened_git`] — see there for why.
+///
+/// `diff.external` is deliberately **absent** from this list, and must stay
+/// absent. It is command-valued like the rest, but unlike the rest there is no
+/// `-c` value that means "none": an empty value does not disable the driver,
+/// it makes git execute the empty string, so `-c diff.external=` turns every
+/// diff into
+///
+/// ```text
+/// error: cannot run : No such file or directory
+/// fatal: external diff died, stopping at <file>
+/// ```
+///
+/// — which is not hardening, it is an outage that merely looks like one
+/// (#5979). The supported way to refuse an external diff driver is the
+/// `--no-ext-diff` flag, which [`super::git_operations`] passes on the one
+/// operation that can run one; verified directly, against a repository whose
+/// `diff.external` names a script that touches a marker file: without the flag
+/// the marker appears, with it the diff is correct and the marker does not.
+/// The env half of the same hole is closed by
+/// [`suppress_ambient_git_config`]'s `GIT_EXTERNAL_DIFF` removal.
 pub(super) const NEUTRALISED_CONFIG: &[&str] = &[
     "core.fsmonitor=",
     "core.sshCommand=",
     "core.pager=cat",
     "core.editor=false",
-    "diff.external=",
     "sequence.editor=false",
     "uploadpack.packObjectsHook=",
 ];

--- a/src/openhuman/tools/impl/filesystem/git_operations_config_tests.rs
+++ b/src/openhuman/tools/impl/filesystem/git_operations_config_tests.rs
@@ -9,7 +9,7 @@
 //! still resolves `GitOperationsTool` the way it did before the split, and so
 //! the fixtures in the sibling test module stay reachable.
 
-use super::super::git_operations_config::normalise_config_key;
+use super::super::git_operations_config::{normalise_config_key, NEUTRALISED_CONFIG};
 // The fixtures stay in `git_operations_tests.rs` and are shared rather than
 // duplicated: both modules are children of `git_operations`, so `pub(super)`
 // there makes them reachable here.
@@ -462,4 +462,150 @@ fn a_subsection_is_elided_so_one_entry_covers_every_remote() {
     );
     // A key with no dot at all is returned unchanged rather than panicking.
     assert_eq!(normalise_config_key("bare"), "bare");
+}
+
+// ── `diff.external` (#5979) ─────────────────────────────────────────────────
+
+/// The regression that started it: a perfectly ordinary repository, with no
+/// config of its own, must be able to produce a diff.
+///
+/// `NEUTRALISED_CONFIG` used to carry `diff.external=`, and an empty value
+/// does not disable an external diff driver — git executes the empty string —
+/// so every `diff` this tool ran died with `cannot run : No such file or
+/// directory`. The hardening layer was an outage wearing hardening's clothes.
+#[tokio::test]
+async fn an_ordinary_repository_still_produces_a_diff() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    std::fs::write(tmp.path().join("tracked.txt"), "first\n").unwrap();
+    commit_all(tmp.path(), "init");
+    std::fs::write(tmp.path().join("tracked.txt"), "first\nsecond\n").unwrap();
+
+    let tool = test_tool(tmp.path());
+    let result = tool
+        .execute(json!({"operation": "diff", "files": "tracked.txt"}))
+        .await
+        .expect("diff should run");
+
+    assert!(
+        !result.is_error,
+        "an ordinary repository's diff must succeed, got: {}",
+        result.output()
+    );
+    assert!(
+        result.output().contains("second"),
+        "the diff should carry the added line, got: {}",
+        result.output()
+    );
+}
+
+/// And the property the broken entry was reaching for still holds: a
+/// repository that names an external diff driver never gets it run.
+///
+/// The allowlist refuses the operation outright — `diff.external` is not on
+/// `ALLOWED_REPO_CONFIG` — which is the fail-closed guarantee. `--no-ext-diff`
+/// on the command is the second layer, for a key written into the repository
+/// in the gap between that inspection and the command itself.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_repository_naming_an_external_diff_driver_never_gets_it_run() {
+    let tmp = TempDir::new().unwrap();
+    init_git_repo(tmp.path());
+    std::fs::write(tmp.path().join("tracked.txt"), "first\n").unwrap();
+    commit_all(tmp.path(), "init");
+    std::fs::write(tmp.path().join("tracked.txt"), "first\nsecond\n").unwrap();
+    let marker = plant_external_diff_driver(tmp.path());
+
+    let tool = test_tool(tmp.path());
+    let result = tool
+        .execute(json!({"operation": "diff", "files": "tracked.txt"}))
+        .await;
+    let msg = error_text(&result);
+
+    assert!(
+        !marker.exists(),
+        "`git diff` executed the command named by the repository's own \
+         config — this tool is a code-execution primitive"
+    );
+    assert!(
+        msg.contains("diff.external"),
+        "the refusal should name the key that caused it, got: {msg}"
+    );
+}
+
+/// `diff.external` must never be re-added to `NEUTRALISED_CONFIG`: there is no
+/// `-c` value for it that means "none", so any entry there breaks every diff.
+#[test]
+fn diff_external_is_not_neutralised_by_a_config_override() {
+    assert!(
+        !NEUTRALISED_CONFIG
+            .iter()
+            .any(|kv| kv.starts_with("diff.external")),
+        "`diff.external` cannot be neutralised with `-c`; use `--no-ext-diff` \
+         on the command instead (#5979)"
+    );
+}
+
+/// Plant an executable external diff driver in the repository's own config,
+/// after first proving the script runs at all — so a passing test means the
+/// tool refused it, not that the fixture was inert.
+#[cfg(unix)]
+fn plant_external_diff_driver(dir: &std::path::Path) -> std::path::PathBuf {
+    let driver = dir.join("extdiff.sh");
+    let marker = dir.join("EXTERNAL_DIFF_RAN");
+    std::fs::write(
+        &driver,
+        format!("#!/bin/sh\ntouch {:?}\nexit 0\n", marker.to_string_lossy()),
+    )
+    .unwrap();
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(&driver, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    std::process::Command::new(&driver).status().unwrap();
+    assert!(marker.exists(), "the planted driver does not run at all");
+    std::fs::remove_file(&marker).unwrap();
+
+    let ok = hermetic(
+        std::process::Command::new("git")
+            .args(["config", "diff.external"])
+            .arg(&driver)
+            .current_dir(dir),
+    )
+    .status()
+    .unwrap();
+    assert!(ok.success(), "could not set diff.external");
+
+    marker
+}
+
+/// Stage everything and commit, hermetically — the surrounding tests need a
+/// commit to diff against.
+fn commit_all(dir: &std::path::Path, message: &str) {
+    let ok = hermetic(
+        std::process::Command::new("git")
+            .args(["add", "-A"])
+            .current_dir(dir),
+    )
+    .status()
+    .unwrap();
+    assert!(ok.success(), "git add failed");
+
+    let ok = hermetic(
+        std::process::Command::new("git")
+            .args([
+                "-c",
+                "user.email=test@example.com",
+                "-c",
+                "user.name=test",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "-m",
+                message,
+            ])
+            .current_dir(dir),
+    )
+    .status()
+    .unwrap();
+    assert!(ok.success(), "git commit failed");
 }


### PR DESCRIPTION
Closes #5979.

## The bug

`hardened_git` injects every `NEUTRALISED_CONFIG` entry as a `-c` override, and one of them was `diff.external=`. An empty value does **not** disable an external diff driver — git tries to execute the empty string — so every `diff` this tool ran died with:

```
error: cannot run : No such file or directory
fatal: external diff died, stopping at <file>
```

That is not hardening; it is an outage wearing hardening's clothes. `GitOperationsTool`'s `diff` operation is broken on `main` for **every** repository, with or without config of its own — this is a user-facing break, not only a test failure.

Reproduced standalone, no OpenHuman involved:

```console
$ git init -q . && echo a > f.txt && git add f.txt && git commit -qm init && echo b >> f.txt

$ git -c diff.external= diff -- f.txt
error: cannot run : No such file or directory
fatal: external diff died, stopping at f.txt

$ git -c diff.external= diff --no-ext-diff -- f.txt
diff --git a/f.txt b/f.txt          # correct
```

## The fix

`diff.external` cannot be neutralised by a `-c` value — there is no value meaning "none". Two things replace it, and together they are strictly stronger than what they replace:

- **The allowlist already refuses it.** `diff.external` is not on `ALLOWED_REPO_CONFIG`, so a repository that sets it is refused outright by `first_disallowed_repo_config_key`. That is the fail-closed guarantee, and the `-c` entry never carried it.
- **`--no-ext-diff` on the command** covers what the `-c` entry was actually reaching for: a key written into the repository in the gap between that inspection and the command itself — the race the `NEUTRALISED_CONFIG` doc comment describes.

Verified directly, against a repository whose `diff.external` names a script that touches a marker file: without the flag the marker appears and the driver's output is used; with it the diff is correct and the marker never appears. `GIT_EXTERNAL_DIFF` was already cleared by `suppress_ambient_git_config`, so the env half was never open.

`git_log` passes `--pretty=format:` and never produces a patch, so it has no external diff to refuse; `diff` is the only affected operation.

## Why it wasn't caught

The coverage lane derives which raw-coverage modules to run from the changed paths, so `tools_network_channels_raw_coverage_e2e` only runs when the diff reaches into that area. It surfaced on #5955 — a PR that touches no git code at all.

## Test plan

- [x] `an_ordinary_repository_still_produces_a_diff` — the regression: a repository with no config of its own can produce a diff
- [x] `a_repository_naming_an_external_diff_driver_never_gets_it_run` — the hardening property still holds; the planted driver is proven to run before it is planted, so a pass means refusal, not an inert fixture
- [x] `diff_external_is_not_neutralised_by_a_config_override` — pins that the entry is never re-added, since the value that looks correct there is the one that breaks the tool
- [x] `tools_network_channels_raw_coverage_e2e::git_operations_cover_read_write_markdown_and_safety_rejections` — the CI test that exposed this now passes
- [x] `cargo clippy` (product feature set) clean at `-D warnings`; `cargo fmt --check` clean
- [x] 15/15 `git_operations::config_tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)