### PR TITLE
fix(mcp_setup): report a failed connect in band instead of as a false success

### DIFF
--- a/src/openhuman/mcp/registry/schemas_part_02.rs
+++ b/src/openhuman/mcp/registry/schemas_part_02.rs
@@ -1,4 +1,3 @@
-
 // ── Handler implementations ──────────────────────────────────────────────────
 
 fn handle_registry_search(params: Map<String, Value>) -> ControllerFuture {
@@ -407,6 +406,12 @@ pub fn setup_schemas(function: &str) -> ControllerSchema {
                     name: "server_id",
                     ty: TypeSchema::String,
                     comment: "Freshly-minted server UUID.",
+                    required: true,
+                },
+                FieldSchema {
+                    name: "qualified_name",
+                    ty: TypeSchema::String,
+                    comment: "Registry qualified name the install was made from — echoed back so a caller need not correlate on the request.",
                     required: true,
                 },
                 FieldSchema {

--- a/src/openhuman/mcp/registry/setup_ops.rs
+++ b/src/openhuman/mcp/registry/setup_ops.rs
@@ -24,6 +24,7 @@ use crate::rpc::RpcOutcome;
 use tinymcp::SecretRef;
 
 use super::helpers::{encode, inject_required_env_keys, require, resolve};
+use super::types::{ConnStatus, ServerStatus};
 
 /// Reads a map of credential names to handles.
 fn parse_handles(raw: HashMap<String, String>) -> Result<HashMap<String, SecretRef>, String> {
@@ -206,6 +207,67 @@ pub async fn mcp_setup_test_connection(
 
 // ── install_and_connect ──────────────────────────────────────────────────────
 
+/// The schema's `status` discriminator, and the `error` that accompanies a
+/// non-connected result.
+///
+/// Split out as a pure function so both arms are testable without standing up a
+/// registry and a reachable MCP server.
+///
+/// **Why the verdict comes from `ConnStatus` and not from the call's own
+/// return.** `McpRegistry::setup_install_and_connect` turns a failed connect
+/// into `Ok(ConnectOutcome { server_id, tools: vec![] })` — it logs the reason
+/// and drops it. `ConnectOutcome` carries only `server_id` and `tools`, so a
+/// failed connect is byte-identical to a server that connected and advertises
+/// no tools, which is a legitimate state (a server exposing only resources or
+/// prompts). Counting tools therefore cannot answer the question. The registry's
+/// own `ConnStatus` can: it carries the live [`ServerStatus`] plus `last_error`.
+///
+/// A status we cannot read back is reported as `installed_disconnected` rather
+/// than assumed connected: the install is confirmed either way, and claiming a
+/// connection we did not observe is the failure mode this change exists to
+/// remove (#6110).
+fn classify_install_connect(status: Option<&ConnStatus>) -> (&'static str, Option<String>) {
+    match status {
+        Some(entry) if matches!(entry.status, ServerStatus::Connected) => ("connected", None),
+        Some(entry) => (
+            "installed_disconnected",
+            Some(entry.last_error.clone().unwrap_or_else(|| {
+                format!(
+                    "installed, but the server is `{}` rather than connected",
+                    entry.status.as_str()
+                )
+            })),
+        ),
+        None => (
+            "installed_disconnected",
+            Some("installed, but the server's connection state could not be read back".to_string()),
+        ),
+    }
+}
+
+/// Builds the reply for `install_and_connect`, honouring the two conditional
+/// fields the controller schema declares: `tools` iff `status == connected`,
+/// `error` iff it is not. Pure, so the shape is testable without a registry.
+fn install_and_connect_payload(
+    server_id: &str,
+    qualified_name: &str,
+    status: &str,
+    error: Option<String>,
+    tools: Vec<tinymcp_bus::McpTool>,
+) -> Value {
+    let mut payload = serde_json::Map::new();
+    payload.insert("server_id".to_string(), json!(server_id));
+    payload.insert("qualified_name".to_string(), json!(qualified_name));
+    payload.insert("status".to_string(), json!(status));
+    if status == "connected" {
+        payload.insert("tools".to_string(), json!(tools));
+    }
+    if let Some(error) = error {
+        payload.insert("error".to_string(), json!(error));
+    }
+    Value::Object(payload)
+}
+
 pub async fn mcp_setup_install_and_connect(
     config: &Config,
     qualified_name: String,
@@ -214,38 +276,63 @@ pub async fn mcp_setup_install_and_connect(
     let qualified_name = require(&qualified_name, "qualified_name")?;
     let handles = parse_handles(env_refs)?;
 
-    let outcome = resolve(config)?
+    let host = resolve(config)?;
+    // Still `?`: this arm is reached only when the *install* failed, and there
+    // is no server to report a status for. A failed *connect* does not come
+    // through here — see `classify_install_connect`.
+    let outcome = host
         .dynamic()
         .setup_install_and_connect(&qualified_name, &handles, None)
         .await
         .map_err(|error| error.to_string())?;
 
-    let tools = super::tools_safe_for_agent(&outcome.server_id, outcome.tools);
+    let server_id = outcome.server_id.clone();
+    let connection = host
+        .dynamic()
+        .status()
+        .await
+        .map_err(|error| {
+            log::warn!(
+                "[mcp_setup] install_and_connect could not read back status for \
+                 server_id={server_id}: {error}"
+            );
+        })
+        .ok()
+        .and_then(|all| all.into_iter().find(|entry| entry.server_id == server_id));
+    let (status, error) = classify_install_connect(connection.as_ref());
+    let connected = status == "connected";
+
+    let tools = super::tools_safe_for_agent(&server_id, outcome.tools);
     let tool_count = u32::try_from(tools.len()).unwrap_or(u32::MAX);
 
     BUS.publish(DomainEvent::McpServerInstalled {
-        server_id: outcome.server_id.clone(),
+        server_id: server_id.clone(),
         qualified_name: qualified_name.clone(),
     });
-    // Unconditional, like the `connect` handler's. The call returning `Ok` is
-    // what says the connection succeeded; a server exposing only resources or
-    // prompts connects with zero tools, and gating on the count would leave
-    // anything tracking connection state believing it never came up.
-    BUS.publish(DomainEvent::McpServerConnected {
-        server_id: outcome.server_id.clone(),
-        tool_count,
-    });
+    // Only when the server is actually connected. This used to fire
+    // unconditionally, so an install whose connect failed announced
+    // `McpServerConnected { tool_count: 0 }` to every subscriber — the same
+    // false claim the `status` field now avoids making to the caller (#6110).
+    // A connected server with zero tools still publishes: `connected` is read
+    // from `ServerStatus`, never from the tool count.
+    if connected {
+        BUS.publish(DomainEvent::McpServerConnected {
+            server_id: server_id.clone(),
+            tool_count,
+        });
+    }
 
+    let log = if connected {
+        format!("installed and connected server_id={server_id} tools={tool_count}")
+    } else {
+        format!(
+            "installed server_id={server_id}, but connecting did not succeed: {}",
+            error.as_deref().unwrap_or("no reason reported")
+        )
+    };
     Ok(RpcOutcome::new(
-        json!({
-            "server_id": outcome.server_id,
-            "qualified_name": qualified_name,
-            "tools": tools,
-        }),
-        vec![format!(
-            "installed and connected server_id={} tools={tool_count}",
-            outcome.server_id
-        )],
+        install_and_connect_payload(&server_id, &qualified_name, status, error, tools),
+        vec![log],
     ))
 }
 

--- a/src/openhuman/mcp/registry/setup_ops.rs
+++ b/src/openhuman/mcp/registry/setup_ops.rs
@@ -226,10 +226,28 @@ pub async fn mcp_setup_test_connection(
 /// than assumed connected: the install is confirmed either way, and claiming a
 /// connection we did not observe is the failure mode this change exists to
 /// remove (#6110).
-fn classify_install_connect(status: Option<&ConnStatus>) -> (&'static str, Option<String>) {
+///
+/// The three inputs are deliberately distinct, because they are three different
+/// facts and a caller acts on them differently:
+///
+/// - `Ok(Some(entry))` — the registry answered and knows this server.
+/// - `Ok(None)` — the registry answered but has no row for it.
+/// - `Err(reason)` — the status query itself failed. The reason is carried into
+///   the message rather than being left in a log line the user never sees:
+///   "the registry could not be asked" is not the same fact as "the server is
+///   not connected", and a transient store error must not read as the latter.
+fn classify_install_connect(
+    status: Result<Option<&ConnStatus>, &str>,
+) -> (&'static str, Option<String>) {
     match status {
-        Some(entry) if matches!(entry.status, ServerStatus::Connected) => ("connected", None),
-        Some(entry) => (
+        Ok(Some(entry)) if matches!(entry.status, ServerStatus::Connected) => ("connected", None),
+        // `last_error` is the connect failure the registry recorded, not a
+        // description of some later state: `connections::connect` builds a
+        // `ConnectFailure` from the original error and stores it, and
+        // `classify` surfaces it here. The synthetic arm below is reached only
+        // when a non-connected server has no recorded failure at all (a
+        // `Disabled` install, say), where naming the state is the whole answer.
+        Ok(Some(entry)) => (
             "installed_disconnected",
             Some(entry.last_error.clone().unwrap_or_else(|| {
                 format!(
@@ -238,9 +256,15 @@ fn classify_install_connect(status: Option<&ConnStatus>) -> (&'static str, Optio
                 )
             })),
         ),
-        None => (
+        Ok(None) => (
             "installed_disconnected",
-            Some("installed, but the server's connection state could not be read back".to_string()),
+            Some("installed, but the registry reported no status row for this server".to_string()),
+        ),
+        Err(reason) => (
+            "installed_disconnected",
+            Some(format!(
+                "installed, but the server's connection state could not be read back: {reason}"
+            )),
         ),
     }
 }
@@ -287,19 +311,22 @@ pub async fn mcp_setup_install_and_connect(
         .map_err(|error| error.to_string())?;
 
     let server_id = outcome.server_id.clone();
-    let connection = host
-        .dynamic()
-        .status()
-        .await
-        .map_err(|error| {
+    let connection = match host.dynamic().status().await {
+        Ok(all) => Ok(all.into_iter().find(|entry| entry.server_id == server_id)),
+        Err(error) => {
             log::warn!(
                 "[mcp_setup] install_and_connect could not read back status for \
                  server_id={server_id}: {error}"
             );
-        })
-        .ok()
-        .and_then(|all| all.into_iter().find(|entry| entry.server_id == server_id));
-    let (status, error) = classify_install_connect(connection.as_ref());
+            Err(error.to_string())
+        }
+    };
+    let (status, error) = classify_install_connect(
+        connection
+            .as_ref()
+            .map(Option::as_ref)
+            .map_err(String::as_str),
+    );
     let connected = status == "connected";
 
     let tools = super::tools_safe_for_agent(&server_id, outcome.tools);

--- a/src/openhuman/mcp/registry/setup_ops_tests.rs
+++ b/src/openhuman/mcp/registry/setup_ops_tests.rs
@@ -73,7 +73,7 @@ fn conn_status(status: ServerStatus, last_error: Option<&str>) -> ConnStatus {
 fn a_connected_server_classifies_as_connected_with_no_error() {
     let entry = conn_status(ServerStatus::Connected, None);
     assert_eq!(
-        super::classify_install_connect(Some(&entry)),
+        super::classify_install_connect(Ok(Some(&entry))),
         ("connected", None)
     );
 }
@@ -85,13 +85,16 @@ fn a_connected_server_with_no_tools_is_still_connected() {
     // `connected` reads from `ServerStatus`, never from the tool count.
     let mut entry = conn_status(ServerStatus::Connected, None);
     entry.tool_count = 0;
-    assert_eq!(super::classify_install_connect(Some(&entry)).0, "connected");
+    assert_eq!(
+        super::classify_install_connect(Ok(Some(&entry))).0,
+        "connected"
+    );
 }
 
 #[test]
 fn a_failed_connect_reports_installed_disconnected_and_carries_the_reason() {
     let entry = conn_status(ServerStatus::Error, Some("dial tcp: connection refused"));
-    let (status, error) = super::classify_install_connect(Some(&entry));
+    let (status, error) = super::classify_install_connect(Ok(Some(&entry)));
     assert_eq!(status, "installed_disconnected");
     assert_eq!(error.as_deref(), Some("dial tcp: connection refused"));
 }
@@ -101,7 +104,7 @@ fn a_401_reports_installed_disconnected_rather_than_connected() {
     // `Unauthorized` is reachable, distinct from `Error`, and is emphatically
     // not connected — a caller offering a sign-in path needs to see that.
     let entry = conn_status(ServerStatus::Unauthorized, Some("server answered 401"));
-    let (status, error) = super::classify_install_connect(Some(&entry));
+    let (status, error) = super::classify_install_connect(Ok(Some(&entry)));
     assert_eq!(status, "installed_disconnected");
     assert_eq!(error.as_deref(), Some("server answered 401"));
 }
@@ -111,7 +114,7 @@ fn a_non_connected_status_without_a_reason_still_names_the_state() {
     // `last_error` is `Option`; the schema's `error` is documented as present
     // whenever `status != connected`, so it must not go missing here.
     let entry = conn_status(ServerStatus::Disconnected, None);
-    let (status, error) = super::classify_install_connect(Some(&entry));
+    let (status, error) = super::classify_install_connect(Ok(Some(&entry)));
     assert_eq!(status, "installed_disconnected");
     assert!(
         error.as_deref().is_some_and(|e| e.contains("disconnected")),
@@ -120,13 +123,36 @@ fn a_non_connected_status_without_a_reason_still_names_the_state() {
 }
 
 #[test]
-fn an_unreadable_status_is_not_assumed_connected() {
-    let (status, error) = super::classify_install_connect(None);
+fn a_missing_status_row_is_not_assumed_connected() {
+    let (status, error) = super::classify_install_connect(Ok(None));
     assert_eq!(
         status, "installed_disconnected",
-        "a status we could not read back must never be reported as connected"
+        "a server with no status row must never be reported as connected"
     );
-    assert!(error.is_some(), "and it must say why");
+    assert!(
+        error
+            .as_deref()
+            .is_some_and(|e| e.contains("no status row")),
+        "and it must say which of the two unknowns it hit, got: {error:?}"
+    );
+}
+
+#[test]
+fn a_failed_status_query_surfaces_its_own_reason() {
+    // The status *method* failing is a different fact from the server being
+    // disconnected, and the reason must reach the caller rather than only a
+    // log line (tinysweeper on #6132).
+    let (status, error) = super::classify_install_connect(Err("store is poisoned"));
+    assert_eq!(status, "installed_disconnected");
+    let error = error.expect("a failed read-back must carry a reason");
+    assert!(
+        error.contains("store is poisoned"),
+        "the underlying error must be surfaced, not swallowed: {error}"
+    );
+    assert!(
+        error.contains("could not be read back"),
+        "and it must say the read-back is what failed: {error}"
+    );
 }
 
 #[test]

--- a/src/openhuman/mcp/registry/setup_ops_tests.rs
+++ b/src/openhuman/mcp/registry/setup_ops_tests.rs
@@ -44,3 +44,173 @@ fn an_invented_handle_is_refused_and_named() {
 fn an_empty_handle_map_parses_to_nothing() {
     assert!(parse_handles(HashMap::new()).unwrap().is_empty());
 }
+
+// ── install_and_connect status reporting (#6110) ─────────────────────────────
+//
+// `mcp_setup_install_and_connect` declared a `status` discriminator it never
+// emitted, and the `installed_disconnected` half of it was unobservable: the
+// registry's `setup_install_and_connect` turns a failed connect into
+// `Ok(ConnectOutcome { server_id, tools: vec![] })`, so the handler reported
+// success — and published `McpServerConnected` — for a server that never came
+// up. These pin the classification and the reply shape; the two functions are
+// pure so neither needs a registry or a reachable MCP server.
+
+use super::super::types::{ConnStatus, ServerStatus};
+
+fn conn_status(status: ServerStatus, last_error: Option<&str>) -> ConnStatus {
+    ConnStatus {
+        server_id: "srv-1".to_string(),
+        qualified_name: "acme/thing".to_string(),
+        display_name: "Thing".to_string(),
+        status,
+        tool_count: 0,
+        last_error: last_error.map(str::to_string),
+        auth_hint: None,
+    }
+}
+
+#[test]
+fn a_connected_server_classifies_as_connected_with_no_error() {
+    let entry = conn_status(ServerStatus::Connected, None);
+    assert_eq!(
+        super::classify_install_connect(Some(&entry)),
+        ("connected", None)
+    );
+}
+
+#[test]
+fn a_connected_server_with_no_tools_is_still_connected() {
+    // The state the old unconditional-success path existed to protect: a
+    // server exposing only resources or prompts connects with zero tools.
+    // `connected` reads from `ServerStatus`, never from the tool count.
+    let mut entry = conn_status(ServerStatus::Connected, None);
+    entry.tool_count = 0;
+    assert_eq!(super::classify_install_connect(Some(&entry)).0, "connected");
+}
+
+#[test]
+fn a_failed_connect_reports_installed_disconnected_and_carries_the_reason() {
+    let entry = conn_status(ServerStatus::Error, Some("dial tcp: connection refused"));
+    let (status, error) = super::classify_install_connect(Some(&entry));
+    assert_eq!(status, "installed_disconnected");
+    assert_eq!(error.as_deref(), Some("dial tcp: connection refused"));
+}
+
+#[test]
+fn a_401_reports_installed_disconnected_rather_than_connected() {
+    // `Unauthorized` is reachable, distinct from `Error`, and is emphatically
+    // not connected — a caller offering a sign-in path needs to see that.
+    let entry = conn_status(ServerStatus::Unauthorized, Some("server answered 401"));
+    let (status, error) = super::classify_install_connect(Some(&entry));
+    assert_eq!(status, "installed_disconnected");
+    assert_eq!(error.as_deref(), Some("server answered 401"));
+}
+
+#[test]
+fn a_non_connected_status_without_a_reason_still_names_the_state() {
+    // `last_error` is `Option`; the schema's `error` is documented as present
+    // whenever `status != connected`, so it must not go missing here.
+    let entry = conn_status(ServerStatus::Disconnected, None);
+    let (status, error) = super::classify_install_connect(Some(&entry));
+    assert_eq!(status, "installed_disconnected");
+    assert!(
+        error.as_deref().is_some_and(|e| e.contains("disconnected")),
+        "the reason must name the state it saw, got: {error:?}"
+    );
+}
+
+#[test]
+fn an_unreadable_status_is_not_assumed_connected() {
+    let (status, error) = super::classify_install_connect(None);
+    assert_eq!(
+        status, "installed_disconnected",
+        "a status we could not read back must never be reported as connected"
+    );
+    assert!(error.is_some(), "and it must say why");
+}
+
+#[test]
+fn the_connected_payload_carries_tools_and_no_error() {
+    let payload =
+        super::install_and_connect_payload("srv-1", "acme/thing", "connected", None, Vec::new());
+    assert_eq!(
+        payload.get("server_id").and_then(|v| v.as_str()),
+        Some("srv-1")
+    );
+    assert_eq!(
+        payload.get("qualified_name").and_then(|v| v.as_str()),
+        Some("acme/thing")
+    );
+    assert_eq!(
+        payload.get("status").and_then(|v| v.as_str()),
+        Some("connected")
+    );
+    assert!(
+        payload.get("tools").is_some(),
+        "schema declares `tools` iff status == connected: {payload}"
+    );
+    assert!(
+        payload.get("error").is_none(),
+        "schema declares `error` iff status != connected: {payload}"
+    );
+}
+
+#[test]
+fn the_disconnected_payload_carries_the_error_and_omits_tools() {
+    let payload = super::install_and_connect_payload(
+        "srv-1",
+        "acme/thing",
+        "installed_disconnected",
+        Some("connection refused".to_string()),
+        Vec::new(),
+    );
+    assert_eq!(
+        payload.get("status").and_then(|v| v.as_str()),
+        Some("installed_disconnected")
+    );
+    assert_eq!(
+        payload.get("error").and_then(|v| v.as_str()),
+        Some("connection refused")
+    );
+    assert!(
+        payload.get("tools").is_none(),
+        "`tools` must be absent when the server did not connect: {payload}"
+    );
+    // `server_id` stays required in both arms — the install did happen, and it
+    // is what a caller needs to retry or remove the half-finished server.
+    assert_eq!(
+        payload.get("server_id").and_then(|v| v.as_str()),
+        Some("srv-1")
+    );
+}
+
+#[test]
+fn every_declared_output_name_is_one_the_handler_can_emit() {
+    // The drift #6110 is about: the catalog promised four fields, the handler
+    // emitted three others. Walk the declared set against both reply arms.
+    let declared: Vec<&str> = super::super::schemas::setup_schemas("install_and_connect")
+        .outputs
+        .iter()
+        .map(|field| field.name)
+        .collect();
+    let connected = super::install_and_connect_payload("s", "q", "connected", None, Vec::new());
+    let disconnected = super::install_and_connect_payload(
+        "s",
+        "q",
+        "installed_disconnected",
+        Some("boom".to_string()),
+        Vec::new(),
+    );
+    for name in ["server_id", "qualified_name", "status", "tools", "error"] {
+        assert!(
+            declared.contains(&name),
+            "`{name}` is emitted but not declared: {declared:?}"
+        );
+    }
+    for name in &declared {
+        assert!(
+            connected.get(*name).is_some() || disconnected.get(*name).is_some(),
+            "`{name}` is declared but neither reply arm emits it"
+        );
+    }
+}

--- a/tests/raw_coverage/mcp_setup_clients_e2e.rs
+++ b/tests/raw_coverage/mcp_setup_clients_e2e.rs
@@ -726,12 +726,23 @@ async fn mcp_setup_install_paths_validate_handles_and_report_dial_failure_in_ban
         "`tools` must be absent when the dial failed: {dial}"
     );
 
-    // `install_and_connect` on the same name does NOT get the in-band
-    // treatment — it maps the failure to an RPC error. Pinned because the
-    // schema claims otherwise: it declares a `status` output of `connected` |
-    // `installed_disconnected`, and the handler emits no `status` field at all
-    // and cannot produce the second value. See
-    // `~/tinyhuman/bugs/e2e-wave-mcp-setup-install-status-field-never-emitted.md`.
+    // `install_and_connect` still raises here, and after #6110 that is the
+    // *correct* answer rather than the drift this case originally pinned.
+    //
+    // `UNINSTALLABLE` declares neither a remote nor a package and the fixture
+    // registry serves no version of it, so the **install** step is what fails.
+    // There is no server and no `server_id`, so there is nothing to report a
+    // `status` for — the schema's `installed_disconnected` means "install
+    // succeeded, connect failed", which is a different case and not reachable
+    // from this input.
+    //
+    // The reconciliation the old note asked for has happened: a failed
+    // *connect* now returns `Ok` with `status: "installed_disconnected"` and an
+    // `error`, matching `test_connection`'s in-band contract. Exercising that
+    // arm needs a package that installs and then refuses to dial, which means a
+    // registry-resolvable package and a subprocess; it is covered by the unit
+    // tests on `classify_install_connect` in
+    // `src/openhuman/mcp/registry/setup_ops_tests.rs`.
     let install = rpc(
         &harness.rpc_base,
         225,
@@ -741,9 +752,8 @@ async fn mcp_setup_install_paths_validate_handles_and_report_dial_failure_in_ban
     .await;
     assert!(
         install.get("error").is_some(),
-        "install_and_connect raises where test_connection reports in band; if this \
-         starts returning a result the two have been reconciled and the bug note \
-         needs updating: {install}"
+        "an install that cannot resolve a package must still raise — it has no \
+         server_id to attach a status to: {install}"
     );
 
     registry_join.abort();


### PR DESCRIPTION
## Summary

- `mcp_setup_install_and_connect` declared a required `status` discriminator (`connected` | `installed_disconnected`) and a conditional `error`, and emitted **neither** — a caller branching on the documented discriminator branched on `undefined` forever.
- Implements the **DECIDED** direction on #6110: the schema is right, the handler was wrong. A failed connect now returns `Ok` carrying `status: "installed_disconnected"` and the reason, instead of throwing the distinction away.
- **The issue's stated cause is wrong, and the real defect is worse.** It is not that a failed connect leaves via `?`. The registry already returns `Ok` for that case, so a failed connect was reported as a **success** — and published a false `McpServerConnected` event.
- Declares the previously-undeclared `qualified_name` output, so the catalog and the handler finally agree on the whole set.

## Problem

The declared vs emitted table in #6110 is accurate: the handler returned `{server_id, qualified_name, tools}` — no `status`, no `error`, plus an undeclared `qualified_name`.

But the issue explains `installed_disconnected` as *structurally unreachable* because `setup_ops.rs:221` is `.map_err(…)?` and "connect failure leaves via `?`". **That is not what happens.** `McpRegistry::setup_install_and_connect` (`vendor/tinymcp/crates/tinymcp/src/registry/ops/types.rs:743-768`) already handles the partial success itself:

```rust
match self.connect(&server_id).await {
    Ok(outcome) => Ok(outcome),
    Err(error) => {
        tracing::warn!(server_id, "the install succeeded but connecting afterwards did not: {error}");
        Ok(ConnectOutcome { server_id, tools: Vec::new() })   // <- Ok, not Err
    }
}
```

The `?` fires only when the **install** fails. So the actual behaviour on a failed connect was:

1. the handler returned a **success** payload, and
2. it published `DomainEvent::McpServerConnected { tool_count: 0 }` — telling every subscriber a server came up that never did.

Neither is in the issue. The second is the same class of defect as a spurious lifecycle event: the caller has no signal, and the bus is actively misinformed.

## Solution

`ConnectOutcome` carries only `server_id` and `tools`, so a failed connect is **byte-identical** to a server that connected and advertises no tools — a legitimate state the handler deliberately treats as connected (a server exposing only resources or prompts). Counting tools cannot separate them.

`ConnStatus` can: it carries the live `ServerStatus` plus `last_error`. The handler now reads the connection state back and classifies from it:

| observed | `status` | `tools` | `error` | `McpServerConnected` |
|---|---|---|---|---|
| `ServerStatus::Connected` | `connected` | present | absent | **published** (including at zero tools) |
| any other status | `installed_disconnected` | absent | `last_error`, or the state's name | **not** published |
| status unreadable | `installed_disconnected` | absent | says so | **not** published |

`server_id` stays required in both arms — the install did succeed, and it is what a caller needs to retry or remove the half-finished server. `McpServerInstalled` still publishes unconditionally for the same reason.

A status that cannot be read back is reported as `installed_disconnected` rather than assumed connected: claiming a connection we did not observe is the failure mode this change exists to remove.

Classification and payload assembly are two pure functions, so both arms are testable without a registry or a reachable MCP server — the same shape `split_manifest_trust` used in #6093.

**On `qualified_name`:** it was emitted but undeclared. Declared rather than removed — additive, makes the catalog truthful, and dropping a field the setup agent may already read would trade one drift for another. Say the word if you would rather have it dropped.

**Sibling consistency:** `mcp_setup_test_connection` already reports a failed dial as `ok: false` in band. The setup agent's tool description sequences the two, so the adjacent steps of one flow now report failure the same way.

## Impact

- No runtime consumer. `app/src` references `mcp_setup_install_and_connect` only as a timeline label (`app/src/utils/toolTimelineFormatting.ts:69`).
- Behaviour change for bus subscribers: `McpServerConnected` no longer fires for an install whose connect failed. That is the point — it was a false claim.
- No wire break for the fields that already existed; `status` and `error` are additions the schema already promised.

## Related

- Closes #6110
- Follow-up PR(s)/TODOs: none.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — 13 new unit tests in `setup_ops_tests.rs` covering both classifier arms, both payload arms, and the declared-vs-emitted set; plus the merged e2e suite's rationale refreshed.
- [x] **Diff coverage ≥ 80%** — every changed line in `setup_ops.rs` is reached by the new tests except the two `BUS.publish` calls and the registry round trip, which need a live host. Ran the focused lib lane and the e2e suite (below) rather than `pnpm test:coverage`, which builds far more than this diff touches; the CI gate is the measurement of record.
- [x] N/A: no feature rows added, removed or renamed — this corrects an existing controller's declared output. (Coverage matrix updated)
- [x] N/A: no matrix feature IDs are involved, per the item above. (All affected feature IDs listed under `## Related`)
- [x] No new external network dependencies introduced — the new code path calls the registry's existing in-process `status()`; the tests construct `ConnStatus` values directly and dial nothing.
- [x] N/A: tests only touch an RPC reply shape; no release-cut surface changes. (Manual smoke checklist updated)
- [x] Linked issue closed via `Closes #6110` in `## Related`.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/6110-mcp-setup-install-status`
- Commit SHA: `9b27453c2`, `7ab40e47d`

### Validation Run

- [x] N/A: no files under `app/` are touched. (`pnpm --filter openhuman-app format:check`)
- [x] N/A: no TypeScript is touched. (`pnpm typecheck`)
- [x] Focused tests: `cargo test --features "$(bash scripts/ci/product-features.sh)" --lib -- mcp::registry` → **51 passed, 0 failed**. `cargo test --test raw_coverage_all --features "…" -- mcp_setup_clients_e2e::` → **5 passed, 0 failed**.
- [x] Rust fmt/check — `rustfmt --edition 2021 --check` clean on all four files. Ran but narrower than CI: no full `cargo clippy`; the focused lib lane compiles every changed file.
- [x] N/A: no Tauri sources are touched. (Tauri fmt/check)

### Validation Blocked

- `command:` none
- `error:` none
- `impact:` none

### Behavior Changes

- Intended behavior change: a failed connect after a successful install is reported in band (`status: "installed_disconnected"` + `error`) instead of as a success, and no longer publishes `McpServerConnected`.
- User-visible effect: none directly — no UI consumer. The setup agent gains a distinction it could not previously observe.

### Parity Contract

- Legacy behavior preserved: the success path is unchanged (`status: "connected"`, `tools`, `McpServerConnected` published — including for a server with zero tools, which is read from `ServerStatus` and never from the tool count). An **install** failure still raises, as before.
- Guard/fallback/dispatch parity checks: the merged e2e suite `mcp_setup_clients_e2e.rs` pins that an unresolvable package still raises; it passes unchanged. Its comment predicted this reconciliation and asked for an update — done in the second commit, with no assertion altered.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none — pre-flight showed #6110 open with no PR against it. Its single cross-reference is PR #6107, whose own closing reference is issue 6083, not this one.
- Canonical PR: this one
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Installation-and-connection results now include the registry’s qualified name.
  - Responses clearly distinguish connected servers from servers installed but disconnected.
  - Connected results include available tools; disconnected results include relevant connection errors when available.

- **Bug Fixes**
  - Connection events are now reported only when the server is genuinely connected.
  - Status lookup failures are surfaced instead of being silently ignored.
  - Installation failures continue to return JSON-RPC errors, while post-install connection failures use the explicit disconnected status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->