### PR TITLE
feat(tools): export the DNS-checking URL guard

### DIFF
--- a/src/openhuman/tools/impl/network/mod.rs
+++ b/src/openhuman/tools/impl/network/mod.rs
@@ -25,6 +25,9 @@ pub use mcp_setup::{
     McpSetupGetTool, McpSetupInstallAndConnectTool, McpSetupRequestSecretTool, McpSetupSearchTool,
     McpSetupTestConnectionTool,
 };
+/// The SSRF guard the network tools apply, so a host outside this crate can
+/// hold user-supplied URLs to the same rule rather than writing a second one.
+pub use url_guard::validate_url_with_dns_check;
 pub use web_fetch::WebFetchTool;
 
 /// Shared test helper for the network tools' local-only enforcement tests

--- a/src/openhuman/tools/impl/network/url_guard.rs
+++ b/src/openhuman/tools/impl/network/url_guard.rs
@@ -97,7 +97,7 @@ pub(super) fn validate_url(raw_url: &str, allowed_domains: &[String]) -> anyhow:
 ///
 /// Callers should use this function instead of `validate_url` in all
 /// paths that make outbound HTTP requests.
-pub(super) async fn validate_url_with_dns_check(
+pub async fn validate_url_with_dns_check(
     raw_url: &str,
     allowed_domains: &[String],
 ) -> anyhow::Result<String> {


### PR DESCRIPTION
## Summary

Makes `validate_url_with_dns_check` reachable from outside this crate. Four lines: the function goes from `pub(super)` to `pub`, and one `pub use` joins the other network-tool exports. No behaviour changes.

## Problem

The network tools already answer the hard half of the SSRF question properly. `validate_url` alone reads the URL as a string, so a hostname that *looks* ordinary passes; `validate_url_with_dns_check` resolves it and refuses when it lands in private or link-local space. That resolve-then-check step is the only thing that catches an attacker-registered hostname whose A record points at, say, cloud metadata.

A host crate embedding this one has exactly the same question to answer about URLs its own users hand it, and no way to reach this answer. The concrete case: OpenCompany's memory ingest fetches a user-supplied link behind a guard that blocks literal IP addresses and `localhost` / `.internal`, but never resolves the name — so the hostname variant walks straight through. Its guard cannot call this one.

Without the export the only options are to write a second resolve-then-check, or to route a whole fetch path through `HttpRequestTool` to reach one function. The first is the real cost: **two implementations of one security rule, which is how a rule ends up with two different answers.** That has already happened once in the consuming codebase with an approval rule read from two places.

## Solution

Export the checked entry point, and only that. `mod url_guard` stays private, `validate_url` and the normalisation helpers stay `pub(super)`, and the resolver-injecting variant stays private — so a caller outside this crate can reach the safe function and cannot reach the unchecked one. `pub mod network` was already public above it, so no further re-export was needed.

The doc comment on the export says why it exists, so a future reader does not narrow it back on the reasonable-looking grounds that nothing in this crate calls it from outside.

## Submission Checklist

- [x] N/A: this changes a visibility modifier and adds a re-export. The exported function's behaviour is unchanged and already carries 55 passing cases in `url_guard`, including the private/link-local refusals and the wildcard-still-blocks-private path.
- [x] **Diff coverage ≥ 80%** — the one executable changed line is the `pub async fn` signature, exercised by the existing `url_guard` suite.
- [x] N/A: behaviour-only change — no feature row added, removed or renamed.
- [x] N/A: no matrix rows are affected, so there are no feature IDs to list.
- [x] No new external network dependencies introduced.
- [x] N/A: no release-cut surface is touched.
- [x] N/A: no issue is filed for this; the consumer-side fix it unblocks is described under Related.

## Impact

Nothing in this crate changes. The exported function is the same one `HttpRequestTool` already calls on every request, so its behaviour is covered by the existing suite either way.

The surface widening is deliberate and narrow: one function that refuses more than it admits. A caller cannot reach the string-only `validate_url` or the resolver-injecting variant through this.

## Related

Unblocks the consumer-side fix in OpenCompany, where link ingest will call this in place of its own literal-only guard. That PR stacks on this one and bumps the vendored pin to whatever commit this lands as — it deliberately does not bump to a local commit, which has broken checkout on every CI lane before.

Known and out of scope: resolve-then-check still leaves a DNS-rebinding window, since the name can answer differently between the check and the connect. Closing that needs validation of the socket's actual peer address, which is a change to how the request is issued rather than to this guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Standardized DNS-aware validation is now publicly available for outbound URL requests.
  - External integrations can apply SSRF protection when validating user-supplied URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
