### PR TITLE
fix(app): stop external links from navigating the main webview away

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -50,6 +50,7 @@ import {
 } from './services/internetStatusListener';
 import { persistor, store } from './store';
 import { DEV_FORCE_ONBOARDING } from './utils/config';
+import { installExternalLinkGuard } from './utils/externalLinkGuard';
 
 startNativeNotificationsService();
 // Connectivity status (#1527): wire navigator.onLine + start core sidecar
@@ -69,6 +70,13 @@ if (import.meta.hot) {
 
 function App() {
   const onMobile = getIsMobile();
+
+  // The desktop shell is one webview with no back button, so a link that
+  // navigates it away strands the user on that page with no route back to the
+  // chat. Chat bubbles route their own links through `openUrl`; this guard
+  // covers every other anchor the app renders. Installed here, above the
+  // router, so it is live for the whole session.
+  useEffect(() => installExternalLinkGuard(), []);
 
   // On mobile (iOS or Android) the SocketProvider would try to connect to the
   // local core HTTP socket, which does not exist on device (the core runs on

--- a/app/src/utils/externalLinkGuard.test.ts
+++ b/app/src/utils/externalLinkGuard.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { installExternalLinkGuard, isExternalNavigation } from './externalLinkGuard';
+import { openUrl } from './openUrl';
+
+vi.mock('./openUrl', () => ({ openUrl: vi.fn(() => Promise.resolve()) }));
+
+const APP_ORIGIN = 'http://localhost:1420';
+
+describe('isExternalNavigation', () => {
+  it('flags a remote page, which is the one-way navigation we must stop', () => {
+    expect(isExternalNavigation('https://example.com/built-site', APP_ORIGIN)).toBe(true);
+  });
+
+  it('leaves the app’s own hash routes alone', () => {
+    expect(isExternalNavigation('#/settings/notifications', APP_ORIGIN)).toBe(false);
+    expect(isExternalNavigation(`${APP_ORIGIN}/#/chat`, APP_ORIGIN)).toBe(false);
+  });
+
+  it('ignores non-http schemes — those are handled by their own components', () => {
+    expect(isExternalNavigation('mailto:someone@example.com', APP_ORIGIN)).toBe(false);
+    expect(isExternalNavigation('data:text/html,<p>hi</p>', APP_ORIGIN)).toBe(false);
+    expect(isExternalNavigation('openhuman://thread/1', APP_ORIGIN)).toBe(false);
+  });
+});
+
+describe('installExternalLinkGuard', () => {
+  let teardown: () => void = () => {};
+
+  beforeEach(() => {
+    vi.mocked(openUrl).mockClear();
+    document.body.innerHTML = '';
+  });
+
+  afterEach(() => teardown());
+
+  const clickAnchor = (html: string): MouseEvent => {
+    document.body.innerHTML = html;
+    const anchor = document.querySelector('a') as HTMLAnchorElement;
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 });
+    anchor.dispatchEvent(event);
+    return event;
+  };
+
+  it('stops an external link from navigating the webview and opens it outside', () => {
+    teardown = installExternalLinkGuard();
+
+    const event = clickAnchor('<a href="https://example.com/site">my site</a>');
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(openUrl).toHaveBeenCalledWith('https://example.com/site');
+  });
+
+  it('lets in-app routes through untouched', () => {
+    teardown = installExternalLinkGuard();
+
+    const event = clickAnchor('<a href="#/chat">back to chat</a>');
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(openUrl).not.toHaveBeenCalled();
+    teardown();
+  });
+
+  // The chat bubble's own anchor already calls preventDefault + openUrl; if the
+  // guard did not defer, one click would open two tabs.
+  it('defers to a component that already handled the click itself', () => {
+    teardown = installExternalLinkGuard();
+    document.body.innerHTML = '<a href="https://example.com/site">handled</a>';
+    const anchor = document.querySelector('a') as HTMLAnchorElement;
+    anchor.addEventListener('click', e => e.preventDefault());
+
+    anchor.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, button: 0 }));
+
+    expect(openUrl).not.toHaveBeenCalled();
+  });
+
+  it('stops listening after teardown', () => {
+    installExternalLinkGuard()();
+
+    const event = clickAnchor('<a href="https://example.com/site">my site</a>');
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(openUrl).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/utils/externalLinkGuard.ts
+++ b/app/src/utils/externalLinkGuard.ts
@@ -1,0 +1,68 @@
+import { openUrl } from './openUrl';
+
+/**
+ * True when `href` would take the main webview away from the app itself.
+ *
+ * The desktop shell is a single webview with no browser chrome — no back
+ * button, no address bar — so any top-level navigation to a remote page is
+ * one-way: the chat is gone until the app is restarted. Only the app's own
+ * origin (its hash routes, `#/chat`, `#/settings/...`) is safe to follow.
+ *
+ * `about:`/`blob:`/`data:` and in-page anchors are left alone: they are not
+ * remote pages, and a `data:` preview is a deliberate in-app render.
+ */
+export function isExternalNavigation(href: string, appOrigin: string): boolean {
+  const trimmed = href.trim();
+  if (!trimmed || trimmed.startsWith('#')) return false;
+  let url: URL;
+  try {
+    url = new URL(trimmed, appOrigin);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+  return url.origin !== appOrigin;
+}
+
+/**
+ * Install a document-level, capture-phase guard that keeps a link click from
+ * navigating the main webview away from the app.
+ *
+ * Chat bubbles already route their links through `openUrl` (see
+ * `AgentMessageBubble`'s `MarkdownAnchor`), but that is one component's
+ * discipline, and every other rendered anchor — tool output, a panel, raw
+ * HTML inside a message — inherits the webview's default behaviour instead.
+ * When one of those is clicked the shell navigates and the user is stranded
+ * on the page with no way back, which is what this guard exists to prevent.
+ *
+ * It listens in the BUBBLE phase, deliberately. In the capture phase this
+ * document-level listener would run *before* the component's own handler, so
+ * a chat link would be opened once here and again by `MarkdownAnchor` — two
+ * browser tabs for one click. Bubbling lets the owning component go first;
+ * anything it already called `preventDefault` on is skipped, and the default
+ * navigation has still not happened by the time this runs, so preventing it
+ * here is not too late.
+ *
+ * Returns the teardown function.
+ */
+export function installExternalLinkGuard(doc: Document = document): () => void {
+  const onClick = (event: MouseEvent) => {
+    if (event.defaultPrevented || event.button !== 0) return;
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+
+    const target = event.target as Element | null;
+    const anchor = target?.closest?.('a[href]') as HTMLAnchorElement | null;
+    if (!anchor) return;
+
+    const href = anchor.getAttribute('href') ?? '';
+    if (!isExternalNavigation(href, doc.location.origin)) return;
+
+    event.preventDefault();
+    void openUrl(anchor.href).catch(() => {
+      // The OS handler refused; staying in the app beats a one-way navigation.
+    });
+  };
+
+  doc.addEventListener('click', onClick);
+  return () => doc.removeEventListener('click', onClick);
+}


### PR DESCRIPTION
## Summary

Clicking a link in the app — for example to a site the agent just built — navigated the **main webview** to that page. The desktop shell is a single webview with no back button and no address bar, so this is one-way: the chat is gone until the app is restarted.

Chat bubbles already route their links through `openUrl` (`AgentMessageBubble`'s `MarkdownAnchor`), but that is one component's discipline. Every other anchor the app renders inherits the webview's default navigation, and there is no shell-level guard to catch them: the main window is declared in `tauri.conf.json`, and `on_navigation` exists only on `WebviewWindowBuilder`, so a config-declared window has nowhere to attach one.

## Related issue

None.

## Changes

- `app/src/utils/externalLinkGuard.ts` — `isExternalNavigation` (pure predicate) plus `installExternalLinkGuard`, a document-level click guard that hands remote `http(s)` links to `openUrl` and prevents the navigation.
- `app/src/App.tsx` — install it once, above the router.

**The guard listens in the bubble phase deliberately.** In the capture phase this document-level listener would run *before* the owning component's handler, so a chat link would be opened twice — once here and once by `MarkdownAnchor` — i.e. two browser tabs for one click. Bubbling lets the component go first; anything it already `preventDefault`-ed is skipped, and the default navigation has still not happened, so preventing it there is not too late. This was caught by the test suite, not by reasoning after the fact.

In-app hash routes, non-http schemes (`mailto:`, `openhuman://`, `data:`), modifier-clicks and non-primary buttons are all left alone.

## API or behavior changes

Behavior only: an anchor that previously replaced the app now opens in the user's browser. No public API.

## Validation

- `npx vitest run --config test/vitest.config.ts src/utils/externalLinkGuard.test.ts` — **7 passed**.
- `pnpm typecheck` — clean.
- `pnpm lint` — 0 errors (82 pre-existing warnings, none in the new files).

## Tests

`app/src/utils/externalLinkGuard.test.ts` — external link is intercepted and opened outside; in-app hash routes pass through; non-http schemes ignored; an already-handled click is deferred to (the double-open regression); teardown removes the listener. jsdom's "Not implemented: navigation to another Document" in the teardown case is the un-guarded behaviour this fix exists to stop.

## Checklist

- [x] The change is focused on one logical change
- [x] No new `#[allow(...)]`, `#[ignore]`, or relaxed lints
- [x] No secrets, tokens, or `.env` contents in the diff or the description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External links now open safely without navigating users away from the app.
  * In-app routes and non-web links continue to behave normally.

* **Bug Fixes**
  * Prevented navigation to external pages that could leave users without a way back to the chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->