### PR TITLE
test(sandbox-panel): wait for the loaded panel, not for the load to start

### DIFF
--- a/app/src/components/settings/panels/__tests__/SandboxSettingsPanel.validation.test.tsx
+++ b/app/src/components/settings/panels/__tests__/SandboxSettingsPanel.validation.test.tsx
@@ -66,7 +66,16 @@ const mockIsTauri = vi.mocked(isTauri);
 async function renderLoaded(overrides: Partial<SandboxSettings> = {}) {
   mockGet.mockResolvedValue({ result: sandboxSettings(overrides), logs: [] });
   renderWithProviders(<SandboxSettingsPanel />);
-  await waitFor(() => expect(mockGet).toHaveBeenCalled());
+  // Not `waitFor(() => expect(mockGet).toHaveBeenCalled())`: the panel calls
+  // openhumanGetSandboxSettings synchronously inside its mount effect, so that
+  // assertion already holds on waitFor's first tick, while isLoading is still
+  // true and the panel is rendering the loading paragraph. The synchronous
+  // getBy* accessors below then query a DOM that has no fields in it yet. The
+  // same trap is described under flushPersist; it applies to readiness too.
+  //
+  // The backend select is rendered only by the loaded branch and by every
+  // override these tests pass, so awaiting it is the signal that was meant.
+  await screen.findByRole('combobox', { name: /backend/i });
 }
 
 /**


### PR DESCRIPTION
`SandboxSettingsPanel.validation.test.tsx` fails intermittently on CI:

```
FAIL  src/components/settings/panels/__tests__/SandboxSettingsPanel.validation.test.tsx
      > SandboxSettingsPanel — memory limit validation > persists a positive integer
TestingLibraryElementError: Unable to find an element with the display value: 512.
```

…and the DOM dump printed with it still shows the loading paragraph:

```html
<p class="text-sm text-content-muted">Loading…</p>
```

## Why

`renderLoaded` takes its readiness signal from the wrong event:

```ts
renderWithProviders(<SandboxSettingsPanel />);
await waitFor(() => expect(mockGet).toHaveBeenCalled());
```

`SandboxSettingsPanel` calls `openhumanGetSandboxSettings()` **synchronously** inside its mount effect (`SandboxSettingsPanel.tsx:55`), so that assertion is already true when `waitFor` first checks it. `isLoading` only flips in the `finally` (`:69`) — one microtask and a re-render later. `renderLoaded` therefore returns while the panel is still on its loading branch, and the **synchronous** `getBy*` accessors below it (`memoryInput`, `cpuInput`, `imageInput`) query a DOM that has no fields in it yet.

Usually the tick `waitFor` costs is enough to cover the microtask. On a loaded runner with coverage instrumentation it is not.

Two things worth noting:

- **The file already documents this exact trap**, in `flushPersist`'s docstring: *"`await waitFor(() => expect(mockGet).toHaveBeenCalled())` is NOT a readiness signal here: `mockGet` fires on mount, so the condition is already true and `waitFor` resolves on its first tick."* It was applied to the negative assertions but the same non-signal was left as the readiness gate.
- **The sibling `SandboxSettingsPanel.test.tsx` does not trip on it** — it reaches for the loaded DOM with `findByRole` / `findByText`, which retry. Only this file uses synchronous accessors.

## The change

Await the backend combobox. It is rendered only by the loaded branch, and by every override these tests pass — including the `docker_memory_limit_mb: null, docker_cpu_limit: null` case, where waiting on a specific field value would not work.

## Verification

The failure is timing-dependent, so I made it deterministic instead of running it until it flaked: have the mock resolve on a **macrotask** rather than a microtask, which is what a contended runner does to it.

| | on `origin/main` | with this change |
|---|---|---|
| load resolves on a macrotask | ✗ fails, `Unable to find…` + `Loading…` in the DOM | ✓ 14/14 |
| unchanged (fast load) | ✓ 14/14 | ✓ 14/14 |

Also clean in `app/`: `npx tsc --noEmit`, `npx prettier --check`.

No production code is touched, and no assertion is weakened — the tests still query the same elements and make the same claims; they just wait for the panel to exist first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved settings panel test synchronization by waiting for backend options to load before querying subsequent fields.
  * Increased test reliability when validating settings after the loading state completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->