### PR TITLE
fix(ui): make skill filter checkbox selection visible

### DIFF
--- a/app/src/components/ui/Checkbox.test.tsx
+++ b/app/src/components/ui/Checkbox.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import Checkbox from './Checkbox';
+
+describe('<Checkbox />', () => {
+  it('keeps the native checked state in sync when toggled', async () => {
+    function ControlledCheckbox() {
+      const [checked, setChecked] = useState(false);
+      return <Checkbox aria-label="Source" checked={checked} onCheckedChange={setChecked} />;
+    }
+    render(<ControlledCheckbox />);
+    const checkbox = screen.getByRole('checkbox', { name: 'Source' });
+    expect(checkbox).not.toBeChecked();
+    await userEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+    await userEvent.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('updates and clears the native indeterminate state', () => {
+    const onCheckedChange = vi.fn();
+    const { rerender } = render(
+      <Checkbox checked={false} indeterminate onCheckedChange={onCheckedChange} />
+    );
+    expect(screen.getByRole('checkbox')).toBePartiallyChecked();
+    rerender(<Checkbox checked={false} indeterminate={false} onCheckedChange={onCheckedChange} />);
+    expect(screen.getByRole('checkbox')).not.toBePartiallyChecked();
+  });
+
+  it('does not toggle a disabled checkbox', async () => {
+    const onCheckedChange = vi.fn();
+    render(<Checkbox checked disabled onCheckedChange={onCheckedChange} />);
+    await userEvent.click(screen.getByRole('checkbox'));
+    expect(screen.getByRole('checkbox')).toBeChecked();
+    expect(onCheckedChange).not.toHaveBeenCalled();
+  });
+});

--- a/app/src/components/ui/Checkbox.tsx
+++ b/app/src/components/ui/Checkbox.tsx
@@ -62,6 +62,9 @@ const Checkbox = ({
       onChange={e => onCheckedChange(e.target.checked)}
       className={cn(
         'h-4 w-4 cursor-pointer rounded-sm border border-line-strong bg-surface accent-primary-500',
+        // The forms plugin draws a white check/dash; bg-surface otherwise
+        // overrides its selected background and hides the mark in light mode.
+        'checked:bg-primary-500 indeterminate:bg-primary-500',
         'transition-colors duration-150',
         'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-1',
         // Offsets against the themed surface. The original used

--- a/app/src/components/ui/Checkbox.tsx
+++ b/app/src/components/ui/Checkbox.tsx
@@ -64,7 +64,9 @@ const Checkbox = ({
         'h-4 w-4 cursor-pointer rounded-sm border border-line-strong bg-surface accent-primary-500',
         // The forms plugin draws a white check/dash; bg-surface otherwise
         // overrides its selected background and hides the mark in light mode.
-        'checked:bg-primary-500 indeterminate:bg-primary-500',
+        // Keep the dark surface: some dark themes have light primary accents
+        // that do not contrast with the plugin's white mark.
+        'checked:bg-primary-500 indeterminate:bg-primary-500 dark:checked:bg-surface dark:indeterminate:bg-surface',
         'transition-colors duration-150',
         'focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-1',
         // Offsets against the themed surface. The original used

--- a/docs/RELEASE-MANUAL-SMOKE.md
+++ b/docs/RELEASE-MANUAL-SMOKE.md
@@ -22,7 +22,7 @@ Applies to every release, all platforms.
 
 ### Checkbox appearance
 
-- [ ] **Skill source filters show their selection** — In Connections → Skills, open the catalog source filter and toggle a source off and on. Verify that the rows filter correctly, the menu stays open, and the selected source has a visible checkmark. Repeat in light and dark themes; selected and indeterminate shared checkboxes must show a contrasting mark, while unchecked boxes remain empty.
+- [ ] **Skill source filters show their selection** — In Connections → Skills, open the catalog source filter and toggle a source off and on. Verify that the rows filter correctly, the menu stays open, and the selected source has a visible checkmark. Repeat in light and dark themes, including Matrix, Ocean and Sepia dark; selected and indeterminate shared checkboxes must show a contrasting mark, while unchecked boxes remain empty.
 
 ### Public installer script
 

--- a/docs/RELEASE-MANUAL-SMOKE.md
+++ b/docs/RELEASE-MANUAL-SMOKE.md
@@ -20,6 +20,10 @@ This is the **only** acceptable substitute for a `🚫` row in [`TEST-COVERAGE-M
 
 Applies to every release, all platforms.
 
+### Checkbox appearance
+
+- [ ] **Skill source filters show their selection** — In Connections → Skills, open the catalog source filter and toggle a source off and on. Verify that the rows filter correctly, the menu stays open, and the selected source has a visible checkmark. Repeat in light and dark themes; selected and indeterminate shared checkboxes must show a contrasting mark, while unchecked boxes remain empty.
+
 ### Public installer script
 
 - [ ] **`scripts/install.sh` downloads the latest asset on a proxy/VPN network** — From a clean checkout, run `bash scripts/install.sh --dry-run --verbose`, then run the public `curl -fsSL https://raw.githubusercontent.com/tinyhumansai/openhuman/main/scripts/install.sh | bash` flow on one macOS or Linux host. Expected: release metadata resolves, the asset downloads successfully, and transient GitHub/CDN HTTP/2 failures retry over HTTP/1.1 instead of surfacing `curl: (16) Error in the HTTP2 framing layer`.


### PR DESCRIPTION
## Summary

- Make checked skill source filters visibly selected in light mode.
- Give the shared checkbox's checked and indeterminate states a primary background in light mode so the forms plugin's white mark remains visible.
- Add native checkbox interaction tests and a visual release smoke check.

## Problem

The skills catalog source filter changes the results correctly but its checkboxes appear empty. `@tailwindcss/forms` removes native appearance and draws a white SVG checkmark; the shared `bg-surface` utility overrides the plugin's selected background. In light mode this renders a white tick on white. The same conflict affects indeterminate checkboxes.

Reproduced with the current app CSS on main (`2e2d0a2b8`): a checked input has `checked=true`, `appearance:none`, a white SVG background image, and `background-color: rgb(255, 255, 255)`.

## Solution

Add selected-state primary backgrounds to the shared native checkbox in light mode. Preserve `bg-surface` in dark mode, where a white mark already contrasts and presets such as Matrix have primary accents too light for white. The unchecked surface, native input semantics, filtering callbacks and disabled behavior are preserved. No flow or logging changes are involved; this is a paint-only correction.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement): checked toggling, indeterminate reset, and disabled input.
- [x] **Diff coverage ≥ 80%** — targeted Vitest coverage reports 100% of Checkbox.tsx lines (6/6); CI remains the authoritative diff gate. Rust is unchanged.
- [x] N/A: Coverage matrix updated — behavior-only correction, no added/removed/renamed feature rows.
- [x] All affected feature IDs from the matrix are listed under `## Related`.
- [x] No new external network dependencies introduced; tests use the existing test setup, and browser checks used local compiled CSS without backend calls.
- [x] Manual smoke checklist updated in [`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md) with the skills filter and light/dark checkbox checks.
- [x] N/A: Linked issue closed — no existing issue found for this specific visual defect.

## Impact

Shared checkbox styling across desktop and web. No Rust, IPC, configuration, authentication, data migration, or provider changes. Other consumers receive the same visible selected/indeterminate background.

## Related

- Closes: N/A — reported during local desktop testing.
- Feature IDs: 13.3.2 (Skill Toggle); shared checkbox appearance also applies across consumers.
- Follow-up PR(s)/TODOs: none.
- Related history: #5698 introduced the shared filter surface; #5843 updated shared controls. Neither fixes this background conflict.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/skill-filter-checkbox`
- Commit SHA: `4f0ce902175f821be1c946c401ee766f53ca7b36`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`: scoped Prettier check passed for all three changed files; unrelated whole-repository formatting was not run.
- [x] `pnpm typecheck`: equivalent `node node_modules/typescript/bin/tsc --noEmit` from app passed.
- [x] Focused tests: Checkbox + DataTable Vitest suites, 11 passed; Checkbox line coverage 100%. Targeted ESLint passed. Production Vite build passed. Local Chrome rendering checks passed for unchecked, checked and indeterminate states across all 10 built-in presets using the built CSS; the white mark/background contrast ranges from 3.45:1 to 19.31:1. The browser check is manual/local validation, not a committed E2E suite.
- [x] N/A: Rust fmt/check — no Rust changes.
- [x] N/A: Tauri fmt/check — no Tauri changes.

### Validation Blocked

- `command:` None outstanding for the changed scope. Sandboxed Vitest was rerun with local socket access for the test mock server.
- `error:` N/A
- `impact:` Native desktop visual smoke remains on the release checklist; browser visual validation used Chrome on macOS.

### Behavior Changes

- Intended behavior change: selected and indeterminate checkboxes have a contrasting primary background in light mode; dark themes preserve their existing surface.
- User-visible effect: the source filter's white checkmark is visible in light mode.

### Parity Contract

- Legacy behavior preserved: native checkbox state, click callbacks, disabled controls, filter selection and unchecked background.
- Guard/fallback/dispatch parity checks: checkbox state/disabled tests plus the existing DataTable filter tests pass.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none found.
- Canonical PR: this PR.
- Resolution (closed/superseded/updated): N/A
