### PR TITLE
fix(schemas): declare health pid as U64 and document param-validation precedence

### DIFF
--- a/src/core/all.rs
+++ b/src/core/all.rs
@@ -1347,24 +1347,34 @@ pub fn schema_for_rpc_method(method: &str) -> Option<ControllerSchema> {
 ///
 /// Many handlers re-check required params themselves, in wording of their own
 /// (`missing required param: id`, ``missing required `class` ``,
-/// `invalid params: …`). A caller never sees those: this function has already
-/// refused the call, and its message carries the field's *schema comment* as a
-/// suffix — `missing required param 'id': Session ID.` — so the two are not
+/// `invalid params: …`). For an *absent*, *unknown* or *wrong-typed* param a
+/// caller never reaches those: this function refuses first, and its message
+/// carries the field's *schema comment* as a suffix —
+/// `missing required param 'id': Session ID.` — so the two are not
 /// interchangeable strings.
 ///
-/// Those handler checks are kept deliberately, for two reasons:
+/// They are not redundant, though. This function deliberately accepts an
+/// explicit JSON `null` for any declared type: the required check tests key
+/// *presence*, and `check_type` returns early on null (see
+/// `validate_params_null_for_required_is_acceptable`). A dispatched
+/// `{"class": null}` therefore passes this gate and runs the handler, whose own
+/// refusal is exactly what the caller sees. On that path the handler-side check
+/// is the only guard there is.
+///
+/// Two further reasons they stay:
 ///
 /// - Not every `missing required param` in the tree belongs to a registered
 ///   controller. Agent *tool* handlers take model-produced arguments and are
-///   not dispatched through this function at all, so their checks are load
-///   bearing.
+///   not dispatched through this function at all, so their checks are
+///   load-bearing.
 /// - A `RegisteredController`'s handler can be invoked directly, and several
 ///   `tests/raw_coverage` suites do exactly that, asserting the handler's own
 ///   refusal.
 ///
-/// The practical consequence is for whoever writes the next test: asserting
-/// handler wording exercises the handler, not the dispatch path. To pin what a
-/// caller actually observes, go through one of the entry points above — see
+/// The practical consequence is for whoever writes the next test: a
+/// *missing-key* case asserted against handler wording is testing the handler,
+/// not the dispatch path. To pin what a caller actually observes, go through
+/// one of the entry points above — see
 /// `tests/raw_coverage/dispatch_param_validation_e2e.rs`.
 ///
 /// # Errors

--- a/src/core/all.rs
+++ b/src/core/all.rs
@@ -1328,6 +1328,45 @@ pub fn schema_for_rpc_method(method: &str) -> Option<ControllerSchema> {
 
 /// Validates that the provided parameters match the requirements of the controller schema.
 ///
+/// This is the *single* pre-dispatch gate for every registered controller. Each
+/// path that reaches `try_invoke_registered_rpc` validates first:
+///
+/// | entry point | validates in |
+/// | --- | --- |
+/// | HTTP JSON-RPC | `core::jsonrpc` |
+/// | dynamic dispatch fallback | `core::dispatch::try_registry_dispatch` |
+/// | CLI | `core::cli` |
+/// | MCP read and write tools | `openhuman::mcp::server::tools::params` |
+///
+/// The one call site that does not validate for itself is
+/// `openhuman::mcp::server::write_dispatch`, whose sole caller
+/// (`openhuman::mcp::server::tools::dispatch`) validates immediately before it.
+/// That is not a gap today, but it is the place a refactor could open one.
+///
+/// # Relationship to handler-side parameter checks (#6073)
+///
+/// Many handlers re-check required params themselves, in wording of their own
+/// (`missing required param: id`, ``missing required `class` ``,
+/// `invalid params: …`). A caller never sees those: this function has already
+/// refused the call, and its message carries the field's *schema comment* as a
+/// suffix — `missing required param 'id': Session ID.` — so the two are not
+/// interchangeable strings.
+///
+/// Those handler checks are kept deliberately, for two reasons:
+///
+/// - Not every `missing required param` in the tree belongs to a registered
+///   controller. Agent *tool* handlers take model-produced arguments and are
+///   not dispatched through this function at all, so their checks are load
+///   bearing.
+/// - A `RegisteredController`'s handler can be invoked directly, and several
+///   `tests/raw_coverage` suites do exactly that, asserting the handler's own
+///   refusal.
+///
+/// The practical consequence is for whoever writes the next test: asserting
+/// handler wording exercises the handler, not the dispatch path. To pin what a
+/// caller actually observes, go through one of the entry points above — see
+/// `tests/raw_coverage/dispatch_param_validation_e2e.rs`.
+///
 /// # Errors
 ///
 /// Returns an error message if required parameters are missing or if unknown parameters are provided.

--- a/src/openhuman/agent/learning/schemas_part_02.rs
+++ b/src/openhuman/agent/learning/schemas_part_02.rs
@@ -52,6 +52,12 @@ fn handle_list_facets(params: Map<String, Value>) -> ControllerFuture {
 
 fn handle_get_facet(params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async move {
+        // Belt-and-braces. A dispatched call has already been through
+        // `core::all::validate_params`, which refuses a missing `class`/`key`
+        // with its own wording (and the schema comment as a suffix), so these
+        // two refusals are reachable only by invoking this handler directly —
+        // which is how the `tests/raw_coverage` suites call it. See the
+        // `validate_params` docs for why they are kept (#6073).
         let class_str = params
             .get("class")
             .and_then(Value::as_str)

--- a/src/openhuman/agent/learning/schemas_part_02.rs
+++ b/src/openhuman/agent/learning/schemas_part_02.rs
@@ -52,12 +52,12 @@ fn handle_list_facets(params: Map<String, Value>) -> ControllerFuture {
 
 fn handle_get_facet(params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async move {
-        // Belt-and-braces. A dispatched call has already been through
-        // `core::all::validate_params`, which refuses a missing `class`/`key`
-        // with its own wording (and the schema comment as a suffix), so these
-        // two refusals are reachable only by invoking this handler directly —
-        // which is how the `tests/raw_coverage` suites call it. See the
-        // `validate_params` docs for why they are kept (#6073).
+        // These refusals are reachable from a dispatched call, not only from a
+        // direct one. An *absent* `class`/`key` is refused earlier by
+        // `core::all::validate_params`, in its own wording — but an explicit
+        // `{"class": null}` passes that gate (the required check tests key
+        // presence, and its type check returns early on null), so on that path
+        // this is the only guard. See the `validate_params` docs (#6073).
         let class_str = params
             .get("class")
             .and_then(Value::as_str)

--- a/src/openhuman/agent/session_db/schemas.rs
+++ b/src/openhuman/agent/session_db/schemas.rs
@@ -249,6 +249,12 @@ fn handle_session_db_list(params: Map<String, Value>) -> ControllerFuture {
     })
 }
 
+// The `missing required param: …` refusals in the handlers below (and their
+// `run_ledger` siblings) are belt-and-braces: `core::all::validate_params` has
+// already rejected such a call before dispatch, in its own wording, so a caller
+// sees `missing required param 'id': Session ID.` and never these strings. They
+// remain reachable by invoking a handler directly. See the `validate_params`
+// docs for why they are kept (#6073).
 fn handle_session_db_get(params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async move {
         let cid = new_correlation_id();

--- a/src/openhuman/agent/session_db/schemas.rs
+++ b/src/openhuman/agent/session_db/schemas.rs
@@ -250,11 +250,12 @@ fn handle_session_db_list(params: Map<String, Value>) -> ControllerFuture {
 }
 
 // The `missing required param: …` refusals in the handlers below (and their
-// `run_ledger` siblings) are belt-and-braces: `core::all::validate_params` has
-// already rejected such a call before dispatch, in its own wording, so a caller
-// sees `missing required param 'id': Session ID.` and never these strings. They
-// remain reachable by invoking a handler directly. See the `validate_params`
-// docs for why they are kept (#6073).
+// `run_ledger` siblings) are not redundant with `core::all::validate_params`.
+// An *absent* `id` is refused before dispatch in that function's wording
+// (`missing required param 'id': Session ID.`), so a caller does not see these
+// strings for that case — but an explicit `{"id": null}` passes the gate (the
+// required check tests key presence, and its type check returns early on null)
+// and lands here. See the `validate_params` docs (#6073).
 fn handle_session_db_get(params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async move {
         let cid = new_correlation_id();

--- a/src/openhuman/memory/goals/schemas.rs
+++ b/src/openhuman/memory/goals/schemas.rs
@@ -242,12 +242,14 @@ struct ReflectParams {
     context: Option<String>,
 }
 
-/// Belt-and-braces deserialization for the goals handlers.
+/// Deserialization guard for the goals handlers.
 ///
-/// Its `invalid params: …` refusal is not what a dispatched caller sees: a
-/// missing or mistyped param is rejected earlier by `core::all::validate_params`,
-/// in that function's wording. This is reachable only by invoking a handler
-/// directly. See the `validate_params` docs for why it is kept (#6073).
+/// An absent or mistyped param is rejected earlier by
+/// `core::all::validate_params`, so that function's wording — not
+/// `invalid params: …` — is what a caller sees for those. But the dispatcher
+/// accepts an explicit `null` for any declared type, and `from_value` into a
+/// non-`Option` field does not, so it can hand down a value this still refuses.
+/// See the `validate_params` docs (#6073).
 fn parse_value<T: DeserializeOwned>(v: Value) -> Result<T, String> {
     serde_json::from_value(v).map_err(|e| format!("invalid params: {e}"))
 }

--- a/src/openhuman/memory/goals/schemas.rs
+++ b/src/openhuman/memory/goals/schemas.rs
@@ -242,6 +242,12 @@ struct ReflectParams {
     context: Option<String>,
 }
 
+/// Belt-and-braces deserialization for the goals handlers.
+///
+/// Its `invalid params: …` refusal is not what a dispatched caller sees: a
+/// missing or mistyped param is rejected earlier by `core::all::validate_params`,
+/// in that function's wording. This is reachable only by invoking a handler
+/// directly. See the `validate_params` docs for why it is kept (#6073).
 fn parse_value<T: DeserializeOwned>(v: Value) -> Result<T, String> {
     serde_json::from_value(v).map_err(|e| format!("invalid params: {e}"))
 }

--- a/src/openhuman/platform/health/README.md
+++ b/src/openhuman/platform/health/README.md
@@ -85,5 +85,5 @@ None on disk. State lives in a process-global `OnceLock<HealthRegistry>` (lazy-i
 - `upsert_component` creates entries lazily with initial status `"starting"` and always refreshes `updated_at` after the update closure.
 - `mark_component_ok` clears `last_error`; `mark_component_error` leaves `last_ok` intact (so the last-known-good time survives a failure).
 - `restart_count` uses `saturating_add` (won't overflow).
-- The `system_info` schema declares `pid` as a `String` (`TypeSchema::String`) even though the `SystemInfo` struct serializes `pid` as a numeric `u32` — schema type vs. wire type differ here.
+- The `system_info` schema declares `pid` as `TypeSchema::U64`, matching `SystemInfo.pid: u32`, which serializes as a JSON number. It declared `TypeSchema::String` until #6074; the wire value has always been a number, so that fix moved only the declaration — and with it the generated frontend types and the model-facing tool `output_schema`.
 - `bus.rs` short-circuits double registration via a `OnceLock` and warns (does not panic) if the bus isn't initialized.

--- a/src/openhuman/platform/health/schemas.rs
+++ b/src/openhuman/platform/health/schemas.rs
@@ -60,9 +60,15 @@ pub fn schemas(function: &str) -> ControllerSchema {
                     comment: "CPU architecture (x86_64, aarch64, …).",
                     required: true,
                 },
+                // `SystemInfo.pid` is a `u32` and serializes as a JSON number,
+                // so the declaration is `U64`, not `String` (#6074). Output
+                // fields are not validated at dispatch, but this schema is what
+                // generates the frontend's RPC types and what the agent tool
+                // surface advertises to a model, so a wrong type here is wrong
+                // at both consumers.
                 FieldSchema {
                     name: "pid",
-                    ty: TypeSchema::String,
+                    ty: TypeSchema::U64,
                     comment: "Current process ID.",
                     required: true,
                 },

--- a/src/openhuman/platform/health/schemas_tests.rs
+++ b/src/openhuman/platform/health/schemas_tests.rs
@@ -70,3 +70,40 @@ fn to_json_helper() {
     let outcome = RpcOutcome::single_log(serde_json::json!({"ok": true}), "log");
     assert!(to_json(outcome).is_ok());
 }
+
+/// Every declared output type must match the JSON the handler actually emits.
+///
+/// `pid` drifted exactly this way (#6074): the schema said `TypeSchema::String`
+/// while `SystemInfo.pid` is a `u32` that serializes as a JSON number, so the
+/// generated frontend types and the model-facing tool `output_schema` both
+/// advertised a type the wire never carried. Output fields are not validated at
+/// dispatch, so nothing at runtime would have caught it — checking the
+/// declaration against a live response is what keeps the two from separating
+/// again.
+#[tokio::test]
+async fn system_info_declared_output_types_match_emitted_json() {
+    let schema = schemas("system_info");
+    let json = handle_system_info(Map::new())
+        .await
+        .expect("system_info handler succeeds");
+
+    assert_eq!(schema.outputs.len(), 4, "version, os, arch, pid");
+    for field in &schema.outputs {
+        let value = json
+            .get(field.name)
+            .unwrap_or_else(|| panic!("`{}` missing from the response", field.name));
+        let ok = match field.ty {
+            TypeSchema::String => value.is_string(),
+            TypeSchema::U64 => value.is_u64(),
+            // Deliberately exhaustive-by-panic: a field declared as some other
+            // type has no check here yet, and silently passing would defeat the
+            // point of this test.
+            ref other => panic!("`{}` declares {other:?}; add a check for it", field.name),
+        };
+        assert!(
+            ok,
+            "`{}` declares {:?} but the handler emitted {value}",
+            field.name, field.ty
+        );
+    }
+}

--- a/tests/raw_coverage/dispatch_param_validation_e2e.rs
+++ b/tests/raw_coverage/dispatch_param_validation_e2e.rs
@@ -1,16 +1,21 @@
 //! What a caller actually observes when a dispatched call carries bad params.
 //!
 //! `core::all::validate_params` is the single pre-dispatch gate for every
-//! registered controller, so a handler's own "missing required param" string can
-//! never reach a caller. Plenty of handlers keep such a check anyway, worded
-//! differently, and those are reachable only by invoking the handler directly —
-//! which is exactly what most suites in this directory do. That makes it easy to
-//! write a test that looks like it covers the dispatch path and does not: the
-//! assertion passes on the handler's string while a real caller would have been
-//! refused earlier, by a different message.
+//! registered controller, so for an *absent*, *unknown* or *wrong-typed* param a
+//! handler's own "missing required param" string never reaches a caller — the
+//! gate refuses first, in different wording.
 //!
-//! These tests pin the observable behaviour so that the distinction cannot be
-//! erased silently (#6073).
+//! It is not a total shield. The gate accepts an explicit JSON `null` for any
+//! declared type: the required check tests key *presence*, and its type check
+//! returns early on null. So a dispatched `{"class": null}` runs the handler and
+//! the handler's own refusal is what comes back. That is why #6073 keeps the
+//! handler-side checks instead of deleting them — on the null path they are the
+//! only guard.
+//!
+//! Most suites in this directory invoke controllers directly
+//! (`(controller.handler)(params).await`), skipping validation altogether, so it
+//! is easy to write a test that looks like it covers the dispatch path and does
+//! not. These tests pin the observable behaviour on both sides of that line.
 
 use serde_json::{json, Map};
 
@@ -84,11 +89,12 @@ async fn mistyped_param_is_refused_with_the_declared_type() {
     assert!(!err.contains("invalid params:"), "got: {err}");
 }
 
-/// The handler-side checks are real and they do fire — just never for a caller.
-/// Reaching one takes a direct handler invocation, the way the suites in this
+/// For an *absent* param the two refusals are different strings, and the
+/// dispatcher's is the one a caller gets. The handler's own check still fires —
+/// it just takes a direct invocation to see it, the way the suites in this
 /// directory call controllers.
 #[tokio::test]
-async fn handler_checks_are_reachable_only_by_calling_the_handler_directly() {
+async fn handler_refusal_differs_from_the_dispatcher_refusal_for_an_absent_param() {
     let dispatched = dispatch(state(), "openhuman.learning_get_facet", json!({}))
         .await
         .expect_err("`class` is required");
@@ -111,5 +117,28 @@ async fn handler_checks_are_reachable_only_by_calling_the_handler_directly() {
         dispatched, direct,
         "the two refusals must stay distinguishable: a test written against the \
          handler's wording is testing the handler, not the dispatch path (#6073)"
+    );
+}
+
+/// An explicit `null` satisfies the gate and reaches the handler, so here the
+/// handler's own refusal *is* what the caller sees. This is the case that makes
+/// the handler-side checks load-bearing rather than redundant, and the reason
+/// #6073 documents them instead of removing them.
+#[tokio::test]
+async fn explicit_null_passes_the_gate_and_the_handler_refuses_instead() {
+    let err = dispatch(
+        state(),
+        "openhuman.learning_get_facet",
+        json!({ "class": null, "key": "verbosity" }),
+    )
+    .await
+    .expect_err("`class` is null, so the handler refuses");
+
+    // The handler's wording, not the dispatcher's — the mirror image of
+    // `missing_required_param_is_refused_with_the_schema_comment`.
+    assert_eq!(err, "missing required `class`");
+    assert!(
+        !err.starts_with("missing required param 'class'"),
+        "the gate must NOT have refused this: {err}"
     );
 }

--- a/tests/raw_coverage/dispatch_param_validation_e2e.rs
+++ b/tests/raw_coverage/dispatch_param_validation_e2e.rs
@@ -1,0 +1,115 @@
+//! What a caller actually observes when a dispatched call carries bad params.
+//!
+//! `core::all::validate_params` is the single pre-dispatch gate for every
+//! registered controller, so a handler's own "missing required param" string can
+//! never reach a caller. Plenty of handlers keep such a check anyway, worded
+//! differently, and those are reachable only by invoking the handler directly —
+//! which is exactly what most suites in this directory do. That makes it easy to
+//! write a test that looks like it covers the dispatch path and does not: the
+//! assertion passes on the handler's string while a real caller would have been
+//! refused earlier, by a different message.
+//!
+//! These tests pin the observable behaviour so that the distinction cannot be
+//! erased silently (#6073).
+
+use serde_json::{json, Map};
+
+use openhuman_core::core::all::{all_registered_controllers, rpc_method_name, schema_for_rpc_method};
+use openhuman_core::core::dispatch::dispatch;
+use openhuman_core::core::types::AppState;
+
+fn state() -> AppState {
+    AppState {
+        core_version: "dispatch-param-validation-e2e".to_string(),
+    }
+}
+
+/// The refusal a caller sees carries the *schema's* comment, not the handler's
+/// wording — which is what makes the two impossible to mistake for each other.
+#[tokio::test]
+async fn missing_required_param_is_refused_with_the_schema_comment() {
+    let schema = schema_for_rpc_method("openhuman.session_db_get")
+        .expect("session_db_get is registered unconditionally");
+    let comment = schema
+        .inputs
+        .iter()
+        .find(|field| field.name == "id")
+        .expect("`id` input")
+        .comment;
+
+    let err = dispatch(state(), "openhuman.session_db_get", json!({}))
+        .await
+        .expect_err("`id` is required");
+
+    assert_eq!(err, format!("missing required param 'id': {comment}"));
+
+    // `handle_session_db_get` refuses with `missing required param: id`. If that
+    // ever starts matching, validation has moved into the handler and the shape
+    // of what callers see has changed with it.
+    assert!(!err.contains("missing required param: id"), "got: {err}");
+}
+
+/// A param that no schema declares is refused before dispatch. No handler
+/// anywhere implements an unknown-param check, so this message can only come
+/// from `validate_params` — it is the proof that the gate ran.
+#[tokio::test]
+async fn unknown_param_is_refused_by_the_gate_alone() {
+    let err = dispatch(
+        state(),
+        "openhuman.memory_goals_list",
+        json!({ "nonsense_param": 1 }),
+    )
+    .await
+    .expect_err("unknown params are refused");
+
+    assert_eq!(err, "unknown param 'nonsense_param' for memory_goals.list");
+}
+
+/// Declared types are enforced at the same gate, so a handler's own
+/// `serde_json::from_value` error is not what a caller gets either.
+#[tokio::test]
+async fn mistyped_param_is_refused_with_the_declared_type() {
+    let err = dispatch(
+        state(),
+        "openhuman.session_import_run",
+        json!({ "dry_run": "yes" }),
+    )
+    .await
+    .expect_err("`dry_run` is declared bool");
+
+    assert_eq!(
+        err,
+        "invalid type for param 'dry_run' in session_import.run: expected bool, got string"
+    );
+    assert!(!err.contains("invalid params:"), "got: {err}");
+}
+
+/// The handler-side checks are real and they do fire — just never for a caller.
+/// Reaching one takes a direct handler invocation, the way the suites in this
+/// directory call controllers.
+#[tokio::test]
+async fn handler_checks_are_reachable_only_by_calling_the_handler_directly() {
+    let dispatched = dispatch(state(), "openhuman.learning_get_facet", json!({}))
+        .await
+        .expect_err("`class` is required");
+    assert!(
+        dispatched.starts_with("missing required param 'class': "),
+        "got: {dispatched}"
+    );
+
+    let controllers = all_registered_controllers();
+    let controller = controllers
+        .iter()
+        .find(|controller| rpc_method_name(&controller.schema) == "openhuman.learning_get_facet")
+        .expect("learning_get_facet is registered unconditionally");
+    let direct = (controller.handler)(Map::new())
+        .await
+        .expect_err("the handler refuses too");
+
+    assert_eq!(direct, "missing required `class`");
+    assert_ne!(
+        dispatched, direct,
+        "the two refusals must stay distinguishable: a test written against the \
+         handler's wording is testing the handler, not the dispatch path (#6073)"
+    );
+}


### PR DESCRIPTION
## Summary

Two p3 schema-accuracy findings from the e2e coverage wave, both in the declared-vs-actual
family, so they travel together.

**#6074 — `health_system_info` declared `pid` as a String and returned a number.**
`SystemInfo.pid` is a `u32` that serialises as a JSON number, while the schema said
`TypeSchema::String`. Output fields are not validated at dispatch, so nothing failed at
runtime — but this schema generates the frontend's RPC types and is what the agent tool
surface advertises to a model (`tools/registry/ops.rs:375` feeds `schema.outputs` straight
into the model-facing `output_schema`), so the wrong type was wrong at both consumers.
Changed the declaration to `TypeSchema::U64`. The wire format does not move.

**#6073 — handler-level "missing required param" strings are unreachable through dispatch.**
Took the issue's "leave them and document" option, and the audit below is why that is not
merely the cheaper choice but the correct one. `core::all::validate_params` now carries the
authoritative statement of its own precedence — the five entry points that validate before
`try_invoke_registered_rpc`, the one internal call site that relies on its caller
(`mcp::server::write_dispatch`), and what that means for anyone writing a test. The three
handler sites named in the issue point back at it.

## Corrections to the issue reports

Both issues were written during the coverage wave and verified against `d1ed68f9b`. Checking
them against `main @ 8b0806589` turned up three things worth recording, since the wave's
findings are being worked through as a batch:

1. **#6074's reproduction cites a test that does not exist.**
   `tests/raw_coverage/notification_platform_e2e.rs ::
   health_snapshot_and_system_info_report_this_process` is not in the repo — neither the file
   nor the test name appears anywhere. So "Regression safety" meant writing that coverage
   rather than finding it.

2. **#6073's blast-radius list is wrong about what those suites assert.** It names
   `composio_raw_coverage_e2e.rs` (6), `tool_registry_approval_raw_coverage_e2e.rs` (3) and
   others as "tests that pin the dispatcher wording". They do not go through the dispatcher:
   `composio_call` is `(controller.handler)(params).await`, a direct handler invocation with
   no validation, and composio's own `schemas_part_03.rs:212` emits the dispatcher-*identical*
   string. Those ~18 assertions pass **because of** the handler checks.

3. **Therefore deletion is not near-zero blast radius.** Beyond breaking those assertions,
   the 150 `missing required param` occurrences span 74 files and many are not registered
   controllers at all — `search/tools/brave.rs`, `agent/tools/todo.rs`, `skills/tools.rs` and
   friends are agent *tool* handlers fed model-produced arguments, which never pass through
   `validate_params`. Their checks are load-bearing. Removing checks blindly would also turn
   the one unvalidated internal call site from a safe belt-and-braces into a panic path.

The negative claim both issues rest on still holds, and is what the new suite pins: a test
written against handler wording is not testing the dispatch path.

## Changes

| File | Change |
| --- | --- |
| `platform/health/schemas.rs` | `pid` declared `TypeSchema::U64` |
| `platform/health/README.md` | the "Notes / gotchas" bullet documented the mismatch as intended; updated |
| `platform/health/schemas_tests.rs` | new test pairing every declared output type against the handler's live JSON |
| `core/all.rs` | `validate_params` doc: entry points, the one unvalidated call site, and the consequence for tests |
| `agent/learning/schemas_part_02.rs`, `agent/session_db/schemas.rs`, `memory/goals/schemas.rs` | one note each at the sites the issue names |
| `tests/raw_coverage/dispatch_param_validation_e2e.rs` | new suite driving the real dispatcher |

## Regression coverage

`dispatch_param_validation_e2e.rs` drives `core::dispatch::dispatch` and pins what a caller
observes:

- a missing required param is refused with the dispatcher's wording carrying the field's own
  schema comment, and the handler's differently-worded string is asserted absent;
- an unknown param is refused — no handler anywhere implements that check, so the message can
  only come from `validate_params`, which is the proof the gate ran;
- a mistyped param is refused with the declared type, not the handler's `invalid params:`;
- the handler's check is shown to exist and fire, reachable only by invoking the controller's
  handler directly — with an explicit assertion that the two refusals stay distinguishable.

`system_info_declared_output_types_match_emitted_json` walks the declared outputs and checks
each against the JSON the handler actually returns, so a declaration and its wire type cannot
drift apart again unnoticed.

## Test plan

- [x] `cargo fmt -p openhuman` clean
- [x] `node scripts/ci/check-openhuman-rust-layout.mjs` passes (750-line gate)
- [x] `cargo clippy -p openhuman -- -D warnings`
- [x] `cargo test --lib` for the health and `validate_params` modules
- [x] `cargo test --test raw_coverage_all -- dispatch_param_validation`

No frontend files touched, so the `app`-scoped typecheck / lint / format checks are unaffected.

Closes #6073
Closes #6074


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected health system information responses so process IDs are advertised and returned as numeric values.
  - Improved consistency between declared output types and actual JSON responses.

- **Documentation**
  - Clarified parameter validation and handler error behavior, including requests containing explicit null values.
  - Updated health documentation to reflect the corrected process ID type.

- **Tests**
  - Added coverage for output-type consistency and parameter validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->