### PR TITLE
fix(session_db): remove the six read controllers with no writer

### DIFF
--- a/src/core/all.rs
+++ b/src/core/all.rs
@@ -963,7 +963,7 @@ fn build_registered_controllers() -> Vec<GroupedController> {
         DomainGroup::Security,
         crate::openhuman::security::devices::all_devices_registered_controllers(),
     );
-    // Durable agent session database — queryable index over transcripts, lineage, tool calls
+    // Durable agent/workflow run ledger — read surface over run state, lineage, events, telemetry
     push(
         &mut controllers,
         DomainGroup::Agent,

--- a/src/core/all_tests.rs
+++ b/src/core/all_tests.rs
@@ -2481,3 +2481,59 @@ fn memory_diff_controllers_are_gone_and_memory_survives() {
         "removing the git ledger must not remove the memory domain"
     );
 }
+
+// ---- session_db removal (#6082) --------------------------------------------
+
+/// The six read-only `session_db` controllers were removed in #6082: they
+/// queried a session index that nothing in `src/` ever writes (permanently
+/// empty in production, no frontend consumer). The three `run_ledger`
+/// controllers live in the same module and read a table that *is* written
+/// (from `web_chat::progress_bridge` and `agent::progress_tracing`), so they
+/// must stay fully registered.
+///
+/// `run_ledger` is asserted present in the same test on purpose: the removal
+/// took the dead read surface, not the run-ledger domain. Splitting that into a
+/// separate test would let one pass while the other silently regressed.
+#[test]
+fn session_db_controllers_are_gone_and_run_ledger_survives() {
+    let methods: Vec<String> = all_controller_schemas()
+        .iter()
+        .map(rpc_method_name)
+        .collect();
+
+    for removed in [
+        "openhuman.session_db_list",
+        "openhuman.session_db_get",
+        "openhuman.session_db_search",
+        "openhuman.session_db_get_messages",
+        "openhuman.session_db_get_tool_calls",
+        "openhuman.session_db_get_children",
+    ] {
+        assert!(
+            !methods.contains(&removed.to_string()),
+            "removed session_db controller `{removed}` must be absent \
+             (unknown-method over /rpc, omitted from /schema), got: {methods:?}"
+        );
+    }
+
+    for kept in [
+        "openhuman.run_ledger_list",
+        "openhuman.run_ledger_get",
+        "openhuman.run_ledger_events",
+    ] {
+        assert!(
+            methods.contains(&kept.to_string()),
+            "run_ledger controller `{kept}` must stay registered — removing the \
+             dead session_db read surface must not touch the run ledger"
+        );
+    }
+
+    let namespaces: Vec<&str> = all_controller_schemas()
+        .iter()
+        .map(|s| s.namespace)
+        .collect();
+    assert!(
+        !namespaces.contains(&"session_db"),
+        "the `session_db` namespace was removed and must not be registered, got: {namespaces:?}"
+    );
+}

--- a/src/openhuman/agent/session_db/mod.rs
+++ b/src/openhuman/agent/session_db/mod.rs
@@ -1,21 +1,25 @@
-//! JSON-RPC surface for the durable agent session database.
+//! JSON-RPC surface for the durable agent run ledger.
 //!
-//! The store itself — sessions, messages, tool calls, cost metadata,
-//! parent/child lineage, and the run ledger — lives in
-//! [`tinyagents::session`]. Only the controller schemas and
+//! The store itself — run ledger rows, child lineage, events, and telemetry —
+//! lives in [`tinyagents::session::run_ledger`]. Only the controller schemas and
 //! their handlers stay here, because the RPC envelope, config resolution, and
 //! `RpcOutcome` shape are host concerns the runtime crate has no business
 //! knowing about.
 //!
-//! Call the store directly (`tinyagents_session::…`) rather
+//! Call the store directly (`tinyagents_session::run_ledger::…`) rather
 //! than through this module; it deliberately re-exports no storage API.
 //!
 //! Every store entry point takes the workspace root, so handlers pass
 //! `config.workspace_dir`. The database path is
-//! `{workspace}/session_db/sessions.db` — unchanged by the move, so existing
-//! installs keep their history.
+//! `{workspace}/session_db/sessions.db` — unchanged, so existing installs keep
+//! their run-ledger history.
 //!
-//! The `session_db` and `run_ledger` RPC namespaces are unchanged.
+//! The `run_ledger` RPC namespace is unchanged. The six read-only `session_db`
+//! controllers were removed in #6082: they queried a session index that nothing
+//! in `src/` ever writes (permanently empty in production, no frontend
+//! consumer). The run ledger below is written from
+//! [`crate::openhuman::web_chat::progress_bridge`] and
+//! [`crate::openhuman::agent::progress_tracing`], so it stays fully functional.
 
 mod schemas;
 

--- a/src/openhuman/agent/session_db/schemas.rs
+++ b/src/openhuman/agent/session_db/schemas.rs
@@ -1,4 +1,4 @@
-//! Controller schemas and JSON-RPC dispatchers for the session database.
+//! Controller schemas and JSON-RPC dispatchers for the durable run ledger.
 
 use serde_json::{Map, Value};
 
@@ -8,16 +8,9 @@ use crate::openhuman::config::rpc as config_rpc;
 use crate::rpc::RpcOutcome;
 
 use tinyagents_session::run_ledger::{AgentRunListRequest, RunEventListRequest};
-use tinyagents_session::types::SessionSearchParams;
 
 pub fn all_controller_schemas() -> Vec<ControllerSchema> {
     vec![
-        schema_for("session_db_list"),
-        schema_for("session_db_get"),
-        schema_for("session_db_search"),
-        schema_for("session_db_get_messages"),
-        schema_for("session_db_get_tool_calls"),
-        schema_for("session_db_get_children"),
         schema_for("run_ledger_list"),
         schema_for("run_ledger_get"),
         schema_for("run_ledger_events"),
@@ -26,30 +19,6 @@ pub fn all_controller_schemas() -> Vec<ControllerSchema> {
 
 pub fn all_registered_controllers() -> Vec<RegisteredController> {
     vec![
-        RegisteredController {
-            schema: schema_for("session_db_list"),
-            handler: handle_session_db_list,
-        },
-        RegisteredController {
-            schema: schema_for("session_db_get"),
-            handler: handle_session_db_get,
-        },
-        RegisteredController {
-            schema: schema_for("session_db_search"),
-            handler: handle_session_db_search,
-        },
-        RegisteredController {
-            schema: schema_for("session_db_get_messages"),
-            handler: handle_session_db_get_messages,
-        },
-        RegisteredController {
-            schema: schema_for("session_db_get_tool_calls"),
-            handler: handle_session_db_get_tool_calls,
-        },
-        RegisteredController {
-            schema: schema_for("session_db_get_children"),
-            handler: handle_session_db_get_children,
-        },
         RegisteredController {
             schema: schema_for("run_ledger_list"),
             handler: handle_run_ledger_list,
@@ -67,86 +36,6 @@ pub fn all_registered_controllers() -> Vec<RegisteredController> {
 
 fn schema_for(function: &str) -> ControllerSchema {
     match function {
-        "session_db_list" => ControllerSchema {
-            namespace: "session_db",
-            function: "list",
-            description: "List agent sessions with optional filters (status, parent) \
-                          and pagination.",
-            inputs: vec![
-                optional_u64("limit", "Max sessions to return (default 50, max 500)."),
-                optional_u64("offset", "Pagination offset."),
-                optional_str(
-                    "status",
-                    "Filter by status (running, completed, failed, interrupted).",
-                ),
-                optional_str("parentSessionId", "Filter by parent session ID."),
-            ],
-            outputs: vec![json_output(
-                "result",
-                "SessionSearchResult with sessions array and total count.",
-            )],
-        },
-        "session_db_get" => ControllerSchema {
-            namespace: "session_db",
-            function: "get",
-            description: "Get a single session by ID.",
-            inputs: vec![required_str("id", "Session ID.")],
-            outputs: vec![json_output("session", "Full SessionRecord.")],
-        },
-        "session_db_search" => ControllerSchema {
-            namespace: "session_db",
-            function: "search",
-            description: "Search sessions by full-text query, agent ID, tool name, \
-                          source channel, thread ID, parent, and/or status.",
-            inputs: vec![
-                optional_str("query", "Full-text search query."),
-                optional_str("agentId", "Filter by agent definition ID."),
-                optional_str("toolName", "Filter to sessions that used this tool."),
-                optional_str("sourceChannel", "Filter by source channel."),
-                optional_str("threadId", "Filter by thread ID."),
-                optional_str("parentSessionId", "Filter by parent session ID."),
-                optional_str("status", "Filter by status."),
-                optional_u64("limit", "Max results (default 50, max 500)."),
-                optional_u64("offset", "Pagination offset."),
-            ],
-            outputs: vec![json_output(
-                "result",
-                "SessionSearchResult with sessions array and total count.",
-            )],
-        },
-        "session_db_get_messages" => ControllerSchema {
-            namespace: "session_db",
-            function: "get_messages",
-            description: "Get messages for a session.",
-            inputs: vec![
-                required_str("sessionId", "Session ID."),
-                optional_u64("limit", "Max messages (default 200, max 1000)."),
-            ],
-            outputs: vec![json_output("messages", "Array of SessionMessage objects.")],
-        },
-        "session_db_get_tool_calls" => ControllerSchema {
-            namespace: "session_db",
-            function: "get_tool_calls",
-            description: "Get tool calls for a session.",
-            inputs: vec![
-                required_str("sessionId", "Session ID."),
-                optional_u64("limit", "Max tool calls (default 200, max 1000)."),
-            ],
-            outputs: vec![json_output(
-                "toolCalls",
-                "Array of SessionToolCall objects.",
-            )],
-        },
-        "session_db_get_children" => ControllerSchema {
-            namespace: "session_db",
-            function: "get_children",
-            description: "Get child (sub-agent) sessions for a parent session.",
-            inputs: vec![required_str("sessionId", "Parent session ID.")],
-            outputs: vec![json_output(
-                "children",
-                "Array of child SessionRecord objects.",
-            )],
-        },
         "run_ledger_list" => ControllerSchema {
             namespace: "run_ledger",
             function: "list",
@@ -187,9 +76,9 @@ fn schema_for(function: &str) -> ControllerSchema {
             )],
         },
         _ => ControllerSchema {
-            namespace: "session_db",
+            namespace: "run_ledger",
             function: "unknown",
-            description: "Unknown session_db controller.",
+            description: "Unknown run_ledger controller.",
             inputs: vec![],
             outputs: vec![FieldSchema {
                 name: "error",
@@ -203,192 +92,6 @@ fn schema_for(function: &str) -> ControllerSchema {
 
 fn new_correlation_id() -> String {
     uuid::Uuid::new_v4().simple().to_string()[..8].to_string()
-}
-
-fn handle_session_db_list(params: Map<String, Value>) -> ControllerFuture {
-    Box::pin(async move {
-        let cid = new_correlation_id();
-        log::debug!(target: "session_db_rpc", "[session_db_rpc][{cid}] list.entry");
-        let config = config_rpc::load_config_with_timeout().await.inspect_err(|err| {
-            log::warn!(target: "session_db_rpc", "[session_db_rpc][{cid}] list.config_failed err={err}");
-        })?;
-
-        let limit = params
-            .get("limit")
-            .and_then(|v| v.as_u64())
-            .map(|v| v as u32);
-        let offset = params
-            .get("offset")
-            .and_then(|v| v.as_u64())
-            .map(|v| v as u32);
-        let status = params
-            .get("status")
-            .and_then(|v| v.as_str())
-            .map(String::from);
-        let parent_id = params
-            .get("parentSessionId")
-            .and_then(|v| v.as_str())
-            .map(String::from);
-
-        let result = tinyagents_session::list_sessions(
-            &config.workspace_dir,
-            limit,
-            offset,
-            status.as_deref(),
-            parent_id.as_deref(),
-        )
-        .map_err(|e| {
-            let s = e.to_string();
-            log::warn!(target: "session_db_rpc", "[session_db_rpc][{cid}] list.error err={s}");
-            s
-        })?;
-
-        let json = to_json(result);
-        log::debug!(target: "session_db_rpc", "[session_db_rpc][{cid}] list.exit ok={}", json.is_ok());
-        json
-    })
-}
-
-fn handle_session_db_get(params: Map<String, Value>) -> ControllerFuture {
-    Box::pin(async move {
-        let cid = new_correlation_id();
-        log::debug!(target: "session_db_rpc", "[session_db_rpc][{cid}] get.entry");
-        let config = config_rpc::load_config_with_timeout().await.inspect_err(|err| {
-            log::warn!(target: "session_db_rpc", "[session_db_rpc][{cid}] get.config_failed err={err}");
-        })?;
-
-        let id = params
-            .get("id")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| "missing required param: id".to_string())?;
-
-        let session = tinyagents_session::get_session(&config.workspace_dir, id).map_err(|e| {
-            let s = e.to_string();
-            log::warn!(target: "session_db_rpc", "[session_db_rpc][{cid}] get.error id={id} err={s}");
-            s
-        })?;
-
-        let json = to_json(session);
-        log::debug!(target: "session_db_rpc", "[session_db_rpc][{cid}] get.exit ok={}", json.is_ok());
-        json
-    })
-}
-
-fn handle_session_db_search(params: Map<String, Value>) -> ControllerFuture {
-    Box::pin(async move {
-        let cid = new_correlation_id();
-        log::debug!(target: "session_db_rpc", "[session_db_rpc][{cid}] search.entry");
-        let config = config_rpc::load_config_with_timeout().await.inspect_err(|err| {
-            log::warn!(target: "session_db_rpc", "[session_db_rpc][{cid}] search.config_failed err={err}");
-        })?;
-
-        let search_params: SessionSearchParams = if params.is_empty() {
-            SessionSearchParams::default()
-        } else {
-            serde_json::from_value(Value::Object(params)).map_err(|e| {
-                let s = format!("invalid search params: {e}");
-                log::warn!(target: "session_db_rpc", "[session_db_rpc][{cid}] search.bad_params err={s}");
-                s
-            })?
-        };
-
-        let result = tinyagents_session::search_sessions(
-            &config.workspace_dir,
-            &search_params,
-        )
-        .map_err(|e| {
-            let s = e.to_string();
-            log::warn!(target: "session_db_rpc", "[session_db_rpc][{cid}] search.error err={s}");
-            s
-        })?;
-
-        let json = to_json(result);
-        log::debug!(target: "session_db_rpc", "[session_db_rpc][{cid}] search.exit ok={}", json.is_ok());
-        json
-    })
-}
-
-fn handle_session_db_get_messages(params: Map<String, Value>) -> ControllerFuture {
-    Box::pin(async move {
-        let cid = new_correlation_id();
-        log::debug!(target: "session_db_rpc", "[session_db_rpc][{cid}] get_messages.entry");
-        let config = config_rpc::load_config_with_timeout().await.inspect_err(|err| {
-            log::warn!(target: "session_db_rpc", "[session_db_rpc][{cid}] get_messages.config_failed err={err}");
-        })?;
-
-        let session_id = params
-            .get("sessionId")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| "missing required param: sessionId".to_string())?;
-        let limit = params
-            .get("limit")
-            .and_then(|v| v.as_u64())
-            .map(|v| v as u32);
-
-        let messages = tinyagents_session::list_messages(&config.workspace_dir, session_id, limit).map_err(|e| {
-            let s = e.to_string();
-            log::warn!(target: "session_db_rpc", "[session_db_rpc][{cid}] get_messages.error err={s}");
-            s
-        })?;
-
-        let json = to_json(messages);
-        log::debug!(target: "session_db_rpc", "[session_db_rpc][{cid}] get_messages.exit ok={}", json.is_ok());
-        json
-    })
-}
-
-fn handle_session_db_get_tool_calls(params: Map<String, Value>) -> ControllerFuture {
-    Box::pin(async move {
-        let cid = new_correlation_id();
-        log::debug!(target: "session_db_rpc", "[session_db_rpc][{cid}] get_tool_calls.entry");
-        let config = config_rpc::load_config_with_timeout().await.inspect_err(|err| {
-            log::warn!(target: "session_db_rpc", "[session_db_rpc][{cid}] get_tool_calls.config_failed err={err}");
-        })?;
-
-        let session_id = params
-            .get("sessionId")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| "missing required param: sessionId".to_string())?;
-        let limit = params
-            .get("limit")
-            .and_then(|v| v.as_u64())
-            .map(|v| v as u32);
-
-        let tool_calls = tinyagents_session::list_tool_calls(&config.workspace_dir, session_id, limit).map_err(|e| {
-            let s = e.to_string();
-            log::warn!(target: "session_db_rpc", "[session_db_rpc][{cid}] get_tool_calls.error err={s}");
-            s
-        })?;
-
-        let json = to_json(tool_calls);
-        log::debug!(target: "session_db_rpc", "[session_db_rpc][{cid}] get_tool_calls.exit ok={}", json.is_ok());
-        json
-    })
-}
-
-fn handle_session_db_get_children(params: Map<String, Value>) -> ControllerFuture {
-    Box::pin(async move {
-        let cid = new_correlation_id();
-        log::debug!(target: "session_db_rpc", "[session_db_rpc][{cid}] get_children.entry");
-        let config = config_rpc::load_config_with_timeout().await.inspect_err(|err| {
-            log::warn!(target: "session_db_rpc", "[session_db_rpc][{cid}] get_children.config_failed err={err}");
-        })?;
-
-        let session_id = params
-            .get("sessionId")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| "missing required param: sessionId".to_string())?;
-
-        let children = tinyagents_session::list_children(&config.workspace_dir, session_id).map_err(|e| {
-            let s = e.to_string();
-            log::warn!(target: "session_db_rpc", "[session_db_rpc][{cid}] get_children.error err={s}");
-            s
-        })?;
-
-        let json = to_json(children);
-        log::debug!(target: "session_db_rpc", "[session_db_rpc][{cid}] get_children.exit ok={}", json.is_ok());
-        json
-    })
 }
 
 fn handle_run_ledger_list(params: Map<String, Value>) -> ControllerFuture {

--- a/src/openhuman/agent/session_db/schemas_tests.rs
+++ b/src/openhuman/agent/session_db/schemas_tests.rs
@@ -25,7 +25,9 @@ fn session_db_controllers_are_absent() {
     ];
     let schemas = all_controller_schemas();
     assert!(
-        schemas.iter().all(|schema| schema.namespace != "session_db"),
+        schemas
+            .iter()
+            .all(|schema| schema.namespace != "session_db"),
         "the removed `session_db` namespace must not be registered"
     );
     let registered = all_registered_controllers();

--- a/src/openhuman/agent/session_db/schemas_tests.rs
+++ b/src/openhuman/agent/session_db/schemas_tests.rs
@@ -3,13 +3,40 @@ use super::*;
 #[test]
 fn all_controller_schemas_lists_registered_functions() {
     let schemas = all_controller_schemas();
-    assert_eq!(schemas.len(), 9);
+    assert_eq!(schemas.len(), 3);
+    // The six read-only `session_db` controllers were removed in #6082; only the
+    // durable run-ledger read surface remains here.
     assert!(schemas
         .iter()
-        .any(|schema| schema.namespace == "session_db"));
-    assert!(schemas
-        .iter()
-        .any(|schema| schema.namespace == "run_ledger"));
+        .all(|schema| schema.namespace == "run_ledger"));
+}
+
+/// The removed `session_db` surface must stay removed: none of the six read
+/// controllers may reappear in this module's aggregators (#6082).
+#[test]
+fn session_db_controllers_are_absent() {
+    let removed = [
+        "list",
+        "get",
+        "search",
+        "get_messages",
+        "get_tool_calls",
+        "get_children",
+    ];
+    let schemas = all_controller_schemas();
+    assert!(
+        schemas.iter().all(|schema| schema.namespace != "session_db"),
+        "the removed `session_db` namespace must not be registered"
+    );
+    let registered = all_registered_controllers();
+    for name in removed {
+        assert!(
+            registered
+                .iter()
+                .all(|rc| rc.schema.namespace != "session_db" || rc.schema.function != name),
+            "removed session_db controller '{name}' must not be registered"
+        );
+    }
 }
 
 #[test]
@@ -26,40 +53,6 @@ fn all_registered_controllers_match_schemas() {
             rc.schema.function
         );
     }
-}
-
-#[test]
-fn schema_for_list_has_optional_inputs() {
-    let s = schema_for("session_db_list");
-    assert_eq!(s.function, "list");
-    assert!(s.inputs.iter().all(|i| !i.required));
-}
-
-#[test]
-fn schema_for_get_requires_id() {
-    let s = schema_for("session_db_get");
-    assert_eq!(s.function, "get");
-    assert_eq!(s.inputs.len(), 1);
-    assert!(s.inputs[0].required);
-    assert_eq!(s.inputs[0].name, "id");
-}
-
-#[test]
-fn schema_for_search_has_query_and_filters() {
-    let s = schema_for("session_db_search");
-    assert_eq!(s.function, "search");
-    let names: Vec<&str> = s.inputs.iter().map(|i| i.name).collect();
-    assert!(names.contains(&"query"));
-    assert!(names.contains(&"agentId"));
-    assert!(names.contains(&"toolName"));
-    assert!(names.contains(&"sourceChannel"));
-    assert!(names.contains(&"threadId"));
-}
-
-#[test]
-fn schema_for_unknown_returns_error_shape() {
-    let s = schema_for("session_db_nonexistent");
-    assert_eq!(s.function, "unknown");
 }
 
 #[test]

--- a/tests/raw_coverage/dispatch_param_validation_e2e.rs
+++ b/tests/raw_coverage/dispatch_param_validation_e2e.rs
@@ -19,7 +19,9 @@
 
 use serde_json::{json, Map};
 
-use openhuman_core::core::all::{all_registered_controllers, rpc_method_name, schema_for_rpc_method};
+use openhuman_core::core::all::{
+    all_registered_controllers, rpc_method_name, schema_for_rpc_method,
+};
 use openhuman_core::core::dispatch::dispatch;
 use openhuman_core::core::types::AppState;
 
@@ -33,8 +35,8 @@ fn state() -> AppState {
 /// wording — which is what makes the two impossible to mistake for each other.
 #[tokio::test]
 async fn missing_required_param_is_refused_with_the_schema_comment() {
-    let schema = schema_for_rpc_method("openhuman.session_db_get")
-        .expect("session_db_get is registered unconditionally");
+    let schema = schema_for_rpc_method("openhuman.run_ledger_get")
+        .expect("run_ledger_get is registered unconditionally");
     let comment = schema
         .inputs
         .iter()
@@ -42,13 +44,13 @@ async fn missing_required_param_is_refused_with_the_schema_comment() {
         .expect("`id` input")
         .comment;
 
-    let err = dispatch(state(), "openhuman.session_db_get", json!({}))
+    let err = dispatch(state(), "openhuman.run_ledger_get", json!({}))
         .await
         .expect_err("`id` is required");
 
     assert_eq!(err, format!("missing required param 'id': {comment}"));
 
-    // `handle_session_db_get` refuses with `missing required param: id`. If that
+    // `handle_run_ledger_get` refuses with `missing required param: id`. If that
     // ever starts matching, validation has moved into the handler and the shape
     // of what callers see has changed with it.
     assert!(!err.contains("missing required param: id"), "got: {err}");

--- a/tests/raw_coverage/session_store_e2e.rs
+++ b/tests/raw_coverage/session_store_e2e.rs
@@ -1,6 +1,6 @@
 //! JSON-RPC E2E coverage for the session / artifact / compression store domains:
-//! `session_db`, `session_import`, `tokenjuice` (compress + retrieve), `ai`
-//! (artifact CRUD) and `test_support`.
+//! `session_import`, `tokenjuice` (compress + retrieve), `ai` (artifact CRUD)
+//! and `test_support`.
 //!
 //! Every case boots the real axum JSON-RPC router (`build_core_http_router`)
 //! against a per-test temp workspace, dispatches over HTTP, and
@@ -17,21 +17,13 @@
 //! crate-wide `SHARED_ENV_LOCK` around each case and reads the live RPC bearer
 //! back rather than assuming its own — see `env_lock` and `rpc_bearer`.
 //!
-//! ## Two things this file documents rather than asserts as correct
+//! ## One thing this file documents rather than asserts as correct
 //!
-//! 1. **`session_db` reads a table the product never writes.** Nothing under
-//!    `src/` calls `tinyagents_session::record_session_start` / `record_message`
-//!    / `record_tool_call`; the host only uses the sibling `run_ledger`. So the
-//!    six `session_db.*` controllers are permanently empty in production. The
-//!    cases below therefore assert the empty-store contract and the failure
-//!    paths, which is the whole of the behaviour that is reachable.
-//!    See `~/tinyhuman/bugs/e2e-wave-session_db-never-written.md`.
-//!
-//! 2. **`test_support.*` is gated behind `e2e-test-support`,** which is not in
-//!    `scripts/ci/product-features.sh`. Under the product feature set those
-//!    five controllers must be *absent* — that gate is the reason the
-//!    destructive `test_reset` never ships — so the case here asserts the
-//!    absence, and the positive path is compiled in only when the feature is.
+//! **`test_support.*` is gated behind `e2e-test-support`,** which is not in
+//! `scripts/ci/product-features.sh`. Under the product feature set those
+//! five controllers must be *absent* — that gate is the reason the
+//! destructive `test_reset` never ships — so the case here asserts the
+//! absence, and the positive path is compiled in only when the feature is.
 
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
@@ -166,7 +158,8 @@ async fn serve_rpc() -> (
         .await
         .expect("bind rpc listener");
     let addr = listener.local_addr().expect("rpc listener addr");
-    let join = tokio::spawn(async move { axum::serve(listener, build_core_http_router(false)).await });
+    let join =
+        tokio::spawn(async move { axum::serve(listener, build_core_http_router(false)).await });
     (addr, join)
 }
 
@@ -279,151 +272,6 @@ fn error_message(value: &Value, context: &str) -> String {
         .to_string()
 }
 
-// ── session_db ────────────────────────────────────────────────────────────
-
-/// The six `session_db.*` reads over a workspace with no session database yet.
-///
-/// This is the only state the product ever puts them in — see the module docs
-/// and the bug file — so the empty-store contract *is* the contract: the schema
-/// is created on first read, `list`/`search` answer a well-formed empty page
-/// rather than erroring, and the per-session reads answer empty collections for
-/// an id that does not exist.
-#[tokio::test]
-async fn session_db_reads_answer_a_wellformed_empty_store() {
-    let _lock = env_lock();
-    let harness = setup().await;
-
-    let list = rpc(&harness.rpc_base, 30_001, "openhuman.session_db_list", json!({})).await;
-    let list = payload(&list, "session_db_list");
-    assert_eq!(
-        list.get("sessions").and_then(Value::as_array).map(Vec::len),
-        Some(0),
-        "a fresh workspace has no sessions: {list}"
-    );
-    assert_eq!(
-        list.get("total").and_then(Value::as_u64),
-        Some(0),
-        "total must be present and zero: {list}"
-    );
-
-    // The read created the database — proof the handler reached storage and
-    // applied migrations rather than short-circuiting on a missing file. The
-    // path is `tinyagents_session::store::db_path`'s, spelled out because that
-    // crate is a normal dependency and an integration test cannot name it.
-    let db = harness.workspace.join("session_db").join("sessions.db");
-    assert!(
-        db.exists(),
-        "a session-db read must materialise {:?}; workspace holds: {:?}",
-        db,
-        std::fs::read_dir(&harness.workspace)
-            .map(|rd| rd
-                .filter_map(Result::ok)
-                .map(|e| e.file_name())
-                .collect::<Vec<_>>())
-            .unwrap_or_default()
-    );
-
-    let search = rpc(
-        &harness.rpc_base,
-        30_002,
-        "openhuman.session_db_search",
-        json!({ "query": "nothing-matches-this", "limit": 10 }),
-    )
-    .await;
-    let search = payload(&search, "session_db_search");
-    assert_eq!(
-        search.get("sessions").and_then(Value::as_array).map(Vec::len),
-        Some(0),
-        "search over an empty store returns no rows: {search}"
-    );
-    assert_eq!(search.get("total").and_then(Value::as_u64), Some(0));
-
-    // The per-session reads take an unknown id and answer empty collections,
-    // NOT an error — the store has no row to refuse over.
-    for (id, method, context) in [
-        (30_003_i64, "openhuman.session_db_get_messages", "get_messages"),
-        (30_004, "openhuman.session_db_get_tool_calls", "get_tool_calls"),
-    ] {
-        let response = rpc(
-            &harness.rpc_base,
-            id,
-            method,
-            json!({ "sessionId": "no-such-session" }),
-        )
-        .await;
-        let body = payload(&response, context);
-        let rows = body
-            .as_array()
-            .unwrap_or_else(|| panic!("{context} must return an array, got: {body}"));
-        assert!(rows.is_empty(), "{context} for an unknown session: {body}");
-    }
-
-    let children = rpc(
-        &harness.rpc_base,
-        30_005,
-        "openhuman.session_db_get_children",
-        json!({ "sessionId": "no-such-session" }),
-    )
-    .await;
-    let children = payload(&children, "session_db_get_children");
-    assert_eq!(
-        children.as_array().map(Vec::len),
-        Some(0),
-        "an unknown parent has no children: {children}"
-    );
-
-    harness.join.abort();
-}
-
-/// Failure paths: a missing required param is refused by name, and `get` for an
-/// absent id is an error rather than a null row.
-///
-/// The wording is `core::all::validate_params`' — the schema gate at
-/// `src/core/all.rs:1334` refuses on required-presence and declared type before
-/// any handler body runs, so the handlers' own "missing required param: id"
-/// strings never reach a caller over RPC.
-#[tokio::test]
-async fn session_db_rejects_missing_params_and_unknown_ids() {
-    let _lock = env_lock();
-    let harness = setup().await;
-
-    let no_id = rpc(&harness.rpc_base, 30_101, "openhuman.session_db_get", json!({})).await;
-    assert!(
-        error_message(&no_id, "session_db_get without id").contains("missing required param 'id'"),
-        "the refusal must name the param: {no_id}"
-    );
-
-    let no_session_id = rpc(
-        &harness.rpc_base,
-        30_102,
-        "openhuman.session_db_get_messages",
-        json!({ "limit": 5 }),
-    )
-    .await;
-    assert!(
-        error_message(&no_session_id, "get_messages without sessionId")
-            .contains("missing required param 'sessionId'"),
-        "the refusal must name the param: {no_session_id}"
-    );
-
-    // `get` is the one read that resolves a single row, so absence is an error.
-    let missing = rpc(
-        &harness.rpc_base,
-        30_103,
-        "openhuman.session_db_get",
-        json!({ "id": "session-that-was-never-recorded" }),
-    )
-    .await;
-    let message = error_message(&missing, "session_db_get for an unknown id");
-    assert!(
-        message.to_lowercase().contains("not found")
-            || message.contains("session-that-was-never-recorded"),
-        "the error must identify the missing session, got: {message}"
-    );
-
-    harness.join.abort();
-}
-
 // ── session_import ────────────────────────────────────────────────────────
 
 /// `session_import.run` over a seeded legacy `session_raw/` directory:
@@ -515,7 +363,10 @@ async fn session_import_plans_imports_then_skips_on_rerun() {
     )
     .await;
     let imported = payload(&imported, "session_import_run");
-    assert_eq!(imported.get("dry_run").and_then(Value::as_bool), Some(false));
+    assert_eq!(
+        imported.get("dry_run").and_then(Value::as_bool),
+        Some(false)
+    );
     assert_eq!(
         imported.get("imported").and_then(Value::as_u64),
         Some(1),
@@ -703,7 +554,9 @@ async fn tokenjuice_compress_agrees_with_detect_and_never_loses_content() {
     let applied = compressed
         .get("applied")
         .and_then(Value::as_bool)
-        .unwrap_or_else(|| panic!("compress must report whether it changed the content: {compressed}"));
+        .unwrap_or_else(|| {
+            panic!("compress must report whether it changed the content: {compressed}")
+        });
     let lossy = compressed
         .get("lossy")
         .and_then(Value::as_bool)
@@ -742,7 +595,9 @@ async fn tokenjuice_compress_agrees_with_detect_and_never_loses_content() {
             .get("ccrToken")
             .and_then(Value::as_str)
             .unwrap_or_else(|| {
-                panic!("a lossy compaction over the CCR threshold must be recoverable: {compressed}")
+                panic!(
+                    "a lossy compaction over the CCR threshold must be recoverable: {compressed}"
+                )
             })
             .to_string();
 
@@ -972,7 +827,10 @@ async fn ai_artifacts_list_filter_get_and_delete() {
     .await;
     let got = payload(&got, "ai_get_artifact");
     assert_eq!(got.get("title").and_then(Value::as_str), Some("Q2 deck"));
-    assert_eq!(got.get("kind").and_then(Value::as_str), Some("presentation"));
+    assert_eq!(
+        got.get("kind").and_then(Value::as_str),
+        Some("presentation")
+    );
     let absolute = got
         .get("absolute_path")
         .and_then(Value::as_str)
@@ -1196,7 +1054,10 @@ async fn test_support_introspection_reads_the_live_workspace() {
     )
     .await;
     let listing = payload(&listing, "test_support_list_workspace_files");
-    assert_eq!(listing.get("truncated").and_then(Value::as_bool), Some(false));
+    assert_eq!(
+        listing.get("truncated").and_then(Value::as_bool),
+        Some(false)
+    );
     let entries = listing
         .get("entries")
         .and_then(Value::as_array)
@@ -1231,8 +1092,14 @@ async fn test_support_introspection_reads_the_live_workspace() {
     )
     .await;
     let clipped = payload(&clipped, "test_support_read_workspace_file clipped");
-    assert_eq!(clipped.get("truncated").and_then(Value::as_bool), Some(true));
-    assert_eq!(clipped.get("returned_bytes").and_then(Value::as_u64), Some(5));
+    assert_eq!(
+        clipped.get("truncated").and_then(Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        clipped.get("returned_bytes").and_then(Value::as_u64),
+        Some(5)
+    );
     assert_eq!(
         clipped.get("content_utf8").and_then(Value::as_str),
         Some("hello")


### PR DESCRIPTION
## Summary

- Removes the six `session_db_*` read controllers (`list`, `get`, `search`, `get_messages`, `get_tool_calls`, `get_children`) — they queried a sessions table that nothing in `src/` ever writes, so all six were permanently empty in production with no frontend consumer.
- The three `run_ledger_*` controllers in the same module (which read a table that **is** written) are left fully intact and registered.

## Problem

The `session_db_*` namespace advertised a "durable index over transcripts, lineage, tool calls" (`src/core/all.rs`), but the three recording entry points (`record_session_start` / `record_message` / `record_tool_call`) are referenced only by `tinyagents-session`'s own tests — never from `src/`. OpenHuman's only use of the crate in `src/` is the sibling `run_ledger`, a different table. So the six read controllers answered `{sessions: [], total: 0}` for a fresh workspace and for a long-running install alike, and `run_ledger` (which does store run metadata) is not a superset — it holds no transcripts. Per maintainer decision (no writer, no UI consumer), the dead read surface is removed rather than wired up.

## Solution

- Delete the six handlers, their `ControllerSchema`s, the now-unused `tinyagents_session::{list_sessions, …}` / `SessionSearchParams` imports, and their tests from `session_db/schemas.rs`; the shared aggregator now returns only the three `run_ledger_*` entries.
- Update the `src/core/all.rs` registration comment so it no longer advertises the removed surface; the `DomainGroup::Agent` push and `run_ledger` registration/description are unchanged.
- The on-disk `session_db/sessions.db` directory path (used by `run_ledger` and `session_import`) is deliberately untouched.
- Regression test asserts the six `openhuman.session_db_*` methods are absent from the registered set / schema while the three `openhuman.run_ledger_*` remain (mirrors the existing removal-test pattern in `all_tests.rs`).

## Submission Checklist

- [x] Tests added or updated — absence of the six + survival of the three (registry-level and module-level).
- [x] **Diff coverage ≥ 80%** — this is primarily a deletion; the added assertions cover the surviving registration. (Full `diff-cover` runs in CI.)
- [x] Coverage matrix updated — `N/A: the only session_db mention in the matrix is the on-disk DB path in test row 16.1.1, not these controllers`.
- [x] All affected feature IDs listed under `## Related` — `N/A`.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — `N/A: removed surface has no UI/release-cut consumer`.
- [x] Linked issue closed via `Closes #NNN`.

## Impact

- The `session_db_*` methods become unknown-method (they returned empty in production regardless). `run_ledger_*` — including the frontend `run_ledger_list`/`get`/`events` calls — is unaffected. Reversible if queryable session transcripts are wanted later (would require wiring the writers first).

## Related

- Closes: #6082

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/session-db-remove-dead-controllers-6082


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changed**
  - Replaced the read-only session database interface with the run ledger interface.
  - The following session database operations are no longer available: listing, retrieving, searching, viewing messages, viewing tool calls, and viewing child sessions.
  - The run ledger continues to support listing runs, retrieving run details, and viewing run events.
  - Updated interface metadata and validation to reflect the available operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->