### PR TITLE
fix(turn_state): persist sub-agent child tool arguments in snapshots

### DIFF
--- a/app/src/features/conversations/components/__tests__/SubagentDrawer.test.tsx
+++ b/app/src/features/conversations/components/__tests__/SubagentDrawer.test.tsx
@@ -344,4 +344,26 @@ describe('SubagentDrawer', () => {
     expect(screen.queryByTestId('assistant-ui-tool-input')).toBeNull();
     expect(screen.queryByTestId('assistant-ui-tool-output')).toBeNull();
   });
+
+  it('derives a search label from the arguments when the server label degraded to "tool"', () => {
+    // A provider that hands back a generic `tool` name leaves the row with
+    // nothing better than "Tool" unless the arguments are there to read. Those
+    // arguments only survive a reload because the snapshot now carries them
+    // (#5987) — without them this row reads "Tool" again after a refresh.
+    const transcript: SubagentTranscriptItem[] = [
+      {
+        kind: 'tool',
+        iteration: 1,
+        callId: 'c1',
+        toolName: 'tool',
+        status: 'success',
+        displayName: 'tool',
+        args: { query: 'openhuman turn state' },
+      },
+    ];
+    render(
+      <SubagentDrawer subagent={activity({ transcript })} status="success" onClose={() => {}} />
+    );
+    expect(screen.getByTestId('assistant-ui-tool-call').textContent).toContain('Searched the web');
+  });
 });

--- a/app/src/store/__tests__/chatRuntimeSlice.subagentStream.test.ts
+++ b/app/src/store/__tests__/chatRuntimeSlice.subagentStream.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import type { PersistedTurnState } from '../../types/turnState';
 import reducer, {
   appendSubagentStreamDelta,
+  hydrateRuntimeFromSnapshot,
   markSubagentCancelled,
   recordSubagentTranscriptTool,
   resolveSubagentTranscriptTool,
@@ -212,5 +214,72 @@ describe('markSubagentCancelled', () => {
     expect(
       reducer(base, markSubagentCancelled({ threadId: 'other-thread', taskId: 'sub-1' }))
     ).toEqual(base);
+  });
+});
+
+describe('hydrateRuntimeFromSnapshot — sub-agent child tool arguments', () => {
+  function settledSnapshot(args: unknown): PersistedTurnState {
+    return {
+      threadId: THREAD,
+      requestId: 'req-1',
+      lifecycle: 'completed',
+      iteration: 1,
+      maxIterations: 10,
+      streamingText: '',
+      thinking: '',
+      startedAt: '2026-09-03T00:00:00Z',
+      updatedAt: '2026-09-03T00:00:00Z',
+      toolTimeline: [
+        {
+          id: ROW_ID,
+          name: 'subagent:researcher',
+          round: 1,
+          status: 'success',
+          subagent: {
+            taskId: 'sub-1',
+            agentId: 'researcher',
+            toolCalls: [
+              {
+                callId: 'c1',
+                toolName: 'tool',
+                status: 'success',
+                iteration: 1,
+                args,
+                output: '3 hits',
+              },
+            ],
+            transcript: [
+              { kind: 'tool', iteration: 1, callId: 'c1', toolName: 'tool', status: 'success' },
+            ],
+          },
+        },
+      ],
+    };
+  }
+
+  it('restores the child call arguments onto the call row and its transcript item', () => {
+    const state = reducer(
+      undefined,
+      hydrateRuntimeFromSnapshot({ snapshot: settledSnapshot({ query: 'turn state' }) })
+    );
+    const subagent = state.toolTimelineByThread[THREAD][0].subagent;
+    expect(subagent?.toolCalls[0].args).toEqual({ query: 'turn state' });
+    // The transcript item has no `args` of its own in the snapshot — it is
+    // grafted from the matching call by `callId`, the same way `output` and
+    // `failure` already are.
+    const item = subagent?.transcript?.[0];
+    expect(item?.kind).toBe('tool');
+    expect(item && item.kind === 'tool' ? item.args : undefined).toEqual({ query: 'turn state' });
+  });
+
+  it('leaves the arguments undefined for a snapshot written before the field existed', () => {
+    const snapshot = settledSnapshot(undefined);
+    delete snapshot.toolTimeline[0].subagent!.toolCalls[0].args;
+    const state = reducer(undefined, hydrateRuntimeFromSnapshot({ snapshot }));
+    const subagent = state.toolTimelineByThread[THREAD][0].subagent;
+    expect(subagent?.toolCalls[0].args).toBeUndefined();
+    // The rest of the row still rehydrates — a legacy snapshot must not be
+    // rejected, only rendered without an input block.
+    expect(subagent?.toolCalls[0].result).toBe('3 hits');
   });
 });

--- a/app/src/store/chatRuntimeSlice.ts
+++ b/app/src/store/chatRuntimeSlice.ts
@@ -810,6 +810,10 @@ function subagentToolCallFromPersisted(call: PersistedSubagentToolCall): Subagen
     outputChars: call.outputChars,
     displayName: call.displayName,
     detail: call.detail,
+    // Carry the persisted arguments so a rehydrated child row keeps its input
+    // block, and a degraded generic `tool` name can still derive its search
+    // label from `query` (#5987).
+    args: call.args,
     // Carry the persisted failure explanation across the round-trip (#4459).
     failure: parseToolFailure(call.failure),
     // Carry the persisted (capped) result text so a rehydrated child row can

--- a/app/src/types/turnState.ts
+++ b/app/src/types/turnState.ts
@@ -63,6 +63,15 @@ export interface PersistedSubagentToolCall {
   displayName?: string;
   /** Server-computed contextual detail (path / recipient / query). */
   detail?: string;
+  /** Size-capped arguments the child invoked the tool with, so a rehydrated
+   *  row shows what the sub-agent did and not just which tool it reached for
+   *  (#5987). Mirrors the live `subagent_tool_call` event's `args`; an
+   *  oversized payload arrives as a truncated string. Absent when the child's
+   *  arguments were never materialised and on snapshots written before this
+   *  field. Deliberately not repeated on {@link PersistedSubagentTranscriptItem}
+   *  — like `output` and `failure` it is grafted onto the transcript item by
+   *  `callId` in `subagentActivityFromPersisted`. */
+  args?: unknown;
   /** Plain-language failure explanation for a FAILED child call (#4459).
    *  Mirrors the parent {@link PersistedToolTimelineEntry.failure}; absent on
    *  successful rows and on snapshots written before this field. */

--- a/src/openhuman/threads/turn_state/mirror_part_01.rs
+++ b/src/openhuman/threads/turn_state/mirror_part_01.rs
@@ -90,9 +90,12 @@ fn cap_persisted_output(output: &str) -> Option<String> {
 }
 
 /// Cap `arguments` for snapshot persistence. Returns `None` for a null
-/// payload — the observability bridge emits `Value::Null` on the paths where
-/// the child's arguments were never materialised, and a null would otherwise
-/// persist as a meaningless "Input: null" row.
+/// payload, which would otherwise persist as a meaningless "Input: null" row.
+///
+/// A null is not the same as "this call had no input": on the tinyagents path
+/// the *started* event always carries `Value::Null` and the captured arguments
+/// only arrive with `SubagentToolCallCompleted`, so the completion arm
+/// backfills what this returns `None` for at start.
 ///
 /// A payload that serialises within [`MAX_PERSISTED_TOOL_ARGS`] is kept
 /// verbatim, so the rehydrated row renders the same structured input the live

--- a/src/openhuman/threads/turn_state/mirror_part_01.rs
+++ b/src/openhuman/threads/turn_state/mirror_part_01.rs
@@ -30,6 +30,13 @@ const MAX_PERSISTED_TRANSCRIPT_ITEM: usize = 16 * 1024;
 /// Marker appended once when a transcript prose item is truncated at its cap.
 const TRANSCRIPT_TRUNCATION_MARKER: &str = "\n…[truncated]";
 
+/// Upper bound on the child tool arguments persisted per sub-agent call.
+/// Sized like [`MAX_PERSISTED_TRANSCRIPT_ITEM`] rather than the looser
+/// [`MAX_PERSISTED_TOOL_OUTPUT`]: a sub-agent turn accumulates many child
+/// calls and the snapshot file is rewritten in full at every tool boundary,
+/// so one `write_file`-shaped payload must not dominate every rewrite.
+const MAX_PERSISTED_TOOL_ARGS: usize = 16 * 1024;
+
 /// Append `delta` to a coalescing transcript prose buffer, enforcing
 /// [`MAX_PERSISTED_TRANSCRIPT_ITEM`] on a char boundary and stamping a one-time
 /// truncation marker the first time the cap is hit. Once at the cap, further
@@ -80,6 +87,36 @@ fn cap_persisted_output(output: &str) -> Option<String> {
         "{}\n…[truncated {omitted} bytes of tool output]",
         &output[..end]
     ))
+}
+
+/// Cap `arguments` for snapshot persistence. Returns `None` for a null
+/// payload — the observability bridge emits `Value::Null` on the paths where
+/// the child's arguments were never materialised, and a null would otherwise
+/// persist as a meaningless "Input: null" row.
+///
+/// A payload that serialises within [`MAX_PERSISTED_TOOL_ARGS`] is kept
+/// verbatim, so the rehydrated row renders the same structured input the live
+/// row did. An oversized one degrades to a truncated *string* carrying the
+/// same marker shape [`cap_persisted_output`] uses: the prefix is what the
+/// reader actually wants ("what did it search for?"), and a string is honest
+/// about no longer being parseable JSON.
+fn cap_persisted_args(arguments: &serde_json::Value) -> Option<serde_json::Value> {
+    if arguments.is_null() {
+        return None;
+    }
+    let rendered = arguments.to_string();
+    if rendered.len() <= MAX_PERSISTED_TOOL_ARGS {
+        return Some(arguments.clone());
+    }
+    let mut end = MAX_PERSISTED_TOOL_ARGS.saturating_sub(TRUNCATION_MARKER_BUDGET);
+    while end > 0 && !rendered.is_char_boundary(end) {
+        end -= 1;
+    }
+    let omitted = rendered.len() - end;
+    Some(serde_json::Value::String(format!(
+        "{}\n…[truncated {omitted} bytes of tool arguments]",
+        &rendered[..end]
+    )))
 }
 
 /// In-process cursor that keeps the authoritative [`TurnState`] in sync

--- a/src/openhuman/threads/turn_state/mirror_part_02.rs
+++ b/src/openhuman/threads/turn_state/mirror_part_02.rs
@@ -235,6 +235,7 @@ impl TurnStateMirror {
                 task_id,
                 call_id,
                 tool_name,
+                arguments,
                 iteration,
                 display_label,
                 display_detail,
@@ -251,6 +252,10 @@ impl TurnStateMirror {
                             output_chars: None,
                             display_name: display_label.clone(),
                             detail: display_detail.clone(),
+                            // The live socket event already carries these; the
+                            // snapshot has to as well or a reloaded child row
+                            // comes back without its input (#5987).
+                            args: cap_persisted_args(arguments),
                             failure: None,
                             output: None,
                         });

--- a/src/openhuman/threads/turn_state/mirror_part_02.rs
+++ b/src/openhuman/threads/turn_state/mirror_part_02.rs
@@ -285,6 +285,7 @@ impl TurnStateMirror {
                 success,
                 output,
                 output_chars,
+                arguments,
                 elapsed_ms,
                 failure,
                 ..
@@ -310,6 +311,19 @@ impl TurnStateMirror {
                             // keeps its explanation across a round-trip (#4459).
                             call.failure = persisted_failure;
                             call.output = cap_persisted_output(output);
+                            // Backfill the input on the tinyagents path, where
+                            // the *started* event carries `Value::Null` and the
+                            // captured arguments only reach us here (see
+                            // `SubagentToolCallCompleted::arguments`). Without
+                            // this the ordinary sub-agent tool — the common
+                            // case — still rehydrates with no input (#5987).
+                            // Only fills a gap: a start event that already
+                            // supplied arguments stays authoritative.
+                            if call.args.is_none() {
+                                if let Some(arguments) = arguments {
+                                    call.args = cap_persisted_args(arguments);
+                                }
+                            }
                         }
                         // Keep the transcript's Tool item in lockstep so the
                         // rehydrated row shows the terminal status + timing.

--- a/src/openhuman/threads/turn_state/mirror_tests_part_02_tests.rs
+++ b/src/openhuman/threads/turn_state/mirror_tests_part_02_tests.rs
@@ -261,11 +261,12 @@ fn subagent_tool_call_persists_its_arguments() {
     );
 }
 
-/// The observability bridge emits `Value::Null` on the paths where a child's
-/// arguments were never materialised. Persisting that would render a
-/// meaningless "Input: null" row, so it must serialize away entirely.
+/// A `Value::Null` payload must serialize away rather than persist a
+/// meaningless "Input: null" row. This is the state *at start* on the
+/// tinyagents path; the arguments arrive later and are backfilled by
+/// `tinyagents_path_backfills_arguments_from_the_completion_event`.
 #[test]
-fn null_child_arguments_are_not_persisted() {
+fn null_child_arguments_are_not_persisted_at_start() {
     let (_d, mut m) = fresh("t");
     m.observe(&AgentProgress::SubagentSpawned {
         agent_id: "researcher".into(),
@@ -377,4 +378,111 @@ fn legacy_subagent_tool_call_without_args_deserializes() {
     assert_eq!(call.args, None);
     assert_eq!(call.call_id, "c1");
     assert_eq!(call.output.as_deref(), Some("3 hits"));
+}
+
+/// The ordinary sub-agent tool path — the common case, and the one #5987 was
+/// actually reported against. `observability_part_02.rs` emits
+/// `SubagentToolCallStarted.arguments` as `Value::Null` there and only supplies
+/// the captured input on `SubagentToolCallCompleted.arguments`, so persisting
+/// the start event alone leaves these calls with no input after a reload.
+#[test]
+fn tinyagents_path_backfills_arguments_from_the_completion_event() {
+    let (_d, mut m) = fresh("t");
+    m.observe(&AgentProgress::SubagentSpawned {
+        agent_id: "researcher".into(),
+        task_id: "sub-1".into(),
+        mode: "typed".into(),
+        dedicated_thread: false,
+        prompt_chars: 10,
+        prompt: String::new(),
+        worker_thread_id: None,
+        display_name: Some("Researcher".into()),
+    });
+    // Start carries no arguments — exactly what the tinyagents bridge sends.
+    m.observe(&AgentProgress::SubagentToolCallStarted {
+        agent_id: "researcher".into(),
+        task_id: "sub-1".into(),
+        call_id: "c1".into(),
+        tool_name: "web_search".into(),
+        arguments: serde_json::Value::Null,
+        iteration: 1,
+        display_label: Some("Searching the web".into()),
+        display_detail: None,
+    });
+    m.observe(&AgentProgress::SubagentToolCallCompleted {
+        agent_id: "researcher".into(),
+        task_id: "sub-1".into(),
+        call_id: "c1".into(),
+        tool_name: "web_search".into(),
+        success: true,
+        output_chars: 6,
+        output: "3 hits".into(),
+        arguments: Some(serde_json::json!({ "query": "latest rust release" })),
+        elapsed_ms: 12,
+        iteration: 1,
+        failure: None,
+    });
+
+    let activity = m.snapshot().tool_timeline[0]
+        .subagent
+        .as_ref()
+        .expect("activity")
+        .clone();
+    assert_eq!(
+        activity.tool_calls[0].args,
+        Some(serde_json::json!({ "query": "latest rust release" })),
+        "completion arguments must backfill a call the start event left empty"
+    );
+}
+
+/// The backfill only fills a gap. A start event that already supplied the
+/// arguments stays authoritative, so a completion payload cannot rewrite the
+/// input the row was actually invoked with.
+#[test]
+fn completion_arguments_do_not_overwrite_arguments_captured_at_start() {
+    let (_d, mut m) = fresh("t");
+    m.observe(&AgentProgress::SubagentSpawned {
+        agent_id: "researcher".into(),
+        task_id: "sub-1".into(),
+        mode: "typed".into(),
+        dedicated_thread: false,
+        prompt_chars: 10,
+        prompt: String::new(),
+        worker_thread_id: None,
+        display_name: Some("Researcher".into()),
+    });
+    m.observe(&AgentProgress::SubagentToolCallStarted {
+        agent_id: "researcher".into(),
+        task_id: "sub-1".into(),
+        call_id: "c1".into(),
+        tool_name: "web_search".into(),
+        arguments: serde_json::json!({ "query": "from start" }),
+        iteration: 1,
+        display_label: Some("Searching the web".into()),
+        display_detail: None,
+    });
+    m.observe(&AgentProgress::SubagentToolCallCompleted {
+        agent_id: "researcher".into(),
+        task_id: "sub-1".into(),
+        call_id: "c1".into(),
+        tool_name: "web_search".into(),
+        success: true,
+        output_chars: 6,
+        output: "3 hits".into(),
+        arguments: Some(serde_json::json!({ "query": "from completion" })),
+        elapsed_ms: 12,
+        iteration: 1,
+        failure: None,
+    });
+
+    let activity = m.snapshot().tool_timeline[0]
+        .subagent
+        .as_ref()
+        .expect("activity")
+        .clone();
+    assert_eq!(
+        activity.tool_calls[0].args,
+        Some(serde_json::json!({ "query": "from start" })),
+        "arguments captured at start must not be rewritten on completion"
+    );
 }

--- a/src/openhuman/threads/turn_state/mirror_tests_part_02_tests.rs
+++ b/src/openhuman/threads/turn_state/mirror_tests_part_02_tests.rs
@@ -209,3 +209,172 @@ fn finish_first_turn_without_transcript_is_noop() {
     assert_eq!(listed.lifecycle, TurnLifecycle::Interrupted);
     assert_eq!(listed.streaming_text, "orphan partial");
 }
+
+/// A sub-agent's child tool call must persist the arguments it was invoked
+/// with. Live, the `subagent_tool_call` socket event carries them; before
+/// #5987 the snapshot did not, so a reloaded child row came back with no
+/// "Input" block at all.
+#[test]
+fn subagent_tool_call_persists_its_arguments() {
+    let (_d, mut m) = fresh("t");
+    m.observe(&AgentProgress::SubagentSpawned {
+        agent_id: "researcher".into(),
+        task_id: "sub-1".into(),
+        mode: "typed".into(),
+        dedicated_thread: false,
+        prompt_chars: 10,
+        prompt: String::new(),
+        worker_thread_id: None,
+        display_name: Some("Researcher".into()),
+    });
+    m.observe(&AgentProgress::SubagentToolCallStarted {
+        agent_id: "researcher".into(),
+        task_id: "sub-1".into(),
+        call_id: "c1".into(),
+        tool_name: "tool".into(),
+        arguments: serde_json::json!({ "query": "openhuman turn state" }),
+        iteration: 1,
+        display_label: None,
+        display_detail: None,
+    });
+
+    let activity = m.snapshot().tool_timeline[0]
+        .subagent
+        .as_ref()
+        .expect("activity")
+        .clone();
+    assert_eq!(
+        activity.tool_calls[0].args,
+        Some(serde_json::json!({ "query": "openhuman turn state" })),
+        "child arguments must reach the snapshot verbatim"
+    );
+
+    // The payload is stored exactly once. `output` and `failure` already live
+    // only on the call row and are grafted onto the transcript item by
+    // `call_id` on the frontend; `args` deliberately follows them rather than
+    // duplicating up to 16 KiB into every full-file snapshot rewrite.
+    let json = serde_json::to_string(m.snapshot()).expect("serialize");
+    assert_eq!(
+        json.matches("\"args\"").count(),
+        1,
+        "arguments must be persisted once, on the call row only"
+    );
+}
+
+/// The observability bridge emits `Value::Null` on the paths where a child's
+/// arguments were never materialised. Persisting that would render a
+/// meaningless "Input: null" row, so it must serialize away entirely.
+#[test]
+fn null_child_arguments_are_not_persisted() {
+    let (_d, mut m) = fresh("t");
+    m.observe(&AgentProgress::SubagentSpawned {
+        agent_id: "researcher".into(),
+        task_id: "sub-1".into(),
+        mode: "typed".into(),
+        dedicated_thread: false,
+        prompt_chars: 10,
+        prompt: String::new(),
+        worker_thread_id: None,
+        display_name: Some("Researcher".into()),
+    });
+    m.observe(&AgentProgress::SubagentToolCallStarted {
+        agent_id: "researcher".into(),
+        task_id: "sub-1".into(),
+        call_id: "c1".into(),
+        tool_name: "search".into(),
+        arguments: serde_json::Value::Null,
+        iteration: 1,
+        display_label: Some("Searching".into()),
+        display_detail: None,
+    });
+
+    let activity = m.snapshot().tool_timeline[0]
+        .subagent
+        .as_ref()
+        .expect("activity")
+        .clone();
+    assert_eq!(activity.tool_calls[0].args, None);
+    let json = serde_json::to_string(m.snapshot()).expect("serialize");
+    assert!(
+        !json.contains("\"args\""),
+        "a null payload must not occupy a field in the snapshot"
+    );
+}
+
+/// The snapshot file is rewritten in full at every tool boundary, so one
+/// `write_file`-shaped payload must not dominate it. An oversized argument
+/// blob degrades to a truncated string carrying the same marker shape a
+/// truncated tool output uses.
+#[test]
+fn oversized_child_arguments_are_truncated() {
+    let (_d, mut m) = fresh("t");
+    m.observe(&AgentProgress::SubagentSpawned {
+        agent_id: "writer".into(),
+        task_id: "sub-1".into(),
+        mode: "typed".into(),
+        dedicated_thread: false,
+        prompt_chars: 10,
+        prompt: String::new(),
+        worker_thread_id: None,
+        display_name: Some("Writer".into()),
+    });
+    let huge = "x".repeat(32 * 1024);
+    let arguments = serde_json::json!({ "path": "notes.md", "content": huge });
+    m.observe(&AgentProgress::SubagentToolCallStarted {
+        agent_id: "writer".into(),
+        task_id: "sub-1".into(),
+        call_id: "c1".into(),
+        tool_name: "write_file".into(),
+        arguments: arguments.clone(),
+        iteration: 1,
+        display_label: Some("Writing file".into()),
+        display_detail: None,
+    });
+
+    let activity = m.snapshot().tool_timeline[0]
+        .subagent
+        .as_ref()
+        .expect("activity")
+        .clone();
+    let args = activity.tool_calls[0].args.clone().expect("args persisted");
+    let text = args.as_str().expect("oversized args degrade to a string");
+    assert!(
+        text.len() <= 16 * 1024,
+        "truncated arguments must stay within the cap, got {}",
+        text.len()
+    );
+    assert!(
+        text.contains("…[truncated"),
+        "truncation must be visible to the reader"
+    );
+    // What is kept is a genuine prefix of the real arguments, not a summary —
+    // that leading slice is what tells the reader what the call was doing.
+    // Asserted against the serialized head rather than a specific key so the
+    // test does not depend on JSON object ordering.
+    let kept = text.split('\n').next().expect("prefix line");
+    assert!(
+        arguments.to_string().starts_with(kept),
+        "the persisted text must be the head of the real arguments"
+    );
+}
+
+/// `args` is additive: a snapshot written before #5987 has no such field and
+/// must still deserialize, leaving the row without an input rather than
+/// failing the whole thread's rehydration.
+#[test]
+fn legacy_subagent_tool_call_without_args_deserializes() {
+    let legacy = r#"{
+        "callId": "c1",
+        "toolName": "search",
+        "status": "success",
+        "iteration": 1,
+        "elapsedMs": 12,
+        "outputChars": 6,
+        "displayName": "Searching",
+        "output": "3 hits"
+    }"#;
+    let call: SubagentToolCall = serde_json::from_str(legacy).expect("legacy row must load");
+    assert_eq!(call.args, None);
+    assert_eq!(call.call_id, "c1");
+    assert_eq!(call.output.as_deref(), Some("3 hits"));
+}

--- a/src/openhuman/threads/turn_state/store_tests.rs
+++ b/src/openhuman/threads/turn_state/store_tests.rs
@@ -86,6 +86,7 @@ fn roundtrips_subagent_interleaved_transcript_with_full_fidelity() {
             output_chars: Some(6),
             display_name: Some("Searching".into()),
             detail: None,
+            args: Some(serde_json::json!({ "query": "rust serde" })),
             failure: None,
             output: Some("3 hits".into()),
         }],
@@ -151,6 +152,15 @@ fn roundtrips_subagent_interleaved_transcript_with_full_fidelity() {
         activity.transcript[2],
         SubagentTranscriptItem::Text { .. }
     ));
+    // The child call's arguments are what the reloaded row's "Input" block
+    // renders from. Spot-checked by value (like the interleaving above) so a
+    // regression names the field instead of failing as one opaque struct
+    // inequality (#5987).
+    assert_eq!(
+        activity.tool_calls[0].args,
+        Some(serde_json::json!({ "query": "rust serde" })),
+        "child tool arguments must survive the disk round-trip"
+    );
     assert_eq!(loaded.tool_timeline[0].seq, Some(3));
 }
 

--- a/src/openhuman/threads/turn_state/types.rs
+++ b/src/openhuman/threads/turn_state/types.rs
@@ -199,8 +199,12 @@ pub struct SubagentToolCall {
     /// row shows *what* the sub-agent did and not just which tool it reached
     /// for (#5987). Mirrors the live `subagent_tool_call` event's `args`
     /// verbatim when it fits the cap; an oversized payload degrades to a
-    /// truncated string. `None` when the child's arguments were never
-    /// materialised and on legacy snapshots.
+    /// truncated string. Taken from the started event when it carries the
+    /// arguments, otherwise backfilled from
+    /// [`AgentProgress::SubagentToolCallCompleted::arguments`] — the tinyagents
+    /// path emits `Value::Null` at start and only captures the input on
+    /// completion. `None` when the harness captured no input at all
+    /// (`PayloadCapture::tool_io` off) and on legacy snapshots.
     ///
     /// Deliberately absent from [`SubagentTranscriptItem::Tool`]: like
     /// `output` and `failure`, this is a heavy payload that lives once on the

--- a/src/openhuman/threads/turn_state/types.rs
+++ b/src/openhuman/threads/turn_state/types.rs
@@ -195,6 +195,19 @@ pub struct SubagentToolCall {
     /// Server-computed contextual detail (e.g. the path / recipient).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
+    /// Size-capped arguments the child invoked the tool with, so a rehydrated
+    /// row shows *what* the sub-agent did and not just which tool it reached
+    /// for (#5987). Mirrors the live `subagent_tool_call` event's `args`
+    /// verbatim when it fits the cap; an oversized payload degrades to a
+    /// truncated string. `None` when the child's arguments were never
+    /// materialised and on legacy snapshots.
+    ///
+    /// Deliberately absent from [`SubagentTranscriptItem::Tool`]: like
+    /// `output` and `failure`, this is a heavy payload that lives once on the
+    /// call row, and the frontend grafts it onto the matching transcript item
+    /// by `call_id` when it rehydrates.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub args: Option<serde_json::Value>,
     /// Plain-language failure explanation for a FAILED child call, so a
     /// sub-agent's failed row carries the same "why + next" copy as a
     /// main-agent row and it survives a snapshot round-trip (#4459). `None` on

--- a/tests/raw_coverage/memory_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/memory_raw_coverage_e2e.rs
@@ -632,6 +632,7 @@ fn threads_turn_state_store_skips_corrupt_entries_and_marks_interrupted() {
                 display_name: None,
                 output: None,
                 detail: None,
+                args: None,
                 failure: None,
             }],
             transcript: vec![],

--- a/tests/raw_coverage/memory_threads_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/memory_threads_raw_coverage_e2e.rs
@@ -3388,6 +3388,7 @@ fn turn_state_store_persists_lists_marks_and_clears_snapshots() {
                 display_name: None,
                 output: None,
                 detail: None,
+                args: None,
                 failure: None,
             }],
             transcript: vec![],


### PR DESCRIPTION
## Summary

A sub-agent's child tool call carried its arguments on the live `subagent_tool_call` socket event but never into the turn-state snapshot. After a reload the same card came back from the persisted snapshot with **no input at all**, and a degraded generic `tool` name lost the `query` that `inferredToolLabel` derives its search label from.

The frontend mapper was not at fault — the data never left the core. `SubagentToolCall` had nowhere to put the arguments, and `mirror_part_02.rs` never read them off either progress event.

- **Rust** — new optional `args: Option<serde_json::Value>` on `SubagentToolCall`, filled through a new `cap_persisted_args` helper.
- **Frontend** — `args?: unknown` on `PersistedSubagentToolCall`, copied through in `subagentToolCallFromPersisted`.

## The arguments arrive on two different events

This is the part worth reviewing carefully, and the first commit got it wrong.

| Path | `SubagentToolCallStarted.arguments` | `SubagentToolCallCompleted.arguments` |
|---|---|---|
| Unknown-tool calls (`observability_part_02.rs:323`) | the real arguments | — |
| **Ordinary sub-agent tools (tinyagents, `:373`)** | **`Value::Null`** | **the captured input** |

The second row is the common case, and the one #5987 was reported against — `SubagentToolCallCompleted::arguments` documents it outright: *"the started event's `arguments` is `Null` on the tinyagents path"*. Persisting only the start event therefore fixed the rarer path and left the reported bug in place.

So the mirror writes at start when arguments are present, and the completion arm backfills when they are not — guarded on `call.args.is_none()`, so arguments captured at start stay authoritative and a completion payload cannot rewrite the input a row was invoked with.

Caught in review by Codex; the gap and both misleading comments around it are fixed in `c479ea7b6`.

## Design notes

**16 KiB cap, not 64 KiB.** The snapshot is rewritten in full at every tool boundary and a turn accumulates many child calls, so this follows `MAX_PERSISTED_TRANSCRIPT_ITEM` rather than the looser `MAX_PERSISTED_TOOL_OUTPUT`. An oversized payload degrades to a truncated *string* carrying the same marker shape `cap_persisted_output` already uses — the prefix is what a reader actually wants, and a string is honest about no longer being parseable JSON.

**A null payload is "not known yet", not "no input".** It serializes away rather than persisting an "Input: null" row, and the backfill above is what fills it in. The original comments described it as *"arguments were never materialised"*, which is what made the gap read as intentional.

**Deliberately *not* repeated on `SubagentTranscriptItem::Tool`** — the issue asked for both. `output` and `failure` are also heavy per-call payloads and both live only on `tool_calls`; the transcript item carries neither, and the frontend grafts them onto the matching item by `callId` in `subagentActivityFromPersisted`. That graft already reads `call.args`, so the call row alone fixes both the drawer and the inline thoughts, while a second copy would be written on every full-file rewrite and immediately overwritten by the graft. A test pins that `args` appears exactly once in the serialized snapshot.

**Not a new exposure class.** Tool arguments are not redacted anywhere on the progress-event path (`tool_policy.rs` redacts only in `Debug` impls), and the parent's `args_buffer` already persists raw arguments to the same file. Stating it explicitly rather than leaving it implied.

**Pre-existing, left alone:** the parent `ToolTimelineEntry.args_buffer` is uncapped — the `ToolCallArgsDelta` arm appends deltas without bound. Out of scope; happy to file separately.

## Acceptance criteria

- [x] **Repro gone** — child tool rows keep their input across a reload on **both** event paths; a degraded `tool` name still derives its search label from the restored `query`.
- [x] **Regression safety** — Rust snapshot round-trip covers the new field; Vitest covers the persisted → runtime mapping restoring `args`.
- [x] **Older snapshots load** — additive and optional on both sides, with a test deserializing a pre-#5987 row.
- [x] **Diff coverage ≥ 80%** — enforced and passing on the `Rust Core Coverage` / `PR CI Gate` lanes.

## Test plan

`cargo test --features "$(bash scripts/ci/product-features.sh)" --lib -- threads::turn_state` — **39 passed**, 6 new:

| Test | Pins |
|---|---|
| `subagent_tool_call_persists_its_arguments` | args reach the snapshot; stored exactly once |
| `tinyagents_path_backfills_arguments_from_the_completion_event` | the common path — Null at start, args on completion |
| `completion_arguments_do_not_overwrite_arguments_captured_at_start` | start stays authoritative |
| `null_child_arguments_are_not_persisted_at_start` | no "Input: null" row |
| `oversized_child_arguments_are_truncated` | 16 KiB cap; kept text is a real prefix |
| `legacy_subagent_tool_call_without_args_deserializes` | pre-#5987 snapshots still load |

Plus `roundtrips_subagent_interleaved_transcript_with_full_fidelity` extended to pin `args` by value.

- `cargo check --features "…,voice,inference" --test raw_coverage_all` — clean (two struct literals there updated).
- `cargo clippy --features "$(bash scripts/ci/product-features.sh)" --lib -- -D warnings`, `cargo fmt --check`, Rust layout gate — clean.
- Vitest: `chatRuntimeSlice.subagentStream.test.ts` (restore + legacy) and `SubagentDrawer.test.tsx` (degraded label from restored args) — 28 passed.
- `tsc --noEmit`, eslint, prettier — clean.

Not exercised as a live desktop run — the flow is traced end-to-end through all nine hops (event → mirror → disk → `threads_turn_state_get` → `threadApi` → `hydrateRuntimeFromSnapshot` → graft → `ChildToolCallCard` → input block) and covered by unit tests at both ends.

Closes #5987

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved sub-agent tool invocation details when conversations are reloaded.
  * Improved tool activity labels by displaying “Searched the web” when a web search is identified, instead of a generic “Tool” label.
  * Maintained compatibility with older saved conversations that do not include tool arguments.
  * Limited oversized invocation details while retaining useful information for display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->