### PR TITLE
fix(socket): gate emit on Connected so pre-handshake sends are not falsely acked

### DIFF
--- a/src/openhuman/platform/socket/manager.rs
+++ b/src/openhuman/platform/socket/manager.rs
@@ -11,7 +11,7 @@
 
 use std::collections::HashMap;
 use std::sync::{
-    atomic::{AtomicU64, Ordering},
+    atomic::{AtomicBool, AtomicU64, Ordering},
     Arc, OnceLock,
 };
 
@@ -62,6 +62,25 @@ pub(super) struct SharedState {
     /// (e.g. "backend redirected ws→wss; update BACKEND_URL"). Cleared on every
     /// successful handshake and on disconnect.
     pub(super) error: RwLock<Option<String>>,
+}
+
+/// The outbound emit channel bundled with the readiness flag of the **same**
+/// connection that owns it.
+///
+/// Readiness travels with the channel so `emit` can decide "is this message
+/// deliverable?" atomically with picking the channel it would send on: both are
+/// read under the single `emit_tx` lock. `spawn_loop` installs a fresh
+/// `EmitChannel` (fresh sender + fresh `ready = false` flag) for every
+/// connection, and the background loop flips *this connection's* `ready` to
+/// `true` only after the Socket.IO CONNECT ACK and back to `false` on teardown.
+/// A reconnect therefore swaps the sender and its flag together — an `emit`
+/// holding the lock can never pair a live-looking status with a stale
+/// pre-handshake channel (the reverse of the TOCTOU the status-only gate had).
+pub(super) struct EmitChannel {
+    /// Sender into the background loop's outbound queue.
+    pub(super) tx: mpsc::UnboundedSender<String>,
+    /// `true` only between this connection's CONNECT ACK and its teardown.
+    pub(super) ready: Arc<AtomicBool>,
 }
 
 pub(super) struct AckRegistry {
@@ -116,8 +135,10 @@ impl AckRegistry {
 pub struct SocketManager {
     /// Shared state accessible from both the manager and the background loop.
     pub(super) shared: Arc<SharedState>,
-    /// Channel for sending outgoing messages to the background loop.
-    emit_tx: tokio::sync::Mutex<Option<mpsc::UnboundedSender<String>>>,
+    /// Channel for sending outgoing messages to the background loop, bundled
+    /// with the readiness flag of the connection that owns it so `emit` reads
+    /// both atomically under one lock (see [`EmitChannel`]).
+    emit_tx: tokio::sync::Mutex<Option<EmitChannel>>,
     /// Channel for signaling the background loop to shut down.
     shutdown_tx: tokio::sync::Mutex<Option<watch::Sender<bool>>>,
     /// Join handle for the background connection loop.
@@ -264,14 +285,33 @@ impl SocketManager {
         let internal_tx = emit_tx.clone();
         let (shutdown_tx, shutdown_rx) = watch::channel(false);
 
-        *self.emit_tx.lock().await = Some(emit_tx);
+        // Per-connection readiness flag: starts `false` (pre-handshake) and is
+        // flipped by `ws_loop` at CONNECT ACK. Bundled with the sender so `emit`
+        // reads the flag belonging to exactly this channel, not a flag a later
+        // reconnect may have swapped underneath it.
+        let emit_ready = Arc::new(AtomicBool::new(false));
+        let loop_ready = Arc::clone(&emit_ready);
+
+        *self.emit_tx.lock().await = Some(EmitChannel {
+            tx: emit_tx,
+            ready: emit_ready,
+        });
         *self.shutdown_tx.lock().await = Some(shutdown_tx);
 
         let url = url.to_string();
         let shared = Arc::clone(&self.shared);
 
         let handle = tokio::spawn(async move {
-            ws_loop(url, provider, shared, emit_rx, shutdown_rx, internal_tx).await;
+            ws_loop(
+                url,
+                provider,
+                shared,
+                emit_rx,
+                shutdown_rx,
+                internal_tx,
+                loop_ready,
+            )
+            .await;
         });
 
         *self.loop_handle.lock().await = Some(handle);
@@ -299,24 +339,39 @@ impl SocketManager {
 
     /// Emit a Socket.IO event to the server.
     ///
-    /// Gated on connection **readiness**, not merely on the emit channel
-    /// existing. `spawn_loop` installs `emit_tx` while the status is still
-    /// `Connecting` (before the Engine.IO / Socket.IO handshake completes), so a
-    /// channel-only guard would report success for a message that `ws_loop`'s
-    /// `drain_pending_emits` silently discards if the handshake then fails
-    /// (#4355). Callers must be told the truth, so an emit before the socket is
-    /// `Connected` returns the same `"Not connected"` error as an emit before
-    /// `connect` was ever called.
+    /// Gated on the **owning connection's** readiness flag, not on the emit
+    /// channel merely existing nor on the presentation-layer `status`. Two races
+    /// motivate this:
+    ///
+    /// - `spawn_loop` installs `emit_tx` while the handshake is still in flight,
+    ///   so a channel-only guard would report success for a message that
+    ///   `ws_loop`'s `drain_pending_emits` silently discards if the handshake
+    ///   then fails (#4355 / #6084 pre-handshake false success).
+    /// - Reading `status` and then acquiring the `emit_tx` lock are two separate
+    ///   steps; a reconnect in between could flip `status` and swap in a fresh
+    ///   pre-handshake channel, so a `status`-only gate could enqueue onto the
+    ///   *new* channel and return `Ok` for a message that channel then drops.
+    ///
+    /// The flag is created with, owned by, and flipped for a single connection,
+    /// and it is read here under the same lock that hands us the channel — so
+    /// status and channel can never be swapped mid-emit. Because readiness is
+    /// cleared only on that connection's teardown (not on a presentation-layer
+    /// `error` event that leaves the socket live), a still-connected socket
+    /// keeps accepting emits. A pre-handshake or disconnected emit returns the
+    /// same `"Not connected"` error as an emit before `connect` was ever called.
     pub async fn emit(&self, event: &str, data: serde_json::Value) -> Result<(), String> {
-        if !self.is_connected() {
+        let guard = self.emit_tx.lock().await;
+        let Some(channel) = guard.as_ref() else {
+            return Err("Not connected".to_string());
+        };
+        if !channel.ready.load(Ordering::Acquire) {
             return Err("Not connected".to_string());
         }
-        if let Some(ref tx) = *self.emit_tx.lock().await {
-            let msg = encode_sio_event(event, data, None)?;
-            tx.send(msg).map_err(|_| "Socket not connected".to_string())
-        } else {
-            Err("Not connected".to_string())
-        }
+        let msg = encode_sio_event(event, data, None)?;
+        channel
+            .tx
+            .send(msg)
+            .map_err(|_| "Socket not connected".to_string())
     }
 
     /// Emit a Socket.IO event and wait for the backend ACK callback.
@@ -338,7 +393,8 @@ impl SocketManager {
             .emit_tx
             .lock()
             .await
-            .clone()
+            .as_ref()
+            .map(|c| c.tx.clone())
             .ok_or_else(|| "Not connected".to_string())?;
         let (ack_id, ack_rx) = self.shared.ack_registry.register();
         let msg = encode_sio_event(event, data, Some(ack_id))?;

--- a/src/openhuman/platform/socket/manager.rs
+++ b/src/openhuman/platform/socket/manager.rs
@@ -320,6 +320,14 @@ impl SocketManager {
     }
 
     /// Emit a Socket.IO event and wait for the backend ACK callback.
+    ///
+    /// Unlike [`emit`](Self::emit), this deliberately does **not** gate on
+    /// `Connected`: a message queued while `Connecting` is flushed once the
+    /// handshake completes, and if the handshake fails instead the ack simply
+    /// never arrives and this returns a timeout `Err`. Because delivery is
+    /// confirmed by the ack (or its absence), a pre-handshake `emit_with_ack`
+    /// cannot report a false success the way a bare `emit` could (#6084), so it
+    /// keeps the queue-then-confirm behaviour rather than rejecting early.
     pub async fn emit_with_ack(
         &self,
         event: &str,

--- a/src/openhuman/platform/socket/manager.rs
+++ b/src/openhuman/platform/socket/manager.rs
@@ -172,7 +172,6 @@ impl SocketManager {
     }
 
     /// Check if the socket is currently connected.
-    #[allow(dead_code)]
     pub fn is_connected(&self) -> bool {
         *self.shared.status.read() == ConnectionStatus::Connected
     }
@@ -299,7 +298,19 @@ impl SocketManager {
     }
 
     /// Emit a Socket.IO event to the server.
+    ///
+    /// Gated on connection **readiness**, not merely on the emit channel
+    /// existing. `spawn_loop` installs `emit_tx` while the status is still
+    /// `Connecting` (before the Engine.IO / Socket.IO handshake completes), so a
+    /// channel-only guard would report success for a message that `ws_loop`'s
+    /// `drain_pending_emits` silently discards if the handshake then fails
+    /// (#4355). Callers must be told the truth, so an emit before the socket is
+    /// `Connected` returns the same `"Not connected"` error as an emit before
+    /// `connect` was ever called.
     pub async fn emit(&self, event: &str, data: serde_json::Value) -> Result<(), String> {
+        if !self.is_connected() {
+            return Err("Not connected".to_string());
+        }
         if let Some(ref tx) = *self.emit_tx.lock().await {
             let msg = encode_sio_event(event, data, None)?;
             tx.send(msg).map_err(|_| "Socket not connected".to_string())

--- a/src/openhuman/platform/socket/manager.rs
+++ b/src/openhuman/platform/socket/manager.rs
@@ -11,7 +11,7 @@
 
 use std::collections::HashMap;
 use std::sync::{
-    atomic::{AtomicBool, AtomicU64, Ordering},
+    atomic::{AtomicU64, Ordering},
     Arc, OnceLock,
 };
 
@@ -64,6 +64,22 @@ pub(super) struct SharedState {
     pub(super) error: RwLock<Option<String>>,
 }
 
+/// The connection's readiness flag, guarded by a lock so a reader can hold the
+/// flag `true` across the send it authorises.
+///
+/// A bare `AtomicBool` cannot express that: `emit` would load `true`, and the
+/// background loop's teardown could then clear the flag *and* drain the emit
+/// queue in the gap before `emit`'s `tx.send` runs, so the message lands in the
+/// just-drained channel and rides the *next* reconnect's socket (a fresh sid
+/// whose roster the backend has already cleared). Both critical sections —
+/// `emit`'s "is-ready? then send" and teardown's "clear then drain" — take this
+/// lock, so they are mutually exclusive and that interleaving cannot happen. The
+/// guard is a leaf: it is only ever held for a synchronous flag read/write plus
+/// a non-blocking channel `send`/`try_recv`, never across an `.await` and never
+/// while another socket lock is held, so it introduces no lock-ordering hazard
+/// with `emit_tx` or the `status` `RwLock`.
+pub(super) type EmitReady = Arc<Mutex<bool>>;
+
 /// The outbound emit channel bundled with the readiness flag of the **same**
 /// connection that owns it.
 ///
@@ -76,11 +92,16 @@ pub(super) struct SharedState {
 /// A reconnect therefore swaps the sender and its flag together — an `emit`
 /// holding the lock can never pair a live-looking status with a stale
 /// pre-handshake channel (the reverse of the TOCTOU the status-only gate had).
+///
+/// `ready` is additionally the serialization point between `emit` and teardown:
+/// see [`EmitReady`] for why the flag is a `Mutex<bool>` rather than an atomic.
 pub(super) struct EmitChannel {
     /// Sender into the background loop's outbound queue.
     pub(super) tx: mpsc::UnboundedSender<String>,
-    /// `true` only between this connection's CONNECT ACK and its teardown.
-    pub(super) ready: Arc<AtomicBool>,
+    /// `true` only between this connection's CONNECT ACK and its teardown, and
+    /// the lock that makes `emit`'s check+send exclusive with teardown's
+    /// clear+drain (see [`EmitReady`]).
+    pub(super) ready: EmitReady,
 }
 
 pub(super) struct AckRegistry {
@@ -136,8 +157,11 @@ pub struct SocketManager {
     /// Shared state accessible from both the manager and the background loop.
     pub(super) shared: Arc<SharedState>,
     /// Channel for sending outgoing messages to the background loop, bundled
-    /// with the readiness flag of the connection that owns it so `emit` reads
-    /// both atomically under one lock (see [`EmitChannel`]).
+    /// with the readiness flag of the connection that owns it. `emit` selects the
+    /// channel under this lock, then gates its check+send on the channel's own
+    /// `ready` lock, so a reconnect can never swap the channel out mid-emit nor
+    /// let teardown drain between the readiness check and the send
+    /// (see [`EmitChannel`] and [`EmitReady`]).
     emit_tx: tokio::sync::Mutex<Option<EmitChannel>>,
     /// Channel for signaling the background loop to shut down.
     shutdown_tx: tokio::sync::Mutex<Option<watch::Sender<bool>>>,
@@ -288,8 +312,10 @@ impl SocketManager {
         // Per-connection readiness flag: starts `false` (pre-handshake) and is
         // flipped by `ws_loop` at CONNECT ACK. Bundled with the sender so `emit`
         // reads the flag belonging to exactly this channel, not a flag a later
-        // reconnect may have swapped underneath it.
-        let emit_ready = Arc::new(AtomicBool::new(false));
+        // reconnect may have swapped underneath it. It is a `Mutex<bool>` rather
+        // than an atomic so `emit`'s check+send and the loop's clear+drain can be
+        // made mutually exclusive (see [`EmitReady`]).
+        let emit_ready: EmitReady = Arc::new(Mutex::new(false));
         let loop_ready = Arc::clone(&emit_ready);
 
         *self.emit_tx.lock().await = Some(EmitChannel {
@@ -359,15 +385,29 @@ impl SocketManager {
     /// `error` event that leaves the socket live), a still-connected socket
     /// keeps accepting emits. A pre-handshake or disconnected emit returns the
     /// same `"Not connected"` error as an emit before `connect` was ever called.
+    ///
+    /// The readiness check and the `tx.send` it authorises are performed under
+    /// the `ready` lock (see [`EmitReady`]), so the background loop's teardown
+    /// cannot clear the flag and drain the queue in the gap between them — which
+    /// would otherwise let this method return `Ok(())` for a message that lands
+    /// in the just-drained channel and rides the *next* reconnect's socket.
     pub async fn emit(&self, event: &str, data: serde_json::Value) -> Result<(), String> {
+        // Encode outside the readiness lock: it is fallible and touches neither
+        // the flag nor the channel, so there is no reason to widen the critical
+        // section around it.
+        let msg = encode_sio_event(event, data, None)?;
         let guard = self.emit_tx.lock().await;
         let Some(channel) = guard.as_ref() else {
             return Err("Not connected".to_string());
         };
-        if !channel.ready.load(Ordering::Acquire) {
+        // Hold `ready` across the check *and* the send so teardown's clear+drain
+        // (which takes the same lock) cannot interleave between them. `send` on an
+        // unbounded channel does not block, so this leaf lock is never held over
+        // an `.await`.
+        let ready = channel.ready.lock();
+        if !*ready {
             return Err("Not connected".to_string());
         }
-        let msg = encode_sio_event(event, data, None)?;
         channel
             .tx
             .send(msg)

--- a/src/openhuman/platform/socket/manager_tests.rs
+++ b/src/openhuman/platform/socket/manager_tests.rs
@@ -57,6 +57,51 @@ async fn emit_without_connection_errors_without_panic() {
 }
 
 #[tokio::test]
+async fn emit_while_connecting_errors_even_with_emit_channel_present() {
+    // Arrange: mirror `spawn_loop`'s pre-handshake state — the emit channel is
+    // installed (so the old channel-only guard would pass) but the socket has
+    // not finished the SIO handshake yet.
+    let mgr = SocketManager::new();
+    let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+    *mgr.emit_tx.lock().await = Some(tx);
+    *mgr.shared.status.write() = ConnectionStatus::Connecting;
+
+    // Act
+    let err = mgr
+        .emit("test.event", json!({ "k": "v" }))
+        .await
+        .unwrap_err();
+
+    // Assert: the caller is told the truth, and nothing was queued onto a
+    // channel whose message `drain_pending_emits` would discard (#4355).
+    assert_eq!(err, "Not connected");
+    assert!(
+        rx.try_recv().is_err(),
+        "emit must not queue a message before the socket is Connected"
+    );
+}
+
+#[tokio::test]
+async fn emit_when_connected_queues_the_encoded_event() {
+    // Arrange
+    let mgr = SocketManager::new();
+    let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+    *mgr.emit_tx.lock().await = Some(tx);
+    *mgr.shared.status.write() = ConnectionStatus::Connected;
+
+    // Act
+    mgr.emit("test.event", json!({ "k": "v" }))
+        .await
+        .expect("emit must succeed once the socket is Connected");
+
+    // Assert: the encoded Socket.IO event lands on the outbound channel.
+    let queued = rx
+        .try_recv()
+        .expect("expected the emitted event to be queued");
+    assert_eq!(queued, r#"42["test.event",{"k":"v"}]"#);
+}
+
+#[tokio::test]
 async fn emit_with_ack_without_connection_errors_without_waiting() {
     let mgr = SocketManager::new();
     let err = mgr

--- a/src/openhuman/platform/socket/manager_tests.rs
+++ b/src/openhuman/platform/socket/manager_tests.rs
@@ -66,7 +66,7 @@ async fn emit_while_connecting_errors_even_with_emit_channel_present() {
     let (tx, mut rx) = mpsc::unbounded_channel::<String>();
     *mgr.emit_tx.lock().await = Some(EmitChannel {
         tx,
-        ready: Arc::new(AtomicBool::new(false)),
+        ready: Arc::new(Mutex::new(false)),
     });
     *mgr.shared.status.write() = ConnectionStatus::Connecting;
 
@@ -93,7 +93,7 @@ async fn emit_when_connected_queues_the_encoded_event() {
     let (tx, mut rx) = mpsc::unbounded_channel::<String>();
     *mgr.emit_tx.lock().await = Some(EmitChannel {
         tx,
-        ready: Arc::new(AtomicBool::new(true)),
+        ready: Arc::new(Mutex::new(true)),
     });
     *mgr.shared.status.write() = ConnectionStatus::Connected;
 
@@ -123,7 +123,7 @@ async fn emit_does_not_land_on_a_reconnects_pre_handshake_channel() {
     let (_old_tx, mut old_rx) = mpsc::unbounded_channel::<String>();
     *mgr.emit_tx.lock().await = Some(EmitChannel {
         tx: _old_tx,
-        ready: Arc::new(AtomicBool::new(true)),
+        ready: Arc::new(Mutex::new(true)),
     });
     *mgr.shared.status.write() = ConnectionStatus::Connected;
 
@@ -133,7 +133,7 @@ async fn emit_does_not_land_on_a_reconnects_pre_handshake_channel() {
     let (new_tx, mut new_rx) = mpsc::unbounded_channel::<String>();
     *mgr.emit_tx.lock().await = Some(EmitChannel {
         tx: new_tx,
-        ready: Arc::new(AtomicBool::new(false)),
+        ready: Arc::new(Mutex::new(false)),
     });
     // Status may still read Connected in the narrow window before the loop
     // updates it — leaving it Connected here is the adversarial case a
@@ -171,7 +171,7 @@ async fn emit_still_succeeds_after_server_error_on_live_connection() {
     let (tx, mut rx) = mpsc::unbounded_channel::<String>();
     *mgr.emit_tx.lock().await = Some(EmitChannel {
         tx,
-        ready: Arc::new(AtomicBool::new(true)),
+        ready: Arc::new(Mutex::new(true)),
     });
     *mgr.shared.status.write() = ConnectionStatus::Connected;
 
@@ -202,6 +202,82 @@ async fn emit_still_succeeds_after_server_error_on_live_connection() {
     assert_eq!(queued, r#"42["test.event",{"k":"v"}]"#);
 }
 
+/// Teardown-vs-emit interleaving (the CodeRabbit Major on #6103): the
+/// background loop clears the readiness flag and drains the emit queue on
+/// teardown, and `emit` checks the flag then sends. If those two are not
+/// mutually exclusive, an `emit` that observed `ready == true` can have its
+/// `tx.send` land *after* the drain — leaving a stale message in the channel
+/// that the next reconnect (a fresh sid whose roster the backend cleared)
+/// forwards. This is the exact race `medulla::workflows::with_live_connection`
+/// already guards for the medulla handlers; the bare `emit` path is closed by
+/// making both critical sections take the connection's `ready` lock.
+///
+/// The barrier: the test task takes the `ready` lock (standing in for teardown
+/// holding the gate) *before* clearing it, then spawns an `emit`. If `emit` and
+/// teardown share the lock, `emit` blocks at its readiness check and cannot
+/// complete while the guard is held — proven by the pending-while-locked
+/// assertion. Teardown then runs under the held lock (clear + drain) exactly as
+/// `ws_loop` does, releases, and only then does `emit` resume — observing
+/// `ready == false` and enqueuing nothing. Reverting the flag to a bare
+/// `AtomicBool` (no shared lock) removes the block, so `emit` would slip its
+/// send past the drain and this test's guarantees would no longer hold.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn emit_cannot_send_past_a_concurrent_teardown_drain() {
+    let mgr = Arc::new(SocketManager::new());
+
+    // A live, handshaked connection. Keep a clone of its readiness gate and its
+    // receiver so the test can drive teardown's clear+drain directly.
+    let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+    let gate = Arc::new(Mutex::new(true));
+    *mgr.emit_tx.lock().await = Some(EmitChannel {
+        tx,
+        ready: Arc::clone(&gate),
+    });
+    *mgr.shared.status.write() = ConnectionStatus::Connected;
+
+    // Teardown begins: take the gate before clearing it, mirroring `ws_loop`'s
+    // "clear the flag and drain under the same lock" critical section.
+    let mut teardown_guard = gate.lock();
+
+    // A concurrent emit starts while teardown holds the gate.
+    let emit_mgr = Arc::clone(&mgr);
+    let mut emit_task =
+        tokio::spawn(async move { emit_mgr.emit("test.event", json!({ "k": "v" })).await });
+
+    // While the gate is held, `emit` must not be able to complete: it is blocked
+    // at its readiness check on the same lock teardown holds. A bare atomic flag
+    // would let it read `true` and send here, past the drain below.
+    assert!(
+        tokio::time::timeout(Duration::from_millis(200), &mut emit_task)
+            .await
+            .is_err(),
+        "emit must block on the readiness gate while teardown holds it"
+    );
+
+    // Teardown's clear + drain, under the held lock. `drain_pending_emits` lives
+    // in the sibling `ws_loop` module; the loop replicates its try_recv sweep.
+    *teardown_guard = false;
+    let mut drained = 0usize;
+    while rx.try_recv().is_ok() {
+        drained += 1;
+    }
+    assert_eq!(drained, 0, "nothing was queued before teardown began");
+    drop(teardown_guard);
+
+    // With the gate released and cleared, the previously-blocked emit resumes,
+    // sees `ready == false`, and rejects — enqueuing nothing onto the channel
+    // the next reconnect would forward from.
+    let result = tokio::time::timeout(Duration::from_secs(1), emit_task)
+        .await
+        .expect("emit must resume once teardown releases the gate")
+        .expect("emit task must not panic");
+    assert_eq!(result.unwrap_err(), "Not connected");
+    assert!(
+        rx.try_recv().is_err(),
+        "emit must not send past the teardown drain — a message here rides the next reconnect"
+    );
+}
+
 #[tokio::test]
 async fn emit_with_ack_without_connection_errors_without_waiting() {
     let mgr = SocketManager::new();
@@ -221,7 +297,7 @@ async fn emit_with_ack_uses_emit_queue_while_connecting() {
     let (tx, mut rx) = mpsc::unbounded_channel::<String>();
     *mgr.emit_tx.lock().await = Some(EmitChannel {
         tx,
-        ready: Arc::new(AtomicBool::new(false)),
+        ready: Arc::new(Mutex::new(false)),
     });
     *mgr.shared.status.write() = ConnectionStatus::Connecting;
 

--- a/src/openhuman/platform/socket/manager_tests.rs
+++ b/src/openhuman/platform/socket/manager_tests.rs
@@ -59,11 +59,15 @@ async fn emit_without_connection_errors_without_panic() {
 #[tokio::test]
 async fn emit_while_connecting_errors_even_with_emit_channel_present() {
     // Arrange: mirror `spawn_loop`'s pre-handshake state — the emit channel is
-    // installed (so the old channel-only guard would pass) but the socket has
-    // not finished the SIO handshake yet.
+    // installed (so the old channel-only guard would pass) but the connection's
+    // readiness flag is still `false` because the SIO handshake has not
+    // completed.
     let mgr = SocketManager::new();
     let (tx, mut rx) = mpsc::unbounded_channel::<String>();
-    *mgr.emit_tx.lock().await = Some(tx);
+    *mgr.emit_tx.lock().await = Some(EmitChannel {
+        tx,
+        ready: Arc::new(AtomicBool::new(false)),
+    });
     *mgr.shared.status.write() = ConnectionStatus::Connecting;
 
     // Act
@@ -77,27 +81,124 @@ async fn emit_while_connecting_errors_even_with_emit_channel_present() {
     assert_eq!(err, "Not connected");
     assert!(
         rx.try_recv().is_err(),
-        "emit must not queue a message before the socket is Connected"
+        "emit must not queue a message before the connection is ready"
     );
 }
 
 #[tokio::test]
 async fn emit_when_connected_queues_the_encoded_event() {
-    // Arrange
+    // Arrange: a handshaked connection — its readiness flag is set, mirroring
+    // what `run_connection` does after the SIO CONNECT ACK.
     let mgr = SocketManager::new();
     let (tx, mut rx) = mpsc::unbounded_channel::<String>();
-    *mgr.emit_tx.lock().await = Some(tx);
+    *mgr.emit_tx.lock().await = Some(EmitChannel {
+        tx,
+        ready: Arc::new(AtomicBool::new(true)),
+    });
     *mgr.shared.status.write() = ConnectionStatus::Connected;
 
     // Act
     mgr.emit("test.event", json!({ "k": "v" }))
         .await
-        .expect("emit must succeed once the socket is Connected");
+        .expect("emit must succeed once the connection is ready");
 
     // Assert: the encoded Socket.IO event lands on the outbound channel.
     let queued = rx
         .try_recv()
         .expect("expected the emitted event to be queued");
+    assert_eq!(queued, r#"42["test.event",{"k":"v"}]"#);
+}
+
+/// F2 (TOCTOU with reconnect): a reconnect that swaps in a fresh, not-yet-ready
+/// channel while an `emit` is in flight must not let that `emit` succeed onto
+/// the new pre-handshake channel. The readiness flag travels with the channel,
+/// so replacing the channel replaces its flag too — a `status`-only gate would
+/// have enqueued onto the new channel and returned `Ok`, then `drain_pending_emits`
+/// would have discarded it (the exact false success #6084 targets).
+#[tokio::test]
+async fn emit_does_not_land_on_a_reconnects_pre_handshake_channel() {
+    let mgr = SocketManager::new();
+
+    // Old, live connection: ready channel + Connected status.
+    let (_old_tx, mut old_rx) = mpsc::unbounded_channel::<String>();
+    *mgr.emit_tx.lock().await = Some(EmitChannel {
+        tx: _old_tx,
+        ready: Arc::new(AtomicBool::new(true)),
+    });
+    *mgr.shared.status.write() = ConnectionStatus::Connected;
+
+    // A reconnect begins: `spawn_loop` would flip status→Connecting and install
+    // a fresh channel whose readiness flag is still `false` (handshake pending).
+    // We reproduce exactly that swap.
+    let (new_tx, mut new_rx) = mpsc::unbounded_channel::<String>();
+    *mgr.emit_tx.lock().await = Some(EmitChannel {
+        tx: new_tx,
+        ready: Arc::new(AtomicBool::new(false)),
+    });
+    // Status may still read Connected in the narrow window before the loop
+    // updates it — leaving it Connected here is the adversarial case a
+    // `status`-only gate would have failed.
+    *mgr.shared.status.write() = ConnectionStatus::Connected;
+
+    // Act
+    let err = mgr
+        .emit("test.event", json!({ "k": "v" }))
+        .await
+        .unwrap_err();
+
+    // Assert: rejected, and nothing queued onto either channel.
+    assert_eq!(err, "Not connected");
+    assert!(
+        new_rx.try_recv().is_err(),
+        "emit must not enqueue onto a reconnect's pre-handshake channel"
+    );
+    assert!(
+        old_rx.try_recv().is_err(),
+        "emit must not enqueue onto the replaced channel either"
+    );
+}
+
+/// F1 (server `error` on a still-live socket): a server-emitted `error` event
+/// flips the presentation status to `Error` but does not tear down the
+/// transport, so the connection is still live and its readiness flag is
+/// untouched. `emit` must therefore keep succeeding — a gate that rejected on
+/// `status != Connected` would wedge every subsequent emit forever.
+#[tokio::test]
+async fn emit_still_succeeds_after_server_error_on_live_connection() {
+    let mgr = SocketManager::new();
+
+    // Live, handshaked connection.
+    let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+    *mgr.emit_tx.lock().await = Some(EmitChannel {
+        tx,
+        ready: Arc::new(AtomicBool::new(true)),
+    });
+    *mgr.shared.status.write() = ConnectionStatus::Connected;
+
+    // Drive the real handler for a server `error` event. It sets status=Error
+    // on the same live socket without closing the transport — and has no access
+    // to the readiness flag, which is owned by the connection loop.
+    let (sink_tx, _sink_rx) = mpsc::unbounded_channel::<String>();
+    super::super::event_handlers::handle_sio_event(
+        "error",
+        json!({ "message": "boom" }),
+        &sink_tx,
+        &mgr.shared,
+    );
+    assert_eq!(
+        *mgr.shared.status.read(),
+        ConnectionStatus::Error,
+        "server error event must flip presentation status to Error"
+    );
+
+    // Act: the socket is still live, so emit must still be delivered.
+    mgr.emit("test.event", json!({ "k": "v" }))
+        .await
+        .expect("emit must still succeed on a live socket after a server error");
+
+    let queued = rx
+        .try_recv()
+        .expect("the event must be queued for the live connection");
     assert_eq!(queued, r#"42["test.event",{"k":"v"}]"#);
 }
 
@@ -113,9 +214,15 @@ async fn emit_with_ack_without_connection_errors_without_waiting() {
 
 #[tokio::test]
 async fn emit_with_ack_uses_emit_queue_while_connecting() {
+    // `emit_with_ack` deliberately does not gate on readiness (its delivery is
+    // confirmed by the ack), so a pre-handshake channel (`ready = false`) must
+    // still enqueue the frame.
     let mgr = SocketManager::new();
     let (tx, mut rx) = mpsc::unbounded_channel::<String>();
-    *mgr.emit_tx.lock().await = Some(tx);
+    *mgr.emit_tx.lock().await = Some(EmitChannel {
+        tx,
+        ready: Arc::new(AtomicBool::new(false)),
+    });
     *mgr.shared.status.write() = ConnectionStatus::Connecting;
 
     let result = mgr

--- a/src/openhuman/platform/socket/ws_loop_part_01.rs
+++ b/src/openhuman/platform/socket/ws_loop_part_01.rs
@@ -1,5 +1,6 @@
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+
+use parking_lot::Mutex;
 
 use futures_util::{SinkExt, StreamExt};
 use serde_json::json;
@@ -69,7 +70,7 @@ pub(super) async fn ws_loop(
     mut emit_rx: mpsc::UnboundedReceiver<String>,
     mut shutdown_rx: watch::Receiver<bool>,
     internal_tx: mpsc::UnboundedSender<String>,
-    emit_ready: Arc<AtomicBool>,
+    emit_ready: Arc<Mutex<bool>>,
 ) {
     let mut backoff = Duration::from_millis(1000);
     let max_backoff = Duration::from_secs(30);
@@ -158,13 +159,29 @@ pub(super) async fn ws_loop(
         )
         .await;
 
-        // The connection is over. Clear this connection's readiness flag
-        // *before* draining so a concurrent `emit` cannot pass its readiness
-        // check and enqueue a message this connection is about to discard.
-        // `run_connection` only ever sets it `true` after the CONNECT ACK, so
-        // clearing here also covers a connection that never handshook. It is a
-        // no-op on a `Failed` attempt that never flipped it.
-        emit_ready.store(false, Ordering::Release);
+        // The connection is over. Clear this connection's readiness flag and
+        // drain whatever is still queued, both under the `emit_ready` lock so a
+        // concurrent `emit` cannot slip between them: without the shared lock,
+        // `emit` could observe `ready == true`, this teardown could clear+drain,
+        // and `emit`'s `tx.send` could then land a message in the just-emptied
+        // channel — where the next reconnect (a fresh sid, whose roster the
+        // backend has cleared) would forward it. `emit` takes the same lock
+        // across its check+send, so that interleaving cannot occur.
+        //
+        // Clearing also covers a connection that never handshook (`run_connection`
+        // only sets `true` after the CONNECT ACK), and draining is the backstop
+        // for anything already queued: `emit_rx` is owned by this loop, not by
+        // the connection, so a leftover message would otherwise be flushed onto
+        // the next socket. It is a no-op on a `Failed` attempt that never flipped
+        // the flag or queued anything.
+        let dropped = {
+            let mut ready = emit_ready.lock();
+            *ready = false;
+            drain_pending_emits(&mut emit_rx)
+        };
+        if dropped > 0 {
+            log::warn!("[socket] Dropped {dropped} queued emit(s) on disconnect");
+        }
 
         // The connection attempt has ended (lost, failed, or shutdown), so any
         // in-flight `emit_with_ack` waiter can never receive its ACK now. Cancel
@@ -173,18 +190,6 @@ pub(super) async fn ws_loop(
         // `SocketManager::disconnect()` (CodeRabbit #4355).
         shared.ack_registry.cancel_all();
         super::medulla::workflows::end_connection_generation();
-
-        // Backstop for anything that was already queued when the connection
-        // ended. `emit_rx` is owned by this loop, not by the connection, so
-        // without this a message sitting in the channel is flushed onto the
-        // *next* socket — a different sid, whose roster the backend has already
-        // cleared. The per-handler guard in `event_handlers` closes the common
-        // case; this covers the window between an emit being queued and the
-        // generation being cancelled.
-        let dropped = drain_pending_emits(&mut emit_rx);
-        if dropped > 0 {
-            log::warn!("[socket] Dropped {dropped} queued emit(s) on disconnect");
-        }
 
         match outcome {
             ConnectionOutcome::Shutdown => {
@@ -460,7 +465,7 @@ async fn run_connection(
     emit_rx: &mut mpsc::UnboundedReceiver<String>,
     shutdown_rx: &mut watch::Receiver<bool>,
     internal_tx: &mpsc::UnboundedSender<String>,
-    emit_ready: &AtomicBool,
+    emit_ready: &Mutex<bool>,
 ) -> ConnectionOutcome {
     log::info!("[socket] WS URL: {}", ws_url);
 
@@ -534,7 +539,7 @@ async fn run_connection(
     // stays set — emits keep flowing until the connection is actually torn down.
     *shared.status.write() = ConnectionStatus::Connected;
     *shared.socket_id.write() = sio_sid;
-    emit_ready.store(true, Ordering::Release);
+    *emit_ready.lock() = true;
     emit_state_change(shared);
 
     // 7. Main event loop

--- a/src/openhuman/platform/socket/ws_loop_part_01.rs
+++ b/src/openhuman/platform/socket/ws_loop_part_01.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use futures_util::{SinkExt, StreamExt};
@@ -68,6 +69,7 @@ pub(super) async fn ws_loop(
     mut emit_rx: mpsc::UnboundedReceiver<String>,
     mut shutdown_rx: watch::Receiver<bool>,
     internal_tx: mpsc::UnboundedSender<String>,
+    emit_ready: Arc<AtomicBool>,
 ) {
     let mut backoff = Duration::from_millis(1000);
     let max_backoff = Duration::from_secs(30);
@@ -152,8 +154,17 @@ pub(super) async fn ws_loop(
             &mut emit_rx,
             &mut shutdown_rx,
             &internal_tx,
+            &emit_ready,
         )
         .await;
+
+        // The connection is over. Clear this connection's readiness flag
+        // *before* draining so a concurrent `emit` cannot pass its readiness
+        // check and enqueue a message this connection is about to discard.
+        // `run_connection` only ever sets it `true` after the CONNECT ACK, so
+        // clearing here also covers a connection that never handshook. It is a
+        // no-op on a `Failed` attempt that never flipped it.
+        emit_ready.store(false, Ordering::Release);
 
         // The connection attempt has ended (lost, failed, or shutdown), so any
         // in-flight `emit_with_ack` waiter can never receive its ACK now. Cancel
@@ -449,6 +460,7 @@ async fn run_connection(
     emit_rx: &mut mpsc::UnboundedReceiver<String>,
     shutdown_rx: &mut watch::Receiver<bool>,
     internal_tx: &mpsc::UnboundedSender<String>,
+    emit_ready: &AtomicBool,
 ) -> ConnectionOutcome {
     log::info!("[socket] WS URL: {}", ws_url);
 
@@ -513,9 +525,16 @@ async fn run_connection(
         .map(String::from);
     log::info!("[socket] SIO CONNECT ACK: sid={:?}", sio_sid);
 
-    // 6. Update state to Connected
+    // 6. Update state to Connected and mark this connection ready to emit.
+    // The readiness flag is the emit gate (see `SocketManager::emit`): only now,
+    // past a completed Socket.IO CONNECT ACK, is a queued message guaranteed to
+    // ride *this* live socket rather than be dropped by `drain_pending_emits`.
+    // A later server `error` EVENT flips `status` to `Error` for the UI but does
+    // not return from this function, so the socket stays live and this flag
+    // stays set — emits keep flowing until the connection is actually torn down.
     *shared.status.write() = ConnectionStatus::Connected;
     *shared.socket_id.write() = sio_sid;
+    emit_ready.store(true, Ordering::Release);
     emit_state_change(shared);
 
     // 7. Main event loop

--- a/src/openhuman/platform/socket/ws_loop_tests.rs
+++ b/src/openhuman/platform/socket/ws_loop_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
-use parking_lot::RwLock;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use parking_lot::{Mutex, RwLock};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio_tungstenite::tungstenite::http::{header::LOCATION, Response, StatusCode};
 
 use crate::openhuman::platform::socket::token_provider::{

--- a/src/openhuman/platform/socket/ws_loop_tests.rs
+++ b/src/openhuman/platform/socket/ws_loop_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use parking_lot::RwLock;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use tokio_tungstenite::tungstenite::http::{header::LOCATION, Response, StatusCode};
 
 use crate::openhuman::platform::socket::token_provider::{

--- a/src/openhuman/platform/socket/ws_loop_tests_part_01_tests.rs
+++ b/src/openhuman/platform/socket/ws_loop_tests_part_01_tests.rs
@@ -418,7 +418,7 @@ async fn ws_loop_completes_handshake_and_shuts_down_cleanly() {
             emit_rx,
             shutdown_rx,
             internal_tx,
-            Arc::new(AtomicBool::new(false)),
+            Arc::new(Mutex::new(false)),
         )
         .await;
     });
@@ -477,7 +477,7 @@ async fn ws_loop_handles_connect_error_and_shutdown() {
             emit_rx,
             shutdown_rx,
             internal_tx,
-            Arc::new(AtomicBool::new(false)),
+            Arc::new(Mutex::new(false)),
         )
         .await;
     });
@@ -512,7 +512,7 @@ async fn ws_loop_handles_bad_eio_open_and_shutdown() {
             emit_rx,
             shutdown_rx,
             internal_tx,
-            Arc::new(AtomicBool::new(false)),
+            Arc::new(Mutex::new(false)),
         )
         .await;
     });
@@ -568,7 +568,7 @@ async fn ws_loop_refuses_to_start_with_empty_token() {
             emit_rx,
             shutdown_rx,
             internal_tx,
-            Arc::new(AtomicBool::new(false)),
+            Arc::new(Mutex::new(false)),
         )
         .await;
     });
@@ -605,7 +605,7 @@ async fn ws_loop_exits_cleanly_when_provider_returns_error() {
             emit_rx,
             shutdown_rx,
             internal_tx,
-            Arc::new(AtomicBool::new(false)),
+            Arc::new(Mutex::new(false)),
         )
         .await;
     });

--- a/src/openhuman/platform/socket/ws_loop_tests_part_01_tests.rs
+++ b/src/openhuman/platform/socket/ws_loop_tests_part_01_tests.rs
@@ -418,6 +418,7 @@ async fn ws_loop_completes_handshake_and_shuts_down_cleanly() {
             emit_rx,
             shutdown_rx,
             internal_tx,
+            Arc::new(AtomicBool::new(false)),
         )
         .await;
     });
@@ -476,6 +477,7 @@ async fn ws_loop_handles_connect_error_and_shutdown() {
             emit_rx,
             shutdown_rx,
             internal_tx,
+            Arc::new(AtomicBool::new(false)),
         )
         .await;
     });
@@ -510,6 +512,7 @@ async fn ws_loop_handles_bad_eio_open_and_shutdown() {
             emit_rx,
             shutdown_rx,
             internal_tx,
+            Arc::new(AtomicBool::new(false)),
         )
         .await;
     });
@@ -565,6 +568,7 @@ async fn ws_loop_refuses_to_start_with_empty_token() {
             emit_rx,
             shutdown_rx,
             internal_tx,
+            Arc::new(AtomicBool::new(false)),
         )
         .await;
     });
@@ -601,6 +605,7 @@ async fn ws_loop_exits_cleanly_when_provider_returns_error() {
             emit_rx,
             shutdown_rx,
             internal_tx,
+            Arc::new(AtomicBool::new(false)),
         )
         .await;
     });

--- a/src/openhuman/platform/socket/ws_loop_tests_part_02_tests.rs
+++ b/src/openhuman/platform/socket/ws_loop_tests_part_02_tests.rs
@@ -33,6 +33,7 @@ async fn ws_loop_follows_301_to_working_backend() {
             emit_rx,
             shutdown_rx,
             internal_tx,
+            Arc::new(AtomicBool::new(false)),
         )
         .await;
     });
@@ -146,6 +147,7 @@ async fn ws_loop_calls_provider_before_each_attempt() {
             emit_rx,
             shutdown_rx,
             internal_tx,
+            Arc::new(AtomicBool::new(false)),
         )
         .await;
     });
@@ -201,6 +203,7 @@ async fn ws_loop_escalates_immediately_on_invalid_token_no_refresh() {
             emit_rx,
             shutdown_rx,
             internal_tx,
+            Arc::new(AtomicBool::new(false)),
         )
         .await;
     });
@@ -270,6 +273,7 @@ async fn ws_loop_retries_with_fresh_token_on_invalid_token() {
             emit_rx,
             shutdown_rx,
             internal_tx,
+            Arc::new(AtomicBool::new(false)),
         )
         .await;
     });
@@ -358,6 +362,7 @@ async fn ws_loop_bounds_fresh_token_retries_with_rotating_provider() {
             emit_rx,
             shutdown_rx,
             internal_tx,
+            Arc::new(AtomicBool::new(false)),
         )
         .await;
     });

--- a/src/openhuman/platform/socket/ws_loop_tests_part_02_tests.rs
+++ b/src/openhuman/platform/socket/ws_loop_tests_part_02_tests.rs
@@ -33,7 +33,7 @@ async fn ws_loop_follows_301_to_working_backend() {
             emit_rx,
             shutdown_rx,
             internal_tx,
-            Arc::new(AtomicBool::new(false)),
+            Arc::new(Mutex::new(false)),
         )
         .await;
     });
@@ -147,7 +147,7 @@ async fn ws_loop_calls_provider_before_each_attempt() {
             emit_rx,
             shutdown_rx,
             internal_tx,
-            Arc::new(AtomicBool::new(false)),
+            Arc::new(Mutex::new(false)),
         )
         .await;
     });
@@ -203,7 +203,7 @@ async fn ws_loop_escalates_immediately_on_invalid_token_no_refresh() {
             emit_rx,
             shutdown_rx,
             internal_tx,
-            Arc::new(AtomicBool::new(false)),
+            Arc::new(Mutex::new(false)),
         )
         .await;
     });
@@ -273,7 +273,7 @@ async fn ws_loop_retries_with_fresh_token_on_invalid_token() {
             emit_rx,
             shutdown_rx,
             internal_tx,
-            Arc::new(AtomicBool::new(false)),
+            Arc::new(Mutex::new(false)),
         )
         .await;
     });
@@ -362,7 +362,7 @@ async fn ws_loop_bounds_fresh_token_retries_with_rotating_provider() {
             emit_rx,
             shutdown_rx,
             internal_tx,
-            Arc::new(AtomicBool::new(false)),
+            Arc::new(Mutex::new(false)),
         )
         .await;
     });


### PR DESCRIPTION
## Summary

- `socket_emit` no longer returns `{ok: true}` for a message the loop then silently drops.
- `SocketManager::emit` is gated on connection **readiness** (`status == Connected`), not merely on the emit channel existing.
- A pre-handshake emit now returns the same `"Not connected"` error it already returns before `connect` was ever called.

## Problem

`emit` guarded only on `emit_tx.is_some()`, which `spawn_loop` sets **before** the Socket.IO handshake completes. So between `socket_connect` returning `Connecting` and a successful SIO CONNECT ACK, every `socket_emit` returned `{ok: true}` — even though, if the connection then failed, `ws_loop`'s `drain_pending_emits` discards the queued messages (deliberate, #4355). The caller was told success for a message that was never delivered, with no ack, error, or counter to consult. This is not RPC-only: production callers include `tunnel:connect`/`tunnel:frame`, `webhook:response`, and the medulla emitters, so the silent-loss window costs more than one misleading RPC reply.

## Solution

- Add a readiness check at the top of `emit`: `if !self.is_connected() { return Err("Not connected") }` before locking/sending (reusing the existing `is_connected()`, whose `#[allow(dead_code)]` is now removed since it has a real caller). The exact error string is preserved for backward compatibility with the existing pre-connect path.
- `drain_pending_emits` is unchanged (dropping queued emits on disconnect is correct). `emit_with_ack` is intentionally left as-is and documented: it keeps queue-then-confirm while `Connecting` because its ack/timeout confirms delivery, so it cannot report a false success the way a bare `emit` could.
- All production `.emit(` callers already handle the `Err` return, so this surfaces failures rather than introducing them.

## Submission Checklist

- [x] Tests added or updated (happy path + failure/edge case) — emit-while-`Connecting` returns `Err` and queues nothing even with the channel present; emit-when-`Connected` still encodes and queues.
- [x] **Diff coverage ≥ 80%** — the changed guard lines are covered by the new manager tests. (Full `diff-cover` runs in CI.)
- [x] Coverage matrix updated — `N/A: behaviour fix, no feature row added/removed`.
- [x] All affected feature IDs listed under `## Related` — `N/A`.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — `N/A: does not touch a release-cut surface`.
- [x] Linked issue closed via `Closes #NNN`.

## Impact

- `socket_emit` (and every `SocketManager::emit` caller) now returns `"Not connected"` during the handshake window instead of a false success. Callers already treat this as an error. No wire/schema change.

## Related

- Closes: #6084
- Follow-up PR(s)/TODOs: optionally gate `emit_with_ack` on `Connected` for a faster failure (documented as deliberate today) — not required for this fix.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/socket-emit-connected-guard-6084


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Messages sent while a socket is connecting or reconnecting now return a clear “Not connected” error instead of being queued prematurely.
  - Messages remain deliverable once the connection handshake completes, including after connection status errors.
  - Message sending is prevented during connection teardown, avoiding delivery through an invalid or newly reconnected channel.
  - Improved synchronization prevents messages from being stranded or delivered on the wrong connection during rapid reconnects.
- **Tests**
  - Expanded coverage for connection readiness, teardown, reconnecting, handshake completion, and acknowledgment-based messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->