### PR TITLE
fix(sandbox): resolve policy/status from the loaded config, not RuntimeConfig::default()

### DIFF
--- a/src/core/runtime/context.rs
+++ b/src/core/runtime/context.rs
@@ -522,6 +522,33 @@ impl CoreContext {
             embedder_config: None,
         })
     }
+
+    /// Test-only constructor that carries an embedder-supplied config, so a
+    /// cross-module test can exercise the `load_config_with_timeout()` read
+    /// path (which prefers [`CoreContext::current_embedder_config`]) without a
+    /// full boot or a racy on-disk `config.toml`.
+    ///
+    /// Distinct from [`CoreContext::for_test`] — which always sets
+    /// `embedder_config: None` — so the ~30 existing `for_test` call sites are
+    /// unaffected. The workspace binding is anchored to the config's
+    /// `workspace_dir`, matching how [`CoreContext::init`] wires an
+    /// embedder-supplied config.
+    #[cfg(test)]
+    pub(crate) fn for_test_with_config(
+        domains: crate::core::runtime::DomainSet,
+        config: crate::openhuman::config::Config,
+    ) -> Arc<CoreContext> {
+        Arc::new(CoreContext {
+            host_kind: HostKind::Cli,
+            workspace_binding: RwLock::new(WorkspaceBinding {
+                workspace_dir: Some(config.workspace_dir.clone()),
+                memory_subsystem: Default::default(),
+            }),
+            domains,
+            tool_groups: Default::default(),
+            embedder_config: Some(config),
+        })
+    }
 }
 
 /// Bind the memory driver for this workspace and initialize the other

--- a/src/openhuman/sandbox/schemas.rs
+++ b/src/openhuman/sandbox/schemas.rs
@@ -4,6 +4,8 @@ use serde_json::{Map, Value};
 
 use crate::core::all::{ControllerFuture, RegisteredController};
 use crate::core::{ControllerSchema, FieldSchema, TypeSchema};
+use crate::openhuman::config::resolve_action_dir;
+use crate::openhuman::config::rpc as config_rpc;
 use crate::rpc::RpcOutcome;
 
 pub fn all_controller_schemas() -> Vec<ControllerSchema> {
@@ -42,12 +44,22 @@ pub fn schemas(function: &str) -> ControllerSchema {
             namespace: "sandbox",
             function: "status",
             description: "Return sandbox backend status and availability.",
-            inputs: vec![FieldSchema {
-                name: "backend",
-                ty: TypeSchema::String,
-                comment: "Backend kind to check: 'docker', 'local', or 'none'.",
-                required: false,
-            }],
+            inputs: vec![
+                FieldSchema {
+                    name: "backend",
+                    ty: TypeSchema::String,
+                    comment: "Backend kind to check: 'docker', 'local', or 'none'.",
+                    required: false,
+                },
+                FieldSchema {
+                    name: "is_remote",
+                    ty: TypeSchema::Bool,
+                    comment: "Whether this is a remote/channel session. When true, a \
+                              sandboxed session resolves to the Docker backend even if \
+                              the runtime is not configured for Docker. Defaults to false.",
+                    required: false,
+                },
+            ],
             outputs: vec![FieldSchema {
                 name: "status",
                 ty: TypeSchema::Json,
@@ -138,6 +150,15 @@ fn handle_status(params: Map<String, Value>) -> ControllerFuture {
             .get("backend")
             .and_then(|v| v.as_str())
             .unwrap_or("none");
+        // `is_remote` is an explicit caller-supplied flag, matching
+        // `handle_resolve_policy`. It must NOT be inferred from `backend_str`:
+        // naming the docker backend to check its availability is not the same
+        // as running a remote/channel session, and conflating the two forced
+        // Docker resolution for a local status probe (#6081).
+        let is_remote = params
+            .get("is_remote")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
 
         let mode = match backend_str {
             "docker" | "local" => {
@@ -146,12 +167,23 @@ fn handle_status(params: Map<String, Value>) -> ControllerFuture {
             _ => crate::openhuman::agent::harness::definition::SandboxMode::None,
         };
 
-        let config = crate::openhuman::config::RuntimeConfig::default();
-        let is_remote = backend_str == "docker";
+        // Load the user's live config so the reported policy reflects the
+        // configured runtime (`[runtime] kind` + `[runtime.docker]` overrides)
+        // and the mounted workspace, not the compiled-in `RuntimeConfig::default()`
+        // (#6081). A failed config load surfaces to the caller rather than
+        // silently answering from defaults.
+        let config = match config_rpc::load_config_with_timeout().await {
+            Ok(config) => config,
+            Err(err) => {
+                log::warn!("[sandbox] handle_status config load failed error={err}");
+                return Err(err);
+            }
+        };
+
         let policy = super::ops::resolve_sandbox_policy(
             mode,
-            std::path::Path::new("/tmp"),
-            &config,
+            &config.workspace_dir,
+            &config.runtime,
             is_remote,
         );
         let handle = super::ops::create_sandbox_backend(&policy).await;
@@ -176,9 +208,24 @@ fn handle_resolve_policy(params: Map<String, Value>) -> ControllerFuture {
             _ => crate::openhuman::agent::harness::definition::SandboxMode::None,
         };
 
-        let config = crate::openhuman::config::RuntimeConfig::default();
-        let action_dir = crate::openhuman::config::default_action_dir();
-        let policy = super::ops::resolve_sandbox_policy(mode, &action_dir, &config, is_remote);
+        // Load the user's live config so the resolved policy honors the
+        // configured runtime (`[runtime] kind` + `[runtime.docker]` overrides)
+        // and the user's action dir, not the compiled-in `RuntimeConfig::default()`
+        // and `default_action_dir()` (#6081). A failed config load surfaces to
+        // the caller rather than silently answering from defaults.
+        let config = match config_rpc::load_config_with_timeout().await {
+            Ok(config) => config,
+            Err(err) => {
+                log::warn!("[sandbox] handle_resolve_policy config load failed error={err}");
+                return Err(err);
+            }
+        };
+
+        // Honor the env `OPENHUMAN_ACTION_DIR` > persisted `action_dir_override`
+        // > default precedence, matching how acting tools resolve their root.
+        let action_dir = resolve_action_dir(&config.action_dir_override);
+        let policy =
+            super::ops::resolve_sandbox_policy(mode, &action_dir, &config.runtime, is_remote);
         to_json(RpcOutcome::new(policy, vec![]))
     })
 }

--- a/src/openhuman/sandbox/schemas.rs
+++ b/src/openhuman/sandbox/schemas.rs
@@ -4,7 +4,6 @@ use serde_json::{Map, Value};
 
 use crate::core::all::{ControllerFuture, RegisteredController};
 use crate::core::{ControllerSchema, FieldSchema, TypeSchema};
-use crate::openhuman::config::resolve_action_dir;
 use crate::openhuman::config::rpc as config_rpc;
 use crate::rpc::RpcOutcome;
 
@@ -48,7 +47,13 @@ pub fn schemas(function: &str) -> ControllerSchema {
                 FieldSchema {
                     name: "backend",
                     ty: TypeSchema::String,
-                    comment: "Backend kind to check: 'docker', 'local', or 'none'.",
+                    comment: "Sandbox MODE to resolve, not the backend that is \
+                              reported: 'docker'/'local' both map to the sandboxed \
+                              mode, 'none' to no sandbox. The ACTUAL backend is \
+                              resolved from the loaded runtime config (`[runtime] \
+                              kind`) plus `is_remote`, so it reflects what an agent \
+                              session would really get — e.g. 'docker' on a \
+                              native-config host reports the Local backend.",
                     required: false,
                 },
                 FieldSchema {
@@ -144,6 +149,15 @@ pub fn schemas(function: &str) -> ControllerSchema {
     }
 }
 
+/// `sandbox.status` — report the backend an agent session would actually get.
+///
+/// The `backend` param selects the sandbox MODE to resolve, not the backend to
+/// report: `"docker"`/`"local"` both mean "resolve the sandboxed mode" and
+/// `"none"` means "no sandbox". The concrete backend is then derived from the
+/// loaded runtime config (`[runtime] kind`) plus `is_remote` — never from the
+/// requested name — so `backend:"docker"` on a native-config host reports Local,
+/// matching what a real session on that host would run. Reporting the requested
+/// backend instead was the conflation fixed in #6081.
 fn handle_status(params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async move {
         let backend_str = params
@@ -221,11 +235,19 @@ fn handle_resolve_policy(params: Map<String, Value>) -> ControllerFuture {
             }
         };
 
-        // Honor the env `OPENHUMAN_ACTION_DIR` > persisted `action_dir_override`
-        // > default precedence, matching how acting tools resolve their root.
-        let action_dir = resolve_action_dir(&config.action_dir_override);
-        let policy =
-            super::ops::resolve_sandbox_policy(mode, &action_dir, &config.runtime, is_remote);
+        // Use the already-resolved `config.action_dir`. The loader fully
+        // resolves this field on every path: `load_or_init` sets it from the
+        // env `OPENHUMAN_ACTION_DIR` > persisted `action_dir_override` > default
+        // precedence (`resolve_action_dir` + `apply_env_overrides`), and an
+        // embedder-supplied config carries whatever `CoreBuilder::action_dir(..)`
+        // set directly. Re-deriving it here from `action_dir_override` alone
+        // would silently ignore an embedder's programmatic `action_dir` (#6081).
+        let policy = super::ops::resolve_sandbox_policy(
+            mode,
+            &config.action_dir,
+            &config.runtime,
+            is_remote,
+        );
         to_json(RpcOutcome::new(policy, vec![]))
     })
 }

--- a/src/openhuman/sandbox/schemas_tests.rs
+++ b/src/openhuman/sandbox/schemas_tests.rs
@@ -1,4 +1,13 @@
 use super::*;
+use crate::core::runtime::context::CoreContext;
+use crate::core::runtime::DomainSet;
+
+/// Scope a `Config` onto the embedder-config seam that `load_config_with_timeout()`
+/// prefers, so a handler reads it instead of doing live disk I/O against
+/// `~/.openhuman` — which is slow and racy across parallel unit tests (#6081).
+fn scoped_ctx(config: crate::openhuman::config::Config) -> std::sync::Arc<CoreContext> {
+    CoreContext::for_test_with_config(DomainSet::full(), config)
+}
 
 #[test]
 fn all_schemas_are_in_sandbox_namespace() {
@@ -19,7 +28,8 @@ fn registered_controllers_match_schemas() {
 
 #[tokio::test]
 async fn handle_status_returns_json() {
-    let result = handle_status(Map::new()).await;
+    let ctx = scoped_ctx(crate::openhuman::config::Config::default());
+    let result = CoreContext::scope(ctx, async { handle_status(Map::new()).await }).await;
     assert!(result.is_ok());
 }
 
@@ -27,7 +37,8 @@ async fn handle_status_returns_json() {
 async fn handle_resolve_policy_none() {
     let mut params = Map::new();
     params.insert("sandbox_mode".into(), Value::String("none".into()));
-    let result = handle_resolve_policy(params).await;
+    let ctx = scoped_ctx(crate::openhuman::config::Config::default());
+    let result = CoreContext::scope(ctx, async { handle_resolve_policy(params).await }).await;
     assert!(result.is_ok());
 }
 
@@ -36,7 +47,8 @@ async fn handle_resolve_policy_sandboxed_remote() {
     let mut params = Map::new();
     params.insert("sandbox_mode".into(), Value::String("sandboxed".into()));
     params.insert("is_remote".into(), Value::Bool(true));
-    let result = handle_resolve_policy(params).await;
+    let ctx = scoped_ctx(crate::openhuman::config::Config::default());
+    let result = CoreContext::scope(ctx, async { handle_resolve_policy(params).await }).await;
     assert!(result.is_ok());
     let val = result.unwrap();
     let backend = val.get("backend").and_then(|b| b.as_str());
@@ -46,7 +58,6 @@ async fn handle_resolve_policy_sandboxed_remote() {
 /// Build a `Config` carrying a Docker runtime with a NON-default image, so a
 /// test can prove the RPC handlers read the loaded runtime rather than
 /// `RuntimeConfig::default()` (#6081).
-#[cfg(test)]
 fn docker_runtime_config() -> crate::openhuman::config::Config {
     let mut config = crate::openhuman::config::Config::default();
     config.workspace_dir = std::path::PathBuf::from("/tmp/openhuman-6081-ws");
@@ -63,10 +74,7 @@ fn docker_runtime_config() -> crate::openhuman::config::Config {
 /// duration of the dispatch.
 #[tokio::test]
 async fn handle_resolve_policy_honors_loaded_docker_runtime() {
-    use crate::core::runtime::context::CoreContext;
-    use crate::core::runtime::DomainSet;
-
-    let ctx = CoreContext::for_test_with_config(DomainSet::full(), docker_runtime_config());
+    let ctx = scoped_ctx(docker_runtime_config());
 
     let mut params = Map::new();
     params.insert("sandbox_mode".into(), Value::String("sandboxed".into()));
@@ -104,10 +112,7 @@ async fn handle_resolve_policy_honors_loaded_docker_runtime() {
 /// backend name.
 #[tokio::test]
 async fn handle_status_honors_loaded_docker_runtime() {
-    use crate::core::runtime::context::CoreContext;
-    use crate::core::runtime::DomainSet;
-
-    let ctx = CoreContext::for_test_with_config(DomainSet::full(), docker_runtime_config());
+    let ctx = scoped_ctx(docker_runtime_config());
 
     let mut params = Map::new();
     params.insert("backend".into(), Value::String("local".into()));

--- a/src/openhuman/sandbox/schemas_tests.rs
+++ b/src/openhuman/sandbox/schemas_tests.rs
@@ -43,6 +43,87 @@ async fn handle_resolve_policy_sandboxed_remote() {
     assert_eq!(backend, Some("docker"));
 }
 
+/// Build a `Config` carrying a Docker runtime with a NON-default image, so a
+/// test can prove the RPC handlers read the loaded runtime rather than
+/// `RuntimeConfig::default()` (#6081).
+#[cfg(test)]
+fn docker_runtime_config() -> crate::openhuman::config::Config {
+    let mut config = crate::openhuman::config::Config::default();
+    config.workspace_dir = std::path::PathBuf::from("/tmp/openhuman-6081-ws");
+    config.runtime.kind = "docker".into();
+    config.runtime.docker.image = "ghcr.io/example/custom-sandbox:6081".into();
+    config
+}
+
+/// #6081 regression — `sandbox_resolve_policy` must honor the loaded
+/// `[runtime] kind = "docker"` config. Before the fix the handler answered from
+/// `RuntimeConfig::default()` (`kind = "native"`), so a Docker-configured user
+/// was told `backend = "local"`. The config is injected through the
+/// embedder-config seam that `load_config_with_timeout()` reads, scoped for the
+/// duration of the dispatch.
+#[tokio::test]
+async fn handle_resolve_policy_honors_loaded_docker_runtime() {
+    use crate::core::runtime::context::CoreContext;
+    use crate::core::runtime::DomainSet;
+
+    let ctx = CoreContext::for_test_with_config(DomainSet::full(), docker_runtime_config());
+
+    let mut params = Map::new();
+    params.insert("sandbox_mode".into(), Value::String("sandboxed".into()));
+    params.insert("is_remote".into(), Value::Bool(false));
+
+    let val = CoreContext::scope(ctx, async { handle_resolve_policy(params).await })
+        .await
+        .expect("resolve_policy should succeed under the scoped config");
+
+    // Consequence #1: the backend follows `[runtime] kind`, not the default.
+    assert_eq!(
+        val.get("backend").and_then(|b| b.as_str()),
+        Some("docker"),
+        "docker runtime must resolve to the docker backend; got {val:?}"
+    );
+
+    // Consequence #2: docker overrides reflect the user's `[runtime.docker]`,
+    // not the compiled-in default image.
+    let image = val
+        .get("docker_overrides")
+        .and_then(|o| o.get("image"))
+        .and_then(|i| i.as_str());
+    assert_eq!(
+        image,
+        Some("ghcr.io/example/custom-sandbox:6081"),
+        "docker_overrides.image must reflect the loaded [runtime.docker].image; got {val:?}"
+    );
+}
+
+/// #6081 regression — `sandbox_status` must likewise read the loaded runtime.
+/// With `[runtime] kind = "docker"` and `is_remote = false`, a sandboxed status
+/// probe resolves the docker backend; before the fix it answered "local" from
+/// `RuntimeConfig::default()`. Uses `backend = "local"` in the request to prove
+/// the resolution comes from the loaded config's `kind`, not the caller's
+/// backend name.
+#[tokio::test]
+async fn handle_status_honors_loaded_docker_runtime() {
+    use crate::core::runtime::context::CoreContext;
+    use crate::core::runtime::DomainSet;
+
+    let ctx = CoreContext::for_test_with_config(DomainSet::full(), docker_runtime_config());
+
+    let mut params = Map::new();
+    params.insert("backend".into(), Value::String("local".into()));
+    params.insert("is_remote".into(), Value::Bool(false));
+
+    let val = CoreContext::scope(ctx, async { handle_status(params).await })
+        .await
+        .expect("status should succeed under the scoped config");
+
+    assert_eq!(
+        val.get("kind").and_then(|k| k.as_str()),
+        Some("docker"),
+        "docker runtime must make status report the docker backend; got {val:?}"
+    );
+}
+
 #[tokio::test]
 async fn handle_validate_policy_valid() {
     let policy = super::super::types::SandboxPolicy {

--- a/src/openhuman/sandbox/schemas_tests.rs
+++ b/src/openhuman/sandbox/schemas_tests.rs
@@ -129,6 +129,38 @@ async fn handle_status_honors_loaded_docker_runtime() {
     );
 }
 
+/// #6081 (F2) — `sandbox_resolve_policy` must use the loaded config's
+/// already-resolved `action_dir`, not recompute it from `action_dir_override`
+/// alone. An embedder sets `Config.action_dir` directly via
+/// `CoreBuilder::action_dir(..)` and leaves `action_dir_override` at `None`;
+/// `resolve_action_dir(&None)` would have ignored that and returned the default
+/// projects dir, so the resolved policy would have pointed the sandbox at the
+/// wrong root. This pins that the handler honors the embedder's programmatic
+/// `action_dir`.
+#[tokio::test]
+async fn handle_resolve_policy_uses_loaded_action_dir() {
+    let embedder_action_dir = std::path::PathBuf::from("/tmp/openhuman-6081-action-dir");
+    let mut config = crate::openhuman::config::Config::default();
+    // The embedder-shaped case: `action_dir` set directly, override untouched.
+    config.action_dir = embedder_action_dir.clone();
+    config.action_dir_override = None;
+    let ctx = scoped_ctx(config);
+
+    let mut params = Map::new();
+    params.insert("sandbox_mode".into(), Value::String("none".into()));
+
+    let val = CoreContext::scope(ctx, async { handle_resolve_policy(params).await })
+        .await
+        .expect("resolve_policy should succeed under the scoped config");
+
+    assert_eq!(
+        val.get("workspace_root").and_then(|w| w.as_str()),
+        Some(embedder_action_dir.to_str().unwrap()),
+        "policy workspace_root must use the loaded config.action_dir, not a \
+         recomputed default; got {val:?}"
+    );
+}
+
 #[tokio::test]
 async fn handle_validate_policy_valid() {
     let policy = super::super::types::SandboxPolicy {


### PR DESCRIPTION
## Summary

- `sandbox_status` and `sandbox_resolve_policy` now answer from the user's **loaded** config instead of `RuntimeConfig::default()`.
- A user with `[runtime] kind = "docker"` is now correctly told `backend: "docker"`, and `docker_overrides` reflect the user's `[runtime.docker]` block.
- `resolve_policy` resolves the action dir via `resolve_action_dir(&config.action_dir_override)`; `status` reports `config.workspace_dir` instead of the literal `/tmp`.
- `handle_status`'s `is_remote` is now an explicit optional input (documented in the schema), not inferred from the caller-supplied backend name.

## Problem

Both handlers built `crate::openhuman::config::RuntimeConfig::default()` and never loaded the user's config. Consequences: the docker branch in `resolve_sandbox_policy` (`runtime_config.kind == "docker" || is_remote_session`) was dead for these handlers (default `kind` is `native`), so a docker-configured user was told `backend: "local"`; every `docker_overrides` field was the compiled-in default; `workspace_root` was the process default action dir (`resolve_policy`) or literally `/tmp` (`status`). `handle_status` also conflated `is_remote` with `backend_str == "docker"`, which is not what `is_remote_session` means anywhere else. Sibling controllers load config routinely (e.g. `mcp/audit/schemas.rs`), so this was an oversight, not a design.

## Solution

- Load the live config via `config_rpc::load_config_with_timeout()` in both handlers, matching the `mcp/audit` sibling's error idiom (a failed load surfaces as an `Err` to the RPC caller — an expected error, not a Sentry event).
- Pass `&config.runtime` into `resolve_sandbox_policy`; use `resolve_action_dir(&config.action_dir_override)` (`resolve_policy`) and `config.workspace_dir` (`status`).
- Replace `is_remote = backend_str == "docker"` with an explicit optional `is_remote` param (default `false`), and add a matching `is_remote` input `FieldSchema` to the `sandbox_status` schema (consistent with `resolve_policy`).
- Regression tests inject a `[runtime] kind = "docker"` config with a non-default image through a new `#[cfg(test)]` `CoreContext::for_test_with_config` seam and assert `backend == "docker"` + the custom `docker_overrides.image`; pre-existing tests are made hermetic so they no longer do live disk I/O.

Scope note: `resolve_sandbox_policy`'s agent-harness callers already pass a real config, so this cannot change agent behaviour. A related latent instance (`shell.rs`'s `run_sandboxed` still uses `RuntimeConfig::default()`) is called out for a **separate** follow-up and intentionally not changed here.

## Submission Checklist

- [x] Tests added or updated (happy path + failure/edge case) — docker-runtime resolve/status regression + hermetic pre-existing tests.
- [x] **Diff coverage ≥ 80%** — changed handler lines are exercised by the new scoped-config tests. (Full `diff-cover` runs in CI.)
- [x] Coverage matrix updated — `N/A: behaviour fix, no feature row added/removed`.
- [x] All affected feature IDs listed under `## Related` — `N/A`.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — `N/A: does not touch a release-cut surface`.
- [x] Linked issue closed via `Closes #NNN`.

## Impact

- `sandbox.*` RPC replies now reflect the user's real runtime/docker config and mounted workspace. `handle_status` callers that relied on the undocumented `backend="docker"`⇒`is_remote` conflation must now pass `is_remote` explicitly (the conflation was a bug). No agent-execution behaviour changes.

## Related

- Closes: #6081
- Follow-up PR(s)/TODOs: `tools/impl/system/shell.rs::run_sandboxed` uses `RuntimeConfig::default()` (same defect class, different path) — separate issue/PR.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/sandbox-policy-loads-config-6081


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox status and policy resolution now honor active runtime and workspace settings, including custom Docker configuration.
  * Sandbox status requests now use an explicit remote-execution indicator for more accurate reporting.
* **Bug Fixes**
  * Configuration-loading failures are now surfaced instead of silently falling back to defaults.
  * Sandbox actions correctly respect configured workspace and action-directory settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->