### PR TITLE
refactor(medulla): rename client EventEnvelope to WireEventEnvelope

### DIFF
--- a/src/embed/medulla.rs
+++ b/src/embed/medulla.rs
@@ -23,8 +23,8 @@ use super::error::CoreError;
 use crate::core::runtime::CoreRuntime;
 
 pub use crate::openhuman::medulla::client::{
-    AbortResult, EventEnvelope, Message, RosterWorker, SendResult, SessionCreated, SessionDetail,
-    SessionSummary,
+    AbortResult, Message, RosterWorker, SendResult, SessionCreated, SessionDetail, SessionSummary,
+    WireEventEnvelope,
 };
 pub use crate::openhuman::medulla::ops::MedullaStatus;
 
@@ -141,7 +141,7 @@ impl Medulla<'_> {
         &self,
         session_id: &str,
         after: Option<i64>,
-    ) -> Result<Vec<EventEnvelope>, CoreError> {
+    ) -> Result<Vec<WireEventEnvelope>, CoreError> {
         call(
             self.0,
             "openhuman.medulla_list_events",

--- a/src/embed/mod.rs
+++ b/src/embed/mod.rs
@@ -68,8 +68,8 @@ pub use harness::{Access, Harness, HarnessBuilder, HarnessError, Provider, Works
 pub use harness::{HttpHeader, McpAuthConfig, McpServer};
 #[cfg(feature = "medulla")]
 pub use medulla::{
-    AbortResult, EventEnvelope, Medulla, MedullaStatus, Message, RosterWorker, SendResult,
-    SessionCreated, SessionDetail, SessionSummary,
+    AbortResult, Medulla, MedullaStatus, Message, RosterWorker, SendResult, SessionCreated,
+    SessionDetail, SessionSummary, WireEventEnvelope,
 };
 
 use std::sync::Arc;

--- a/src/openhuman/medulla/client/sessions.rs
+++ b/src/openhuman/medulla/client/sessions.rs
@@ -100,7 +100,7 @@ impl MedullaClient {
         &self,
         session_id: &str,
         after: Option<i64>,
-    ) -> Result<Vec<EventEnvelope>> {
+    ) -> Result<Vec<WireEventEnvelope>> {
         let mut req = self
             .http
             .get(self.url(&format!("/medulla/v1/sessions/{session_id}/events")));
@@ -129,7 +129,7 @@ impl MedullaClient {
         &self,
         session_id: &str,
         last_event_id: Option<u64>,
-    ) -> impl Stream<Item = Result<EventEnvelope>> {
+    ) -> impl Stream<Item = Result<WireEventEnvelope>> {
         let url = format!(
             "{}/medulla/v1/sessions/{}/stream?token={}",
             self.base_url,

--- a/src/openhuman/medulla/client/sse/mod.rs
+++ b/src/openhuman/medulla/client/sse/mod.rs
@@ -11,7 +11,7 @@
 //! ```
 //!
 //! `id:` sets the replay cursor (persisted events only; deltas omit it),
-//! `data:` carries the JSON [`EventEnvelope`], comment lines (`: ping`) are
+//! `data:` carries the JSON [`WireEventEnvelope`], comment lines (`: ping`) are
 //! ignored, and a blank line terminates the current frame.
 
 use std::collections::VecDeque;
@@ -19,7 +19,7 @@ use std::collections::VecDeque;
 use futures::stream::{Stream, StreamExt};
 
 use crate::openhuman::medulla::client::error::{ClientError, Result};
-use crate::openhuman::medulla::client::types::EventEnvelope;
+use crate::openhuman::medulla::client::types::WireEventEnvelope;
 
 impl SseParser {
     /// Create an empty parser.
@@ -151,7 +151,7 @@ impl StreamState {
         if trimmed.is_empty() {
             return;
         }
-        match serde_json::from_str::<EventEnvelope>(trimmed) {
+        match serde_json::from_str::<WireEventEnvelope>(trimmed) {
             Ok(env) => self.pending.push_back(Ok(env)),
             Err(e) => self
                 .pending
@@ -162,7 +162,7 @@ impl StreamState {
     /// Produce the next stream item, reconnecting as needed. Returns `None`
     /// only when the stream is permanently exhausted (never, in practice —
     /// it reconnects on end-of-body).
-    async fn next(&mut self) -> Option<Result<EventEnvelope>> {
+    async fn next(&mut self) -> Option<Result<WireEventEnvelope>> {
         loop {
             if let Some(item) = self.pending.pop_front() {
                 return Some(item);
@@ -196,7 +196,7 @@ impl StreamState {
     }
 }
 
-/// Build a reconnecting SSE stream of [`EventEnvelope`]s.
+/// Build a reconnecting SSE stream of [`WireEventEnvelope`]s.
 ///
 /// `url` must already include auth (`?token=<jwt>`). The stream reconnects with
 /// the `Last-Event-ID` header and de-duplicates replayed frames by seq. Drop
@@ -205,7 +205,7 @@ pub fn event_stream(
     http: reqwest::Client,
     url: String,
     last_event_id: Option<u64>,
-) -> impl Stream<Item = Result<EventEnvelope>> {
+) -> impl Stream<Item = Result<WireEventEnvelope>> {
     let state = StreamState {
         http,
         url,

--- a/src/openhuman/medulla/client/sse/types.rs
+++ b/src/openhuman/medulla/client/sse/types.rs
@@ -35,7 +35,7 @@ pub(super) struct StreamState {
     pub(super) url: String,
     pub(super) parser: SseParser,
     pub(super) dedup: SeqDedup,
-    pub(super) pending: VecDeque<Result<EventEnvelope>>,
+    pub(super) pending: VecDeque<Result<WireEventEnvelope>>,
     pub(super) body: Option<futures::stream::BoxStream<'static, reqwest::Result<Vec<u8>>>>,
     pub(super) first_connect: bool,
 }

--- a/src/openhuman/medulla/client/tests/decode_tests.rs
+++ b/src/openhuman/medulla/client/tests/decode_tests.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 // Event envelope / kind decode fixtures
 // ---------------------------------------------------------------------------
 
-fn envelope(event: Value) -> EventEnvelope {
+fn envelope(event: Value) -> WireEventEnvelope {
     let raw = json!({
         "seq": 5,
         "at": 1234,
@@ -17,6 +17,36 @@ fn envelope(event: Value) -> EventEnvelope {
         "event": event,
     });
     serde_json::from_value(raw).unwrap()
+}
+
+#[test]
+fn wire_envelope_carries_session_and_cycle_ids() {
+    // The wire type is what `ops::list_events` returns; it must decode the
+    // `sessionId` / `cycleId` fields the in-process contract type lacks. This
+    // pins the distinction from `events::EventEnvelope` so a future edit cannot
+    // silently reintroduce the naming ambiguity (#6078).
+    let env: WireEventEnvelope = serde_json::from_value(json!({
+        "at": 42,
+        "sessionId": "sess-1",
+        "event": {"kind": "user", "body": "hi"},
+    }))
+    .unwrap();
+    assert_eq!(env.session_id, "sess-1");
+    assert_eq!(env.at, 42);
+    // `seq` and `cycleId` are optional on the wire.
+    assert_eq!(env.seq, None);
+    assert_eq!(env.cycle_id, None);
+
+    let with_optionals: WireEventEnvelope = serde_json::from_value(json!({
+        "seq": 7,
+        "at": 43,
+        "sessionId": "sess-1",
+        "cycleId": "cyc-9",
+        "event": {"kind": "assistant", "body": "yo"},
+    }))
+    .unwrap();
+    assert_eq!(with_optionals.seq, Some(7));
+    assert_eq!(with_optionals.cycle_id, Some("cyc-9".into()));
 }
 
 #[test]

--- a/src/openhuman/medulla/client/types/event.rs
+++ b/src/openhuman/medulla/client/types/event.rs
@@ -9,10 +9,16 @@ use serde_json::Value;
 
 /// Envelope wrapping every event on the session stream.
 ///
-/// `event` retains the raw JSON payload; [`EventEnvelope::kind`] parses it into
-/// a typed [`EventKind`].
+/// This is the **wire** shape: it carries `sessionId` / `cycleId` and matches
+/// what `ops::list_events` returns over the RPC surface. Distinct from the
+/// in-process contract type `events::EventEnvelope`, which has neither field —
+/// the two are named apart so a consumer cannot build one where the other is
+/// expected (see #6078).
+///
+/// `event` retains the raw JSON payload; [`WireEventEnvelope::kind`] parses it
+/// into a typed [`EventKind`].
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EventEnvelope {
+pub struct WireEventEnvelope {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub seq: Option<u64>,
     pub at: u64,
@@ -24,14 +30,14 @@ pub struct EventEnvelope {
     pub event: Value,
 }
 
-impl EventEnvelope {
+impl WireEventEnvelope {
     /// Parse the raw `event` payload into a typed [`EventKind`].
     pub fn kind(&self) -> EventKind {
         EventKind::from_value(&self.event)
     }
 }
 
-/// Typed event payload parsed from [`EventEnvelope::event`].
+/// Typed event payload parsed from [`WireEventEnvelope::event`].
 ///
 /// `Unknown` preserves the raw value for forward-compatibility with event
 /// kinds this client does not yet model.

--- a/src/openhuman/medulla/client/types/mod.rs
+++ b/src/openhuman/medulla/client/types/mod.rs
@@ -12,7 +12,7 @@ mod reward;
 mod run;
 mod session;
 
-pub use event::{EventEnvelope, EventKind};
+pub use event::{EventKind, WireEventEnvelope};
 pub use reward::{
     HistoryRewardBreakdown, HistoryRewardClaim, HistoryRewardStatus, HistoryUploadResult,
 };

--- a/src/openhuman/medulla/ops.rs
+++ b/src/openhuman/medulla/ops.rs
@@ -11,8 +11,8 @@ use crate::openhuman::config::Config;
 use crate::rpc::{RpcOutcome, StructuredRpcError};
 
 use super::client::{
-    AbortResult, ClientError, EventEnvelope, MedullaClient, Message, RosterWorker, SendResult,
-    SessionCreated, SessionDetail, SessionSummary,
+    AbortResult, ClientError, MedullaClient, Message, RosterWorker, SendResult, SessionCreated,
+    SessionDetail, SessionSummary, WireEventEnvelope,
 };
 use super::resolve::{self, NotConfigured};
 
@@ -163,7 +163,7 @@ pub async fn list_events(
     config: &Config,
     session_id: &str,
     after: Option<i64>,
-) -> Result<RpcOutcome<Vec<EventEnvelope>>, String> {
+) -> Result<RpcOutcome<Vec<WireEventEnvelope>>, String> {
     let client = resolved(config)?;
     let events = call(
         client.list_events(session_id, after).await,


### PR DESCRIPTION
## Summary

- Renames the medulla **client/wire** struct `EventEnvelope` to `WireEventEnvelope`, so it can no longer be confused with the in-process contract type of the same name.
- The contract type (`events::EventEnvelope`) and the `medulla/mod.rs` public re-export are left unchanged.

## Problem

`medulla` had two structs named `EventEnvelope`: the contract type (`events::` — `seq: u64`, `at: i64`, `event: SessionEvent`) and the wire type (`client::` — `seq: Option<u64>`, `at: u64`, required `sessionId`, `cycleId`, `event: Value`). `medulla/mod.rs` re-exported the **contract** one as the domain's public `EventEnvelope`, while `ops::list_events` (behind `openhuman.medulla_list_events`) returns the **wire** one. A consumer reading the public surface and building a payload from it hits `missing field 'sessionId'`. The hazard is purely the shared name plus the re-export pointing at the type the RPC does not speak.

## Solution

- Rename the client type to `WireEventEnvelope` at its definition and every client-side reference (`client/types`, `client/sessions.rs`, `client/sse/*`, `ops.rs`'s import + `list_events` return, `embed/medulla.rs`, `embed/mod.rs`). The grep was re-run after the edit to confirm every remaining bare `EventEnvelope` is the contract type.
- **Zero serde/JSON changes** — the wire format is governed by the unchanged `#[serde(rename = "sessionId"/"cycleId")]` attributes, not the struct name, so this is pure in-crate source churn with no wire-compatibility impact.
- The decode test is renamed to the new type and gains an assertion that a payload carrying `sessionId` (the field the contract type lacks) round-trips into `WireEventEnvelope`, documenting the distinction so it can't silently regress.

## Submission Checklist

- [x] Tests added or updated — `WireEventEnvelope` decodes a `sessionId`/`cycleId` payload (the wire shape `list_events` returns).
- [x] **Diff coverage ≥ 80%** — the renamed lines are exercised by the existing + new client decode tests. (Full `diff-cover` runs in CI.)
- [x] Coverage matrix updated — `N/A: rename/refactor, no feature row added/removed`.
- [x] All affected feature IDs listed under `## Related` — `N/A`.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — `N/A: in-crate rename, no user-facing change`.
- [x] Linked issue closed via `Closes #NNN`.

## Impact

- In-crate source only; no wire, schema, or runtime behaviour change. A consumer reading `medulla`'s public surface can no longer mistake the contract type for the RPC's wire type.

## Related

- Closes: #6078

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/medulla-event-envelope-name-6078


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **API Changes**
  - Event retrieval and streaming APIs now return `WireEventEnvelope` records.
  - Event records consistently expose session and timestamp information, while preserving optional sequence and cycle identifiers.
  - Updated event decoding supports both present and absent optional fields.
  - The previous `EventEnvelope` name is no longer exported by these APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->