### PR TITLE
fix(memory_sources): Composio dispatch in Apply-all, and seal the tree after a connector sync

### DIFF
--- a/src/openhuman/integrations/composio/ops/providers_ops.rs
+++ b/src/openhuman/integrations/composio/ops/providers_ops.rs
@@ -503,6 +503,56 @@ pub(crate) async fn run_sync_pass(
         .await
         .map_err(|error| format!("ingesting {toolkit} records failed: {error}"))?;
 
+    // openhuman#6007: ask for the summary tree to be sealed once this pass has
+    // written something.
+    //
+    // Tree ingest writes its L0 chunk rows synchronously, but the Memory Tree
+    // graph and tree-backed recall read *sealed* summaries. A buffer seals on
+    // the 50k-token budget or, failing that, on the seven-day
+    // `DEFAULT_FLUSH_AGE_SECS` force-flush — and nothing on the sync path ever
+    // asked for one. So an incremental run of a handful of messages stayed
+    // under the budget and its memories were invisible for up to a week, while
+    // the source row reported them ingested the entire time.
+    //
+    // `flush_pending` enqueues a flush with `max_age_secs = 0`, so every buffer
+    // is considered rather than only the stale ones. The engine dedupes it on
+    // `date + hour/3`, which is what makes asking once per page affordable:
+    // after the first writing page the rest answer `enqueued: false` and ride
+    // the job already scheduled. That three-hour window is also the residual
+    // latency ceiling, and it is the engine's dedupe key — not something a host
+    // can shorten from here.
+    //
+    // Here rather than at the callers: `run_sync_pass` has three of them (the
+    // budgeted loop in this file, the Slack trigger RPC, and the sync bus), and
+    // one rule spread across call sites is exactly what caused #6007 — two
+    // would have got the flush and the third would have been forgotten.
+    //
+    // Best-effort by construction. The records are committed; an unsealed
+    // buffer is a delay, not a loss, and the scheduled flush still sits behind
+    // it. Nothing here may turn a successful sync into a failed one.
+    if outcome.written > 0 {
+        match binding.provider().as_maintenance() {
+            Some(maintenance) => match maintenance.flush_pending().await {
+                Ok(flush) => tracing::debug!(
+                    toolkit = %toolkit,
+                    enqueued = flush.enqueued,
+                    stale_buffers = flush.stale_buffers,
+                    "[composio] summary-tree flush requested after sync pass"
+                ),
+                Err(error) => tracing::warn!(
+                    toolkit = %toolkit,
+                    error = %error,
+                    "[composio] summary-tree flush could not be enqueued; ingested \
+                     records stay unsealed until the scheduled flush reaches them"
+                ),
+            },
+            None => tracing::debug!(
+                driver = %binding.driver_id(),
+                "[composio] bound driver serves no Maintenance; skipping the post-sync flush"
+            ),
+        }
+    }
+
     if !response.batch.complete {
         // The module keeps its own cursor, so the next call resumes where this
         // one stopped. Saying so is worth a line: a partial run that looked

--- a/src/openhuman/memory/sources/rpc_part_01.rs
+++ b/src/openhuman/memory/sources/rpc_part_01.rs
@@ -502,6 +502,53 @@ pub struct SyncResponse {
     pub source_id: String,
 }
 
+/// Which sync path a source row belongs to.
+///
+/// Extracted because there are **two** callers and they disagreed. The per-row
+/// Sync button ([`sync_rpc`]) special-cased Composio; the Apply-all sweep
+/// ([`apply_all_in_rpc`]) dispatched every enabled row through
+/// `MemorySourceSync`, which the driver refuses for Composio ("… is synced
+/// through the connector module, not this engine"). So "sync everything" failed
+/// for exactly the rows a user most expects it to fix (openhuman#6007). Two call
+/// sites open-coding one rule is how that happened; both now match on this.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SyncDispatch {
+    /// Connector-mediated. tinymemory v1.13.4 removed the engine's in-process
+    /// Composio sync, so the connector-backed run IS the sync for this kind —
+    /// the same entry point the `openhuman.composio_sync` RPC uses, which reads
+    /// the connected account through the module and ingests through this same
+    /// binding.
+    Connector {
+        connection_id: String,
+        max_items: Option<u32>,
+    },
+    /// The memory driver's own source pipeline — folder, git, RSS, and every
+    /// other tree-coupled kind.
+    Driver,
+}
+
+/// Resolve a source row to its sync path.
+///
+/// The only failure is a Composio row carrying no `connection_id`: the connector
+/// call is addressed *by* connection, so there is nothing to sync and nothing to
+/// guess. That is a malformed row rather than a transient fault, which is why the
+/// message says to remove and re-add rather than to retry.
+pub(crate) fn sync_dispatch(entry: &MemorySourceEntry) -> Result<SyncDispatch, String> {
+    if entry.kind != tinymemory_sources::types::SourceKind::Composio {
+        return Ok(SyncDispatch::Driver);
+    }
+    let connection_id = entry.connection_id.clone().ok_or_else(|| {
+        format!(
+            "composio source '{}' has no connection_id; remove and re-add the source",
+            entry.id
+        )
+    })?;
+    Ok(SyncDispatch::Connector {
+        connection_id,
+        max_items: entry.max_items,
+    })
+}
+
 pub async fn sync_rpc(req: SyncRequest) -> Result<RpcOutcome<SyncResponse>, String> {
     tracing::info!(source_id = %req.source_id, "[memory_sources] sync_rpc: entry");
 
@@ -522,26 +569,20 @@ pub async fn sync_rpc(req: SyncRequest) -> Result<RpcOutcome<SyncResponse>, Stri
         if !entry.enabled {
             return Err(format!("source '{}' is disabled", entry.id));
         }
-        // Composio rows never reach the memory driver's pipeline: v1.13.4
-        // removed the engine's in-process Composio sync, and the driver now
-        // answers this id with "synced through the connector module, not this
-        // pipeline". The connector-backed run IS the sync for this kind, so
-        // the one Sync button dispatches there — same entry point the
-        // `openhuman.composio_sync` RPC uses, which reads the connected
-        // account through the module and ingests through this same binding.
-        if entry.kind == tinymemory_sources::types::SourceKind::Composio {
-            let connection_id = entry.connection_id.as_deref().ok_or_else(|| {
-                format!(
-                    "composio source '{}' has no connection_id; remove and re-add the source",
-                    entry.id
-                )
-            })?;
+        // Composio rows never reach the memory driver's pipeline — see
+        // [`SyncDispatch`], which both this button and the Apply-all sweep read
+        // the rule from.
+        if let SyncDispatch::Connector {
+            connection_id,
+            max_items,
+        } = sync_dispatch(&entry)?
+        {
             crate::openhuman::integrations::composio::ops::composio_sync_budgeted(
                 &config,
-                connection_id,
+                &connection_id,
                 Some("manual".to_string()),
                 Some(entry.id.clone()),
-                entry.max_items,
+                max_items,
             )
             .await?;
             return Ok(RpcOutcome::new(

--- a/src/openhuman/memory/sources/rpc_part_02.rs
+++ b/src/openhuman/memory/sources/rpc_part_02.rs
@@ -415,12 +415,17 @@ pub struct AllInResponse {
 /// Takes the trigger as a closure rather than the driver trait object so the
 /// aggregation is unit-testable without a full `MemorySourceSync` stub; the
 /// RPC owns config/binding resolution and the response shape.
+///
+/// The closure receives the whole entry, not just the id: since openhuman#6007
+/// the caller has to route each row by [`SyncDispatch`], which reads the kind,
+/// the connection and the per-source cap. Owned rather than borrowed so the
+/// returned future does not have to borrow from the sweep's loop body.
 async fn trigger_enabled_syncs<F, Fut>(
     sources: &[MemorySourceEntry],
     mut trigger: F,
 ) -> (u32, Vec<String>)
 where
-    F: FnMut(String) -> Fut,
+    F: FnMut(MemorySourceEntry) -> Fut,
     Fut: std::future::Future<Output = Result<(), String>>,
 {
     let mut sync_triggered: u32 = 0;
@@ -434,7 +439,7 @@ where
             kind = %source.kind.as_str(),
             "[memory_sources] apply_all_in_rpc: triggering sync"
         );
-        match trigger(source.id.clone()).await {
+        match trigger(source.clone()).await {
             Ok(()) => {
                 sync_triggered += 1;
             }
@@ -469,22 +474,51 @@ pub async fn apply_all_in_rpc() -> Result<RpcOutcome<AllInResponse>, String> {
     // Trigger a background sync for every enabled source.
     let config = config_rpc::load_config_with_timeout().await?;
 
-    // Resolved once for the whole sweep: a driver that serves no sync has
-    // nothing to say about any source, and refusing per source would turn one
-    // fact into a warning per row.
     let binding = crate::openhuman::memory::binding::for_config(&config)?;
-    let sync = binding.provider().as_source_sync().ok_or_else(|| {
-        format!(
-            "the bound memory driver '{}' does not serve source sync",
-            binding.driver_id()
-        )
-    })?;
+    // Resolved once for the whole sweep, but as an `Option` rather than a hard
+    // error. A driver that serves `as_sources` without `as_source_sync` can
+    // still sync every Composio row through the connector, and failing the whole
+    // sweep over a capability those rows never use is the review finding the
+    // row-level path already carries (#5932) — for a Composio-only user it
+    // turned "sync everything" into one flat refusal. A row that genuinely needs
+    // the family reports the refusal as its own per-source error, which is
+    // exactly what this sweep aggregates.
+    let source_sync = binding.provider().as_source_sync();
+    let config_ref = &config;
+    let driver_id = binding.driver_id();
 
-    let (sync_triggered, sync_errors) = trigger_enabled_syncs(&sources, |source_id| async move {
-        sync.run_source_sync(&source_id)
+    let (sync_triggered, sync_errors) = trigger_enabled_syncs(&sources, move |source| async move {
+        match sync_dispatch(&source)? {
+            // The connector-backed run IS the sync for this kind, so the sweep
+            // takes the same dispatch the per-row Sync button does. Before
+            // openhuman#6007 every Composio row came back "synced through the
+            // connector module, not this engine" here.
+            SyncDispatch::Connector {
+                connection_id,
+                max_items,
+            } => crate::openhuman::integrations::composio::ops::composio_sync_budgeted(
+                config_ref,
+                &connection_id,
+                // `manual`, not a sweep-specific reason: Apply-all is a user
+                // action, and `parse_sync_reason` accepts only `manual`,
+                // `periodic` and `connection_created` — an invented reason would
+                // fail every Composio row here with "unrecognized sync reason".
+                Some("manual".to_string()),
+                Some(source.id.clone()),
+                max_items,
+            )
             .await
-            .map(|_| ())
-            .map_err(|error| error.to_string())
+            .map(|_| ()),
+            SyncDispatch::Driver => {
+                let sync = source_sync.ok_or_else(|| {
+                    format!("the bound memory driver '{driver_id}' does not serve source sync")
+                })?;
+                sync.run_source_sync(&source.id)
+                    .await
+                    .map(|_| ())
+                    .map_err(|error| error.to_string())
+            }
+        }
     })
     .await;
 

--- a/src/openhuman/memory/sources/rpc_tests.rs
+++ b/src/openhuman/memory/sources/rpc_tests.rs
@@ -74,12 +74,13 @@ async fn trigger_sweep_aggregates_failures_instead_of_laundering_them() {
 
     // Succeeds for ids starting `ok`, refuses everything else the way the
     // incident did.
-    let (triggered, errors) = trigger_enabled_syncs(&sources, |source_id| async move {
-        if source_id.starts_with("ok") {
+    let (triggered, errors) = trigger_enabled_syncs(&sources, |source| async move {
+        if source.id.starts_with("ok") {
             Ok(())
         } else {
             Err(format!(
-                "not found: no memory source registered as {source_id}"
+                "not found: no memory source registered as {}",
+                source.id
             ))
         }
     })
@@ -97,5 +98,68 @@ async fn trigger_sweep_aggregates_failures_instead_of_laundering_them() {
         errors[1].starts_with("src_also_gone: "),
         "got: {}",
         errors[1]
+    );
+}
+
+/// openhuman#6007: the per-row Sync button and the Apply-all sweep must route a
+/// row the same way, so the decision is one function and this is its test.
+///
+/// The bug was not that either call site was wrong in isolation — it was that
+/// there were two of them. Apply-all sent Composio rows through
+/// `MemorySourceSync`, which the driver refuses for exactly that kind, so "sync
+/// everything" failed for every connector source. Asserting the *rule* is what
+/// stops the two drifting again; a test that drove a full sync could not, since
+/// these handlers read the bound driver and are not reachable from a test.
+#[test]
+fn composio_rows_dispatch_to_the_connector_and_everything_else_to_the_driver() {
+    fn composio(id: &str, connection_id: Option<&str>) -> MemorySourceEntry {
+        let mut entry: MemorySourceEntry = serde_json::from_value(serde_json::json!({
+            "id": id,
+            "kind": "composio",
+            "label": "Gmail",
+            "enabled": true,
+            "toolkit": "gmail",
+            "connection_id": connection_id,
+        }))
+        .expect("a valid composio source entry");
+        // Set through the struct rather than the JSON so this test does not
+        // depend on `max_items` being an accepted input field for the kind.
+        entry.max_items = Some(25);
+        entry
+    }
+
+    fn folder(id: &str) -> MemorySourceEntry {
+        serde_json::from_value(serde_json::json!({
+            "id": id,
+            "kind": "folder",
+            "label": "Notes",
+            "enabled": true,
+            "path": ".",
+        }))
+        .expect("a valid folder source entry")
+    }
+
+    assert_eq!(
+        sync_dispatch(&composio("src_gmail", Some("ca_1"))).expect("a connected composio row"),
+        SyncDispatch::Connector {
+            connection_id: "ca_1".to_string(),
+            max_items: Some(25),
+        },
+        "a Composio row must route to the connector, carrying its connection and cap"
+    );
+
+    assert_eq!(
+        sync_dispatch(&folder("src_notes")).expect("a folder row"),
+        SyncDispatch::Driver,
+        "every non-Composio kind stays on the driver's own pipeline"
+    );
+
+    // A connection-less Composio row is malformed, not retryable: the connector
+    // call is addressed by connection, so there is nothing to sync.
+    let error = sync_dispatch(&composio("src_broken", None))
+        .expect_err("a composio row with no connection cannot be dispatched");
+    assert!(
+        error.contains("src_broken") && error.contains("remove and re-add"),
+        "the refusal must name the row and say what to do about it, got: {error}"
     );
 }


### PR DESCRIPTION
## Summary

The two host-side halves of #6007. Neither needs a module release; both are openhuman-only.

### 1. Apply all / sync everything never worked for a Composio source

The per-row Sync button special-cased Composio; the Apply-all sweep did not. It dispatched every enabled row through `MemorySourceSync::run_source_sync`, which the driver refuses for this kind — `"… is synced through the connector module, not this engine"` — so "sync everything" failed for exactly the rows a user reaches for it to fix.

Two call sites open-coding one rule is how they drifted, so the decision is now one pure function:

- `sync_dispatch(&entry) -> Result<SyncDispatch, String>`, returning `SyncDispatch::Connector { connection_id, max_items }` or `SyncDispatch::Driver`. Both the row Sync button and the sweep match on it.
- `trigger_enabled_syncs`' closure now takes the whole `MemorySourceEntry` rather than just the id, because routing needs the kind, the connection and the per-source cap.

**A second defect in the same function:** `apply_all_in_rpc` resolved `as_source_sync()` up front and **hard-errored the whole sweep** when it answered `None`. For a Composio-only profile that turned Apply-all into one flat refusal over a capability none of its rows use — the same trade the row-level path already documents as a review finding on #5932. The family is now resolved as an `Option` and refused **per row**, which is what this sweep already aggregates into `sync_errors` / `sync_failed` (#5820).

Note the deliberate behaviour change: a driver serving no source sync at all now yields `sync_failed: N` with one message per row instead of a single RPC error. That is this function's own aggregation contract.

One trap worth naming: the sweep passes `manual` as the sync reason, not something sweep-specific. `parse_sync_reason` accepts only `manual`, `periodic` and `connection_created` — an invented reason would have failed every Composio row with `"unrecognized sync reason"`, i.e. reproduced the bug through a different door.

### 2. A synced connector item could stay invisible for up to a week

Found while answering "after the fix, will syncing Gmail actually add nodes to the memory tree?" — and the honest answer was "eventually".

Tree ingest writes its L0 chunk rows synchronously, but the Memory Tree graph and tree-backed recall read **sealed** summaries. A buffer seals on the 50k-token budget (`INPUT_TOKEN_BUDGET`) or, failing that, on the seven-day force-flush (`DEFAULT_FLUSH_AGE_SECS = 604_800`) — and nothing on the sync path ever asked for a seal. So a large first backfill sealed continuously and looked fine, while an **incremental** sync of a handful of messages stayed under the token budget and its memories were invisible for up to a week, with the source row reporting them ingested the whole time.

`run_sync_pass` now asks the driver to seal once a pass has written something, via `MemoryMaintenance::flush_pending()` (`max_age_secs = 0`, so every buffer is considered rather than only the stale ones). The enqueue wakes the seal worker, so the wait becomes queue-claim plus summariser latency — **seconds to a couple of minutes** — instead of up to seven days.

Placement notes, both deliberate:

- **Inside `run_sync_pass`, not at its callers.** It has three (the budgeted loop in `providers_ops.rs`, the Slack trigger RPC, and the sync bus). One rule spread across call sites is exactly what caused #6007 — two would have got the flush and the third would have been forgotten.
- **Per page is affordable because the engine dedupes** on `date + hour/3`: while a flush for the current window is `ready`/`running`, later pages answer `enqueued: false` and ride it. Note the dedupe is a *partial* unique index (`idx_mem_tree_jobs_dedupe_active`, `WHERE status IN ('ready','running')`), so a completed flush leaves the index and the next enqueue succeeds — the three-hour block is the key's granularity, not a cooldown.

  The one residual gap is a race rather than a schedule, and it is worth stating with its real cost: if a flush is already `running` when a pass's chunks land, the enqueue is suppressed, and that in-flight job may have already walked past the new buffer. Those items then wait for the next *force* flush. The periodic scheduler does **not** rescue them — it enqueues `FlushStalePayload::default()`, whose `max_age_secs` is `None` and resolves to `L0_DEFAULT_FLUSH_AGE_SECS` (7 days), so its three-hourly tick only seals genuinely stale buffers. In practice the next connector sync clears it (by then the previous job has completed and left the partial index); absent another sync, it is the seven-day flush.

  Closing that properly wants a per-tree seal: `force_flush_tree` exists in the engine but is not on the driver contract, so reaching it means a new contract member and another module release. Follow-up, not a blocker — the race is narrow and strictly better than the pre-change behaviour, which had *every* small sync waiting seven days.

Best-effort by construction: gated on `outcome.written > 0`, a driver serving no `Maintenance` is skipped with a debug line, and a flush error is a warn. The records are already committed and an unsealed buffer is a delay rather than a loss, so nothing here may turn a successful sync into a failed one. `flush_pending` is not guard-wrapped, so there is no policy gate or denial path in this call.

## What is NOT in this PR

The **primary** half of #6007 — connector items writing namespace documents and vector chunks but never `mem_tree_chunks`, so Gmail syncs and every tree-backed surface reports zero — is fixed in tinymemory: **tinyhumansai/tinymemory#134**.

It cannot ride along here. This repo only *dev*-depends on `tinymemory-tinycortex`; the production engine ships inside the prebuilt TinyBus module pinned at `1.13.7` in `src/openhuman/modules/registry_part_01.rs`. That half reaches users through a tinymemory patch release plus a registry re-pin (which also requires bumping `ARTIFACT_CAPABILITIES_PIN`, or `the_capability_list_matches_the_pinned_release` goes red). Follow-up PR once the release is cut.

Half 2 does not do much for *connector* content until half 1 ships — before it, nothing connector-shaped is in an L0 buffer to seal. But it is not a no-op in the meantime, and that is worth being explicit about: `flush_pending` considers **every** L0 buffer in the workspace, not only the syncing source's, so a connector sync will now also seal whatever a folder or `github_repo` source has left pending. That is a scheduling side effect of using the existing engine-wide flush rather than a per-tree one (`force_flush_tree` is per-tree, but is not on the contract). It brings other sources' summaries forward, never drops or reorders anything — but it does mean a Composio sync now nudges unrelated trees, so flag it if that is not wanted here.

So please **do not close #6007 on this merge** — hence `Refs`, not `Closes`.

Backfill for already-synced records is tracked separately in #6012.

## Test plan

- [x] `cargo check --all-targets` — clean, no new warnings
- [x] `cargo test --lib memory::sources` — pass, including the new dispatch test
- [x] `cargo test --lib composio` — pass
- [x] `cargo fmt --all --check`

New `composio_rows_dispatch_to_the_connector_and_everything_else_to_the_driver` asserts the rule itself: a connected Composio row routes to the connector carrying its connection and cap, every other kind stays on the driver, and a connection-less Composio row is refused by name. Asserting the *rule* is what stops the two call sites drifting again.

**The post-sync flush is not unit-tested, deliberately.** `run_sync_pass` reads the bound driver and the connector module and is not reachable from a test — the same constraint that makes the dispatch decision worth extracting as a pure function. Its observable effect is a queue enqueue inside the module. Stating that rather than implying coverage it does not have.

Frontend untouched, so the pnpm lanes were not re-run.

Refs #6007


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Manual and “Apply all” synchronization now consistently route each memory source through the appropriate connector or driver.
  * Synchronization continues for other sources when a driver lacks source-sync support, with errors reported per source.
  * Successful syncs now request background maintenance to refresh summary data when new records are added.

* **Bug Fixes**
  * Improved handling and error reporting for connector sources missing required connection details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->