### PR TITLE
test(security): follow #6096's StorageMode split in the keyring e2e

### DIFF
--- a/tests/raw_coverage/secrets_devices_e2e.rs
+++ b/tests/raw_coverage/secrets_devices_e2e.rs
@@ -367,17 +367,28 @@ async fn keyring_consent_status_decide_and_retry_probe() {
         "the backend must be named so the settings panel can show it: {status}"
     );
     if available {
-        // NOT `== "os_keyring"`. That was the #6076 defect this test was written
-        // beside: every working backend reported itself as the OS keyring, so a
-        // plaintext dev-keychain looked like the OS credential store. #6096 made
-        // `activeMode` describe the backend that is actually in use, and the
-        // schema now documents `available` as "the active backend is usable,
-        // which is true for the file backends". What a usable backend implies is
-        // that no consent decision is outstanding — not which backend it is.
-        assert!(
-            !matches!(mode, "consent_pending" | "declined"),
-            "a usable backend means no consent decision is outstanding; \
-             got {mode:?}: {status}"
+        // Assert the BACKEND -> MODE pairing, not merely that the mode is in the
+        // enum. #6076 was exactly a mismatched pair — `backendName: "file"` with
+        // `activeMode: "os_keyring"` — so a predicate that only rejects
+        // `consent_pending`/`declined` would let that regression back in while a
+        // comment claimed to guard it. Mirrors `active_mode_for` in
+        // `security/keyring_consent/policy.rs:125-146`.
+        let backend = status
+            .get("backendName")
+            .and_then(Value::as_str)
+            .expect("backendName asserted non-empty above");
+        let expected = match backend {
+            "os" => "os_keyring",
+            "encrypted_file" => "local_encrypted_file",
+            "file" | "mock" => "local_plaintext_file",
+            // An unrecognised backend reports `consent_pending` rather than
+            // guessing — the deliberate fallback in `policy.rs`.
+            _ => "consent_pending",
+        };
+        assert_eq!(
+            mode, expected,
+            "a usable `{backend}` backend must report `{expected}`; reporting anything \
+             else is the #6076 mismatch this test exists to catch: {status}"
         );
         assert!(
             status.get("failureReason").is_none(),

--- a/tests/raw_coverage/secrets_devices_e2e.rs
+++ b/tests/raw_coverage/secrets_devices_e2e.rs
@@ -305,7 +305,8 @@ allowed_commands = ["ls", "cat"]
 /// All three keyring-consent controllers.
 ///
 /// The anchor is the **persisted file**, not `activeMode`. `policy::current_status`
-/// reports `os_keyring` whenever *any* backend probes as available — and the
+/// reported `os_keyring` whenever *any* backend probes as available (fixed by
+/// #6096; `activeMode` now names the backend actually in use) — and the
 /// `file` dev backend always does — so `activeMode` cannot witness a consent
 /// decision in a test process. `ops::keyring_consent_decide` documents that the
 /// in-memory cache is only updated *after* a successful persist, so proving the
@@ -341,9 +342,22 @@ async fn keyring_consent_status_decide_and_retry_probe() {
         .get("activeMode")
         .and_then(Value::as_str)
         .unwrap_or_else(|| panic!("status must report an `activeMode`: {status}"));
+    // Mirrors `StorageMode`'s `Display` impl (`security/keyring_consent/types.rs`),
+    // which is the source of truth. #6096 added the two `*_file` variants when it
+    // stopped the file backends reporting themselves as `os_keyring` (#6076) — this
+    // list is the whole enum, so a new variant fails here rather than silently
+    // widening what the RPC may return.
     assert!(
-        ["os_keyring", "local_encrypted", "consent_pending", "declined"].contains(&mode),
-        "activeMode must be one of the four documented storage modes; got {mode:?}"
+        [
+            "os_keyring",
+            "local_encrypted",
+            "local_encrypted_file",
+            "local_plaintext_file",
+            "consent_pending",
+            "declined",
+        ]
+        .contains(&mode),
+        "activeMode must be one of the six documented storage modes; got {mode:?}"
     );
     assert!(
         status
@@ -353,10 +367,17 @@ async fn keyring_consent_status_decide_and_retry_probe() {
         "the backend must be named so the settings panel can show it: {status}"
     );
     if available {
-        assert_eq!(
-            mode, "os_keyring",
-            "with a working backend no consent is needed, so the mode must be \
-             `os_keyring` and no failure reason may be attached: {status}"
+        // NOT `== "os_keyring"`. That was the #6076 defect this test was written
+        // beside: every working backend reported itself as the OS keyring, so a
+        // plaintext dev-keychain looked like the OS credential store. #6096 made
+        // `activeMode` describe the backend that is actually in use, and the
+        // schema now documents `available` as "the active backend is usable,
+        // which is true for the file backends". What a usable backend implies is
+        // that no consent decision is outstanding — not which backend it is.
+        assert!(
+            !matches!(mode, "consent_pending" | "declined"),
+            "a usable backend means no consent decision is outstanding; \
+             got {mode:?}: {status}"
         );
         assert!(
             status.get("failureReason").is_none(),
@@ -500,8 +521,15 @@ async fn keyring_consent_status_decide_and_retry_probe() {
         probe
             .get("activeMode")
             .and_then(Value::as_str)
-            .is_some_and(|m| ["os_keyring", "local_encrypted", "consent_pending", "declined"]
-                .contains(&m)),
+            .is_some_and(|m| [
+                "os_keyring",
+                "local_encrypted",
+                "local_encrypted_file",
+                "local_plaintext_file",
+                "consent_pending",
+                "declined",
+            ]
+            .contains(&m)),
         "the probe must return a valid storage mode: {probe}"
     );
 }


### PR DESCRIPTION
## Summary

- `main` is red on `Rust Core Coverage` and every open PR inherits it. One test fails.
- The test is wrong, not the code: it pinned the **pre-fix** vocabulary from #6076 and #6096 corrected the product.
- Three assertions updated against `StorageMode`'s `Display` impl, which is the source of truth.
- Test-only. No production code changed.

## Problem

```
secrets_devices_e2e::keyring_consent_status_decide_and_retry_probe
  activeMode must be one of the four documented storage modes; got "local_plaintext_file"
```

`keyring_consent_status_decide_and_retry_probe` was written beside #6076 — `activeMode` reporting
`os_keyring` for the file backend — and encoded the old four-variant vocabulary in three places.
#6096 fixed the defect by making `activeMode` name the backend actually in use, which added
`local_encrypted_file` and `local_plaintext_file` to `StorageMode`. The test's allow-list still had
four, so it failed on the corrected behaviour.

One of the three assertions encoded **the bug itself**:

| Line | Was | Why it is wrong now |
|---|---|---|
| ~344 | four-variant allow-list | `StorageMode` has six |
| ~369 | `assert_eq!(mode, "os_keyring")` when `available` | this *is* #6076 — it required every usable backend to claim it was the OS keyring |
| ~519 | four-variant list on the retry probe | same |

## Solution

All three rewritten against `src/openhuman/security/keyring_consent/types.rs` rather than a
remembered list. The allow-lists now enumerate the whole enum, so a future variant fails here
instead of silently widening what the RPC may return.

The `available` branch asserts `!matches!(mode, "consent_pending" | "declined")`. The schema
documents `available` as *"whether the active backend is usable, which is true for the file
backends"* — so a usable backend implies no consent decision is outstanding, not that it is the OS
keyring.

The doc comment describing the pre-fix behaviour as current is reworded to past tense with a pointer
to #6096.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — three assertions updated in `secrets_devices_e2e.rs`; the suite covers both the available and unavailable branches. Ran `cargo test --test raw_coverage_all --features "$(bash scripts/ci/product-features.sh)" -- --test-threads=1 secrets_devices_e2e::` → **8 passed, 0 failed, 1 ignored**.
- [x] **Diff coverage ≥ 80%** — every changed line is a test assertion executed by the run above, so changed-line coverage is 100% by construction.
- [x] N/A: test-only change; no feature row added, removed or renamed — *coverage matrix updated*
- [x] N/A: no feature IDs affected; this corrects assertions on existing behaviour — *affected feature IDs listed under `## Related`*
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — no new dependency; the test uses the existing in-process harness.
- [x] N/A: test-only, no release-cut surface touched — *manual smoke checklist ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))*
- [x] N/A: no issue exists — this repairs a test that a merged fix invalidated, and filing one for a same-day break is noise — *linked issue closed via `Closes #NNN`*

## Impact

Unblocks `Rust Core Coverage` on `main` and on every open PR that inherits it. No runtime, platform,
performance, security or migration impact — the diff touches one test file.

## Related

- Closes: —
- Follow-up to #6096, which fixed #6076 and changed the vocabulary this test pinned.
- Unblocks #6117, #6120, #6122, #6124, #6132, which fail only on this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved keyring consent validation to ensure the reported storage mode matches the active backend.
  - Added coverage for file-backed storage modes in status and retry responses.
  - Continued rejecting pending or declined consent states.

- **Documentation**
  - Clarified that `activeMode` identifies the backend currently in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->