### PR TITLE
fix(tinyagents): deliver TurnCompleted instead of dropping it on a full channel

### DIFF
--- a/src/openhuman/agent/tinyagents/mod_part_02.rs
+++ b/src/openhuman/agent/tinyagents/mod_part_02.rs
@@ -547,9 +547,32 @@ pub(crate) async fn run_turn_via_tinyagents_shared(
     // (`defer_turn_completed_to_caller`, #4457 defect C) — so this is the single
     // emission point for callers with no post-run streaming (channel/CLI).
     if let Some(sink) = &turn_completed_sink {
-        let _ = sink.try_send(AgentProgress::TurnCompleted {
-            iterations: run.model_calls as u32,
-        });
+        // NOT best-effort. `TurnCompleted` is the web bridge's sole completion
+        // signal: drop it and `parent_completed` stays false, so the bridge
+        // marks a turn that actually finished as `interrupted` and never emits
+        // `chat_done`. The turn's output still reaches the journal, session
+        // transcript and memory tree, so the agent "remembers" replying while
+        // the user's thread shows silence. A heavy turn (many tools + long
+        // streaming) reliably fills the 256-slot channel, which is why only
+        // tool-heavy turns were affected.
+        //
+        // Blocking is safe *here specifically*: this site is guarded by
+        // `subagent_scope.is_none()`, so it only ever runs on a parent turn
+        // with nothing awaiting it. The sub-agent stall documented on
+        // `tool_progress::emit` comes from parking a *sub-agent's* loop while
+        // the orchestrator awaits its tool call — unreachable from this path.
+        // Deltas and sub-agent lifecycle events stay lossy via `emit`.
+        if let Err(err) = sink
+            .send(AgentProgress::TurnCompleted {
+                iterations: run.model_calls as u32,
+            })
+            .await
+        {
+            tracing::warn!(
+                error = %err,
+                "[tinyagents] TurnCompleted not delivered — progress receiver gone"
+            );
+        }
     }
 
     // Response-cache effectiveness for this turn (issue #4249, 03.2). Additive —


### PR DESCRIPTION
## Problem

`AgentProgress` rides a bounded 256-slot mpsc (`web_chat/run_task.rs`) whose producer uses `try_send`, so events are dropped when the consumer is behind. The terminal `TurnCompleted` was emitted through that same lossy path:

```rust
let _ = sink.try_send(AgentProgress::TurnCompleted { .. });
```

The web-chat progress bridge sets `parent_completed` on `TurnCompleted` **and on nothing else**. When the event is dropped, the bridge falls out of its loop on sender-drop with `parent_completed == false`, records the run as `interrupted` ("progress bridge exited before turn completion"), and never emits `chat_done`.

The turn has already succeeded at that point. The journal records `run_completed`, and the reply is persisted to the journal, the session transcript and the memory tree. Only the user-visible thread misses it, so:

- the UI shows a tool running, then silence, forever — no error, no retry affordance
- the agent reads its own reply back as context next turn and behaves as though it had answered, which reads to the user as the agent gaslighting them

Only tool-heavy turns are affected, because only they generate enough events to fill the buffer. On the affected deployment, turns with 5 tool calls were reliably lost while 0-tool turns always completed.

## Fix

`try_send` → `send().await` at that one call site, with the send error logged rather than discarded.

Blocking is safe **here specifically**: the site is guarded by `subagent_scope.is_none()`, so it only runs on a parent turn that nothing is awaiting. The sub-agent stall documented on `harness::session::tool_progress::emit` requires parking a *sub-agent's* loop while the orchestrator awaits its tool call, which is unreachable from this path. Deltas and sub-agent lifecycle events keep the lossy `emit` path deliberately — this does not touch them.

## Verification

On a self-hosted core, driving real turns over the socket:

| turn shape | before | after |
| --- | --- | --- |
| `tools=5 out=1044` | `interrupted`, no `chat_done` | — |
| `tools=6 out=2407` | — | `completed` |
| `tools=16 out=444` | — | `completed` |

16 tool calls now completes and emits `chat_done`; 5 previously did not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUGA1hdDQCr2u1b1hKwpV7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved turn completion handling to ensure finished turns are consistently reported as complete.
  - Prevented successfully completed turns from being incorrectly marked as interrupted when completion notifications are delayed.
  - Added clearer warning visibility when a completion notification cannot be delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->