### PR TITLE
test(journal): add UTF-8 boundary regression test for #5599

### DIFF
--- a/src/openhuman/agent/tinyagents/journal_tests.rs
+++ b/src/openhuman/agent/tinyagents/journal_tests.rs
@@ -121,3 +121,113 @@ async fn read_run_events_at(
         .await
         .unwrap()
 }
+
+/// Asserts that the durable journal sink and underlying append store handle
+/// multi-byte UTF-8 sequences straddling the 4096-byte lookback window boundary
+/// without failing validation or dropping observations (#5599).
+///
+/// `JsonlAppendStore::next_offset` seeks to `len - 4096`. When that byte offset lands
+/// mid-character, older implementations using `read_to_string` failed with "stream did
+/// not contain valid UTF-8". This test asserts that such boundary straddles are genuinely
+/// induced (`assert!(!torn.is_empty())`) and that subsequent appends and late-attach
+/// replays succeed contiguously.
+#[tokio::test]
+async fn journal_sink_handles_multibyte_utf8_spanning_window_boundary() {
+    const WINDOW: usize = 4096;
+    let mut torn = Vec::new();
+
+    // Walk a padding range to sweep the (len - 4096) lookback boundary across
+    // the continuation bytes of a multi-byte UTF-8 sequence.
+    for pad in 0..20usize {
+        let tmp = std::env::temp_dir().join(format!(
+            "oh-journal-utf8-test-{pad}-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let run_id = mint_run_id();
+
+        let stores = open_session_stores(&tmp);
+        let journal: Arc<dyn HarnessEventJournal> =
+            Arc::new(StoreEventJournal::new(stores.journal));
+        let sink = EventSink::with_stream_id(run_id.as_str());
+        let journal_sink = Arc::new(JournalSink::new(journal, run_id.clone()));
+        sink.subscribe(Arc::new(FanOutSink::new().with(journal_sink.clone())));
+
+        // 10 base events with multi-byte emoji payloads to approach and exceed WINDOW (4096 bytes).
+        for i in 0..10 {
+            sink.emit(AgentEvent::ModelStarted {
+                call_id: format!("call-{i}").into(),
+                model: "🦀".repeat(50),
+            });
+        }
+
+        // An 11th event whose model string is padded byte-by-byte to sweep the window boundary.
+        sink.emit(AgentEvent::ModelStarted {
+            call_id: "call-10".into(),
+            model: "x".repeat(pad),
+        });
+        journal_sink.flush();
+
+        // Inspect the underlying stream file to verify whether this pad placed the
+        // 4096-byte lookback window start inside a multi-byte UTF-8 character.
+        let stream_path = tmp
+            .join("tinyagents_store")
+            .join("journal")
+            .join(format!("{}.jsonl", run_id.as_str()));
+        let raw = std::fs::read(&stream_path).expect("read stream file");
+        if raw.len() > WINDOW {
+            let start = raw.len() - WINDOW;
+            let text = std::str::from_utf8(&raw).expect("stream file itself is valid UTF-8");
+            if !text.is_char_boundary(start) {
+                torn.push(pad);
+            }
+        }
+
+        // Emit a subsequent tool event across the boundary: this forces next_offset
+        // to resolve the stream tail and assign the next sequential offset.
+        sink.emit(AgentEvent::ToolStarted {
+            call_id: "call-11".into(),
+            tool_name: "test_tool".to_string(),
+        });
+        journal_sink.flush();
+
+        // Verify replay: all 12 events must be present and contiguous from offset 0.
+        let replayed = read_run_events_at(&tmp, run_id.as_str(), 0).await;
+        assert_eq!(
+            replayed.len(),
+            12,
+            "pad {pad}: all observations must be retained"
+        );
+        for (i, obs) in replayed.iter().enumerate() {
+            assert_eq!(
+                obs.offset, i as u64,
+                "pad {pad}: observation {i} offset must be contiguous"
+            );
+            assert_eq!(
+                obs.event_id.as_str(),
+                format!("{}-evt-{i}", run_id.as_str()),
+                "pad {pad}: event id should follow stable prefix pattern"
+            );
+        }
+
+        // Verify model contents on the first and 11th observations match exactly.
+        if let AgentEvent::ModelStarted { model, .. } = &replayed[0].event {
+            assert_eq!(model, &"🦀".repeat(50));
+        } else {
+            panic!("pad {pad}: expected ModelStarted at offset 0");
+        }
+        if let AgentEvent::ModelStarted { model, .. } = &replayed[10].event {
+            assert_eq!(model, &"x".repeat(pad));
+        } else {
+            panic!("pad {pad}: expected ModelStarted at offset 10");
+        }
+        assert!(matches!(replayed[11].event, AgentEvent::ToolStarted { .. }));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    assert!(
+        !torn.is_empty(),
+        "no pad put the 4096-byte window start inside a multi-byte character; \
+         adjust padding range so the test proves boundary recovery"
+    );
+}

--- a/src/openhuman/agent/tinyagents/journal_tests.rs
+++ b/src/openhuman/agent/tinyagents/journal_tests.rs
@@ -176,7 +176,7 @@ async fn journal_sink_handles_multibyte_utf8_spanning_window_boundary() {
         let raw = std::fs::read(&stream_path).expect("read stream file");
         if raw.len() > WINDOW {
             let start = raw.len() - WINDOW;
-            let text = std::str::from_utf8(&raw).expect("stream file itself is valid UTF-8");
+            let text = String::from_utf8_lossy(&raw);
             if !text.is_char_boundary(start) {
                 torn.push(pad);
             }


### PR DESCRIPTION
## Summary

Adds an OpenHuman-level regression test in `src/openhuman/agent/tinyagents/journal_tests.rs` covering multi-byte UTF-8 characters that bisect the 4096-byte lookback window boundary of `JsonlAppendStore::next_offset`.

Refs #5599

## Background

In #5599, staging sessions experienced silent observation drops (`durable append failed: stream did not contain valid UTF-8`) when `JsonlAppendStore::next_offset` sought to `len - 4096` and used `read_to_string` on an arbitrary byte offset. When `len - 4096` landed mid-character, `read_to_string` rejected the continuation byte.

The underlying fix landed upstream in `tinyagents#115` & `#109` (reading raw bytes and decoding from the first newline) and is pinned in `vendor/tinyagents` on `main`. Following maintainer feedback on #5630, this PR provides the corresponding OpenHuman-level regression test.

## Changes

- Added `journal_sink_handles_multibyte_utf8_spanning_window_boundary` to `src/openhuman/agent/tinyagents/journal_tests.rs`:
  - Emits base events with multi-byte UTF-8 sequences (`🦀` 4-byte emojis) to exceed the 4096-byte window.
  - Sweeps a padding range across iterations to walk `start = len - 4096` across continuation bytes.
  - Inspects the stream file `{tmp}/tinyagents_store/journal/{run_id}.jsonl` to ensure `!text.is_char_boundary(start)` is genuinely induced (`assert!(!torn.is_empty())`).
  - Appends subsequent events across the torn boundary to verify `next_offset` calculates the next offset without failing.
  - Replays all observations from offset 0 via `read_run_events_at` and verifies that all events replay with strictly contiguous offsets `0..N`, stable `{run_id}-evt-{offset}` IDs, and exact payload matches.
  - Keeps tests strictly within `journal_tests.rs` (232 lines, well under the 750-line gate).

## Checklist

- [x] Tested against latest `upstream/main`
- [x] Verified `!text.is_char_boundary(start)` is strictly hit and asserted
- [x] Clean replay assertions (ordered offsets 0..N, matching payloads)
- [x] Formatted with `rustfmt`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded automated coverage for journal storage with multi-byte UTF-8 content crossing internal boundaries.
  - Verified that subsequent writes and replayed entries remain contiguous, preserve exact payloads, maintain stable event identifiers, and report correct offsets.
  - Added coverage for reconnecting or attaching to existing journal data after such boundary conditions.
  - Improved boundary detection coverage to handle invalid UTF-8 safely without panicking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->