### PR TITLE
test(flows): invert the two e2e assertions #6093 fixed (unblocks red main)

### DIFF
--- a/tests/raw_coverage/flows_lifecycle_e2e.rs
+++ b/tests/raw_coverage/flows_lifecycle_e2e.rs
@@ -930,19 +930,22 @@ async fn flows_approval_manifest_classifies_every_gated_node_kind() {
             "a candidate graph joined against no flow holds no grants: {already:?}"
         );
     } else {
-        // Gate uninstalled: nothing ever parks, so `missing` is empty by
-        // definition. The approvable keys are currently routed into
-        // `already_trusted` instead of a third state, which claims grants the
-        // flow does not hold — see
-        // `~/tinyhuman/bugs/e2e-wave-flows-approval-manifest-already-trusted-without-gate.md`.
-        // Pinned as-is so the fix has to come past this assertion.
+        // Gate uninstalled: nothing ever parks, so nothing is `missing`; and no
+        // grant was ever made, so nothing is `already_trusted` either.
+        // `gate_installed: false` is the caller's only signal.
+        //
+        // This branch used to assert the opposite — the approvable keys landed
+        // in `already_trusted`, claiming grants the flow did not hold. openhuman#6093
+        // fixed that (`split_manifest_trust` returns two empty lists when the
+        // gate is absent), so the assertion is inverted to the fixed behaviour.
         assert!(
             missing.is_empty(),
             "with no gate installed nothing can park, so nothing is missing: {missing:?}"
         );
         assert!(
-            already.contains(&"flows_http_request") && already.contains(&"flows_code"),
-            "current behaviour: un-gated approvable keys land in already_trusted: {already:?}"
+            already.is_empty(),
+            "with no gate installed no grant was ever made, so nothing is already \
+             trusted either: {already:?}"
         );
     }
     for list in [&missing, &already] {
@@ -1070,12 +1073,9 @@ async fn flows_tool_catalog_surface_degrades_without_composio_credentials() {
         "an unreachable catalog contributes zero rows rather than erroring: {search}"
     );
 
-    // The `<TOOLKIT>_<ACTION>` shape diagnostic. `toolkit_from_slug` splits on
-    // `_` and falls back to the whole string, so the ONLY input that reaches
-    // this message is one that trims to empty — a single-token slug like
-    // `nodashhere` is accepted as its own toolkit and fails later, at the
-    // catalog, with a much less useful message. See
-    // `~/tinyhuman/bugs/e2e-wave-flows-tool-contract-slug-guard-unreachable.md`.
+    // The `<TOOLKIT>_<ACTION>` shape diagnostic, checked before any I/O.
+    // A slug that trims to empty has no toolkit segment, so it is refused here
+    // rather than at the catalog.
     let malformed = h
         .err(
             1802,
@@ -1088,8 +1088,15 @@ async fn flows_tool_catalog_surface_degrades_without_composio_credentials() {
         "the shape diagnostic names the expected form: {malformed}"
     );
 
-    // Current behaviour for a single-token slug: it is treated as a toolkit
-    // name rather than rejected, so the failure surfaces at the catalog.
+    // A single-token slug has no action segment, so it cannot name an action a
+    // contract fetch could return — it is refused by the same shape guard.
+    //
+    // This used to assert the opposite: `toolkit_from_slug` falls back to the
+    // whole string, so `nodashhere` was accepted as its own toolkit and failed
+    // later at the catalog with an unrelated message. openhuman#6093 added
+    // `toolkit_for_contract_slug`, which requires non-empty segments either
+    // side of the first `_` before delegating, so the assertion is inverted to
+    // the fixed behaviour.
     let single_token = h
         .err(
             1806,
@@ -1098,8 +1105,13 @@ async fn flows_tool_catalog_surface_degrades_without_composio_credentials() {
         )
         .await;
     assert!(
-        single_token.contains("nodashhere") && single_token.contains("catalog"),
-        "a dashless slug is not caught by the shape guard: {single_token}"
+        single_token.contains("nodashhere") && single_token.contains("GMAIL_SEND_EMAIL"),
+        "a dashless slug is caught by the shape guard, quoting the caller's own slug \
+         and the expected form: {single_token}"
+    );
+    assert!(
+        !single_token.contains("catalog"),
+        "and it is refused before any catalog round trip: {single_token}"
     );
 
     let unreachable = h


### PR DESCRIPTION
## Summary

- Inverts two assertions in `tests/raw_coverage/flows_lifecycle_e2e.rs` that **deliberately pinned pre-fix behaviour**, and which #6093 then fixed four minutes after #6055 merged.
- `main` has been red on `Rust Core Coverage (cargo-llvm-cov)` since 08:44 UTC as a result. This is a test-only change; no production code is touched.
- Both assertions now assert what #6093 actually implemented, read from its diff rather than assumed.
- The "current behaviour" / "Pinned as-is" comments are rewritten — they described a bug that no longer exists, and leaving them would tell the next reader it is still live.

## Problem

#6055 (the e2e coverage wave) merged at **08:40:39 UTC**. It included two assertions that pinned behaviour I had reported as buggy, each with a comment saying so and a pointer to a bug file — the intent being that a fix would have to come past them.

#6093 merged at **08:44:56 UTC** and fixed exactly those two bugs. Its author could not have known: the tests had existed on `main` for four minutes.

Pinning current buggy behaviour is a legitimate way to make a reviewer confront it, but it is a tripwire with an owner. I wrote these; inverting them is mine.

## Solution

Read from #6093's diff, not inferred:

**1. `flows_approval_manifest_classifies_every_gated_node_kind`**

#6093 extracted `split_manifest_trust` (`src/openhuman/flows/ops_part_12.rs`), which returns two empty lists when the gate is absent:

```rust
if !gate_installed {
    return (missing, already_trusted);   // both empty
}
```

So with no gate installed `already_trusted` is now empty, where it previously carried every approvable key — claiming grants the flow did not hold. `gate_installed: false` is the caller's only signal, which #6093 also documented in the `already_trusted` field comment (`flows_schema_part_02.rs`).

The `else` branch now asserts `already.is_empty()` alongside the unchanged `missing.is_empty()`. The `gate_installed == true` branch is untouched and still passes.

**2. `flows_tool_catalog_surface_degrades_without_composio_credentials`**

#6093 added `toolkit_for_contract_slug`, which requires non-empty segments either side of the first `_` before delegating to the permissive `toolkit_from_slug`:

```rust
let (toolkit_segment, action_segment) = trimmed.split_once('_')?;
if toolkit_segment.is_empty() || action_segment.is_empty() { return None; }
```

So `nodashhere` is now refused by the shape guard, before any catalog round trip, instead of being accepted as its own toolkit and failing later with an unrelated "could not fetch the catalog" message.

The assertion now checks the error names both the caller's own slug and the expected form, plus a second assertion that it does **not** mention the catalog — pinning the "before any I/O" property #6093's doc comment calls out, so a regression that reintroduced the round trip would be caught.

The whitespace-slug case (`"   "`) is unchanged and still passes: it has no toolkit segment, so it takes the same guard.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — this PR *is* the test update; both changed cases already cover a failure path, and the slug case gains one assertion.
- [x] **Diff coverage ≥ 80%** — `N/A: test-only change, no production lines added or modified.` Verified with CI's own filter: `cargo test --test raw_coverage_all --features "$(bash scripts/ci/product-features.sh)" -- 'flows_lifecycle_e2e::' --test-threads=1`.
- [x] Coverage matrix updated — `N/A: no feature rows added, removed or renamed.`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature IDs involved.`
- [x] No new external network dependencies introduced — none; the second assertion explicitly pins that no catalog round trip happens.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: adds no product surface.`
- [x] Linked issue closed via `Closes #NNN` — `N/A: deliberately no issue. This is a four-hour-old self-inflicted break from our own merge ordering; filing an issue to close in the same breath would be noise.`

## Impact

Test-only. Unblocks `main` and every open PR failing `Rust Core Coverage` on these two cases — #6115, #6116, #6117 and #6124 were all inheriting this failure and need a re-run once this lands, not a code change.

## Related

- Fixed by: #6093 (`fix(flows): stop claiming ungranted trust and reject malformed contract slugs`) — the change these assertions now match.
- Introduced by: #6055 (`test(e2e): cover 37 untested RPC controllers across 10 namespaces`) — the wave PR carrying the pinned assertions.
- No `Closes` — see the checklist note.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/flows-e2e-assertions-after-6093`
- Commit SHA: see head commit

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no files under app/ changed.`
- [x] `pnpm typecheck` — `N/A: no TypeScript changed.`
- [x] Focused tests: `cargo test --test raw_coverage_all --features "$(bash scripts/ci/product-features.sh)" -- 'flows_lifecycle_e2e::' --test-threads=1` — the exact filter and thread count CI uses.
- [x] Rust fmt/check (if changed): `cargo fmt -- --check` clean.
- [x] Tauri fmt/check (if changed): `N/A: no Tauri code changed.`

### Validation Blocked

- `command:` none
- `error:` none
- `impact:` none

### Behavior Changes

- Intended behavior change: none. Assertions only.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: yes — no production code touched; `git diff` is one test file.
- Guard/fallback/dispatch parity checks: the inverted assertions now pin #6093's guards — that `split_manifest_trust` reports no grant without a gate, and that `toolkit_for_contract_slug` refuses an unshaped slug before any I/O.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none.
- Canonical PR: this one.
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for tool-contract requests by rejecting blank or incomplete slugs before processing.
  - Tool-contract slugs must now follow the expected `TOOLKIT_ACTION` format.
  - Approval status handling now correctly reports no missing or already-trusted items when no approval gate is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->