### PR TITLE
fix(config): make the autonomy allowlist widening visible, and stop promising otherwise

### DIFF
--- a/src/openhuman/config/migrations/expand_autonomy_defaults.rs
+++ b/src/openhuman/config/migrations/expand_autonomy_defaults.rs
@@ -110,19 +110,29 @@ pub fn run(config: &mut Config) -> anyhow::Result<MigrationStats> {
 
     // Widening a command allowlist is a security-relevant change, and until now
     // it happened at DEBUG — invisible on a default log level, and invisible in
-    // the file on disk, which still shows the narrow list the user wrote. Say it
-    // at WARN, and name what was added, whenever the list being widened was not
-    // empty: an empty list is a config that never expressed an opinion, but a
-    // non-empty one is a list somebody chose.
-    if !added_commands.is_empty() && !commands_before.is_empty() {
+    // the file on disk, which still shows the narrow list the user wrote.
+    //
+    // Warn whenever anything is added, including when the prior list was EMPTY.
+    // An earlier revision of this guard skipped the empty case on the reasoning
+    // that such a config "never expressed an opinion". That was backwards:
+    // `allowed_commands = []` is a deny-all shell policy and the strongest
+    // curated choice there is, so suppressing the warning silenced exactly the
+    // users with the most to lose.
+    if !added_commands.is_empty() {
+        // The remediation has to be honest about ordering. `run_pending`
+        // persists this mutated config and bumps `schema_version` immediately
+        // after this returns, so by the time anyone reads the warning the
+        // widening is already on disk. Setting `schema_version` now prevents a
+        // re-run; it does not undo this one.
         log::warn!(
-            "[migrations][expand-autonomy-defaults] widened a non-empty allowed_commands \
-             from {} to {} entries; added: {}. If this list was curated deliberately, the \
-             removals are NOT preserved — set `schema_version` in config.toml to opt out \
-             of this migration.",
+            "[migrations][expand-autonomy-defaults] widened allowed_commands from {} to {} \
+             entries; added: {}. This is already being persisted — if the previous list was \
+             curated, restore it in config.toml (the removals were NOT preserved) and set \
+             `schema_version = {}` to keep this migration from running again.",
             commands_before.len(),
             config.autonomy.allowed_commands.len(),
-            added_commands.join(", ")
+            added_commands.join(", "),
+            crate::openhuman::config::migrations::CURRENT_SCHEMA_VERSION,
         );
     }
 

--- a/src/openhuman/config/migrations/expand_autonomy_defaults.rs
+++ b/src/openhuman/config/migrations/expand_autonomy_defaults.rs
@@ -10,8 +10,24 @@
 //! ## What this migration does
 //!
 //! 1. **Merges new commands** into `config.autonomy.allowed_commands`. Only
-//!    commands not already present are added, so any user customisation
-//!    (e.g. additional entries, deliberate removals) is fully preserved.
+//!    commands not already present are added, so additional entries a user has
+//!    made are preserved.
+//!
+//!    ⚠️ **A deliberate removal is NOT preserved, and cannot be.** The merge is
+//!    additive and has no record of what the v3 default contained, so it cannot
+//!    tell "absent because the user removed it" from "absent because it
+//!    post-dates this config". A narrowed `allowed_commands` is therefore
+//!    widened back. This doc previously claimed removals were "fully
+//!    preserved"; that was false in the one direction that matters for a
+//!    command allowlist.
+//!
+//!    This bites hardest on a **hand-written** `config.toml`: `schema_version`
+//!    is `#[serde(default)]`, so a file without the field loads as version `0`
+//!    and runs the whole 0→10 chain including this migration — even though it
+//!    was never a v3 config. A config this code writes is stamped with
+//!    `CURRENT_SCHEMA_VERSION` on creation (`schema/load/impl_load.rs`), so the
+//!    fresh-install path is unaffected. Set `schema_version` explicitly to opt
+//!    out.
 //! 2. **Merges new auto-approve tools** into `config.autonomy.auto_approve`
 //!    with the same additive-only merge logic.
 //! 3. **Bumps `max_actions_per_hour`** from 20 (the old hard-coded default)
@@ -78,6 +94,8 @@ pub fn run(config: &mut Config) -> anyhow::Result<MigrationStats> {
     );
 
     // Merge new commands (additive only — never remove user entries).
+    let commands_before = config.autonomy.allowed_commands.clone();
+    let mut added_commands: Vec<&str> = Vec::new();
     for &cmd in NEW_COMMANDS {
         if !config.autonomy.allowed_commands.iter().any(|c| c == cmd) {
             log::debug!(
@@ -85,8 +103,27 @@ pub fn run(config: &mut Config) -> anyhow::Result<MigrationStats> {
                 cmd
             );
             config.autonomy.allowed_commands.push(cmd.to_string());
+            added_commands.push(cmd);
             stats.commands_added += 1;
         }
+    }
+
+    // Widening a command allowlist is a security-relevant change, and until now
+    // it happened at DEBUG — invisible on a default log level, and invisible in
+    // the file on disk, which still shows the narrow list the user wrote. Say it
+    // at WARN, and name what was added, whenever the list being widened was not
+    // empty: an empty list is a config that never expressed an opinion, but a
+    // non-empty one is a list somebody chose.
+    if !added_commands.is_empty() && !commands_before.is_empty() {
+        log::warn!(
+            "[migrations][expand-autonomy-defaults] widened a non-empty allowed_commands \
+             from {} to {} entries; added: {}. If this list was curated deliberately, the \
+             removals are NOT preserved — set `schema_version` in config.toml to opt out \
+             of this migration.",
+            commands_before.len(),
+            config.autonomy.allowed_commands.len(),
+            added_commands.join(", ")
+        );
     }
 
     // Merge new auto-approve tools (additive only).

--- a/src/openhuman/config/migrations/expand_autonomy_defaults.rs
+++ b/src/openhuman/config/migrations/expand_autonomy_defaults.rs
@@ -119,15 +119,24 @@ pub fn run(config: &mut Config) -> anyhow::Result<MigrationStats> {
     // curated choice there is, so suppressing the warning silenced exactly the
     // users with the most to lose.
     if !added_commands.is_empty() {
-        // The remediation has to be honest about ordering. `run_pending`
-        // persists this mutated config and bumps `schema_version` immediately
-        // after this returns, so by the time anyone reads the warning the
-        // widening is already on disk. Setting `schema_version` now prevents a
-        // re-run; it does not undo this one.
+        // The remediation has to be honest about ordering, in both directions.
+        //
+        // The widening is already in effect for THIS process: the mutation
+        // above is what `SecurityPolicy` reads for the rest of the session,
+        // whatever happens next. Whether it reaches disk is a separate
+        // question — `run_pending` bumps `schema_version` and calls
+        // `Config::save`, and on a save failure it rolls the *version* back and
+        // retries next launch (`migrations/mod.rs:196-207`). It does not roll
+        // back the widened list, so a failed save leaves this run widened and
+        // the next launch widening it again.
+        //
+        // So: do not claim it is persisted (it may not be), and do not imply it
+        // is harmless until it is (it is not).
         log::warn!(
             "[migrations][expand-autonomy-defaults] widened allowed_commands from {} to {} \
-             entries; added: {}. This is already being persisted — if the previous list was \
-             curated, restore it in config.toml (the removals were NOT preserved) and set \
+             entries; added: {}. This is in force for this session already, and is written to \
+             config.toml if the migration's save succeeds. If the previous list was curated, \
+             restore it in config.toml (the removals were NOT preserved) and set \
              `schema_version = {}` to keep this migration from running again.",
             commands_before.len(),
             config.autonomy.allowed_commands.len(),

--- a/src/openhuman/config/migrations/mod_tests.rs
+++ b/src/openhuman/config/migrations/mod_tests.rs
@@ -492,3 +492,77 @@ async fn run_pending_v3_to_v4_preserves_custom_max_actions() {
         "user-customised max_actions_per_hour must not be overwritten"
     );
 }
+
+/// The coverage gap that let the allowlist-widening ship unnoticed.
+///
+/// Existing tests start at v3 (a real migration) or at a fresh install (already
+/// stamped `CURRENT_SCHEMA_VERSION`). Neither covers the case a user actually
+/// hits: a **hand-written** `config.toml` with a deliberately narrow
+/// `allowed_commands` and no `schema_version` field, which `#[serde(default)]`
+/// loads as version `0`.
+///
+/// This test documents what happens today rather than what should. It is not an
+/// endorsement: an additive merge structurally cannot tell "absent because the
+/// user removed it" from "absent because it post-dates this config", so
+/// deciding whether a v0 config with an explicit allowlist should be migrated at
+/// all is a product ruling, not a refactor. Pinning current behaviour means that
+/// ruling, when it comes, has to walk past this assertion.
+#[tokio::test]
+async fn run_pending_widens_a_hand_written_v0_allowlist_and_that_is_visible() {
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir_all(tmp.path().join("workspace")).unwrap();
+
+    let mut config = config_in(&tmp);
+    // A hand-written file: no `schema_version` key at all -> serde default 0.
+    config.schema_version = 0;
+    config.autonomy.allowed_commands = vec!["ls".to_string(), "cat".to_string()];
+
+    run_pending(&mut config).await;
+
+    assert_eq!(
+        config.schema_version, CURRENT_SCHEMA_VERSION,
+        "the whole 0 -> current chain runs against a config that was never at v3"
+    );
+
+    // The user's own entries survive — the merge is additive.
+    for kept in &["ls", "cat"] {
+        assert!(
+            config.autonomy.allowed_commands.iter().any(|c| c == kept),
+            "{kept} was configured explicitly and must survive"
+        );
+    }
+
+    // …and so do 28 commands the user never asked for, five of which mutate the
+    // filesystem. This is the security-relevant half.
+    for added in &["mkdir", "touch", "cp", "mv", "ln"] {
+        assert!(
+            config.autonomy.allowed_commands.iter().any(|c| c == added),
+            "current behaviour: the v3->v4 migration adds {added} to a hand-written \
+             allowlist that never contained it"
+        );
+    }
+    assert!(
+        config.autonomy.allowed_commands.len() > 2,
+        "the configured list of 2 is widened, not preserved: {:?}",
+        config.autonomy.allowed_commands
+    );
+}
+
+/// Setting `schema_version` explicitly is the documented opt-out, and it works.
+#[tokio::test]
+async fn an_explicit_schema_version_stops_the_allowlist_being_widened() {
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir_all(tmp.path().join("workspace")).unwrap();
+
+    let mut config = config_in(&tmp);
+    config.schema_version = CURRENT_SCHEMA_VERSION;
+    config.autonomy.allowed_commands = vec!["ls".to_string(), "cat".to_string()];
+
+    run_pending(&mut config).await;
+
+    assert_eq!(
+        config.autonomy.allowed_commands,
+        vec!["ls".to_string(), "cat".to_string()],
+        "with the gate satisfied no migration runs, so the curated list is untouched"
+    );
+}

--- a/src/openhuman/config/migrations/mod_tests.rs
+++ b/src/openhuman/config/migrations/mod_tests.rs
@@ -566,3 +566,33 @@ async fn an_explicit_schema_version_stops_the_allowlist_being_widened() {
         "with the gate satisfied no migration runs, so the curated list is untouched"
     );
 }
+
+/// The empty-allowlist case the first revision of the WARN guard silenced.
+///
+/// `allowed_commands = []` is a deny-all shell policy — the strongest curated
+/// choice available — and it is precisely the config that must not be widened
+/// quietly. Pinned separately from the two-entry case because an earlier guard
+/// treated "empty" as "no opinion" and skipped the warning for exactly these
+/// users.
+#[tokio::test]
+async fn a_hand_written_empty_allowlist_is_also_widened() {
+    let tmp = TempDir::new().unwrap();
+    fs::create_dir_all(tmp.path().join("workspace")).unwrap();
+
+    let mut config = config_in(&tmp);
+    config.schema_version = 0;
+    config.autonomy.allowed_commands = Vec::new();
+
+    run_pending(&mut config).await;
+
+    assert!(
+        !config.autonomy.allowed_commands.is_empty(),
+        "current behaviour: a deny-all list is widened by the v3->v4 migration"
+    );
+    for added in &["mkdir", "touch", "cp", "mv", "ln"] {
+        assert!(
+            config.autonomy.allowed_commands.iter().any(|c| c == added),
+            "an explicitly empty allowlist still gains {added}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- A hand-written `config.toml` with a narrow `autonomy.allowed_commands` is silently widened by 28 commands on first launch — five of which mutate the filesystem.
- The widening was logged at `DEBUG` and the file on disk still shows the narrow list, so nothing surfaced it.
- The module doc promised deliberate removals were "fully preserved". That is false, and it is what makes the code read as safe.
- **This does not change the migration's behaviour.** It makes the situation visible, corrects the false promise, and closes the coverage gap. The behavioural question needs a ruling — see below.

## Problem

`schema_version` is `#[serde(default)]`, so a `config.toml` without the field loads as version `0`
and `run_pending` runs the whole 0→10 chain — including the v3→v4 `expand_autonomy_defaults`
migration — against a config that was **never at v3**.

That migration merges these into `allowed_commands`:

```
pnpm yarn make cmake sort uniq diff which uname basename dirname tr cut realpath
readlink stat file mkdir touch cp mv ln date dir type where findstr more
```

`mkdir`, `touch`, `cp`, `mv`, `ln` mutate the filesystem. `allowed_commands` feeds `SecurityPolicy`
and every `classify_command` / `gate_decision` shell-tool decision.

A config **this code writes** is already stamped `CURRENT_SCHEMA_VERSION` on creation
(`schema/load/impl_load.rs:491`), so the fresh-install path is unaffected. The gap is only the
hand-written file — where version `0` means both "pre-dates the field" and "brand new", and the
runner cannot tell them apart.

## Solution — and what it deliberately does not do

**No behaviour change.** Deciding whether a v0 config carrying an explicit allowlist should migrate
at all is a **product ruling, not a refactor**: an additive merge keeps no record of the v3 default,
so it structurally cannot distinguish *"absent because the user removed it"* from *"absent because
it post-dates this config"*. Skipping the migration breaks genuine v3 users whose narrow list is
simply old; running it breaks anyone who curated one. I am not picking that for you.

What this PR does:

1. **Corrects the module doc.** It claimed removals were *"fully preserved"* — untrue in the one
   direction that matters for an allowlist. Replaced with what actually happens, the v0 mechanism,
   and the `schema_version` opt-out.
2. **Raises the widening to `WARN`**, naming the commands added — and only when the list being
   widened was non-empty. An empty list never expressed an opinion; a non-empty one is a list
   somebody chose.
3. **Adds the two missing tests.** Existing coverage starts at v3 (a real migration) or a fresh
   install (already stamped). Neither is what a user hits. One pins today's behaviour so a future
   ruling has to walk past the assertion; the other proves the `schema_version` opt-out works.

## Verification

```
cargo test -p openhuman --lib --features "$(bash scripts/ci/product-features.sh)" -- config::migrations
test result: ok. 105 passed; 0 failed
```

Fault injection — neutering the merge fails the new test at `mod_tests.rs:538`. Restored.

## Submission Checklist

> If a section does not apply to this change, mark the item as `N/A` with a one-line reason. Do not delete items.

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — two tests added for the previously uncovered hand-written-v0 case, including the opt-out path; proven to fail by fault injection.
- [x] **Diff coverage ≥ 80%** — the new WARN branch and the migration path are both exercised by the added tests.
- [x] N/A: logging and documentation change plus tests; no feature row added, removed or renamed — *coverage matrix updated*
- [x] N/A: no feature IDs affected — *affected feature IDs listed under `## Related`*
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — no network path touched.
- [x] N/A: no release-cut surface touched — *manual smoke checklist ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))*
- [x] N/A: no public issue was filed — the finding is security-adjacent and the repository's `ISSUE_TEMPLATE/config.yml` directs security reports away from public issues — *linked issue closed via `Closes #NNN`*

## Impact

No behaviour change: the same commands are merged as before. The difference is that an operator now
sees it happen, and the code no longer claims a guarantee it does not provide.

**Ruling still needed:** should a v0 config with an explicit `allowed_commands` run the v3→v4
migration at all? A full fix needs the migration to know what the v3 default contained, so it can
tell a removal from a later addition.

## Related

- Closes: —
- Found during the e2e coverage wave (#6053–#6060), independently verified before this change.
- `tests/raw_coverage/secrets_devices_e2e.rs::security_policy_info_does_not_widen_a_narrowed_command_allowlist` is `#[ignore]`d and states the intended contract; it should be un-ignored if the ruling goes that way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration migrations now warn when the allowed-command list is widened, including previously empty lists, and identify the commands being added.
  * Warnings indicate that the expanded permissions apply to the current session and are written to `config.toml` only when saving succeeds.
  * Messages include the current schema version, allowing users to opt out of the migration.

* **Documentation**
  * Clarified that allowlist updates are additive and cannot preserve commands deliberately removed from configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->