### PR TITLE
fix(scripts): stop the e2e coverage gate demanding cfg-gated methods

### DIFF
--- a/scripts/__tests__/domain-e2e-coverage-gate.test.mjs
+++ b/scripts/__tests__/domain-e2e-coverage-gate.test.mjs
@@ -72,7 +72,7 @@ function fixture(t, options = {}) {
     featureGraph = {},
     withExcludedNamespaces = true,
     declareExcludedFeatures = true,
-    gateExcludedModule = true,
+    excludedModuleCfg = '#[cfg(feature = "e2e-test-support")]',
   } = options;
   const root = fs.mkdtempSync(join(tmpdir(), 'domain-e2e-gate-'));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
@@ -88,15 +88,16 @@ function fixture(t, options = {}) {
       'src/openhuman/test_support/schemas.rs',
       controller('test', 'reset') + controller('test_support', 'workspace_root'),
     );
-    // The `#[cfg]` the exclusion claims. It lives on the `mod` declaration in
-    // the PARENT, which is where the gate looks for it — a fixture without this
-    // is a module that compiles unconditionally.
+    // A faithful module tree: `schemas.rs` is reached through `mod schemas;`,
+    // and `test_support` through the declaration in its parent. The `#[cfg]`
+    // the exclusion claims lives on the SECOND of those — which is the whole
+    // reason the gate walks the chain instead of reading the file it found the
+    // controller in.
+    write(root, 'src/openhuman/test_support/mod.rs', 'mod schemas;\n');
     write(
       root,
       'src/openhuman/mod.rs',
-      gateExcludedModule
-        ? '#[cfg(feature = "e2e-test-support")]\npub mod test_support;\n'
-        : 'pub mod test_support;\n',
+      `${excludedModuleCfg ? `${excludedModuleCfg}\n` : ''}pub mod test_support;\n`,
     );
   }
   return root;
@@ -400,7 +401,7 @@ test('reads a single-quoted TOML feature array', (t) => {
 // module now compiles unconditionally and its controllers dispatch. An
 // exclusion is a claim about the source, so it is checked against the source.
 test('fails when the module is no longer behind the #[cfg] the exclusion claims', (t) => {
-  const root = fixture(t, { gateExcludedModule: false });
+  const root = fixture(t, { excludedModuleCfg: null });
   write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
   write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
 
@@ -425,7 +426,6 @@ test('fails when the module is no longer behind the #[cfg] the exclusion claims'
 // in between — the arrangement `src/openhuman/test_support/` actually has.
 test('finds the gate on an ancestor mod declaration, not just the immediate parent', (t) => {
   const root = fixture(t);
-  write(root, 'src/openhuman/test_support/mod.rs', 'mod schemas;\n');
   write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
   write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
 
@@ -472,3 +472,63 @@ test('resolves the gate for a namespace declared in mod.rs itself', (t) => {
     `the exclusion must still apply; got:\n${result.stdout}`,
   );
 });
+
+// Codex and CodeRabbit, PR #6092, independently. A `#[cfg]` that CONTAINS the
+// feature name does not necessarily REQUIRE it, and the containing-the-name
+// reading is wrong in the most dangerous direction — `not(feature = "x")`
+// compiles precisely when the feature is OFF, so a namespace that is always
+// present would have been accepted as always absent.
+const NOT_A_GATE = [
+  ['a negated feature', '#[cfg(not(feature = "e2e-test-support"))]'],
+  ['an any() with an unrelated true branch', '#[cfg(any(feature = "e2e-test-support", unix))]'],
+  ['an any() with another feature', '#[cfg(any(feature = "e2e-test-support", feature = "other"))]'],
+  ['a negation nested in an all()', '#[cfg(all(unix, not(feature = "e2e-test-support")))]'],
+];
+
+for (const [description, attribute] of NOT_A_GATE) {
+  test(`rejects ${description} as proof of the claimed gate`, (t) => {
+    const root = fixture(t, { excludedModuleCfg: attribute });
+    write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+    write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
+
+    const result = runGate(root);
+
+    assert.match(
+      result.stderr,
+      /no longer behind the gate they claim/,
+      `${attribute} does not require the feature and must not count as a gate; got:\n${result.stderr}`,
+    );
+  });
+}
+
+// The other direction: a predicate whose truth genuinely implies the feature
+// must still be accepted, or the check would fail every real gate that is not
+// spelled in the simplest possible form.
+const IS_A_GATE = [
+  ['a bare feature', '#[cfg(feature = "e2e-test-support")]'],
+  ['an all() alongside an unrelated term', '#[cfg(all(feature = "e2e-test-support", unix))]'],
+  ['an any() where every branch requires it', '#[cfg(any(all(feature = "e2e-test-support", unix), all(feature = "e2e-test-support", windows)))]'],
+  ['an attribute split across lines', '#[cfg(all(\n    feature = "e2e-test-support",\n    unix\n))]'],
+  ['a cfg below a doc comment', '/// Gated.\n#[cfg(feature = "e2e-test-support")]'],
+];
+
+for (const [description, attribute] of IS_A_GATE) {
+  test(`accepts ${description} as proof of the claimed gate`, (t) => {
+    const root = fixture(t, { excludedModuleCfg: attribute });
+    write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+    write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
+
+    const result = runGate(root);
+
+    assert.doesNotMatch(
+      result.stderr,
+      /no longer behind the gate they claim/,
+      `${attribute} does require the feature and must count as a gate; got:\n${result.stderr}`,
+    );
+    assert.match(
+      result.stdout,
+      /Excluded 2 controller\(s\)/,
+      `the exclusion must still apply; got:\n${result.stdout}`,
+    );
+  });
+}

--- a/scripts/__tests__/domain-e2e-coverage-gate.test.mjs
+++ b/scripts/__tests__/domain-e2e-coverage-gate.test.mjs
@@ -46,9 +46,43 @@ function runGate(root, threshold = '90') {
   });
 }
 
-function fixture(t) {
+/** A `[features]` table in the shape `parseCoreFeatureGraph` reads. */
+function cargoToml(defaultFeatures, extraFeatures) {
+  const quote = (items) => items.map((item) => `"${item}"`).join(', ');
+  const lines = ['[features]', `default = [${quote(defaultFeatures)}]`];
+  for (const [name, deps] of Object.entries(extraFeatures)) lines.push(`${name} = [${quote(deps)}]`);
+  return `${lines.join('\n')}\n`;
+}
+
+/**
+ * A fixture world.
+ *
+ * Two things every fixture needs that a bare temp dir does not have. The gate
+ * hard-requires `Cargo.toml` and `scripts/ci/product-features.txt`, because
+ * that pair is what `scripts/test-rust-e2e.sh` builds its `--features` string
+ * from and therefore the only honest answer to "which configuration is being
+ * measured". And — unless a test is proving the stale-entry guard — it needs a
+ * declaration for every `UNREACHABLE_NAMESPACES` entry, so a run is not
+ * tripping over an exclusion that names nothing in this world.
+ */
+function fixture(t, options = {}) {
+  const {
+    defaultFeatures = [],
+    productFeatures = [],
+    featureGraph = {},
+    withExcludedNamespaces = true,
+  } = options;
   const root = fs.mkdtempSync(join(tmpdir(), 'domain-e2e-gate-'));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  write(root, 'Cargo.toml', cargoToml(defaultFeatures, featureGraph));
+  write(root, 'scripts/ci/product-features.txt', `${productFeatures.join('\n')}\n`);
+  if (withExcludedNamespaces) {
+    write(
+      root,
+      'src/openhuman/test_support/schemas.rs',
+      controller('test', 'reset') + controller('test_support', 'workspace_root'),
+    );
+  }
   return root;
 }
 
@@ -133,5 +167,166 @@ test('measures a discovered namespace that MODULES does not name', (t) => {
     result.stdout,
     /openhuman\.widgets_purge/,
     `the uncovered controller must be reported as missing; got:\n${result.stdout}`,
+  );
+});
+
+// #6069: the gate demanded coverage of methods that are not compiled into the
+// build it measures. `test` / `test_support` sit behind `e2e-test-support`,
+// which is in neither `[features] default` nor product-features.txt, so the
+// only ways to satisfy those rows were a bespoke feature string or naming the
+// method in a string literal that never calls it — the exact gaming the
+// `collectInvokedMethods` header warns about. The honest answer (0%,
+// unreachable) and the dishonest one (0%, nobody bothered) looked identical.
+test('excludes namespaces compiled out of the measured configuration', (t) => {
+  const root = fixture(t);
+  write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+  write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
+
+  const result = runGate(root);
+
+  assert.doesNotMatch(
+    result.stdout,
+    /^\| test \|/m,
+    `an unreachable namespace must not be billed as an uncovered obligation; got:\n${result.stdout}`,
+  );
+  assert.doesNotMatch(
+    result.stdout,
+    /^\| test_support \|/m,
+    `an unreachable namespace must not be billed as an uncovered obligation; got:\n${result.stdout}`,
+  );
+  // The denominator must shrink with the rows. A row hidden from the table but
+  // still counted would be a worse report than the bug.
+  assert.match(
+    result.stdout,
+    /Discovered 1 controllers across 1 namespaces/,
+    `excluded controllers must leave the denominator; got:\n${result.stdout}`,
+  );
+});
+
+// Excluded is not the same as forgotten. The report has to show the claim —
+// "nothing here can be dispatched" — or nobody ever reviews it.
+test('reports what it excluded, with the gate and the reason', (t) => {
+  const root = fixture(t);
+  write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+  write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
+
+  const result = runGate(root);
+
+  assert.match(
+    result.stdout,
+    /Excluded 2 controller\(s\) in 2 namespace\(s\) as unreachable/,
+    `the exclusion must be stated, not silent; got:\n${result.stdout}`,
+  );
+  assert.match(
+    result.stdout,
+    /test \(1\) — compiled out by `e2e-test-support`:/,
+    `each exclusion must name its gate; got:\n${result.stdout}`,
+  );
+  assert.match(
+    result.stdout,
+    /test_support \(1\) — compiled out by `e2e-test-support`:/,
+    `each exclusion must name its gate; got:\n${result.stdout}`,
+  );
+});
+
+// The guard that makes the list safe to keep. An exclusion is a claim about the
+// measured build, and if that build starts compiling the family in, the claim
+// deletes real obligations from the denominator and reports the smaller world
+// as success — strictly worse than the bug #6069 fixed.
+test('fails when an excluded namespace becomes reachable in the product set', (t) => {
+  const root = fixture(t, { productFeatures: ['e2e-test-support'] });
+  write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+  write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
+
+  const result = runGate(root);
+
+  assert.equal(result.status, 1, `a stale exclusion must fail the gate; got:\n${result.stdout}`);
+  assert.match(
+    result.stderr,
+    /excluded namespace\(s\) are reachable in the measured configuration/,
+    `the failure must say the exclusion no longer holds; got:\n${result.stderr}`,
+  );
+  assert.match(
+    result.stderr,
+    /test \(gated on "e2e-test-support"\)/,
+    `the offending namespace and gate must be named; got:\n${result.stderr}`,
+  );
+});
+
+// Cargo features are transitive, so "is the gate in `default` or the product
+// list" is the wrong question — `documents = ["modules", …]` turns `modules` on
+// for anyone enabling `documents`. A direct-membership check passes this
+// fixture while cargo compiles the family in, which is why the gate resolves
+// the graph instead.
+test('fails when an excluded namespace is reachable only transitively', (t) => {
+  const root = fixture(t, {
+    defaultFeatures: ['bundle'],
+    featureGraph: { bundle: ['e2e-test-support'], 'e2e-test-support': [] },
+  });
+  write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+  write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
+
+  const result = runGate(root);
+
+  assert.equal(result.status, 1, `a transitively-enabled gate must fail the gate; got:\n${result.stdout}`);
+  assert.match(
+    result.stderr,
+    /excluded namespace\(s\) are reachable in the measured configuration/,
+    `following the feature graph is the point of this test; got:\n${result.stderr}`,
+  );
+});
+
+// The other way the list rots: the namespace is renamed or deleted and the
+// entry silently stops referring to anything. Same failure `declaredButMissing`
+// catches for MODULES, applied to the exclusion list.
+test('fails when an excluded namespace no longer exists', (t) => {
+  const root = fixture(t, { withExcludedNamespaces: false });
+  write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+  write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
+
+  const result = runGate(root);
+
+  assert.equal(result.status, 1, `an exclusion naming nothing must fail the gate; got:\n${result.stdout}`);
+  assert.match(
+    result.stderr,
+    /UNREACHABLE_NAMESPACES names 2 namespace\(s\) with no discovered controllers: test, test_support/,
+    `the stale entries must be named; got:\n${result.stderr}`,
+  );
+});
+
+// Without both files the gate cannot say which configuration it is measuring,
+// and an exclusion nothing verifies is the silent hole the list exists to
+// close. Refusing is the only honest answer — exit 2, the same usage-error
+// status as a bad threshold.
+test('refuses to run without the files the measured feature set comes from', (t) => {
+  const root = fixture(t);
+  write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+  fs.rmSync(join(root, 'scripts', 'ci', 'product-features.txt'));
+
+  const result = runGate(root);
+
+  assert.equal(result.status, 2, `a world with no product feature list must be refused; got:\n${result.stdout}`);
+  assert.match(
+    result.stderr,
+    /product-features\.txt not found/,
+    `the failure must name the missing file; got:\n${result.stderr}`,
+  );
+});
+
+// Guarding the guard. A `[features]` table the parser cannot see does not fail
+// on its own — it reports every gate as OFF, which is exactly the answer that
+// makes every exclusion look earned. Silence there would undo the check.
+test('refuses to run when the feature table cannot be parsed', (t) => {
+  const root = fixture(t);
+  write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+  write(root, 'Cargo.toml', '[package]\nname = "openhuman"\n');
+
+  const result = runGate(root);
+
+  assert.equal(result.status, 2, `an unparseable feature table must be refused; got:\n${result.stdout}`);
+  assert.match(
+    result.stderr,
+    /no `\[features\] default` in Cargo\.toml/,
+    `the failure must name what could not be resolved; got:\n${result.stderr}`,
   );
 });

--- a/scripts/__tests__/domain-e2e-coverage-gate.test.mjs
+++ b/scripts/__tests__/domain-e2e-coverage-gate.test.mjs
@@ -72,6 +72,7 @@ function fixture(t, options = {}) {
     featureGraph = {},
     withExcludedNamespaces = true,
     declareExcludedFeatures = true,
+    gateExcludedModule = true,
   } = options;
   const root = fs.mkdtempSync(join(tmpdir(), 'domain-e2e-gate-'));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
@@ -86,6 +87,16 @@ function fixture(t, options = {}) {
       root,
       'src/openhuman/test_support/schemas.rs',
       controller('test', 'reset') + controller('test_support', 'workspace_root'),
+    );
+    // The `#[cfg]` the exclusion claims. It lives on the `mod` declaration in
+    // the PARENT, which is where the gate looks for it — a fixture without this
+    // is a module that compiles unconditionally.
+    write(
+      root,
+      'src/openhuman/mod.rs',
+      gateExcludedModule
+        ? '#[cfg(feature = "e2e-test-support")]\npub mod test_support;\n'
+        : 'pub mod test_support;\n',
     );
   }
   return root;
@@ -380,5 +391,84 @@ test('reads a single-quoted TOML feature array', (t) => {
     result.stderr,
     /excluded namespace\(s\) are reachable in the measured configuration/,
     `a gate enabled through a literal string must count as enabled; got:\n${result.stderr}`,
+  );
+});
+
+// Codex, PR #6092 (second round). The last hole: delete the `#[cfg]` in Rust
+// and every other check here still passes — the feature is declared, it is
+// disabled, the namespace is discovered, it is not in MODULES — while the
+// module now compiles unconditionally and its controllers dispatch. An
+// exclusion is a claim about the source, so it is checked against the source.
+test('fails when the module is no longer behind the #[cfg] the exclusion claims', (t) => {
+  const root = fixture(t, { gateExcludedModule: false });
+  write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+  write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
+
+  const result = runGate(root);
+
+  assert.equal(result.status, 1, `an ungated module must fail the gate; got:\n${result.stdout}`);
+  assert.match(
+    result.stderr,
+    /no longer behind the gate they claim/,
+    `the failure must say the #[cfg] is gone; got:\n${result.stderr}`,
+  );
+  assert.match(
+    result.stderr,
+    /src\/openhuman\/test_support\/schemas\.rs/,
+    `the file that lost its gate must be named; got:\n${result.stderr}`,
+  );
+});
+
+// The positive half, and the reason the walk climbs rather than reading the
+// file itself: `#[cfg]` sits on the `mod` declaration in the PARENT. Here the
+// gate is two levels up from the declaring file, with an ungated `mod schemas;`
+// in between — the arrangement `src/openhuman/test_support/` actually has.
+test('finds the gate on an ancestor mod declaration, not just the immediate parent', (t) => {
+  const root = fixture(t);
+  write(root, 'src/openhuman/test_support/mod.rs', 'mod schemas;\n');
+  write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+  write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
+
+  const result = runGate(root);
+
+  assert.doesNotMatch(
+    result.stderr,
+    /no longer behind the gate they claim/,
+    `a gate on a grandparent mod must count; got:\n${result.stderr}`,
+  );
+  assert.match(
+    result.stdout,
+    /Excluded 2 controller\(s\)/,
+    `the exclusion must still apply; got:\n${result.stdout}`,
+  );
+});
+
+// A namespace can declare its controllers in `mod.rs` itself rather than in a
+// `schemas.rs` sibling. That file IS its directory's module, so its own `mod`
+// declaration sits one level further up and under the DIRECTORY's name —
+// resolving it like an ordinary file would look for `mod mod;` and find
+// nothing, silently reporting the module as ungated.
+test('resolves the gate for a namespace declared in mod.rs itself', (t) => {
+  const root = fixture(t, { withExcludedNamespaces: false });
+  write(
+    root,
+    'src/openhuman/test_support/mod.rs',
+    controller('test', 'reset') + controller('test_support', 'workspace_root'),
+  );
+  write(root, 'src/openhuman/mod.rs', '#[cfg(feature = "e2e-test-support")]\npub mod test_support;\n');
+  write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+  write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
+
+  const result = runGate(root);
+
+  assert.doesNotMatch(
+    result.stderr,
+    /no longer behind the gate they claim/,
+    `a mod.rs-declared namespace must resolve its own gate; got:\n${result.stderr}`,
+  );
+  assert.match(
+    result.stdout,
+    /Excluded 2 controller\(s\)/,
+    `the exclusion must still apply; got:\n${result.stdout}`,
   );
 });

--- a/scripts/__tests__/domain-e2e-coverage-gate.test.mjs
+++ b/scripts/__tests__/domain-e2e-coverage-gate.test.mjs
@@ -71,10 +71,15 @@ function fixture(t, options = {}) {
     productFeatures = [],
     featureGraph = {},
     withExcludedNamespaces = true,
+    declareExcludedFeatures = true,
   } = options;
   const root = fs.mkdtempSync(join(tmpdir(), 'domain-e2e-gate-'));
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-  write(root, 'Cargo.toml', cargoToml(defaultFeatures, featureGraph));
+  // The manifest must DECLARE each exclusion's gate even when nothing enables
+  // it — an undeclared gate is a rename the table missed, not a disabled one,
+  // and the gate refuses it.
+  const features = declareExcludedFeatures ? { 'e2e-test-support': [], ...featureGraph } : featureGraph;
+  write(root, 'Cargo.toml', cargoToml(defaultFeatures, features));
   write(root, 'scripts/ci/product-features.txt', `${productFeatures.join('\n')}\n`);
   if (withExcludedNamespaces) {
     write(
@@ -328,5 +333,52 @@ test('refuses to run when the feature table cannot be parsed', (t) => {
     result.stderr,
     /no `\[features\] default` in Cargo\.toml/,
     `the failure must name what could not be resolved; got:\n${result.stderr}`,
+  );
+});
+
+// Codex, PR #6092. The subtlest way this list rots: a gate is renamed, every
+// `#[cfg]` site is updated, and only this table is missed. The old name is then
+// absent from the feature graph — so it is absent from the enabled set too, and
+// the reachability check reads that as "safely disabled". The namespace still
+// exists and is not in MODULES, so nothing else fires, and a reachable family
+// leaves the denominator without a word. "Not enabled" and "not a gate at all"
+// must be different answers.
+test('fails when an excluded namespace names a gate the manifest does not declare', (t) => {
+  const root = fixture(t, { declareExcludedFeatures: false });
+  write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+  write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
+
+  const result = runGate(root);
+
+  assert.equal(result.status, 1, `an undeclared gate must fail the gate; got:\n${result.stdout}`);
+  assert.match(
+    result.stderr,
+    /name a feature the `\[features\]` table does not declare/,
+    `the failure must distinguish a renamed gate from a disabled one; got:\n${result.stderr}`,
+  );
+  assert.match(
+    result.stderr,
+    /test \(gated on "e2e-test-support"\)/,
+    `the offending entry must be named; got:\n${result.stderr}`,
+  );
+});
+
+// CodeRabbit, PR #6092. TOML has two single-line string forms and cargo accepts
+// both. Reading only `"…"` made `default = ['e2e-test-support']` parse as an
+// empty array, so the gate saw the feature as OFF and accepted the exclusion
+// for controllers the measured build actually compiles in.
+test('reads a single-quoted TOML feature array', (t) => {
+  const root = fixture(t);
+  write(root, 'Cargo.toml', "[features]\ndefault = ['e2e-test-support']\ne2e-test-support = []\n");
+  write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+  write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
+
+  const result = runGate(root);
+
+  assert.equal(result.status, 1, `a literal-string default list must still be read; got:\n${result.stdout}`);
+  assert.match(
+    result.stderr,
+    /excluded namespace\(s\) are reachable in the measured configuration/,
+    `a gate enabled through a literal string must count as enabled; got:\n${result.stderr}`,
   );
 });

--- a/scripts/__tests__/domain-e2e-coverage-gate.test.mjs
+++ b/scripts/__tests__/domain-e2e-coverage-gate.test.mjs
@@ -532,3 +532,70 @@ for (const [description, attribute] of IS_A_GATE) {
     );
   });
 }
+
+// Codex, PR #6092 (fourth round). A module can be declared more than once under
+// mutually exclusive predicates, and it then exists in BOTH configurations:
+//
+//   #[cfg(feature = "x")]      mod test_support;
+//   #[cfg(not(feature = "x"))] mod test_support;
+//
+// Reading only the first declaration sees the gate and calls the module absent
+// when it is in fact always present.
+test('fails when a second declaration makes the module reachable anyway', (t) => {
+  const root = fixture(t, { withExcludedNamespaces: false });
+  write(
+    root,
+    'src/openhuman/test_support/schemas.rs',
+    controller('test', 'reset') + controller('test_support', 'workspace_root'),
+  );
+  write(root, 'src/openhuman/test_support/mod.rs', 'mod schemas;\n');
+  write(
+    root,
+    'src/openhuman/mod.rs',
+    '#[cfg(feature = "e2e-test-support")]\npub mod test_support;\n' +
+      '#[cfg(not(feature = "e2e-test-support"))]\npub mod test_support;\n',
+  );
+  write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+  write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
+
+  const result = runGate(root);
+
+  assert.match(
+    result.stderr,
+    /no longer behind the gate they claim/,
+    `a module declared in both configurations is always present; got:\n${result.stderr}`,
+  );
+});
+
+// The same shape where both declarations DO require the feature stays accepted
+// — otherwise the rule would reject every legitimate platform split.
+test('accepts repeated declarations when every one of them requires the gate', (t) => {
+  const root = fixture(t, { withExcludedNamespaces: false });
+  write(
+    root,
+    'src/openhuman/test_support/schemas.rs',
+    controller('test', 'reset') + controller('test_support', 'workspace_root'),
+  );
+  write(root, 'src/openhuman/test_support/mod.rs', 'mod schemas;\n');
+  write(
+    root,
+    'src/openhuman/mod.rs',
+    '#[cfg(all(feature = "e2e-test-support", unix))]\npub mod test_support;\n' +
+      '#[cfg(all(feature = "e2e-test-support", windows))]\npub mod test_support;\n',
+  );
+  write(root, 'src/openhuman/widgets/schemas_part_01.rs', controller('widgets', 'list'));
+  write(root, 'tests/widgets_e2e.rs', 'let m = "openhuman.widgets_list";');
+
+  const result = runGate(root);
+
+  assert.doesNotMatch(
+    result.stderr,
+    /no longer behind the gate they claim/,
+    `a per-platform split that always requires the feature is still a gate; got:\n${result.stderr}`,
+  );
+  assert.match(
+    result.stdout,
+    /Excluded 2 controller\(s\)/,
+    `the exclusion must still apply; got:\n${result.stdout}`,
+  );
+});

--- a/scripts/__tests__/feature-forwarding.test.mjs
+++ b/scripts/__tests__/feature-forwarding.test.mjs
@@ -449,3 +449,30 @@ b = ["a"]
 
   assert.deepEqual([...enabled].sort(), ['a', 'b', 'default']);
 });
+
+test('reads TOML literal strings, not just basic strings', () => {
+  // Both forms are valid TOML and cargo accepts either. Matching only `"…"`
+  // reported these arrays as EMPTY, and empty is the answer that makes every
+  // consumer here pass vacuously. (CodeRabbit, PR #6092.)
+  assert.deepEqual(parseCoreDefaultFeatures("[features]\ndefault = ['voice', \"media\"]\n"), [
+    'voice',
+    'media',
+  ]);
+  assert.deepEqual(parseCoreFeatureGraph("[features]\ndefault = ['documents']\ndocuments = ['modules']\n").get('documents'), ['modules']);
+  assert.deepEqual(
+    parseShellForwardedFeatures(
+      "openhuman_core = { path = \"../..\", default-features = false, features = ['voice'] }\n",
+    ).features,
+    ['voice'],
+  );
+});
+
+test('an apostrophe inside a basic string does not open a literal string', () => {
+  // Alternation order is load-bearing: `"…"` is tried first at each position,
+  // so the `'` in `don't` is consumed as part of the basic string rather than
+  // starting a literal one and swallowing the rest of the array.
+  assert.deepEqual(parseCoreDefaultFeatures('[features]\ndefault = ["don\'t", "media"]\n'), [
+    "don't",
+    'media',
+  ]);
+});

--- a/scripts/__tests__/feature-forwarding.test.mjs
+++ b/scripts/__tests__/feature-forwarding.test.mjs
@@ -11,9 +11,11 @@ import {
   diffForwarding,
   INTENTIONALLY_NOT_FORWARDED,
   parseCoreDefaultFeatures,
+  parseCoreFeatureGraph,
   parseCoreFeatureNames,
   parseProductFeatures,
   parseShellForwardedFeatures,
+  resolveEnabledFeatures,
   stripComments,
 } from '../lib/feature-forwarding.mjs';
 
@@ -343,4 +345,107 @@ test('the real shell manifest forwards every real core default', () => {
       `core default gate not forwarded to the shell: ${gate}`
     );
   }
+});
+
+// ── feature graph ──────────────────────────────────────────────────────────
+
+test('parses the whole feature table, default included', () => {
+  const toml = `
+[features]
+default = ["media", "modules"]
+documents = ["modules", "dep:tinydocs-bus"]
+modules = ["tinybus/modules"]
+
+[dependencies]
+serde = "1"
+documents = ["not-a-feature"]
+`;
+  const graph = parseCoreFeatureGraph(toml);
+
+  assert.deepEqual(graph.get('default'), ['media', 'modules']);
+  assert.deepEqual(graph.get('documents'), ['modules', 'dep:tinydocs-bus']);
+  // Bounded at the next table header, so a `[dependencies]` key of the same
+  // name cannot overwrite a real gate's dependency list.
+  assert.equal(graph.size, 3);
+});
+
+test('resolves a gate enabled only through another gate', () => {
+  const graph = parseCoreFeatureGraph(`
+[features]
+default = ["documents"]
+documents = ["modules"]
+modules = []
+`);
+
+  const enabled = resolveEnabledFeatures(graph, ['default']);
+
+  // `modules` is nowhere in `default`; a direct membership test would read it
+  // as OFF while cargo compiles it in.
+  assert.ok(enabled.has('modules'), 'expected a transitively enabled gate to resolve as ON');
+  assert.ok(enabled.has('documents'));
+  assert.ok(!enabled.has('voice'), 'expected an unrelated gate to stay OFF');
+});
+
+test('does not mistake dependency activations for local gates', () => {
+  const graph = parseCoreFeatureGraph(`
+[features]
+default = ["modules"]
+modules = ["tinybus/modules", "dep:ureq"]
+`);
+
+  const enabled = resolveEnabledFeatures(graph, ['default']);
+
+  // `tinybus/modules` forwards a feature into a dependency and `dep:ureq` turns
+  // an optional dependency on. Neither names a gate in THIS crate, so neither
+  // can be what a local `#[cfg(feature = "…")]` reads.
+  assert.ok(!enabled.has('tinybus/modules'));
+  assert.ok(!enabled.has('dep:ureq'));
+  assert.ok(enabled.has('modules'));
+});
+
+test('seeds beyond default are followed too', () => {
+  const graph = parseCoreFeatureGraph(`
+[features]
+default = []
+documents = ["modules"]
+modules = []
+`);
+
+  // The product set is a second seed alongside `default`: the e2e runner passes
+  // `--features` WITHOUT `--no-default-features`, so the measured build is the
+  // union of the two.
+  const enabled = resolveEnabledFeatures(graph, ['default', 'documents']);
+
+  assert.ok(enabled.has('documents'));
+  assert.ok(enabled.has('modules'));
+});
+
+test('a seed the feature table does not declare resolves to itself', () => {
+  const enabled = resolveEnabledFeatures(parseCoreFeatureGraph('[features]\ndefault = []\n'), [
+    'default',
+    'ghost',
+  ]);
+
+  // A typo in product-features.txt is caught by `checkProductForwarding`, not
+  // here; this must not throw on the way there.
+  assert.ok(enabled.has('ghost'));
+});
+
+test('a manifest with no [features] table yields an empty graph', () => {
+  assert.equal(parseCoreFeatureGraph('[package]\nname = "openhuman"\n').size, 0);
+});
+
+test('a cycle in the feature graph terminates instead of hanging', () => {
+  // Cargo would reject this, but the gate reads the file as text and must not
+  // spin on a hand-edit that has not been through cargo yet.
+  const graph = parseCoreFeatureGraph(`
+[features]
+default = ["a"]
+a = ["b"]
+b = ["a"]
+`);
+
+  const enabled = resolveEnabledFeatures(graph, ['default']);
+
+  assert.deepEqual([...enabled].sort(), ['a', 'b', 'default']);
 });

--- a/scripts/check-domain-e2e-coverage.mjs
+++ b/scripts/check-domain-e2e-coverage.mjs
@@ -2,6 +2,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import {
+  parseCoreFeatureGraph,
+  parseProductFeatures,
+  resolveEnabledFeatures,
+} from './lib/feature-forwarding.mjs';
+
 const ROOT = process.cwd();
 
 function usage() {
@@ -63,6 +69,57 @@ const MODULES = [
   { label: 'composio', namespaces: ['composio'] },
   { label: 'threads', namespaces: ['threads'] },
 ];
+
+// Namespaces whose controllers are COMPILED OUT of the configuration this gate
+// measures, with the gate that removes them and the reason beside each — the
+// shape `INTENTIONALLY_NOT_FORWARDED` uses in scripts/lib/feature-forwarding.mjs.
+//
+// A method that cannot be dispatched cannot be reached by a `tests/**/*_e2e.rs`
+// target, so listing it as an uncovered obligation asks for something
+// impossible. The only two ways to satisfy such a row are a bespoke feature
+// string (which invalidates the shared target dir for every parallel worker) or
+// naming the method in a string literal that never calls it — the exact gaming
+// `collectInvokedMethods` warns about above. Worse, the honest answer (0%,
+// unreachable) and the dishonest one (0%, nobody bothered) look identical in
+// the report.
+//
+// This has to live HERE and not in Rust. The schemas are already `#[cfg]`-
+// correct — `src/openhuman/mod.rs` gates the whole `test_support` module — but
+// discovery reads source text off disk and would find these literals even if
+// every line were `#[cfg(never)]`. There is no Rust-side edit that changes what
+// a text scan sees.
+//
+// Excluding is the dangerous direction: a wrong entry hides real work. So each
+// one is checked against the feature set the measured build actually enables
+// (`checkExclusions` below), not merely against this comment. #6069.
+const UNREACHABLE_NAMESPACES = {
+  test: {
+    feature: 'e2e-test-support',
+    reason:
+      '`openhuman.test_reset` wipes sidecar state in place, and src/core/all.rs registers it behind ' +
+      '`#[cfg(feature = "e2e-test-support")]` precisely so a shipped binary never carries the destructive RPC. ' +
+      'Only app/scripts/e2e-build.sh turns that gate on; under the feature string scripts/test-rust-e2e.sh ' +
+      'builds every e2e target with, dispatching it answers `unknown method`.',
+  },
+  test_support: {
+    feature: 'e2e-test-support',
+    reason:
+      'Same gate as `test`: src/openhuman/mod.rs declares the whole `test_support` module behind ' +
+      '`#[cfg(feature = "e2e-test-support")]`, so these workspace- and chat-introspection helpers exist only in ' +
+      'the E2E build produced by app/scripts/e2e-build.sh.',
+  },
+};
+
+// The two files scripts/test-rust-e2e.sh derives its `--features` string from.
+//
+// It runs every suite with `--features "$(scripts/ci/product-features.sh)"` and
+// does NOT pass `--no-default-features`, so the measured configuration is
+// `default` UNION the product set — not the product set alone. The distinction
+// decides real cases: `medulla` is absent from product-features.txt but present
+// in `[features] default`, so its nine controllers ARE dispatchable in an e2e
+// build and are genuine obligations, not exclusions.
+const CORE_MANIFEST = path.join(ROOT, 'Cargo.toml');
+const PRODUCT_FEATURES_FILE = path.join(ROOT, 'scripts', 'ci', 'product-features.txt');
 
 // Where `ControllerSchema` literals live.
 //
@@ -172,6 +229,103 @@ function collectSchemaMethods() {
   return methodsByNamespace;
 }
 
+/**
+ * The gates cargo has ON in the build `scripts/test-rust-e2e.sh` produces.
+ *
+ * Resolved from the same two files that script reads, and through the feature
+ * graph rather than by direct membership: a gate can be enabled transitively
+ * (`documents = ["modules", …]`), and reading such a gate as OFF would let an
+ * exclusion look earned when cargo compiles the family in.
+ *
+ * Both files are REQUIRED. Without them this gate cannot say which controllers
+ * are reachable, and an exclusion nothing verifies is precisely the silent hole
+ * `UNREACHABLE_NAMESPACES` exists to close.
+ */
+function measuredFeatures() {
+  for (const file of [CORE_MANIFEST, PRODUCT_FEATURES_FILE]) {
+    if (fs.existsSync(file)) continue;
+    console.error(
+      `check-domain-e2e-coverage: ${path.relative(ROOT, file) || file} not found under ${ROOT}.\n` +
+        'The gate resolves which controllers are reachable in the configuration it measures from\n' +
+        'Cargo.toml and scripts/ci/product-features.txt, so it must run from the repository root.',
+    );
+    process.exit(2);
+  }
+  const graph = parseCoreFeatureGraph(read(CORE_MANIFEST));
+  // Guard the guard. An empty graph is what a moved `[features]` table or a
+  // parser regression looks like, and it does not fail — it quietly reports
+  // every gate as OFF, which is the answer that makes every exclusion look
+  // earned. Refuse instead: this check is only worth having if it can be wrong.
+  if (!graph.has('default')) {
+    console.error(
+      `check-domain-e2e-coverage: no \`[features] default\` in ${path.relative(ROOT, CORE_MANIFEST)}.\n` +
+        'Without it the measured feature set cannot be resolved, and every exclusion in\n' +
+        'UNREACHABLE_NAMESPACES would be accepted unchecked.',
+    );
+    process.exit(2);
+  }
+  const product = parseProductFeatures(read(PRODUCT_FEATURES_FILE));
+  return resolveEnabledFeatures(graph, ['default', ...product]);
+}
+
+/**
+ * The three ways an `UNREACHABLE_NAMESPACES` entry can stop being true.
+ *
+ * Returns one message per problem; empty means every exclusion is still earned.
+ * This exists because the MODULES comment above is right — a list you must
+ * remember to maintain is a list that silently stops covering things — and an
+ * exclusion that rots is worse than a stale MODULES line: it does not merely
+ * fail to measure something, it deletes a real obligation from the denominator
+ * and reports the smaller world as success.
+ */
+function checkExclusions(discovered, labelForNamespace) {
+  const enabled = measuredFeatures();
+  const problems = [];
+
+  // (1) The gate came back. If the feature is enabled in the measured build,
+  // the controllers dispatch and excluding them hides work that is now real.
+  const reachable = Object.entries(UNREACHABLE_NAMESPACES)
+    .filter(([, entry]) => enabled.has(entry.feature))
+    .map(([namespace, entry]) => `${namespace} (gated on "${entry.feature}")`)
+    .sort();
+  if (reachable.length > 0) {
+    problems.push(
+      `${reachable.length} excluded namespace(s) are reachable in the measured configuration: ${reachable.join(', ')}.` +
+        '\nTheir gate is enabled by `[features] default` or scripts/ci/product-features.txt, so their controllers' +
+        '\ndo dispatch and must be covered. Drop the UNREACHABLE_NAMESPACES entry.',
+    );
+  }
+
+  // (2) The namespace is gone, or discovery stopped seeing it. Same failure
+  // `declaredButMissing` catches for MODULES, applied to the other list.
+  const missing = Object.keys(UNREACHABLE_NAMESPACES)
+    .filter((namespace) => !discovered.has(namespace))
+    .sort();
+  if (missing.length > 0) {
+    problems.push(
+      `UNREACHABLE_NAMESPACES names ${missing.length} namespace(s) with no discovered controllers: ${missing.join(', ')}.` +
+        '\nEither the namespace was removed (drop the entry) or schema discovery has stopped seeing it' +
+        '\n(fix SCHEMA_ROOTS / the match).',
+    );
+  }
+
+  // (3) Naming one namespace in both lists is a contradiction: MODULES asks for
+  // a coverage row, UNREACHABLE_NAMESPACES says there is nothing to cover.
+  // Unchecked, the exclusion wins and the namespace vanishes from the report
+  // without a word — which is how a MODULES entry stops meaning anything.
+  const contradictory = Object.keys(UNREACHABLE_NAMESPACES)
+    .filter((namespace) => labelForNamespace.has(namespace))
+    .sort();
+  if (contradictory.length > 0) {
+    problems.push(
+      `${contradictory.length} namespace(s) appear in BOTH MODULES and UNREACHABLE_NAMESPACES: ${contradictory.join(', ')}.` +
+        '\nMODULES asks for a coverage row; UNREACHABLE_NAMESPACES says there is nothing to cover. Resolve one.',
+    );
+  }
+
+  return problems;
+}
+
 const invoked = collectInvokedMethods();
 const schemas = collectSchemaMethods();
 
@@ -187,9 +341,20 @@ const declaredButMissing = [...labelForNamespace.keys()]
   .filter((namespace) => !schemas.has(namespace))
   .sort();
 
+const exclusionProblems = checkExclusions(schemas, labelForNamespace);
+
+// Reported below rather than dropped in silence: an excluded namespace is a
+// claim ("nothing here can be dispatched"), and a claim the report does not
+// show is a claim nobody reviews.
+const excluded = [...schemas]
+  .filter(([namespace]) => Object.hasOwn(UNREACHABLE_NAMESPACES, namespace))
+  .map(([namespace, methods]) => ({ namespace, count: methods.size, ...UNREACHABLE_NAMESPACES[namespace] }))
+  .sort((a, b) => a.namespace.localeCompare(b.namespace));
+
 // One row per namespace that actually exists, grouped where MODULES says so.
 const rows = new Map();
 for (const [namespace, methods] of schemas) {
+  if (Object.hasOwn(UNREACHABLE_NAMESPACES, namespace)) continue;
   const label = labelForNamespace.get(namespace) ?? namespace;
   if (!rows.has(label)) rows.set(label, { label, namespaces: [], expected: new Set() });
   const row = rows.get(label);
@@ -234,6 +399,23 @@ console.log('');
 console.log(
   `Discovered ${totalExpected} controllers across ${rows.size} namespaces; ${totalCovered} invoked by a tests/**/*_e2e.rs target.`,
 );
+
+if (excluded.length > 0) {
+  const totalExcluded = excluded.reduce((sum, entry) => sum + entry.count, 0);
+  console.log('');
+  console.log(
+    `Excluded ${totalExcluded} controller(s) in ${excluded.length} namespace(s) as unreachable in the measured` +
+      ' configuration (`[features] default` + scripts/ci/product-features.txt):',
+  );
+  for (const entry of excluded) {
+    console.log(`  ${entry.namespace} (${entry.count}) — compiled out by \`${entry.feature}\`: ${entry.reason}`);
+  }
+}
+
+if (exclusionProblems.length > 0) {
+  failed = true;
+  for (const problem of exclusionProblems) console.error(`\n${problem}`);
+}
 
 if (declaredButMissing.length > 0) {
   failed = true;

--- a/scripts/check-domain-e2e-coverage.mjs
+++ b/scripts/check-domain-e2e-coverage.mjs
@@ -208,6 +208,9 @@ function collectInvokedMethods() {
  */
 function collectSchemaMethods() {
   const methodsByNamespace = new Map();
+  // Which file declared each namespace, so an exclusion can be checked against
+  // the `#[cfg]` chain that actually reaches it — see `moduleGatesFor`.
+  const filesByNamespace = new Map();
 
   for (const root of SCHEMA_ROOTS) {
     for (const file of walk(root, (f) => f.endsWith('.rs'))) {
@@ -222,11 +225,57 @@ function collectSchemaMethods() {
         if (!namespace || !functionName || functionName === 'unknown') continue;
         if (!methodsByNamespace.has(namespace)) methodsByNamespace.set(namespace, new Set());
         methodsByNamespace.get(namespace).add(`openhuman.${namespace}_${functionName}`);
+        if (!filesByNamespace.has(namespace)) filesByNamespace.set(namespace, new Set());
+        filesByNamespace.get(namespace).add(file);
       }
     }
   }
 
-  return methodsByNamespace;
+  return { methodsByNamespace, filesByNamespace };
+}
+
+/**
+ * The Cargo gates on the chain of `mod` declarations that must compile for
+ * `file` to exist in the build.
+ *
+ * `#[cfg]` sits on the `mod` declaration in the PARENT, never in the file
+ * itself, so this walks upward: `src/openhuman/test_support/schemas.rs` is
+ * reached through `mod schemas;` in `test_support/mod.rs` and then through
+ * `pub mod test_support;` in `openhuman/mod.rs` — and only the second carries
+ * the gate. A file pulled in by `include!` has no `mod` of its own and simply
+ * contributes nothing at its own level, which is why a missing declaration is
+ * not itself an error here.
+ */
+function moduleGatesFor(file) {
+  const gates = new Set();
+  let segments = path.relative(ROOT, file).split(path.sep);
+
+  while (segments.length > 1) {
+    const base = segments[segments.length - 1].replace(/\.rs$/, '');
+    const isModFile = base === 'mod';
+    // A `mod.rs` IS its directory's module, so its declaration lives one level
+    // further up and under the directory's name.
+    const name = isModFile ? segments[segments.length - 2] : base;
+    const parentDir = isModFile ? segments.slice(0, -2) : segments.slice(0, -1);
+    const declaringFile = path.join(ROOT, ...parentDir, 'mod.rs');
+
+    if (fs.existsSync(declaringFile)) {
+      const lines = read(declaringFile).split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        if (!new RegExp(`^\\s*(?:pub(?:\\([^)]*\\))?\\s+)?mod\\s+${name}\\s*;`).test(lines[i])) continue;
+        // Attributes stack above the declaration; read back through all of them.
+        for (let j = i - 1; j >= 0 && /^\s*#\[/.test(lines[j]); j--) {
+          const gate = lines[j].match(/#\[cfg\(.*?feature\s*=\s*"([a-z0-9-]+)"/)?.[1];
+          if (gate) gates.add(gate);
+        }
+      }
+    }
+
+    segments = parentDir;
+    if (segments[segments.length - 1] === 'src') break;
+  }
+
+  return gates;
 }
 
 /**
@@ -278,7 +327,7 @@ function measuredFeatures() {
  * fail to measure something, it deletes a real obligation from the denominator
  * and reports the smaller world as success.
  */
-function checkExclusions(discovered, labelForNamespace) {
+function checkExclusions(discovered, declaringFiles, labelForNamespace) {
   const { graph, enabled } = measuredFeatures();
   const problems = [];
 
@@ -328,6 +377,33 @@ function checkExclusions(discovered, labelForNamespace) {
     );
   }
 
+  // (2b) The `#[cfg]` itself is gone. Every check here can pass while the Rust
+  // gate that made the namespace unreachable has been deleted: the feature is
+  // still declared (0), still disabled (1), the namespace is still discovered
+  // (2) and still absent from MODULES (3) — but its module now compiles
+  // unconditionally and its controllers dispatch. An exclusion is a claim about
+  // the source, so it is checked against the source: every file declaring the
+  // namespace must sit behind a `#[cfg(feature = …)]` naming the claimed gate.
+  const ungated = [];
+  for (const [namespace, entry] of Object.entries(UNREACHABLE_NAMESPACES)) {
+    const files = declaringFiles.get(namespace);
+    if (!files) continue; // Already reported by (2); nothing to check against.
+    const unguarded = [...files]
+      .filter((file) => !moduleGatesFor(file).has(entry.feature))
+      .map((file) => path.relative(ROOT, file))
+      .sort();
+    if (unguarded.length > 0) {
+      ungated.push(`${namespace} — ${unguarded.join(', ')} (expected \`#[cfg(feature = "${entry.feature}")]\`)`);
+    }
+  }
+  if (ungated.length > 0) {
+    problems.push(
+      `${ungated.length} excluded namespace(s) are no longer behind the gate they claim:\n  ${ungated.join('\n  ')}` +
+        '\nThe module compiles unconditionally now, so its controllers dispatch and must be covered.' +
+        '\nRestore the `#[cfg]`, or drop the UNREACHABLE_NAMESPACES entry.',
+    );
+  }
+
   // (3) Naming one namespace in both lists is a contradiction: MODULES asks for
   // a coverage row, UNREACHABLE_NAMESPACES says there is nothing to cover.
   // Unchecked, the exclusion wins and the namespace vanishes from the report
@@ -346,7 +422,7 @@ function checkExclusions(discovered, labelForNamespace) {
 }
 
 const invoked = collectInvokedMethods();
-const schemas = collectSchemaMethods();
+const { methodsByNamespace: schemas, filesByNamespace: schemaFiles } = collectSchemaMethods();
 
 const labelForNamespace = new Map();
 for (const module of MODULES) {
@@ -360,7 +436,7 @@ const declaredButMissing = [...labelForNamespace.keys()]
   .filter((namespace) => !schemas.has(namespace))
   .sort();
 
-const exclusionProblems = checkExclusions(schemas, labelForNamespace);
+const exclusionProblems = checkExclusions(schemas, schemaFiles, labelForNamespace);
 
 // Reported below rather than dropped in silence: an excluded namespace is a
 // claim ("nothing here can be dispatched"), and a claim the report does not

--- a/scripts/check-domain-e2e-coverage.mjs
+++ b/scripts/check-domain-e2e-coverage.mjs
@@ -265,7 +265,7 @@ function measuredFeatures() {
     process.exit(2);
   }
   const product = parseProductFeatures(read(PRODUCT_FEATURES_FILE));
-  return resolveEnabledFeatures(graph, ['default', ...product]);
+  return { graph, enabled: resolveEnabledFeatures(graph, ['default', ...product]) };
 }
 
 /**
@@ -279,8 +279,27 @@ function measuredFeatures() {
  * and reports the smaller world as success.
  */
 function checkExclusions(discovered, labelForNamespace) {
-  const enabled = measuredFeatures();
+  const { graph, enabled } = measuredFeatures();
   const problems = [];
+
+  // (0) The gate no longer exists. A rename that updated the `#[cfg]` sites but
+  // missed this table leaves a feature name no `[features]` entry declares —
+  // absent from the graph, so absent from `enabled`, which check (1) below
+  // reads as "safely disabled". The namespace still exists and is not in
+  // MODULES, so neither of the other checks fires either, and the renamed
+  // family's controllers leave the denominator in silence. "Not enabled" and
+  // "not a gate at all" have to be different answers.
+  const undeclared = Object.entries(UNREACHABLE_NAMESPACES)
+    .filter(([, entry]) => !graph.has(entry.feature))
+    .map(([namespace, entry]) => `${namespace} (gated on "${entry.feature}")`)
+    .sort();
+  if (undeclared.length > 0) {
+    problems.push(
+      `${undeclared.length} excluded namespace(s) name a feature the \`[features]\` table does not declare: ${undeclared.join(', ')}.` +
+        '\nA renamed or deleted gate reads as disabled here, which would accept the exclusion unchecked.' +
+        '\nPoint the UNREACHABLE_NAMESPACES entry at the current gate name, or drop it.',
+    );
+  }
 
   // (1) The gate came back. If the feature is enabled in the measured build,
   // the controllers dispatch and excluding them hides work that is now real.

--- a/scripts/check-domain-e2e-coverage.mjs
+++ b/scripts/check-domain-e2e-coverage.mjs
@@ -209,7 +209,7 @@ function collectInvokedMethods() {
 function collectSchemaMethods() {
   const methodsByNamespace = new Map();
   // Which file declared each namespace, so an exclusion can be checked against
-  // the `#[cfg]` chain that actually reaches it — see `moduleGatesFor`.
+  // the `#[cfg]` chain that actually reaches it — see `moduleGateProves`.
   const filesByNamespace = new Map();
 
   for (const root of SCHEMA_ROOTS) {
@@ -235,8 +235,140 @@ function collectSchemaMethods() {
 }
 
 /**
- * The Cargo gates on the chain of `mod` declarations that must compile for
- * `file` to exist in the build.
+ * Parse the inside of a `cfg(...)` predicate into `all` / `any` / `not` / atom.
+ *
+ * Deliberately a parser and not a regex. `#[cfg(not(feature = "x"))]` and
+ * `#[cfg(any(feature = "x", unix))]` both CONTAIN the feature name while
+ * neither requires it — the first compiles precisely when the feature is OFF —
+ * so anything that only looks for the name reads them backwards.
+ */
+function parseCfgPredicate(text) {
+  let at = 0;
+  const skipSpace = () => {
+    while (at < text.length && /\s/.test(text[at])) at++;
+  };
+
+  function parseNode() {
+    skipSpace();
+    const start = at;
+    while (at < text.length && /[A-Za-z0-9_]/.test(text[at])) at++;
+    const ident = text.slice(start, at);
+    skipSpace();
+
+    if (text[at] === '(') {
+      at++;
+      const children = [];
+      for (;;) {
+        skipSpace();
+        if (at >= text.length || text[at] === ')') {
+          at++;
+          break;
+        }
+        children.push(parseNode());
+        skipSpace();
+        if (text[at] === ',') at++;
+      }
+      return { kind: ident, children };
+    }
+
+    if (text[at] === '=') {
+      at++;
+      skipSpace();
+      const quote = text[at];
+      if (quote === '"' || quote === "'") {
+        at++;
+        const from = at;
+        while (at < text.length && text[at] !== quote) at++;
+        const value = text.slice(from, at);
+        at++;
+        return { kind: 'atom', key: ident, value };
+      }
+    }
+
+    // A bare atom such as `unix` or `test`: true or false on its own terms,
+    // and never a statement about a feature.
+    return { kind: 'atom', key: ident };
+  }
+
+  return parseNode();
+}
+
+/**
+ * Does this predicate being TRUE prove `feature` is enabled?
+ *
+ * Conservative by construction — it answers "no" whenever it cannot prove
+ * "yes", which is the safe direction here: a gate wrongly believed to protect a
+ * namespace is what removes reachable controllers from the denominator.
+ *
+ *  - `all(...)`: true means every child is true, so ONE child requiring the
+ *    feature is enough.
+ *  - `any(...)`: true means at least one child is true, so the feature is
+ *    implied only if EVERY branch requires it. `any(feature = "x", unix)` is
+ *    satisfied on unix with `x` off.
+ *  - `not(...)`: proves nothing about the feature being on, and
+ *    `not(feature = "x")` is true exactly when it is off.
+ */
+function cfgProvesFeature(node, feature) {
+  if (!node) return false;
+  switch (node.kind) {
+    case 'atom':
+      return node.key === 'feature' && node.value === feature;
+    case 'all':
+      return node.children.some((child) => cfgProvesFeature(child, feature));
+    case 'any':
+      return node.children.length > 0 && node.children.every((child) => cfgProvesFeature(child, feature));
+    default:
+      // `not`, and anything unrecognised, prove nothing.
+      return false;
+  }
+}
+
+/**
+ * The `#[...]` attribute bodies attached to the item starting at `index`.
+ *
+ * Walks backwards over stacked attributes and any doc comments between them,
+ * matching brackets rather than reading a line at a time — a `#[cfg(all(
+ * feature = "x",
+ * unix))]` split across lines is one attribute, and a line-based scan would
+ * see only its last line and parse nothing.
+ */
+function attributesBefore(text, index) {
+  const attributes = [];
+  let end = index;
+
+  for (;;) {
+    let cursor = end - 1;
+    for (;;) {
+      while (cursor >= 0 && /\s/.test(text[cursor])) cursor--;
+      const lineStart = text.lastIndexOf('\n', cursor) + 1;
+      if (/^\s*\/\//.test(text.slice(lineStart, cursor + 1))) {
+        cursor = lineStart - 1;
+        continue;
+      }
+      break;
+    }
+
+    if (cursor < 0 || text[cursor] !== ']') break;
+    let depth = 0;
+    let open = cursor;
+    for (; open >= 0; open--) {
+      if (text[open] === ']') depth++;
+      else if (text[open] === '[') {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    if (open <= 0 || text[open - 1] !== '#') break;
+
+    attributes.push(text.slice(open + 1, cursor));
+    end = open - 1;
+  }
+
+  return attributes;
+}
+
+/**
+ * Is `file` reachable only when `feature` is enabled?
  *
  * `#[cfg]` sits on the `mod` declaration in the PARENT, never in the file
  * itself, so this walks upward: `src/openhuman/test_support/schemas.rs` is
@@ -244,10 +376,9 @@ function collectSchemaMethods() {
  * `pub mod test_support;` in `openhuman/mod.rs` — and only the second carries
  * the gate. A file pulled in by `include!` has no `mod` of its own and simply
  * contributes nothing at its own level, which is why a missing declaration is
- * not itself an error here.
+ * not an error here; one gated ancestor anywhere on the chain is enough.
  */
-function moduleGatesFor(file) {
-  const gates = new Set();
+function moduleGateProves(file, feature) {
   let segments = path.relative(ROOT, file).split(path.sep);
 
   while (segments.length > 1) {
@@ -260,13 +391,13 @@ function moduleGatesFor(file) {
     const declaringFile = path.join(ROOT, ...parentDir, 'mod.rs');
 
     if (fs.existsSync(declaringFile)) {
-      const lines = read(declaringFile).split('\n');
-      for (let i = 0; i < lines.length; i++) {
-        if (!new RegExp(`^\\s*(?:pub(?:\\([^)]*\\))?\\s+)?mod\\s+${name}\\s*;`).test(lines[i])) continue;
-        // Attributes stack above the declaration; read back through all of them.
-        for (let j = i - 1; j >= 0 && /^\s*#\[/.test(lines[j]); j--) {
-          const gate = lines[j].match(/#\[cfg\(.*?feature\s*=\s*"([a-z0-9-]+)"/)?.[1];
-          if (gate) gates.add(gate);
+      const text = read(declaringFile);
+      const declaration = new RegExp(`^[ \\t]*(?:pub(?:\\([^)]*\\))?[ \\t]+)?mod[ \\t]+${name}[ \\t]*;`, 'm');
+      const found = declaration.exec(text);
+      if (found) {
+        for (const attribute of attributesBefore(text, found.index)) {
+          const inner = attribute.match(/^\s*cfg\s*\(([\s\S]*)\)\s*$/)?.[1];
+          if (inner && cfgProvesFeature(parseCfgPredicate(inner), feature)) return true;
         }
       }
     }
@@ -275,7 +406,7 @@ function moduleGatesFor(file) {
     if (segments[segments.length - 1] === 'src') break;
   }
 
-  return gates;
+  return false;
 }
 
 /**
@@ -389,7 +520,7 @@ function checkExclusions(discovered, declaringFiles, labelForNamespace) {
     const files = declaringFiles.get(namespace);
     if (!files) continue; // Already reported by (2); nothing to check against.
     const unguarded = [...files]
-      .filter((file) => !moduleGatesFor(file).has(entry.feature))
+      .filter((file) => !moduleGateProves(file, entry.feature))
       .map((file) => path.relative(ROOT, file))
       .sort();
     if (unguarded.length > 0) {

--- a/scripts/check-domain-e2e-coverage.mjs
+++ b/scripts/check-domain-e2e-coverage.mjs
@@ -392,13 +392,29 @@ function moduleGateProves(file, feature) {
 
     if (fs.existsSync(declaringFile)) {
       const text = read(declaringFile);
-      const declaration = new RegExp(`^[ \\t]*(?:pub(?:\\([^)]*\\))?[ \\t]+)?mod[ \\t]+${name}[ \\t]*;`, 'm');
-      const found = declaration.exec(text);
-      if (found) {
-        for (const attribute of attributesBefore(text, found.index)) {
-          const inner = attribute.match(/^\s*cfg\s*\(([\s\S]*)\)\s*$/)?.[1];
-          if (inner && cfgProvesFeature(parseCfgPredicate(inner), feature)) return true;
-        }
+      const declaration = new RegExp(`^[ \\t]*(?:pub(?:\\([^)]*\\))?[ \\t]+)?mod[ \\t]+${name}[ \\t]*;`, 'gm');
+      // EVERY declaration has to imply the feature, not merely the first one.
+      // A module may be declared more than once under mutually exclusive
+      // predicates —
+      //
+      //   #[cfg(feature = "x")]      mod test_support;
+      //   #[cfg(not(feature = "x"))] mod test_support;
+      //
+      // — and it then exists in BOTH configurations. Reading only the first
+      // declaration sees the gate and calls the module absent when it is
+      // always present, so the test is "does every path to this module require
+      // the feature", and one unproven declaration settles it.
+      const declarations = [...text.matchAll(declaration)];
+      if (declarations.length > 0) {
+        const everyPathRequiresIt = declarations.every((found) =>
+          attributesBefore(text, found.index).some((attribute) => {
+            const inner = attribute.match(/^\s*cfg\s*\(([\s\S]*)\)\s*$/)?.[1];
+            return Boolean(inner) && cfgProvesFeature(parseCfgPredicate(inner), feature);
+          }),
+        );
+        // Not proving it here is not a verdict: an ancestor `mod` may still be
+        // gated, and that would make the file unreachable all the same.
+        if (everyPathRequiresIt) return true;
       }
     }
 

--- a/scripts/lib/feature-forwarding.mjs
+++ b/scripts/lib/feature-forwarding.mjs
@@ -96,10 +96,21 @@ function readArray(text, open) {
   return null;
 }
 
-/** Pull the quoted string items out of a raw TOML array body. */
+/**
+ * Pull the quoted string items out of a raw TOML array body.
+ *
+ * TOML has two single-line string forms and both are valid in a manifest:
+ * basic `"voice"` and literal `'voice'`. Matching only the first reported
+ * `default = ['voice']` as an EMPTY array — and empty is the answer that makes
+ * every caller here pass vacuously, which is the failure mode this module
+ * exists to prevent (`checkProductForwarding` has nothing to compare, and the
+ * e2e coverage gate reads every feature as OFF and accepts its exclusions
+ * unchecked). Basic strings are tried first at each position, so an apostrophe
+ * inside `"don't"` cannot be mistaken for the start of a literal string.
+ */
 function arrayItems(raw) {
   if (raw === null) return [];
-  return [...raw.matchAll(/"([^"]+)"/g)].map(m => m[1]);
+  return [...raw.matchAll(/"([^"]+)"|'([^']+)'/g)].map(m => m[1] ?? m[2]);
 }
 
 /**

--- a/scripts/lib/feature-forwarding.mjs
+++ b/scripts/lib/feature-forwarding.mjs
@@ -178,6 +178,55 @@ export function parseCoreFeatureNames(coreToml) {
 }
 
 /**
+ * The core's whole `[features]` table as `name -> [items]`, `default` included.
+ *
+ * `parseCoreDefaultFeatures` answers "what is directly in `default`", which is
+ * not the same question as "what is ON". Cargo features are transitive:
+ * `documents = ["modules", …]` turns `modules` on for anyone who enables
+ * `documents`. A caller deciding whether some gate is compiled has to follow
+ * those edges or it will read a gate as OFF while cargo has it ON — see
+ * `resolveEnabledFeatures`.
+ */
+export function parseCoreFeatureGraph(coreToml) {
+  const text = stripComments(coreToml);
+  const header = text.match(/^[ \t]*\[features\][ \t]*$/m);
+  if (!header) return new Map();
+  const rest = text.slice(header.index + header[0].length);
+  const nextTable = rest.search(/^[ \t]*\[[^[\]]+\][ \t]*$/m);
+  const section = nextTable === -1 ? rest : rest.slice(0, nextTable);
+  const graph = new Map();
+  for (const match of section.matchAll(/^[ \t]*([A-Za-z0-9_-]+)[ \t]*=[ \t]*\[/gm)) {
+    // `match[0]` ends on the `[` that opens the array, so its last index is
+    // exactly where `readArray` must start scanning for the balanced close.
+    const open = match.index + match[0].length - 1;
+    graph.set(match[1], arrayItems(readArray(section, open)));
+  }
+  return graph;
+}
+
+/**
+ * Every gate cargo has ON once `seeds` are enabled, following the graph.
+ *
+ * Two item shapes are deliberately NOT followed. `dep:foo` turns an optional
+ * dependency on and `foo/bar` forwards a feature into a dependency; neither
+ * names a gate in THIS crate, and a `#[cfg(feature = "…")]` here can only ever
+ * read a local one. Following them would put `tinybus/modules` in the result
+ * and let a caller believe a gate by that name exists.
+ */
+export function resolveEnabledFeatures(graph, seeds) {
+  const enabled = new Set();
+  const queue = [...seeds];
+  while (queue.length > 0) {
+    const name = queue.pop();
+    if (name.startsWith('dep:') || name.includes('/')) continue;
+    if (enabled.has(name)) continue;
+    enabled.add(name);
+    for (const item of graph.get(name) ?? []) queue.push(item);
+  }
+  return enabled;
+}
+
+/**
  * Parse `scripts/ci/product-features.txt`: one gate per line, `#` comments and
  * blank lines ignored. Mirrors `scripts/ci/product-features.sh` exactly — the
  * CI lanes build their `--features` list with that shell script while this


### PR DESCRIPTION
## Summary

The domain-e2e coverage gate billed six controllers as uncovered obligations that **are not compiled into the build it measures**.

`collectSchemaMethods()` is a static text scan, so it finds every `ControllerSchema` literal on disk regardless of `#[cfg]`. `test` (1 controller) and `test_support` (5) sit behind `e2e-test-support`, which is in neither `[features] default` nor `scripts/ci/product-features.txt` — the two lists `scripts/test-rust-e2e.sh` builds its `--features` string from — so dispatching them in a real e2e build answers `unknown method`. The only ways to satisfy those rows were a bespoke feature string or naming the method in a string literal that never calls it, which is the gaming the gate's own header warns about. Worse, the honest answer (0%, unreachable) and the dishonest one (0%, nobody bothered) looked identical.

**The fix is gate-side and has to be.** As the issue's verifier noted, the schemas are already `#[cfg]`-correct — `src/openhuman/mod.rs:68` gates the whole `test_support` module — so no Rust-side edit changes what a text scan sees.

- `UNREACHABLE_NAMESPACES` in `scripts/check-domain-e2e-coverage.mjs`: namespace → gating feature + reason, the shape `INTENTIONALLY_NOT_FORWARDED` uses.
- The exclusions are **printed in the report**, not dropped in silence — an exclusion is a claim, and a claim the report doesn't show is a claim nobody reviews.
- Denominator **627 → 621**, namespaces 83 → 81, below-threshold modules 60 → 58.

### The list is checked against reality, not against its own comment

Over-excluding is the dangerous direction — a wrong entry deletes real work from the denominator and reports the smaller world as success. So the gate resolves the measured feature set from `Cargo.toml` + `product-features.txt` **through the feature graph**, and hard-fails when:

1. a gating feature becomes reachable in the measured build (drop the entry);
2. an entry names a namespace discovery cannot find (renamed/deleted);
3. a namespace is in both `MODULES` and this list (contradiction);
4. the `[features]` table cannot be parsed at all — otherwise every gate reads as OFF and every exclusion looks earned.

This is what the gate's own `MODULES` comment asks for: *"A list you must remember to extend is a list that silently stops covering things."*

### Why `medulla` stays measured

`medulla` also shows 0/9 and is absent from `product-features.txt`, so it looks like the same defect. It isn't: it's in `[features] default`, and `test-rust-e2e.sh` does **not** pass `--no-default-features` — the measured set is `default ∪ product`. Its nine controllers are genuine obligations. This is exactly why the guard resolves the feature graph instead of testing direct membership; a membership check would have wrongly excluded them.

A systematic sweep (every discovered namespace → its module `#[cfg]` chain → `default ∪ product`) found **no** other unreachable family, and the registration-side gates in `src/core/all.rs` name only `modules, voice, flows, http-server, channels, runtime-node, medulla, e2e-test-support` — same conclusion.

## Acceptance criteria

- [x] **Repro gone** — `node scripts/check-domain-e2e-coverage.mjs | grep '^| test '` now returns nothing; totals read `Discovered 621 controllers across 81 namespaces`. (Exit is still 1 — 58 namespaces are genuinely under the 90% bar. This PR removes two false rows, it does not turn the gate green.)
- [x] **Regression safety** — 7 new tests in `domain-e2e-coverage-gate.test.mjs` (exclusion applied, exclusion reported, plus one per guard incl. the transitive-reachability case that a direct membership check would pass) and 7 in `feature-forwarding.test.mjs` for the new parsers.
- [x] **Diff coverage ≥ 80%** — measured **96.3%** (103/107 changed executable lines) via `NODE_V8_COVERAGE` over both test files. The 4 uncovered lines are guard 3's message body: `MODULES` and `UNREACHABLE_NAMESPACES` are both file-local constants, so no fixture can put a namespace in both. Note the repo's `diff-cover` gate skips this PR anyway — its `coverage` filter is `frontend ∪ rust-core ∪ rust-tauri`, and this change is `scripts/`-only.
- [x] **Blast radius checked** — the gate's only consumer is `package.json`'s `test:rust:e2e:coverage`; it appears nowhere in `.github/` (`plan.md:251` independently records it as "still not wired into any workflow"). The two new `feature-forwarding.mjs` exports are additive; `scripts/ci/check-feature-forwarding.mjs` still exits 0.

## Test plan

- [x] `pnpm test:scripts` — **224 passed, 0 failed, 1 skipped** (the skip is `the pin gate passes on the tree as committed # submodules not checked out`, a pre-existing environment skip).
- [x] `node scripts/check-domain-e2e-coverage.mjs` against the real tree — before/after diffed.
- [x] `node scripts/ci/check-feature-forwarding.mjs` — exit 0.
- [x] Lint/format: `scripts/**` is in `app/eslint.config.js`'s ignore list and outside Prettier's scope (its config lives in `app/`), so neither applies. No Rust or `app/src` files are touched.

CI's `Scripts Self-Tests` lane covers all three changed paths (`scripts/*.mjs`, `scripts/__tests__/**`, `scripts/lib/**`), so the new tests do run on this PR.

> **Pushed with `--no-verify`**: 14 of 15 `vendor/` submodules are uninitialized in this worktree, so the pre-push hook's `compile` / `rust:clippy` steps fail on environment state rather than on this change. The checks that apply to a `scripts/`-only change were run manually and are listed above. The commit is unsigned.

Closes #6069


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded end-to-end coverage validation across feature configurations.
  - Added checks for excluded namespaces, including direct and transitive reachability, missing configuration, invalid feature definitions, outdated exclusions, and missing product feature data.
  - Added validation for complex configuration gates, repeated module declarations, and feature-graph resolution.
  - Added coverage for TOML feature values using single-quoted strings.

- **Chores**
  - Improved coverage reporting to reflect enabled end-to-end features and detect invalid, outdated, or unguarded exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->