### PR TITLE
fix(app_state): stop blocking every snapshot poll on a backend round trip

### DIFF
--- a/src/openhuman/desktop/app_state/ops.rs
+++ b/src/openhuman/desktop/app_state/ops.rs
@@ -2,6 +2,9 @@
 #[path = "ops_current_user_backoff_tests.rs"]
 mod current_user_backoff_tests;
 #[cfg(test)]
+#[path = "ops_snapshot_latency_tests.rs"]
+mod snapshot_latency_tests;
+#[cfg(test)]
 #[path = "ops_tests.rs"]
 mod tests;
 include!("ops_auth_timeout.rs");

--- a/src/openhuman/desktop/app_state/ops_current_user_backoff_tests.rs
+++ b/src/openhuman/desktop/app_state/ops_current_user_backoff_tests.rs
@@ -25,7 +25,10 @@ use once_cell::sync::Lazy as TestLazy;
 /// whole point of that test is that `fetch_current_user_cached` consults the
 /// record. Kept distinct from `APP_STATE_CACHE_TEST_LOCK` because the two guard
 /// different globals and nothing here writes the positive cache.
-static CURRENT_USER_FAILURE_TEST_LOCK: TestLazy<tokio::sync::Mutex<()>> =
+/// `pub(super)` because `ops_tests.rs` needs it too: a successful fetch calls
+/// `clear_current_user_failure`, which wipes this global, so a test that lets a
+/// real fetch complete has to serialise against the tests seeding outages here.
+pub(super) static CURRENT_USER_FAILURE_TEST_LOCK: TestLazy<tokio::sync::Mutex<()>> =
     TestLazy::new(|| tokio::sync::Mutex::new(()));
 
 /// Drops the seeded outage on the way out, so one test cannot leak into the next.

--- a/src/openhuman/desktop/app_state/ops_part_01.rs
+++ b/src/openhuman/desktop/app_state/ops_part_01.rs
@@ -512,23 +512,34 @@ pub fn save_app_state(config: &Config, state: &StoredAppState) -> Result<(), Str
     save_stored_app_state_unlocked(config, state)
 }
 
-fn build_client() -> Result<Client, String> {
+/// One process-wide client for `GET /auth/me`, so its pooled TCP+TLS
+/// connection survives between snapshot polls instead of being handshaken
+/// again on every one.
+///
+/// `app_state_snapshot` polls this endpoint for the life of the session. A
+/// `Client` built per call gave each poll its own connection pool, so every one
+/// paid a fresh TCP connect *and* TLS handshake before the request could go out
+/// — two extra WAN round trips on top of the one the request itself costs.
+/// Measured against the production backend over a ~250ms RTT link: ~780-1420ms
+/// on a cold connection versus ~380-540ms on a reused one (#6180).
+///
+/// `reqwest::Client` is internally reference-counted and built to be shared;
+/// holding one is the only way to keep its pool.
+///
+/// The product-identity header moved to the request rather than
+/// `default_headers`, because this client now outlives
+/// [`crate::api::product::set_product_identity`] — baking the header in here
+/// would pin whichever identity happened to be installed when the first
+/// snapshot ran. `MedullaClient` reads it per request for the same reason.
+static CURRENT_USER_CLIENT: Lazy<Result<Client, String>> = Lazy::new(|| {
     // Platform-appropriate TLS backend — see [`crate::openhuman::util::tls`].
     crate::openhuman::util::tls::tls_client_builder()
         .http1_only()
         .timeout(Duration::from_secs(30))
         .connect_timeout(Duration::from_secs(10))
-        // `GET /auth/me` is backend traffic like any other, so it carries the
-        // product identity. This client is hand-rolled rather than obtained
-        // from `BackendOAuthClient`, so it inherits nothing from that path's
-        // default headers — see [`crate::api::product`]. Set here rather than
-        // at the one call site because every user of this builder is
-        // backend-bound by construction (`resolve_base` resolves the backend
-        // API URL and nothing else).
-        .default_headers(crate::api::product::product_identity_headers())
         .build()
         .map_err(|e| format!("failed to build HTTP client: {e}"))
-}
+});
 
 fn resolve_base(config: &Config) -> Result<Url, String> {
     let base = effective_backend_api_url(&config.api_url);
@@ -545,13 +556,20 @@ async fn fetch_current_user(
     config: &Config,
     token: &str,
 ) -> Result<Option<Value>, CurrentUserFetchError> {
-    let client = build_client().map_err(CurrentUserFetchError::FetchFailed)?;
+    let client = CURRENT_USER_CLIENT
+        .as_ref()
+        .map_err(|e| CurrentUserFetchError::FetchFailed(e.clone()))?;
     let base = resolve_base(config).map_err(CurrentUserFetchError::FetchFailed)?;
     let url = base
         .join("auth/me")
         .map_err(|e| CurrentUserFetchError::FetchFailed(format!("build URL failed: {e}")))?;
     let response = client
         .request(Method::GET, url.clone())
+        // `GET /auth/me` is backend traffic like any other, so it carries the
+        // product identity. This request is hand-rolled rather than issued
+        // through `BackendOAuthClient`, so it inherits nothing from that path's
+        // default headers — see [`crate::api::product`].
+        .headers(crate::api::product::product_identity_headers())
         .header(AUTHORIZATION, bearer_authorization_value(token))
         .send()
         .await

--- a/src/openhuman/desktop/app_state/ops_part_02.rs
+++ b/src/openhuman/desktop/app_state/ops_part_02.rs
@@ -199,16 +199,13 @@ async fn fetch_current_user_cached(
             // trip under every `app_state_snapshot` (#6180: 732 calls in 3.5h,
             // not one of them under 500ms).
             //
-            // This does move the refresh cadence, and it is worth being exact
-            // about how: the background refresh stamps `fetched_at` when it
-            // *completes*, so the next poll finds the entry still inside the
-            // TTL and serves it without revalidating. `GET /auth/me` is
-            // therefore refreshed about every other poll (~10s) rather than
-            // every poll (~5.5s). That is acceptable because this payload is
-            // display-only profile data (`firstName`, `lastName`, `username`,
-            // `_id`) and not the session-validity check, and it halves this
-            // endpoint's share of the background RPC load #6180 also reports.
-            // The snapshot keeps reporting the true age it is serving in
+            // The refresh cadence is unchanged by this: `refresh_current_user_now`
+            // stamps `fetched_at` when the request goes out, not when it lands,
+            // so the round trip is not folded into the next TTL window and the
+            // poll after this one expires on the same schedule it always did.
+            // Stamping at completion would have quietly halved the cadence —
+            // see the note there (#6190 review). The snapshot keeps reporting
+            // the true age of the data it is serving in
             // `current_user_stale_seconds`.
             //
             // Only the expired-entry path revalidates in the background. With
@@ -359,6 +356,24 @@ async fn refresh_current_user_now(
     origin: RefreshOrigin,
 ) -> Result<Option<Value>, CurrentUserFetchError> {
     let api_base = current_user_api_base(config);
+    // The TTL clock starts when the request goes out, not when it lands.
+    //
+    // `fetched_at` is what `CURRENT_USER_REFRESH_TTL` is measured against, and
+    // the poll loop schedules itself from the previous *response*. Stamping at
+    // completion would therefore fold the round trip into the next window: a
+    // refresh taking `L` leaves the following poll only `TTL - L` from expiry,
+    // it reads the entry as fresh, and the refresh after that is skipped
+    // entirely — halving the cadence as a side effect of not blocking (#6190
+    // review). Stamping at initiation keeps the wall-clock refresh cadence
+    // exactly what it was before this path became non-blocking; the only thing
+    // that changed is who waits for it.
+    //
+    // It also errs the safe way. The data itself arrives at `started_at + L`,
+    // so calling it `started_at` slightly *overstates* its age and expires the
+    // entry sooner — never later. `note_current_user_success` below is the
+    // stamp that answers "how old is the data we are showing", and it stays at
+    // completion, because that is when the data actually arrived.
+    let started_at = Instant::now();
     let fetched = match fetch_current_user(config, token).await {
         Ok(user) => sanitize_snapshot_user(user),
         Err(error) => {
@@ -403,7 +418,7 @@ async fn refresh_current_user_now(
                     *cache = Some(CachedCurrentUser {
                         api_base: api_base.clone(),
                         token: token.to_string(),
-                        fetched_at: Instant::now(),
+                        fetched_at: started_at,
                         user,
                     });
                 }

--- a/src/openhuman/desktop/app_state/ops_part_02.rs
+++ b/src/openhuman/desktop/app_state/ops_part_02.rs
@@ -349,18 +349,6 @@ enum RefreshOrigin {
     Background,
 }
 
-/// Whether the cache has moved to an identity other than this refresh's.
-///
-/// An *empty* cache is deliberately not "moved on": a background refresh that
-/// started before anything was cached is still the right answer for the
-/// identity that asked for it.
-fn cached_identity_moved_on(api_base: &str, token: &str) -> bool {
-    CURRENT_USER_CACHE
-        .lock()
-        .as_ref()
-        .is_some_and(|entry| entry.api_base != api_base || entry.token != token)
-}
-
 /// Go to the backend, then reconcile the caches and freshness stamps with what
 /// came back. The blocking half of [`fetch_current_user_cached`], split out so
 /// the background refresh runs exactly the same path rather than a parallel
@@ -385,21 +373,50 @@ async fn refresh_current_user_now(
     // reads that slot WITHOUT a key check (#926), so the regressed entry would
     // be embedded in the agent's prompts as the current user. The keyed reads
     // in `fetch_current_user_cached` would merely miss; that one would be
-    // wrong. Checked before the writes rather than at the cache lock, so a
-    // discarded refresh cannot clear the *newer* identity's failure record on
-    // its way out. The blocking path cannot race this way, so it never
-    // discards.
-    // A detached refresh can land after the app has moved to another identity,
-    // and every write below is process-global. Committing then would regress
-    // the cache to the previous user — and `peek_cached_current_user_identity`
-    // reads that slot WITHOUT a key check (#926), so the regressed entry would
-    // be embedded in the agent's prompts as the current user. The keyed reads
-    // in `fetch_current_user_cached` would merely miss; that one would be
-    // wrong. Checked before the writes rather than at the cache lock, so a
-    // discarded refresh cannot clear the *newer* identity's failure record on
-    // its way out. The blocking path cannot race this way, so it never
-    // discards.
-    if origin == RefreshOrigin::Background && cached_identity_moved_on(&api_base, token) {
+    // wrong.
+    //
+    // The check and the commit share ONE lock acquisition, and nothing between
+    // them can suspend or release it. Validating through a separate read would
+    // leave a window in which a blocking refresh for a newer identity commits
+    // after this one has already decided it is current — narrow, but the
+    // runtime is multi-threaded, so "narrow" is not "impossible".
+    //
+    // The failure and freshness stamps stay OUTSIDE this scope: they take their
+    // own locks, and this module's rule is that `LAST_CURRENT_USER_SUCCESS` is
+    // never nested inside `CURRENT_USER_CACHE`. They therefore run *after* the
+    // commit rather than before it, which is also what lets a discarded refresh
+    // leave the newer identity's `CURRENT_USER_FAILURE` record alone —
+    // `clear_current_user_failure` is unkeyed and would otherwise wipe it. The
+    // stamp is only ever read as an age in seconds, so moving it to the far
+    // side of the commit cannot change an observable answer.
+    let committed = {
+        let mut cache = CURRENT_USER_CACHE.lock();
+        let moved_on = cache
+            .as_ref()
+            .is_some_and(|entry| entry.api_base != api_base || entry.token != token);
+        if origin == RefreshOrigin::Background && moved_on {
+            false
+        } else {
+            match fetched.clone() {
+                Some(user) => {
+                    debug!("{LOG_PREFIX} refreshed current user from backend");
+                    *cache = Some(CachedCurrentUser {
+                        api_base: api_base.clone(),
+                        token: token.to_string(),
+                        fetched_at: Instant::now(),
+                        user,
+                    });
+                }
+                None => {
+                    debug!("{LOG_PREFIX} backend returned empty current user; clearing cache");
+                    *cache = None;
+                }
+            }
+            true
+        }
+    };
+
+    if !committed {
         debug!(
             "{LOG_PREFIX} discarding background current user refresh; the cache moved to \
              another identity while it was in flight"
@@ -414,28 +431,8 @@ async fn refresh_current_user_now(
     // for data that was never replaced. `clear_current_user_failure` still runs
     // either way: an empty answer is the backend being healthy, just not
     // useful, and it should not keep the backoff window open.
-    //
-    // Read before the cache lock rather than inside the `Some` arm below, so
-    // this never nests `LAST_CURRENT_USER_SUCCESS` inside `CURRENT_USER_CACHE`.
     if fetched.is_some() {
         note_current_user_success(&api_base, token);
-    }
-
-    let mut cache = CURRENT_USER_CACHE.lock();
-    match fetched.clone() {
-        Some(user) => {
-            debug!("{LOG_PREFIX} refreshed current user from backend");
-            *cache = Some(CachedCurrentUser {
-                api_base,
-                token: token.to_string(),
-                fetched_at: Instant::now(),
-                user,
-            });
-        }
-        None => {
-            debug!("{LOG_PREFIX} backend returned empty current user; clearing cache");
-            *cache = None;
-        }
     }
 
     Ok(fetched)

--- a/src/openhuman/desktop/app_state/ops_part_02.rs
+++ b/src/openhuman/desktop/app_state/ops_part_02.rs
@@ -184,20 +184,36 @@ async fn fetch_current_user_cached(
     let api_base = current_user_api_base(config);
 
     if allow_cache {
-        {
-            let cache = CURRENT_USER_CACHE.lock();
-            if let Some(entry) = cache.as_ref() {
-                if entry.api_base == api_base
-                    && entry.token == token
-                    && entry.fetched_at.elapsed() < CURRENT_USER_REFRESH_TTL
-                {
-                    debug!(
-                        "{LOG_PREFIX} using cached current user age_ms={}",
-                        entry.fetched_at.elapsed().as_millis()
-                    );
-                    return Ok(Some(entry.user.clone()));
-                }
+        if let Some((user, age)) = cached_current_user(&api_base, token) {
+            if age < CURRENT_USER_REFRESH_TTL {
+                debug!(
+                    "{LOG_PREFIX} using cached current user age_ms={}",
+                    age.as_millis()
+                );
+                return Ok(Some(user));
             }
+            // Stale-while-revalidate. The entry has expired, but we already
+            // know who this is — serve that and re-confirm it behind the poll
+            // instead of making the shell wait on a WAN round trip to be told
+            // the same thing. Blocking here is what put a floor of one round
+            // trip under every `app_state_snapshot` (#6180: 732 calls in 3.5h,
+            // not one of them under 500ms).
+            //
+            // This costs no freshness: the refresh is still triggered on the
+            // same cadence and by the same poll that would have blocked for it,
+            // so the data is exactly as new as before — it just lands one poll
+            // later instead of holding this one open. The snapshot keeps
+            // reporting the true age it is serving in `current_user_stale_seconds`.
+            //
+            // Only the expired-entry path revalidates in the background. With
+            // no entry at all the shell has no identity to render, so that
+            // first fetch after login still blocks, below.
+            spawn_current_user_refresh(config, token);
+            debug!(
+                "{LOG_PREFIX} serving expired current user age_ms={} while refreshing behind the poll",
+                age.as_millis()
+            );
+            return Ok(Some(user));
         }
 
         // Nothing fresh to serve, so this poll would normally go to the network
@@ -228,6 +244,101 @@ async fn fetch_current_user_cached(
         }
     }
 
+    refresh_current_user_now(config, token).await
+}
+
+/// The cached user for this identity and how old it is, if the cache holds one.
+///
+/// Reads under one lock and hands back an owned copy, so no caller holds
+/// `CURRENT_USER_CACHE` across a decision — the freshness test and the
+/// stale-while-revalidate branch below both need the same read.
+fn cached_current_user(api_base: &str, token: &str) -> Option<(Value, Duration)> {
+    let cache = CURRENT_USER_CACHE.lock();
+    let entry = cache.as_ref()?;
+    (entry.api_base == api_base && entry.token == token)
+        .then(|| (entry.user.clone(), entry.fetched_at.elapsed()))
+}
+
+/// Single-flight gate for the background refresh.
+///
+/// An async mutex held by the spawned task for its lifetime, taken with
+/// `try_lock` so a poll that finds a refresh already running simply declines to
+/// start a second one rather than queueing behind it. Same gate, same reason as
+/// [`RUNTIME_SNAPSHOT_REBUILD`]: without it every overlapping poll launches its
+/// own fetch. Using a guard rather than a flag means a panicking refresh
+/// releases the gate instead of wedging it shut for the life of the process.
+static CURRENT_USER_REFRESH_INFLIGHT: Lazy<tokio::sync::Mutex<()>> =
+    Lazy::new(|| tokio::sync::Mutex::new(()));
+
+/// Refresh the cached current user without making the caller wait for it.
+///
+/// Declines to start when the backoff window from an earlier failure is still
+/// open — a background refresh would re-pay exactly the timeout that window
+/// exists to avoid (#5624) — and when a previous poll's refresh is still in
+/// flight.
+fn spawn_current_user_refresh(config: &Config, token: &str) {
+    if let Some((error, consecutive, remaining)) =
+        suppressed_current_user_failure(&current_user_api_base(config), token)
+    {
+        // Logged here because the stale-while-revalidate return above means an
+        // outage no longer reaches the replay branch in
+        // `fetch_current_user_cached` — without this line a backend that has
+        // been down for minutes leaves no trace at all in the snapshot logs.
+        // `debug!`, not `warn!`: no request was made and nothing waited on it
+        // (#5930).
+        debug!(
+            "{LOG_PREFIX} not refreshing current user behind the poll; backend failed \
+             {consecutive}x, retrying in {}ms: {}",
+            remaining.as_millis(),
+            error.message()
+        );
+        return;
+    }
+    let gate: &'static tokio::sync::Mutex<()> = &CURRENT_USER_REFRESH_INFLIGHT;
+    let Ok(guard) = gate.try_lock() else {
+        return;
+    };
+
+    let config = config.clone();
+    let token = token.to_string();
+    tokio::spawn(async move {
+        let _guard = guard;
+        // Bounded by the same budget the blocking path spends, so a hung
+        // backend cannot leave the gate closed for longer than one window.
+        match tokio::time::timeout(
+            auth_fetch_timeout(),
+            refresh_current_user_now(&config, &token),
+        )
+        .await
+        {
+            Ok(Ok(_)) => {}
+            // The stale entry stands and the failure is recorded, so the next
+            // poll takes the backoff path. Not a failure of any user-visible
+            // operation — nothing was waiting on this.
+            Ok(Err(error)) => debug!(
+                "{LOG_PREFIX} background current user refresh failed; serving stale entry: {}",
+                error.message()
+            ),
+            Err(_) => {
+                debug!(
+                    "{LOG_PREFIX} background current user refresh timed out after {}s; serving stale entry",
+                    auth_fetch_timeout().as_secs()
+                );
+                note_current_user_timeout(&config, &token);
+            }
+        }
+    });
+}
+
+/// Go to the backend, then reconcile the caches and freshness stamps with what
+/// came back. The blocking half of [`fetch_current_user_cached`], split out so
+/// the background refresh runs exactly the same path rather than a parallel
+/// copy of it that could drift.
+async fn refresh_current_user_now(
+    config: &Config,
+    token: &str,
+) -> Result<Option<Value>, CurrentUserFetchError> {
+    let api_base = current_user_api_base(config);
     let fetched = match fetch_current_user(config, token).await {
         Ok(user) => sanitize_snapshot_user(user),
         Err(error) => {

--- a/src/openhuman/desktop/app_state/ops_part_02.rs
+++ b/src/openhuman/desktop/app_state/ops_part_02.rs
@@ -199,11 +199,17 @@ async fn fetch_current_user_cached(
             // trip under every `app_state_snapshot` (#6180: 732 calls in 3.5h,
             // not one of them under 500ms).
             //
-            // This costs no freshness: the refresh is still triggered on the
-            // same cadence and by the same poll that would have blocked for it,
-            // so the data is exactly as new as before — it just lands one poll
-            // later instead of holding this one open. The snapshot keeps
-            // reporting the true age it is serving in `current_user_stale_seconds`.
+            // This does move the refresh cadence, and it is worth being exact
+            // about how: the background refresh stamps `fetched_at` when it
+            // *completes*, so the next poll finds the entry still inside the
+            // TTL and serves it without revalidating. `GET /auth/me` is
+            // therefore refreshed about every other poll (~10s) rather than
+            // every poll (~5.5s). That is acceptable because this payload is
+            // display-only profile data (`firstName`, `lastName`, `username`,
+            // `_id`) and not the session-validity check, and it halves this
+            // endpoint's share of the background RPC load #6180 also reports.
+            // The snapshot keeps reporting the true age it is serving in
+            // `current_user_stale_seconds`.
             //
             // Only the expired-entry path revalidates in the background. With
             // no entry at all the shell has no identity to render, so that
@@ -244,7 +250,7 @@ async fn fetch_current_user_cached(
         }
     }
 
-    refresh_current_user_now(config, token).await
+    refresh_current_user_now(config, token, RefreshOrigin::Blocking).await
 }
 
 /// The cached user for this identity and how old it is, if the cache holds one.
@@ -307,7 +313,7 @@ fn spawn_current_user_refresh(config: &Config, token: &str) {
         // backend cannot leave the gate closed for longer than one window.
         match tokio::time::timeout(
             auth_fetch_timeout(),
-            refresh_current_user_now(&config, &token),
+            refresh_current_user_now(&config, &token, RefreshOrigin::Background),
         )
         .await
         {
@@ -330,6 +336,31 @@ fn spawn_current_user_refresh(config: &Config, token: &str) {
     });
 }
 
+/// Where a refresh was started from, which decides whether its answer may still
+/// be committed by the time it lands.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum RefreshOrigin {
+    /// The caller is still awaiting this refresh and still holds the identity
+    /// it asked for, so the answer is authoritative by construction.
+    Blocking,
+    /// Detached from the poll that started it, and therefore able to outlive
+    /// the identity it was started for — a logout and re-login, or an
+    /// environment switch, can land in between.
+    Background,
+}
+
+/// Whether the cache has moved to an identity other than this refresh's.
+///
+/// An *empty* cache is deliberately not "moved on": a background refresh that
+/// started before anything was cached is still the right answer for the
+/// identity that asked for it.
+fn cached_identity_moved_on(api_base: &str, token: &str) -> bool {
+    CURRENT_USER_CACHE
+        .lock()
+        .as_ref()
+        .is_some_and(|entry| entry.api_base != api_base || entry.token != token)
+}
+
 /// Go to the backend, then reconcile the caches and freshness stamps with what
 /// came back. The blocking half of [`fetch_current_user_cached`], split out so
 /// the background refresh runs exactly the same path rather than a parallel
@@ -337,6 +368,7 @@ fn spawn_current_user_refresh(config: &Config, token: &str) {
 async fn refresh_current_user_now(
     config: &Config,
     token: &str,
+    origin: RefreshOrigin,
 ) -> Result<Option<Value>, CurrentUserFetchError> {
     let api_base = current_user_api_base(config);
     let fetched = match fetch_current_user(config, token).await {
@@ -346,6 +378,35 @@ async fn refresh_current_user_now(
             return Err(error);
         }
     };
+
+    // A detached refresh can land after the app has moved to another identity,
+    // and every write below is process-global. Committing then would regress
+    // the cache to the previous user — and `peek_cached_current_user_identity`
+    // reads that slot WITHOUT a key check (#926), so the regressed entry would
+    // be embedded in the agent's prompts as the current user. The keyed reads
+    // in `fetch_current_user_cached` would merely miss; that one would be
+    // wrong. Checked before the writes rather than at the cache lock, so a
+    // discarded refresh cannot clear the *newer* identity's failure record on
+    // its way out. The blocking path cannot race this way, so it never
+    // discards.
+    // A detached refresh can land after the app has moved to another identity,
+    // and every write below is process-global. Committing then would regress
+    // the cache to the previous user — and `peek_cached_current_user_identity`
+    // reads that slot WITHOUT a key check (#926), so the regressed entry would
+    // be embedded in the agent's prompts as the current user. The keyed reads
+    // in `fetch_current_user_cached` would merely miss; that one would be
+    // wrong. Checked before the writes rather than at the cache lock, so a
+    // discarded refresh cannot clear the *newer* identity's failure record on
+    // its way out. The blocking path cannot race this way, so it never
+    // discards.
+    if origin == RefreshOrigin::Background && cached_identity_moved_on(&api_base, token) {
+        debug!(
+            "{LOG_PREFIX} discarding background current user refresh; the cache moved to \
+             another identity while it was in flight"
+        );
+        return Ok(fetched);
+    }
+
     clear_current_user_failure();
     // Only a *refreshed user* makes the displayed data fresh. The backend can
     // answer 200 with no user at all, and the snapshot caller then falls back

--- a/src/openhuman/desktop/app_state/ops_snapshot_latency_tests.rs
+++ b/src/openhuman/desktop/app_state/ops_snapshot_latency_tests.rs
@@ -172,3 +172,91 @@ async fn current_user_fetches_reuse_one_connection() {
          one costs a TCP and a TLS handshake before the request goes out (#6180)"
     );
 }
+
+/// A detached refresh must not commit an identity the app has already left.
+///
+/// The background refresh outlives the poll that started it, so a logout and
+/// re-login (or an environment switch) can land while it is still in flight.
+/// Every write it then makes is process-global. The keyed reads in
+/// `fetch_current_user_cached` would only miss on a regressed entry — but
+/// `peek_cached_current_user_identity` reads that same slot with **no** key
+/// check, to embed the user in the agent's prompts (#926), so a regressed entry
+/// is served there as the current user.
+#[tokio::test]
+async fn a_background_refresh_does_not_overwrite_a_newer_identity() {
+    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.lock().await;
+    let _failure_lock = super::current_user_backoff_tests::CURRENT_USER_FAILURE_TEST_LOCK
+        .lock()
+        .await;
+    struct CacheResetGuard;
+    impl Drop for CacheResetGuard {
+        fn drop(&mut self) {
+            *CURRENT_USER_CACHE.lock() = None;
+        }
+    }
+    let _reset = CacheResetGuard;
+
+    let app = axum::Router::new().route(
+        "/auth/me",
+        axum::routing::get(|| async {
+            axum::Json(json!({ "success": true, "data": { "firstName": "signed-out-user" } }))
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let stale_config = Config {
+        api_url: Some(format!("http://{addr}")),
+        ..Config::default()
+    };
+
+    // The identity the app moved to while the refresh below was in flight.
+    *CURRENT_USER_CACHE.lock() = Some(CachedCurrentUser {
+        api_base: current_user_api_base(&stale_config),
+        token: "token-for-the-user-who-just-signed-in".into(),
+        fetched_at: Instant::now(),
+        user: json!({ "firstName": "signed-in-user" }),
+    });
+
+    // The refresh the *previous* identity started, landing late.
+    refresh_current_user_now(
+        &stale_config,
+        "token-for-the-user-who-signed-out",
+        RefreshOrigin::Background,
+    )
+    .await
+    .expect("the stub answers /auth/me");
+
+    let cached = CURRENT_USER_CACHE
+        .lock()
+        .as_ref()
+        .and_then(|entry| entry.user.get("firstName").cloned());
+    assert_eq!(
+        cached,
+        Some(json!("signed-in-user")),
+        "a background refresh for the previous identity overwrote the current one; \
+         `peek_cached_current_user_identity` reads this slot unkeyed (#926)"
+    );
+
+    // The blocking path is authoritative by construction — its caller is still
+    // awaiting it — so it must still commit.
+    refresh_current_user_now(
+        &stale_config,
+        "token-for-the-user-who-signed-out",
+        RefreshOrigin::Blocking,
+    )
+    .await
+    .expect("the stub answers /auth/me");
+    let cached = CURRENT_USER_CACHE
+        .lock()
+        .as_ref()
+        .and_then(|entry| entry.user.get("firstName").cloned());
+    assert_eq!(
+        cached,
+        Some(json!("signed-out-user")),
+        "the blocking path must still commit; only detached refreshes are discarded"
+    );
+}

--- a/src/openhuman/desktop/app_state/ops_snapshot_latency_tests.rs
+++ b/src/openhuman/desktop/app_state/ops_snapshot_latency_tests.rs
@@ -260,3 +260,65 @@ async fn a_background_refresh_does_not_overwrite_a_newer_identity() {
         "the blocking path must still commit; only detached refreshes are discarded"
     );
 }
+
+/// The TTL clock must start when the request goes out, not when it lands.
+///
+/// `CURRENT_USER_REFRESH_TTL` is measured against `fetched_at`, and the poll
+/// loop schedules itself from the previous *response*. Stamping `fetched_at` at
+/// completion folds the round trip into the next window: a refresh taking `L`
+/// leaves the following poll only `TTL - L` from expiry, that poll reads the
+/// entry as fresh, and the refresh after it never happens — the cadence halves
+/// as a silent side effect of no longer blocking (#6190 review). Stamping at
+/// initiation keeps the wall-clock cadence exactly what it was before.
+#[tokio::test]
+async fn the_refresh_ttl_clock_starts_when_the_request_goes_out() {
+    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.lock().await;
+    let _failure_lock = super::current_user_backoff_tests::CURRENT_USER_FAILURE_TEST_LOCK
+        .lock()
+        .await;
+    struct CacheResetGuard;
+    impl Drop for CacheResetGuard {
+        fn drop(&mut self) {
+            *CURRENT_USER_CACHE.lock() = None;
+        }
+    }
+    let _reset = CacheResetGuard;
+
+    // Stands in for the WAN round trip the issue measured at ~380-540ms.
+    const BACKEND_LATENCY: Duration = Duration::from_millis(600);
+
+    let app = axum::Router::new().route(
+        "/auth/me",
+        axum::routing::get(|| async move {
+            tokio::time::sleep(BACKEND_LATENCY).await;
+            axum::Json(json!({ "success": true, "data": { "firstName": "steven" } }))
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let config = Config {
+        api_url: Some(format!("http://{addr}")),
+        ..Config::default()
+    };
+    refresh_current_user_now(&config, "tok", RefreshOrigin::Blocking)
+        .await
+        .expect("the stub answers /auth/me");
+
+    let age = CURRENT_USER_CACHE
+        .lock()
+        .as_ref()
+        .expect("the refresh committed an entry")
+        .fetched_at
+        .elapsed();
+
+    assert!(
+        age >= BACKEND_LATENCY,
+        "the entry is {age:?} old immediately after a {BACKEND_LATENCY:?} fetch, so the clock \
+         was started on the response: the round trip has been folded into the next TTL window \
+         and the poll after next will skip its refresh (#6190)"
+    );
+}

--- a/src/openhuman/desktop/app_state/ops_snapshot_latency_tests.rs
+++ b/src/openhuman/desktop/app_state/ops_snapshot_latency_tests.rs
@@ -1,0 +1,174 @@
+//! What one `app_state_snapshot` poll costs, and what the core can stop paying.
+//!
+//! Split out of `ops_tests.rs` for the layout gate. Kept as one file because
+//! both subjects are one measurement: #6180 reported 732 snapshot calls in
+//! ~3.5h with no call under 500ms and spikes to 1910ms, and the two tests here
+//! pin the two halves of that number the core controls.
+
+use super::tests::APP_STATE_CACHE_TEST_LOCK;
+use super::*;
+use serde_json::json;
+// Measured against the production backend over a ~250ms RTT link, one
+// `GET /auth/me` costs ~380-540ms on a warm connection and ~780-1420ms on a
+// cold one — and a 404 for a route that does not exist on the same host costs
+// the same as `/auth/me`, so the floor is the round trip itself, not the
+// endpoint. Neither number is something the core can shrink. What it can do is
+// stop paying them: not block the poll on the round trip, and not open a new
+// connection each time it makes one. One test each.
+
+/// Serve the identity we already have; re-confirm it behind the poll.
+///
+/// `fetch_current_user_cached` used to block on `GET /auth/me` the moment its
+/// entry aged past the TTL, which — with the frontend scheduling the next poll
+/// from the previous *response* — was every poll. That put a floor of one WAN
+/// round trip under every `app_state_snapshot`. The stub here answers slowly on
+/// purpose: an expired entry must come back immediately anyway, and the refresh
+/// must still land.
+#[tokio::test]
+async fn an_expired_current_user_is_served_while_it_refreshes() {
+    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.lock().await;
+    // A successful refresh calls `clear_current_user_failure`, which wipes a
+    // global the backoff tests seed.
+    let _failure_lock = super::current_user_backoff_tests::CURRENT_USER_FAILURE_TEST_LOCK
+        .lock()
+        .await;
+    struct CacheResetGuard;
+    impl Drop for CacheResetGuard {
+        fn drop(&mut self) {
+            *CURRENT_USER_CACHE.lock() = None;
+        }
+    }
+    let _reset = CacheResetGuard;
+
+    const BACKEND_DELAY: Duration = Duration::from_millis(2000);
+
+    let app = axum::Router::new().route(
+        "/auth/me",
+        axum::routing::get(|| async move {
+            tokio::time::sleep(BACKEND_DELAY).await;
+            axum::Json(json!({ "success": true, "data": { "firstName": "from-backend" } }))
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    let config = Config {
+        api_url: Some(format!("http://{addr}")),
+        ..Config::default()
+    };
+    // The failure record is keyed on `(api_base, token)` and this base carries a
+    // fresh ephemeral port, so no seeded outage can match it and none is seeded
+    // here — nothing to clean up, and no cross-test write.
+    *CURRENT_USER_CACHE.lock() = Some(CachedCurrentUser {
+        api_base: current_user_api_base(&config),
+        token: "tok".into(),
+        fetched_at: Instant::now() - (CURRENT_USER_REFRESH_TTL + Duration::from_secs(1)),
+        user: json!({ "firstName": "from-cache" }),
+    });
+
+    let started = Instant::now();
+    let served = fetch_current_user_cached(&config, "tok", true)
+        .await
+        .expect("an expired entry is still an answer");
+    let waited = started.elapsed();
+
+    assert_eq!(
+        served.as_ref().and_then(|u| u.get("firstName")),
+        Some(&json!("from-cache")),
+        "the expired entry must be what the poll is handed"
+    );
+    assert!(
+        waited < Duration::from_millis(400),
+        "the poll waited {waited:?} on the backend; serving the entry it already \
+         had is the whole point — this is #6180's per-poll round trip"
+    );
+
+    // ...and the refresh must actually happen, or "fast" is just "never
+    // refreshes". Wait past the stub's delay for the cache to flip.
+    let refreshed = tokio::time::timeout(BACKEND_DELAY * 3, async {
+        loop {
+            let landed = CURRENT_USER_CACHE
+                .lock()
+                .as_ref()
+                .and_then(|entry| entry.user.get("firstName").cloned());
+            if landed == Some(json!("from-backend")) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await;
+    assert!(
+        refreshed.is_ok(),
+        "the background refresh never replaced the stale entry; \
+         serving stale forever is not stale-while-revalidate"
+    );
+}
+
+/// Successive `/auth/me` fetches must share one TCP connection.
+///
+/// `fetch_current_user` built a fresh `reqwest::Client` per call, and a
+/// `Client` owns its connection pool — so every fetch opened a new connection
+/// and paid a TCP handshake plus a TLS handshake before the request could go
+/// out. Over a WAN link that is two extra round trips on top of the one the
+/// request costs, and it is the gap between #6180's ~500ms floor and its
+/// ~1900ms spikes.
+///
+/// Asserted on the wire, because `reqwest::Client` exposes no pool statistics:
+/// the server sees a distinct ephemeral source port for every new connection,
+/// so a reused connection is exactly one distinct peer address across N
+/// requests.
+#[tokio::test]
+async fn current_user_fetches_reuse_one_connection() {
+    use axum::extract::ConnectInfo;
+    use std::collections::BTreeSet;
+    use std::net::SocketAddr;
+    use std::sync::{Arc, Mutex as StdMutex};
+
+    type Peers = Arc<StdMutex<BTreeSet<SocketAddr>>>;
+    let peers: Peers = Arc::new(StdMutex::new(BTreeSet::new()));
+    let peers_for_route = peers.clone();
+
+    let app = axum::Router::new().route(
+        "/auth/me",
+        axum::routing::get(move |ConnectInfo(peer): ConnectInfo<SocketAddr>| {
+            let peers = peers_for_route.clone();
+            async move {
+                peers.lock().unwrap().insert(peer);
+                axum::Json(json!({ "success": true, "data": { "firstName": "steven" } }))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<SocketAddr>(),
+        )
+        .await;
+    });
+
+    let config = Config {
+        api_url: Some(format!("http://{addr}")),
+        ..Config::default()
+    };
+
+    // Sequential, like the poll loop: each call must find the previous call's
+    // connection idle in the pool and reuse it.
+    for _ in 0..3 {
+        fetch_current_user(&config, "tok")
+            .await
+            .expect("the stub answers /auth/me");
+    }
+
+    let distinct = peers.lock().unwrap().len();
+    assert_eq!(
+        distinct, 1,
+        "three sequential /auth/me fetches opened {distinct} connections; each new \
+         one costs a TCP and a TLS handshake before the request goes out (#6180)"
+    );
+}

--- a/src/openhuman/desktop/app_state/ops_tests.rs
+++ b/src/openhuman/desktop/app_state/ops_tests.rs
@@ -4,7 +4,15 @@ use parking_lot::Mutex as TestMutex;
 use serde_json::json;
 use tempfile::tempdir;
 
-static APP_STATE_CACHE_TEST_LOCK: TestLazy<TestMutex<()>> = TestLazy::new(|| TestMutex::new(()));
+/// Serialises every test that reads or writes the process-global snapshot
+/// caches. A `tokio` mutex rather than a `parking_lot` one so async tests can
+/// hold it across an `.await` — sibling `ops_current_user_backoff_tests.rs`
+/// guards its own global the same way.
+///
+/// `pub(super)` for `ops_snapshot_latency_tests.rs`, which seeds the positive
+/// cache and so has to serialise against the readers here.
+pub(super) static APP_STATE_CACHE_TEST_LOCK: TestLazy<tokio::sync::Mutex<()>> =
+    TestLazy::new(|| tokio::sync::Mutex::new(()));
 
 #[test]
 fn sanitize_snapshot_user_drops_empty_payloads() {
@@ -142,7 +150,7 @@ fn save_and_reload_stored_app_state_round_trips() {
 
 #[test]
 fn peek_cached_current_user_identity_plucks_known_fields() {
-    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.lock();
+    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.blocking_lock();
     struct CacheResetGuard;
     impl Drop for CacheResetGuard {
         fn drop(&mut self) {
@@ -170,7 +178,7 @@ fn peek_cached_current_user_identity_plucks_known_fields() {
 
 #[test]
 fn peek_cached_current_user_identity_returns_none_when_only_empty_fields_exist() {
-    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.lock();
+    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.blocking_lock();
     struct CacheResetGuard;
     impl Drop for CacheResetGuard {
         fn drop(&mut self) {
@@ -203,7 +211,7 @@ impl Drop for SnapshotCacheResetGuard {
 
 #[test]
 fn runtime_snapshot_cache_hit_within_ttl() {
-    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.lock();
+    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.blocking_lock();
     let _reset = SnapshotCacheResetGuard;
 
     let dummy = build_dummy_runtime_snapshot();
@@ -224,7 +232,7 @@ fn runtime_snapshot_cache_hit_within_ttl() {
 
 #[test]
 fn runtime_snapshot_cache_miss_after_ttl() {
-    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.lock();
+    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.blocking_lock();
     let _reset = SnapshotCacheResetGuard;
 
     *RUNTIME_SNAPSHOT_CACHE.lock() = Some(CachedRuntimeSnapshot {
@@ -243,7 +251,7 @@ fn runtime_snapshot_cache_miss_after_ttl() {
 
 #[test]
 fn fresh_cached_runtime_snapshot_returns_entry_within_ttl() {
-    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.lock();
+    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.blocking_lock();
     let _reset = SnapshotCacheResetGuard;
 
     let dummy = build_dummy_runtime_snapshot();
@@ -260,7 +268,7 @@ fn fresh_cached_runtime_snapshot_returns_entry_within_ttl() {
 
 #[test]
 fn fresh_cached_runtime_snapshot_misses_when_stale_or_empty() {
-    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.lock();
+    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.blocking_lock();
     let _reset = SnapshotCacheResetGuard;
 
     let cfg = Config::default();
@@ -280,7 +288,7 @@ fn fresh_cached_runtime_snapshot_misses_when_stale_or_empty() {
 
 #[test]
 fn fresh_cached_runtime_snapshot_misses_on_config_key_mismatch() {
-    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.lock();
+    let _cache_lock = APP_STATE_CACHE_TEST_LOCK.blocking_lock();
     let _reset = SnapshotCacheResetGuard;
 
     // A fresh entry cached for one workspace must never be served to another


### PR DESCRIPTION
## Summary

- `app_state_snapshot` no longer blocks on a backend round trip once its cached user expires — it serves the identity it already has and revalidates behind the poll, on the same cadence as before.
- `GET /auth/me` now reuses one pooled connection instead of building a fresh `reqwest::Client` (and so a fresh TCP + TLS handshake) on every call.
- Measured finding, recorded in the code: the ~500ms floor in #6180 is one WAN round trip to the backend and is **not** reducible from the core. What this PR removes is paying it on every poll, and paying two extra handshake round trips on top when we do.

## Problem

#6180 reports 732 `app_state_snapshot` calls in ~3.5h, **none under 500ms**, spiking to 1910ms.

Measuring the backend directly from a ~250ms RTT link:

| | TCP connect | TLS | total |
|---|---|---|---|
| cold connection (what the code did) | ~180–280ms | ~360–550ms | **780–1424ms** |
| reused connection | 0 | 0 | **380–540ms** |

A `404` for a route that does not exist on the same host costs the same ~380–410ms as `/auth/me`, so the floor is the round trip, not the endpoint — the issue's "p99 under 100ms" expectation is not reachable from this side. The reported 501ms minimum bounds everything the core does per snapshot (config load, auth-profile read, local state) at roughly 120ms combined.

Two things the core does control, both real:

1. **The cache could never hit.** `CURRENT_USER_REFRESH_TTL` was 5s (`ops_part_01.rs:36`) and `STABLE_POLL_MS` is 5s (`CoreStateProvider.tsx:61`) — but the frontend schedules the next poll 5000ms after the previous *response* resolves (`CoreStateProvider.tsx:622-628`), so the gap between two cache reads is always `poll period + snapshot duration`, strictly greater than the TTL. Every one of the 732 polls went to the network by construction. This is the same fault already documented two constants below on `RUNTIME_SNAPSHOT_TTL` ("stale before it was even written").
2. **No connection reuse.** `fetch_current_user` built a `reqwest::Client` per call (`ops_part_01.rs:515`), and a `Client` owns its connection pool — so every fetch paid TCP + TLS again. That is the gap between the 500ms floor and the 1900ms spikes.

## Solution

**Stale-while-revalidate** (`ops_part_02.rs`). An expired entry is served immediately and the refresh is spawned behind the poll, gated by an async mutex held for the task's lifetime (same single-flight pattern, and same reason, as the existing `RUNTIME_SNAPSHOT_REBUILD`).

Chosen over simply raising the TTL, deliberately:

- **It removes the wait without moving the knob.** Raising `CURRENT_USER_REFRESH_TTL` would cut how often the fetch happens but leave every remaining fetch blocking a poll for a full round trip, and it would trade real freshness. Not waiting is what the reported symptom actually needs, and it costs no freshness at all.
- **It touches neither constant.** `CURRENT_USER_REFRESH_TTL` is capped under 10s by #5624's `backoff > TTL` invariant (`ops_current_user_backoff_tests.rs:101`, floor 10s), so raising it usefully would have meant moving `CURRENT_USER_BACKOFF_BASE_FLOOR` too and squeezing the 10→60s backoff ramp. This PR leaves that guard alone.

**Effect on refresh cadence: none — after two corrections.** An earlier revision of this description claimed the cadence was unchanged; review showed it was not, because a background refresh stamped `fetched_at` on *completion*, folding the round trip into the next TTL window and silently halving the cadence. Rather than defend that as an acceptable trade, the fix now stamps `fetched_at` when the request goes **out**. The poll after a refresh expires on exactly the schedule it always did, so `GET /auth/me` is refreshed as often as before and the only thing that changed is who waits for it.

It also errs the safe way: the data arrives at `started_at + L`, so calling it `started_at` slightly *overstates* its age and expires the entry sooner, never later. `note_current_user_success` — the stamp behind `current_user_stale_seconds` — still records completion, because that is when the data actually arrived. The two stamps answer different questions and are deliberately taken at different moments. `the_refresh_ttl_clock_starts_when_the_request_goes_out` pins this: with a 600ms stub the entry must already read as ≥600ms old the instant it is committed.

Safety of serving an expired entry:

- It is **not** the session-validity check. Outside a `pending_backend_validation` pass a rejected token already leaves the stored user in place rather than signing anyone out, so no signed-out user can be shown as signed-in by this path.
- **A detached refresh cannot commit an identity the app has already left.** The background refresh can outlive the identity that started it, and every write it makes is process-global; `RefreshOrigin::Background` discards its answer when the cache has moved on. The keyed reads here would only miss on a regressed entry, but `peek_cached_current_user_identity` reads that same slot with no key check to embed the user in agent prompts (#926), where it would be served as current.
- The paths that need a live answer bypass it by construction: revalidation passes `allow_cache = false`, and login / logout / deep-link handoff all change the token, which re-keys the cache into a miss.
- With no entry at all — the first snapshot after login — the fetch still blocks, because the shell has no identity to render.
- The backoff window is still honoured: a background refresh is declined while an earlier failure's window is open, so an outage cannot turn into a spawn-per-poll treadmill (#5624).
- `current_user_stale_seconds` still reports the true age being served.

**Pooled client** (`ops_part_01.rs`). One process-wide `Lazy<Client>`. The product-identity header moved from `default_headers` onto the request, because the client now outlives `set_product_identity` and baking it in would pin whichever identity was installed when the first snapshot ran — `MedullaClient` reads it per request for the same reason. The pre-existing `current_user_fetch_carries_the_product_identity` test asserts on the wire and still passes.

Also added a `debug!` on the suppressed-refresh path: the stale-while-revalidate return means an outage no longer reaches the replay branch in `fetch_current_user_cached`, and without it a backend down for minutes would leave no trace in the snapshot logs.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — both changed production paths are covered by the two new tests; each was confirmed failing against pristine production code before the fix, and the stale-while-revalidate change re-confirmed failing under an isolated revert. `pnpm test:coverage` / `pnpm test:rust` not run in full: this worker runs cargo under a shared 2-slot fleet cap and the full suites do not fit it — the focused lane `cargo test -p openhuman --lib app_state::ops` was run instead (40 passed).
- [x] N/A: Coverage matrix updated — behaviour-only change to an existing RPC; no feature rows added, removed or renamed.
- [x] N/A: All affected feature IDs from the matrix are listed under `## Related` — no matrix rows are affected by this change.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — both tests drive in-process `axum` stubs on `127.0.0.1:0`. The latency figures quoted above came from ad-hoc `curl` measurement during investigation, not from any test.
- [x] N/A: Manual smoke checklist updated — no release-cut surface changes; the snapshot's shape and fields are unchanged.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Impact

- **Desktop.** `app_state_snapshot` is the app's most-called RPC. After this, a steady-state poll returns without touching the network at all, and the refreshes it does make cost one round trip instead of three.
- **No API or schema change.** `AppStateSnapshot` fields, including `currentUserStale` / `currentUserStaleSeconds`, are unchanged.
- **Backend load is unchanged by design** — the refresh cadence is the same, it just no longer blocks the caller. Cutting the *number* of calls needs the TTL/backoff question above, or the frontend items below.
- One extra spawned task per refresh, bounded to one in flight at a time and to `auth_fetch_timeout` in duration.

## Related

- Closes: #6180
- Follow-up PR(s)/TODOs:
  - **Frontend, different reviewer:** the poll loop (`CoreStateProvider.tsx:620-631`) is a bare `setTimeout` with no `document.hidden` check, so it polls whether or not the window is focused. Not folded in here — it changes who reviews.
  - `CURRENT_USER_REFRESH_TTL` cannot exceed 10s without moving `CURRENT_USER_BACKOFF_BASE_FLOOR` and reshaping the #5624 backoff ramp. Worth a decision if call *volume* matters.
  - `team_get_usage` (154 calls, 500–1140ms in the same issue) is the same WAN round trip on a different endpoint, with the same non-fix.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/6180-app-state-snapshot-latency`
- Commit SHA: see head of this PR

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend files changed.
- [x] N/A: `pnpm typecheck` — no TypeScript changed.
- [x] Focused tests: `cargo test -p openhuman --lib app_state::ops` → 40 passed, 0 failed (baseline before the fix: 2 failed, each on its own assertion).
- [x] Rust fmt/check (if changed): `cargo fmt --check` → exit 0, no diff. `cargo clippy -p openhuman --lib --all-targets` → no finding on any line this PR adds or changes. It exits 101 on a **pre-existing** `clippy::approx_constant` error at `src/core/rpc_log.rs:105`, a file this PR does not touch and whose offending line is byte-identical on `upstream/main`.
- [x] N/A: Tauri fmt/check — nothing under `app/src-tauri/` changed.

### Validation Blocked

- `command:` full `pnpm test:coverage` / `pnpm test:rust`
- `error:` not attempted
- `impact:` fleet-wide 2-slot cap on local cargo runs; the focused `app_state::ops` lane covers every changed line and was run before and after the fix, plus an isolated revert of the stale-while-revalidate half. CI runs the full gate.

### Behavior Changes

- Intended behavior change: an expired `current_user` cache entry is served immediately and refreshed in the background instead of blocking the snapshot on `GET /auth/me`; that fetch now reuses a pooled connection.
- User-visible effect: `app_state_snapshot` returns without a network round trip in steady state. No change to what the snapshot reports, or to how often the user's profile is refreshed.

### Parity Contract

- Legacy behavior preserved: first snapshot after login still blocks; `pending_backend_validation` still forces a live fetch (`allow_cache = false`); a rejected deferred session is still cleared; the failure-backoff window is still honoured before any refresh, foreground or background; `current_user_stale` / `current_user_stale_seconds` semantics unchanged.
- Guard/fallback/dispatch parity checks: `the_derived_backoff_base_outlasts_every_permitted_fetch_timeout`, `fetch_current_user_cached_replays_a_recorded_failure_without_calling_the_backend` and `current_user_fetch_carries_the_product_identity` all still pass unmodified.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none — checked issue state, cross-referenced PRs and `upstream/main` commits for `#6180` before starting.
- Canonical PR: this one
- Resolution: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ipSkHi47nsBmnxX5dC4dA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved current-user checks by reusing secure connections between requests.
  - Reduced perceived wait times by displaying cached account information immediately while updates continue in the background.

- **Reliability**
  - Prevented delayed account updates from overwriting newer sign-in or sign-out state.
  - Improved cache freshness tracking to maintain consistent refresh timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->