### PR TITLE
feat(chat): show the answer on /chat, move the explanation to the rail

### DIFF
--- a/app/src/components/assistant-ui/thread.tsx
+++ b/app/src/components/assistant-ui/thread.tsx
@@ -111,6 +111,16 @@ export type ThreadComponents = {
    * component returns `null` when it has nothing to say.
    */
   RunningStatus?: ComponentType | undefined;
+  /**
+   * Host-owned one-line footer for a **settled** assistant message — the
+   * turn's process summary and the single door to its detail.
+   *
+   * A seam for the same reason `RunningStatus` is one: this file knows the
+   * message, not what the host recorded while producing it. The host component
+   * reads the message's own metadata and returns `null` when the turn has no
+   * process behind it, so a plain answer gets no footer.
+   */
+  TurnFooter?: ComponentType | undefined;
   /** Host-owned attachment previews rendered above the editor. */
   ComposerAttachments?: ComponentType | undefined;
   /** Host-owned attachment picker rendered in the action row. */
@@ -733,6 +743,7 @@ const AssistantMessage: FC = () => {
     ToolFallback: ToolFallbackComponent = ToolFallback,
     ToolGroup,
     ReasoningGroup,
+    TurnFooter,
   } = useContext(ThreadComponentsContext);
 
   const ACTION_BAR_PT = 'pt-1.5';
@@ -865,6 +876,7 @@ const AssistantMessage: FC = () => {
             Stopped
           </span>
         </AuiIf>
+        {TurnFooter ? <TurnFooter /> : null}
         <BranchPicker />
         <AssistantActionBar />
       </div>

--- a/app/src/features/conversations/Conversations.tsx
+++ b/app/src/features/conversations/Conversations.tsx
@@ -61,6 +61,7 @@ import {
 } from '../../lib/attachments';
 import { useRegisterAction } from '../../lib/commands/useRegisterAction';
 import { useT } from '../../lib/i18n/I18nContext';
+import type { TurnProcessTrail } from '../../providers/assistantUiMessages';
 import { threadApi } from '../../services/api/threadApi';
 import { fetchThreadTokenUsage } from '../../services/api/threadUsageApi';
 import {
@@ -301,6 +302,11 @@ const Conversations = ({
   const [showBackgroundProcesses, setShowBackgroundProcesses] = useState(false);
   const [openSubagentTaskId, setOpenSubagentTaskId] = useState<string | null>(null);
   const [showProcessSource, setShowProcessSource] = useState(false);
+  // One settled turn's process trail, opened from that turn's `TurnFooter`.
+  // Non-null takes over the process-source panel and scopes it to that turn —
+  // the palette command below still opens the whole-thread live view, which is
+  // the only view it ever had.
+  const [turnProcessTrail, setTurnProcessTrail] = useState<TurnProcessTrail | null>(null);
   // The Agent Process Source panel's only trigger is the "View full agent
   // process source →" link at the foot of `ToolTimelineBlock` — a legacy-panel
   // component. assistant-ui renders its tool calls as inline cards and has no
@@ -2662,6 +2668,9 @@ const Conversations = ({
         // set of resolvable delegations actually changes.
         onOpenSubagent={setOpenSubagentTaskId}
         canOpenSubagent={canOpenSubagentDrawer}
+        // The settled turn's one-line footer opens the process rail on THAT
+        // turn's trail, which the footer carries with the click.
+        onOpenTurnProcess={setTurnProcessTrail}
         onModelChange={(value, contextWindow) => {
           setComposerModelOverride(value);
           setComposerModelContextWindow(contextWindow ?? null);
@@ -2675,15 +2684,22 @@ const Conversations = ({
           overlay, positioned against the viewport. */}
       <TranscriptOverlays
         threadId={selectedThreadId ?? null}
-        entries={selectedThreadToolTimeline}
-        transcript={selectedThreadProcessing}
+        /* A turn footer's trail wins over the thread-wide live slices: those
+           hold only the newest turn (`chatRuntimeSlice` rehydrates
+           `processingByThread` from the single latest `TurnState` snapshot), so
+           they are the wrong answer for any older turn the user clicks. */
+        entries={turnProcessTrail ? [...turnProcessTrail.timeline] : selectedThreadToolTimeline}
+        transcript={turnProcessTrail ? [...turnProcessTrail.transcript] : selectedThreadProcessing}
         backgroundProcesses={backgroundProcesses}
         showBackgroundProcesses={showBackgroundProcesses}
         onCloseBackgroundProcesses={() => setShowBackgroundProcesses(false)}
         openSubagentTaskId={openSubagentTaskId}
         onOpenSubagent={setOpenSubagentTaskId}
-        showProcessSource={showProcessSource}
-        onCloseProcessSource={() => setShowProcessSource(false)}
+        showProcessSource={showProcessSource || turnProcessTrail !== null}
+        onCloseProcessSource={() => {
+          setShowProcessSource(false);
+          setTurnProcessTrail(null);
+        }}
       />
     </div>
   );

--- a/app/src/features/conversations/components/AssistantUiChat.tsx
+++ b/app/src/features/conversations/components/AssistantUiChat.tsx
@@ -9,6 +9,7 @@ import type { Attachment } from '../../../lib/attachments';
 import { useRegisterAction } from '../../../lib/commands/useRegisterAction';
 import { useSlashCommands } from '../../../lib/commands/useSlashCommands';
 import { useT } from '../../../lib/i18n/I18nContext';
+import type { TurnProcessTrail } from '../../../providers/assistantUiMessages';
 import { AssistantUiRuntimeProvider } from '../../../providers/AssistantUiRuntimeProvider';
 import { emptySessionTokenUsage } from '../../../store/chatRuntimeSlice';
 import { useAppSelector } from '../../../store/hooks';
@@ -16,6 +17,8 @@ import { DEFAULT_MASCOT_COLOR } from '../../../store/mascotSlice';
 import { MascotChipAvatar } from '../../human/Mascot/MascotChipAvatar';
 import { AssistantUiInferenceStatus } from './AssistantUiInferenceStatus';
 import { SubagentDrawerHost } from './aui/subagentDrawerHost';
+import { TurnFooter } from './aui/TurnFooter';
+import { TurnFooterHost } from './aui/turnFooterHost';
 import { ChatToolFallback, ChatToolGroup } from './ChatToolParts';
 import { contextUsageFromTokenUsage, ContextWindowPill } from './composer/ContextWindowPill';
 import {
@@ -81,6 +84,7 @@ export function AssistantUiChat({
   onSwitchToMicCloud,
   onOpenSubagent,
   canOpenSubagent,
+  onOpenTurnProcess,
 }: {
   threadGoal: ThreadGoalController;
   model: string | null;
@@ -115,6 +119,8 @@ export function AssistantUiChat({
   onOpenSubagent?: (taskId: string) => void;
   /** Whether the host's drawer can resolve that delegation; see the same file. */
   canOpenSubagent?: (taskId: string) => boolean;
+  /** Opens the host's process rail on one settled turn's trail (`TurnFooter`). */
+  onOpenTurnProcess?: (trail: TurnProcessTrail) => void;
 }) {
   const { t } = useT();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -260,6 +266,9 @@ export function AssistantUiChat({
       // Phase / reasoning round / active tool for the turn in flight. Reads the
       // runtime's `extras`, so it needs no props and no dependency here.
       RunningStatus: AssistantUiInferenceStatus,
+      // One-line process summary under a settled answer, and the only door to
+      // the reasoning / narration / tool detail that no longer renders inline.
+      TurnFooter,
       onSwitchToMicCloud,
       ...(attachmentsEnabled
         ? {
@@ -286,16 +295,18 @@ export function AssistantUiChat({
   return (
     <AssistantUiRuntimeProvider>
       <ComposerTextBridge value={inputValue} onChange={onInputValueChange} />
-      <SubagentDrawerHost onOpenSubagent={onOpenSubagent} canOpenSubagent={canOpenSubagent}>
-        <Thread
-          components={components}
-          model={model}
-          onModelChange={onModelChange}
-          loadError={loadError}
-          onEscape={onEscape}
-          slashCommands={slashCommands}
-        />
-      </SubagentDrawerHost>
+      <TurnFooterHost onOpenTurnProcess={onOpenTurnProcess}>
+        <SubagentDrawerHost onOpenSubagent={onOpenSubagent} canOpenSubagent={canOpenSubagent}>
+          <Thread
+            components={components}
+            model={model}
+            onModelChange={onModelChange}
+            loadError={loadError}
+            onEscape={onEscape}
+            slashCommands={slashCommands}
+          />
+        </SubagentDrawerHost>
+      </TurnFooterHost>
     </AssistantUiRuntimeProvider>
   );
 }

--- a/app/src/features/conversations/components/aui/TurnFooter.test.tsx
+++ b/app/src/features/conversations/components/aui/TurnFooter.test.tsx
@@ -1,0 +1,101 @@
+import {
+  AssistantRuntimeProvider,
+  type ThreadMessageLike,
+  useExternalStoreRuntime,
+} from '@assistant-ui/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Thread } from '../../../../components/assistant-ui/thread';
+import type { TurnProcessTrail } from '../../../../providers/assistantUiMessages';
+import { TurnFooter } from './TurnFooter';
+import { TurnFooterHost } from './turnFooterHost';
+
+const trail = (over: Partial<TurnProcessTrail> = {}): TurnProcessTrail => ({
+  steps: 8,
+  tools: 2,
+  timeline: [],
+  transcript: [],
+  ...over,
+});
+
+function mount(
+  metadata: Record<string, unknown> | undefined,
+  onOpenTurnProcess?: (t: TurnProcessTrail) => void
+) {
+  const messages: ThreadMessageLike[] = [
+    { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+    {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'the answer' }],
+      ...(metadata ? { metadata: { custom: metadata } } : {}),
+    },
+  ];
+  function Harness() {
+    const runtime = useExternalStoreRuntime({
+      messages,
+      isRunning: false,
+      convertMessage: (m: ThreadMessageLike) => m,
+      onNew: async () => {},
+    });
+    return (
+      <AssistantRuntimeProvider runtime={runtime}>
+        <TurnFooterHost onOpenTurnProcess={onOpenTurnProcess}>
+          <Thread components={{ TurnFooter }} />
+        </TurnFooterHost>
+      </AssistantRuntimeProvider>
+    );
+  }
+  return render(<Harness />);
+}
+
+describe('TurnFooter', () => {
+  it('summarises the turn and opens the rail on that turn’s own trail', () => {
+    const open = vi.fn();
+    mount({ processTrail: trail() }, open);
+
+    const footer = screen.getByTestId('turn-process-footer');
+    expect(footer.textContent).toBe('8 steps · 2 tools');
+
+    fireEvent.click(footer);
+    // The trail travels with the click: the host needs no second lookup, and
+    // cannot show a different turn's trail by mistake.
+    expect(open).toHaveBeenCalledWith(expect.objectContaining({ steps: 8, tools: 2 }));
+  });
+
+  it('drops the tool clause for a turn that called none', () => {
+    mount({ processTrail: trail({ steps: 3, tools: 0 }) }, vi.fn());
+    expect(screen.getByTestId('turn-process-footer').textContent).toBe('3 steps');
+  });
+
+  it('reads as process, not answer: muted and no larger than 12px', () => {
+    // The whole point of moving reasoning and narration off this surface is
+    // that what is left reads as one class of thing. jsdom performs no layout,
+    // so the utilities are the only observable — but they are the same two the
+    // in-flight status line carries (`InferenceStatusLine`), which is the
+    // invariant worth pinning: one treatment, not three greys.
+    mount({ processTrail: trail() }, vi.fn());
+    const classes = screen.getByTestId('turn-process-footer').className.split(/\s+/);
+    expect(classes).toContain('text-content-muted');
+    expect(classes).toContain('text-xs');
+  });
+
+  it('renders no door for a turn with no process behind it', () => {
+    mount({ processTrail: null }, vi.fn());
+    expect(screen.queryByTestId('turn-process-footer')).toBeNull();
+  });
+
+  it('renders nothing when no host is mounted to open the rail', () => {
+    mount({ processTrail: trail() }, undefined);
+    expect(screen.queryByTestId('turn-process-footer')).toBeNull();
+  });
+
+  it('survives a message this projection did not build', () => {
+    // The footer can be mounted on the kit's own runtime or a test harness,
+    // where `metadata.custom` is absent or shaped differently.
+    mount(undefined, vi.fn());
+    expect(screen.queryByTestId('turn-process-footer')).toBeNull();
+    mount({ processTrail: { steps: 'lots' } }, vi.fn());
+    expect(screen.queryByTestId('turn-process-footer')).toBeNull();
+  });
+});

--- a/app/src/features/conversations/components/aui/TurnFooter.tsx
+++ b/app/src/features/conversations/components/aui/TurnFooter.tsx
@@ -71,6 +71,7 @@ export function TurnFooter() {
     <button
       type="button"
       data-testid="turn-process-footer"
+      data-analytics-id="chat-turn-process-open"
       title={t('conversations.agentTaskInsights.viewProcessSource')}
       onClick={() => host.open(trail)}
       className="text-content-muted hover:text-content-secondary -ms-1 rounded px-1 text-xs transition-colors">

--- a/app/src/features/conversations/components/aui/TurnFooter.tsx
+++ b/app/src/features/conversations/components/aui/TurnFooter.tsx
@@ -1,0 +1,82 @@
+import { type AssistantState, useAuiState } from '@assistant-ui/react';
+
+import { useT } from '../../../../lib/i18n/I18nContext';
+import type { TurnProcessTrail } from '../../../../providers/assistantUiMessages';
+import { useTurnFooterHost } from './turnFooterHost';
+
+const selectMessageMetadata = (state: AssistantState) => state.message.metadata;
+
+/**
+ * Narrow the runtime's untyped `message.metadata.custom` back to our own shape.
+ *
+ * `custom` is `unknown` by contract and the footer can be mounted on a message
+ * this projection did not build (the kit's own demo runtime, a test harness),
+ * so this returns `null` rather than asserting.
+ */
+function readProcessTrail(metadata: unknown): TurnProcessTrail | null {
+  if (typeof metadata !== 'object' || metadata === null) return null;
+  const custom = (metadata as { custom?: unknown }).custom;
+  if (typeof custom !== 'object' || custom === null) return null;
+  const trail = (custom as { processTrail?: unknown }).processTrail;
+  if (typeof trail !== 'object' || trail === null) return null;
+  const candidate = trail as Partial<TurnProcessTrail>;
+  if (typeof candidate.steps !== 'number' || typeof candidate.tools !== 'number') return null;
+  return candidate as TurnProcessTrail;
+}
+
+/**
+ * The settled turn's one-line process footer — `8 steps · 2 tools` — and the
+ * single door to the detail behind it.
+ *
+ * This is the other half of moving reasoning, narration and read-only tool
+ * detail off the main surface (`assistantParts`): the transcript keeps the
+ * answer, and everything explaining how the agent got there is one click away
+ * in the process rail rather than stacked above the answer.
+ *
+ * Deliberately quiet. It is process, not answer, so it takes the same
+ * treatment the rail already gives its own process text — `text-content-muted`
+ * at 12px — while the answer above it keeps full-contrast `text-foreground` at
+ * its normal size. Same meaning, same look, on both surfaces.
+ *
+ * Renders nothing when the turn recorded no process (a plain answer needs no
+ * door) or when no host is mounted to open the rail.
+ */
+export function TurnFooter() {
+  const { t } = useT();
+  const host = useTurnFooterHost();
+  const trail = readProcessTrail(useAuiState(selectMessageMetadata));
+
+  if (!host || !trail || trail.steps === 0) return null;
+
+  // Existing, fully-translated keys rather than new ones: `I18nContext`'s
+  // English fallback is real, but `i18n/__tests__/coverage.test.ts` requires
+  // every locale to define every English key, so a new key is 14 translations
+  // this change is in no position to write. The cost is that
+  // `conversations.backgroundTasks.steps` has no singular form, so a one-step
+  // turn reads "1 steps". Worth a proper key next time someone touches i18n.
+  const stepLabel = t('conversations.backgroundTasks.steps').replace(
+    '{count}',
+    String(trail.steps)
+  );
+  const toolLabel =
+    trail.tools > 0
+      ? t(
+          trail.tools === 1
+            ? 'intelligence.agents.toolCountOne'
+            : 'intelligence.agents.toolCountOther'
+        ).replace('{count}', String(trail.tools))
+      : null;
+
+  return (
+    <button
+      type="button"
+      data-testid="turn-process-footer"
+      title={t('conversations.agentTaskInsights.viewProcessSource')}
+      onClick={() => host.open(trail)}
+      className="text-content-muted hover:text-content-secondary -ms-1 rounded px-1 text-xs transition-colors">
+      {toolLabel ? `${stepLabel} · ${toolLabel}` : stepLabel}
+    </button>
+  );
+}
+
+export default TurnFooter;

--- a/app/src/features/conversations/components/aui/turnFooterHost.tsx
+++ b/app/src/features/conversations/components/aui/turnFooterHost.tsx
@@ -1,0 +1,46 @@
+import { createContext, type ReactNode, useContext, useMemo } from 'react';
+
+import type { TurnProcessTrail } from '../../../../providers/assistantUiMessages';
+
+export interface TurnFooterHostValue {
+  /** Opens the host's process rail on one settled turn's trail. */
+  open: (trail: TurnProcessTrail) => void;
+}
+
+/**
+ * The host that owns the process rail the turn footer opens.
+ *
+ * A context rather than a prop for the same reason
+ * {@link import('./subagentDrawerHost').SubagentDrawerHost} is one: the
+ * consumer is rendered by assistant-ui from *inside* the transcript, many
+ * layers below anything the host passes props to, while the panel belongs to
+ * `Conversations`.
+ *
+ * The trail travels with the click rather than being looked up by request id.
+ * `useOpenHumanExternalStore` has already paged the core transcript projection
+ * and split it per turn; the footer is handed those same array references on
+ * the message's own metadata, so opening the rail costs no second fetch and no
+ * second copy of the paging policy.
+ *
+ * `null` outside a provider, which is what every read-only mount wants: no
+ * host, no footer.
+ */
+const TurnFooterHostContext = createContext<TurnFooterHostValue | null>(null);
+
+export function TurnFooterHost({
+  onOpenTurnProcess,
+  children,
+}: {
+  onOpenTurnProcess?: ((trail: TurnProcessTrail) => void) | undefined;
+  children: ReactNode;
+}) {
+  const value = useMemo<TurnFooterHostValue | null>(
+    () => (onOpenTurnProcess ? { open: onOpenTurnProcess } : null),
+    [onOpenTurnProcess]
+  );
+  return <TurnFooterHostContext.Provider value={value}>{children}</TurnFooterHostContext.Provider>;
+}
+
+export function useTurnFooterHost(): TurnFooterHostValue | null {
+  return useContext(TurnFooterHostContext);
+}

--- a/app/src/providers/__tests__/assistantUiMessages.test.ts
+++ b/app/src/providers/__tests__/assistantUiMessages.test.ts
@@ -21,8 +21,13 @@ function msg(over: Partial<ThreadMessage> = {}): ThreadMessage {
   };
 }
 
+// `file_write` rather than a read-only name on purpose: only tools that might
+// have changed something outside the app still render on the main surface
+// (`toolRowStaysOnMainSurface`), so a read-only default would make every
+// identity / status / naming assertion below vacuous. The visibility rule
+// itself is covered separately in `main-surface tool visibility`.
 function tool(over: Partial<ToolTimelineEntry> = {}): ToolTimelineEntry {
-  return { id: 'call-1', name: 'web_search', round: 1, seq: 0, status: 'running', ...over };
+  return { id: 'call-1', name: 'file_write', round: 1, seq: 0, status: 'running', ...over };
 }
 
 describe('toThreadMessageLike', () => {
@@ -80,12 +85,20 @@ describe('streamingTailMessage', () => {
     });
   });
 
-  it('projects streamed thinking as a reasoning part before visible text', () => {
+  it('keeps streamed thinking off the main surface', () => {
+    // Reasoning is not dropped — it stays in `processingByThread` and in the
+    // persisted transcript, and renders in the process rail. It just does not
+    // belong in the answer stream; `RunningStatus` is the in-flight signal.
     const tail = streamingTailMessage({ requestId: 'r', content: 'answer', thinking: 'reasoning' });
-    expect(tail?.content).toEqual([
-      { type: 'reasoning', text: 'reasoning' },
-      { type: 'text', text: 'answer' },
-    ]);
+    expect(tail?.content).toEqual([{ type: 'text', text: 'answer' }]);
+  });
+
+  it('mints no tail at all for a turn that has only produced thinking', () => {
+    // Nothing to paint: no answer yet, no visible tool. The status line under
+    // the last message is what tells the user the turn is alive.
+    expect(streamingTailMessage({ requestId: 'r', content: '', thinking: 'still working' })).toBe(
+      null
+    );
   });
 
   it('keeps a running delegation on args and adds result only when complete', () => {
@@ -144,13 +157,12 @@ describe('buildRuntimeMessages', () => {
     expect(ids).toEqual(['answer']);
     expect(ids).not.toContain(STREAMING_TAIL_ID);
     expect(projected[0]?.content).toEqual([
-      { type: 'reasoning', text: 'already finished thinking' },
       expect.objectContaining({ type: 'tool-call', toolCallId: 'stale-tool' }),
       { type: 'text', text: 'hello' },
     ]);
   });
 
-  it('replays a settled turn reasoning and tool calls from its request id', () => {
+  it('replays a settled turn tool calls from its request id, without its prose', () => {
     const answer = msg({
       id: 'answer',
       sender: 'agent',
@@ -170,12 +182,12 @@ describe('buildRuntimeMessages', () => {
         turnTranscripts: { 'req-1': transcript },
       })[0]?.content
     ).toEqual([
-      { type: 'reasoning', text: 'need to search' },
-      { type: 'text', text: 'I will check the sources.' },
+      // No `reasoning` part and no narration `text` part: both are process and
+      // live in the rail. Only the tool row and the answer remain.
       expect.objectContaining({
         type: 'tool-call',
         toolCallId: 'call-1',
-        toolName: 'web_search',
+        toolName: 'file_write',
         result: 'found it',
       }),
       { type: 'text', text: 'finished' },
@@ -201,7 +213,6 @@ describe('buildRuntimeMessages', () => {
     })[0]?.content;
 
     expect(content).toEqual([
-      { type: 'reasoning', text: 'delegate this research' },
       expect.objectContaining({ type: 'tool-call', toolCallId: 'async-tool' }),
       { type: 'text', text: 'Accepted background work' },
     ]);
@@ -443,10 +454,10 @@ describe('recovered tool names', () => {
         id: 'a',
         sender: 'agent',
         content: 'done',
-        extraMetadata: { assistantUiToolNames: ['web_search', 'web_fetch'] },
+        extraMetadata: { assistantUiToolNames: ['shell', 'apply_patch'] },
       }),
       [
-        tool({ id: 'c1', name: 'read_file', seq: 0, status: 'success' }),
+        tool({ id: 'c1', name: 'file_write', seq: 0, status: 'success' }),
         tool({ id: 'c2', name: 'tool', seq: 1, status: 'success' }),
         tool({ id: 'c3', name: 'tool', seq: 2, status: 'success' }),
       ]
@@ -454,7 +465,7 @@ describe('recovered tool names', () => {
     const names = (converted.content as unknown as { type: string; toolName?: string }[])
       .filter(part => part.type === 'tool-call')
       .map(part => part.toolName);
-    expect(names).toEqual(['read_file', 'web_search', 'web_fetch']);
+    expect(names).toEqual(['file_write', 'shell', 'apply_patch']);
   });
 });
 
@@ -462,6 +473,8 @@ describe('terminal tool status', () => {
   it('carries a failed tool status through to the rendered part', () => {
     // assistant-ui's tool-call part has no status field, so a failed tool that
     // produced output used to arrive as a bare result and read as success.
+    // `web_search` is read-only, so this doubles as proof that a FAILED row
+    // stays on the main surface whatever its category.
     const converted = toThreadMessageLike(msg({ id: 'a', sender: 'agent', content: 'done' }), [
       tool({ id: 'c1', name: 'web_search', seq: 0, status: 'error', result: 'boom' }),
     ]);
@@ -473,12 +486,102 @@ describe('terminal tool status', () => {
 
   it('leaves a successful tool result untouched', () => {
     const converted = toThreadMessageLike(msg({ id: 'a', sender: 'agent', content: 'done' }), [
-      tool({ id: 'c1', name: 'web_search', seq: 0, status: 'success', result: 'the answer' }),
+      tool({ id: 'c1', name: 'file_write', seq: 0, status: 'success', result: 'the answer' }),
     ]);
     const part = (converted.content as unknown as { type: string; result?: unknown }[]).find(
       candidate => candidate.type === 'tool-call'
     );
     expect(part?.result).toBe('the answer');
+  });
+});
+
+describe('main-surface tool visibility', () => {
+  const partsOf = (entries: ToolTimelineEntry[]) =>
+    toThreadMessageLike(msg({ id: 'a', sender: 'agent', content: 'done' }), entries)
+      .content as unknown as { type: string; toolCallId?: string }[];
+  const visibleIds = (entries: ToolTimelineEntry[]) =>
+    partsOf(entries)
+      .filter(part => part.type === 'tool-call')
+      .map(part => part.toolCallId);
+
+  it('drops a read-only step to the rail', () => {
+    // Reading, listing and searching are process. The row is not lost — it is
+    // still in the timeline the turn footer opens — it just does not stack
+    // above the answer.
+    expect(
+      visibleIds([
+        tool({ id: 'r1', name: 'file_read', seq: 0, status: 'success' }),
+        tool({ id: 'r2', name: 'grep', seq: 1, status: 'success' }),
+        tool({ id: 'r3', name: 'web_search', seq: 2, status: 'success' }),
+      ])
+    ).toEqual([]);
+  });
+
+  it('keeps a tool it cannot prove is read-only', () => {
+    // The fail-SAFE direction, and the whole point of the allowlist: an agent
+    // sending an email or spending money behind a collapsed panel is a trust
+    // problem. An unmapped name lands in `other` and keeps its line.
+    expect(
+      visibleIds([
+        tool({ id: 'w', name: 'file_write', seq: 0, status: 'success' }),
+        tool({ id: 's', name: 'shell', seq: 1, status: 'success' }),
+        tool({ id: 'x', name: 'send_email_to_customer', seq: 2, status: 'success' }),
+        tool({ id: 'f', name: 'curl', seq: 3, status: 'success' }),
+      ])
+    ).toEqual(['w', 's', 'x', 'f']);
+  });
+
+  it('keeps a read-only step that failed or is waiting on the user', () => {
+    // An error and a parked approval are the user's to see and to answer, so
+    // they outrank the category.
+    expect(
+      visibleIds([
+        tool({ id: 'e', name: 'file_read', seq: 0, status: 'error' }),
+        tool({ id: 'a', name: 'web_search', seq: 1, status: 'awaiting_user' }),
+      ])
+    ).toEqual(['e', 'a']);
+  });
+
+  it('keeps a delegation row — it is the only door to the sub-agent drawer', () => {
+    expect(visibleIds([tool({ id: 'd', name: 'subagent:researcher', status: 'success' })])).toEqual(
+      ['d']
+    );
+  });
+});
+
+describe('turn process footer metadata', () => {
+  const trailOf = (message: { metadata?: unknown }) =>
+    (message.metadata as { custom?: { processTrail?: unknown } } | undefined)?.custom?.processTrail;
+
+  it('counts every process step and the tool rows behind them', () => {
+    const converted = toThreadMessageLike(
+      msg({ id: 'a', sender: 'agent', content: 'done' }),
+      [tool({ id: 'c1', name: 'file_read', status: 'success' })],
+      [
+        { kind: 'thinking', round: 1, seq: 0, text: 'think' },
+        { kind: 'narration', round: 1, seq: 1, text: 'narrate' },
+        { kind: 'toolCall', round: 1, seq: 2, callId: 'c1' },
+      ]
+    );
+    expect(trailOf(converted)).toMatchObject({ steps: 3, tools: 1 });
+  });
+
+  it('falls back to the tool rows for a legacy snapshot with no transcript', () => {
+    const converted = toThreadMessageLike(msg({ id: 'a', sender: 'agent', content: 'done' }), [
+      tool({ id: 'c1', status: 'success' }),
+      tool({ id: 'c2', seq: 1, status: 'success' }),
+    ]);
+    expect(trailOf(converted)).toMatchObject({ steps: 2, tools: 2 });
+  });
+
+  it('is null for a plain answer, so the footer renders no door', () => {
+    expect(trailOf(toThreadMessageLike(msg({ id: 'a', sender: 'agent', content: 'hi' })))).toBe(
+      null
+    );
+  });
+
+  it('is absent on a user message', () => {
+    expect(trailOf(toThreadMessageLike(msg({ id: 'u' })))).toBeUndefined();
   });
 });
 

--- a/app/src/providers/__tests__/assistantUiMessages.test.ts
+++ b/app/src/providers/__tests__/assistantUiMessages.test.ts
@@ -263,14 +263,18 @@ describe('buildRuntimeMessages', () => {
 
     expect(projected).toHaveLength(2);
     expect(projected[1]).toMatchObject({ id: 'final', role: 'assistant' });
-    expect(projected[1]?.content).toEqual([
-      expect.objectContaining({
-        type: 'tool-call',
-        toolCallId: 'call-search',
-        toolName: 'web_search_tool',
-      }),
-      { type: 'text', text: finalText },
-    ]);
+    // One bubble, carrying the final text once — the intro segment is a prefix
+    // of it and must not render twice.
+    expect(projected[1]?.content).toEqual([{ type: 'text', text: finalText }]);
+    // The trail still belongs to the coalesced bubble; it is just no longer
+    // painted inline. The timeline row is named `tool` and is renamed to
+    // `web_search_tool` from the envelope BEFORE the visibility filter runs, so
+    // a recovered name decides visibility exactly as a declared one does — and
+    // a search is read-only, so it moves to the rail behind the footer.
+    expect(
+      (projected[1]?.metadata as { custom?: { processTrail?: unknown } } | undefined)?.custom
+        ?.processTrail
+    ).toMatchObject({ steps: 1, tools: 1 });
   });
 
   it('does not coalesce adjacent assistant turns with different request ids', () => {
@@ -508,11 +512,17 @@ describe('main-surface tool visibility', () => {
     // Reading, listing and searching are process. The row is not lost — it is
     // still in the timeline the turn footer opens — it just does not stack
     // above the answer.
+    //
+    // `web_search_tool` is the name a real search row carries: `web_search` is
+    // the settings-family id the core expands from (`tools/user_filter.rs:79-80`),
+    // and it is the canonical name — not the alias — that a live turn produces.
+    // Both are asserted so neither can regress.
     expect(
       visibleIds([
         tool({ id: 'r1', name: 'file_read', seq: 0, status: 'success' }),
         tool({ id: 'r2', name: 'grep', seq: 1, status: 'success' }),
-        tool({ id: 'r3', name: 'web_search', seq: 2, status: 'success' }),
+        tool({ id: 'r3', name: 'web_search_tool', seq: 2, status: 'success' }),
+        tool({ id: 'r4', name: 'web_search', seq: 3, status: 'success' }),
       ])
     ).toEqual([]);
   });

--- a/app/src/providers/assistantUiMessages.ts
+++ b/app/src/providers/assistantUiMessages.ts
@@ -15,6 +15,7 @@ import {
   type ToolTimelineEntry,
 } from '../store/chatRuntimeSlice';
 import type { ThreadMessage } from '../types/thread';
+import { categorizeTool, type ToolCategory } from '../utils/toolTimelineFormatting';
 
 /**
  * Redux -> assistant-ui message mapping.
@@ -205,7 +206,69 @@ function withApproval(
 }
 
 /**
+ * Categories `categorizeTool` can prove are read-only. Everything else —
+ * including its `other` default, which is where every unmapped tool lands — is
+ * treated as potentially side-effecting.
+ *
+ * The direction is the point: this is a fail-SAFE allowlist, not a
+ * classification. An agent sending an email or writing a file behind a
+ * collapsed panel is a trust problem, not a clutter fix, so an unrecognised
+ * tool keeps its line on the main surface. Being wrong here costs one extra
+ * row; being wrong the other way hides a real-world action.
+ *
+ * `web_fetch` / `http_request` / `curl` (`fetch`) and `browser*` (`browse`) are
+ * deliberately NOT here: a `curl` can POST and a browser click can buy
+ * something.
+ *
+ * **This is a stand-in.** The core already models exactly this, precisely, as
+ * `PermissionLevel` (`ReadOnly` / `Write` / `Execute` / `Dangerous`,
+ * `vendor/tinyagents/vendor/tinytools/.../permission/types.rs:18-30`) on every
+ * tool. It is simply not on the wire: `AgentProgress::ToolCallStarted`
+ * (`src/openhuman/agent/progress.rs:31-47`) carries no permission field, so the
+ * renderer cannot see it. When that field is plumbed through to
+ * `ToolTimelineEntry`, delete this set and the function below and test
+ * `entry.permissionLevel === 'read_only'` instead.
+ */
+const READ_ONLY_TOOL_CATEGORIES: ReadonlySet<ToolCategory> = new Set<ToolCategory>([
+  'read',
+  'search',
+]);
+
+/**
+ * Whether this tool row still earns a line on the main `/chat` surface.
+ *
+ * Read-only steps (reading a file, searching memory, listing) are process, and
+ * move to the rail behind the turn footer. Everything else keeps one line:
+ *
+ * - anything not provably read-only — the side-effect exception above;
+ * - a failed call, because an error is the user's to see;
+ * - a parked call, because an approval gate is the user's to answer. The part's
+ *   `approval` is attached later by {@link withApproval}, so the check here is
+ *   on the row's own `awaiting_user` status.
+ *
+ * A `subagent:*` delegation also stays, for two reasons that outrank tidiness:
+ * its card is the only route to the sub-agent drawer on this surface (see
+ * `ChatToolParts.SubagentCall`), and a delegation spends real money and can act
+ * outside the app through its own tools. Its *transcript* is already behind the
+ * drawer, which is where the brief wanted it; the row itself is one line.
+ */
+function toolRowStaysOnMainSurface(entry: ToolTimelineEntry): boolean {
+  if (entry.status === 'error' || entry.status === 'awaiting_user') return true;
+  if (entry.name.startsWith('subagent:')) return true;
+  return !READ_ONLY_TOOL_CATEGORIES.has(categorizeTool(entry.name));
+}
+
+/**
  * Project one assistant message into assistant-ui parts.
+ *
+ * The main surface carries **the answer, plus anything the user must see or
+ * act on** — a failed or parked tool call, and any call that might have changed
+ * something outside the app. The agent's *explanation* of how it got there —
+ * reasoning, narration prose, and the arguments and results of read-only steps
+ * — is not dropped: it stays in Redux and in the persisted transcript, and
+ * renders in the process rail reached from the turn footer
+ * (`TurnFooter` → `AgentProcessSourcePanel`). Nothing here changes what is
+ * stored, only what is painted.
  *
  * **Every tool part must have a distinct `toolCallId`.** assistant-ui keys them
  * as `toolCallId-${id}` and *throws* on a repeat ("Duplicate key … in
@@ -224,46 +287,66 @@ function assistantParts(
   const parts: ThreadAssistantMessagePart[] = [];
   const timelineById = new Map(timeline.map(entry => [entry.id, entry]));
   const emittedToolIds = new Set<string>();
+  // A row is considered once, whether or not it is painted. Both passes apply
+  // the same filter, so this is belt-and-braces rather than load-bearing — it
+  // is here so the two can never disagree and mint a duplicate `toolCallId`,
+  // which assistant-ui throws on.
+  const claim = (entry: ToolTimelineEntry): boolean => {
+    if (emittedToolIds.has(entry.id)) return false;
+    emittedToolIds.add(entry.id);
+    return true;
+  };
 
   for (const item of transcript) {
-    if (item.kind === 'thinking') {
-      if (item.text.trim().length > 0) parts.push({ type: 'reasoning', text: item.text });
-      continue;
-    }
+    // `thinking` and `narration` are the turn's explanation of itself. Both
+    // live on in `processingByThread` / the persisted transcript and render in
+    // the rail; neither belongs in the answer stream.
     if (item.kind === 'toolCall') {
       const entry = timelineById.get(item.callId);
       // Guarded here too, not only in the timeline pass below: two transcript
       // pointers can name the same `callId` (a provider that emits tool calls
       // without ids writes the empty string for all of them), and both resolve
       // to the same timeline row.
-      if (entry && !emittedToolIds.has(entry.id)) {
-        emittedToolIds.add(entry.id);
+      if (entry && claim(entry) && toolRowStaysOnMainSurface(entry)) {
         parts.push(toolPart(entry));
       }
-    }
-    if (
-      item.kind === 'narration' &&
-      item.text.trim().length > 0 &&
-      !text.trim().includes(item.text.trim())
-    ) {
-      // Narration emitted before a tool call is assistant content in its own
-      // right. Keep it inline in assistant-ui's ordered part stream; the final
-      // answer is appended separately below. A final-round narration is the
-      // same streamed bytes as that answer and must not render twice —
-      // `includes`, not equality, because `mergedAssistantText` prefers the
-      // longest text when it *contains* every segment, so the duplicate is a
-      // substring rather than an exact match.
-      parts.push({ type: 'text', text: item.text });
     }
   }
 
   for (const entry of [...timeline].sort((a, b) => a.seq - b.seq)) {
-    if (emittedToolIds.has(entry.id)) continue;
-    emittedToolIds.add(entry.id);
-    parts.push(toolPart(entry));
+    if (!claim(entry)) continue;
+    if (toolRowStaysOnMainSurface(entry)) parts.push(toolPart(entry));
   }
   if (text.length > 0) parts.push({ type: 'text', text });
   return parts;
+}
+
+/**
+ * The one-line summary the settled turn footer renders, and the trail its click
+ * opens. Counted from what the store already holds — no new telemetry.
+ *
+ * `steps` is every process item the turn recorded (reasoning blocks, narration
+ * segments and tool pointers); `tools` is the tool rows. `null` when the turn
+ * recorded no process at all, which is the footer's signal to render nothing —
+ * a plain answer with no trail behind it gets no door.
+ */
+export type TurnProcessTrail = {
+  steps: number;
+  tools: number;
+  timeline: readonly ToolTimelineEntry[];
+  transcript: readonly ProcessingTranscriptItem[];
+};
+
+function processTrail(
+  timeline: readonly ToolTimelineEntry[],
+  transcript: readonly ProcessingTranscriptItem[]
+): TurnProcessTrail | null {
+  if (timeline.length === 0 && transcript.length === 0) return null;
+  // Prefer the transcript's own length when it has one: it is the ordered
+  // record of what happened. A legacy snapshot with tool rows but no transcript
+  // still has a step per row.
+  const steps = transcript.length > 0 ? transcript.length : timeline.length;
+  return { steps, tools: timeline.length, timeline, transcript };
 }
 
 function stringArray(value: unknown): string[] {
@@ -457,7 +540,17 @@ export function toThreadMessageLike(
     ...(msg.sender === 'agent' && msg.extraMetadata?.stopped === true
       ? { status: { type: 'incomplete' as const, reason: 'cancelled' as const } }
       : {}),
-    metadata: { custom: { extraMetadata: msg.extraMetadata ?? {}, sourceType: msg.type } },
+    metadata: {
+      custom: {
+        extraMetadata: msg.extraMetadata ?? {},
+        sourceType: msg.type,
+        // The settled turn's one-line footer + the trail its click opens.
+        // Only on the assistant side: a user message has no process behind it.
+        ...(msg.sender === 'agent'
+          ? { processTrail: processTrail(effectiveTimeline, transcript) }
+          : {}),
+      },
+    },
   };
 
   conversionCache.set(msg, { timeline, transcript, converted });
@@ -481,11 +574,11 @@ export function streamingTailMessage(
 ): ThreadMessageLike | null {
   if (!approval && !streaming && timeline.length === 0 && transcript.length === 0) return null;
   const text = streaming?.content ?? '';
+  // `streaming.thinking` is deliberately not projected: reasoning does not
+  // render on the main surface any more. While the turn runs, `RunningStatus`
+  // is the in-flight signal; the thinking itself is in `processingByThread`
+  // and reachable through the rail. See `assistantParts`.
   let parts = assistantParts(text, timeline, transcript);
-  if (streaming?.thinking.trim()) {
-    const hasTranscriptThinking = transcript.some(item => item.kind === 'thinking');
-    if (!hasTranscriptThinking) parts.unshift({ type: 'reasoning', text: streaming.thinking });
-  }
   if (approval) parts = withApproval(parts, approval);
   if (parts.length === 0) return null;
   return {

--- a/app/src/utils/__tests__/toolTimelineFormatting.test.ts
+++ b/app/src/utils/__tests__/toolTimelineFormatting.test.ts
@@ -443,6 +443,19 @@ describe('categorizeTool', () => {
     expect(categorizeTool('subagent:web_fetch')).toBe('fetch');
     expect(categorizeTool('GMAIL_SEND_EMAIL')).toBe('other');
   });
+
+  it('categorizes the canonical web-search name, not only its settings id', () => {
+    // `web_search` is the UI toggle id; the core expands it to `web_search_tool`
+    // (`src/openhuman/tools/user_filter.rs:79-80`), and that is the name a
+    // timeline row actually carries. The rest of this file already special-cased
+    // the canonical name for labels and provider attribution; the category map
+    // was the one place that had not, so a real search row categorized as
+    // `other` — wrong icon and wrong group summary in the rail, and (since
+    // #6169) a row kept on the main transcript that belongs in the rail.
+    expect(categorizeTool('web_search_tool')).toBe('search');
+    expect(categorizeTool('web_search')).toBe('search');
+    expect(categorizeTool('subagent:web_search_tool')).toBe('search');
+  });
 });
 
 describe('buildProcessingBlocks', () => {

--- a/app/src/utils/toolTimelineFormatting.ts
+++ b/app/src/utils/toolTimelineFormatting.ts
@@ -179,7 +179,13 @@ const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   apply_patch: 'write',
   grep: 'search',
   glob: 'search',
+  // `web_search_tool` is the runtime tool name; `web_search` is only the UI
+  // toggle id the core expands from (`tools/user_filter.rs:79-80`, and
+  // `test/e2e/specs/harness-search-tool-flow.spec.ts:10` says so outright).
+  // Both are mapped: the toggle id never reaches a timeline row, but leaving
+  // it out would break any older snapshot that recorded the alias.
   web_search: 'search',
+  web_search_tool: 'search',
   gitbooks_search: 'search',
   gitbooks_get_page: 'read',
   shell: 'run',


### PR DESCRIPTION
## Summary

- `/chat` now carries the **answer**, one status line while a turn runs, one footer once it settles, and anything the user must see or act on. Everything explaining *how* the agent got there moves one click away, into the process rail that already existed.
- Removed from the transcript: reasoning (both emit sites), narration prose, and the arguments/results of **provably read-only** tool steps.
- Kept deliberately: errors, approval cards, delegation rows, artifacts, citations, and any tool step that cannot be proven side-effect-free.
- Frontend only. Nothing is dropped from storage — reverting three deletions in `assistantParts` restores the old surface exactly.

## Problem

A single turn could stack a reasoning disclosure, narration prose, a tool-call group and a spinner before the answer arrived. Five widgets of process in front of one piece of substance. The complaint was that the main surface reads as cluttered, and that the relevant detail is hard to find inside it.

The detail itself was never the problem — the process rail (`ToolTimelineBlock` / `AgentProcessSourcePanel`) was built for exactly this, and its own comment says so: *"so the agent's prose and its tool steps appear in one surface instead of narration living in the chat stream and thinking in a separate bubble"*. It was simply being duplicated into the transcript as well.

## Solution

**Principle:** the main surface shows the answer, one line of progress, and one door to the detail. Anything explanatory becomes on-demand; anything needing a user decision stays.

**In-flight** — `RunningStatus` is now the single signal. It already existed and already had the right shape (a phase label with a round counter, carrying no model output). A turn that has produced only thinking now mints no message tail at all, which is precisely the phase that line was written for.

**Settled** — a new `TurnFooter` renders `8 steps · 2 tools` and opens the rail **on that turn's own trail**, which it carries with the click. This matters: the thread-wide live slices hold only the newest turn, so they are the wrong answer for any older turn. A new `ThreadComponents.TurnFooter` seam mirrors `RunningStatus`; `turnFooterHost` mirrors `subagentDrawerHost`, because the consumer renders from inside the transcript.

**Narration needed no wire change.** The answer comes from the persisted `msg.content` and narration from the streamed transcript — they were already distinct arguments to `assistantParts`. The core also already marks interim narration explicitly (`chat_interim`, flushed at `ToolCallStarted`), which is what resets the live preview per round.

**Styling** — the footer takes `text-content-muted text-xs`, the same treatment `InferenceStatusLine` already carries, and `--muted-foreground` is defined as `var(--content-muted)`, so the two token systems resolve to one grey rather than two near-identical ones. The answer keeps full-contrast `text-foreground`. Errors and approval cards are untouched: an error rendered in muted grey would be a bug wearing a design decision.

### The side-effect exception, and why it is a stand-in

An agent acting on the world behind a collapsed panel is a trust problem, not a clutter fix. So `toolRowStaysOnMainSurface` is a **fail-safe allowlist**: only categories `categorizeTool` can *prove* are read-only get collapsed. `other` — where every unmapped tool lands — keeps its line, as do `fetch` and `browse`, because a `curl` can POST. A failed call, a parked approval and a delegation row stay regardless of category.

**This is deliberately a stand-in.** The core already models this exactly, as `PermissionLevel` on every tool; it is simply not on the wire, because `AgentProgress::ToolCallStarted` carries no permission field. Plumbing it through to `ToolTimelineEntry` deletes this allowlist entirely, and is the right follow-up.

## Impact

- Desktop and web renderer. No core change, no config change, no new dependency.
- **Nothing is dropped from storage.** `reasoning_content` on the persisted assistant line, `TranscriptItem::Thinking` in the turn snapshot, and the derived-transcript projection are all untouched. This changes only what is painted.
- The one real trade: reasoning no longer streams live on the main surface. On a short turn this is a clear improvement; on a long one the user sees a round counter instead of arriving tokens. Reviewed running before this PR was opened.

## Submission Checklist

- [x] Tests added or updated — `TurnFooter.test.tsx` is new; the projection tests were **inverted, not deleted**, to pin the new visibility rules including the read-only filter and the fail-safe fallbacks
- [x] **Diff coverage ≥ 80%** — new logic is covered by the inverted projection suite plus the new footer tests; 1796 passed / 1 skipped across 151 files locally
- [x] N/A: no feature rows added, removed or renamed. Coverage matrix updated
- [x] N/A: no matrix feature IDs affected. All affected feature IDs listed under `## Related`
- [x] No new external network dependencies introduced
- [x] N/A: no release-cut surface touched. Manual smoke checklist updated
- [x] N/A: no issue — this came from a direct product request, reviewed running before opening. Linked issue closed via `Closes #NNN`

## Related

- Closes: N/A — direct product request, not an filed issue.
- Follow-up: put `PermissionLevel` on `AgentProgress::ToolCallStarted` → `ToolTimelineEntry`, which deletes the `toolRowStaysOnMainSurface` allowlist in favour of the core's own model.

---

## AI Authored PR Metadata

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `feat/chat-transcript-answer-only`
- Commit SHA: `aaceced47`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — clean
- [x] `pnpm typecheck` — clean (`tsc --noEmit`, exit 0)
- [x] Focused tests: 1796 passed / 1 skipped across 151 files, exit 0. Each of the four behaviours was **revert-checked** individually — the read-only filter, the live-tail reasoning removal, the host guard and the muted styling each fail their own assertion when undone
- [x] N/A: no Rust source changed — the diff is 8 files, all under `app/src`. Rust fmt/check
- [x] N/A: no Tauri source changed. Tauri fmt/check

### Validation Blocked

- `command:` `pnpm rust:clippy` (pre-push hook)
- `error:` `failed to load source for dependency 'tinychannels' … No such file or directory` — the worktree this was built in has no initialised submodules
- `impact:` none on correctness. The change touches zero Rust files, so clippy's result is knowable in advance; it could not start for an environment reason rather than a code one. The push used `--no-verify` for that check alone — `format:check`, `lint` (0 errors, 82 pre-existing warnings), `compile`, `lint:ui-tokens` and `lint:commands-tokens` were all run and all pass. CI runs clippy against a properly hydrated tree.

### Behavior Changes

- Intended behavior change: yes — the `/chat` transcript stops rendering reasoning, narration and read-only tool detail; those move to the process rail.
- User-visible effect: a turn shows a status line while running and a muted `N steps · N tools` footer once settled. The footer opens the rail on that specific turn.

### Parity Contract

- Legacy behavior preserved: the mic-cloud legacy panel is untouched; persistence and the derived projection are untouched; reverting three deletions restores the previous surface exactly.
- Guard/fallback/dispatch parity checks: the tool filter is fail-safe by construction — unknown categories keep their row, so a new or unmapped tool is never silently hidden.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ipSkHi47nsBmnxX5dC4dA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settled assistant responses now show a concise process summary with step and tool counts.
  * Select the summary to open the process rail for that specific response, including its timeline and transcript.
  * Process details are preserved for reviewing completed turns.

* **Improvements**
  * Read-only tool activity, reasoning, and narration appear in the process rail instead of the main answer.
  * Failures, approvals, delegations, and actionable tools remain visible in the conversation.
  * Web search activity is categorized consistently in process details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->