### PR TITLE
fix(flows): apply static Composio arg rules in the tool_call preflight (#6154)

### DIFF
--- a/src/openhuman/flows/tinyflows/caps/ops.rs
+++ b/src/openhuman/flows/tinyflows/caps/ops.rs
@@ -407,15 +407,41 @@ pub struct OpenHumanTools {
 /// with a message that names the field and the likely fix — instead of letting
 /// the raw provider error surface from deep inside the call.
 ///
-/// Best-effort by design: when the action's schema cannot be looked up the
-/// check is skipped (never blocks on catalog availability).
+/// Two independent halves:
+///
+/// 1. The **static** rules `prepare_execute_arguments` already enforces at
+///    dispatch (`GMAIL_SEND_EMAIL` needs a recipient, `GOOGLECALENDAR_*` time
+///    bounds must be RFC 3339, …). These need no catalog, no network and no
+///    API key, so they always run.
+/// 2. The **catalog-driven** required-arg list, which is best-effort: when the
+///    action's schema cannot be looked up that half is skipped (never blocks
+///    on catalog availability).
+///
+/// Before #6154 only (2) existed, so a host with no reachable Composio
+/// catalog — the common case in a dry run, and any offline/unkeyed run — had
+/// a preflight that silently passed everything and left the failure to
+/// surface from inside the dispatch instead.
 pub(crate) async fn preflight_composio_args(
     config: &Config,
     slug: &str,
     args: &Value,
 ) -> Result<()> {
+    // (1) Static rules — the same validation the Composio dispatch runs, hoisted
+    // ahead of it. Only the `Err` matters here; the normalized arguments it
+    // returns are recomputed (and used) at dispatch.
+    if let Err(e) =
+        crate::openhuman::integrations::composio::execute_prepare::prepare_execute_arguments(
+            slug,
+            Some(args.clone()),
+        )
+    {
+        tracing::warn!(target: "flows", %slug, error = %e, "[flows] preflight: static arg rule rejected the call — failing before dispatch");
+        return Err(EngineError::Capability(format!("tool_call `{slug}`: {e}")));
+    }
+
+    // (2) Catalog-driven required args.
     let Some(required) = composio_required_args(config, slug).await else {
-        tracing::debug!(target: "flows", %slug, "[flows] preflight: no schema for action — skipping required-arg check");
+        tracing::info!(target: "flows", %slug, "[flows] preflight: no live catalog schema for action — required-arg check limited to static rules");
         return Ok(());
     };
     let missing = missing_required_args(&required, args);

--- a/src/openhuman/flows/tinyflows/tinyflows_tests_part_01_tests.rs
+++ b/src/openhuman/flows/tinyflows/tinyflows_tests_part_01_tests.rs
@@ -379,6 +379,41 @@ async fn preflight_skips_when_no_schema_is_available() {
 }
 
 #[tokio::test]
+async fn preflight_applies_static_arg_rules_without_a_catalog() {
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+    // No catalog seeding for this slug — `GMAIL_ADD_LABEL_TO_EMAIL` is never
+    // seeded anywhere, so `composio_required_args` returns `None` whether or
+    // not another test has cached the `gmail` toolkit. That used to make the
+    // whole preflight inert (#6154): the node sailed through and only failed
+    // at dispatch, inside `prepare_execute_arguments`.
+    //
+    // Those dispatch-time rules are static — no catalog, no network, no key —
+    // so the preflight must apply them regardless of catalog availability.
+    let err = super::super::caps::preflight_composio_args(
+        &config,
+        "GMAIL_ADD_LABEL_TO_EMAIL",
+        &json!({ "add_label_ids": ["INBOX"] }),
+    )
+    .await
+    .expect_err("a statically-known missing required arg must fail preflight");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("message_id"),
+        "error must name the missing field: {msg}"
+    );
+
+    // Args that satisfy the static rules still pass (no catalog needed).
+    super::super::caps::preflight_composio_args(
+        &config,
+        "GMAIL_ADD_LABEL_TO_EMAIL",
+        &json!({ "message_id": "abc123", "add_label_ids": ["INBOX"] }),
+    )
+    .await
+    .expect("statically-valid args must pass preflight");
+}
+
+#[tokio::test]
 async fn preflight_invoker_gates_the_mock_tool_path() {
     use tinyflows::caps::ToolInvoker as _;
 


### PR DESCRIPTION
## Summary

- The Composio `tool_call` pre-flight (`preflight_composio_args`) was **inert whenever no live catalog contract was available** — it logged at `debug!` and returned `Ok(())`, letting a mis-wired node through to dispatch.
- Hoisted the **static** argument rules (`prepare_execute_arguments`) ahead of the catalog lookup, so they apply unconditionally — no catalog, no network, no API key needed.
- The catalog-driven half stays best-effort, unchanged.
- The "no schema" skip is no longer silent: `info!` instead of `debug!`, and it now says the check was *narrowed to the static rules* rather than skipped outright.
- Run-time only. `validate_tool_contracts` (author/save time) is deliberately untouched.

## Problem

#6154 reports a *missing* pre-flight argument check for `GMAIL_SEND_EMAIL`. **The check is not missing — it is inert.**

`preflight_composio_args` (`src/openhuman/flows/tinyflows/caps/ops.rs:412`) has always run before dispatch and always produced a good, field-naming error. But its only gate was the live-catalog required-arg list, behind an early return:

```rust
let Some(required) = composio_required_args(config, slug).await else {
    tracing::debug!(... "no schema for action — skipping required-arg check");
    return Ok(());
};
```

`composio_required_args` (`src/openhuman/integrations/composio/catalog_part_02.rs:156`) returns `None` on an unknown toolkit, a failed Composio client construction, a failed/empty listing, **or the slug simply not being present in the cached catalog**. In a dry run, an offline run, or any run without a reachable Composio catalog that is the *normal* path — so the whole pre-flight passed everything.

The existing regression test `dry_run_catches_unwired_required_composio_arg` passes only because it calls `seed_live_catalog_cache(...)` first; the fixture supplied the very contract whose absence is the bug (see #6165).

Two corrections to the issue's framing, for the record:

- The error the reporter saw in their log came from **our own** validator, `validate_gmail_send_email` (`src/openhuman/integrations/composio/execute_prepare.rs:103`), at dispatch time — not from Composio. So no Composio request was made and **no credits were spent**. The wasted flow-run attempt is real; the credit cost is not.
- The rules were never missing. `prepare_execute_arguments` already encodes them; they were simply enforced too late to be actionable.

## Solution

`prepare_execute_arguments` is the authoritative, static, catalog-free validator for the slugs it knows (`GMAIL_SEND_EMAIL` recipient, `GMAIL_ADD_LABEL_TO_EMAIL` `message_id` + label, `GOOGLECALENDAR_*` RFC 3339 time bounds, `NOTION_FETCH_DATA` fetch type). Call it from the pre-flight and map its `Err` to `EngineError::Capability`:

```rust
// (1) Static rules — the same validation the Composio dispatch runs, hoisted ahead of it.
if let Err(e) = execute_prepare::prepare_execute_arguments(slug, Some(args.clone())) {
    tracing::warn!(...);
    return Err(EngineError::Capability(format!("tool_call `{slug}`: {e}")));
}
// (2) Catalog-driven required args — unchanged, still best-effort.
```

Only the `Err` is consumed; the normalized arguments it returns are recomputed (and used) at dispatch, so normalization behaviour is unchanged.

**One seam covers both paths.** `preflight_composio_args` is what both the real dispatch (`ComposioToolBackend::invoke`, `caps/tools/composio.rs:147`) and the dry run (`ComposioToolBackend::preflight`, `caps/tools/composio.rs:80`) call — so the fix lands once and applies everywhere, rather than being patched into each caller.

**Deliberately out of scope.** Adding this to `validate_tool_contracts` (author/save time) would turn currently-savable graphs into rejected ones: an existing saved flow with a broken node would start failing `save_workflow` on its next edit, including edits unrelated to that node. That is a product decision, not a bug fix, and is left alone.

### Verification

Test-first, per the repo standard:

1. Added `preflight_applies_static_arg_rules_without_a_catalog` (`tinyflows_tests_part_01_tests.rs`) **before** touching production code. It calls the pre-flight for `GMAIL_ADD_LABEL_TO_EMAIL` — a slug no test ever seeds into `LIVE_CATALOG_CACHE`, so `composio_required_args` returns `None` deterministically regardless of test order — with `message_id` absent.
2. It failed, naming the assertion: `a statically-known missing required arg must fail preflight: ()` at `tinyflows_tests_part_01_tests.rs:399`. The pre-flight had returned `Ok(())`.
3. With the fix: passes.
4. **Revert-check:** removed the fix from `ops.rs`, re-ran — `FAILED`, panicking at the same line 399 with my assertion's message. Re-applied, green again.

Also ran, with the fix applied:

- `cargo test -p openhuman --lib flows::` — **687 passed, 0 failed**.
- `cargo test -p openhuman --lib preflight` — 25 passed, including the three pre-existing pre-flight tests.
- `cargo clippy -p openhuman --no-deps` — clean (only a pre-existing vendored `tinyagents` warning).
- `cargo fmt --check` — clean.

Note on `raw_coverage_all`: a name-filtered run of that aggregated target shows 2–4 failures in `composio_*_raw_coverage_e2e` (trigger-history `state_dir`, module-route). **These are pre-existing and order-dependent**, not caused by this change — a baseline run with the fix reverted fails a different, overlapping subset, and each failing test passes in isolation with the fix applied. Cause is shared process-global state (module route, shared temp state dir) under partial selection of the aggregated target.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — `preflight_applies_static_arg_rules_without_a_catalog` covers both: the failure path (missing `message_id` → `Err` naming the field) and the happy path (statically-valid args pass with no catalog present).
- [x] **Diff coverage ≥ 80%** — every changed production line is executed by the new test: the `prepare_execute_arguments` call, the `Err` branch (first assertion), the `Ok` fall-through into the catalog lookup, and the narrowed-skip `info!` (second assertion). Full local `pnpm test:coverage` / `pnpm test:rust` not run — see the note under Validation Blocked.
- [x] N/A: behaviour-only change — no feature row added, removed, or renamed in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] N/A: no coverage-matrix feature IDs apply to this change (see the item above).
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — the new test deliberately runs with **no** Composio client and **no** seeded catalog; that absence is the condition under test.
- [x] N/A: does not touch a release-cut surface in `docs/RELEASE-MANUAL-SMOKE.md` — this is an internal validation ordering change inside the flows engine.
- [x] Linked issue closed via `Closes #6154` in the `## Related` section.

## Impact

- **Runtime/platform:** desktop + CLI, anywhere the tinyflows engine runs a Composio `tool_call` node. No UI change.
- **Behaviour change:** a `tool_call` whose arguments violate a statically-known rule now fails at the pre-flight instead of at dispatch. The run outcome is the same (the call was going to be rejected either way) — it fails *earlier*, with the failure attributed to the node's wiring, and **before** the approval gate, so the user is no longer asked to approve a call that cannot succeed.
- **No behaviour change** for any slug `prepare_execute_arguments` has no rules for, or for any call that already satisfies them.
- **Performance:** one extra synchronous, allocation-only validation per Composio `tool_call`; no I/O.
- **Security/migration/compatibility:** none. No saved flow becomes unsavable — author-time validation is untouched.

## Related

- Closes: Closes #6154
- Follow-up PR(s)/TODOs: tinyhumansai/openhuman#6165 tracks the test fixture (`seed_live_catalog_cache`) that masked this — not addressed here.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A — filed as a GitHub issue, not Linear.
- URL: N/A — see tinyhumansai/openhuman#6154.

### Commit & Branch

- Branch: `fix/6154-composio-preflight`
- Commit SHA: `61a03d8a693f707a2ac7d2eba285e7a403d8c1fa`

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend files changed (Rust only).
- [x] N/A: `pnpm typecheck` — no TypeScript files changed.
- [x] Focused tests: `cargo test -p openhuman --features "$(bash scripts/ci/product-features.sh)" --no-default-features --lib flows::` → 687 passed, 0 failed. Test-first + revert-check performed on `preflight_applies_static_arg_rules_without_a_catalog` (see Verification).
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo clippy -p openhuman --no-deps` clean.
- [x] N/A: Tauri fmt/check — no files under the Tauri shell changed.

### Validation Blocked

- `command:` full `pnpm test:coverage` / `pnpm test:rust` (whole-workspace coverage)
- `error:` not run — the fleet is capped at 3 concurrent local cargo slots and a full-workspace coverage build is not affordable in this lane.
- `impact:` diff coverage is asserted from the new test's execution path (every changed line is exercised) rather than from a `diff-cover` number. CI's coverage gate is authoritative.

### Behavior Changes

- Intended behavior change: statically-known invalid Composio `tool_call` arguments are rejected at the pre-flight, before the approval gate and before dispatch, instead of at dispatch.
- User-visible effect: the flow error names the offending field and the node wiring instead of surfacing from inside the Composio dispatch; a doomed call no longer prompts for approval first.

### Parity Contract

- Legacy behavior preserved: the catalog-driven required-arg check is byte-for-byte unchanged, including its message and its best-effort skip. Argument *normalization* still happens only at dispatch — the pre-flight discards the prepared value and consumes only the `Err`.
- Guard/fallback/dispatch parity checks: the pre-flight now runs exactly the validator the dispatch runs (`prepare_execute_arguments`), so the two cannot disagree — any call the pre-flight admits is one the dispatch's own validation also admits. Both the real path (`ComposioToolBackend::invoke`) and the dry run (`ComposioToolBackend::preflight`) route through the single `preflight_composio_args` seam.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A — no other PR references #6154 (checked via the issue timeline and `git log upstream/main --grep`).
- Canonical PR: this one.
- Resolution: N/A — nothing superseded.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ipSkHi47nsBmnxX5dC4dA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preflight validation for Gmail actions by enforcing known required arguments before execution, even when catalog information is unavailable.
  - Calls with missing required values, such as an email message ID, are now rejected earlier with a clear capability error.
  - Valid requests containing all required Gmail arguments continue to proceed without catalog access.
  - Updated logging provides clearer information when catalog-based validation is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->