### PR TITLE
fix(embeddings): retain editable custom settings

### DIFF
--- a/app/src/components/settings/panels/EmbeddingsPanel.tsx
+++ b/app/src/components/settings/panels/EmbeddingsPanel.tsx
@@ -137,9 +137,8 @@ const EmbeddingsPanel = ({ embedded = false }: EmbeddingsPanelProps = {}) => {
     if (entry.slug !== 'managed') setManagedSessionMissing(false);
 
     if (entry.slug === 'custom') {
-      // Custom doubles as an editable saved profile. It must reopen even when
-      // already selected, and it must hydrate from the retained profile when
-      // embeddings are currently disabled or routed elsewhere.
+      // Custom is an editable profile, not a plain selection: reopen (and
+      // hydrate from the retained profile) even when already selected.
       const loadedSettings = settings!;
       const activeEndpoint = loadedSettings.provider.startsWith('custom:')
         ? loadedSettings.provider.slice('custom:'.length)

--- a/app/src/components/settings/panels/EmbeddingsPanel.tsx
+++ b/app/src/components/settings/panels/EmbeddingsPanel.tsx
@@ -135,20 +135,38 @@ const EmbeddingsPanel = ({ embedded = false }: EmbeddingsPanelProps = {}) => {
 
   function handleProviderClick(entry: EmbeddingProviderEntry) {
     if (entry.slug !== 'managed') setManagedSessionMissing(false);
+
+    if (entry.slug === 'custom') {
+      // Custom doubles as an editable saved profile. It must reopen even when
+      // already selected, and it must hydrate from the retained profile when
+      // embeddings are currently disabled or routed elsewhere.
+      const loadedSettings = settings!;
+      const activeEndpoint = loadedSettings.provider.startsWith('custom:')
+        ? loadedSettings.provider.slice('custom:'.length)
+        : '';
+      const profile = activeEndpoint
+        ? {
+            endpoint: activeEndpoint,
+            model: loadedSettings.model,
+            dimensions: loadedSettings.dimensions,
+          }
+        : loadedSettings.custom_settings;
+      setCustomEndpoint(profile?.endpoint ?? customEndpoint);
+      setCustomModel(profile?.model ?? customModel);
+      setCustomDims(String(profile?.dimensions ?? customDims));
+      setSetupProvider(entry);
+      setSetupKey('');
+      setSetupShowKey(false);
+      setSetupTestResult(null);
+      setSetupError('');
+      return;
+    }
+
     if (entry.slug === selectedProvider) return;
 
     if (entry.slug === 'managed' && isLocalSession) {
       setManagedSessionMissing(true);
       setStatus({ kind: 'error', message: managedLoginMessage });
-      return;
-    }
-
-    if (entry.slug === 'custom') {
-      // For custom, open setup popup to enter endpoint
-      setSetupProvider(entry);
-      setSetupKey('');
-      setSetupTestResult(null);
-      setSetupError('');
       return;
     }
 

--- a/app/src/components/settings/panels/__tests__/EmbeddingsPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/EmbeddingsPanel.test.tsx
@@ -392,6 +392,69 @@ describe('EmbeddingsPanel', () => {
     );
   });
 
+  it('reopens the selected custom provider with its active settings populated', async () => {
+    const settings = makeSettings({
+      provider: 'custom:https://embeddings.example.com/v1',
+      model: 'acme-embed-v2',
+      dimensions: 2048,
+      providers: [
+        makeProvider('managed', { requires_api_key: false }),
+        makeProvider('custom', {
+          requires_api_key: true,
+          requires_endpoint: true,
+          has_api_key: true,
+        }),
+      ],
+    });
+    vi.mocked(loadEmbeddingsSettings).mockResolvedValue(settings);
+
+    renderWithProviders(<EmbeddingsPanel />);
+    await screen.findByText('Custom');
+
+    fireEvent.click(screen.getByRole('radio', { name: /custom/i }));
+
+    expect(await screen.findByPlaceholderText(/https:\/\/your-endpoint/i)).toHaveValue(
+      'https://embeddings.example.com/v1'
+    );
+    expect(screen.getByPlaceholderText('text-embedding-3-small')).toHaveValue('acme-embed-v2');
+    expect(screen.getByRole('spinbutton')).toHaveValue(2048);
+    expect(screen.getByPlaceholderText(/paste your api key/i)).toHaveValue('');
+    expect(vi.mocked(updateEmbeddingsSettings)).not.toHaveBeenCalled();
+  });
+
+  it('opens a retained custom profile while embeddings are disabled', async () => {
+    const settings = makeSettings({
+      provider: 'none',
+      model: 'acme-embed-v2',
+      dimensions: 2048,
+      custom_settings: {
+        endpoint: 'https://embeddings.example.com/v1',
+        model: 'acme-embed-v2',
+        dimensions: 2048,
+      },
+      providers: [
+        makeProvider('none', { requires_api_key: false }),
+        makeProvider('custom', {
+          requires_api_key: true,
+          requires_endpoint: true,
+          has_api_key: true,
+        }),
+      ],
+    });
+    vi.mocked(loadEmbeddingsSettings).mockResolvedValue(settings);
+
+    renderWithProviders(<EmbeddingsPanel />);
+    await screen.findByText('Custom');
+
+    fireEvent.click(screen.getByRole('radio', { name: /custom/i }));
+
+    expect(await screen.findByPlaceholderText(/https:\/\/your-endpoint/i)).toHaveValue(
+      'https://embeddings.example.com/v1'
+    );
+    expect(screen.getByPlaceholderText('text-embedding-3-small')).toHaveValue('acme-embed-v2');
+    expect(screen.getByRole('spinbutton')).toHaveValue(2048);
+  });
+
   it('can fill and save the custom endpoint form', async () => {
     const settings = makeSettings({
       providers: [

--- a/app/src/services/api/embeddingsApi.ts
+++ b/app/src/services/api/embeddingsApi.ts
@@ -44,6 +44,8 @@ export interface EmbeddingsSettings {
   model: string;
   dimensions: number;
   rate_limit_per_min: number;
+  /** Last verified Custom profile, retained even while another provider is active. */
+  custom_settings?: { endpoint: string; model: string; dimensions: number } | null;
   providers: EmbeddingProviderEntry[];
   vector_search_enabled: boolean;
 }

--- a/app/test/playwright/specs/embeddings-setup-modal.spec.ts
+++ b/app/test/playwright/specs/embeddings-setup-modal.spec.ts
@@ -2,6 +2,7 @@ import { expect, test } from '@playwright/test';
 
 import {
   bootRuntimeReadyGuestPage,
+  callCoreRpc,
   dismissWalkthroughIfPresent,
   signInViaCallbackToken,
   waitForAppReady,
@@ -98,5 +99,63 @@ test.describe('Embeddings setup — Test connection for a custom endpoint', () =
     await expect(keyField).toBeVisible();
     await keyField.fill('sk-not-a-real-key-0000000000');
     await expect(testButton).toBeEnabled();
+  });
+
+  test('reopens and retains a configured custom profile after embeddings are disabled', async ({
+    page,
+  }) => {
+    await openEmbeddingsTab(page, 'pw-embed-custom-reopen');
+
+    const mockPort = process.env.E2E_MOCK_PORT || '18473';
+    const endpoint = `http://127.0.0.1:${mockPort}/openai/v1`;
+    await callCoreRpc('openhuman.embeddings_update_settings', {
+      provider: 'custom',
+      custom_endpoint: endpoint,
+      model: 'e2e-custom-embedding',
+      dimensions: 1024,
+      confirm_wipe: true,
+    });
+
+    await page.reload();
+    await waitForAppReady(page);
+    await dismissWalkthroughIfPresent(page);
+
+    const customOption = page.getByRole('radio').filter({ hasText: CUSTOM_LABEL });
+    await expect(customOption).toHaveAttribute('aria-checked', 'true');
+    await customOption.click();
+
+    const endpointField = page.getByPlaceholder('https://your-endpoint.com/v1');
+    const modelField = page.getByPlaceholder('text-embedding-3-small');
+    const dimensionsField = page.getByRole('spinbutton');
+    await expect(endpointField).toHaveValue(endpoint);
+    await expect(modelField).toHaveValue('e2e-custom-embedding');
+    await expect(dimensionsField).toHaveValue('4');
+
+    await page.getByRole('button', { name: /^Cancel$/ }).click();
+    await page
+      .getByRole('radio')
+      .filter({ hasText: /Disabled/ })
+      .click();
+    await expect
+      .poll(async () => {
+        const response = await callCoreRpc<{ result?: { provider?: string }; provider?: string }>(
+          'openhuman.embeddings_get_settings'
+        );
+        return response.result?.provider ?? response.provider;
+      })
+      .toBe('none');
+
+    // A real page reload proves this is retained by the core rather than only
+    // surviving in the current React component's local state.
+    await page.reload();
+    await waitForAppReady(page);
+    await dismissWalkthroughIfPresent(page);
+    await page.getByRole('radio').filter({ hasText: CUSTOM_LABEL }).click();
+
+    await expect(page.getByPlaceholder('https://your-endpoint.com/v1')).toHaveValue(endpoint);
+    await expect(page.getByPlaceholder('text-embedding-3-small')).toHaveValue(
+      'e2e-custom-embedding'
+    );
+    await expect(page.getByRole('spinbutton')).toHaveValue('4');
   });
 });

--- a/src/openhuman/config/schema/types_part_01.rs
+++ b/src/openhuman/config/schema/types_part_01.rs
@@ -444,9 +444,8 @@ pub struct Config {
     #[serde(default)]
     pub embeddings_provider: Option<String>,
 
-    /// Last successfully verified Custom embeddings profile. This is not the
-    /// active-provider selector; it is retained when embeddings are disabled
-    /// so the Custom setup dialog can be reopened for review or editing.
+    /// Retained Custom profile; not the active-provider selector. See
+    /// [`CustomEmbeddingsConfig`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_embeddings: Option<CustomEmbeddingsConfig>,
 

--- a/src/openhuman/config/schema/types_part_01.rs
+++ b/src/openhuman/config/schema/types_part_01.rs
@@ -72,6 +72,19 @@ pub struct ModelRegistryEntry {
     pub vision: bool,
 }
 
+/// Last successfully verified Custom embeddings configuration.
+///
+/// The active provider lives in [`Config::embeddings_provider`] and
+/// [`MemoryConfig::embedding_provider`]. Keeping this profile separately lets
+/// users temporarily disable embeddings (or select another provider) without
+/// losing the endpoint/model they configured for a later switch back.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct CustomEmbeddingsConfig {
+    pub endpoint: String,
+    pub model: String,
+    pub dimensions: usize,
+}
+
 /// Top-level configuration (config.toml root).
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct Config {
@@ -430,6 +443,12 @@ pub struct Config {
     /// Provider string for embedding generation.
     #[serde(default)]
     pub embeddings_provider: Option<String>,
+
+    /// Last successfully verified Custom embeddings profile. This is not the
+    /// active-provider selector; it is retained when embeddings are disabled
+    /// so the Custom setup dialog can be reopened for review or editing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_embeddings: Option<CustomEmbeddingsConfig>,
 
     /// Provider string for the heartbeat background-reasoning loop.
     #[serde(default)]

--- a/src/openhuman/config/schema/types_part_02.rs
+++ b/src/openhuman/config/schema/types_part_02.rs
@@ -216,6 +216,7 @@ impl Default for Config {
             vision_provider: None,
             memory_provider: None,
             embeddings_provider: None,
+            custom_embeddings: None,
             heartbeat_provider: None,
             learning_provider: None,
             subconscious_provider: None,

--- a/src/openhuman/inference/embeddings/rpc_part_01.rs
+++ b/src/openhuman/inference/embeddings/rpc_part_01.rs
@@ -145,12 +145,49 @@ fn final_probe_dims(model: &str, configured: usize, actual: usize) -> usize {
     }
 }
 
+fn active_custom_profile(
+    config: &Config,
+) -> Option<crate::openhuman::config::schema::CustomEmbeddingsConfig> {
+    let endpoint = config
+        .memory
+        .embedding_provider
+        .strip_prefix("custom:")?
+        .trim();
+    if endpoint.is_empty() {
+        return None;
+    }
+    Some(crate::openhuman::config::schema::CustomEmbeddingsConfig {
+        endpoint: endpoint.to_string(),
+        model: config.memory.embedding_model.clone(),
+        dimensions: config.memory.embedding_dimensions,
+    })
+}
+
+fn remember_active_custom_profile(config: &mut Config) {
+    if let Some(profile) = active_custom_profile(config) {
+        config.custom_embeddings = Some(profile);
+    }
+}
+
 /// Returns the current embedding settings plus the provider catalog.
 pub async fn get_settings(config: &Config) -> Result<RpcOutcome<serde_json::Value>, String> {
     let provider = &config.memory.embedding_provider;
     let model = &config.memory.embedding_model;
     let dimensions = config.memory.embedding_dimensions;
     let rate_limit = config.memory.embedding_rate_limit_per_min;
+
+    // Older configs encode the endpoint only in the active provider string.
+    // Prefer that live value when Custom is selected, and otherwise return the
+    // retained profile so disabling embeddings does not blank the edit form.
+    let custom_settings = active_custom_profile(config)
+        .or_else(|| config.custom_embeddings.clone())
+        .map(|profile| {
+            serde_json::json!({
+                "endpoint": profile.endpoint,
+                "model": profile.model,
+                "dimensions": profile.dimensions,
+            })
+        });
 
     let auth = AuthService::from_config(config);
     let providers: Vec<serde_json::Value> = catalog::all_providers()
@@ -201,6 +238,7 @@ pub async fn get_settings(config: &Config) -> Result<RpcOutcome<serde_json::Valu
         "model": model,
         "dimensions": dimensions,
         "rate_limit_per_min": rate_limit,
+        "custom_settings": custom_settings,
         "providers": providers,
         "vector_search_enabled": vector_search_enabled,
     });
@@ -234,6 +272,11 @@ pub async fn update_settings(
     use crate::openhuman::inference::embeddings::format_embedding_signature;
 
     let mut config = config_rpc::load_config_with_timeout().await?;
+
+    // Upgrade-in-place for users whose endpoint predates the retained Custom
+    // profile: if they disable or switch away now, capture the active profile
+    // before `memory.embedding_provider` is overwritten below.
+    remember_active_custom_profile(&mut config);
 
     let old_sig = format_embedding_signature(
         &config.memory.embedding_provider,
@@ -457,6 +500,12 @@ pub async fn update_settings(
     if let Some(ep) = &custom_endpoint {
         if new_provider == "custom" || new_provider.starts_with("custom:") {
             config.memory.embedding_provider = format!("custom:{ep}");
+            config.custom_embeddings =
+                Some(crate::openhuman::config::schema::CustomEmbeddingsConfig {
+                    endpoint: ep.clone(),
+                    model: new_model.clone(),
+                    dimensions: new_dims,
+                });
         }
     }
 

--- a/src/openhuman/inference/embeddings/rpc_tests.rs
+++ b/src/openhuman/inference/embeddings/rpc_tests.rs
@@ -80,6 +80,31 @@ async fn get_settings_reports_effective_provider_separately_from_the_setting() {
     );
 }
 
+#[tokio::test]
+async fn custom_profile_is_retained_and_returned_while_embeddings_are_disabled() {
+    let mut config = Config::default();
+    config.memory.embedding_provider = "custom:https://embeddings.example.com/v1".to_string();
+    config.memory.embedding_model = "acme-embed-v2".to_string();
+    config.memory.embedding_dimensions = 2048;
+
+    remember_active_custom_profile(&mut config);
+    config.memory.embedding_provider = "none".to_string();
+    config.embeddings_provider = Some("none".to_string());
+
+    let out = get_settings(&config)
+        .await
+        .expect("get_settings must return the retained Custom profile");
+    assert_eq!(out.value["provider"], "none");
+    assert_eq!(
+        out.value["custom_settings"],
+        serde_json::json!({
+            "endpoint": "https://embeddings.example.com/v1",
+            "model": "acme-embed-v2",
+            "dimensions": 2048,
+        })
+    );
+}
+
 /// `custom:<url>` providers must look up under the `embeddings:custom`
 /// slug (the inline URL is not part of the credential key), mirroring the
 /// slug normalization in `embed`/`set_api_key`.

--- a/tests/embeddings_rpc_e2e.rs
+++ b/tests/embeddings_rpc_e2e.rs
@@ -958,3 +958,70 @@ async fn embeddings_update_settings_adopts_custom_endpoint_native_dimension() {
 
     mock_join.abort();
 }
+
+/// The retained Custom profile must survive config loading and JSON-RPC
+/// serialization while another provider is active. The UI depends on this
+/// field to reopen the populated form after a reload in Disabled mode.
+#[tokio::test(flavor = "multi_thread")]
+async fn embeddings_get_settings_returns_retained_custom_profile_while_disabled() {
+    let _lock = embeddings_e2e_env_lock();
+    let (rpc_base, tmp, _guards, _join) = setup_embeddings_test().await;
+    for config_path in [
+        tmp.path().join(".openhuman").join("config.toml"),
+        tmp.path()
+            .join(".openhuman")
+            .join("users")
+            .join("local")
+            .join("config.toml"),
+    ] {
+        let config = std::fs::read_to_string(&config_path).expect("read test config");
+        let config = config.replace(
+            "\n[secrets]",
+            r#"
+embeddings_provider = "none"
+
+[custom_embeddings]
+endpoint = "https://embeddings.example.com/v1"
+model = "remembered-embedding-model"
+dimensions = 2048
+
+[memory]
+embedding_provider = "none"
+embedding_model = "remembered-embedding-model"
+embedding_dimensions = 2048
+
+[secrets]"#,
+        );
+        std::fs::write(&config_path, config).expect("write retained Custom profile");
+    }
+
+    let get = post_json_rpc(
+        &rpc_base,
+        100,
+        "openhuman.embeddings_get_settings",
+        json!({}),
+    )
+    .await;
+    let get_result = assert_no_rpc_error(&get, "get settings after disabling custom");
+    let get_inner = get_result.get("result").unwrap_or(get_result);
+    let retained = get_inner
+        .get("custom_settings")
+        .unwrap_or_else(|| panic!("missing retained custom settings: {get_inner}"));
+
+    assert_eq!(
+        get_inner.get("provider").and_then(Value::as_str),
+        Some("none")
+    );
+    assert_eq!(
+        retained.get("endpoint").and_then(Value::as_str),
+        Some("https://embeddings.example.com/v1")
+    );
+    assert_eq!(
+        retained.get("model").and_then(Value::as_str),
+        Some("remembered-embedding-model")
+    );
+    assert_eq!(
+        retained.get("dimensions").and_then(Value::as_u64),
+        Some(2048)
+    );
+}


### PR DESCRIPTION
## Summary

- Reopen the Custom embeddings setup dialog even when Custom is already selected.
- Populate the dialog with the active or last successfully verified endpoint, model, and dimensions.
- Retain the Custom profile when embeddings are disabled or another provider is selected.
- Keep stored API keys secret: existing keys are never returned to or prefilled in the form.
- Add frontend, Rust RPC, and browser regression coverage for both reported flows.

## Problem

Custom currently serves as both a provider selector and the entry point to its setup dialog. The generic selected-provider no-op prevents reopening an active Custom provider. In addition, the endpoint is encoded only in the active `custom:<endpoint>` provider string, so switching to Disabled removes the data needed to populate the dialog even though the API key remains configured.

These two symptoms share the same state-model problem: a reusable Custom profile was not represented independently from the active provider selection.

## Solution

- Handle Custom clicks before the generic already-selected early return and hydrate the form from RPC settings.
- Persist a separate `custom_embeddings` profile containing only endpoint, model, and verified dimensions.
- Capture legacy active `custom:<endpoint>` settings before switching away, providing an upgrade path without a migration.
- Return the retained profile as an additive `custom_settings` field from `embeddings_get_settings`.
- Prefer the active Custom values while selected, then fall back to the retained profile while Disabled or using another provider.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — pending the PR coverage gate; focused frontend and Rust tests pass locally.
- [x] Coverage matrix updated — N/A: behaviour-only change; no matching feature row exists.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related` — N/A: no matching feature ID.
- [x] No new external network dependencies introduced (existing mock backend used for browser coverage).
- [x] Manual smoke checklist updated if this touches release-cut surfaces — N/A: this application interaction is covered by automated tests and does not add an OS-only release surface.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Impact

Desktop Connections → API Keys → Vector embeddings UX only. Existing configs remain compatible: active legacy Custom settings are derived on read and retained on the next settings update. The new config field is optional and additive. No API key or other credential is added to the settings response. There are no new runtime dependencies or network destinations.

## Related

- Fixes #5995
- Related: #5943 fixed the separate Custom endpoint Test connection affordance.
- Feature IDs: N/A — no matching row in `docs/TEST-COVERAGE-MATRIX.md`.
- Follow-up PR(s)/TODOs: None.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A — GitHub issue #5995 is the source issue.
- URL: N/A

### Commit & Branch

- Branch: `fix/custom-embedding-settings`
- Commit SHA: `5be77655ec338dee73568de9792402ce4003bdad`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` (via `pnpm format:check`)
- [x] `pnpm typecheck`
- [x] Focused tests:
  - `pnpm debug unit src/components/settings/panels/__tests__/EmbeddingsPanel.test.tsx` — 35 passed
  - `cargo test --lib custom_profile_is_retained_and_returned_while_embeddings_are_disabled` — passed
  - `cargo test --test embeddings_rpc_e2e embeddings_get_settings_returns_retained_custom_profile_while_disabled -- --exact` — passed
  - `pnpm --filter openhuman-app test:e2e:web:build` — passed
- [x] Rust fmt/check (if changed): `pnpm format:check` and pre-push root clippy passed
- [x] Tauri fmt/check (if changed): pre-push Tauri clippy passed

### Validation Blocked

- `command:` `bash app/scripts/e2e-web-session.sh test/playwright/specs/embeddings-setup-modal.spec.ts`
- `error:` all three specs, including the two pre-existing cases, timed out in the shared auth callback helper before reaching the Embeddings page (`auth callback did not reach the post-auth landing surface after retry`).
- `impact:` local browser behavior confirmation was not reached; focused component and real RPC tests pass, and CI can rerun the committed Playwright regression in its configured environment.

### Behavior Changes

- Intended behavior change: Custom always opens an editable populated setup dialog and its verified profile survives switching to Disabled.
- User-visible effect: users can inspect or replace an existing Custom embeddings model without losing its endpoint/model/dimensions when temporarily disabling embeddings.

### Parity Contract

- Legacy behavior preserved: Custom saves still require the existing verification probe; blank API key input preserves the keyring credential; dimension changes keep the existing wipe confirmation behavior.
- Guard/fallback/dispatch parity checks: active `custom:<endpoint>` remains authoritative while selected; retained settings are only a fallback when Custom is inactive; no credential is serialized.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): None found in open PR search. #5943 is related but addresses only Test connection behavior.
- Canonical PR: This PR.
- Resolution (closed/superseded/updated): N/A.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Custom embeddings profiles are retained when embeddings are disabled or another provider is selected.
  - Reopening Custom embeddings settings restores the saved endpoint, model, and dimensions.
  - Saved Custom settings remain available when no embeddings provider is active.
  - Reopening the setup dialog does not save changes until the profile is applied.

- **Bug Fixes**
  - Selecting the already-active Custom provider now correctly reopens its configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
