### PR TITLE
fix(turn_state): persist snapshots on long Windows paths

### DIFF
--- a/src/openhuman/threads/turn_state/store.rs
+++ b/src/openhuman/threads/turn_state/store.rs
@@ -80,8 +80,7 @@ impl TurnStateStore {
         tmp.as_file()
             .sync_all()
             .map_err(|e| format!("fsync turn-state tempfile: {e}"))?;
-        tmp.persist(&path)
-            .map_err(|e| format!("persist turn-state file {}: {e}", path.display()))?;
+        persist_temp_file(tmp, &path)?;
         // Sync the directory entry created by the rename — without this a crash
         // or power loss between persist() and the next fs flush can drop the
         // snapshot, defeating the cold-boot recovery guarantee. Best-effort on
@@ -454,8 +453,7 @@ impl TurnStateStore {
         tmp.as_file()
             .sync_all()
             .map_err(|e| format!("fsync turn-state tempfile: {e}"))?;
-        tmp.persist(&path)
-            .map_err(|e| format!("persist turn-state file {}: {e}", path.display()))?;
+        persist_temp_file(tmp, &path)?;
         if let Err(err) = sync_dir(&dir) {
             log::warn!("{LOG_PREFIX} failed to fsync {}: {err}", dir.display());
         }
@@ -494,6 +492,22 @@ impl TurnStateStore {
             }
         }
     }
+}
+
+#[cfg(windows)]
+fn persist_temp_file(tmp: NamedTempFile, path: &Path) -> Result<(), String> {
+    let (_file, temp_path) = tmp
+        .keep()
+        .map_err(|e| format!("persist turn-state file {}: {e}", path.display()))?;
+    fs::rename(&temp_path, path)
+        .map_err(|e| format!("persist turn-state file {}: {e}", path.display()))
+}
+
+#[cfg(not(windows))]
+fn persist_temp_file(tmp: NamedTempFile, path: &Path) -> Result<(), String> {
+    tmp.persist(path)
+        .map(|_| ())
+        .map_err(|e| format!("persist turn-state file {}: {e}", path.display()))
 }
 
 /// Pick the latest turn (greatest `started_at`, ties broken by `updated_at`).

--- a/src/openhuman/threads/turn_state/store_tests.rs
+++ b/src/openhuman/threads/turn_state/store_tests.rs
@@ -53,6 +53,20 @@ fn put_then_get_roundtrips_state() {
     assert_eq!(loaded, state);
 }
 
+#[cfg(windows)]
+#[test]
+fn put_roundtrips_snapshot_with_a_path_longer_than_max_path() {
+    let dir = tempdir().expect("tempdir");
+    let workspace = dir.path().join("w".repeat(50));
+    let thread_id = "t".repeat(43);
+    let request_id = "r".repeat(36);
+    let state = turn(&thread_id, &request_id, "2026-05-04T10:00:00Z");
+    let store = TurnStateStore::new(workspace);
+
+    store.put(&state).expect("persist a snapshot past MAX_PATH");
+    assert_eq!(store.get(&thread_id).expect("get"), Some(state));
+}
+
 #[test]
 fn roundtrips_subagent_interleaved_transcript_with_full_fidelity() {
     // A settled turn whose subagent streamed reasoning, called a tool, then


### PR DESCRIPTION
## Summary

Turn-state snapshots fail on Windows when hex-encoded identifiers make the destination path exceed MAX_PATH. Use the standard filesystem rename path on Windows while preserving the existing Unix persistence path and on-disk layout.

## Related

Closes #6009

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot persistence on Windows, including support for workspace paths exceeding the platform’s maximum path length.
  * Ensured saved turn state snapshots can be successfully retrieved after writing on affected Windows paths.

* **Tests**
  * Added coverage validating long-path snapshot persistence and round-tripping on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->