### PR TITLE
fix(agent): keep a content-returning action on the Gmail sub-agent surface

### DIFF
--- a/src/openhuman/agent/harness/archivist/helpers.rs
+++ b/src/openhuman/agent/harness/archivist/helpers.rs
@@ -11,9 +11,21 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// delegation return path uses it to notice a sub-agent that emitted a
 /// tool call instead of executing one (#6033).
 pub(crate) fn looks_like_unexecuted_tool_call(text: &str) -> bool {
-    text.contains("<tool_call>")
-        || text.contains("{\"tool_calls\"")
-        || text.contains("\"tool_use\"")
+    contains_tool_call_payload(text) || text.contains("\"tool_use\"")
+}
+
+/// Whether `text` carries a **call-shaped** payload — an XML tool-call span
+/// or a `tool_calls` JSON key.
+///
+/// Narrower than [`looks_like_unexecuted_tool_call`] on purpose: `"tool_use"`
+/// alone appears in ordinary prose about the protocol, which is fine for
+/// deciding whether stripping is worth attempting but not for deciding that
+/// a sub-agent produced no answer.
+///
+/// The JSON key is matched without assuming it opens the object, so a
+/// pretty-printed `{\n  "tool_calls": [...]\n}` is recognised too.
+pub(crate) fn contains_tool_call_payload(text: &str) -> bool {
+    text.contains("<tool_call>") || text.contains("\"tool_calls\"")
 }
 
 /// Strip tool-call JSON blocks from an assistant response, leaving only the

--- a/src/openhuman/agent/harness/archivist/helpers.rs
+++ b/src/openhuman/agent/harness/archivist/helpers.rs
@@ -4,6 +4,18 @@ use std::collections::hash_map::RandomState;
 use std::hash::{BuildHasher, Hasher};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+/// Whether `text` carries tool-call markup rather than (only) prose.
+///
+/// This is the single place the marker vocabulary is written down. The
+/// archivist uses it to decide whether stripping is needed at all; the
+/// delegation return path uses it to notice a sub-agent that emitted a
+/// tool call instead of executing one (#6033).
+pub(crate) fn looks_like_unexecuted_tool_call(text: &str) -> bool {
+    text.contains("<tool_call>")
+        || text.contains("{\"tool_calls\"")
+        || text.contains("\"tool_use\"")
+}
+
 /// Strip tool-call JSON blocks from an assistant response, leaving only the
 /// prose text.
 ///
@@ -17,13 +29,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// raw JSON objects that begin with `{"tool_calls":`. The output may be empty
 /// if the entire response was tool-call markup — callers should handle that
 /// case (empty text → no-op ingest).
-pub(super) fn strip_tool_calls_from_response(response: &str) -> String {
+pub(crate) fn strip_tool_calls_from_response(response: &str) -> String {
     // Fast path: if the response contains no obvious tool-call markers, return
     // it unchanged to avoid unnecessary allocation.
-    if !response.contains("<tool_call>")
-        && !response.contains("{\"tool_calls\"")
-        && !response.contains("\"tool_use\"")
-    {
+    if !looks_like_unexecuted_tool_call(response) {
         return response.to_string();
     }
 

--- a/src/openhuman/agent/harness/archivist/mod.rs
+++ b/src/openhuman/agent/harness/archivist/mod.rs
@@ -18,7 +18,7 @@
 
 pub mod boundary;
 mod events_heuristic;
-mod helpers;
+pub(crate) mod helpers;
 mod hook_impl;
 mod lifecycle;
 mod recap;

--- a/src/openhuman/agent/harness/subagent_runner/ops/runner.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops/runner.rs
@@ -32,7 +32,7 @@ use crate::openhuman::agent::harness::subagent_runner::handoff::ResultHandoffCac
 use crate::openhuman::agent::harness::subagent_runner::subagent_iter_cap_with_autonomous_lift;
 use crate::openhuman::agent::harness::subagent_runner::tool_prep::{
     build_text_mode_tool_instructions, filter_tool_indices, is_subagent_spawn_tool,
-    load_prompt_source, top_k_for_toolkit,
+    load_prompt_source, select_actions_with_essentials, top_k_for_toolkit,
 };
 use crate::openhuman::agent::harness::subagent_runner::types::{
     SubagentMode, SubagentRunError, SubagentRunOptions, SubagentRunOutcome, SubagentRunStatus,
@@ -1072,15 +1072,26 @@ async fn run_typed_mode(
                 let selected: Vec<
                     &crate::openhuman::agent::context::prompt::ConnectedIntegrationTool,
                 > = if filter_hits.len() >= super::super::super::tool_filter::MIN_CONFIDENT_HITS {
+                    // The ranker's verb gate can drop every content-returning
+                    // action for a find/search prompt, so the toolkit's
+                    // essentials are reserved inside the same budget (#6033).
+                    let kept_idx =
+                        select_actions_with_essentials(tk, &integration.tools, &filter_hits, top_k);
+                    let kept: Vec<_> = kept_idx.iter().map(|&i| &integration.tools[i]).collect();
                     tracing::info!(
                         agent_id = %definition.id,
                         toolkit = %tk,
                         total = integration.tools.len(),
-                        kept = filter_hits.len(),
+                        kept = kept.len(),
                         top_k = top_k,
+                        kept_actions = %kept
+                            .iter()
+                            .map(|a| a.name.as_str())
+                            .collect::<Vec<_>>()
+                            .join(","),
                         "[subagent_runner:typed] fuzzy tool filter narrowed toolkit"
                     );
-                    filter_hits.iter().map(|&i| &integration.tools[i]).collect()
+                    kept
                 } else {
                     tracing::info!(
                         agent_id = %definition.id,

--- a/src/openhuman/agent/harness/subagent_runner/tool_prep.rs
+++ b/src/openhuman/agent/harness/subagent_runner/tool_prep.rs
@@ -36,6 +36,39 @@ const HEAVY_SCHEMA_TOOLKITS: &[&str] = &[
 const TOOL_FILTER_TOP_K_DEFAULT: usize = 25;
 const TOOL_FILTER_TOP_K_HEAVY: usize = 12;
 
+/// Actions a toolkit must keep on the sub-agent's surface even when the
+/// fuzzy ranker does not pick them.
+///
+/// The ranker (`tinyagents_harness::tool::select`) derives an intent verb
+/// from the prompt and then **drops** every tool whose own name-verb
+/// conflicts with it. `FETCH`/`GET` are the `Read` verb and `find`/`search`
+/// are `List`, so a plain "find the emails about X" prompt removes
+/// `GMAIL_FETCH_EMAILS` and both `GMAIL_FETCH_MESSAGE_BY_*` before scoring
+/// even starts. A flat verb-alignment bonus then lets zero-overlap tools
+/// fill the budget, so the surviving surface can be twelve `GMAIL_LIST_*`
+/// actions — ids and settings, nothing that returns a message body. The
+/// sub-agent burns its iterations and answers without the email (#6033).
+///
+/// These names are **reserved inside** the top-K budget, never appended
+/// past it: [`TOOL_FILTER_TOP_K_HEAVY`] exists because Gmail at top-K=25
+/// produced a 276k-token first-iteration prompt, so an essential displaces
+/// the lowest-ranked hit rather than growing the surface.
+///
+/// Only Gmail is seeded, deliberately. A wrong entry spends a slot on
+/// every prompt for that toolkit, so add one only with a fixture-backed
+/// repro — the ranker's general behaviour is the upstream fix.
+const TOOLKIT_ESSENTIAL_ACTIONS: &[(&str, &[&str])] = &[(
+    "gmail",
+    &[
+        // The only action that returns message *content* for a search.
+        "GMAIL_FETCH_EMAILS",
+        // The follow-up once `GMAIL_LIST_MESSAGES` has handed back bare ids.
+        "GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID",
+        // Keeps the write path reachable when a read prompt wins the ranking.
+        "GMAIL_SEND_EMAIL",
+    ],
+)];
+
 /// Pick a top-K budget for the fuzzy filter based on how dense the
 /// toolkit's action schemas tend to be. Match is case-insensitive so
 /// we don't care whether the caller passed `"Gmail"` or `"gmail"`.
@@ -48,6 +81,78 @@ pub(super) fn top_k_for_toolkit(toolkit: &str) -> usize {
     } else {
         TOOL_FILTER_TOP_K_DEFAULT
     }
+}
+
+/// Actions [`TOOLKIT_ESSENTIAL_ACTIONS`] reserves for `toolkit`, or an
+/// empty slice when the toolkit has no entry. Case-insensitive, matching
+/// [`top_k_for_toolkit`].
+pub(super) fn essential_actions_for_toolkit(toolkit: &str) -> &'static [&'static str] {
+    TOOLKIT_ESSENTIAL_ACTIONS
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case(toolkit))
+        .map(|(_, actions)| *actions)
+        .unwrap_or(&[])
+}
+
+/// Pick the action indices the sub-agent will actually see: the toolkit's
+/// essentials first, then the ranker's hits in rank order, deduplicated and
+/// truncated to `top_k`.
+///
+/// An essential that the connected toolkit does not actually expose is
+/// skipped rather than guessed at, so a stale table entry costs nothing and
+/// can never produce an out-of-range index. A toolkit with no entry returns
+/// the ranker's hits unchanged (capped at `top_k`), which is what every
+/// call site did before the essentials existed.
+pub(super) fn select_actions_with_essentials(
+    toolkit: &str,
+    actions: &[crate::openhuman::agent::context::prompt::ConnectedIntegrationTool],
+    filter_hits: &[usize],
+    top_k: usize,
+) -> Vec<usize> {
+    let essentials = essential_actions_for_toolkit(toolkit);
+    if essentials.is_empty() || top_k == 0 {
+        return filter_hits.iter().take(top_k).copied().collect();
+    }
+
+    let mut selected: Vec<usize> = Vec::with_capacity(top_k.min(actions.len()));
+    let mut reserved: Vec<&str> = Vec::new();
+    for essential in essentials {
+        if selected.len() >= top_k {
+            break;
+        }
+        let found = actions
+            .iter()
+            .position(|a| a.name.eq_ignore_ascii_case(essential));
+        if let Some(idx) = found {
+            if !selected.contains(&idx) {
+                selected.push(idx);
+                reserved.push(essential);
+            }
+        }
+    }
+
+    let ranked_before = filter_hits.len().min(top_k);
+    for &idx in filter_hits {
+        if selected.len() >= top_k {
+            break;
+        }
+        if !selected.contains(&idx) {
+            selected.push(idx);
+        }
+    }
+
+    // A reserved action the ranker had already chosen costs nothing; the
+    // rest displace the lowest-ranked hits that no longer fit.
+    let ranked_kept = filter_hits.iter().filter(|i| selected.contains(i)).count();
+    tracing::debug!(
+        toolkit = %toolkit,
+        reserved = %reserved.join(","),
+        kept = selected.len(),
+        top_k = top_k,
+        dropped_ranked = ranked_before.saturating_sub(ranked_kept),
+        "[subagent_runner:tools] reserved essential actions inside the top-K budget"
+    );
+    selected
 }
 
 // ── Text-mode protocol block ────────────────────────────────────────────

--- a/src/openhuman/agent/harness/subagent_runner/tool_prep.rs
+++ b/src/openhuman/agent/harness/subagent_runner/tool_prep.rs
@@ -54,6 +54,16 @@ const TOOL_FILTER_TOP_K_HEAVY: usize = 12;
 /// produced a 276k-token first-iteration prompt, so an essential displaces
 /// the lowest-ranked hit rather than growing the surface.
 ///
+/// **Every entry must be read-only.** These actions are forced onto a
+/// delegation whatever it asked for, so a write action here would hand a
+/// "read my email" task an unrequested side-effecting capability — and a
+/// `ComposioActionTool` does not override `external_effect`, so the
+/// approval middleware (which gates on `external_effect_with_args`) would
+/// not stop it. Prompt-injected instructions inside a fetched email could
+/// then act on the mailbox with no human in the loop. Send and the rest of
+/// the write surface stay where they were: reachable when the prompt
+/// actually asks for them, via the ranker.
+///
 /// Only Gmail is seeded, deliberately. A wrong entry spends a slot on
 /// every prompt for that toolkit, so add one only with a fixture-backed
 /// repro — the ranker's general behaviour is the upstream fix.
@@ -64,8 +74,6 @@ const TOOLKIT_ESSENTIAL_ACTIONS: &[(&str, &[&str])] = &[(
         "GMAIL_FETCH_EMAILS",
         // The follow-up once `GMAIL_LIST_MESSAGES` has handed back bare ids.
         "GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID",
-        // Keeps the write path reachable when a read prompt wins the ranking.
-        "GMAIL_SEND_EMAIL",
     ],
 )];
 

--- a/src/openhuman/agent/harness/subagent_runner/tool_prep_tests.rs
+++ b/src/openhuman/agent/harness/subagent_runner/tool_prep_tests.rs
@@ -95,13 +95,13 @@ fn essentials_are_reserved_ahead_of_ranked_hits() {
     let names: Vec<&str> = selected.iter().map(|&i| actions[i].name.as_str()).collect();
 
     assert_eq!(
-        &names[..3],
-        &[
-            "GMAIL_FETCH_EMAILS",
-            "GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID",
-            "GMAIL_SEND_EMAIL"
-        ],
+        &names[..2],
+        &["GMAIL_FETCH_EMAILS", "GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID"],
         "essentials come first, in table order"
+    );
+    assert!(
+        !names.contains(&"GMAIL_SEND_EMAIL"),
+        "a read prompt must not be handed the send action: {names:?}"
     );
     assert!(
         names.contains(&"GMAIL_LIST_MESSAGES"),
@@ -282,5 +282,30 @@ fn gmail_read_prompt_keeps_a_content_returning_action() {
                 .len(),
             "prompt {prompt:?} produced a duplicate index"
         );
+    }
+}
+
+#[test]
+fn every_essential_action_is_read_only() {
+    // Essentials are forced onto a delegation whatever it asked for, so a
+    // write action here would hand a read task an unrequested
+    // side-effecting capability that the approval middleware does not gate
+    // (a ComposioActionTool does not override `external_effect`).
+    const WRITE_VERBS: &[&str] = &[
+        "SEND", "CREATE", "DELETE", "UPDATE", "PATCH", "MOVE", "MODIFY", "ADD", "REMOVE", "TRASH",
+        "REPLY", "FORWARD", "DRAFT",
+    ];
+    for (toolkit, essentials) in TOOLKIT_ESSENTIAL_ACTIONS {
+        for essential in *essentials {
+            let verb = essential
+                .split('_')
+                .nth(1)
+                .unwrap_or_default()
+                .to_ascii_uppercase();
+            assert!(
+                !WRITE_VERBS.contains(&verb.as_str()),
+                "{toolkit} essential {essential} is a write action; essentials must be read-only"
+            );
+        }
     }
 }

--- a/src/openhuman/agent/harness/subagent_runner/tool_prep_tests.rs
+++ b/src/openhuman/agent/harness/subagent_runner/tool_prep_tests.rs
@@ -55,3 +55,232 @@ fn unprefixed_delegate_name_overrides_are_treated_as_spawn_tools() {
         );
     }
 }
+
+// ── Essential-action reservation (#6033) ────────────────────────────────
+
+use crate::openhuman::agent::context::prompt::ConnectedIntegrationTool;
+
+fn action(name: &str) -> ConnectedIntegrationTool {
+    ConnectedIntegrationTool {
+        name: name.to_string(),
+        description: format!("{name} description"),
+        parameters: None,
+    }
+}
+
+/// The catalogue the ranker sees for Gmail in the failing case: every
+/// content-returning action gated out, twelve `LIST_*` slots kept.
+fn gmail_catalogue() -> Vec<ConnectedIntegrationTool> {
+    [
+        "GMAIL_LIST_CSE_IDENTITIES",
+        "GMAIL_LIST_DRAFTS",
+        "GMAIL_LIST_LABELS",
+        "GMAIL_LIST_MESSAGES",
+        "GMAIL_LIST_THREADS",
+        "GMAIL_FETCH_EMAILS",
+        "GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID",
+        "GMAIL_SEND_EMAIL",
+    ]
+    .iter()
+    .map(|n| action(n))
+    .collect()
+}
+
+#[test]
+fn essentials_are_reserved_ahead_of_ranked_hits() {
+    let actions = gmail_catalogue();
+    // The ranker picked only LIST_* actions — the #6033 repro.
+    let hits = vec![0, 1, 2, 3, 4];
+    let selected = select_actions_with_essentials("gmail", &actions, &hits, 12);
+    let names: Vec<&str> = selected.iter().map(|&i| actions[i].name.as_str()).collect();
+
+    assert_eq!(
+        &names[..3],
+        &[
+            "GMAIL_FETCH_EMAILS",
+            "GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID",
+            "GMAIL_SEND_EMAIL"
+        ],
+        "essentials come first, in table order"
+    );
+    assert!(
+        names.contains(&"GMAIL_LIST_MESSAGES"),
+        "ranked hits still follow the essentials"
+    );
+}
+
+#[test]
+fn an_essential_the_ranker_already_picked_costs_no_extra_slot() {
+    let actions = gmail_catalogue();
+    // Index 5 is GMAIL_FETCH_EMAILS — already ranked.
+    let hits = vec![5, 0, 1];
+    let selected = select_actions_with_essentials("gmail", &actions, &hits, 12);
+
+    let fetches = selected
+        .iter()
+        .filter(|&&i| actions[i].name == "GMAIL_FETCH_EMAILS")
+        .count();
+    assert_eq!(
+        fetches, 1,
+        "no duplicate index for an already-ranked essential"
+    );
+    assert_eq!(
+        selected.len(),
+        selected
+            .iter()
+            .collect::<std::collections::HashSet<_>>()
+            .len(),
+        "selection is duplicate-free"
+    );
+}
+
+#[test]
+fn selection_never_exceeds_the_top_k_budget() {
+    let actions = gmail_catalogue();
+    let hits: Vec<usize> = (0..actions.len()).collect();
+    for top_k in [0_usize, 1, 3, 4, 12] {
+        let selected = select_actions_with_essentials("gmail", &actions, &hits, top_k);
+        assert!(
+            selected.len() <= top_k,
+            "top_k={top_k} budget exceeded: {} kept",
+            selected.len()
+        );
+        assert_eq!(
+            selected.len(),
+            selected
+                .iter()
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            "top_k={top_k} produced a duplicate index"
+        );
+    }
+}
+
+#[test]
+fn an_unlisted_toolkit_is_an_exact_passthrough() {
+    let actions: Vec<_> = ["SLACK_SEND_MESSAGE", "SLACK_LIST_CHANNELS"]
+        .iter()
+        .map(|n| action(n))
+        .collect();
+    let hits = vec![1, 0];
+    assert_eq!(
+        select_actions_with_essentials("slack", &actions, &hits, 12),
+        hits,
+        "a toolkit with no essentials must rank exactly as before"
+    );
+}
+
+#[test]
+fn an_essential_absent_from_the_toolkit_is_skipped_not_guessed() {
+    // Connected Gmail exposing none of the essentials: the helper must not
+    // invent an index or panic.
+    let actions: Vec<_> = ["GMAIL_LIST_LABELS", "GMAIL_LIST_THREADS"]
+        .iter()
+        .map(|n| action(n))
+        .collect();
+    let hits = vec![0, 1];
+    let selected = select_actions_with_essentials("gmail", &actions, &hits, 12);
+    assert_eq!(selected, hits);
+    assert!(selected.iter().all(|&i| i < actions.len()));
+}
+
+#[test]
+fn toolkit_lookup_is_case_insensitive() {
+    assert_eq!(
+        essential_actions_for_toolkit("Gmail"),
+        essential_actions_for_toolkit("gmail")
+    );
+    assert!(!essential_actions_for_toolkit("GMAIL").is_empty());
+    assert!(essential_actions_for_toolkit("slack").is_empty());
+}
+
+#[test]
+fn every_essential_name_exists_in_the_real_toolkit_fixture() {
+    // A stale table entry would silently spend no slot and hide the bug it
+    // was added for, so pin the names against the real Composio dump.
+    for (toolkit, essentials) in TOOLKIT_ESSENTIAL_ACTIONS {
+        let path = format!(
+            "{}/tests/fixtures/composio_{}.json",
+            env!("CARGO_MANIFEST_DIR"),
+            toolkit
+        );
+        let raw = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read fixture {path}: {e}"));
+        let parsed: serde_json::Value =
+            serde_json::from_str(&raw).unwrap_or_else(|e| panic!("failed to parse {path}: {e}"));
+        let names: Vec<String> = parsed
+            .pointer("/result/result/tools")
+            .and_then(|t| t.as_array())
+            .unwrap_or_else(|| panic!("missing /result/result/tools in {path}"))
+            .iter()
+            .filter_map(|t| {
+                t.pointer("/function/name")
+                    .and_then(|n| n.as_str())
+                    .map(str::to_string)
+            })
+            .collect();
+        for essential in *essentials {
+            assert!(
+                names.iter().any(|n| n == essential),
+                "{toolkit} essential {essential} is not a real action in {path}"
+            );
+        }
+    }
+}
+
+#[test]
+fn gmail_read_prompt_keeps_a_content_returning_action() {
+    // The two prompts from #6033: the ranker returns twelve LIST_* actions
+    // and nothing that returns a message body. After reservation the
+    // sub-agent can actually read an email.
+    let path = format!(
+        "{}/tests/fixtures/composio_gmail.json",
+        env!("CARGO_MANIFEST_DIR")
+    );
+    let raw = std::fs::read_to_string(&path).expect("gmail fixture");
+    let parsed: serde_json::Value = serde_json::from_str(&raw).expect("gmail fixture parses");
+    let actions: Vec<ConnectedIntegrationTool> = parsed
+        .pointer("/result/result/tools")
+        .and_then(|t| t.as_array())
+        .expect("fixture tools")
+        .iter()
+        .map(|t| ConnectedIntegrationTool {
+            name: t
+                .pointer("/function/name")
+                .and_then(|n| n.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            description: t
+                .pointer("/function/description")
+                .and_then(|d| d.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            parameters: t.pointer("/function/parameters").cloned(),
+        })
+        .collect();
+
+    for prompt in [
+        "find job opportunities from the last 5 days",
+        "Search the user's Gmail inbox for job opportunity emails from the last 5 days and summarize sender, subject and date",
+    ] {
+        let hits = crate::openhuman::agent::harness::tool_filter::filter_actions_by_prompt(
+            prompt, &actions, 12,
+        );
+        let selected = select_actions_with_essentials("gmail", &actions, &hits, 12);
+        let names: Vec<&str> = selected.iter().map(|&i| actions[i].name.as_str()).collect();
+
+        assert!(
+            names.contains(&"GMAIL_FETCH_EMAILS"),
+            "prompt {prompt:?} must keep a content-returning action; got {names:?}"
+        );
+        assert!(selected.len() <= 12, "prompt {prompt:?} exceeded the budget");
+        assert_eq!(
+            selected.len(),
+            selected
+                .iter()
+                .collect::<std::collections::HashSet<_>>()
+                .len(),
+            "prompt {prompt:?} produced a duplicate index"
+        );
+    }
+}

--- a/src/openhuman/agent/orchestration/tools/dispatch.rs
+++ b/src/openhuman/agent/orchestration/tools/dispatch.rs
@@ -169,6 +169,12 @@ pub(crate) async fn dispatch_subagent(
         );
     }
 
+    // Past this point the run is synchronous whichever mode was requested:
+    // the async branch above returns when it is taken, so a `PreferAsync`
+    // that fell through registers no durable worker either and its result
+    // must say so (#6033).
+    let mode = DispatchMode::Blocking;
+
     let parent_session = parent_ctx
         .as_ref()
         .map(|p| p.session_id.clone())
@@ -497,10 +503,28 @@ fn format_subagent_failure(tool_name: &str, message: &str) -> String {
 /// carries an answer and passes through untouched.
 pub(crate) fn is_unexecuted_tool_call_stub(output: &str) -> bool {
     use crate::openhuman::agent::harness::archivist::helpers::{
-        looks_like_unexecuted_tool_call, strip_tool_calls_from_response,
+        contains_tool_call_payload, strip_tool_calls_from_response,
     };
-    looks_like_unexecuted_tool_call(output)
-        && strip_tool_calls_from_response(output).trim().is_empty()
+    if !contains_tool_call_payload(output) {
+        // Prose merely naming a protocol field is not a stub.
+        return false;
+    }
+    // A whole-text JSON payload carrying `tool_calls` is a stub however it
+    // is formatted — line-based stripping cannot see that the object's
+    // inner members belong to the call rather than to an answer.
+    if let Ok(serde_json::Value::Object(map)) =
+        serde_json::from_str::<serde_json::Value>(output.trim())
+    {
+        if map.contains_key("tool_calls") {
+            return true;
+        }
+    }
+    // Otherwise (XML spans, mixed prose): a stub is what leaves no words
+    // behind once the markup is stripped. Structural punctuation is not an
+    // answer.
+    !strip_tool_calls_from_response(output)
+        .chars()
+        .any(char::is_alphanumeric)
 }
 
 /// The sentence appended to a blocking delegation's result.
@@ -511,6 +535,12 @@ pub(crate) fn is_unexecuted_tool_call_stub(output: &str) -> bool {
 /// the result itself stops it hunting for a worker that never existed
 /// (#6033).
 const INLINE_RESULT_NOTE: &str = "\n\n[INLINE_RESULT] This delegation ran inline and is complete as returned — there is no sub-agent worker for it. Do NOT call wait_subagent, list_subagents or continue_subagent for this delegation.";
+
+/// The same disclosure for a run that did **not** finish. It must not claim
+/// the result is complete — that would contradict the
+/// `[SUBAGENT_INCOMPLETE]` guardrail it is appended to — so it says only
+/// that there is no worker, and what to do instead.
+const NO_WORKER_NOTE: &str = "\n\n[INLINE_RESULT] This delegation ran inline and registered no sub-agent worker, so there is nothing to collect: do NOT call wait_subagent, list_subagents or continue_subagent for it. Re-delegate with a corrected prompt instead.";
 
 /// Append [`INLINE_RESULT_NOTE`] when the dispatch was blocking.
 pub(crate) fn with_inline_result_note(output: String, mode: DispatchMode) -> String {
@@ -528,14 +558,16 @@ pub(crate) fn incomplete_envelope(
     output: &str,
     mode: DispatchMode,
 ) -> String {
-    with_inline_result_note(
-        format!(
-            "[SUBAGENT_INCOMPLETE] the {tool_name} sub-agent {reason} and did not \
-             finish. Below is partial progress only — do NOT report it as done or \
-             re-run the identical delegation unchanged.\n\nPartial progress:\n{output}"
-        ),
-        mode,
-    )
+    let envelope = format!(
+        "[SUBAGENT_INCOMPLETE] the {tool_name} sub-agent {reason} and did not \
+         finish. Below is partial progress only — do NOT report it as done or \
+         re-run the identical delegation unchanged.\n\nPartial progress:\n{output}"
+    );
+    if mode == DispatchMode::Blocking {
+        format!("{envelope}{NO_WORKER_NOTE}")
+    } else {
+        envelope
+    }
 }
 
 #[cfg(test)]

--- a/src/openhuman/agent/orchestration/tools/dispatch.rs
+++ b/src/openhuman/agent/orchestration/tools/dispatch.rs
@@ -334,7 +334,28 @@ pub(crate) async fn dispatch_subagent(
                     outcome.iterations,
                     outcome.output.chars().count()
                 );
-                Ok(ToolResult::success(outcome.output))
+                // A sub-agent that emitted a tool call instead of executing one
+                // "completes" with markup where the answer should be. Passing
+                // that through reads as a finished result, so frame it the way
+                // an iteration-cap stop is framed (#6033, #4096 precedent).
+                if is_unexecuted_tool_call_stub(&outcome.output) {
+                    log::info!(
+                        "[agent] {} returned an unexecuted tool-call stub (task_id={} output_chars={}) — reframing as incomplete",
+                        tool_name,
+                        outcome.task_id,
+                        outcome.output.chars().count()
+                    );
+                    return Ok(ToolResult::success(incomplete_envelope(
+                        tool_name,
+                        "returned an unexecuted tool call instead of a result",
+                        &outcome.output,
+                        mode,
+                    )));
+                }
+                Ok(ToolResult::success(with_inline_result_note(
+                    outcome.output,
+                    mode,
+                )))
             }
             // A stuck halt / iteration-cap stop returns `Incomplete`; frame the
             // partial progress so the orchestrator can't mistake it for a
@@ -376,11 +397,11 @@ pub(crate) async fn dispatch_subagent(
                     outcome.task_id,
                     outcome.iterations,
                 );
-                Ok(ToolResult::success(format!(
-                    "[SUBAGENT_INCOMPLETE] the {tool_name} sub-agent {reason} and did not \
-                         finish. Below is partial progress only — do NOT report it as done or \
-                         re-run the identical delegation unchanged.\n\nPartial progress:\n{}",
-                    outcome.output
+                Ok(ToolResult::success(incomplete_envelope(
+                    tool_name,
+                    reason,
+                    &outcome.output,
+                    mode,
                 )))
             }
         },
@@ -464,6 +485,56 @@ fn format_subagent_failure(tool_name: &str, message: &str) -> String {
         "{tool_name} failed and did not complete — no work was performed and no \
          results were produced. Do NOT treat this as success or fabricate an \
          output; report the failure to the user. Error: {message}"
+    )
+}
+
+/// Whether a "completed" sub-agent output is only an unexecuted tool call.
+///
+/// The marker vocabulary lives in
+/// [`crate::openhuman::agent::harness::archivist::helpers::looks_like_unexecuted_tool_call`];
+/// this adds the second half of the question — that stripping the markup
+/// leaves no prose behind. A reply that merely *mentions* a tool call still
+/// carries an answer and passes through untouched.
+pub(crate) fn is_unexecuted_tool_call_stub(output: &str) -> bool {
+    use crate::openhuman::agent::harness::archivist::helpers::{
+        looks_like_unexecuted_tool_call, strip_tool_calls_from_response,
+    };
+    looks_like_unexecuted_tool_call(output)
+        && strip_tool_calls_from_response(output).trim().is_empty()
+}
+
+/// The sentence appended to a blocking delegation's result.
+///
+/// Integration delegations run [`DispatchMode::Blocking`] and register no
+/// durable worker, but the orchestrator's `[active_subagents]` guidance
+/// tells it to collect completed work with `wait_subagent`. Saying so on
+/// the result itself stops it hunting for a worker that never existed
+/// (#6033).
+const INLINE_RESULT_NOTE: &str = "\n\n[INLINE_RESULT] This delegation ran inline and is complete as returned — there is no sub-agent worker for it. Do NOT call wait_subagent, list_subagents or continue_subagent for this delegation.";
+
+/// Append [`INLINE_RESULT_NOTE`] when the dispatch was blocking.
+pub(crate) fn with_inline_result_note(output: String, mode: DispatchMode) -> String {
+    if mode == DispatchMode::Blocking {
+        format!("{output}{INLINE_RESULT_NOTE}")
+    } else {
+        output
+    }
+}
+
+/// The partial-progress envelope shared by every non-finishing outcome.
+pub(crate) fn incomplete_envelope(
+    tool_name: &str,
+    reason: &str,
+    output: &str,
+    mode: DispatchMode,
+) -> String {
+    with_inline_result_note(
+        format!(
+            "[SUBAGENT_INCOMPLETE] the {tool_name} sub-agent {reason} and did not \
+             finish. Below is partial progress only — do NOT report it as done or \
+             re-run the identical delegation unchanged.\n\nPartial progress:\n{output}"
+        ),
+        mode,
     )
 }
 

--- a/src/openhuman/agent/orchestration/tools/dispatch_tests.rs
+++ b/src/openhuman/agent/orchestration/tools/dispatch_tests.rs
@@ -266,4 +266,49 @@ fn the_incomplete_envelope_frames_a_stub_without_claiming_success() {
     assert!(envelope.contains("do NOT report it as done"));
     assert!(envelope.contains("returned an unexecuted tool call"));
     assert!(envelope.contains("[INLINE_RESULT]"));
+    assert!(
+        !envelope.contains("complete as returned"),
+        "an unfinished run must never be described as complete"
+    );
+    assert!(envelope.contains("Re-delegate with a corrected prompt"));
+}
+
+#[test]
+fn an_unfinished_envelope_never_claims_completeness() {
+    // The completed note and the not-finished note are deliberately
+    // different: appending "is complete as returned" under a
+    // [SUBAGENT_INCOMPLETE] header would contradict the guardrail.
+    let done = super::with_inline_result_note("answer".to_string(), super::DispatchMode::Blocking);
+    assert!(done.contains("complete as returned"));
+
+    let unfinished = super::incomplete_envelope(
+        "delegate_to_integrations_agent",
+        "hit its iteration cap",
+        "partial",
+        super::DispatchMode::Blocking,
+    );
+    assert!(!unfinished.contains("complete as returned"));
+    assert!(unfinished.contains("nothing to collect"));
+}
+
+#[test]
+fn a_pretty_printed_tool_call_payload_is_still_a_stub() {
+    // The marker is matched as a JSON key, not as "{\"tool_calls\"", so
+    // whitespace before it does not hide the payload; and the leftover
+    // braces are punctuation, not an answer.
+    assert!(super::is_unexecuted_tool_call_stub(
+        "{\n  \"tool_calls\": [\n    {\"name\": \"GMAIL_FETCH_EMAILS\"}\n  ]\n}"
+    ));
+}
+
+#[test]
+fn prose_naming_a_protocol_field_is_not_a_stub() {
+    // "tool_use" alone is enough for the archivist to attempt a strip, but
+    // never enough to decide a sub-agent produced no answer.
+    assert!(!super::is_unexecuted_tool_call_stub(
+        "The \"tool_use\" field is how the provider reports a call."
+    ));
+    assert!(!super::is_unexecuted_tool_call_stub(
+        "I could not read the inbox: the connection is not authorised."
+    ));
 }

--- a/src/openhuman/agent/orchestration/tools/dispatch_tests.rs
+++ b/src/openhuman/agent/orchestration/tools/dispatch_tests.rs
@@ -205,3 +205,65 @@ fn the_question_in_an_unpersisted_pause_failure_is_encoded_not_interpolated() {
         "the question should appear JSON-escaped rather than raw: {out}"
     );
 }
+
+// ── Unexecuted tool-call stubs + inline-result framing (#6033) ──────────
+
+#[test]
+fn a_tool_call_stub_is_recognised_as_unexecuted() {
+    assert!(super::is_unexecuted_tool_call_stub(
+        "<tool_call>{\"name\": \"GMAIL_LIST_MESSAGES\", \"arguments\": {}}</tool_call>"
+    ));
+    assert!(super::is_unexecuted_tool_call_stub(
+        "{\"tool_calls\": [{\"name\": \"GMAIL_FETCH_EMAILS\"}]}"
+    ));
+}
+
+#[test]
+fn a_real_answer_that_mentions_a_tool_call_is_not_a_stub() {
+    assert!(!super::is_unexecuted_tool_call_stub(
+        "I found 3 job emails. I used <tool_call>GMAIL_FETCH_EMAILS</tool_call> to read them."
+    ));
+    assert!(!super::is_unexecuted_tool_call_stub(
+        "Here are the emails from the last 5 days: Acme, Globex, Initech."
+    ));
+    assert!(
+        !super::is_unexecuted_tool_call_stub(""),
+        "empty output carries no markup, so it is not a stub"
+    );
+}
+
+#[test]
+fn a_blocking_delegation_says_its_result_is_inline() {
+    let framed = super::with_inline_result_note(
+        "the emails are …".to_string(),
+        super::DispatchMode::Blocking,
+    );
+    assert!(framed.starts_with("the emails are …"));
+    assert!(framed.contains("[INLINE_RESULT]"));
+    assert!(framed.contains("no sub-agent worker"));
+    assert!(framed.contains("wait_subagent"));
+}
+
+#[test]
+fn an_async_delegation_keeps_its_output_untouched() {
+    let output = "the emails are …".to_string();
+    assert_eq!(
+        super::with_inline_result_note(output.clone(), super::DispatchMode::PreferAsync),
+        output,
+        "only a blocking dispatch may claim there is no worker"
+    );
+}
+
+#[test]
+fn the_incomplete_envelope_frames_a_stub_without_claiming_success() {
+    let envelope = super::incomplete_envelope(
+        "delegate_to_integrations_agent",
+        "returned an unexecuted tool call instead of a result",
+        "<tool_call>GMAIL_LIST_MESSAGES</tool_call>",
+        super::DispatchMode::Blocking,
+    );
+    assert!(envelope.starts_with("[SUBAGENT_INCOMPLETE]"));
+    assert!(envelope.contains("do NOT report it as done"));
+    assert!(envelope.contains("returned an unexecuted tool call"));
+    assert!(envelope.contains("[INLINE_RESULT]"));
+}

--- a/src/openhuman/agent/orchestration/tools/tools_e2e_tests.rs
+++ b/src/openhuman/agent/orchestration/tools/tools_e2e_tests.rs
@@ -368,7 +368,18 @@ async fn skill_delegation_tool_runs_integrations_agent_e2e() {
     .expect("tool execution");
 
     assert!(!result.is_error, "{}", result.output());
-    assert_eq!(result.output(), "skill-delegation-child-answer");
+    // The sub-agent's answer comes back verbatim, followed by the
+    // inline-result note: this delegation is blocking and registers no
+    // worker, so the orchestrator must not go hunting for one (#6033).
+    let output = result.output();
+    assert!(
+        output.starts_with("skill-delegation-child-answer"),
+        "the child's answer must lead the result: {output}"
+    );
+    assert!(
+        output.contains("[INLINE_RESULT]") && output.contains("no sub-agent worker"),
+        "a blocking delegation must say its result is inline: {output}"
+    );
     assert!(provider.saw(SKILL_DELEGATION_CANARY));
     assert!(provider.saw("gmail"));
 }

--- a/src/openhuman/agent/orchestration/tools/tools_e2e_tests.rs
+++ b/src/openhuman/agent/orchestration/tools/tools_e2e_tests.rs
@@ -81,7 +81,18 @@ async fn archetype_delegation_tool_runs_child_agent_e2e() {
     .expect("tool execution");
 
     assert!(!result.is_error, "{}", result.output());
-    assert_eq!(result.output(), "archetype-delegation-child-answer");
+    // This archetype delegation asks for async but has no delivery thread in
+    // a test, so it falls back to running inline — and a fallback registers
+    // no durable worker either, so the result says so (#6033).
+    let output = result.output();
+    assert!(
+        output.starts_with("archetype-delegation-child-answer"),
+        "the child's answer must lead the result: {output}"
+    );
+    assert!(
+        output.contains("[INLINE_RESULT]"),
+        "an async delegation that fell back to blocking must disclose that no worker exists: {output}"
+    );
     assert!(provider.saw(ARCHETYPE_DELEGATION_CANARY));
 }
 


### PR DESCRIPTION
## Summary

- Reading Gmail through `delegate_to_integrations_agent` returned no email content: the sub-agent's twelve-action surface contained no action that returns a message body. A per-toolkit **essentials** set now reserves those actions **inside** the existing top-K budget.
- A sub-agent that emits a tool call instead of executing one no longer reads as a finished answer — it comes back in the `[SUBAGENT_INCOMPLETE]` envelope.
- A blocking delegation now says its result is inline and that there is no worker to wait for, so the orchestrator stops hunting with `wait_subagent` / `list_subagents`.
- The narrowed toolkit surface is logged with the action **names** it kept.

## Problem

Three defects stack up on one delegation.

**1. The ranked surface cannot read email.** Gmail is a heavy-schema toolkit, so the fuzzy filter keeps at most 12 actions ([`tool_prep.rs`](../blob/main/src/openhuman/agent/harness/subagent_runner/tool_prep.rs)). The ranker (`tinyagents_harness::tool::select`) derives an intent verb from the prompt and then **drops every tool whose own name-verb conflicts**: `FETCH`/`GET` are the `Read` verb, `find`/`search` are `List`. A flat `+3` verb-alignment bonus then qualifies tools with zero token overlap, because the keep rule is `score > 0`.

Re-run against the checked-in dump (`tests/fixtures/composio_gmail.json`, 62 actions) through the shipped adapter:

```
"find job opportunities from the last 5 days"
  → GMAIL_LIST_CSE_IDENTITIES, GMAIL_LIST_CSE_KEYPAIRS, GMAIL_LIST_DRAFTS,
    GMAIL_LIST_FILTERS, GMAIL_LIST_FORWARDING_ADDRESSES, GMAIL_LIST_HISTORY,
    GMAIL_LIST_LABELS, GMAIL_LIST_MESSAGES, GMAIL_LIST_SEND_AS,
    GMAIL_LIST_SMIME_INFO, GMAIL_LIST_THREADS, GMAIL_SEARCH_PEOPLE
  GMAIL_FETCH_EMAILS: OUT    GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID: OUT
```

`GMAIL_LIST_MESSAGES` returns ids, not bodies, and the sub-agent cannot fetch by id either. Whether the orchestrator happened to write a Read verb into the prompt decided the outcome; the reporter's phrasing did not. Two more cases found while verifying: `show me new emails about job opportunities` admits `GMAIL_CREATE_EMAIL_DRAFT` / `CREATE_FILTER` / `CREATE_LABEL` ("new" reads as a Create verb), and `what emails did I get this week?` spends slots on `GET_AUTO_FORWARDING`, `GET_VACATION_SETTINGS` and `SETTINGS_GET_IMAP`.

**2. A stub could be reported as an answer.** The `Completed` arm returned `outcome.output` verbatim with no check that it contains a result rather than an unexecuted tool call. Only the archivist had such a guard.

**3. The orchestrator was told to collect from a worker that never existed.** Integration delegations are deliberately `DispatchMode::Blocking` with `dedicated_thread: false`, so no durable worker is registered — while the `[active_subagents]` block instructs the orchestrator to "use wait_subagent to collect a `completed` one". After an unusable result it followed that guidance and found nothing.

## Solution

- **`TOOLKIT_ESSENTIAL_ACTIONS`** (`tool_prep.rs`) maps a toolkit to the actions that must stay reachable — Gmail: `GMAIL_FETCH_EMAILS`, `GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID`, `GMAIL_SEND_EMAIL`. `select_actions_with_essentials` puts those first, then the ranker's hits in rank order, deduplicated and truncated to `top_k`. An essential the connected toolkit does not expose is skipped rather than guessed at, and a toolkit with no entry is an exact passthrough — so Slack/Notion ranking is untouched. **Reserve, never append**: the budget is what stops the 276k-token prompt.
- **Only Gmail is seeded, deliberately.** A wrong entry spends a slot on every prompt for that toolkit, so a new one needs a fixture-backed repro.
- **`is_unexecuted_tool_call_stub`** = the archivist's `looks_like_unexecuted_tool_call` **and** nothing surviving its strip, so a real answer that merely quotes a tool call passes through untouched. A stub is reframed with the existing `[SUBAGENT_INCOMPLETE]` envelope.
- **`with_inline_result_note`** appends the inline-result sentence for `DispatchMode::Blocking` only; async delegations are byte-identical to before.
- The `narrowed toolkit` log line gains `kept_actions`.

## Submission Checklist

- [x] Tests added or updated — 12 new tests; the delegation e2e now pins the inline-result contract.
- [x] **Diff coverage ≥ 80%** — every new branch is exercised directly (budget, dedupe, absent essential, unlisted toolkit, case-insensitivity, both issue prompts, stub vs real answer, blocking vs async). Full `diff-cover` runs in CI.
- [x] Coverage matrix updated — `N/A: no feature row added or removed`.
- [x] All affected feature IDs listed under `## Related` — `N/A`.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — `N/A: pinned by the fixture-backed ranking test`.
- [x] Linked issue closed via `Closes #NNN`.

## Impact

Reading email — one of the most-used integrations — works for natural phrasings that carry no Read verb. Cost is three of twelve slots on Gmail prompts, and because essentials **replace** ranked entries rather than extend the list, the rendered schema size is roughly unchanged.

**Not fixed here, and deliberately:** the ranker's own behaviour is upstream in vendored `tinyagents` (a path dependency, so it needs an upstream PR plus a submodule bump). Every other heavy toolkit keeps the same failure mode. Worth recording for that PR: the issue's suggested "require at least one token hit before the verb bonus can qualify a tool" would **backfire** here — nearly every Gmail action has zero token overlap with the reporter's prompt, so requiring a hit drops the count below `MIN_CONFIDENT_HITS` and triggers this host's *full-toolkit* fallback, i.e. all 62 dense schemas, which is the blow-up the top-K cap exists to prevent. The safe upstream change is the issue's other suggestion: treat `Read` and `List` as compatible intents so `FETCH` re-enters the pool instead of the pool emptying.

## Related

- Closes: #6033
- #5119 — the contract-gate auto-proceed net that bounds the iteration burn here.
- #4853 — an earlier form of the same surface problem.
- #5318 — the agent is told what a toolkit can do, never what its actions return.
- #4746 — the empty-reply-on-exhaustion envelope this reuses.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: fix/6033-gmail-read-toolkit-surface


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Essential read-only Gmail actions are preserved when available tools are narrowed.
  - Blocking delegated results now include clearer inline fallback notes.
  - Delegated responses now prioritize the child answer in end-to-end workflows.

- **Bug Fixes**
  - Formatted tool-call payloads are detected more reliably.
  - Unexecuted tool-call placeholders are no longer reported as successful completed responses.
  - Partial or incomplete delegated work is presented more clearly instead of appearing as a finished answer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->