### PR TITLE
fix(webhooks): honour an explicit list_logs limit of 0

### DIFF
--- a/src/openhuman/skills/webhooks/router.rs
+++ b/src/openhuman/skills/webhooks/router.rs
@@ -456,7 +456,7 @@ impl WebhookRouter {
 
     /// List recent webhook logs, newest first.
     pub fn list_logs(&self, limit: Option<usize>) -> Vec<WebhookDebugLogEntry> {
-        let limit = limit.unwrap_or(100).max(1);
+        let limit = limit.unwrap_or(100);
         self.debug_logs
             .read()
             .map(|logs| logs.iter().take(limit).cloned().collect())

--- a/src/openhuman/skills/webhooks/router_tests.rs
+++ b/src/openhuman/skills/webhooks/router_tests.rs
@@ -186,6 +186,23 @@ fn list_logs_respects_limit() {
 }
 
 #[test]
+fn list_logs_zero_limit_returns_nothing() {
+    let router = WebhookRouter::new(None);
+    for i in 0..3 {
+        router.record_parse_error(
+            format!("corr-{i}"),
+            None,
+            None,
+            None,
+            json!({}),
+            "error".into(),
+        );
+    }
+    // `limit` is a maximum, so an explicit 0 asks for nothing.
+    assert!(router.list_logs(Some(0)).is_empty());
+}
+
+#[test]
 fn list_logs_default_limit() {
     let router = WebhookRouter::new(None);
     for i in 0..5 {

--- a/tests/raw_coverage/webhooks_ingress_e2e.rs
+++ b/tests/raw_coverage/webhooks_ingress_e2e.rs
@@ -678,8 +678,24 @@ async fn webhooks_debug_log_ring_records_and_clears() {
         "no response recorded yet ⇒ status_code must still be null: {entry}"
     );
 
+    // `limit` is a maximum, so an explicit 0 asks for nothing — and it must survive
+    // the wire as `Some(0)` rather than being read as an absent limit.
+    let none = post_json_rpc(
+        &rpc_base,
+        7104,
+        "openhuman.webhooks_list_logs",
+        json!({ "limit": 0 }),
+    )
+    .await;
+    let result = peel(assert_no_jsonrpc_error(&none, "webhooks_list_logs (limit 0)"));
+    assert_eq!(
+        result.get("logs").and_then(Value::as_array).map(Vec::len),
+        Some(0),
+        "limit: 0 must return no entries even with one recorded: {result}"
+    );
+
     // clear_logs reports the count it removed, and the ring is empty afterwards.
-    let cleared = post_json_rpc(&rpc_base, 7104, "openhuman.webhooks_clear_logs", json!({})).await;
+    let cleared = post_json_rpc(&rpc_base, 7105, "openhuman.webhooks_clear_logs", json!({})).await;
     let result = peel(assert_no_jsonrpc_error(&cleared, "webhooks_clear_logs"));
     assert_eq!(
         result.get("cleared").and_then(Value::as_u64),
@@ -687,7 +703,7 @@ async fn webhooks_debug_log_ring_records_and_clears() {
         "clear_logs must report the number of entries it removed: {result}"
     );
 
-    let after = post_json_rpc(&rpc_base, 7105, "openhuman.webhooks_list_logs", json!({})).await;
+    let after = post_json_rpc(&rpc_base, 7106, "openhuman.webhooks_list_logs", json!({})).await;
     let result = peel(assert_no_jsonrpc_error(&after, "webhooks_list_logs (after)"));
     assert_eq!(
         result.get("logs").and_then(Value::as_array).map(Vec::len),


### PR DESCRIPTION
## Summary

- `webhooks_list_logs` clamped a caller-supplied `limit: 0` up to `1`, so a caller asking for nothing got one log entry.
- Drops the `.max(1)` in `WebhookRouter::list_logs`; `unwrap_or(100)` already covers the absent case, so the clamp could only ever rewrite an explicit `0`.
- Adds a router unit test for `Some(0)` and a wire-level assertion in the existing webhooks debug-log e2e test.

## Problem

`src/openhuman/skills/webhooks/router.rs:459` read:

```rust
let limit = limit.unwrap_or(100).max(1);
```

`limit` is declared `Option<U64>`, "Maximum number of log entries to return" (`schemas.rs:151-160`). A maximum of zero is zero, but `.max(1)` promoted an explicit `0` to `1`, so `{"limit": 0}` returned one entry against a router with any recorded request.

The clamp reads as protecting the default, but `unwrap_or(100)` already does that — the only value `.max(1)` could alter was a caller-supplied `0`. `.take(0)` is well-defined on an iterator, so it was not guarding against anything either.

I traced the full path to confirm nothing between the wire and the clamp rewrites the value:
`handle_list_logs` (`schemas.rs:386`) → `WebhookListLogsParams { limit: Option<usize> }` (`schemas.rs:11`) → `ops::list_logs` (`ops.rs:76-81`) → `router.list_logs`. The clamp was the sole cause.

Reproduced before the fix: the new unit test failed with `assertion failed: router.list_logs(Some(0)).is_empty()` while the other 25 router tests passed.

## Solution

One-token change — `limit.unwrap_or(100)` — so `.take(0)` yields an empty list. This preserves the "maximum" reading of the parameter, which the declared input comment already promises; rejecting `0` with a typed error would be equally defensible but is a louder API change for a cosmetic defect.

Coverage added at both levels, because they fail differently:

- `list_logs_zero_limit_returns_nothing` (`router_tests.rs`) pins the clamp itself.
- The `limit: 0` assertion in `webhooks_debug_log_ring_records_and_clears` pins the wire path — specifically that `0` deserialises to `Some(0)` and not an absent limit, which the unit test cannot see and which would silently return 100 entries instead of 0.

## Impact

Runtime: Rust core only, no frontend or Tauri surface. No migration or compatibility concern — the only behaviour change is that `limit: 0` now returns `[]` instead of one entry.

Blast radius: `list_logs` has exactly one non-test caller, `ops.rs:81`. No existing test passes `0` — `router_tests.rs` uses `Some(3)`, `None`, `Some(1)`, `Some(10)` and `Some(MAX_DEBUG_LOG_ENTRIES + 100)`, and the e2e log-ring test uses `limit: 50` and an omitted limit. All still pass.

## Related

- Closes: #6090
- Feature IDs: 13.4.1 Webhook Inspection (`docs/TEST-COVERAGE-MATRIX.md`) — already `✅`, unchanged by this PR.
- Follow-up PR(s)/TODOs: `src/openhuman/cron/ops.rs:318` has the same shape (`limit.unwrap_or(20).max(1)`), but `cron::list_runs` clamps again at `cron/store_part_01.rs:628`, so fixing it is a separate two-site change. Left out to keep this scoped to #6090 — happy to file it if wanted.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `limit: 0` (the edge case) plus the existing populated/empty/default-limit assertions in the same tests.
- [x] **Diff coverage ≥ 80%** — the changed line in `router.rs` is executed by `list_logs_zero_limit_returns_nothing`, `list_logs_respects_limit`, `list_logs_default_limit` and `truncate_logs_respects_max`; the changed test lines execute themselves.
- [x] Coverage matrix updated — `N/A: behaviour-only change`, no feature leaf added, removed or renamed.
- [x] All affected feature IDs from the matrix are listed in the PR description under `## Related`
- [x] No new external network dependencies introduced
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: does not touch a release-cut surface.`
- [x] Linked issue closed via `Closes #6090` in the `## Related` section

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

This PR was authored by Claude Code.

### Linear Issue

- Key: `N/A` — filed on GitHub, not Linear.
- URL: https://github.com/tinyhumansai/openhuman/issues/6090

### Commit & Branch

- Branch: `fix/6090-webhooks-list-logs-limit-zero`
- Commit SHA: `10f4d8c526e992f4ec117cc5de9ffd78b163c297`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no frontend files changed.`
- [x] `pnpm typecheck` — `N/A: no TypeScript changed.`
- [x] Focused tests:
  - `cargo test --lib webhooks::` → 84 passed, 0 failed, 6 ignored.
  - `cargo test --test raw_coverage_all --features "$(bash scripts/ci/product-features.sh)" webhooks_debug_log_ring` → 1 passed, 0 failed.
  - Both new assertions were confirmed to bite: with `.max(1)` restored, the unit test fails (`assertion failed: router.list_logs(Some(0)).is_empty()`) and the e2e test fails with `left: Some(1), right: Some(0)` — the issue's reported repro, reproduced through the real RPC router.
- [x] Rust fmt/check: `cargo fmt --manifest-path Cargo.toml --all --check` clean (exit 0).
- [x] Tauri fmt/check (if changed): `N/A: app/src-tauri untouched.`

### Validation Blocked

- `command:` `rustup toolchain install 1.96.1`
- `error:` `could not download file from 'https://static.rust-lang.org/dist/channel-rust-1.96.1.toml' ... peer closed connection without sending TLS close_notify`
- `impact:` The pinned toolchain would not download here, so everything above ran on **1.96.0**, which still satisfies the rusqlite/`cfg_select!` floor documented in `rust-toolchain.toml`. CI should be treated as the authority on the pinned version.

- `command:` `cargo test --lib` (whole-crate run)
- `error:` `thread '...cron::scheduler::tests::part_02_tests::run_agent_job_returns_error_without_provider_key' has overflowed its stack / fatal runtime error: stack overflow`
- `impact:` Pre-existing and unrelated — I confirmed it reproduces on a clean `upstream/main` checkout with my two source changes stashed, and it is in `cron::scheduler`, which has no call path to `webhooks`. It aborts the test binary, so I could not get a single clean whole-crate run locally; the webhooks module and the changed line are fully covered by the focused runs above.

### Behavior Changes

- Intended behavior change: `webhooks_list_logs` with `limit: 0` returns zero entries instead of one.
- User-visible effect: A caller paginating from zero no longer receives one unexpected row. No UI surface passes `0` today, so nothing in the app changes.

### Parity Contract

- Legacy behavior preserved: every other `limit` value, including an omitted limit, is unchanged — `unwrap_or(100)` still supplies the default and `MAX_DEBUG_LOG_ENTRIES` truncation is untouched.
- Guard/fallback/dispatch parity checks: `.take(limit)` is safe at `0`, so removing the clamp introduces no panic or empty-iterator edge; the `RwLock` read-failure fallback to `unwrap_or_default()` is unchanged.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none — no open PR referenced #6090 at the time of writing.
- Canonical PR: this one.
- Resolution (closed/superseded/updated): `N/A`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook log requests with a limit of `0` now correctly return no entries instead of the newest entry.
  * Debug-log behavior is now consistently validated for zero-entry requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->