### PR TITLE
fix(skills): declare correct controller output names (new_workflows/workflow)

### DIFF
--- a/src/openhuman/skills/schemas/controller_schemas.rs
+++ b/src/openhuman/skills/schemas/controller_schemas.rs
@@ -275,9 +275,9 @@ pub fn skills_schemas(function: &str) -> ControllerSchema {
                 },
             ],
             outputs: vec![FieldSchema {
-                name: "skill",
+                name: "workflow",
                 ty: TypeSchema::Ref("WorkflowSummary"),
-                comment: "The newly created skill, re-discovered through the standard pipeline.",
+                comment: "The newly created workflow, re-discovered through the standard pipeline.",
                 required: true,
             }],
         },
@@ -328,9 +328,9 @@ pub fn skills_schemas(function: &str) -> ControllerSchema {
                     required: true,
                 },
                 FieldSchema {
-                    name: "new_skills",
+                    name: "new_workflows",
                     ty: TypeSchema::Array(Box::new(TypeSchema::String)),
-                    comment: "Slugs of skills that appeared in the catalog as a result of the install.",
+                    comment: "Slugs of workflows that appeared in the catalog as a result of the install.",
                     required: true,
                 },
             ],

--- a/src/openhuman/skills/schemas_tests.rs
+++ b/src/openhuman/skills/schemas_tests.rs
@@ -32,3 +32,47 @@ fn skill_summary_round_trip_minimum_fields() {
     assert_eq!(summary.name, "demo");
     assert_eq!(summary.description, "desc");
 }
+
+/// Pins the declared controller-schema output names to the workflow-spelled
+/// wire reality. The skills→workflows rename left two schemas emitting the old
+/// spelling (`new_skills` / `skill`) while the handlers and wire structs
+/// (`WorkflowsInstallFromUrlResult.new_workflows`, `WorkflowsCreateResult.workflow`)
+/// switched to the new one — a silent schema/wire divergence the frontend
+/// papered over by reading the wire names directly. These assertions fail on
+/// the pre-rename schema and stop it from drifting back.
+#[test]
+fn install_and_create_schemas_declare_workflow_output_names() {
+    // Arrange
+    let install = skills_schemas("skills_install_from_url");
+    let create = skills_schemas("skills_create");
+    let update = skills_schemas("skills_update");
+
+    // Act
+    let has_output = |schema: &crate::core::ControllerSchema, name: &str| {
+        schema.outputs.iter().any(|f| f.name == name)
+    };
+
+    // Assert — install echoes the workflow-spelled slug list, never the old one.
+    assert!(
+        has_output(&install, "new_workflows"),
+        "skills_install_from_url must declare `new_workflows`; outputs: {:?}",
+        install.outputs.iter().map(|f| f.name).collect::<Vec<_>>()
+    );
+    assert!(
+        !has_output(&install, "new_skills"),
+        "skills_install_from_url must not declare the pre-rename `new_skills`"
+    );
+
+    // create / update share one schema; both carry the `workflow` output.
+    for (function, schema) in [("skills_create", &create), ("skills_update", &update)] {
+        assert!(
+            has_output(schema, "workflow"),
+            "{function} must declare `workflow`; outputs: {:?}",
+            schema.outputs.iter().map(|f| f.name).collect::<Vec<_>>()
+        );
+        assert!(
+            !has_output(schema, "skill"),
+            "{function} must not declare the pre-rename `skill`"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes the `skills_install_from_url` and `skills_create` controller schemas to declare the output field names the handlers actually emit: `new_workflows` and `workflow` (they declared `new_skills` and `skill`).
- Schema-only change — no wire struct, handler, or frontend edits. `skills_update` inherits the fix by cloning `skills_create`'s schema.

## Problem

Fallout from the skills→workflows rename: the wire structs kept `new_workflows` / `workflow` (bare `#[derive(Serialize)]`, no serde rename) and the frontend reads those names (`app/src/services/api/skillsApi.ts`), but the controller catalog was written with the newer `skill` vocabulary and nothing cross-checks the two. The catalog exists "for CLI/RPC smoke-test script generation", so a wrong name there generates a script that reads a field never sent — the failure mode nobody notices because every real caller was written against the wire. (`skillRegistryApi.ts` reads `new_skills`, but it calls the different `skill_registry_install` namespace and is untouched.)

## Solution

- In `controller_schemas.rs`, change the `skills_install_from_url` output field `new_skills` → `new_workflows` and the `skills_create` output field `skill` → `workflow` (names + comments only; `TypeSchema` unchanged). `skills_update` clones `skills_create` and inherits the fix.
- Regression test pins the declared output names to the wire reality (`new_workflows`/`workflow` present, `new_skills`/`skill` absent) across create/update/install so the drift can't silently return.

## Submission Checklist

- [x] Tests added or updated — schema-output-name assertions across the three controllers.
- [x] **Diff coverage ≥ 80%** — the two changed schema lines are covered by the new assertions. (Full `diff-cover` runs in CI.)
- [x] Coverage matrix updated — `N/A: schema-name fix, no feature row added/removed`.
- [x] All affected feature IDs listed under `## Related` — `N/A`.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — `N/A: catalog-metadata fix, no runtime change`.
- [x] Linked issue closed via `Closes #NNN`.

## Impact

- Published controller catalog / `/schema` now matches the JSON the handlers emit, so generated smoke scripts read the right fields. No runtime, wire, or frontend behaviour change (the frontend already read the wire names).

## Related

- Closes: #6083

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/skills-schema-output-names-6083


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed schema output fields from `skill` to `workflow` and from `new_skills` to `new_workflows`.
  * Clients consuming these schemas must update references to the renamed fields.

* **Tests**
  * Added coverage confirming the new workflow-oriented output names and preventing use of the previous names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->