### PR TITLE
fix(socket): publish `status` in one vocabulary across the namespace

### DIFF
--- a/src/openhuman/platform/socket/schemas.rs
+++ b/src/openhuman/platform/socket/schemas.rs
@@ -6,6 +6,7 @@ use crate::core::all::{ControllerFuture, RegisteredController};
 use crate::core::{ControllerSchema, FieldSchema, TypeSchema};
 
 use super::manager::global_socket_manager;
+use crate::api::models::socket::{ConnectionStatus, SocketState};
 
 // ---------------------------------------------------------------------------
 // Schema catalog
@@ -159,6 +160,29 @@ fn require_manager() -> Result<&'static std::sync::Arc<super::SocketManager>, St
         .ok_or_else(|| "SocketManager not initialized — runtime not bootstrapped".to_string())
 }
 
+/// Serialise a [`ConnectionStatus`] the way every other surface publishes it.
+///
+/// `socket_state` (`serde_json::to_value(state)`) and `connectivity_diag` both go through
+/// `ConnectionStatus`' `#[serde(rename_all = "lowercase")]`, so the lifecycle handlers below use
+/// the same encoding instead of `format!("{:?}", …)` (#6111). `Debug` and serde disagree —
+/// `"Disconnected"` vs `"disconnected"` — and one namespace publishing a field two ways is a
+/// contract a caller cannot rely on.
+fn status_payload(state: &SocketState) -> Value {
+    json!({ "status": Value::String(status_slug(state.status)) })
+}
+
+/// The serde spelling of `status`, as a plain string.
+///
+/// Goes through `serde_json::to_value` rather than a hand-written match so the mapping cannot
+/// drift from the `rename_all` attribute that `socket_state` relies on. `ConnectionStatus` is a
+/// unit-variant enum, so this cannot fail; the fallback keeps the function total.
+fn status_slug(status: ConnectionStatus) -> String {
+    serde_json::to_value(status)
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_string))
+        .unwrap_or_else(|| format!("{status:?}").to_lowercase())
+}
+
 fn handle_connect(params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async move {
         let mgr = require_manager()?;
@@ -172,7 +196,7 @@ fn handle_connect(params: Map<String, Value>) -> ControllerFuture {
             .ok_or("missing required param 'token'")?;
 
         let state = super::ops::connect_static(mgr, url, token).await?;
-        Ok(json!({ "status": format!("{:?}", state.status) }))
+        Ok(status_payload(&state))
     })
 }
 
@@ -180,7 +204,7 @@ fn handle_disconnect(_params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async move {
         let mgr = require_manager()?;
         let state = super::ops::disconnect(mgr).await?;
-        Ok(json!({ "status": format!("{:?}", state.status) }))
+        Ok(status_payload(&state))
     })
 }
 
@@ -212,7 +236,7 @@ fn handle_connect_with_session(_params: Map<String, Value>) -> ControllerFuture 
     Box::pin(async move {
         let mgr = require_manager()?;
         let state = super::ops::connect_with_session(mgr).await?;
-        Ok(json!({ "status": format!("{:?}", state.status) }))
+        Ok(status_payload(&state))
     })
 }
 

--- a/src/openhuman/platform/socket/schemas_tests.rs
+++ b/src/openhuman/platform/socket/schemas_tests.rs
@@ -128,3 +128,68 @@ async fn handlers_error_without_initialized_manager() {
     let err = handle_emit(Map::new()).await.unwrap_err();
     assert!(err.contains("SocketManager not initialized"));
 }
+
+/// #6111 — the lifecycle handlers and `socket_state` must publish `status` in one vocabulary.
+///
+/// The three lifecycle handlers used to build their payload with `format!("{:?}", status)` while
+/// `socket_state` went through `ConnectionStatus`' `#[serde(rename_all = "lowercase")]`, so one
+/// namespace answered `"Disconnected"` and `"disconnected"` for the same field. This pins the
+/// decided direction (serde) against the source of truth — the serde encoding itself — rather
+/// than against a hand-written list that could drift with it.
+#[test]
+fn status_payload_matches_the_serde_encoding_for_every_variant() {
+    for status in [
+        ConnectionStatus::Disconnected,
+        ConnectionStatus::Connecting,
+        ConnectionStatus::Connected,
+        ConnectionStatus::Reconnecting,
+        ConnectionStatus::Error,
+    ] {
+        let state = SocketState {
+            status,
+            socket_id: None,
+            error: None,
+        };
+
+        // What `socket_state` publishes for this status.
+        let from_state = serde_json::to_value(&state).expect("serialize SocketState");
+        let expected = from_state
+            .get("status")
+            .and_then(Value::as_str)
+            .expect("SocketState serialises a status field");
+
+        // What the lifecycle handlers publish for the same status.
+        let payload = status_payload(&state);
+        assert_eq!(
+            payload.get("status").and_then(Value::as_str),
+            Some(expected),
+            "lifecycle handlers and socket_state must agree on {status:?}"
+        );
+        assert_ne!(
+            payload.get("status").and_then(Value::as_str),
+            Some(format!("{status:?}").as_str()),
+            "{status:?} must not be published in Rust's Debug spelling"
+        );
+    }
+}
+
+/// The slug is lowercase for every variant — the property `connectivity_diag` and the frontend's
+/// lowercase comparisons rely on.
+#[test]
+fn status_slug_is_lowercase_for_every_variant() {
+    for status in [
+        ConnectionStatus::Disconnected,
+        ConnectionStatus::Connecting,
+        ConnectionStatus::Connected,
+        ConnectionStatus::Reconnecting,
+        ConnectionStatus::Error,
+    ] {
+        let slug = status_slug(status);
+        assert!(!slug.is_empty(), "{status:?} produced an empty slug");
+        assert_eq!(
+            slug,
+            slug.to_lowercase(),
+            "{status:?} slug is not lowercase"
+        );
+    }
+}

--- a/tests/raw_coverage/channel_socket_e2e.rs
+++ b/tests/raw_coverage/channel_socket_e2e.rs
@@ -411,19 +411,19 @@ async fn socket_connect_then_disconnect_round_trips_state() {
     let result = peel(assert_no_jsonrpc_error(&connected, "socket_connect"));
     assert_eq!(
         result.get("status").and_then(Value::as_str),
-        Some("Connecting"),
-        "connect returns as soon as the loop is spawned, in the Connecting state. NOTE the \
-         capitalisation: this handler formats the status with `{{:?}}` while `socket_state` \
-         serialises it through serde (lowercase `connecting`). See \
-         bugs/e2e-wave-socket-status-casing-split.md: {result}"
+        Some("connecting"),
+        "connect returns as soon as the loop is spawned, in the Connecting state. The spelling \
+         is the serde one (`rename_all = \"lowercase\"`), the same encoding `socket_state` and \
+         `connectivity_diag` publish — this handler used to emit Rust's `Debug` \
+         (`\"Connecting\"`) and the split was #6111: {result}"
     );
 
     let disconnected = post_json_rpc(&h.rpc_base, 8102, "openhuman.socket_disconnect", json!({})).await;
     let result = peel(assert_no_jsonrpc_error(&disconnected, "socket_disconnect"));
     assert_eq!(
         result.get("status").and_then(Value::as_str),
-        Some("Disconnected"),
-        "disconnect must report the manager back at rest: {result}"
+        Some("disconnected"),
+        "disconnect must report the manager back at rest, in the serde spelling (#6111): {result}"
     );
 
     let state = post_json_rpc(&h.rpc_base, 8103, "openhuman.socket_state", json!({})).await;
@@ -431,7 +431,8 @@ async fn socket_connect_then_disconnect_round_trips_state() {
     assert_eq!(
         result.get("status").and_then(Value::as_str),
         Some("disconnected"),
-        "state must agree with disconnect's own report (modulo the casing split): {result}"
+        "state must agree with disconnect's own report exactly — one namespace, one status \
+         vocabulary (#6111): {result}"
     );
     assert!(
         result.get("socket_id").map(Value::is_null).unwrap_or(false),
@@ -500,8 +501,9 @@ async fn socket_connect_with_session_requires_a_stored_session() {
     ));
     assert_eq!(
         result.get("status").and_then(Value::as_str),
-        Some("Connecting"),
-        "a stored session must get past the guard and start the loop: {result}"
+        Some("connecting"),
+        "a stored session must get past the guard and start the loop, reporting the serde \
+         spelling (#6111): {result}"
     );
 
     let stopped = post_json_rpc(&h.rpc_base, 8205, "openhuman.socket_disconnect", json!({})).await;
@@ -509,7 +511,7 @@ async fn socket_connect_with_session_requires_a_stored_session() {
         peel(assert_no_jsonrpc_error(&stopped, "socket_disconnect"))
             .get("status")
             .and_then(Value::as_str),
-        Some("Disconnected")
+        Some("disconnected")
     );
 
     manager.disconnect().await.expect("teardown disconnect");


### PR DESCRIPTION
## Summary

- `socket_connect`, `socket_disconnect` and `socket_connect_with_session` published `status` via Rust's `Debug` (`"Connecting"`, `"Disconnected"`) while `socket_state` published it via serde (`"connecting"`, `"disconnected"`). One namespace, one field, two encodings.
- **Aligned on serde, as decided on #6111.**
- Three handlers now share a `status_payload` helper that routes through `serde_json::to_value`, so the spelling cannot drift from the `rename_all` attribute `socket_state` depends on.
- Two new unit tests pin the decided direction against the serde encoding itself; four e2e assertions that pinned the `Debug` spelling are updated.

## Problem

`ConnectionStatus` carries `#[serde(rename_all = "lowercase")]` (`src/api/models/socket.rs:4-14`). `handle_state` serialises the whole `SocketState` and therefore emits the serde spelling. The three lifecycle handlers instead built their payload by hand:

```rust
Ok(json!({ "status": format!("{:?}", state.status) }))
```

A caller that stores what `socket_connect` returned and later compares it with `socket_state` never matches, even when nothing changed.

## Solution

**DECIDED on #6111: align on serde (lowercase).** `socket_state` and `connectivity_diag` already publish that spelling — two of the three surfaces agreed and the lifecycle handlers were the outlier — so the three handlers move to it.

```rust
fn status_slug(status: ConnectionStatus) -> String {
    serde_json::to_value(status).ok().and_then(|v| v.as_str().map(str::to_string))
        .unwrap_or_else(|| format!("{status:?}").to_lowercase())
}
```

Deriving the slug from `serde_json::to_value` rather than a hand-written `match` is the point: a future edit to `rename_all` moves `socket_state` and these handlers together, so the split cannot reopen. `ConnectionStatus` is a unit-variant enum so the fallback is unreachable; it is there to keep the function total.

## Impact

- **No renderer risk, checked.** `app/src` consumes neither return value: `SocketProvider.tsx:53` calls `socket_connect_with_session` as `void callCoreRpc(...).catch(...)` and discards the result. The `socketStatus` the app branches on comes from redux `selectSocketStatus`, fed by the renderer's own socket, and already compares lowercase.
- **Tests pinning the serde spelling are untouched** — `channel_socket_e2e.rs:300`, `:354`, `:433`, `:476` and `connectivity_raw_coverage_e2e.rs:435-437` all pass unchanged, which is the corroboration that serde was the right side to standardise on.
- The four assertions that pinned `Debug` (`:414`, `:425`, `:503`, `:512`) are updated, as the issue directed.
- Handler behaviour is otherwise identical: same lifecycle, same errors, same `socket_id`/`error` fields.

## Related

- Closes: #6111
- Follow-up PR(s)/TODOs: none.

---

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `status_payload_matches_the_serde_encoding_for_every_variant` covers all five `ConnectionStatus` variants and asserts the `Debug` spelling is *not* emitted; the e2e cases cover connect, disconnect and the signed-out/signed-in halves of `connect_with_session`.
- [x] **Diff coverage ≥ 80%** — both new helpers are executed by the two unit tests across every enum variant, and the three changed handler lines by the e2e cases. Ran the lib + `raw_coverage_all` targets under the product feature string, **not** the full `diff-cover` merge; CI computes the real number.
- [x] N/A: no feature rows added, removed or renamed — an encoding fix to existing controllers, so `docs/TEST-COVERAGE-MATRIX.md` needs no row change.
- [x] N/A: no matrix feature IDs apply, per the item above.
- [x] No new external network dependencies introduced — unit tests are pure; the e2e cases use the existing in-process mock and a deliberately closed loopback port.
- [x] N/A: no release-cut surface touched — the renderer consumes neither return value (see Impact), so `docs/RELEASE-MANUAL-SMOKE.md` is unaffected.
- [x] Linked issue closed via `Closes` in the `## Related` section — #6111.

## Revert-check

Run: `cargo test --lib --test raw_coverage_all --features "$(bash scripts/ci/product-features.sh)" -- webhooks socket`

**Fault injected:** `Ok(status_payload(&state))` → `Ok(json!({ "status": format!("{:?}", state.status) }))` on all three handlers.

```
---- channel_socket_e2e::socket_connect_then_disconnect_round_trips_state ----
  channel_socket_e2e.rs:412: … the spelling is the serde one … {"status":"Connecting"}
  left: Some("Connecting")   right: Some("connecting")

---- channel_socket_e2e::socket_connect_with_session_requires_a_stored_session ----
  channel_socket_e2e.rs:502: a stored session must get past the guard … {"status":"Connecting"}
  left: Some("Connecting")   right: Some("connecting")
```

Baseline with the fix: **256 passed / 0 failed** (lib), **13 passed / 0 failed** (`raw_coverage_all`). Restored from a snapshot afterwards.

### An observation from that revert-check, not a regression in this PR

Under the injected fault, `connectivity_raw_coverage_e2e::connectivity_ops_schema_and_socket_snapshot_paths_are_exercised` also failed (`left: "connecting", right: "disconnected"`). That is a **cascade, not a second defect**: the socket e2e cases share the process-global `SocketManager` with that suite and disconnect it in their teardown, so a case that panics mid-body skips the teardown and leaves the manager `Connecting` for whoever runs next. It cannot fire on a green run — and did not, in the baseline above. Left alone here to keep the diff to the decided fix; worth a small `Drop`-based teardown in `channel_socket_e2e.rs` if it ever bites in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Connection lifecycle status messages now use consistent lowercase values, such as `connecting` and `disconnected`, improving compatibility for clients consuming socket events.

- **Tests**
  - Added coverage ensuring all connection status values use stable, lowercase serialized representations.
  - Updated end-to-end lifecycle checks to validate the corrected status values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->