### PR TITLE
fix(tokenjuice): compress exposes all five ContentHint fields

### DIFF
--- a/src/openhuman/inference/tokenjuice/schemas.rs
+++ b/src/openhuman/inference/tokenjuice/schemas.rs
@@ -11,7 +11,7 @@ use serde_json::{Map, Value};
 use crate::core::all::{ControllerFuture, RegisteredController};
 use crate::core::{ControllerSchema, FieldSchema, TypeSchema};
 
-use super::types::ContentHint;
+use super::types::{ContentHint, ContentKind};
 
 pub fn all_controller_schemas() -> Vec<ControllerSchema> {
     vec![
@@ -112,6 +112,32 @@ pub fn schemas(function: &str) -> ControllerSchema {
                     name: "tool_name",
                     ty: TypeSchema::String,
                     comment: "Optional producing tool name (prior hint).",
+                    required: false,
+                },
+                FieldSchema {
+                    name: "mime",
+                    ty: TypeSchema::String,
+                    comment: "Optional MIME type hint (`text/html`, `application/json`, …).",
+                    required: false,
+                },
+                FieldSchema {
+                    name: "extension",
+                    ty: TypeSchema::String,
+                    comment: "Optional file extension hint (no dot).",
+                    required: false,
+                },
+                FieldSchema {
+                    name: "query",
+                    ty: TypeSchema::String,
+                    comment: "Optional search/query string; the search compressor ranks \
+                              matches by query-term density.",
+                    required: false,
+                },
+                FieldSchema {
+                    name: "explicit",
+                    ty: TypeSchema::String,
+                    comment: "Optional hard override of the detected kind, skipping detection \
+                              entirely. One of: json, code, log, search, diff, html, plain_text.",
                     required: false,
                 },
             ],
@@ -238,13 +264,39 @@ fn handle_detect(params: Map<String, Value>) -> ControllerFuture {
     })
 }
 
+/// Build a [`ContentHint`] from `compress`'s params.
+///
+/// All five hint fields are caller-supplied. Before #6088 only `source_tool` was
+/// read, so the debug controller could not reproduce what the content router
+/// actually does — in particular it could not force a kind via `explicit`, which
+/// is the one field that skips detection entirely.
+///
+/// An unrecognised `explicit` is refused rather than ignored: silently detecting
+/// instead of overriding is exactly the confusion this controller exists to
+/// resolve.
+fn compress_hint_from_params(params: &Map<String, Value>) -> Result<ContentHint, String> {
+    let explicit = match str_param(params, "explicit") {
+        Some(raw) => Some(raw.parse::<ContentKind>().map_err(|()| {
+            format!(
+                "invalid 'explicit': {raw:?} — expected one of: \
+                 json, code, log, search, diff, html, plain_text"
+            )
+        })?),
+        None => None,
+    };
+    Ok(ContentHint {
+        source_tool: str_param(params, "tool_name"),
+        mime: str_param(params, "mime"),
+        extension: str_param(params, "extension"),
+        query: str_param(params, "query"),
+        explicit,
+    })
+}
+
 fn handle_compress(params: Map<String, Value>) -> ControllerFuture {
     Box::pin(async move {
         let content = str_param(&params, "content").ok_or("missing 'content'")?;
-        let hint = ContentHint {
-            source_tool: str_param(&params, "tool_name"),
-            ..Default::default()
-        };
+        let hint = compress_hint_from_params(&params)?;
         let res = super::compress(content, hint).await?;
         Ok(serde_json::json!({
             "applied": res.applied,

--- a/src/openhuman/inference/tokenjuice/schemas_tests.rs
+++ b/src/openhuman/inference/tokenjuice/schemas_tests.rs
@@ -26,3 +26,124 @@ async fn cache_stats_handler_returns_counts() {
     let out = handle_cache_stats(Map::new()).await.unwrap();
     assert!(out["entries"].is_u64());
 }
+
+// ── #6088: `compress` must expose all five ContentHint fields ────────────────
+
+/// Before #6088 the handler built `ContentHint { source_tool, ..Default::default() }`,
+/// so four of the five fields were unreachable and the debug controller could not
+/// reproduce what the content router does. These assert the mapping directly —
+/// no module, no router — so they run everywhere.
+#[test]
+fn compress_hint_carries_every_caller_supplied_field() {
+    let mut p = Map::new();
+    p.insert("tool_name".into(), Value::from("grep"));
+    p.insert("mime".into(), Value::from("text/html"));
+    p.insert("extension".into(), Value::from("rs"));
+    p.insert("query".into(), Value::from("needle"));
+    p.insert("explicit".into(), Value::from("search"));
+
+    let hint = compress_hint_from_params(&p).expect("a well-formed hint must parse");
+    assert_eq!(
+        hint.source_tool.as_deref(),
+        Some("grep"),
+        "`tool_name` was the only field the old handler read"
+    );
+    assert_eq!(
+        hint.mime.as_deref(),
+        Some("text/html"),
+        "`mime` must reach the router; it was dropped before #6088"
+    );
+    assert_eq!(
+        hint.extension.as_deref(),
+        Some("rs"),
+        "`extension` must reach the router; it was dropped before #6088"
+    );
+    assert_eq!(
+        hint.query.as_deref(),
+        Some("needle"),
+        "`query` must reach the router — the search compressor ranks by it"
+    );
+    assert_eq!(
+        hint.explicit,
+        Some(ContentKind::Search),
+        "`explicit` is the field that skips detection entirely — without it the \
+         controller cannot force a kind, which is the point of the fix"
+    );
+}
+
+#[test]
+fn compress_hint_defaults_every_field_to_none() {
+    let mut p = Map::new();
+    p.insert("content".into(), Value::from("hello"));
+    let hint = compress_hint_from_params(&p).expect("an empty hint must parse");
+    assert!(hint.source_tool.is_none());
+    assert!(hint.mime.is_none());
+    assert!(hint.extension.is_none());
+    assert!(hint.query.is_none());
+    assert!(hint.explicit.is_none());
+}
+
+#[test]
+fn compress_hint_refuses_an_unknown_explicit_kind() {
+    let mut p = Map::new();
+    p.insert("explicit".into(), Value::from("nonsense"));
+    let err = compress_hint_from_params(&p)
+        .expect_err("an unrecognised kind must be refused, not silently detected");
+    assert!(
+        err.contains("nonsense") && err.contains("plain_text"),
+        "the refusal must quote the bad value and list the accepted set: {err}"
+    );
+}
+
+/// `plain_text` is the spelling `ContentKind::from_str` accepts; serde renders the
+/// same variant as `plainText`. The vendored `from_str` doc calls this out as the
+/// exact trap, so pin the spelling the schema advertises.
+#[test]
+fn compress_hint_accepts_the_documented_plain_text_spelling() {
+    let mut p = Map::new();
+    p.insert("explicit".into(), Value::from("plain_text"));
+    assert_eq!(
+        compress_hint_from_params(&p)
+            .expect("plain_text must parse")
+            .explicit,
+        Some(ContentKind::PlainText),
+        "`plain_text` is the spelling `ContentKind::from_str` accepts and the one \
+         the schema advertises; serde's `plainText` must not be what we parse"
+    );
+}
+
+#[test]
+fn compress_schema_declares_all_five_hint_inputs() {
+    let s = schemas("compress");
+    for field in [
+        "content",
+        "tool_name",
+        "mime",
+        "extension",
+        "query",
+        "explicit",
+    ] {
+        assert!(
+            s.inputs.iter().any(|f| f.name == field),
+            "`compress` must declare `{field}`; a hint field the schema does not \
+             name is one a caller cannot discover"
+        );
+    }
+    assert!(
+        s.inputs
+            .iter()
+            .find(|f| f.name == "content")
+            .is_some_and(|f| f.required),
+        "only `content` is required"
+    );
+    for optional in ["tool_name", "mime", "extension", "query", "explicit"] {
+        assert!(
+            !s.inputs
+                .iter()
+                .find(|f| f.name == optional)
+                .unwrap()
+                .required,
+            "`{optional}` must stay optional"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `openhuman.tokenjuice_compress` now declares and forwards all five `ContentHint` fields; it previously exposed only `tool_name`.
- `mime`, `extension`, `query` and `explicit` are added as optional inputs, so the debug controller can reproduce what the content router actually does — including forcing a kind via `explicit`, which skips detection entirely.
- An unrecognised `explicit` is refused with the accepted set, rather than silently ignored.
- This is **part (a)** of #6088. Part (b) is deliberately not addressed — see below.

## Problem

`handle_compress` built

```rust
let hint = ContentHint { source_tool: str_param(&params, "tool_name"), ..Default::default() };
```

so four of the hint's five fields were unreachable, and the `"compress"` schema arm declared only `content` + `tool_name`. The namespace advertises this controller as a way to dry-run the content router over a blob, but it could not drive the router the way the router's own API allows — most importantly it could not set `explicit`, the hard override that bypasses detection.

The schema is not decorative here: `skill_runtime_schemas`' own description says these schemas exist "for CLI/RPC smoke-test script generation", so a hint field the catalog does not name is one a generated script cannot produce.

## Solution

- `compress_hint_from_params(&params) -> Result<ContentHint, String>` maps all five fields. Split out as its own function so the mapping is unit-testable without running the router or loading the TinyJuice module — the existing handler tests in this file are `#[ignore]`d for exactly that reason.
- The four new inputs are declared `required: false`; `content` remains the only required input, so **no existing caller breaks** — the change is purely additive on the schema.
- `explicit` is parsed through `ContentKind::from_str` and an unknown value is rejected naming the accepted set. Silently detecting when the caller explicitly asked for an override is the confusion this controller exists to resolve.
- One trap worth knowing, pinned by a test: the accepted spelling is `plain_text` (what `from_str` parses), **not** serde's `plainText`. The vendored `from_str` doc calls this out as the exact mistake every host makes.

### Not addressed: part (b)

The issue's second half — whether `log_line_ratio` should measure failure density or log formatting, and whether the search rule should ignore an `HH:MM:SS` timestamp so a timestamped log is not misrouted to the search compressor — is scoped by the issue itself to a decision **inside `vendor/tinyjuice`, not openhuman**, and `detect_content_kind` also backs `tokenjuice_detect` and the production compaction path (a different bus member). It is left alone.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per Testing Strategy — five unit tests: all five fields carried, all-absent defaults, unknown `explicit` refused (failure path), the `plain_text` spelling, and the schema declaring every input.
- [x] **Diff coverage ≥ 80%** — every changed line in `compress_hint_from_params` and the schema arm is exercised; ran `cargo test --lib --features "$(bash scripts/ci/product-features.sh)"` locally. N/A for Vitest: no frontend code changed.
- [x] Coverage matrix updated — `N/A: behaviour-only change` to a debug controller's inputs; no feature row added, removed or renamed.
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature rows affected.`
- [x] No new external network dependencies introduced — no network code touched.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: a debug/introspection controller, not a release-cut surface.`
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

Additive on the schema; `content` remains the only required input, so every existing caller keeps working. `tests/json_rpc_e2e.rs` is the only existing target naming `openhuman.tokenjuice_*` and does not pass any of the new params.

One behaviour change worth calling out: a caller that previously sent `explicit` (silently ignored, since it was undeclared) now gets an error if the value is not a valid kind. That is the intended direction — the old behaviour was to ignore an override the caller asked for.

**Revert-check.** Two faults injected, separately verified:

1. `compress_hint_from_params` restored to reading only `source_tool`:
   - `compress_hint_carries_every_caller_supplied_field` → ```assertion `left == right` failed: `mime` must reach the router; it was dropped before #6088```
   - `compress_hint_accepts_the_documented_plain_text_spelling` → ```assertion `left == right` failed: `plain_text` is the spelling `ContentKind::from_str` accepts and the one the schema advertises; serde's `plainText` must not be what we parse```
2. The `mime` `FieldSchema` removed from the `compress` arm:
   - `compress_schema_declares_all_five_hint_inputs` → ````compress` must declare `mime`; a hint field the schema does not name is one a caller cannot discover```

`compress_hint_defaults_every_field_to_none` and `compress_hint_refuses_an_unknown_explicit_kind` correctly still passed under fault 1 — defaults still hold when only one field is read, and the refusal happens before the struct is built. Both faults reverted; `git status` is clean of them.

## Related

- Closes: Closes #6088
- Follow-up PR(s)/TODOs: part (b) of #6088 (`log_line_ratio` semantics and the timestamp→search misclassification) remains open and belongs in `vendor/tinyjuice`.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/6088-tokenjuice-compress-hint-fields`
- Commit SHA: `d8c38faa1eb8acd28684deb602b243c38889b3b5`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — N/A: no frontend files changed.
- [x] `pnpm typecheck` — N/A: no TypeScript changed.
- [x] Focused tests: `cargo test --lib --features "$(bash scripts/ci/product-features.sh)" -- compress_hint compress_schema_declares` → 5 passed.
- [x] Rust fmt/check (if changed): `cargo fmt` run; its reformatting of the test file is folded into the single commit.
- [x] Tauri fmt/check (if changed): N/A: no Tauri/shell code changed.

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: `tokenjuice_compress` accepts and forwards `mime`, `extension`, `query` and `explicit`; an invalid `explicit` is now an error.
- User-visible effect: the debug controller can reproduce the router's behaviour. Previously-ignored `explicit` values now take effect (or are refused if invalid).

### Parity Contract

- Legacy behavior preserved: yes for every existing caller — `content` is still the only required input and `tool_name` behaves identically. The one divergence is that an invalid `explicit`, previously ignored, now errors.
- Guard/fallback/dispatch parity checks: `handle_detect` (which already read `extension`) is untouched; the output payload shape is unchanged.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none.
- Canonical PR: this one.
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The content compression interface now accepts optional hints for MIME type, file extension, query context, source tool, and explicit content kind.
  * Recognized content kinds are parsed and applied to improve compression behavior.

* **Bug Fixes**
  * Invalid content-kind hints now return a clear error instead of being silently ignored.

* **Tests**
  * Added coverage for hint handling, defaults, schema validation, and supported content-kind values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->