### PR TITLE
fix(tokenjuice): declare compress's `explicit` as a schema enum

### DIFF
--- a/src/openhuman/inference/tokenjuice/schemas.rs
+++ b/src/openhuman/inference/tokenjuice/schemas.rs
@@ -135,9 +135,25 @@ pub fn schemas(function: &str) -> ControllerSchema {
                 },
                 FieldSchema {
                     name: "explicit",
-                    ty: TypeSchema::String,
+                    // Declared as an enum, not a bare string: `/schema` is what
+                    // generators and model-facing tool definitions read, and an
+                    // unrestricted string there invites callers to propose values
+                    // that only fail once the handler runs. `check_type`
+                    // (`core/all.rs`) enforces the variant list at the dispatch
+                    // boundary, so the published contract and the rejection agree.
+                    ty: TypeSchema::Option(Box::new(TypeSchema::Enum {
+                        variants: vec![
+                            "json",
+                            "code",
+                            "log",
+                            "search",
+                            "diff",
+                            "html",
+                            "plain_text",
+                        ],
+                    })),
                     comment: "Optional hard override of the detected kind, skipping detection \
-                              entirely. One of: json, code, log, search, diff, html, plain_text.",
+                              entirely.",
                     required: false,
                 },
             ],

--- a/src/openhuman/inference/tokenjuice/schemas_tests.rs
+++ b/src/openhuman/inference/tokenjuice/schemas_tests.rs
@@ -147,3 +147,44 @@ fn compress_schema_declares_all_five_hint_inputs() {
         );
     }
 }
+
+/// `/schema` is what generators and model-facing tool definitions read. Declaring
+/// `explicit` as a bare string there invites a caller to propose a value that only
+/// fails once the handler runs; as an enum, `check_type` rejects it at the dispatch
+/// boundary and the published contract matches the rejection.
+#[test]
+fn compress_declares_explicit_as_an_enum_of_the_accepted_kinds() {
+    let s = schemas("compress");
+    let explicit = s
+        .inputs
+        .iter()
+        .find(|f| f.name == "explicit")
+        .expect("`compress` must declare `explicit`");
+
+    let TypeSchema::Option(inner) = &explicit.ty else {
+        panic!(
+            "`explicit` is optional and must be declared as such: {:?}",
+            explicit.ty
+        );
+    };
+    let TypeSchema::Enum { variants } = inner.as_ref() else {
+        panic!(
+            "`explicit` must be an enum so the accepted kinds are discoverable \
+             from /schema rather than only from the handler: {inner:?}"
+        );
+    };
+    assert_eq!(
+        variants,
+        &[
+            "json",
+            "code",
+            "log",
+            "search",
+            "diff",
+            "html",
+            "plain_text"
+        ],
+        "the declared variants must be exactly what `ContentKind::from_str` parses \
+         — note `plain_text`, not serde's `plainText`"
+    );
+}


### PR DESCRIPTION
## Summary

- Declares `tokenjuice.compress`'s `explicit` input as a schema enum instead of an unrestricted string.
- Moves rejection of an invalid value to the dispatch boundary, so the published contract and the point of refusal agree.
- Recovered work: written as a review response **after** #6121 had already merged, so it landed on a branch with no open PR and would never have shipped.

## Problem

`compress_hint_from_params` accepts only the seven `ContentKind` spellings, but the schema declared
`explicit` as `TypeSchema::String`. `/schema` is what CLI/RPC smoke-test generation and model-facing
tool definitions read, so:

- a generator had no way to know the accepted set, and
- a proposed value failed only once the handler ran, rather than at dispatch.

## Solution

Declare it as `Option(Enum { variants })`. `check_type` in `core/all.rs` enforces the variant list at
the dispatch boundary. The handler's own parse stays — it still has to produce the `ContentKind`.

A test pins the declared variants, including that they are the snake_case spellings (`plain_text`,
not `PlainText`) the handler actually accepts.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — a test pins the full variant list and their snake_case spelling; the invalid-value path is the enum rejection at dispatch.
- [x] **Diff coverage ≥ 80%** — the schema change and its test land together; the added test exercises the changed declaration.
- [x] N/A: schema-shape change to an existing controller; no feature row added, removed or renamed — *coverage matrix updated*
- [x] N/A: no feature IDs affected; this tightens an existing input declaration — *affected feature IDs listed under `## Related`*
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — no dependency change.
- [x] N/A: no release-cut surface touched — *manual smoke checklist ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))*
- [x] N/A: #6088 was already closed by #6121; this is the review follow-up to that PR, not a second fix for the issue — *linked issue closed via `Closes #NNN`*

## Impact

Wire-contract tightening on one input: `/schema` now advertises the accepted set, and an invalid
value is refused at dispatch rather than in the handler. No behaviour change for a caller that was
already sending a valid value.

## Related

- Closes: —
- Follow-up to #6121, which closed #6088.
