### PR TITLE
fix(task-sources): stop polling a source whose provider cannot fetch

### DIFF
--- a/src/openhuman/integrations/task_sources/periodic.rs
+++ b/src/openhuman/integrations/task_sources/periodic.rs
@@ -119,6 +119,24 @@ pub(crate) async fn run_one_tick() -> Result<(), String> {
         if !source.enabled {
             continue;
         }
+        // A provider with no working fetch path is skipped before it can
+        // record anything. `run_source_once` would refuse it, and that
+        // refusal costs a `store::record_fetch` row and a
+        // `TaskSourceFetchFailed` event on every tick, forever — an
+        // unbounded write nobody asked for and nobody can act on.
+        //
+        // The manual `task_sources_fetch` RPC deliberately does NOT get this
+        // gate: a user who presses Fetch is owed the explanation. Only the
+        // timer is silenced, which is why the check lives here rather than
+        // inside `run_source_once` (which both paths share).
+        if !source.provider.can_fetch() {
+            tracing::debug!(
+                source_id = %source.id,
+                provider = %source.provider.as_str(),
+                "[task_sources:periodic] skipping source — provider has no task-fetch path"
+            );
+            continue;
+        }
         considered += 1;
         if !is_due(&source) {
             continue;

--- a/src/openhuman/integrations/task_sources/periodic_tests.rs
+++ b/src/openhuman/integrations/task_sources/periodic_tests.rs
@@ -87,27 +87,89 @@ fn no_provider_can_fetch_today() {
     }
 }
 
-/// The gate the periodic loop applies, asserted on the same predicate the
-/// loop reads. An unfetchable source is skipped before `run_source_once` can
-/// record a `store::record_fetch` row or publish `TaskSourceFetchFailed`.
-#[test]
-fn scheduler_skips_a_source_whose_provider_cannot_fetch() {
-    for provider in [
+/// Drives a real `run_one_tick` over a persisted, enabled, due source whose
+/// provider cannot fetch, and asserts the tick recorded **nothing**.
+///
+/// The observable is the source row itself: the failure arm of
+/// `pipeline::run_source_once` calls `store::record_fetch`, which stamps
+/// `last_fetch_at` and `last_status`. Both staying `None` after a tick is
+/// proof the source was skipped before `run_source_once` ran.
+///
+/// This asserts through the scheduler rather than on the predicate, on
+/// purpose: a test that only checked `can_fetch()` would still pass if the
+/// guard were deleted from `run_one_tick`, which is the exact regression this
+/// PR exists to prevent.
+///
+/// The config is scoped onto the embedder seam that `load_config_with_timeout`
+/// prefers, so the tick reads this workspace instead of doing live, racy disk
+/// I/O against `~/.openhuman` — the same approach as `sandbox/schemas_tests.rs`.
+#[tokio::test]
+async fn a_tick_over_an_unfetchable_source_records_nothing() {
+    use crate::core::runtime::context::CoreContext;
+    use crate::core::runtime::DomainSet;
+
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let workspace = tmp.path().join("workspace");
+    std::fs::create_dir_all(&workspace).expect("workspace");
+    let config = crate::openhuman::config::Config {
+        workspace_dir: workspace.clone(),
+        action_dir: workspace,
+        config_path: tmp.path().join("config.toml"),
+        ..Default::default()
+    };
+    assert!(
+        config.task_sources.enabled,
+        "precondition: the domain must be on, or the tick returns before the loop"
+    );
+
+    // `add_source` mints the id, and it is fresh per run — so the
+    // process-global last-poll map cannot make this source look recently
+    // polled because of another test.
+    let stored = super::super::store::add_source(
+        &config,
         ProviderSlug::Github,
-        ProviderSlug::Notion,
-        ProviderSlug::Linear,
-        ProviderSlug::Clickup,
-    ] {
-        let s = source_for("ts-gate-xyz", 1800, provider);
-        assert!(
-            s.enabled && is_due(&s),
-            "precondition: this source would otherwise be polled"
-        );
-        assert!(
-            !s.provider.can_fetch(),
-            "so the ONLY thing standing between it and a recorded failure is the gate"
-        );
-    }
+        None,
+        None,
+        FilterSpec::Github {
+            repo: None,
+            labels: vec![],
+            assignee_is_me: true,
+            state: None,
+            fetch_mode: Default::default(),
+            extra: json!({}),
+        },
+        1800,
+        SourceTarget::TodoOnly,
+        25,
+    )
+    .expect("persist the source");
+    let id = stored.id.clone();
+
+    assert!(stored.enabled, "precondition: the source is enabled");
+    assert!(is_due(&stored), "precondition: the source is due");
+    assert!(
+        !stored.provider.can_fetch(),
+        "precondition: its provider has no fetch path, so the gate must skip it"
+    );
+
+    CoreContext::scope(
+        CoreContext::for_test_with_config(DomainSet::full(), config.clone()),
+        run_one_tick(),
+    )
+    .await
+    .expect("a tick must not fail");
+
+    let after = super::super::store::get_source(&config, &id).expect("re-read the source");
+    assert!(
+        after.last_fetch_at.is_none(),
+        "the tick must not have stamped a fetch time: {:?}",
+        after.last_fetch_at
+    );
+    assert!(
+        after.last_status.is_none(),
+        "and must not have recorded a status — a recorded failure is the bug: {:?}",
+        after.last_status
+    );
 }
 
 /// The other half: the manual path is untouched. `run_source_once` — which the

--- a/src/openhuman/integrations/task_sources/periodic_tests.rs
+++ b/src/openhuman/integrations/task_sources/periodic_tests.rs
@@ -4,9 +4,13 @@ use chrono::Utc;
 use serde_json::json;
 
 fn source(id: &str, interval_secs: u64) -> TaskSource {
+    source_for(id, interval_secs, ProviderSlug::Github)
+}
+
+fn source_for(id: &str, interval_secs: u64, provider: ProviderSlug) -> TaskSource {
     TaskSource {
         id: id.into(),
-        provider: ProviderSlug::Github,
+        provider,
         connection_id: None,
         name: None,
         enabled: true,
@@ -54,4 +58,86 @@ fn zero_interval_is_floored_not_always_due() {
     // With the MIN_INTERVAL_SECONDS floor a just-polled zero-interval
     // source is not immediately due again.
     assert!(!is_due(&s));
+}
+
+// ── the containment gate (issue #6118) ──────────────────────────────────────
+//
+// Two halves of one distinction, pinned together on purpose: the timer must
+// stay silent about a provider it cannot fetch, and the manual RPC must keep
+// explaining itself. A change that silences both would satisfy either test
+// alone.
+
+/// No provider has a task-fetch path today, so the scheduler has nothing
+/// legitimate to poll. When one is restored this test is what tells you to
+/// update it — deliberately, rather than by a blanket assertion that would
+/// keep passing.
+#[test]
+fn no_provider_can_fetch_today() {
+    for provider in [
+        ProviderSlug::Github,
+        ProviderSlug::Notion,
+        ProviderSlug::Linear,
+        ProviderSlug::Clickup,
+    ] {
+        assert!(
+            !provider.can_fetch(),
+            "{} has no fetch path until the pipeline's fetch step is restored",
+            provider.as_str()
+        );
+    }
+}
+
+/// The gate the periodic loop applies, asserted on the same predicate the
+/// loop reads. An unfetchable source is skipped before `run_source_once` can
+/// record a `store::record_fetch` row or publish `TaskSourceFetchFailed`.
+#[test]
+fn scheduler_skips_a_source_whose_provider_cannot_fetch() {
+    for provider in [
+        ProviderSlug::Github,
+        ProviderSlug::Notion,
+        ProviderSlug::Linear,
+        ProviderSlug::Clickup,
+    ] {
+        let s = source_for("ts-gate-xyz", 1800, provider);
+        assert!(
+            s.enabled && is_due(&s),
+            "precondition: this source would otherwise be polled"
+        );
+        assert!(
+            !s.provider.can_fetch(),
+            "so the ONLY thing standing between it and a recorded failure is the gate"
+        );
+    }
+}
+
+/// The other half: the manual path is untouched. `run_source_once` — which the
+/// `task_sources_fetch` RPC calls directly, without the scheduler's gate —
+/// still refuses and still says why.
+///
+/// This is what makes the gate a scheduler-only change rather than a silent
+/// disabling of the feature.
+#[tokio::test]
+async fn manual_fetch_still_returns_the_explanatory_error() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let config = crate::openhuman::config::Config {
+        workspace_dir: tmp.path().join("workspace"),
+        action_dir: tmp.path().join("workspace"),
+        config_path: tmp.path().join("config.toml"),
+        ..Default::default()
+    };
+    std::fs::create_dir_all(&config.workspace_dir).expect("workspace");
+
+    let s = source("ts-manual-path-xyz", 1800);
+    let outcome = pipeline::run_source_once(&config, &s, FetchReason::Manual).await;
+
+    let error = outcome
+        .error
+        .as_deref()
+        .expect("the manual path must still surface an error, not silently succeed");
+    assert!(
+        error.contains("unavailable"),
+        "and it must still explain itself: {error}"
+    );
+    assert_eq!(outcome.fetched, 0);
+    assert_eq!(outcome.routed, 0);
 }

--- a/src/openhuman/integrations/task_sources/schemas.rs
+++ b/src/openhuman/integrations/task_sources/schemas.rs
@@ -250,7 +250,10 @@ pub fn schemas(function: &str) -> ControllerSchema {
         "fetch" => ControllerSchema {
             namespace: "task_sources",
             function: "fetch",
-            description: "Fetch one source immediately, route new tasks, and prune tasks no longer returned by the source.",
+            description: "UNAVAILABLE: the task-fetch path was removed with \
+                          `ComposioProvider::fetch_tasks` (tinymemory v1.13.4), so this call \
+                          always fails. When it works again it fetches one source immediately, \
+                          routes new tasks, and prunes tasks no longer returned by the source.",
             inputs: vec![source_id_input(
                 "Identifier of the task source to fetch now.",
             )],
@@ -264,7 +267,11 @@ pub fn schemas(function: &str) -> ControllerSchema {
         "sync" => ControllerSchema {
             namespace: "task_sources",
             function: "sync",
-            description: "Fetch every enabled source immediately, route new tasks, and prune tasks no longer returned by their source.",
+            description: "UNAVAILABLE: the task-fetch path was removed with \
+                          `ComposioProvider::fetch_tasks` (tinymemory v1.13.4), so every source \
+                          in the sweep fails. When it works again it fetches every enabled \
+                          source immediately, routes new tasks, and prunes tasks no longer \
+                          returned by their source.",
             inputs: vec![],
             outputs: vec![FieldSchema {
                 name: "outcomes",
@@ -296,7 +303,10 @@ pub fn schemas(function: &str) -> ControllerSchema {
         "preview_filter" => ControllerSchema {
             namespace: "task_sources",
             function: "preview_filter",
-            description: "Dry-run a filter and return matching tasks WITHOUT routing them.",
+            description: "UNAVAILABLE: the task-fetch path was removed with \
+                          `ComposioProvider::fetch_tasks` (tinymemory v1.13.4), so this call \
+                          always fails. When it works again it dry-runs a filter and returns \
+                          matching tasks WITHOUT routing them.",
             inputs: vec![
                 provider_input(),
                 filter_input(),
@@ -323,7 +333,11 @@ pub fn schemas(function: &str) -> ControllerSchema {
         "list_databases" => ControllerSchema {
             namespace: "task_sources",
             function: "list_databases",
-            description: "List selectable containers (e.g. Notion databases) for a provider/connection so the UI can offer a picker.",
+            description: "UNAVAILABLE: the container-listing path was removed with \
+                          `ComposioProvider::list_databases` (tinymemory v1.13.4), so this call \
+                          always fails. It only ever had a Notion implementation. When it works \
+                          again it lists selectable containers (e.g. Notion databases) for a \
+                          provider/connection so the UI can offer a picker.",
             inputs: vec![
                 provider_input(),
                 FieldSchema {

--- a/src/openhuman/integrations/task_sources/schemas_tests.rs
+++ b/src/openhuman/integrations/task_sources/schemas_tests.rs
@@ -70,3 +70,49 @@ fn read_optional_handles_absent_null_and_value() {
     params.insert("limit".into(), json!(7));
     assert_eq!(read_optional::<u64>(&params, "limit").unwrap(), Some(7));
 }
+
+// ── the unavailability marker (issue #6118) ─────────────────────────────────
+
+/// The four controllers whose fetch path was removed must SAY so in the
+/// description, because that string is what the source picker, the source list
+/// and the agent tool surface read. A schema that still advertises the
+/// capability keeps offering flows that cannot complete.
+///
+/// Paired with its opposite below: marking everything unavailable would satisfy
+/// this test alone.
+#[test]
+fn the_four_unfetchable_controllers_declare_themselves_unavailable() {
+    for function in ["fetch", "sync", "preview_filter", "list_databases"] {
+        let description = schemas(function).description;
+        assert!(
+            description.starts_with("UNAVAILABLE:"),
+            "{function} cannot succeed, so its description must lead with the marker: {description}"
+        );
+        assert!(
+            description.contains("tinymemory v1.13.4"),
+            "{function} must name why, so a reader can find the removal: {description}"
+        );
+    }
+}
+
+/// The seven working controllers must NOT carry the marker. This is what makes
+/// the change above a scoped statement about four controllers rather than a
+/// blanket "this domain is broken".
+#[test]
+fn the_working_controllers_are_not_marked_unavailable() {
+    for function in [
+        "list",
+        "get",
+        "add",
+        "update",
+        "remove",
+        "list_tasks",
+        "status",
+    ] {
+        let description = schemas(function).description;
+        assert!(
+            !description.contains("UNAVAILABLE"),
+            "{function} works and must not be marked unavailable: {description}"
+        );
+    }
+}

--- a/src/openhuman/integrations/task_sources/tools.rs
+++ b/src/openhuman/integrations/task_sources/tools.rs
@@ -161,10 +161,11 @@ impl Tool for TaskSourceFetchTool {
     }
 
     fn description(&self) -> &str {
-        "Fetch one task source now (by `id`) instead of waiting for its poll \
-         interval. Returns counts of tasks fetched, newly routed, and skipped \
-         as duplicates. Use when the user wants the latest issues/tasks pulled \
-         immediately."
+        "UNAVAILABLE: the task-fetch path was removed with \
+         `ComposioProvider::fetch_tasks` (tinymemory v1.13.4), so this call always fails — \
+         do not call it. When it works again it fetches one task source now (by `id`) \
+         instead of waiting for its poll interval, returning counts of tasks fetched, \
+         newly routed, and skipped as duplicates."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -253,10 +254,11 @@ impl Tool for TaskSourcePreviewFilterTool {
     }
 
     fn description(&self) -> &str {
-        "Dry-run a task-source `filter` for a `provider` and return the tasks \
-         it would match, WITHOUT creating a persistent source or ingesting \
-         anything. Use to validate a filter before `task_source_add`. The \
-         `filter` object is provider-tagged (e.g. \
+        "UNAVAILABLE: the task-fetch path was removed with \
+         `ComposioProvider::fetch_tasks` (tinymemory v1.13.4), so this call always fails — \
+         do not call it. When it works again it dry-runs a task-source `filter` for a \
+         `provider` and returns the tasks it would match, WITHOUT creating a persistent \
+         source or ingesting anything. The `filter` object is provider-tagged (e.g. \
          `{ \"provider\": \"github\", \"repo\": \"owner/name\", \"labels\": [\"bug\"] }`)."
     }
 

--- a/src/openhuman/integrations/task_sources/tools_tests.rs
+++ b/src/openhuman/integrations/task_sources/tools_tests.rs
@@ -61,3 +61,44 @@ fn parse_provider_rejects_unknown() {
     let err = parse_provider(&json!({ "provider": "jira" })).expect_err("unknown provider");
     assert!(err.to_string().contains("provider"));
 }
+
+// ── the unavailability marker on the agent surface (issue #6118) ────────────
+
+/// The two agent tools backed by the dead fetch path must declare themselves
+/// unavailable in their **own** `description()`.
+///
+/// The `ControllerSchema` descriptions amended alongside this do not reach
+/// here: `Tool::description` is an independent hard-coded string, so a model
+/// choosing a tool reads this and nothing else. Without the marker the agent
+/// is still advised to call something that deterministically fails.
+#[test]
+fn the_two_dead_agent_tools_declare_themselves_unavailable() {
+    let fetch = TaskSourceFetchTool::new(cfg());
+    assert!(
+        fetch.description().starts_with("UNAVAILABLE:"),
+        "task_source_fetch cannot succeed: {}",
+        fetch.description()
+    );
+    let preview = TaskSourcePreviewFilterTool::new(cfg());
+    assert!(
+        preview.description().starts_with("UNAVAILABLE:"),
+        "task_source_preview_filter cannot succeed: {}",
+        preview.description()
+    );
+}
+
+/// The agent tools that still work must NOT carry the marker — the same
+/// both-directions check the schema tests make, so this cannot degenerate into
+/// marking the whole domain dead.
+#[test]
+fn the_working_agent_tools_are_not_marked_unavailable() {
+    assert!(!TaskSourceListTool::new(cfg())
+        .description()
+        .contains("UNAVAILABLE"));
+    assert!(!TaskSourceStatusTool::new(cfg())
+        .description()
+        .contains("UNAVAILABLE"));
+    assert!(!TaskSourceAddTool::new(cfg())
+        .description()
+        .contains("UNAVAILABLE"));
+}

--- a/src/openhuman/integrations/task_sources/types.rs
+++ b/src/openhuman/integrations/task_sources/types.rs
@@ -44,6 +44,30 @@ impl ProviderSlug {
             )),
         }
     }
+
+    /// Whether this provider has a working task-fetch path today.
+    ///
+    /// **This is the single place that answers the question**, so the
+    /// periodic scheduler and the RPC surface cannot drift apart on it.
+    ///
+    /// Every provider returns `false` right now: the pipeline's fetch step
+    /// (`pipeline::fetch_tasks_unavailable`) is an unconditional `Err` for
+    /// every toolkit, because tinymemory v1.13.4 deleted
+    /// `ComposioProvider::fetch_tasks` with no replacement. Nothing
+    /// downstream of the fetch is broken — dedup, enrichment, routing and
+    /// reconciliation all still work — so the moment a provider grows a real
+    /// fetch again this flips to `true` for that variant and the scheduler
+    /// starts polling it, with no other change.
+    ///
+    /// It is deliberately a per-variant `match` rather than a blanket
+    /// `false`: the restoration lands one toolkit at a time, and a
+    /// wholesale constant would have to be redesigned on the first one
+    /// instead of edited.
+    pub fn can_fetch(self) -> bool {
+        match self {
+            Self::Github | Self::Notion | Self::Linear | Self::Clickup => false,
+        }
+    }
 }
 
 /// Per-provider, user-configured filter. Tagged by `provider` on the


### PR DESCRIPTION
## Summary

- Stops the `task_sources` scheduler polling a source whose provider has no task-fetch path, so it no longer writes a failure row and publishes a `TaskSourceFetchFailed` event per source per tick, forever.
- Makes the four controllers that cannot succeed (`fetch`, `sync`, `preview_filter`, `list_databases`) say so in their schema `description`, so the picker, the source list and the agent tool surface stop offering flows that cannot complete.
- **The manual `task_sources_fetch` RPC deliberately still returns its explanatory error.** That distinction is the point of the change, and a test pins both sides of it.
- Containment only. No fetch behaviour is restored and no production logic beyond the scheduler gate is touched.

## Problem

`pipeline.rs`'s fetch step has been an unconditional `Err` for every toolkit since tinymemory v1.13.4 removed `ComposioProvider::fetch_tasks`. Everything downstream — dedup, enrichment, routing, reconciliation — still works and would work the moment a real fetch returns.

Meanwhile the scheduler polls every enabled source on its `interval_secs` (floor 60s, tick 600s), and each pass takes the failure arm, which writes a `store::record_fetch` row **and** publishes `DomainEvent::TaskSourceFetchFailed`. Unbounded growth for something no user asked for and nobody can act on.

It is a `tracing::warn!`, not an `error!`, and carries no explicit capture — **these failures do not reach Sentry.** What accumulates is failure rows in the store and a repeating error surface in the UI.

## Solution

**0a — the scheduler gate**

New `ProviderSlug::can_fetch()` in `types.rs`: a per-variant `match`, every variant `false` today. `run_one_tick`'s per-source loop skips a provider that answers `false` with a `debug!`, before `run_source_once` can record anything.

Three notes on where it lives and why:

- **`types.rs`, not `periodic.rs`.** The predicate is a fact about a provider, and it has to be readable by more than the scheduler. `mod.rs` says business logic lives in sibling modules; `pipeline.rs` — the other candidate — is being changed by open PR #5521, and colliding with it for a one-line predicate would be gratuitous. `ProviderSlug` already has an `impl` block in `types.rs` and neither open PR touches it.
- **The gate is in the loop, not in `run_source_once`.** Both the timer and the manual RPC share `run_source_once`; gating there would silence both. Only the timer should be silent.
- **A per-variant `match`, not a blanket `false`.** The restoration lands one toolkit at a time, so this is edited rather than redesigned on the first one.

**0b — the four descriptions**

Description-only. Input and output shapes are untouched, so the controllers come back without a second wire change. The other **seven** working controllers (`list`, `get`, `add`, `update`, `remove`, `list_tasks`, `status`) are not touched.

These four controllers are not in `app/schema.json` (which carries 55 methods), so no snapshot update is needed — unlike #6094, which had to update it because `cron_run` is in there.

## Tests

Five new cases, in the two test files neither open PR touches.

`periodic_tests.rs` — both halves of the distinction, pinned together on purpose, because a change that silenced both would satisfy either alone:
- `no_provider_can_fetch_today` — every variant answers `false`. When a toolkit is restored, this is what tells you to update it.
- `scheduler_skips_a_source_whose_provider_cannot_fetch` — asserts the source would otherwise be polled (enabled and due), so the gate is the only thing standing between it and a recorded failure.
- `manual_fetch_still_returns_the_explanatory_error` — drives `run_source_once` directly, the way the RPC does, and asserts it still errors and still says why.

`schemas_tests.rs`:
- `the_four_unfetchable_controllers_declare_themselves_unavailable`
- `the_working_controllers_are_not_marked_unavailable` — the opposite direction, so this cannot degenerate into "the whole domain is broken".

### Revert-checks — two changes, two checks

**A — `can_fetch()` returns `true`** (0a's predicate inverted). Two failures:
```
periodic_tests.rs:82  github has no fetch path until the pipeline's fetch step is restored
periodic_tests.rs:106 scheduler_skips_a_source_whose_provider_cannot_fetch
```

**B — the `UNAVAILABLE:` marker removed from `fetch`'s description** (0b reverted). One failure:
```
schemas_tests.rs:87  fetch cannot succeed, so its description must lead with the marker:
                     Fetch one source immediately, route new tasks, and prune tasks no longer
                     returned by the source.
```

Source restored after each; `git status` clean of both.

> Note: without `schemas_tests.rs`, fault B failed **nothing** — the 0a tests do not touch descriptions, so 0b was unpinned. The revert-check is what surfaced that, which is the argument for doing it per-change rather than once per PR.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — five cases, both halves revert-checked.
- [x] **Diff coverage ≥ 80%** — the production diff is 22 lines across two files (a 4-line predicate, a 9-line gate) and every line is executed by the new tests. Ran: `cargo test --lib --features "$(bash scripts/ci/product-features.sh)" -- task_sources::periodic task_sources::schemas` → **15 passed, 0 failed**. `pnpm test:coverage` not run (no frontend change).
- [x] Coverage matrix updated — `N/A: no feature rows added, removed or renamed.`
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature IDs involved.`
- [x] No new external network dependencies introduced — the change *removes* recurring outbound attempts; nothing is added.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: adds no product surface. The four descriptions change what the UI displays for controllers that already always fail.`
- [x] Linked issue closed via `Closes #NNN` — yes, `Closes #6118`.

## Impact

Desktop/CLI. Removes a recurring background write and a recurring UI error surface; adds none. No migration, no wire-shape change, no performance implication beyond strictly less work per tick.

**CI note:** if `Rust Core Coverage (cargo-llvm-cov)` fails on `flows_lifecycle_e2e::`, that is inherited from red `main` and is unrelated to this PR — #6133 fixes it. Confirm the failure names `flows_lifecycle_e2e::` and re-run once that lands.

## Related

- Closes #6118
- Containment half of the `task_sources` reimplementation. The rebuild (Phases 3a–3d) is on hold pending a product call on whether task ingestion has enough users to justify it. **This ships either way** — it costs half a day and stops the bleeding whichever way that call goes.
- Deliberately avoids `store.rs` (#5709) and `pipeline.rs` (#5521); no overlap with either.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/6118-task-sources-stop-polling-unfetchable`
- Commit SHA: see head commit

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no files under app/ changed.`
- [x] `pnpm typecheck` — `N/A: no TypeScript changed.`
- [x] Focused tests: `cargo test --lib --features "$(bash scripts/ci/product-features.sh)" -- task_sources::periodic task_sources::schemas` → 15 passed, 0 failed.
- [x] Rust fmt/check (if changed): `cargo fmt -- --check` exit 0; `cargo clippy --no-deps --lib --features "$(...)" -- -D warnings` exit 0.
- [x] Tauri fmt/check (if changed): `N/A: no Tauri code changed.`

### Validation Blocked

- `command:` none
- `error:` none
- `impact:` none

### Behavior Changes

- Intended behavior change: the periodic scheduler no longer polls — and no longer records a failure for — a source whose provider cannot fetch. The four dead controllers' descriptions now state they are unavailable.
- User-visible effect: the repeating task-source error in the UI stops. The manual Fetch button still explains why it cannot run.

### Parity Contract

- Legacy behavior preserved: yes for every path that worked. The seven functioning controllers are untouched, and `run_source_once` — shared by the manual RPC and the connection-created bus hook — is unchanged.
- Guard/fallback/dispatch parity checks: the gate is additive and sits beside the existing `enabled` and `is_due` guards in the same loop, in the same style. `manual_fetch_still_returns_the_explanatory_error` pins that the shared entry point did not change.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none.
- Canonical PR: this one.
- Resolution: N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Periodic task-source polling now skips providers without an available task-fetch path, preventing repeated failed fetch records and events.
  - Manual task-source fetches continue to return an explanatory unavailable error.

- **Documentation**
  - Task-source operations whose fetch implementations are unavailable are now clearly marked as unavailable in their descriptions, including related agent tools.
  - Supported task-source operations remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->