### PR TITLE
fix(sandbox): report the local jail as inactive when nothing is enforcing

### DIFF
--- a/src/openhuman/sandbox/cwd_jail/mod.rs
+++ b/src/openhuman/sandbox/cwd_jail/mod.rs
@@ -57,7 +57,7 @@ pub mod macos;
 pub mod windows;
 
 pub use jail::{Jail, JailBackend};
-pub use noop::NoopBackend;
+pub use noop::{NoopBackend, NOOP_BACKEND_NAME};
 pub use registry::{JailRecord, JailRegistry};
 
 use std::process::{Child, Command};

--- a/src/openhuman/sandbox/cwd_jail/noop.rs
+++ b/src/openhuman/sandbox/cwd_jail/noop.rs
@@ -8,12 +8,21 @@ use std::process::{Child, Command};
 
 use super::jail::{Jail, JailBackend};
 
+/// The name `NoopBackend` reports, and the value callers compare against to
+/// detect that no OS confinement is in force.
+///
+/// Single-sourced deliberately: `sandbox::ops::create_sandbox_backend` decides
+/// whether the local sandbox handle reports `Ready` or `Inactive` by comparing
+/// against this, so a rename here must not silently turn an unconfined host
+/// back into a `Ready` report.
+pub const NOOP_BACKEND_NAME: &str = "noop";
+
 #[derive(Debug, Default)]
 pub struct NoopBackend;
 
 impl JailBackend for NoopBackend {
     fn name(&self) -> &'static str {
-        "noop"
+        NOOP_BACKEND_NAME
     }
 
     fn is_available(&self) -> bool {

--- a/src/openhuman/sandbox/ops.rs
+++ b/src/openhuman/sandbox/ops.rs
@@ -86,6 +86,25 @@ pub fn resolve_sandbox_policy(
 
 /// Create a backend handle for the resolved policy. For Docker this
 /// checks availability; for Local it checks the OS backend.
+/// The status a `Local` sandbox handle reports, given the backend `pick_backend`
+/// actually chose.
+///
+/// Extracted as a free function so the decision is testable on **any** host.
+/// Asserting it through `create_sandbox_backend` cannot work: which branch runs
+/// depends on whether the machine has an OS jail, so on a host with Seatbelt or
+/// Landlock the noop path is never reached and a regression to "always Ready"
+/// passes unnoticed. That is exactly how the original defect survived.
+pub(crate) fn local_status_for_backend(backend_name: &str) -> SandboxStatus {
+    if backend_name == cwd_jail::NOOP_BACKEND_NAME {
+        // The noop backend enforces nothing — it spawns the command as-is. It is
+        // a documented passthrough rather than a failure, so `Inactive`
+        // ("backend not initialized") is the honest report, not `Error`.
+        SandboxStatus::Inactive
+    } else {
+        SandboxStatus::Ready
+    }
+}
+
 pub async fn create_sandbox_backend(policy: &SandboxPolicy) -> SandboxBackendHandle {
     match policy.backend {
         SandboxBackendKind::None => SandboxBackendHandle {
@@ -95,18 +114,36 @@ pub async fn create_sandbox_backend(policy: &SandboxPolicy) -> SandboxBackendHan
         },
         SandboxBackendKind::Local => {
             let os_backend = cwd_jail::default_backend();
+            let backend_name = os_backend.name();
+            // Derive the status from WHICH backend was chosen, not from
+            // `is_available()`.
+            //
+            // `default_backend()` is `cwd_jail::detect::pick_backend`, which
+            // already performs the availability check and substitutes
+            // `NoopBackend` when no OS jail is usable. `NoopBackend::is_available()`
+            // is unconditionally `true` — pinned as a contract by the #3235
+            // regression test — so asking it here always answered `true` and the
+            // `else` arm was unreachable. The handle therefore reported `Ready`
+            // on a host with no confinement at all, which is the one direction a
+            // sandbox status must never be wrong in: a caller that trusts it
+            // believes commands are jailed when they run unconfined.
+            //
+            // The noop backend is a documented passthrough, not a failure, so
+            // `Inactive` ("backend not initialized") is the honest report rather
+            // than `Error`. `backend_id` still carries the name for a caller that
+            // wants the specific backend.
+            let status = local_status_for_backend(backend_name);
+            if status == SandboxStatus::Inactive {
+                tracing::warn!(
+                    backend = backend_name,
+                    "[sandbox:local] no OS jail available; commands run UNCONFINED and \
+                     the handle reports inactive"
+                );
+            }
             SandboxBackendHandle {
                 kind: SandboxBackendKind::Local,
-                status: if os_backend.is_available() {
-                    SandboxStatus::Ready
-                } else {
-                    tracing::warn!(
-                        backend = os_backend.name(),
-                        "[sandbox:local] OS jail backend not available, falling back to noop"
-                    );
-                    SandboxStatus::Ready
-                },
-                backend_id: Some(os_backend.name().to_string()),
+                status,
+                backend_id: Some(backend_name.to_string()),
             }
         }
         SandboxBackendKind::Docker => docker::docker_backend_handle().await,

--- a/src/openhuman/sandbox/ops_tests.rs
+++ b/src/openhuman/sandbox/ops_tests.rs
@@ -103,7 +103,30 @@ async fn create_sandbox_backend_local() {
     );
     let handle = create_sandbox_backend(&policy).await;
     assert_eq!(handle.kind, SandboxBackendKind::Local);
-    assert_eq!(handle.status, SandboxStatus::Ready);
+
+    // Assert the BACKEND -> STATUS pairing, not a fixed value. This test
+    // previously asserted `Ready` unconditionally, which is precisely the
+    // defect being fixed: on a host with no OS jail, `pick_backend` falls back
+    // to `NoopBackend` and the handle claimed the sandbox was ready while
+    // commands ran unconfined. Which branch runs here depends on the CI host,
+    // so pin the relationship instead of the outcome.
+    let backend_id = handle
+        .backend_id
+        .as_deref()
+        .expect("the local backend must name itself so a caller can tell which jail is in force");
+    if backend_id == cwd_jail::NOOP_BACKEND_NAME {
+        assert_eq!(
+            handle.status,
+            SandboxStatus::Inactive,
+            "the noop passthrough enforces nothing, so it must not report `Ready`"
+        );
+    } else {
+        assert_eq!(
+            handle.status,
+            SandboxStatus::Ready,
+            "a real OS jail ({backend_id}) is in force, so `Ready` is honest"
+        );
+    }
 }
 
 // The `/tmp` path and Unix builtins (`false`) are Unix-only, so these
@@ -256,4 +279,32 @@ fn env_passthrough_includes_safe_vars() {
     assert!(!SANDBOX_ENV_PASSTHROUGH
         .iter()
         .any(|v| v.contains("KEY") || v.contains("SECRET")));
+}
+
+// ── the security-relevant decision, tested independently of the host ─────────
+//
+// `create_sandbox_backend_local` above can only exercise whichever branch this
+// machine happens to take. On a host with Seatbelt or Landlock it never reaches
+// the noop path, so a regression to "always Ready" would pass there unnoticed —
+// which is how the original defect survived. These pin the decision directly.
+
+#[test]
+fn local_status_is_inactive_when_no_os_jail_is_in_force() {
+    assert_eq!(
+        local_status_for_backend(cwd_jail::NOOP_BACKEND_NAME),
+        SandboxStatus::Inactive,
+        "the noop backend enforces nothing; reporting `Ready` tells a caller its \
+         commands are jailed when they run unconfined"
+    );
+}
+
+#[test]
+fn local_status_is_ready_for_a_real_jail() {
+    for backend in ["seatbelt", "landlock", "appcontainer"] {
+        assert_eq!(
+            local_status_for_backend(backend),
+            SandboxStatus::Ready,
+            "a real OS jail ({backend}) is in force, so `Ready` is honest"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- `sandbox_status` with `{"backend":"local"}` reported `Ready` on every host, including one with no OS jail in force.
- The availability guard could never fire, so the handle claimed confinement that was not there.
- Status is now derived from **which** backend was chosen; the noop passthrough reports `Inactive`.
- Two new tests pin the decision on any host — the previous test could only exercise whichever branch the CI machine happened to take.

## Problem

`create_sandbox_backend`'s `Local` arm chose its status with
`if os_backend.is_available() { Ready } else { … Ready }` — both arms returned the same value, so the
conditional was dead.

It could not have worked as written. `default_backend()` is `cwd_jail::detect::pick_backend`, which
**already** performs the availability check and substitutes `NoopBackend` when no OS jail is usable.
`NoopBackend::is_available()` is unconditionally `true` — pinned as a contract by the #3235
regression test, because it must serve as the documented passthrough on unsupported platforms. The
condition was therefore always true, the `else` arm unreachable, and its warning never fired.

The result: on a host with no jail, `sandbox_status` reported `Ready` while commands ran unconfined.
A caller reading `status` had no signal. (`backend_id` did carry `"noop"`, so a caller who knew to
look could tell — but the status field itself was wrong.)

## Solution

Derive the status from the identity of the chosen backend:

- **`local_status_for_backend(name)`** — noop → `Inactive`, any real jail → `Ready`. `Inactive`
  ("backend not initialized") rather than `Error`, because noop is a documented passthrough, not a
  failure.
- **`NOOP_BACKEND_NAME`** is now a constant that `NoopBackend::name()` returns, so a rename cannot
  silently turn an unconfined host back into a `Ready` report.
- The warning fires on the path that actually runs and says plainly that commands run unconfined.

`backend_id` is unchanged. `NoopBackend::is_available()` is **not** touched — #3235 pins it, and
`pick_backend`/`spawn` depend on it.

### Why the decision is a free function

Asserting this through `create_sandbox_backend` only exercises whichever branch the host takes. On a
machine with Seatbelt or Landlock the noop path is never reached — **which is how this survived.**
Verified concretely: with the fix reverted, the end-to-end test still passed on a macOS host because
Seatbelt is present. Extracting the decision makes it assertable everywhere.

## Verification

```
cargo test -p openhuman --lib --features "$(bash scripts/ci/product-features.sh)" -- sandbox::
test result: ok. 88 passed; 0 failed
```

Fault injection — forcing the old always-`Ready` behaviour:

```
local_status_is_inactive_when_no_os_jail_is_in_force ... FAILED
  the noop backend enforces nothing; reporting `Ready` tells a caller its commands
  are jailed when they run unconfined
  left: Ready   right: Inactive
```

Restored; suite green.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — two host-independent tests added; the existing `create_sandbox_backend_local` now asserts the backend→status pairing instead of a fixed `Ready`.
- [x] **Diff coverage ≥ 80%** — the changed decision is covered directly by both new tests, proven by fault injection above.
- [x] N/A: behaviour correction to an existing controller; no feature row added, removed or renamed — *coverage matrix updated*
- [x] N/A: no feature IDs affected — *affected feature IDs listed under `## Related`*
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — no network path touched.
- [x] N/A: no release-cut surface touched; this is an RPC status field — *manual smoke checklist ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))*
- [x] N/A: no public issue was filed — the finding is security-relevant and the repository's `ISSUE_TEMPLATE/config.yml` directs security reports away from public issues — *linked issue closed via `Closes #NNN`*

## Impact

**Behaviour change, deliberately.** A host with no OS jail now reports
`status: "inactive"` for the local backend instead of `"ready"`. Any caller that
branched on `status == "ready"` to decide whether confinement is in force was
previously getting the wrong answer on such hosts and now gets the right one.
`app/src` does not consume this RPC, so there is no renderer impact.

## Related

- Closes: —
- Found during the e2e coverage wave (#6053–#6060) and independently verified before this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected local sandbox status reporting when operating without OS-level confinement. These environments now appear as **Inactive** instead of **Ready**.
  * Local sandboxes using supported OS security mechanisms continue to report **Ready**.
  * Added a warning when OS-level confinement is unavailable and the fallback mode is selected.
  * Improved consistency of sandbox status across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->