### PR TITLE
fix(claude-code): stop handing the CLI's own tool calls to the harness

### DIFF
--- a/src/openhuman/inference/provider/claude_code/driver.rs
+++ b/src/openhuman/inference/provider/claude_code/driver.rs
@@ -16,7 +16,23 @@ use tokio::sync::mpsc;
 
 /// Hard timeout per turn (PLAN §8). If the CLI hangs (network stall,
 /// infinite loop, MCP deadlock) we kill the child and surface a timeout.
-const TURN_TIMEOUT: Duration = Duration::from_secs(300);
+const DEFAULT_TURN_TIMEOUT_SECS: u64 = 900;
+
+/// Hard timeout per turn, overridable with
+/// `OPENHUMAN_CLAUDE_CODE_TURN_TIMEOUT_SECS`.
+///
+/// The default matches the harness's own 900s wall-clock backstop. It used to
+/// be 300s, which is shorter than a turn the CLI is *expected* to take once
+/// full access lets it run its own tools: the child was killed mid-work and the
+/// turn surfaced as a provider timeout rather than a slow answer.
+fn turn_timeout() -> Duration {
+    let secs = std::env::var("OPENHUMAN_CLAUDE_CODE_TURN_TIMEOUT_SECS")
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .unwrap_or(DEFAULT_TURN_TIMEOUT_SECS);
+    Duration::from_secs(secs)
+}
 
 use super::event_mapper::EventMapper;
 use super::input_builder::build_stdin;
@@ -431,7 +447,7 @@ pub async fn run_turn(ctx: TurnContext<'_>) -> anyhow::Result<ChatResponse> {
 
     // Wrap the streaming + wait in a timeout so a stuck CLI doesn't
     // block this task forever (PLAN §8).
-    let timed = tokio::time::timeout(TURN_TIMEOUT, async {
+    let timed = tokio::time::timeout(turn_timeout(), async {
         loop {
             let n = stdout
                 .read(&mut buf)
@@ -468,14 +484,15 @@ pub async fn run_turn(ctx: TurnContext<'_>) -> anyhow::Result<ChatResponse> {
         Ok(inner) => inner?,
         Err(_elapsed) => {
             log::error!(
-                "[claude-code][driver] turn timeout ({TURN_TIMEOUT:?}) exceeded; killing child"
+                "[claude-code][driver] turn timeout ({:?}) exceeded; killing child",
+                turn_timeout()
             );
             // kill_on_drop handles cleanup, but explicit kill gives us
             // a chance to collect stderr.
             let _ = child.kill().await;
             anyhow::bail!(
                 "[claude-code][driver] turn timed out after {:?}",
-                TURN_TIMEOUT
+                turn_timeout()
             );
         }
     };

--- a/src/openhuman/inference/provider/claude_code/event_mapper.rs
+++ b/src/openhuman/inference/provider/claude_code/event_mapper.rs
@@ -172,17 +172,24 @@ impl EventMapper {
                 }
                 let call_id = call_id.unwrap();
                 let tool_name = tool_name.unwrap();
+                // The block is tracked so its `input_json_delta`s and its stop
+                // event are swallowed rather than leaking, but it is NOT
+                // surfaced to OpenHuman's harness — see the note on
+                // `on_block_stop`.
+                log::debug!(
+                    "[claude-code][event-mapper] cli-internal tool_use name={tool_name} id={call_id} (not surfaced)"
+                );
                 self.blocks.insert(
                     index,
                     BlockState {
                         kind: BlockKind::Tool,
-                        call_id: Some(call_id.clone()),
-                        tool_name: Some(tool_name.clone()),
+                        call_id: Some(call_id),
+                        tool_name: Some(tool_name),
                         text_accum: String::new(),
                         input_accum: String::new(),
                     },
                 );
-                vec![ProviderDelta::ToolCallStart { call_id, tool_name }]
+                Vec::new()
             }
             _ => Vec::new(),
         }
@@ -224,12 +231,10 @@ impl EventMapper {
                     .and_then(Value::as_str)
                     .unwrap_or("")
                     .to_string();
+                // Accumulated for the debug log only; the call itself is the
+                // CLI's to run, so nothing is emitted (see `on_block_stop`).
                 state.input_accum.push_str(&partial);
-                let call_id = state.call_id.clone().unwrap_or_default();
-                vec![ProviderDelta::ToolCallArgsDelta {
-                    call_id,
-                    delta: partial,
-                }]
+                Vec::new()
             }
             _ => Vec::new(),
         }
@@ -240,20 +245,26 @@ impl EventMapper {
             return Vec::new();
         };
         if state.kind == BlockKind::Tool {
-            let call_id = state.call_id.unwrap_or_default();
-            let name = state.tool_name.unwrap_or_default();
-            let arguments = if state.input_accum.trim().is_empty() {
-                "{}".to_string()
-            } else {
-                state.input_accum.clone()
-            };
-            self.tool_calls.push(ToolCall {
-                id: call_id,
-                name,
-                arguments,
-                // Claude Code CLI events carry no OpenAI-compat extra_content.
-                extra_content: None,
-            });
+            // A native `tool_use` block from this CLI is the CLI's OWN call —
+            // its builtins (Bash / Read / Write / Edit …) or a server from the
+            // `--mcp-config` we hand it. The CLI executes them itself inside
+            // its own agentic loop, which is why the matching `tool_result`
+            // blocks are deliberately dropped in `map_event`.
+            //
+            // Surfacing the *call* while dropping its *result* handed
+            // OpenHuman's harness a tool it does not own and cannot run: with
+            // `full_access` on (no `--disallowedTools`), a turn that reached
+            // for `Bash` produced repeated tool failures until the circuit
+            // breaker halted the run, and the turn then burned its 900s
+            // wall-clock backstop. So neither half is surfaced, and this
+            // provider behaves as what it is — a chat model whose tool use is
+            // internal. OpenHuman's own tools reach it through the prompt
+            // catalogue, not through native tool calls.
+            log::debug!(
+                "[claude-code][event-mapper] dropping cli-internal tool call name={} args_len={}",
+                state.tool_name.unwrap_or_default(),
+                state.input_accum.len()
+            );
         }
         Vec::new()
     }

--- a/src/openhuman/inference/provider/claude_code/event_mapper_tests.rs
+++ b/src/openhuman/inference/provider/claude_code/event_mapper_tests.rs
@@ -25,22 +25,58 @@ fn text_streams_through() {
     assert_eq!(m.final_text, "hello");
 }
 
+/// A native `tool_use` block is the CLI's own call — a builtin, or a server
+/// from the `--mcp-config` it was handed — and the CLI runs it inside its own
+/// loop. The matching `tool_result` was always dropped; surfacing the call
+/// while dropping its result handed OpenHuman's harness a tool it cannot run,
+/// which failed repeatedly until the circuit breaker halted the whole turn.
+/// Neither half is surfaced now.
 #[test]
-fn tool_call_assembles_input() {
+fn cli_internal_tool_calls_are_not_surfaced_to_the_harness() {
     let mut m = EventMapper::new();
-    let start = json!({"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"call_1","name":"memory_search"}});
-    let d_args = json!({"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"q\":\"foo\"}"}});
+    let start = json!({"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"call_1","name":"Bash"}});
+    let d_args = json!({"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"command\":\"ls\"}"}});
     let stop = json!({"type":"content_block_stop","index":1});
-    let starts = m.handle(ClaudeCodeEvent::StreamEvent { event: start });
+
     assert!(
-        matches!(&starts[0], ProviderDelta::ToolCallStart { tool_name, .. } if tool_name == "memory_search")
+        m.handle(ClaudeCodeEvent::StreamEvent { event: start })
+            .is_empty(),
+        "no ToolCallStart reaches the harness"
     );
-    let args = m.handle(ClaudeCodeEvent::StreamEvent { event: d_args });
-    assert!(matches!(&args[0], ProviderDelta::ToolCallArgsDelta { .. }));
+    assert!(
+        m.handle(ClaudeCodeEvent::StreamEvent { event: d_args })
+            .is_empty(),
+        "no ToolCallArgsDelta reaches the harness"
+    );
     m.handle(ClaudeCodeEvent::StreamEvent { event: stop });
-    assert_eq!(m.tool_calls.len(), 1);
-    assert_eq!(m.tool_calls[0].name, "memory_search");
-    assert_eq!(m.tool_calls[0].arguments, r#"{"q":"foo"}"#);
+
+    assert!(
+        m.tool_calls.is_empty(),
+        "the aggregated response carries no tool calls for the harness to execute"
+    );
+}
+
+/// Text in the same turn still streams normally — dropping the tool block must
+/// not swallow the CLI's actual answer.
+#[test]
+fn text_in_a_turn_with_a_cli_tool_call_still_streams() {
+    let mut m = EventMapper::new();
+    m.handle(ClaudeCodeEvent::StreamEvent {
+        event: json!({"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"call_1","name":"Write"}}),
+    });
+    m.handle(ClaudeCodeEvent::StreamEvent {
+        event: json!({"type":"content_block_stop","index":0}),
+    });
+    m.handle(ClaudeCodeEvent::StreamEvent {
+        event: text_block_start(1),
+    });
+    let deltas = m.handle(ClaudeCodeEvent::StreamEvent {
+        event: text_delta(1, "done"),
+    });
+
+    assert!(matches!(&deltas[0], ProviderDelta::TextDelta { delta } if delta == "done"));
+    assert_eq!(m.final_text, "done");
+    assert!(m.tool_calls.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- A native `tool_use` block from the Claude Code CLI is the **CLI's own** call — a builtin (`Bash` / `Read` / `Write` / `Edit` …) or a server from the `--mcp-config` we hand it. The CLI runs it inside its own agentic loop.
- The matching `tool_result` blocks were already dropped for that reason, but the *call* half was still surfaced to OpenHuman's harness, which cannot run those tools and never sees a result for them.
- With the full-access toggle on (no `--disallowedTools`, so the CLI keeps `Bash`), a turn that reached for a builtin failed repeatedly until the circuit breaker halted the run, then burned the 900s wall-clock backstop.
- Also raises the driver's per-turn timeout from 300s to 900s (overridable), since 300s is shorter than a turn the CLI is expected to take once it is doing real work.

## Problem

Observed in a live desktop session with `chat_provider = "claude-code:claude-opus-5"` and `claude_code_settings.json` = `{"full_access": true}`:

```
[tinyagents::mw] no-progress nudge — steering the model … tool=Bash step=4
[tinyagents::mw] repeated tool failure — halting run … tool=Write step=6
[tinyagents] run halted by circuit breaker; surfacing as breaker_halt (#4466)
[web-channel] run_chat_task failed … openhuman_turn_wall_clock_timeout: agent turn exceeded its 900s …
[claude-code][driver] turn timeout (300s) exceeded; killing child
```

Two independent defects behind one symptom:

1. `event_mapper.rs` mapped every `tool_use` block to `ProviderDelta::ToolCallStart` / `ToolCallArgsDelta` and pushed it into `ChatResponse.tool_calls` — including the CLI's own builtins. The harness then tried to execute `Bash`, which is not an OpenHuman tool. Asymmetric with `map_event`'s `User` arm, which drops the corresponding `tool_result` precisely because "the harness owns tools … not CC internals".
2. `TURN_TIMEOUT` was a hard 300s. Full access means the CLI does real multi-step work; the child was killed mid-turn and the failure read as a provider timeout rather than a slow answer.

## Solution

1. Track the `tool_use` block (so its `input_json_delta`s and stop event are swallowed rather than leaking as stray deltas) but surface nothing — no `ToolCallStart`, no `ToolCallArgsDelta`, no entry in `tool_calls`. The provider is then what it actually is: a chat model whose tool use is internal. OpenHuman's own tools reach it through the prompt catalogue, not native tool calls.
2. `turn_timeout()` reads `OPENHUMAN_CLAUDE_CODE_TURN_TIMEOUT_SECS`, defaulting to 900s to match the harness's own wall-clock backstop.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `cli_internal_tool_calls_are_not_surfaced_to_the_harness` (the regression) and `text_in_a_turn_with_a_cli_tool_call_still_streams` (the answer must survive the dropped block). `tool_call_assembles_input` pinned the old behaviour and was replaced by the first of these.
- [x] **Diff coverage ≥ 80%** — the changed mapper branches are executed by both tests. `cargo test --lib inference::provider::claude_code`: 45 passed, 0 failed.
- [x] Coverage matrix updated — `N/A: bug fix to existing behaviour, no feature row added, removed or renamed`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix row covers the claude-code event mapper`
- [x] No new external network dependencies introduced — unit tests are pure event-mapper tests; no network.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface changes`
- [x] Linked issue closed via `Closes #NNN` — `N/A: no filed issue; found while running the Claude Code CLI provider with full access`

## Impact

Desktop/CLI, and only for workloads routed to `claude-code:<model>`. Behaviour change: the aggregated response no longer reports the CLI's internal tool calls, so a caller that inspected `ChatResponse.tool_calls` for this provider now sees an empty list — which is the honest answer, since those calls were never executable here and never had results attached.

The timeout default triples. A genuinely hung CLI now takes 900s to surface instead of 300s; the env var is there for anyone who wants the old value back.

Verified end to end against the live CLI: "create a file … then read it back" returns `File written, read back: TOOLS_WORK`, the file exists on disk, and the run logs zero `repeated tool failure` / `breaker_halt` lines. The same class of turn halted at step 6 before the change.

## Related

N/A — no linked issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default Claude Code operation timeout to 15 minutes.
  * Added an environment setting to customize the timeout duration.
  * Prevented Claude Code’s internal tool activity from appearing as user-facing tool calls.
  * Preserved normal text streaming when internal tool activity occurs.
  * Updated timeout messages and logs to show the applicable duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->