### PR TITLE
fix(skills): one discovery pass per workflow lookup, drop anonymous deprecation logs

### DIFF
--- a/src/openhuman/skills/ops_discover.rs
+++ b/src/openhuman/skills/ops_discover.rs
@@ -126,7 +126,18 @@ pub fn discover_workflows_with_profile(
     profile_skills_root: Option<&Path>,
     trusted: bool,
 ) -> Vec<Workflow> {
+    #[cfg(test)]
+    DISCOVERY_CALLS.with(|c| c.set(c.get() + 1));
     discover_workflows_inner(home_dir, workspace_dir, profile_skills_root, trusted)
+}
+
+#[cfg(test)]
+thread_local! {
+    /// Test-only counter of full on-disk discovery passes made on this thread.
+    /// Discovery re-reads and re-parses every skill bundle under every root, so
+    /// a caller that runs it twice for one lookup pays the whole tree twice
+    /// (#6166). Thread-local so parallel tests can't perturb each other's count.
+    pub(crate) static DISCOVERY_CALLS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 /// Whether the workspace has opted into loading project-scope skills.

--- a/src/openhuman/skills/ops_types.rs
+++ b/src/openhuman/skills/ops_types.rs
@@ -131,7 +131,6 @@ pub(crate) fn extract_version(fm: &WorkflowFrontmatter, warnings: &mut Vec<Strin
         return v;
     }
     if let Some(v) = fm.extra.get("version").and_then(|v| v.as_str()) {
-        log::warn!("[skills] top-level 'version' is deprecated; move under 'metadata.version'");
         warnings
             .push("top-level 'version' is deprecated; move under 'metadata.version'".to_string());
         return v.to_string();
@@ -147,7 +146,6 @@ pub(crate) fn extract_author(
         return Some(v);
     }
     if let Some(v) = fm.extra.get("author").and_then(|v| v.as_str()) {
-        log::warn!("[skills] top-level 'author' is deprecated; move under 'metadata.author'");
         warnings.push("top-level 'author' is deprecated; move under 'metadata.author'".to_string());
         return Some(v.to_string());
     }
@@ -168,7 +166,6 @@ pub(crate) fn extract_tags(fm: &WorkflowFrontmatter, warnings: &mut Vec<String>)
         tags.extend(metadata_string_seq(hermes_tags));
     }
     if let Some(v) = fm.extra.get("tags") {
-        log::warn!("[skills] top-level 'tags' is deprecated; move under 'metadata.tags'");
         warnings.push("top-level 'tags' is deprecated; move under 'metadata.tags'".to_string());
         tags.extend(metadata_string_seq(v));
     }

--- a/src/openhuman/skills/registry.rs
+++ b/src/openhuman/skills/registry.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 use crate::openhuman::agent::harness::definition::{AgentDefinition, PromptSource};
-use crate::openhuman::skills::WorkflowScope;
+use crate::openhuman::skills::{Workflow, WorkflowScope};
 
 /// One declared input — a parameter the skill needs, with a human description.
 /// `required` inputs must be supplied at run time; `kind` is an optional type
@@ -172,6 +172,20 @@ pub fn load_workflows_with_profile(
     workspace_dir: &Path,
     profile_skills_root: Option<&Path>,
 ) -> Vec<WorkflowDefinition> {
+    load_workflows_and_discovered(workspace_dir, profile_skills_root).0
+}
+
+/// [`load_workflows_with_profile`] plus the discovered bundles the definitions
+/// were built from.
+///
+/// Discovery re-reads and re-parses every bundle under every root, so a caller
+/// that needs both the runnable definitions and the discovered metadata (scope
+/// and frontmatter `name`, which `WorkflowDefinition` does not carry) takes
+/// them from this one pass instead of running discovery a second time (#6166).
+fn load_workflows_and_discovered(
+    workspace_dir: &Path,
+    profile_skills_root: Option<&Path>,
+) -> (Vec<WorkflowDefinition>, Vec<Workflow>) {
     // Prune any legacy bundled skills an older build left behind so discover's
     // legacy scan no longer surfaces them (idempotent).
     prune_legacy_default_workflows(workspace_dir);
@@ -192,12 +206,13 @@ pub fn load_workflows_with_profile(
     // discovery the create/list path uses, then load each one's definition.
     let home = dirs::home_dir();
     let trusted = super::ops_discover::is_workspace_trusted(workspace_dir);
-    for wf in super::ops_discover::discover_workflows_with_profile(
+    let discovered = super::ops_discover::discover_workflows_with_profile(
         home.as_deref(),
         Some(workspace_dir),
         profile_skills_root,
         trusted,
-    ) {
+    );
+    for wf in &discovered {
         let Some(skill_md) = wf.location.as_ref() else {
             continue;
         };
@@ -222,7 +237,7 @@ pub fn load_workflows_with_profile(
             workflows.push(def);
         }
     }
-    workflows
+    (workflows, discovered)
 }
 
 /// Build a runnable [`WorkflowDefinition`] from a single workflow directory.
@@ -287,7 +302,7 @@ pub fn get_workflow_with_profile(
     id: &str,
     profile_skills_root: Option<&Path>,
 ) -> Option<WorkflowDefinition> {
-    let workflows = load_workflows_with_profile(workspace_dir, profile_skills_root);
+    let (workflows, discovered) = load_workflows_and_discovered(workspace_dir, profile_skills_root);
     // Built-ins are prepended and discovered workflows follow them. Search in
     // reverse so the scope-resolved discovered entry (profile wins over global)
     // also wins over a built-in with the same runnable id.
@@ -300,23 +315,19 @@ pub fn get_workflow_with_profile(
     // a private workflow admitted by the profile-local allow set can actually
     // be described and run. Keep the legacy profile-less lookup id-only: global
     // display names have never been runnable ids and may collide with builtins.
-    let home = dirs::home_dir();
-    let trusted = super::ops_discover::is_workspace_trusted(workspace_dir);
-    let slug = super::ops_discover::discover_workflows_with_profile(
-        home.as_deref(),
-        Some(workspace_dir),
-        profile_skills_root,
-        trusted,
-    )
-    .into_iter()
-    .find(|workflow| workflow.scope == WorkflowScope::Profile && workflow.name == id)
-    .map(|workflow| {
-        if workflow.dir_name.is_empty() {
-            workflow.name
-        } else {
-            workflow.dir_name
-        }
-    })?;
+    //
+    // Answered from the discovery pass already in hand — this used to re-run a
+    // full on-disk discovery and re-parse every bundle a second time (#6166).
+    let slug = discovered
+        .into_iter()
+        .find(|workflow| workflow.scope == WorkflowScope::Profile && workflow.name == id)
+        .map(|workflow| {
+            if workflow.dir_name.is_empty() {
+                workflow.name
+            } else {
+                workflow.dir_name
+            }
+        })?;
 
     workflows
         .into_iter()

--- a/src/openhuman/skills/registry_tests.rs
+++ b/src/openhuman/skills/registry_tests.rs
@@ -318,3 +318,47 @@ fn skill_github_config_serializes_lowercase() {
         "lowercase serialization: got {s}"
     );
 }
+
+/// One workflow lookup must run at most one full on-disk discovery pass.
+///
+/// `get_workflow_with_profile` used to discover twice when the id was not an
+/// exact runnable slug: once inside `load_workflows_with_profile`, then again
+/// to resolve a profile display name back to its slug. Discovery re-reads and
+/// re-parses every bundle under every root, so the second pass doubled the cost
+/// — and doubled every per-parse deprecation warning with it (#6166, #6155).
+#[test]
+fn workflow_lookup_discovers_once() {
+    use super::super::ops_discover::DISCOVERY_CALLS;
+
+    let ws = tempfile::TempDir::new().unwrap();
+    let profile_root = tempfile::TempDir::new().unwrap();
+    seed_runnable_with_name(
+        profile_root.path(),
+        "zzcount6166",
+        "Counted Assistant",
+        "COUNT_BODY",
+    );
+
+    // Resolution by display name — the path that took the second pass.
+    DISCOVERY_CALLS.with(|c| c.set(0));
+    let resolved =
+        get_workflow_with_profile(ws.path(), "Counted Assistant", Some(profile_root.path()))
+            .expect("display name must still resolve");
+    assert_eq!(resolved.definition.id, "zzcount6166");
+    assert_eq!(
+        DISCOVERY_CALLS.with(|c| c.get()),
+        1,
+        "display-name lookup must discover the skills tree once, not twice"
+    );
+
+    // A miss walks the same fallback and must not discover twice either.
+    DISCOVERY_CALLS.with(|c| c.set(0));
+    assert!(
+        get_workflow_with_profile(ws.path(), "zznosuch6166", Some(profile_root.path())).is_none()
+    );
+    assert_eq!(
+        DISCOVERY_CALLS.with(|c| c.get()),
+        1,
+        "an unresolvable id must discover the skills tree once, not twice"
+    );
+}


### PR DESCRIPTION
## Summary

- `get_workflow_with_profile` ran a **full on-disk skill discovery twice** per lookup whenever the id was not an exact runnable slug. The second pass is now answered from the first.
- Dropped the three `log::warn!` deprecation lines for top-level `version` / `author` / `tags`. The same deprecations already reach the user on `Workflow.warnings`, attached to the skill they came from; the log lines named no skill and fired once per skill per parse.
- New test counts discovery passes across one lookup and pins it at 1.
- **#6155's stated cause is false** — see Problem. Its remediation step 1 ("migrate bundled skill YAML") has nothing to migrate.

## Problem

**#6166 — the rescan.** `get_workflow_with_profile` (`src/openhuman/skills/registry.rs`) called `load_workflows_with_profile`, which runs `discover_workflows_with_profile` over every skills root and parses every `SKILL.md` / `WORKFLOW.md` bundle it finds. If no `definition.id` matched, it then ran **discovery a second time** to resolve a profile's frontmatter display name back to its directory slug. Any `describe_workflow` / `run_workflow` resolving by display name — and any lookup that simply misses — re-read and re-parsed the entire skills tree twice.

The second pass existed because `load_workflows_with_profile` returns `Vec<WorkflowDefinition>`, which carries neither `scope` nor the frontmatter `name` that name-resolution needs; the discovered `Workflow` values holding both were dropped on the floor at the end of the loop.

**#6155 — the warnings.** `extract_version` / `extract_author` / `extract_tags` (`skills/ops_types.rs:134/150/171` on main) each emitted the same deprecation twice, to two channels:

| channel | names the skill? | reaches the user? | fires |
|---|---|---|---|
| `warnings.push(...)` → `Workflow.warnings` | yes (it rides on the skill) | yes — catalog wire type (`skills/schemas/wire_types.rs:153`) and install stderr (`ops_install_part_01.rs:316/393`) | once per parse |
| `log::warn!("[skills] top-level '…' is deprecated")` | **no** | log file only | once per parse |

The anonymous log channel is the one in the issue's log evidence, and #6166 was doubling it.

**The issue's stated cause does not hold.** #6155 blames "built-in skills (shipping with the app) that use the old schema". OpenHuman ships **no bundled skills**: `LEGACY_BUNDLED_WORKFLOW_IDS` / `prune_legacy_default_workflows` (`skills/registry.rs`) exist precisely to *delete* the three that older builds seeded, and the built-in agents prepended by `load_builtins` (`agent/registry/agents/loader.rs:325`) are baked `AgentDefinition` TOML that never touches `WorkflowFrontmatter`. A tree-wide search finds no shipped `SKILL.md` / `skill.json` in the app payload. Every one of these warnings therefore comes from a skill the user installed or wrote.

## Solution

**#6166.** Split out `load_workflows_and_discovered`, which returns the runnable definitions **together with** the discovered bundles they were built from. `load_workflows_with_profile` is now a one-line wrapper over its `.0`, so its signature and behaviour are unchanged for every other caller. `get_workflow_with_profile` takes both halves and resolves the display name from the vec already in hand.

The full discovered list is kept (not just entries that yielded a definition), so a bundle whose definition fails to load still resolves its name to a slug and then correctly finds nothing — byte-identical to the old two-pass behaviour. Prune-then-discover ordering is preserved.

**#6155.** The three `log::warn!` calls are deleted. The structured warning is untouched and still asserted by the existing `deprecated_top_level_fields_load_with_migration_warning` test, which already covers all three fields including `tags`.

**Not folded in:** caching the discovery pass across lookups. That has a staleness contract (a user editing a `SKILL.md` expects the next run to see it) and belongs in its own change.

## Impact

- Desktop/CLI: halves the disk reads and YAML parses for a workflow lookup by display name or a miss; no change for an exact-slug hit beyond the same single pass it already did.
- No behaviour change to resolution: the same skill resolves to the same definition, and the same lookups return `None`.
- Log volume: the three per-skill-per-parse deprecation lines are gone. The deprecation still reaches users, per-skill, via the catalog `warnings` field and install stderr.
- No API, schema, or migration impact.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `workflow_lookup_discovers_once` covers the resolving case and the unresolvable-id case; both walk the fallback that used to double-discover.
- [x] **Diff coverage ≥ 80%** — the changed `registry.rs` lines are executed by `workflow_lookup_discovers_once` plus the three pre-existing `get_workflow_with_profile` tests; the deleted `ops_types.rs` lines are covered by `deprecated_top_level_fields_load_with_migration_warning`. `diff-cover` itself was not run locally (no local coverage lane held); CI's gate is authoritative.
- [x] N/A: Coverage matrix updated — behaviour-preserving change; no feature row added, removed, or renamed.
- [x] N/A: All affected feature IDs from the matrix are listed under `## Related` — no matrix rows are affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — the tests use `tempfile` dirs only.
- [x] N/A: Manual smoke checklist updated — no release-cut surface changes; skill resolution is unchanged.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Related

- Closes: #6166
- Closes: #6155
- Follow-up PR(s)/TODOs: caching the discovery pass across lookups (deliberately out of scope — needs a staleness story). Separately, `cargo clippy --all-targets` is already red on `upstream/main` at `src/core/rpc_log.rs:105` (`clippy::approx_constant` on `json!(3.14)`); unrelated to this change and left untouched.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A — GitHub issues #6155 / #6166, no Linear issue.
- URL: N/A

### Commit & Branch

- Branch: `fix/6155-6166-skill-parse-noise`
- Commit SHA: `8e166f7810de8024a214f8f1f3fd64183bdebab4`

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend files changed.
- [x] N/A: `pnpm typecheck` — no TypeScript changed.
- [x] Focused tests: `cargo test -p openhuman --no-default-features --features "$(bash scripts/ci/product-features.sh)" --lib skills::` → **297 passed, 0 failed**. Revert-check: with `registry.rs` reverted and the test kept, `workflow_lookup_discovers_once` fails at `registry_tests.rs:348` with `left: 2, right: 1` — the failure names this PR's assertion.
- [x] Rust fmt/check (if changed): `cargo fmt -p openhuman` applied; `cargo clippy -p openhuman --all-targets` emits nothing on the four changed files (its one `error` is the pre-existing `rpc_log.rs:105` break noted above).
- [x] N/A: Tauri fmt/check — no Tauri code changed.

### Validation Blocked

- `command:` a test asserting the **absence** of the deleted `log::warn!` lines
- `error:` no log-capture harness exists in this crate; `log::set_boxed_logger` is process-global and single-shot, hostile in a parallel test binary
- `impact:` the deletion is verified by source inspection and by the structured channel's existing test still passing. The per-parse cost that multiplied those lines *is* under test via the discovery counter.

### Behavior Changes

- Intended behavior change: one on-disk discovery per workflow lookup instead of two; three anonymous log lines no longer emitted.
- User-visible effect: quieter logs on every skill reload (app start, cron tick, install). Skill resolution results are unchanged.

### Parity Contract

- Legacy behavior preserved: `load_workflows_with_profile` keeps its exact signature and return value for all other callers; `get_workflow_with_profile` resolves and fails to resolve exactly as before, verified by the three pre-existing resolution tests (`get_workflow_with_profile_resolution_matrix`, `get_profile_workflow_resolves_distinct_display_name`, `profile_workflow_exact_id_overrides_builtin`), all still green.
- Guard/fallback/dispatch parity checks: the name→slug fallback still filters on `scope == Profile`, still prefers `dir_name` over `name`, and is still fed the *complete* discovered list, so entries whose definition failed to load behave as before.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A — none; both issues were free at branch time.
- Canonical PR: this one.
- Resolution (closed/superseded/updated): N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ipSkHi47nsBmnxX5dC4dA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved workflow lookup efficiency by reusing discovery results, reducing duplicate full scans.
  - Workflow lookups by display name and unresolved IDs now avoid unnecessary repeated discovery.

- **Bug Fixes**
  - Removed duplicate deprecation warning logs while preserving warning messages returned to callers.

- **Tests**
  - Added coverage confirming workflow lookups perform no more than one full discovery pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->