### PR TITLE
fix(subagent): stop mirrored tool results rendering as the user's own message

### DIFF
--- a/src/openhuman/agent/harness/session/builder/builder_tests_part_01_tests.rs
+++ b/src/openhuman/agent/harness/session/builder/builder_tests_part_01_tests.rs
@@ -525,6 +525,26 @@ async fn build_session_agent_uses_profile_memory_instead_of_root_memory() {
 /// #6040 — the memory-access instruction is about the memory tools, not the
 /// learning subsystem, so it must be in the prompt with `learning.enabled`
 /// off (the default) whenever a retrieval tool is registered and visible.
+///
+/// Passes the definition explicitly via [`builtin_def`] rather than letting the
+/// factory resolve `"orchestrator"` from the registry, and that is load-bearing
+/// rather than ceremony.
+///
+/// The section is gated on `memory_recall` being **registered and visible after
+/// tool filtering** (`any_tool_offered`), and the visible set comes from the
+/// resolved definition's tool scope. With `None` here the factory reads
+/// `AgentDefinitionRegistry`'s `static GLOBAL: OnceLock<…>`
+/// (`harness/definition_part_02.rs:24`) — first-write-wins and never reset — so
+/// the test was asserting against whichever definition set some *other* test in
+/// the binary had installed first. That is exactly the hazard `builtin_def`
+/// was written for: it loads fresh from the bundled TOML, "entirely independent
+/// of the global registry singleton".
+///
+/// It is why this passed run alone and failed inside the full
+/// `openhuman::agent` run (`ci-lite` scopes the Rust lane per changed domain,
+/// so the whole scope only runs when a PR touches `agent/`), and why the
+/// sibling write-side test in `builder_tests_part_03_tests.rs` never flaked —
+/// it already supplied `builtin_def("orchestrator")`.
 #[tokio::test]
 async fn memory_access_instruction_is_present_with_learning_disabled() {
     use crate::openhuman::agent::context::prompt::LearnedContextData;
@@ -535,11 +555,20 @@ async fn memory_access_instruction_is_present_with_learning_disabled() {
     let mut config = test_config(&tmp);
     config.learning.enabled = false;
 
-    let agent = Agent::build_session_agent_inner(&config, "orchestrator", None, None, false, None)
-        .expect("build session agent");
+    let orchestrator = builtin_def("orchestrator");
+    let agent = Agent::build_session_agent_inner(
+        &config,
+        "orchestrator",
+        Some(&orchestrator),
+        None,
+        false,
+        None,
+    )
+    .expect("build session agent");
     let prompt = agent
         .build_system_prompt(LearnedContextData::default())
         .expect("build_system_prompt");
+
     assert!(
         prompt.contains(MEMORY_ACCESS_INSTRUCTION.trim()),
         "the memory-access section must not be gated on learning.enabled"

--- a/src/openhuman/agent/harness/subagent_runner/ops/graph_part_02.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops/graph_part_02.rs
@@ -76,6 +76,16 @@ fn append_worker_message(
         "agent_id": agent_id,
         "task_id": task_id,
         "mode": "typed",
+        // #5934: a mirror row that is not the sub-agent speaking is a tool
+        // result, and the renderer maps every non-`"agent"` sender to
+        // `role: 'user'` (`assistantUiMessages.ts`) — so without this flag a
+        // tool's raw output is painted, in an openable worker thread, as
+        // something the human typed. `hidden` keeps the row in the log for the
+        // process rail and the process-source view; it only stops being chat.
+        // Genuine worker-thread user turns are written by
+        // `worker_thread::{create_worker_thread, append_worker_user_message}`,
+        // not here, so they are unaffected. Overridable by `metadata` below.
+        "hidden": sender != "agent",
     });
     if let (Some(base), Some(extra_fields)) = (extra.as_object_mut(), metadata.as_object()) {
         for (k, v) in extra_fields {

--- a/src/openhuman/agent/harness/subagent_runner/ops/graph_tests.rs
+++ b/src/openhuman/agent/harness/subagent_runner/ops/graph_tests.rs
@@ -636,3 +636,109 @@ async fn an_allowlist_that_readmits_a_spawn_tool_is_refused_loudly() {
         "the readmitted spawn tool warns exactly once: {warnings:?}"
     );
 }
+
+/// #5934 (item 1): a mirrored sub-agent **tool result** must not be painted as
+/// something the human typed.
+///
+/// Both worker-thread mirrors write tool output with `sender: "user"`, and the
+/// renderer maps every non-`"agent"` sender to `role: 'user'`
+/// (`app/src/providers/assistantUiMessages.ts:536`) while keying visibility
+/// only on `extraMetadata.hidden` (`:664`, and the same flag in
+/// `ChatThreadView.tsx:312` / `timeline/selectors.ts:50`). Worker threads are
+/// openable chats — `create_worker_thread` stamps `labels: ["tasks"]` and
+/// `threadFilter.ts` lists that tab — so an unflagged mirror row shows the
+/// tool's raw output in a right-aligned user bubble.
+///
+/// The invariant: every non-`"agent"` row these mirrors write is `hidden`. The
+/// record stays in the log for the process rail; it just stops being chat.
+#[test]
+fn mirrored_tool_results_are_hidden_from_the_worker_thread_chat() {
+    use crate::openhuman::memory::conversations::{self as store, CreateConversationThread};
+
+    let dir = std::env::temp_dir().join(format!("wt-5934-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let now = chrono::Utc::now().to_rfc3339();
+    for id in ["worker-typed", "worker-recovered"] {
+        store::ensure_thread(
+            dir.clone(),
+            CreateConversationThread {
+                id: id.to_string(),
+                title: "task".to_string(),
+                created_at: now.clone(),
+                parent_thread_id: Some("parent-1".to_string()),
+                labels: Some(vec!["tasks".to_string()]),
+                personality_id: None,
+            },
+        )
+        .unwrap();
+    }
+
+    const RAW: &str = "{\"events\":[{\"title\":\"raw tool output the human never typed\"}]}";
+
+    // The typed path (`ConversationMessage::ToolResults`), used on a normal run.
+    mirror_worker_thread(
+        &dir,
+        "worker-typed",
+        "researcher",
+        "task-1",
+        &[
+            ConversationMessage::AssistantToolCalls {
+                text: Some("checking the calendar".to_string()),
+                tool_calls: vec![crate::openhuman::inference::provider::ToolCall {
+                    id: "call-1".to_string(),
+                    name: "list_events".to_string(),
+                    arguments: "{}".to_string(),
+                    extra_content: None,
+                }],
+                reasoning_content: None,
+                extra_metadata: None,
+            },
+            ConversationMessage::ToolResults(vec![
+                crate::openhuman::agent::messages::ToolResultMessage {
+                    tool_call_id: "call-1".to_string(),
+                    content: RAW.to_string(),
+                },
+            ]),
+        ],
+        Some("Here is your week."),
+    );
+
+    // The error-recovery path (`role: "tool"`), used when a run fails mid-turn.
+    mirror_worker_thread_from_history(
+        &dir,
+        "worker-recovered",
+        "researcher",
+        "task-1",
+        &[
+            ChatMessage::assistant("checking the calendar"),
+            ChatMessage::tool(RAW),
+        ],
+        Some("[subagent run failed before completion]"),
+    );
+
+    // Collected, not asserted per row: both mirrors must be reported, so a
+    // failure names every path that is still painting a tool result as chat.
+    let mut painted_as_user_chat: Vec<String> = Vec::new();
+    for thread_id in ["worker-typed", "worker-recovered"] {
+        let rows = store::get_messages(dir.clone(), thread_id).unwrap();
+        assert!(
+            rows.iter().any(|r| r.content == RAW),
+            "{thread_id}: the mirror wrote no tool-result row to assert on"
+        );
+        for row in rows.iter().filter(|r| r.sender != "agent") {
+            if row.extra_metadata.get("hidden").and_then(|v| v.as_bool()) != Some(true) {
+                painted_as_user_chat.push(format!(
+                    "{thread_id}: sender={:?} not hidden: {}",
+                    row.sender, row.content
+                ));
+            }
+        }
+    }
+    assert!(
+        painted_as_user_chat.is_empty(),
+        "mirrored tool results render in a user chat bubble:\n{}",
+        painted_as_user_chat.join("\n")
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}


### PR DESCRIPTION
## Summary

- A sub-agent's worker-thread mirror wrote each **tool result** with `sender: "user"` and no visibility flag, so a tool's raw JSON output was painted in a right-aligned bubble as something the human typed, in a thread the user can open.
- Sets `hidden` in `append_worker_message` for any non-`"agent"` sender. The row stays in the JSONL log for the process rail and the process-source view; it only stops being chat.
- Fixed at the shared choke point, not at the reported call site: **both** mirrors had the defect — the typed path (`mirror_worker_thread`, `ConversationMessage::ToolResults`) and the error-recovery path (`mirror_worker_thread_from_history`, `role: "tool"`). The issue names only the first.
- Item 2 of #5934 (narration rendered as plain text) was already fixed by #6169; this PR is item 1 only.

## Problem

`src/openhuman/agent/harness/subagent_runner/ops/graph_part_02.rs` mirrors a sub-agent's turn onto its worker thread. Tool results are written with `sender: "user"` and metadata `{iteration, final, tool_call_id, tool_name}` — no `hidden`.

The renderer then paints them as user chat:

- `app/src/providers/assistantUiMessages.ts:536` — `role: msg.sender === 'agent' ? 'assistant' : 'user'`. Any non-`'agent'` sender is a right-aligned user bubble.
- Visibility is filtered **only** on `extraMetadata.hidden` — `assistantUiMessages.ts:664`, `ChatThreadView.tsx:312`, `Conversations.tsx:1767`, `timeline/selectors.ts:50`.
- The thread is reachable: `worker_thread::create_worker_thread` stamps `labels: ["tasks"]` and sets `parent_thread_id`, and `threadFilter.ts`'s `isTaskThread` lists both in the Tasks tab.

`app/src/types/thread.ts` declares `sender: 'user' | 'agent'`, so `"user"` here is type-legal — there is no type-level distinction between "the human said this" and "this is a mirrored record", which is why nothing caught it.

**Reproduced before changing anything.** `mirrored_tool_results_are_hidden_from_the_worker_thread_chat` drives both mirrors against a real conversation store and reads the rows back. Pre-fix:

```
mirrored tool results render in a user chat bubble:
worker-typed: sender="user" not hidden: {"events":[{"title":"raw tool output the human never typed"}]}
worker-recovered: sender="user" not hidden: {"events":[{"title":"raw tool output the human never typed"}]}
```

## Solution

One flag in `append_worker_message`, the function both mirrors route through:

```rust
"hidden": sender != "agent",
```

Why there rather than at the two `ToolResults` call sites: it is one line instead of two, it covers the recovery path the issue does not mention, and it states the actual invariant — *a mirror row that is not the sub-agent speaking is a record, not chat*. It is placed in the base metadata object, before the caller's `metadata` is merged over it, so a caller can still override.

Genuine worker-thread user turns do **not** go through this function — `worker_thread::create_worker_thread` (the delegation prompt) and `append_worker_user_message` (a follow-up prompt) write their own rows, so those stay visible.

**The sibling arms are correctly distinguished and unchanged.** `AssistantToolCalls` text, the assistant `Chat` arm and the trailing `extra_final` all send `"agent"` — the sub-agent speaking, not a mirrored record — so `sender != "agent"` is false for all three and nothing about them changes.

**No change to `SubagentDrawer`.** Its reopen-from-memory path (`transcriptFromMessages`) does not read `hidden`, and already treats only the *first* `user` row as the delegation prompt and drops the rest — so tool-result rows were never rendered there and still are not.

### Verification

| Step | Result |
| --- | --- |
| New test, fix not yet written | FAILS, naming both mirror paths and the raw tool output |
| Fix applied | `test result: ok. 1 passed` |
| Revert-check (fix removed, test unchanged) | FAILS again, `EXIT:101`, naming *my* assertion and both threads |
| Wider run: `--lib -- subagent_runner orchestration::tools` | `260 passed; 0 failed` |

Run as `cargo test --features "$(bash scripts/ci/product-features.sh)" --no-default-features --lib` with `RUST_MIN_STACK=67108864`.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — one test covering both mirrors, including the error-recovery path (`mirror_worker_thread_from_history`, used when a run fails mid-turn)
- [x] **Diff coverage ≥ 80%** — the changed Rust line is executed by the new test; verified by the revert-check, which fails on that line's absence
- [x] N/A: behaviour-only change to an existing mirror path; no feature row added, removed or renamed — Coverage matrix updated ([`docs/TEST-COVERAGE-MATRIX.md`](../docs/TEST-COVERAGE-MATRIX.md))
- [x] N/A: no matrix feature row is affected — All affected feature IDs from the matrix listed under `## Related`
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — the test uses a temp-dir conversation store and no network
- [x] N/A: removes stray rows from a Tasks-tab thread; no release-cut surface changes behaviour — Manual smoke checklist updated ([`docs/RELEASE-MANUAL-SMOKE.md`](../docs/RELEASE-MANUAL-SMOKE.md))
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Desktop / web chat.** Worker (Tasks-tab) threads stop showing raw tool output as user bubbles. Historical rows written before this change have no `hidden` flag and will still render — this fixes new runs, not the backlog.
- No schema change, no migration. `extra_metadata` is free-form JSON and gains one boolean key.
- The row is still persisted, so nothing that reads the JSONL log, the process rail, the process-source view, conversation search or the cross-thread index loses data.

## Related

- Closes: #5934
- Follow-up PR(s)/TODOs: none for this PR. One adjacent mismatch found and **not** folded in: `SubagentDrawer.transcriptFromMessages` builds its tool rows from `agent` messages carrying `extraMetadata.tool_name`, but the producer puts `tool_name` on the *tool-result* row and `tool_calls` (plural) on the agent row — so a reopened delegation renders no tool rows. Its unit test passes on a hand-written fixture the producer never writes. Reported separately rather than widened into this PR.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/5934-worker-tool-result-hidden`
- Commit SHA: `feb8a802dee46f1e4f0a5d7b1e86c7e4e8c4b89b`

### Validation Run

- [x] N/A: no files under `app/` changed — `pnpm --filter openhuman-app format:check`
- [x] N/A: no TypeScript changed — `pnpm typecheck`
- [x] Focused tests: `cargo test --lib mirrored_tool_results_are_hidden` (fails pre-fix, passes post-fix, fails again on revert); `cargo test --lib -- subagent_runner orchestration::tools` → 260 passed / 0 failed
- [x] Rust fmt/check (if changed): `cargo fmt` run; the crate builds under the product feature set as part of the test runs above
- [x] N/A: `app/src-tauri` untouched — Tauri fmt/check

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: mirrored sub-agent tool results are flagged `hidden`, so they are excluded from the chat transcript of a worker thread.
- User-visible effect: opening a Tasks-tab worker thread no longer shows a tool's raw JSON output in a right-aligned bubble attributed to the user. The delegation prompt, the sub-agent's narration and its final answer are unchanged.

### Parity Contract

- Legacy behavior preserved: the row is still written, with the same `sender`, content and existing metadata keys; consumers that read the log rather than the chat projection see no change. The delegation prompt and follow-up prompts are written elsewhere and stay visible.
- Guard/fallback/dispatch parity checks: the flag is set in the base metadata *before* the caller's `metadata` is merged, so an explicit `hidden` from a call site still wins; the three `"agent"` arms are unaffected because the condition is false for them.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none. #5956 cross-references #5934 but fixed a different thing (autonomous-reply persistence) and is already merged.
- Canonical PR: this one.
- Resolution: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ipSkHi47nsBmnxX5dC4dA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tool results mirrored into worker threads are now hidden from the chat display instead of appearing as messages typed by a human.
  - This applies to both standard tool-result messages and tool output restored during error recovery, improving clarity when reviewing worker-thread conversations.

- **Tests**
  - Added coverage to verify that mirrored tool results remain hidden across supported message paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->