### PR TITLE
fix(update): make the release endpoint injectable for tests, without making it configurable

### DIFF
--- a/src/openhuman/platform/update/core.rs
+++ b/src/openhuman/platform/update/core.rs
@@ -17,6 +17,10 @@ use crate::openhuman::util::utf8_safe_prefix_at_byte_boundary;
 const GITHUB_OWNER: &str = "tinyhumansai";
 const GITHUB_REPO: &str = "openhuman";
 
+/// Origin of the release-metadata API. Not configurable at runtime — see
+/// `check_available_with_base_url`.
+const GITHUB_API_BASE: &str = "https://api.github.com";
+
 /// Current binary version (set at compile time from Cargo.toml).
 pub fn current_version() -> &'static str {
     env!("CARGO_PKG_VERSION")
@@ -87,13 +91,25 @@ fn is_newer(latest: &str, current: &str) -> bool {
 
 /// Check GitHub Releases for a newer version of openhuman-core.
 pub async fn check_available() -> Result<UpdateInfo, String> {
+    check_available_with_base_url(GITHUB_API_BASE).await
+}
+
+/// `check_available`, with the API origin injected.
+///
+/// Deliberately **private**, and deliberately not an env var. `ops::validate_download_url`
+/// pins asset downloads to the GitHub host allowlist on purpose; a runtime-overridable
+/// release endpoint would be a self-update redirection primitive on the highest-trust
+/// path in the product. The only caller besides `check_available` is the unit suite,
+/// which points it at a local mock — which is what the note in `scheduler_tests.rs`
+/// asked for.
+async fn check_available_with_base_url(base_url: &str) -> Result<UpdateInfo, String> {
     let current = current_version();
     log::info!(
         "[update] checking for updates — current version: {}",
         current
     );
 
-    let url = format!("https://api.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases/latest");
+    let url = format!("{base_url}/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases/latest");
 
     let client = reqwest::Client::builder()
         .user_agent("openhuman-core-updater")

--- a/src/openhuman/platform/update/core_tests.rs
+++ b/src/openhuman/platform/update/core_tests.rs
@@ -37,3 +37,131 @@ async fn transport_failure_classifier_catches_unreachable_host() {
         "unreachable-host reqwest error must classify as transport: {err}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #6089: `check_available` used to build `https://api.github.com/...` inline, so
+// the HTTP + JSON-parse path could only be exercised against the live endpoint —
+// which `scheduler_tests.rs` calls out as the reason `tick()` is untested. These
+// drive the private `check_available_with_base_url` seam against a local mock.
+// ---------------------------------------------------------------------------
+
+/// The release JSON GitHub actually returns, trimmed to the fields we parse.
+/// `decoy` is an asset for another platform: it must never be selected.
+fn release_body(tag: &str) -> String {
+    let triple = platform_triple();
+    format!(
+        r#"{{
+            "tag_name": "{tag}",
+            "body": "release notes for {tag}",
+            "published_at": "2026-09-08T00:00:00Z",
+            "assets": [
+                {{"name": "openhuman-core-some-other-triple", "browser_download_url": "https://example.invalid/decoy", "size": 1}},
+                {{"name": "openhuman-core-{triple}", "browser_download_url": "https://example.invalid/{triple}", "size": 2}}
+            ]
+        }}"#
+    )
+}
+
+async fn releases_mock(status: u16, body: &str) -> wiremock::MockServer {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/tinyhumansai/openhuman/releases/latest"))
+        .respond_with(ResponseTemplate::new(status).set_body_string(body))
+        .mount(&server)
+        .await;
+    server
+}
+
+#[tokio::test]
+async fn check_available_parses_a_release_and_picks_this_platforms_asset() {
+    let server = releases_mock(200, &release_body("v99.0.0")).await;
+
+    let info = check_available_with_base_url(&server.uri())
+        .await
+        .expect("mocked release must parse");
+
+    assert_eq!(info.latest_version, "99.0.0", "the leading v is stripped");
+    assert_eq!(info.current_version, current_version());
+    assert!(
+        info.update_available,
+        "99.0.0 is newer than {}",
+        current_version()
+    );
+    assert_eq!(
+        info.asset_name.as_deref(),
+        Some(format!("openhuman-core-{}", platform_triple()).as_str()),
+        "the decoy asset for another triple must not be selected"
+    );
+    assert_eq!(
+        info.download_url.as_deref(),
+        Some(format!("https://example.invalid/{}", platform_triple()).as_str())
+    );
+    assert_eq!(
+        info.release_notes.as_deref(),
+        Some("release notes for v99.0.0")
+    );
+    assert_eq!(info.published_at.as_deref(), Some("2026-09-08T00:00:00Z"));
+}
+
+#[tokio::test]
+async fn check_available_reports_no_update_for_an_older_tag() {
+    let server = releases_mock(200, &release_body("v0.0.1")).await;
+
+    let info = check_available_with_base_url(&server.uri())
+        .await
+        .expect("mocked release must parse");
+
+    assert_eq!(info.latest_version, "0.0.1");
+    assert!(
+        !info.update_available,
+        "0.0.1 must not be newer than {}",
+        current_version()
+    );
+}
+
+#[tokio::test]
+async fn check_available_surfaces_a_non_2xx_as_a_github_api_error() {
+    // 403 is what the unauthenticated rate limit returns — the case the issue
+    // says a caller currently cannot tell apart from "no update".
+    let server = releases_mock(403, r#"{"message":"API rate limit exceeded"}"#).await;
+
+    let err = check_available_with_base_url(&server.uri())
+        .await
+        .expect_err("a 403 must not be reported as a successful check");
+
+    assert!(
+        err.contains("GitHub API error: 403"),
+        "error must name the status, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn check_available_surfaces_a_malformed_body_as_a_parse_error() {
+    let server = releases_mock(200, "{ not json").await;
+
+    let err = check_available_with_base_url(&server.uri())
+        .await
+        .expect_err("a malformed body must not be reported as a successful check");
+
+    assert!(
+        err.contains("failed to parse release JSON"),
+        "error must distinguish parse from transport, got: {err}"
+    );
+}
+
+/// The seam exists for tests only: the shipped binary must still resolve the
+/// pinned GitHub origin. Guards the extraction itself — if someone later makes
+/// the base URL configurable at runtime, this is what breaks, and
+/// `ops::validate_download_url`'s host allowlist is why that matters.
+#[test]
+fn the_default_origin_is_still_the_pinned_github_api() {
+    assert_eq!(GITHUB_API_BASE, "https://api.github.com");
+    assert_eq!(
+        format!("{GITHUB_API_BASE}/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases/latest"),
+        "https://api.github.com/repos/tinyhumansai/openhuman/releases/latest",
+        "the URL check_available() builds must be byte-identical to the pre-refactor literal"
+    );
+}

--- a/src/openhuman/platform/update/scheduler_tests.rs
+++ b/src/openhuman/platform/update/scheduler_tests.rs
@@ -28,9 +28,8 @@ async fn run_returns_immediately_when_disabled() {
 // `update_core::check_available()` which performs a real HTTPS request
 // to api.github.com — running that from the unit suite makes the test
 // flaky (offline CI runners, rate limits, DNS hiccups). Coverage of
-// the HTTP + JSON-parse path is better handled via an integration test
-// that uses an HTTP mock (e.g. `httpmock`) around a refactored
-// `check_available_with_url(base_url)`. For now the surrounding
-// properties are locked down by:
+// the HTTP + JSON-parse path now lives in `core_tests.rs`, which drives
+// `check_available_with_base_url(base_url)` against a wiremock server
+// (#6089). The surrounding scheduler properties are locked down here by:
 //   - `min_interval_is_at_least_ten_minutes` (rate-limit floor)
 //   - `run_returns_immediately_when_disabled` (disabled short-circuit)


### PR DESCRIPTION
## Summary

- Extracts the release-metadata origin out of `check_available()` into a **private** `check_available_with_base_url(base_url)`, so the HTTP + JSON-parse path can be exercised against a local mock instead of `api.github.com` (#6089).
- Adds five tests over that path: asset selection for this platform, the no-update branch, a `403` rate-limit response, a malformed body, and a pin that the shipped binary still resolves the same URL it did before.
- **No runtime override.** The endpoint stays a compile-time constant.
- Updates the `scheduler_tests.rs` NOTE that asked for exactly this refactor by name.

## Problem

`check_available()` built its URL inline:

```rust
let url = format!("https://api.github.com/repos/{GITHUB_OWNER}/{GITHUB_REPO}/releases/latest");
```

There was no override of any kind — the only `env` read in the whole module is `env!("CARGO_PKG_VERSION")`. So `update_check` / `update_run` always reached the public internet, and no test could tell `{"error": "failed to fetch latest release: …"}` from a genuine "no update". `scheduler_tests.rs:27` says so explicitly, and skips testing `tick()` for that reason, naming `check_available_with_url(base_url)` as the fix it wanted.

In CI the call is also subject to GitHub's unauthenticated 60/h/IP limit, so the same test could take either branch on different runs.

## Solution

`check_available()` becomes a two-line wrapper over `check_available_with_base_url(GITHUB_API_BASE)`. Only the URL construction changed; every other line of the function — the transport-failure classifier, the observability branches, the non-2xx handling, asset selection — is untouched.

**Why private and not an env var.** #6089 asks a decision question: should an operator-supplied update endpoint be allowed to bypass the GitHub host allowlist? This PR avoids answering it rather than answering it wrongly. `ops::validate_download_url` pins asset downloads to `github.com` / `api.github.com` / `*.githubusercontent.com` **on purpose**; a runtime-overridable release endpoint would be a self-update redirection primitive on the highest-trust path in the product. A private fn reachable only from the unit suite gives the testability without the primitive, and is what #6089's own Solution section prefers ("a compile-gated or test-only seam over a runtime env var").

The last test guards the refactor itself: if someone later makes the base URL configurable at runtime, `the_default_origin_is_still_the_pinned_github_api` is what breaks.

## Impact

- No behaviour change in a shipped binary — the URL is byte-identical, and there is a test asserting that.
- The self-update path is the highest-trust code in the product; this PR deliberately adds no new way to influence it at runtime.
- Tests use `wiremock` (already a dev-dependency) against a local server; they introduce no network dependency and remove reliance on `api.github.com` for coverage of this path.

## Related

- Closes tinyhumansai/openhuman#6089
- Follow-up PR(s)/TODOs: `scheduler::tick()` is still untested. The seam this PR adds is private, so testing `tick()` needs either a wider seam or a scheduler-level injection point — a separate decision.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — 5 in `src/openhuman/platform/update/core_tests.rs`: platform asset selection against a decoy, the no-update branch, a 403 rate-limit response, a malformed body, and an endpoint pin.
- [x] **Diff coverage ≥ 80%** — ran `cargo test --lib --features "$(bash scripts/ci/product-features.sh)" -- platform::update::` → 47 passed, 0 failed. Not measured with `diff-cover` locally. The changed lines are the URL construction and the two-line wrapper, both executed by these tests.
- [x] N/A: no feature rows added, removed or renamed — `docs/TEST-COVERAGE-MATRIX.md` untouched.
- [x] N/A: no matrix feature IDs affected, per the item above.
- [x] No new external network dependencies introduced — this PR *removes* one. The tests use `wiremock` (already a dev-dependency) against a local server; before this change the only way to exercise this path was a live call to `api.github.com`.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — reviewed `docs/RELEASE-MANUAL-SMOKE.md` and made no change: the self-update flow is already covered there, and this PR is a test-seam extraction whose shipped behaviour is asserted byte-identical by `the_default_origin_is_still_the_pinned_github_api`.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Verification

```
# fix applied
running 47 tests ... test result: ok. 47 passed; 0 failed
  check_available_parses_a_release_and_picks_this_platforms_asset ... ok
  check_available_reports_no_update_for_an_older_tag              ... ok
  check_available_surfaces_a_non_2xx_as_a_github_api_error        ... ok
  check_available_surfaces_a_malformed_body_as_a_parse_error      ... ok
  the_default_origin_is_still_the_pinned_github_api               ... ok

# revert-check: base_url ignored, endpoint hard-coded again
running 4 tests ... test result: FAILED. 0 passed; 4 failed

  "the leading v is stripped"   left: "0.63.12"  right: "99.0.0"
  "a 403 must not be reported as a successful check:
     UpdateInfo { latest_version: "0.63.12", ... }"
  assertion `left == right` failed  left: "0.63.12"  right: "0.0.1"
```

With the seam removed the tests reach the live `api.github.com` and parse the real v0.63.12 release instead of the mock — which is the issue's complaint, reproduced. Source restored byte-identical afterwards.

---

## AI Authored PR Metadata

### Linear Issue

- Key: N/A — filed from the e2e coverage wave on GitHub, no Linear issue.
- URL: N/A

### Commit & Branch

- Branch: `fix/6089-update-check-injectable-base-url`
- Commit SHA: `d67ca5380`

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend files changed.
- [x] N/A: `pnpm typecheck` — no TypeScript changed.
- [x] Focused tests: `cargo test --lib --features "<product>" -- platform::update::` → 47 passed, and the revert-check above.
- [x] Rust fmt/check (if changed): covered by the focused test build under the product feature set.
- [x] N/A: Tauri fmt/check — `app/src-tauri` untouched.

### Behavior Changes

- Intended behavior change: none in a shipped binary. This is a test seam.
- User-visible effect: none. `the_default_origin_is_still_the_pinned_github_api` asserts the URL `check_available()` builds is byte-identical to the previous literal.

### Parity Contract

- Legacy behavior preserved: only the URL construction moved. The transport-failure classifier, both observability branches, the non-2xx handling, JSON parsing and asset selection are untouched, and the 42 pre-existing `platform::update::` tests stay green.
- Guard/fallback/dispatch parity checks: `ops::validate_download_url`'s GitHub host allowlist is deliberately not touched, and the seam is private so no runtime path can reach it.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none — timeline checked immediately before starting.
- Canonical PR: this one.
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for software update checks, including platform-specific release assets, version detection, release metadata, API errors, and malformed responses.
  - Added validation that the default update service endpoint and generated release URL remain unchanged.
- **Refactor**
  - Improved the internal structure of update checking while preserving existing behavior and public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->