### PR TITLE
fix(release): stream git log so release notes survive long tag spans

### DIFF
--- a/.github/workflows/ci-lite.yml
+++ b/.github/workflows/ci-lite.yml
@@ -230,6 +230,11 @@ jobs:
               - 'scripts/mock-api/**'
               - 'scripts/*.mjs'
               - 'scripts/__tests__/**'
+              # The release-notes generator has node --test coverage in
+              # scripts/__tests__/ but lives one directory down, so the
+              # 'scripts/*.mjs' glob above never armed this lane for it — its
+              # tests could not have caught the v0.63.21 git ENOBUFS regression.
+              - 'scripts/release/*.mjs'
               # Bash helpers with node --test coverage in scripts/__tests__/.
               - 'scripts/ci/assert-coverage-presence.sh'
               # Shared logic behind the gate CLIs, and the module-pin gate's own

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -292,7 +292,10 @@ jobs:
           TAG: ${{ needs.prepare-build.outputs.tag }}
         run: |
           set -euo pipefail
-          echo "::warning::AI release notes failed or timed out — using deterministic notes."
+          # `continue-on-error` hides the AI step's real failure, so this warning
+          # must not assert a cause: on v0.63.21 both steps died on the same git
+          # ENOBUFS and the "timed out" wording sent the investigation the wrong way.
+          echo "::warning::AI release notes step did not succeed (outcome=${{ steps.ai-notes.outcome }}) — using deterministic notes. See the 'Generate AI release notes' step log for the reason."
           node scripts/release/generate-release-notes.mjs \
             --from latest-release \
             --to "$TAG" \

--- a/scripts/__tests__/generate-release-notes.test.mjs
+++ b/scripts/__tests__/generate-release-notes.test.mjs
@@ -1,14 +1,21 @@
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
 
 import {
   buildOpenAiRequest,
   buildReleasePayload,
+  collectCommits,
+  createRecordSplitter,
   ensureAllPullRequestsLinked,
   extractPullRequestNumbers,
   parseArgs,
   parseGitHubRepoFromRemote,
   parseGitLog,
+  priorAuthorKeys,
   renderDeterministicNotes,
 } from '../release/generate-release-notes.mjs';
 
@@ -210,4 +217,98 @@ test('deterministic notes omit new contributors section when there are none', ()
 
   const markdown = renderDeterministicNotes({ title: 'v1.0.0 to main', payload });
   assert.doesNotMatch(markdown, /## New Contributors/);
+});
+
+test('record splitter reassembles records across chunk boundaries', () => {
+  const records = [];
+  const splitter = createRecordSplitter('\x1e', (record) => records.push(record));
+
+  // A separator straddling two chunks is the failure mode a naive
+  // `chunk.split(sep)` reader gets wrong, so feed one byte at a time.
+  const stream = 'alpha\x1ebeta\x1egamma';
+  for (const character of stream) {
+    splitter.push(character);
+  }
+  assert.deepEqual(records, ['alpha', 'beta']);
+
+  // The final record has no trailing separator; end() must still emit it.
+  splitter.end();
+  assert.deepEqual(records, ['alpha', 'beta', 'gamma']);
+
+  // end() is idempotent — a second call must not re-emit.
+  splitter.end();
+  assert.deepEqual(records, ['alpha', 'beta', 'gamma']);
+});
+
+test('commit collection survives a git log larger than the 1 MiB spawn buffer', async (t) => {
+  // Regression guard for the v0.63.21 release failure: `execFileSync` buffers the
+  // child's whole stdout and throws `spawnSync git ENOBUFS` past Node's 1 MiB
+  // `maxBuffer` default. The release span grows with every unpublished tag, so the
+  // collector must not have a fixed output ceiling at all.
+  const MAX_BUFFER_BYTES = 1024 * 1024;
+  const repo = mkdtempSync(join(tmpdir(), 'release-notes-enobufs-'));
+  t.after(() => rmSync(repo, { recursive: true, force: true }));
+
+  // Ignore the ambient git config: a developer's global `commit.gpgsign` or
+  // `tag.gpgSign` would otherwise make the fixture prompt or fail.
+  const git = (...args) =>
+    execFileSync('git', args, {
+      cwd: repo,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
+    });
+
+  git('init', '--quiet', '--initial-branch', 'main');
+  git('config', 'user.name', 'Range Fixture');
+  git('config', 'user.email', 'range@example.test');
+  git('config', 'commit.gpgsign', 'false');
+  git('config', 'tag.gpgSign', 'false');
+  git('commit', '--allow-empty', '--quiet', '-m', 'base');
+  git('tag', 'start');
+
+  const COMMITS = 150;
+  const SUBJECT_PADDING = 8000;
+  for (let index = 0; index < COMMITS; index += 1) {
+    git(
+      'commit',
+      '--allow-empty',
+      '--quiet',
+      '-m',
+      `chore: padded commit ${index} ${'x'.repeat(SUBJECT_PADDING)} (#${1000 + index})`,
+    );
+  }
+  git('tag', 'end');
+
+  const previousCwd = process.cwd();
+  process.chdir(repo);
+  t.after(() => process.chdir(previousCwd));
+
+  // The fixture is only a regression guard if it actually overflows the buffer
+  // the old implementation used.
+  const rawBytes = Buffer.byteLength(
+    execFileSync(
+      'git',
+      ['log', 'start..end', '--reverse', '--format=%H%x1f%s%x1f%an%x1f%ae%x1f%aI%x1e'],
+      {
+        cwd: repo,
+        encoding: 'utf8',
+        maxBuffer: 64 * 1024 * 1024,
+        env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
+      },
+    ),
+  );
+  assert.ok(
+    rawBytes > MAX_BUFFER_BYTES,
+    `fixture must exceed the 1 MiB spawn buffer, got ${rawBytes} bytes`,
+  );
+
+  const commits = await collectCommits('start', 'end');
+  assert.equal(commits.length, COMMITS);
+  assert.equal(commits.at(0).primaryPrNumber, 1000);
+  assert.equal(commits.at(-1).primaryPrNumber, 1000 + COMMITS - 1);
+  assert.ok(commits.every((commit) => commit.sha.length === 40));
+
+  const priorKeys = await priorAuthorKeys('start');
+  assert.ok(priorKeys.has('range fixture <range@example.test>'));
 });

--- a/scripts/release/generate-release-notes.mjs
+++ b/scripts/release/generate-release-notes.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 import { existsSync, writeFileSync } from 'node:fs';
 import { basename, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -103,6 +103,80 @@ function runGh(args, options = {}) {
   }).trim();
 }
 
+const RECORD_SEPARATOR = '\x1e';
+
+/**
+ * Split a byte stream into separator-delimited records without ever holding the
+ * whole stream in memory. Chunk boundaries land anywhere, including inside a
+ * record, so the tail of each chunk is carried into the next one.
+ */
+export function createRecordSplitter(separator, onRecord) {
+  let pending = '';
+  return {
+    push(chunk) {
+      pending += chunk;
+      let index = pending.indexOf(separator);
+      while (index !== -1) {
+        onRecord(pending.slice(0, index));
+        pending = pending.slice(index + separator.length);
+        index = pending.indexOf(separator);
+      }
+    },
+    end() {
+      if (pending) {
+        onRecord(pending);
+        pending = '';
+      }
+    },
+  };
+}
+
+/**
+ * Run git and hand each separator-delimited record to `onRecord` as it arrives.
+ *
+ * `execFileSync` buffers the child's entire stdout and dies with ENOBUFS once it
+ * passes Node's 1 MiB `maxBuffer` default. The release ranges this script walks
+ * grow with every unpublished tag, so a buffered read is a ratchet that is
+ * guaranteed to break again at some future span. Streaming has no such ceiling.
+ */
+function streamGitRecords(args, onRecord, options = {}) {
+  const separator = options.separator || RECORD_SEPARATOR;
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn('git', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const splitter = createRecordSplitter(separator, onRecord);
+    let stderr = '';
+
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      try {
+        splitter.push(chunk);
+      } catch (error) {
+        child.kill();
+        reject(error);
+      }
+    });
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(`git ${args.join(' ')} exited with code ${code}${stderr ? `: ${stderr.trim()}` : ''}`));
+        return;
+      }
+      try {
+        splitter.end();
+      } catch (error) {
+        reject(error);
+        return;
+      }
+      resolvePromise();
+    });
+  });
+}
+
 export function parseGitHubRepoFromRemote(remoteUrl) {
   const cleaned = String(remoteUrl || '').trim().replace(/\.git$/, '');
   const sshMatch = cleaned.match(/github\.com[:/]([^/\s]+\/[^/\s]+)$/);
@@ -167,46 +241,53 @@ export function extractPullRequestNumbers(subject) {
   return [...new Set(matches.map((match) => Number(match[1])).filter(Number.isInteger))];
 }
 
+function parseCommitRecord(entry) {
+  const [sha, subject, authorName, authorEmail, authoredAt] = entry.split('\x1f');
+  const prNumbers = extractPullRequestNumbers(subject);
+  return {
+    sha,
+    shortSha: sha.slice(0, 9),
+    subject,
+    authorName,
+    authorEmail,
+    authoredAt,
+    prNumbers,
+    primaryPrNumber: prNumbers.at(-1) || null,
+  };
+}
+
 export function parseGitLog(logText) {
   if (!logText.trim()) {
     return [];
   }
 
   return logText
-    .split('\x1e')
+    .split(RECORD_SEPARATOR)
     .map((entry) => entry.trim())
     .filter(Boolean)
-    .map((entry) => {
-      const [sha, subject, authorName, authorEmail, authoredAt] = entry.split('\x1f');
-      const prNumbers = extractPullRequestNumbers(subject);
-      return {
-        sha,
-        shortSha: sha.slice(0, 9),
-        subject,
-        authorName,
-        authorEmail,
-        authoredAt,
-        prNumbers,
-        primaryPrNumber: prNumbers.at(-1) || null,
-      };
-    });
+    .map(parseCommitRecord);
 }
 
-function collectCommits(from, to) {
+export async function collectCommits(from, to) {
   const format = '%H%x1f%s%x1f%an%x1f%ae%x1f%aI%x1e';
-  const output = runGit(['log', `${from}..${to}`, '--reverse', `--format=${format}`]);
-  return parseGitLog(output);
+  const commits = [];
+  await streamGitRecords(['log', `${from}..${to}`, '--reverse', `--format=${format}`], (entry) => {
+    const trimmed = entry.trim();
+    if (trimmed) {
+      commits.push(parseCommitRecord(trimmed));
+    }
+  });
+  return commits;
 }
 
-function priorAuthorKeys(from) {
-  const output = runGit(['log', from, '--format=%an%x1f%ae%x1e']);
+export async function priorAuthorKeys(from) {
   const keys = new Set();
-  for (const entry of output.split('\x1e')) {
+  await streamGitRecords(['log', from, '--format=%an%x1f%ae%x1e'], (entry) => {
     const [name, email] = entry.trim().split('\x1f');
     if (name || email) {
       keys.add(authorKey({ authorName: name, authorEmail: email }));
     }
-  }
+  });
   return keys;
 }
 
@@ -671,8 +752,8 @@ async function main() {
   assertRefExists(resolvedTo, 'End');
 
   console.error(`[release-notes] Collecting ${repo} changes from ${from} to ${resolvedTo}`);
-  const commits = collectCommits(from, resolvedTo);
-  const contributors = collectContributorStats(commits, priorAuthorKeys(from));
+  const commits = await collectCommits(from, resolvedTo);
+  const contributors = collectContributorStats(commits, await priorAuthorKeys(from));
   const pullRequests = collectPullRequests(repo, commits);
   const payload = buildReleasePayload({
     from,


### PR DESCRIPTION
## Summary

- Stream `git log` in the release-notes generator instead of buffering it, fixing the `spawnSync git ENOBUFS` that has blocked **Release Production** since v0.63.12.
- Apply the same fix to `priorAuthorKeys`, which walks the *entire* repo history and so was unbounded by construction, not just by release span.
- Stop the fallback step from claiming the AI step "failed or timed out" — on the failing run both steps died on the same ENOBUFS, and that wording misdirected the investigation.
- Arm ci-lite's `scripts` lane for `scripts/release/*.mjs`, whose `node --test` suite could not run on changes to the file it covers.

## Problem

Run [33753636908](https://github.com/tinyhumansai/openhuman/actions/runs/33753636908) (branch `release`, sha `399968801`) failed in **Prepare GitHub release**:

```
##[warning]AI release notes failed or timed out — using deterministic notes.
[release-notes] Collecting tinyhumansai/openhuman changes from v0.63.12 to v0.63.21
[release-notes] spawnSync git ENOBUFS
##[error]Process completed with exit code 1.
```

`execFileSync` buffers the child's whole stdout and throws `ENOBUFS` past Node's 1 MiB `maxBuffer` default. The offending line was in `collectCommits`:

```js
const output = runGit(['log', `${from}..${to}`, '--reverse', `--format=${format}`]);
```

**This ratchets.** `--from latest-release` resolves to the last *published* release, so each release that fails to publish lengthens the next range. Measured against the real tags:

| range | commits | `git log` bytes | % of 1 MiB | outcome |
|---|---|---|---|---|
| `v0.63.12..v0.63.17` (2026-08-21) | 2,311 | 394,024 | 38% | published OK |
| `v0.63.12..v0.63.21` (2026-09-03) | 6,973 | 1,178,143 | **112%** | ENOBUFS |

No GitHub Release has been created since v0.63.12 on 2026-08-07; `v0.63.17`, `v0.63.20` and `v0.63.21` are tagged with nothing published behind them.

## Solution

`collectCommits` and `priorAuthorKeys` now stream git's stdout through `spawn` and an incremental record splitter, parsing each `\x1e`-delimited record as it arrives. There is no output ceiling left to cross, so the next long span cannot regress this again.

**Why not just raise `maxBuffer`.** It only moves the wall. The span grows with every unpublished release and `priorAuthorKeys` grows with every commit ever made, so any constant picked today is a future outage with a longer fuse. Streaming removes the limit rather than raising it, and costs one small helper.

The splitter carries the tail of each chunk into the next one — a chunk boundary landing inside a record is the failure mode a naive per-chunk `split()` gets wrong, and it is covered by its own test.

`parseGitLog` keeps its existing exported signature and behaviour; it and the streaming path now share one `parseCommitRecord`.

**Not fixed here (filed in the issue as follow-up):** `collectPullRequests` makes one sequential `gh pr view` per PR — 197 for this range. The end-to-end run below took 1m51s before the OpenAI call, nearly all of it those fetches, so the AI step's `timeout-minutes: 5` does still fit today with ~3 minutes to spare. That headroom shrinks as the span grows, though: it is a second, slower ratchet behind the one this PR removes.

## Impact

- Release lane only — no runtime, app, or CLI surface is touched.
- Memory profile improves: neither collector now holds the full `git log` output.
- Both collectors became `async`; the single call site in `main()` (already `async`) awaits them.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `scripts/__tests__/generate-release-notes.test.mjs` gains two tests: a chunk-boundary test for the splitter, and an end-to-end test that builds a fixture repo whose `git log` output exceeds 1 MiB and asserts every commit is collected. Both were revert-checked (see below).
- [x] N/A: **Diff coverage ≥ 80%** — the diff-cover gate measures Vitest + cargo-llvm-cov; `scripts/**` is outside both instrumented trees. The changed lines are covered by the `node --test` suite in the `scripts` lane, which this PR also arms for this directory.
- [x] N/A: Coverage matrix updated — release-tooling change, no feature row in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] N/A: All affected feature IDs listed under `## Related` — no matrix feature IDs apply.
- [x] No new external network dependencies introduced — the new code spawns `git`, which the script already invoked.
- [x] N/A: Manual smoke checklist updated — `docs/RELEASE-MANUAL-SMOKE.md` covers built artefacts; this changes how release-note text is generated, not what ships.
- [x] Linked issue closed via `Closes #NNN` — see `## Related`.

### How this was verified

1. `node --test scripts/__tests__/generate-release-notes.test.mjs` — **12/12 pass** (was 10 tests before this PR).
2. **Revert-check, streaming collector.** Restoring the `execFileSync` version of `collectCommits` with the new test in place fails with the production error verbatim:
   ```
   ✖ commit collection survives a git log larger than the 1 MiB spawn buffer
     Error: spawnSync git ENOBUFS
   ```
   The test asserts its fixture actually exceeds 1 MiB before collecting, so it cannot pass vacuously on a small repo.
3. **Revert-check, splitter.** Replacing the incremental splitter with a naive per-chunk `chunk.split(separator)` fails the boundary test (`actual` drops records when fed one byte at a time).
4. **End-to-end against the real failing range** — `generate-release-notes.mjs --from v0.63.12 --to v0.63.21 --repo tinyhumansai/openhuman --no-ai`, i.e. the exact command the failing step ran. Exit 0 in 1m51s, writing 19,036 bytes of notes covering 197 PRs across 6,973 commits. The unfixed script died 0.14s into this same command.
5. Both edited workflow files re-parsed as YAML.

## Related

- Closes #6030
- Follow-up PR(s)/TODOs: batch the 197 sequential `gh pr view` calls in `collectPullRequests` before they grow into the AI step's 5-minute timeout (tracked in #6030).
- **This fix must also reach `release` to unblock the next production cut.** This PR targets `main` per branch policy; the maintainer should promote or cherry-pick it onto `release` — I have not pushed to `release`.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/release-notes-git-log-enobufs`
- Commit SHA: `b130e2e24`

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no files under `app/` changed; `format`/`lint` in this repo are scoped to `openhuman-app`.
- [x] N/A: `pnpm typecheck` — no TypeScript changed; the edited files are `.mjs`, YAML, and a `node --test` suite.
- [x] Focused tests: `node --test scripts/__tests__/generate-release-notes.test.mjs` (12/12), plus the two revert-checks and the end-to-end run above.
- [x] N/A: Rust fmt/check — no Rust changed.
- [x] N/A: Tauri fmt/check — no Tauri code changed.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: the release-notes generator no longer has a fixed cap on how much `git log` output it can consume, so it works across arbitrarily long tag spans.
- User-visible effect: `Release Production` can publish again. Release-note *content* is unchanged — same records, same ordering, same rendering.

### Parity Contract

- Legacy behavior preserved: `parseGitLog` keeps its exported signature and output; it and the streaming path share one `parseCommitRecord`, so records parse identically. Record ordering still comes from `git log --reverse`.
- Guard/fallback/dispatch parity checks: `streamGitRecords` rejects on a non-zero git exit and includes git's stderr, so a bad ref still fails loudly rather than yielding empty notes — the buffered `execFileSync` path also threw on non-zero exit.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-note generation for repositories with large commit histories, preventing failures caused by oversized Git output.
  * Release workflow warnings now accurately reflect the AI step’s outcome and direct users to its logs for investigation.

* **Tests**
  * Added coverage for large commit histories and records split across streamed data chunks.

* **Chores**
  * Updates to release-note generator modules now trigger the appropriate self-test workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->