### PR TITLE
fix(tests): send the bearer the process validates, not each suite's own literal

### DIFF
--- a/tests/raw_coverage/connectivity_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/connectivity_raw_coverage_e2e.rs
@@ -104,6 +104,20 @@ fn ensure_rpc_auth() {
     });
 }
 
+/// The bearer this process actually validates.
+///
+/// `core::auth::RPC_TOKEN` is a process-global `OnceLock` and `init_rpc_token`
+/// returns early once it is set — deliberately, so a second call cannot 401 live
+/// clients. Since `tests/raw_coverage/` is one aggregated binary, only the first
+/// suite to reach `ensure_rpc_auth` pins its own `TEST_RPC_TOKEN`; every other
+/// suite sending its literal gets a 401 and trips its own `assert_eq!` (#6112).
+/// Ask the auth module what it settled on instead of assuming we won the race.
+fn rpc_bearer() -> &'static str {
+    ensure_rpc_auth();
+    openhuman_core::core::auth::get_rpc_token()
+        .expect("ensure_rpc_auth initialises the token subsystem on the line above")
+}
+
 async fn serve_rpc() -> (
     SocketAddr,
     tokio::task::JoinHandle<Result<(), std::io::Error>>,
@@ -169,8 +183,8 @@ async fn rpc(rpc_base: &str, id: i64, method: &str, params: Value) -> Value {
         .expect("client");
     let response = client
         .post(rpc_base)
-        .bearer_auth(TEST_RPC_TOKEN)
-        .header(AUTHORIZATION, format!("Bearer {TEST_RPC_TOKEN}"))
+        .bearer_auth(rpc_bearer())
+        .header(AUTHORIZATION, format!("Bearer {}", rpc_bearer()))
         .json(&json!({
             "jsonrpc": "2.0",
             "id": id,

--- a/tests/raw_coverage/connectivity_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/connectivity_raw_coverage_e2e.rs
@@ -9,7 +9,6 @@ use std::net::{SocketAddr, TcpListener as StdTcpListener};
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};
 
-use axum::http::header::AUTHORIZATION;
 use reqwest::StatusCode;
 use serde_json::{json, Value};
 use tempfile::{tempdir, TempDir};
@@ -184,7 +183,6 @@ async fn rpc(rpc_base: &str, id: i64, method: &str, params: Value) -> Value {
     let response = client
         .post(rpc_base)
         .bearer_auth(rpc_bearer())
-        .header(AUTHORIZATION, format!("Bearer {}", rpc_bearer()))
         .json(&json!({
             "jsonrpc": "2.0",
             "id": id,

--- a/tests/raw_coverage/rpc_bearer_hygiene_e2e.rs
+++ b/tests/raw_coverage/rpc_bearer_hygiene_e2e.rs
@@ -10,16 +10,65 @@
 //!
 //! The fix is for every suite to send `get_rpc_token()` — the token the process
 //! actually validates — rather than the literal it hoped to install. This scans
-//! the sibling sources for the literal form so a *new* suite cannot reintroduce
-//! it, which a runtime assertion in one file could not do.
+//! the sibling sources so a *new* suite cannot reintroduce the literal, which a
+//! runtime assertion in one file could not do: that assertion passes whenever its
+//! own file happens to win the scheduling race.
 
 use std::path::Path;
 
-/// Substrings that mean "this suite sends its own literal".
-const FORBIDDEN: &[&str] = &[
-    "bearer_auth(TEST_RPC_TOKEN)",
-    "Bearer {TEST_RPC_TOKEN}",
-];
+/// Does this line send the suite's own `TEST_RPC_TOKEN` as a bearer?
+///
+/// Matches on the *combination* rather than on fixed spellings. An earlier
+/// version listed two literal forms and missed `format!("Bearer {}",
+/// TEST_RPC_TOKEN)` and `bearer_auth(&TEST_RPC_TOKEN)`, which send the same
+/// wrong token (thanks to CodeRabbit on #6124 for catching it). Any line that
+/// names the suite-local constant *and* an authorization-sending construct is
+/// the bug, however it is spelled — including spellings nobody has invented yet.
+///
+/// Comments are exempt: several suites legitimately explain the hazard in prose.
+fn line_sends_local_token(line: &str) -> bool {
+    let code = line.trim_start();
+    if code.starts_with("//") {
+        return false;
+    }
+    code.contains("TEST_RPC_TOKEN") && (code.contains("Bearer") || code.contains("bearer_auth"))
+}
+
+#[test]
+fn the_detector_catches_every_spelling_of_the_bug() {
+    // The two forms the original guard caught.
+    assert!(line_sends_local_token(
+        r#"        .bearer_auth(TEST_RPC_TOKEN)"#
+    ));
+    assert!(line_sends_local_token(
+        r#"        .header(AUTHORIZATION, format!("Bearer {TEST_RPC_TOKEN}"))"#
+    ));
+    // The two it missed.
+    assert!(line_sends_local_token(
+        r#"        .header(AUTHORIZATION, format!("Bearer {}", TEST_RPC_TOKEN))"#
+    ));
+    assert!(line_sends_local_token(
+        r#"        .bearer_auth(&TEST_RPC_TOKEN)"#
+    ));
+    // And a spelling none of the suites use today.
+    assert!(line_sends_local_token(
+        r#"        let h = String::from("Bearer ") + TEST_RPC_TOKEN;"#
+    ));
+
+    // Must NOT fire: the correct call, the seed, the declaration, and prose.
+    assert!(!line_sends_local_token(
+        r#"        .header(AUTHORIZATION, format!("Bearer {}", rpc_bearer()))"#
+    ));
+    assert!(!line_sends_local_token(
+        r#"        std::env::set_var(CORE_TOKEN_ENV_VAR, TEST_RPC_TOKEN);"#
+    ));
+    assert!(!line_sends_local_token(
+        r#"const TEST_RPC_TOKEN: &str = "connectivity-raw-coverage-e2e-token";"#
+    ));
+    assert!(!line_sends_local_token(
+        r#"/// suite sending its own TEST_RPC_TOKEN as a Bearer gets a 401."#
+    ));
+}
 
 #[test]
 fn no_raw_coverage_suite_sends_a_hard_coded_bearer() {
@@ -32,17 +81,19 @@ fn no_raw_coverage_suite_sends_a_hard_coded_bearer() {
         if path.extension().and_then(|e| e.to_str()) != Some("rs") {
             continue;
         }
-        if path.file_name().and_then(|n| n.to_str()) == Some("rpc_bearer_hygiene_e2e.rs") {
-            continue; // this file names the literals on purpose
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default()
+            .to_string();
+        if name == "rpc_bearer_hygiene_e2e.rs" {
+            continue; // this file names the forbidden forms on purpose
         }
         let source = std::fs::read_to_string(&path).expect("suite source must be readable");
         scanned += 1;
-        for needle in FORBIDDEN {
-            if source.contains(needle) {
-                offenders.push(format!(
-                    "{}: sends {needle} — use the process token instead",
-                    path.file_name().and_then(|n| n.to_str()).unwrap_or("?")
-                ));
+        for (i, line) in source.lines().enumerate() {
+            if line_sends_local_token(line) {
+                offenders.push(format!("{name}:{}: {}", i + 1, line.trim()));
             }
         }
     }

--- a/tests/raw_coverage/rpc_bearer_hygiene_e2e.rs
+++ b/tests/raw_coverage/rpc_bearer_hygiene_e2e.rs
@@ -1,0 +1,64 @@
+//! #6112 regression guard: no aggregated suite may send a hard-coded bearer.
+//!
+//! `core::auth::RPC_TOKEN` is a process-global `OnceLock` and `init_rpc_token`
+//! returns early once it is set — deliberately, so a second call cannot 401 live
+//! clients. Since `tests/raw_coverage/` is one binary, only the first suite to
+//! initialise it pins its own `TEST_RPC_TOKEN`; any suite that then sends its own
+//! literal is answered `401` and trips its own `assert_eq!(status, OK)`. Which
+//! suites fail depends on libtest scheduling, so the failure is load-dependent
+//! and invisible to CI, which runs one process per module filter.
+//!
+//! The fix is for every suite to send `get_rpc_token()` — the token the process
+//! actually validates — rather than the literal it hoped to install. This scans
+//! the sibling sources for the literal form so a *new* suite cannot reintroduce
+//! it, which a runtime assertion in one file could not do.
+
+use std::path::Path;
+
+/// Substrings that mean "this suite sends its own literal".
+const FORBIDDEN: &[&str] = &[
+    "bearer_auth(TEST_RPC_TOKEN)",
+    "Bearer {TEST_RPC_TOKEN}",
+];
+
+#[test]
+fn no_raw_coverage_suite_sends_a_hard_coded_bearer() {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/raw_coverage");
+    let mut offenders = Vec::new();
+    let mut scanned = 0usize;
+
+    for entry in std::fs::read_dir(&dir).expect("tests/raw_coverage must be readable") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+            continue;
+        }
+        if path.file_name().and_then(|n| n.to_str()) == Some("rpc_bearer_hygiene_e2e.rs") {
+            continue; // this file names the literals on purpose
+        }
+        let source = std::fs::read_to_string(&path).expect("suite source must be readable");
+        scanned += 1;
+        for needle in FORBIDDEN {
+            if source.contains(needle) {
+                offenders.push(format!(
+                    "{}: sends {needle} — use the process token instead",
+                    path.file_name().and_then(|n| n.to_str()).unwrap_or("?")
+                ));
+            }
+        }
+    }
+
+    // An empty scan is a failure, not a pass: if the glob ever stops matching,
+    // this test would otherwise report clean having read nothing.
+    assert!(
+        scanned > 10,
+        "expected to scan the raw_coverage suites, only saw {scanned} file(s) in {}",
+        dir.display()
+    );
+    assert!(
+        offenders.is_empty(),
+        "raw_coverage suites must send `core::auth::get_rpc_token()`, not their own \
+         `TEST_RPC_TOKEN` literal — only the first suite in the process wins that race \
+         (#6112):\n  {}",
+        offenders.join("\n  ")
+    );
+}

--- a/tests/raw_coverage/tool_registry_approval_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/tool_registry_approval_raw_coverage_e2e.rs
@@ -102,6 +102,20 @@ fn ensure_rpc_auth() {
     });
 }
 
+/// The bearer this process actually validates.
+///
+/// `core::auth::RPC_TOKEN` is a process-global `OnceLock` and `init_rpc_token`
+/// returns early once it is set — deliberately, so a second call cannot 401 live
+/// clients. Since `tests/raw_coverage/` is one aggregated binary, only the first
+/// suite to reach `ensure_rpc_auth` pins its own `TEST_RPC_TOKEN`; every other
+/// suite sending its literal gets a 401 and trips its own `assert_eq!` (#6112).
+/// Ask the auth module what it settled on instead of assuming we won the race.
+fn rpc_bearer() -> &'static str {
+    ensure_rpc_auth();
+    openhuman_core::core::auth::get_rpc_token()
+        .expect("ensure_rpc_auth initialises the token subsystem on the line above")
+}
+
 async fn serve_rpc() -> (
     std::net::SocketAddr,
     tokio::task::JoinHandle<Result<(), std::io::Error>>,
@@ -199,7 +213,7 @@ async fn rpc(rpc_base: &str, id: i64, method: &str, params: Value) -> Value {
     let url = format!("{}/rpc", rpc_base.trim_end_matches('/'));
     let response = client
         .post(&url)
-        .header(AUTHORIZATION, format!("Bearer {TEST_RPC_TOKEN}"))
+        .header(AUTHORIZATION, format!("Bearer {}", rpc_bearer()))
         .json(&json!({
             "jsonrpc": "2.0",
             "id": id,

--- a/tests/raw_coverage/tools_approval_channels_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/tools_approval_channels_raw_coverage_e2e.rs
@@ -367,6 +367,20 @@ fn ensure_rpc_auth() {
     });
 }
 
+/// The bearer this process actually validates.
+///
+/// `core::auth::RPC_TOKEN` is a process-global `OnceLock` and `init_rpc_token`
+/// returns early once it is set — deliberately, so a second call cannot 401 live
+/// clients. Since `tests/raw_coverage/` is one aggregated binary, only the first
+/// suite to reach `ensure_rpc_auth` pins its own `TEST_RPC_TOKEN`; every other
+/// suite sending its literal gets a 401 and trips its own `assert_eq!` (#6112).
+/// Ask the auth module what it settled on instead of assuming we won the race.
+fn rpc_bearer() -> &'static str {
+    ensure_rpc_auth();
+    openhuman_core::core::auth::get_rpc_token()
+        .expect("ensure_rpc_auth initialises the token subsystem on the line above")
+}
+
 async fn serve_rpc() -> (
     std::net::SocketAddr,
     tokio::task::JoinHandle<Result<(), std::io::Error>>,
@@ -729,7 +743,7 @@ async fn rpc(rpc_base: &str, id: i64, method: &str, params: Value) -> Value {
     let url = format!("{}/rpc", rpc_base.trim_end_matches('/'));
     let response = client
         .post(&url)
-        .header(AUTHORIZATION, format!("Bearer {TEST_RPC_TOKEN}"))
+        .header(AUTHORIZATION, format!("Bearer {}", rpc_bearer()))
         .json(&json!({
             "jsonrpc": "2.0",
             "id": id,

--- a/tests/raw_coverage/worker_b_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/worker_b_raw_coverage_e2e.rs
@@ -104,6 +104,20 @@ fn ensure_rpc_auth() {
     });
 }
 
+/// The bearer this process actually validates.
+///
+/// `core::auth::RPC_TOKEN` is a process-global `OnceLock` and `init_rpc_token`
+/// returns early once it is set — deliberately, so a second call cannot 401 live
+/// clients. Since `tests/raw_coverage/` is one aggregated binary, only the first
+/// suite to reach `ensure_rpc_auth` pins its own `TEST_RPC_TOKEN`; every other
+/// suite sending its literal gets a 401 and trips its own `assert_eq!` (#6112).
+/// Ask the auth module what it settled on instead of assuming we won the race.
+fn rpc_bearer() -> &'static str {
+    ensure_rpc_auth();
+    openhuman_core::core::auth::get_rpc_token()
+        .expect("ensure_rpc_auth initialises the token subsystem on the line above")
+}
+
 async fn serve_rpc() -> (
     SocketAddr,
     tokio::task::JoinHandle<Result<(), std::io::Error>>,
@@ -277,7 +291,7 @@ async fn rpc(rpc_base: &str, id: i64, method: &str, params: Value) -> Value {
     let url = format!("{}/rpc", rpc_base.trim_end_matches('/'));
     let response = client
         .post(&url)
-        .header(AUTHORIZATION, format!("Bearer {TEST_RPC_TOKEN}"))
+        .header(AUTHORIZATION, format!("Bearer {}", rpc_bearer()))
         .json(&json!({
             "jsonrpc": "2.0",
             "id": id,


### PR DESCRIPTION
## Summary

- The four `raw_coverage` suites that authenticate over HTTP now send the bearer the **process** validates (`core::auth::get_rpc_token()`) instead of their own `TEST_RPC_TOKEN` literal (#6112).
- Adds a regression guard that fails if any suite in `tests/raw_coverage/` reintroduces a hard-coded bearer — including a suite that does not exist yet.
- Test-only. No production code is touched.

## Problem

`core::auth::RPC_TOKEN` is a process-global `OnceLock`, and `init_rpc_token` returns early once it is set — deliberately, so a second call cannot 401 live clients. That early return is load-bearing and is **not** changed here.

Since `tests/raw_coverage/` was collapsed into one aggregated binary, only the *first* suite to reach `ensure_rpc_auth()` pins the bearer for the whole process. Every other suite kept sending `Bearer <its own TEST_RPC_TOKEN>`, which no longer matches, so `POST /rpc` answers `401` and that suite's own `assert_eq!(status, OK)` fails. Which suites lose depends on libtest scheduling.

Running all four in one process:

```
running 74 tests
test result: FAILED. 63 passed; 11 failed; 0 ignored; 0 measured; 422 filtered out

  connectivity_raw_coverage_e2e              ok=8   FAILED=0   <-- won the token race
  tool_registry_approval_raw_coverage_e2e    ok=10  FAILED=2
  tools_approval_channels_raw_coverage_e2e   ok=23  FAILED=2
  worker_b_raw_coverage_e2e                  ok=0   FAILED=4   <-- every RPC test lost

tool_registry_approval_raw_coverage_e2e.rs:212:5
  assertion `left == right` failed: openhuman.approval_list_pending HTTP status
    left: 401
   right: 200
```

**Why CI is green today.** `scripts/ci/rust-coverage-changed.sh:200-217` runs one process per module filter, with a comment naming "auth tokens" as one of the globals it is preserving isolation for. So CI never puts two of these suites in one process and nothing is blocked there. What is broken is the unfiltered `cargo test --test raw_coverage_all`, which is the natural command to type and fails confusingly.

## Solution

Each suite gains a three-line `rpc_bearer()` that calls `ensure_rpc_auth()` and then asks `get_rpc_token()` what the process settled on. Each file still seeds `CORE_TOKEN_ENV_VAR` with its own `TEST_RPC_TOKEN`, so a suite that *does* win the race is unaffected; it simply no longer assumes it won.

The regression guard is a source scan rather than a runtime assertion, because a runtime assertion in one file passes whenever that file happens to win the scheduling race — it could not fail deterministically, and it could not see a *new* suite reintroducing the literal. The scan asserts it read more than ten files, so an empty scan is a failure rather than a silent pass.

## Impact

- Test-only; no shipped code changes.
- `init_rpc_token`'s early return is untouched — it is what stops a second call from 401'ing live clients.
- Removes 11 of the 12 failures in the unfiltered run. **It does not make that command green** — see below. It does not change the per-module split in `rust-coverage-changed.sh`, which is still what isolates `SHARED_ENV_LOCK`, the event bus and the singleton stores.

### One failure remains, from a different cause

```
before:  63 passed; 12 failed      (11 x 401, plus the new hygiene guard)
after:   74 passed;  1 failed
```

The survivor is
`tools_channels_raw_coverage_e2e::prior_tools_approval_channels_raw_coverage_e2e::proactive_subscriber_routes_web_and_active_external_channel_without_network`,
failing `left: 0, right: 1` — a subscriber count, not an HTTP status.

`tools_channels_raw_coverage_e2e.rs:58` `#[path]`-includes
`tools_approval_channels_raw_coverage_e2e.rs` as a nested module, while `build.rs` also
globs it in at top level. The file is therefore compiled **twice** into one binary and the
two copies race on process globals; the top-level copy of that same test passed in the same
run. The include is upstream (#4721, `04ffc029a`, 2026-07-10) and this PR's diff to that
suite is auth-only, so it is not caused here — it fails identically with these four files
reverted. Reported separately rather than fixed, since it needs a decision about why the
include exists.

## Related

- Closes tinyhumansai/openhuman#6112
- Follow-up PR(s)/TODOs: while running the four suites together, `tools_channels_raw_coverage_e2e::prior_tools_approval_channels_raw_coverage_e2e::*` showed the same three test bodies compiled a second time inside another module — duplicated work in every CI run, worth a separate look. Not addressed here.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — `tests/raw_coverage/rpc_bearer_hygiene_e2e.rs` guards against reintroduction, and the 74 RPC assertions across the four suites are themselves the happy path: they only pass once every suite sends the process token.
- [x] **Diff coverage ≥ 80%** — test-only diff; every changed line is executed by the four-suites-in-one-process run below. Not measured with `diff-cover` locally.
- [x] N/A: no feature rows added, removed or renamed — `docs/TEST-COVERAGE-MATRIX.md` untouched.
- [x] N/A: no matrix feature IDs affected, per the item above.
- [x] No new external network dependencies introduced — the suites bind a loopback router, as before.
- [x] N/A: does not touch a release-cut surface — test files only, no production code.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section.

## Verification

```
# all four token-holding suites + the hygiene guard, ONE process
before:  running 75 tests ... 63 passed; 12 failed
after:   running 75 tests ... 74 passed;  1 failed

# revert-check: all four reverted to their own literals.
# Reverting only one proves nothing — the other three would still ask for the
# process token and pass.
  rpc_bearer_hygiene_e2e::no_raw_coverage_suite_sends_a_hard_coded_bearer   FAILED
  worker_b_raw_coverage_e2e::*                                             FAILED (4)
  tool_registry_approval_raw_coverage_e2e::*                               FAILED (2)
  tools_approval_channels_raw_coverage_e2e::*                              FAILED (2)
  tools_channels_raw_coverage_e2e::prior_...::*                            FAILED (3)

  assertion `left == right` failed: openhuman.approval_list_pending HTTP status
    left: 401
   right: 200
```

All four files restored byte-identical afterwards.

---

## AI Authored PR Metadata

### Linear Issue

- Key: N/A — filed from the e2e coverage wave on GitHub, no Linear issue.
- URL: N/A

### Commit & Branch

- Branch: `fix/6112-raw-coverage-shared-bearer`
- Commit SHA: `953bd1781`

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend files changed.
- [x] N/A: `pnpm typecheck` — no TypeScript changed.
- [x] Focused tests: `cargo test --test raw_coverage_all --features "<product>" -- connectivity_raw_coverage worker_b_raw_coverage tool_registry_approval tools_approval_channels rpc_bearer_hygiene`, both arms above.
- [x] Rust fmt/check (if changed): covered by the integration-target build under the product feature set.
- [x] N/A: Tauri fmt/check — `app/src-tauri` untouched.

### Behavior Changes

- Intended behavior change: none in production. Test files only.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: `init_rpc_token`'s early return is untouched — it is what stops a second call from 401'ing live clients. Each suite still seeds `CORE_TOKEN_ENV_VAR` with its own literal, so a suite that wins the race behaves exactly as before.
- Guard/fallback/dispatch parity checks: the per-module process split in `scripts/ci/rust-coverage-changed.sh` is unchanged; this PR does not rely on it and does not weaken it.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none — timeline checked immediately before starting.
- Canonical PR: this one.
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication reliability across integrated test runs by consistently using the active RPC access token, preventing intermittent authorization failures caused by conflicting token configuration.

- **Tests**
  - Added regression coverage to detect hard-coded authentication tokens in test requests, including alternate formatting patterns.
  - Enhanced diagnostics to identify the exact source line responsible for invalid token usage.
  - Added coverage for shared authentication state across multiple test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->