### PR TITLE
fix(socket): skip the redundant startup connect that opened a second EIO session

### DIFF
--- a/src/core/runtime/services.rs
+++ b/src/core/runtime/services.rs
@@ -505,7 +505,7 @@ pub fn spawn_socket_auto_connect(
                 }
             };
             let api_url = crate::api::config::effective_backend_api_url(&config.api_url);
-            let _initial_token = match crate::api::jwt::get_session_token(&config) {
+            let initial_token = match crate::api::jwt::get_session_token(&config) {
                 Ok(Some(t)) => t,
                 Ok(None) => {
                     log::info!(
@@ -527,6 +527,17 @@ pub fn spawn_socket_auto_connect(
             // changed since CoreRuntime::build(), so the build-time Config is
             // not authoritative here.
             let _rebind = socket_mgr.lock_identity_rebind().await;
+            // The renderer's `socket_connect_with_session` RPC connects the same
+            // core to the same backend with the same token. Whichever path runs
+            // second used to tear the other's live socket down and redo the
+            // handshake (#6181); if it is already up for this identity there is
+            // nothing to rebind.
+            if socket_mgr.is_live_for(&api_url, &initial_token) {
+                log::info!(
+                    "[socket] Auto-connect: {api_url} already connected with this session — nothing to do"
+                );
+                return;
+            }
             if let Err(e) = socket_mgr.disconnect().await {
                 log::error!("[socket] Auto-connect could not stop the prior connection: {e}");
                 return;

--- a/src/core/runtime/services.rs
+++ b/src/core/runtime/services.rs
@@ -533,8 +533,18 @@ pub fn spawn_socket_auto_connect(
             // handshake (#6181); if it is already up for this identity there is
             // nothing to rebind.
             if socket_mgr.is_live_for(&api_url, &initial_token) {
+                // The socket is reusable, the bridge is not: it is pinned to the
+                // `Config` resolved above, which a workspace switch invalidates.
+                // `set_workflow_bridge` re-advertises over a live socket by
+                // design, so reinstall and skip only the handshake.
+                #[cfg(feature = "flows")]
+                if _flows_enabled {
+                    crate::openhuman::flows::medulla_bridge::install(std::sync::Arc::clone(
+                        &config,
+                    ));
+                }
                 log::info!(
-                    "[socket] Auto-connect: {api_url} already connected with this session — nothing to do"
+                    "[socket] Auto-connect: {api_url} already connected with this session — refreshed the workflow bridge, kept the socket"
                 );
                 return;
             }

--- a/src/openhuman/platform/socket/event_handlers_tests.rs
+++ b/src/openhuman/platform/socket/event_handlers_tests.rs
@@ -9,6 +9,7 @@ fn make_shared() -> Arc<SharedState> {
         status: RwLock::new(ConnectionStatus::Disconnected),
         socket_id: RwLock::new(None),
         error: RwLock::new(None),
+        connection_identity: RwLock::new(None),
     })
 }
 

--- a/src/openhuman/platform/socket/manager.rs
+++ b/src/openhuman/platform/socket/manager.rs
@@ -170,6 +170,13 @@ pub struct SocketManager {
     /// Serializes identity-sensitive disconnect → bridge bind → connect
     /// transactions while still allowing ordinary emits and state reads.
     identity_rebind: tokio::sync::Mutex<()>,
+    /// `(url, token)` the background loop is currently serving, recorded when a
+    /// loop is spawned and cleared on disconnect. Read by [`is_live_for`] so a
+    /// redundant connect for the identity that is already live can be skipped
+    /// instead of re-running the whole handshake (#6181).
+    ///
+    /// [`is_live_for`]: SocketManager::is_live_for
+    connection_identity: RwLock<Option<(String, String)>>,
 }
 
 impl SocketManager {
@@ -188,6 +195,7 @@ impl SocketManager {
             shutdown_tx: tokio::sync::Mutex::new(None),
             loop_handle: tokio::sync::Mutex::new(None),
             identity_rebind: tokio::sync::Mutex::new(()),
+            connection_identity: RwLock::new(None),
         }
     }
 
@@ -221,6 +229,29 @@ impl SocketManager {
         *self.shared.status.read() == ConnectionStatus::Connected
     }
 
+    /// True when a **live** connection is already serving exactly this `url`
+    /// under exactly this session token.
+    ///
+    /// Startup has two independent connect paths — the core's bootstrap
+    /// auto-connect and the renderer's `socket_connect_with_session` RPC — and
+    /// each unconditionally tore the other's socket down and redid the whole
+    /// Engine.IO/Socket.IO handshake, so a cold start opened two EIO sessions a
+    /// couple of seconds apart (#6181). Callers consult this before starting an
+    /// identity rebind so the second path becomes a no-op.
+    ///
+    /// Deliberately conservative: a different URL, a different token, or any
+    /// status other than `Connected` all report `false`, so an account switch
+    /// (same URL, new token) still forces a real reconnect and an unhealthy
+    /// socket is still replaced.
+    pub fn is_live_for(&self, url: &str, token: &str) -> bool {
+        self.is_connected()
+            && self
+                .connection_identity
+                .read()
+                .as_ref()
+                .is_some_and(|(u, t)| u == url && t == token)
+    }
+
     // -----------------------------------------------------------------------
     // Connection lifecycle
     // -----------------------------------------------------------------------
@@ -246,7 +277,7 @@ impl SocketManager {
         // live-session refresh, callers should use `connect_with_session` which
         // builds a provider via `token_provider_from_config`.
         let provider = static_token_provider(token.to_string());
-        self.spawn_loop(url, provider).await
+        self.spawn_loop(url, provider, token.to_string()).await
     }
 
     /// Connect using a **live-refresh token provider**.
@@ -268,8 +299,8 @@ impl SocketManager {
         // Validate that a token is available right now before spawning. This
         // mirrors the empty-token guard in `connect()` and ensures callers
         // see an immediate error if the session store is empty.
-        match token_provider() {
-            Ok(t) if !t.trim().is_empty() => {}
+        let token = match token_provider() {
+            Ok(t) if !t.trim().is_empty() => t,
             Ok(_) => {
                 log::error!(
                     "[socket] connect_with_provider: refusing to start — provider returned empty token"
@@ -282,22 +313,37 @@ impl SocketManager {
                 );
                 return Err(e);
             }
-        }
-        self.spawn_loop(url, token_provider).await
+        };
+        self.spawn_loop(url, token_provider, token).await
     }
 
     /// Shared spawn path used by both [`connect`] and [`connect_with_provider`].
     ///
     /// Installs the rustls crypto provider, tears down any existing connection,
-    /// constructs the channel pair, and spawns the background `ws_loop` task.
-    /// Entry-point-specific validation (empty-token guard, provider pre-check)
-    /// is done by the callers before this is called.
-    async fn spawn_loop(&self, url: &str, provider: TokenProvider) -> Result<(), String> {
+    /// records the connection's identity, constructs the channel pair, and
+    /// spawns the background `ws_loop` task. Entry-point-specific validation
+    /// (empty-token guard, provider pre-check) is done by the callers before this
+    /// is called, and `token` is the value they validated — it is recorded, not
+    /// sent, so `is_live_for` compares against the credential this connection was
+    /// actually started with.
+    async fn spawn_loop(
+        &self,
+        url: &str,
+        provider: TokenProvider,
+        token: String,
+    ) -> Result<(), String> {
         // Ensure the rustls crypto provider is installed (needed for wss:// TLS).
         // This is a no-op if already installed.
         let _ = rustls::crypto::ring::default_provider().install_default();
 
         self.disconnect().await?;
+
+        // Record the identity this loop will serve so a redundant connect for
+        // the same url+token can be skipped (see `is_live_for`). This is the
+        // token the caller already validated, not a fresh provider call: the two
+        // must agree, or the guard could match on a credential this connection
+        // never used.
+        *self.connection_identity.write() = Some((url.to_string(), token));
 
         log::info!("[socket] Connecting to {}", url);
 
@@ -358,6 +404,7 @@ impl SocketManager {
         *self.shared.status.write() = ConnectionStatus::Disconnected;
         *self.shared.socket_id.write() = None;
         *self.shared.error.write() = None;
+        *self.connection_identity.write() = None;
         emit_state_change(&self.shared);
         log::debug!("[socket] Disconnected");
         Ok(())

--- a/src/openhuman/platform/socket/manager.rs
+++ b/src/openhuman/platform/socket/manager.rs
@@ -62,6 +62,13 @@ pub(super) struct SharedState {
     /// (e.g. "backend redirected ws→wss; update BACKEND_URL"). Cleared on every
     /// successful handshake and on disconnect.
     pub(super) error: RwLock<Option<String>>,
+    /// `(url, token)` the background loop is currently authenticating with, and
+    /// the reason it lives here rather than on the handle: `ws_loop` re-reads the
+    /// token provider before **every** attempt, so a refresh mid-session would
+    /// leave a manager-side copy naming a credential this socket no longer uses.
+    /// Seeded by `spawn_loop` and rewritten by the loop on each attempt; cleared
+    /// on disconnect. Read by [`SocketManager::is_live_for`].
+    pub(super) connection_identity: RwLock<Option<(String, String)>>,
 }
 
 /// The connection's readiness flag, guarded by a lock so a reader can hold the
@@ -170,13 +177,6 @@ pub struct SocketManager {
     /// Serializes identity-sensitive disconnect → bridge bind → connect
     /// transactions while still allowing ordinary emits and state reads.
     identity_rebind: tokio::sync::Mutex<()>,
-    /// `(url, token)` the background loop is currently serving, recorded when a
-    /// loop is spawned and cleared on disconnect. Read by [`is_live_for`] so a
-    /// redundant connect for the identity that is already live can be skipped
-    /// instead of re-running the whole handshake (#6181).
-    ///
-    /// [`is_live_for`]: SocketManager::is_live_for
-    connection_identity: RwLock<Option<(String, String)>>,
 }
 
 impl SocketManager {
@@ -190,12 +190,12 @@ impl SocketManager {
                 status: RwLock::new(ConnectionStatus::Disconnected),
                 socket_id: RwLock::new(None),
                 error: RwLock::new(None),
+                connection_identity: RwLock::new(None),
             }),
             emit_tx: tokio::sync::Mutex::new(None),
             shutdown_tx: tokio::sync::Mutex::new(None),
             loop_handle: tokio::sync::Mutex::new(None),
             identity_rebind: tokio::sync::Mutex::new(()),
-            connection_identity: RwLock::new(None),
         }
     }
 
@@ -242,10 +242,14 @@ impl SocketManager {
     /// Deliberately conservative: a different URL, a different token, or any
     /// status other than `Connected` all report `false`, so an account switch
     /// (same URL, new token) still forces a real reconnect and an unhealthy
-    /// socket is still replaced.
+    /// socket is still replaced. The token compared against is the one
+    /// `ws_loop` used for its most recent attempt, not the one this manager was
+    /// handed at spawn — a provider that refreshes the session mid-loop keeps
+    /// matching instead of forcing a pointless reconnect.
     pub fn is_live_for(&self, url: &str, token: &str) -> bool {
         self.is_connected()
             && self
+                .shared
                 .connection_identity
                 .read()
                 .as_ref()
@@ -338,12 +342,13 @@ impl SocketManager {
 
         self.disconnect().await?;
 
-        // Record the identity this loop will serve so a redundant connect for
-        // the same url+token can be skipped (see `is_live_for`). This is the
-        // token the caller already validated, not a fresh provider call: the two
-        // must agree, or the guard could match on a credential this connection
-        // never used.
-        *self.connection_identity.write() = Some((url.to_string(), token));
+        // Seed the identity this loop will serve so a redundant connect for the
+        // same url+token can be skipped (see `is_live_for`). This is the token
+        // the caller already validated, not a fresh provider call: the two must
+        // agree, or the guard could match on a credential this connection never
+        // used. `ws_loop` rewrites it before every attempt, so a token refreshed
+        // mid-session replaces this seed rather than going stale behind it.
+        *self.shared.connection_identity.write() = Some((url.to_string(), token));
 
         log::info!("[socket] Connecting to {}", url);
 
@@ -404,7 +409,7 @@ impl SocketManager {
         *self.shared.status.write() = ConnectionStatus::Disconnected;
         *self.shared.socket_id.write() = None;
         *self.shared.error.write() = None;
-        *self.connection_identity.write() = None;
+        *self.shared.connection_identity.write() = None;
         emit_state_change(&self.shared);
         log::debug!("[socket] Disconnected");
         Ok(())

--- a/src/openhuman/platform/socket/manager_tests.rs
+++ b/src/openhuman/platform/socket/manager_tests.rs
@@ -383,6 +383,7 @@ fn emit_state_change_is_safe_to_call_on_empty_shared() {
         status: RwLock::new(ConnectionStatus::Connecting),
         socket_id: RwLock::new(None),
         error: RwLock::new(None),
+        connection_identity: RwLock::new(None),
     };
     // Must not panic even with all default state.
     emit_state_change(&shared);
@@ -396,6 +397,7 @@ fn emit_server_event_is_safe_without_subscribers() {
         status: RwLock::new(ConnectionStatus::Connected),
         socket_id: RwLock::new(Some("x".into())),
         error: RwLock::new(None),
+        connection_identity: RwLock::new(None),
     };
     // Pure logging — must not touch state or panic.
     emit_server_event(&shared, "any.event", json!({}));

--- a/src/openhuman/platform/socket/ops.rs
+++ b/src/openhuman/platform/socket/ops.rs
@@ -45,7 +45,15 @@ pub async fn disconnect(manager: &SocketManager) -> Result<SocketState, String> 
 /// bootstrap auto-connect and this RPC both fire on a cold start, roughly two
 /// seconds apart, and each used to tear the other's freshly handshaked socket
 /// down. When the live connection already serves this exact url+token there is
-/// nothing to rebind — no disconnect, no bridge swap, no second EIO session.
+/// no second EIO session to open.
+///
+/// The socket is reusable; the workflow bridge is not. It is pinned to a
+/// `Config` that a workspace switch invalidates, and `connect_static` clears it
+/// outright while leaving a matching connection identity behind — so skipping
+/// `install_bridge` on the reuse path would leave the workflow plane pointing at
+/// a stale workspace, or disabled entirely. `set_workflow_bridge` re-advertises
+/// over an already-`ready` socket by design, so the install runs on both paths
+/// and only the handshake is skipped.
 async fn connect_with_session_using(
     manager: &SocketManager,
     url: &str,
@@ -55,6 +63,7 @@ async fn connect_with_session_using(
 ) -> Result<SocketState, String> {
     let _rebind = manager.lock_identity_rebind().await;
     if manager.is_live_for(url, token) {
+        install_bridge();
         log::info!(
             "[socket:rpc] connect_with_session — {url} already connected with this session; reusing the live socket"
         );

--- a/src/openhuman/platform/socket/ops.rs
+++ b/src/openhuman/platform/socket/ops.rs
@@ -37,26 +37,55 @@ pub async fn disconnect(manager: &SocketManager) -> Result<SocketState, String> 
     Ok(manager.get_state())
 }
 
+/// Shared body of [`connect_with_session`], with the credential lookup and the
+/// workflow-bridge install lifted out so the transaction can be driven directly
+/// from tests.
+///
+/// The `manager.is_live_for` short-circuit is the fix for #6181: the core's
+/// bootstrap auto-connect and this RPC both fire on a cold start, roughly two
+/// seconds apart, and each used to tear the other's freshly handshaked socket
+/// down. When the live connection already serves this exact url+token there is
+/// nothing to rebind — no disconnect, no bridge swap, no second EIO session.
+async fn connect_with_session_using(
+    manager: &SocketManager,
+    url: &str,
+    token: &str,
+    provider: super::token_provider::TokenProvider,
+    install_bridge: impl FnOnce(),
+) -> Result<SocketState, String> {
+    let _rebind = manager.lock_identity_rebind().await;
+    if manager.is_live_for(url, token) {
+        log::info!(
+            "[socket:rpc] connect_with_session — {url} already connected with this session; reusing the live socket"
+        );
+        return Ok(manager.get_state());
+    }
+    manager.disconnect().await?;
+    install_bridge();
+    manager.connect_with_provider(url, provider).await?;
+    Ok(manager.get_state())
+}
+
 pub async fn connect_with_session(manager: &SocketManager) -> Result<SocketState, String> {
     log::info!("[socket:rpc] connect_with_session — resolving credentials");
     let config =
         std::sync::Arc::new(crate::openhuman::config::rpc::load_config_with_timeout().await?);
     let api_url = crate::api::config::effective_backend_api_url(&config.api_url);
-    crate::api::jwt::get_session_token(&config)
+    let token = crate::api::jwt::get_session_token(&config)
         .map_err(|e| format!("failed to read session token: {e}"))?
         .ok_or("no session token stored — user must log in first")?;
 
-    let _rebind = manager.lock_identity_rebind().await;
-    manager.disconnect().await?;
-    #[cfg(feature = "flows")]
-    if crate::core::runtime::context::CoreContext::current()
-        .is_some_and(|context| context.domains().flows)
-    {
-        crate::openhuman::flows::medulla_bridge::install(std::sync::Arc::clone(&config));
-    }
-    let provider = super::token_provider::token_provider_from_config(config);
-    manager.connect_with_provider(&api_url, provider).await?;
-    Ok(manager.get_state())
+    let provider =
+        super::token_provider::token_provider_from_config(std::sync::Arc::clone(&config));
+    connect_with_session_using(manager, &api_url, &token, provider, move || {
+        #[cfg(feature = "flows")]
+        if crate::core::runtime::context::CoreContext::current()
+            .is_some_and(|context| context.domains().flows)
+        {
+            crate::openhuman::flows::medulla_bridge::install(config);
+        }
+    })
+    .await
 }
 
 #[cfg(test)]

--- a/src/openhuman/platform/socket/ops_tests.rs
+++ b/src/openhuman/platform/socket/ops_tests.rs
@@ -21,3 +21,173 @@ async fn static_token_connection_clears_identity_state_after_disconnect() {
     .unwrap();
     assert!(cleared.load(Ordering::SeqCst));
 }
+
+// ── Redundant-connect suppression (#6181) ──────────────────────────
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+
+use crate::openhuman::platform::socket::token_provider::static_token_provider;
+use crate::openhuman::platform::socket::types::ConnectionStatus;
+
+const TOKEN_A: &str = "session-token-a";
+const TOKEN_B: &str = "session-token-b";
+
+/// EIO v4 mock that counts accepts and completes enough of the handshake for
+/// `SocketManager` to reach `Connected`, then idles. Accepting in a loop is the
+/// point: a duplicate connect shows up as a second accept.
+async fn spawn_accept_counting_eio_server() -> (Arc<AtomicUsize>, std::net::SocketAddr) {
+    use futures_util::{SinkExt, StreamExt};
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::{accept_async, tungstenite::Message as WsMessage};
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let accepts = Arc::new(AtomicUsize::new(0));
+    let counter = Arc::clone(&accepts);
+    tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            counter.fetch_add(1, Ordering::SeqCst);
+            tokio::spawn(async move {
+                let Ok(ws) = accept_async(stream).await else {
+                    return;
+                };
+                let (mut write, mut read) = ws.split();
+                // Long ping intervals so nothing reconnects on its own mid-test.
+                let open = r#"0{"sid":"mock-eio-sid","upgrades":[],"pingInterval":30000,"pingTimeout":30000}"#;
+                let _ = write.send(WsMessage::Text(open.into())).await;
+                let _ = read.next().await; // client SIO CONNECT
+                let _ = write
+                    .send(WsMessage::Text(r#"40{"sid":"mock-sio-sid"}"#.into()))
+                    .await;
+                while let Some(Ok(_)) = read.next().await {}
+            });
+        }
+    });
+    (accepts, addr)
+}
+
+async fn wait_for_connected(manager: &SocketManager) {
+    for _ in 0..200 {
+        if manager.is_connected() {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    panic!("socket never reached Connected");
+}
+
+/// Wait out the window in which a duplicate connect would reach the server.
+///
+/// `connect_with_provider` returns as soon as the background loop is spawned, so
+/// reading the accept counter straight afterwards would pass even when a second
+/// session is on its way — a vacuous assertion. Returns early the moment a
+/// second accept does show up, so the fix's happy path is the only one that pays
+/// the full wait.
+async fn settle_for_a_second_accept(accepts: &AtomicUsize) {
+    for _ in 0..40 {
+        if accepts.load(Ordering::SeqCst) > 1 {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+}
+
+/// Stand-in for the core's bootstrap auto-connect (`spawn_socket_auto_connect`).
+async fn bootstrap_auto_connect(manager: &SocketManager, url: &str, token: &str) {
+    manager
+        .connect_with_provider(url, static_token_provider(token.to_string()))
+        .await
+        .unwrap();
+    wait_for_connected(manager).await;
+}
+
+/// #6181: on a cold start the core auto-connects and the renderer's
+/// `socket_connect_with_session` RPC follows a couple of seconds later with the
+/// same backend URL and the same stored token. The second one must reuse the
+/// live socket rather than tear it down and open a fresh EIO session.
+#[tokio::test]
+async fn a_redundant_session_connect_reuses_the_live_socket() {
+    let (accepts, addr) = spawn_accept_counting_eio_server().await;
+    let url = format!("http://{addr}");
+    let manager = SocketManager::new();
+
+    bootstrap_auto_connect(&manager, &url, TOKEN_A).await;
+
+    let rebound = AtomicBool::new(false);
+    let state = connect_with_session_using(
+        &manager,
+        &url,
+        TOKEN_A,
+        static_token_provider(TOKEN_A.to_string()),
+        || rebound.store(true, Ordering::SeqCst),
+    )
+    .await
+    .unwrap();
+
+    settle_for_a_second_accept(&accepts).await;
+    assert_eq!(
+        accepts.load(Ordering::SeqCst),
+        1,
+        "a redundant connect for an identical identity opened a duplicate EIO session"
+    );
+    assert!(
+        !rebound.load(Ordering::SeqCst),
+        "identity rebind ran for a session that was already live"
+    );
+    // The caller also gets the live socket's state back, not the `Connecting`
+    // of a handshake that has only just been kicked off.
+    assert_eq!(state.status, ConnectionStatus::Connected);
+}
+
+/// The other half of the guard: an account switch keeps the same backend URL but
+/// arrives with a different token, and must still disconnect, rebind the
+/// identity-bound workflow plane, and reconnect.
+#[tokio::test]
+async fn a_session_connect_with_a_different_token_still_rebinds() {
+    let (accepts, addr) = spawn_accept_counting_eio_server().await;
+    let url = format!("http://{addr}");
+    let manager = SocketManager::new();
+
+    bootstrap_auto_connect(&manager, &url, TOKEN_A).await;
+
+    let rebound = AtomicBool::new(false);
+    connect_with_session_using(
+        &manager,
+        &url,
+        TOKEN_B,
+        static_token_provider(TOKEN_B.to_string()),
+        || rebound.store(true, Ordering::SeqCst),
+    )
+    .await
+    .unwrap();
+    wait_for_connected(&manager).await;
+
+    assert!(
+        rebound.load(Ordering::SeqCst),
+        "a new session token must still rebind the identity-bound workflow plane"
+    );
+    assert_eq!(
+        accepts.load(Ordering::SeqCst),
+        2,
+        "a new session token must open a fresh EIO session"
+    );
+}
+
+/// `is_live_for` is identity-scoped, not merely "am I connected": a different
+/// backend URL is a different identity, and a disconnect clears the record so a
+/// later connect is never skipped against a dead socket.
+#[tokio::test]
+async fn is_live_for_is_scoped_to_url_and_token_and_cleared_on_disconnect() {
+    let (_accepts, addr) = spawn_accept_counting_eio_server().await;
+    let url = format!("http://{addr}");
+    let manager = SocketManager::new();
+
+    bootstrap_auto_connect(&manager, &url, TOKEN_A).await;
+
+    assert!(manager.is_live_for(&url, TOKEN_A));
+    assert!(!manager.is_live_for(&url, TOKEN_B));
+    assert!(!manager.is_live_for("http://127.0.0.1:1", TOKEN_A));
+
+    manager.disconnect().await.unwrap();
+    assert!(!manager.is_live_for(&url, TOKEN_A));
+}

--- a/src/openhuman/platform/socket/ops_tests.rs
+++ b/src/openhuman/platform/socket/ops_tests.rs
@@ -26,7 +26,7 @@ async fn static_token_connection_clears_identity_state_after_disconnect() {
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 
-use crate::openhuman::platform::socket::token_provider::static_token_provider;
+use crate::openhuman::platform::socket::token_provider::{static_token_provider, TokenProvider};
 use crate::openhuman::platform::socket::types::ConnectionStatus;
 
 const TOKEN_A: &str = "session-token-a";
@@ -64,6 +64,50 @@ async fn spawn_accept_counting_eio_server() -> (Arc<AtomicUsize>, std::net::Sock
         }
     });
     (accepts, addr)
+}
+
+/// EIO v4 mock that completes one handshake and then holds the connection open
+/// until the returned sender says to hang up, so a test can decide exactly when
+/// the loop is forced to reconnect. Later connections are held indefinitely.
+async fn spawn_server_that_hangs_up_on_cue(
+) -> (std::net::SocketAddr, tokio::sync::watch::Sender<bool>) {
+    use futures_util::{SinkExt, StreamExt};
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::{accept_async, tungstenite::Message as WsMessage};
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let (hang_up, rx) = tokio::sync::watch::channel(false);
+    tokio::spawn(async move {
+        let mut first = true;
+        while let Ok((stream, _)) = listener.accept().await {
+            let mut rx = rx.clone();
+            let hang_up_this_one = std::mem::take(&mut first);
+            tokio::spawn(async move {
+                let Ok(ws) = accept_async(stream).await else {
+                    return;
+                };
+                let (mut write, mut read) = ws.split();
+                let open = r#"0{"sid":"mock-eio-sid","upgrades":[],"pingInterval":30000,"pingTimeout":30000}"#;
+                let _ = write.send(WsMessage::Text(open.into())).await;
+                let _ = read.next().await; // client SIO CONNECT
+                let _ = write
+                    .send(WsMessage::Text(r#"40{"sid":"mock-sio-sid"}"#.into()))
+                    .await;
+                if hang_up_this_one {
+                    while rx.changed().await.is_ok() {
+                        if *rx.borrow() {
+                            break;
+                        }
+                    }
+                    let _ = write.close().await;
+                    return;
+                }
+                while let Some(Ok(_)) = read.next().await {}
+            });
+        }
+    });
+    (addr, hang_up)
 }
 
 async fn wait_for_connected(manager: &SocketManager) {
@@ -113,13 +157,13 @@ async fn a_redundant_session_connect_reuses_the_live_socket() {
 
     bootstrap_auto_connect(&manager, &url, TOKEN_A).await;
 
-    let rebound = AtomicBool::new(false);
+    let bridge_installed = AtomicBool::new(false);
     let state = connect_with_session_using(
         &manager,
         &url,
         TOKEN_A,
         static_token_provider(TOKEN_A.to_string()),
-        || rebound.store(true, Ordering::SeqCst),
+        || bridge_installed.store(true, Ordering::SeqCst),
     )
     .await
     .unwrap();
@@ -130,13 +174,98 @@ async fn a_redundant_session_connect_reuses_the_live_socket() {
         1,
         "a redundant connect for an identical identity opened a duplicate EIO session"
     );
-    assert!(
-        !rebound.load(Ordering::SeqCst),
-        "identity rebind ran for a session that was already live"
-    );
-    // The caller also gets the live socket's state back, not the `Connecting`
-    // of a handshake that has only just been kicked off.
+    // The caller gets the live socket's state back, not the `Connecting` of a
+    // handshake that has only just been kicked off.
     assert_eq!(state.status, ConnectionStatus::Connected);
+    // Reusing the socket must not skip the bridge: it is pinned to a `Config`,
+    // and `connect_static` can have cleared it while leaving a matching identity
+    // behind, so the workflow plane would be left stale or disabled.
+    assert!(
+        bridge_installed.load(Ordering::SeqCst),
+        "reusing the socket skipped the workflow-bridge install"
+    );
+}
+
+/// The bridge half of the reuse path, end to end through the operation that
+/// clears it: `openhuman.socket_connect` disables the identity-bound workflow
+/// plane and leaves a matching connection identity behind, so a following
+/// `connect_with_session` for the same url+token must still restore it.
+#[tokio::test]
+async fn a_reused_socket_still_restores_a_bridge_a_static_connect_cleared() {
+    let (accepts, addr) = spawn_accept_counting_eio_server().await;
+    let url = format!("http://{addr}");
+    let manager = SocketManager::new();
+
+    let cleared = AtomicBool::new(false);
+    connect_static_using(&manager, &url, TOKEN_A, || {
+        cleared.store(true, Ordering::SeqCst)
+    })
+    .await
+    .unwrap();
+    wait_for_connected(&manager).await;
+    assert!(cleared.load(Ordering::SeqCst));
+
+    let bridge_installed = AtomicBool::new(false);
+    connect_with_session_using(
+        &manager,
+        &url,
+        TOKEN_A,
+        static_token_provider(TOKEN_A.to_string()),
+        || bridge_installed.store(true, Ordering::SeqCst),
+    )
+    .await
+    .unwrap();
+
+    settle_for_a_second_accept(&accepts).await;
+    assert!(
+        bridge_installed.load(Ordering::SeqCst),
+        "the workflow plane stayed disabled after a static connect cleared it"
+    );
+    assert_eq!(
+        accepts.load(Ordering::SeqCst),
+        1,
+        "restoring the bridge should not cost a fresh EIO session"
+    );
+}
+
+/// `ws_loop` re-reads the token provider before every attempt, so a session
+/// refreshed mid-loop leaves the socket authenticated with a token the manager
+/// was never handed. The recorded identity has to follow, or the next session
+/// connect tears down a perfectly healthy socket.
+#[tokio::test]
+async fn a_token_refreshed_mid_loop_updates_the_recorded_identity() {
+    let (addr, hang_up) = spawn_server_that_hangs_up_on_cue().await;
+    let url = format!("http://{addr}");
+    let manager = SocketManager::new();
+
+    // A provider whose answer changes under the loop, exactly as a live session
+    // refresh does.
+    let refreshed = Arc::new(AtomicBool::new(false));
+    let seen = Arc::clone(&refreshed);
+    let provider: TokenProvider = Arc::new(move || {
+        Ok(if seen.load(Ordering::SeqCst) {
+            TOKEN_B.to_string()
+        } else {
+            TOKEN_A.to_string()
+        })
+    });
+
+    manager.connect_with_provider(&url, provider).await.unwrap();
+    wait_for_connected(&manager).await;
+    assert!(manager.is_live_for(&url, TOKEN_A));
+
+    // Refresh the session, then drop the socket so the loop reconnects with the
+    // new token.
+    refreshed.store(true, Ordering::SeqCst);
+    let _ = hang_up.send(true);
+
+    for _ in 0..200 {
+        if manager.is_live_for(&url, TOKEN_B) {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    panic!("the recorded identity still names the pre-refresh token after a reconnect");
 }
 
 /// The other half of the guard: an account switch keeps the same backend URL but
@@ -150,20 +279,20 @@ async fn a_session_connect_with_a_different_token_still_rebinds() {
 
     bootstrap_auto_connect(&manager, &url, TOKEN_A).await;
 
-    let rebound = AtomicBool::new(false);
+    let bridge_installed = AtomicBool::new(false);
     connect_with_session_using(
         &manager,
         &url,
         TOKEN_B,
         static_token_provider(TOKEN_B.to_string()),
-        || rebound.store(true, Ordering::SeqCst),
+        || bridge_installed.store(true, Ordering::SeqCst),
     )
     .await
     .unwrap();
     wait_for_connected(&manager).await;
 
     assert!(
-        rebound.load(Ordering::SeqCst),
+        bridge_installed.load(Ordering::SeqCst),
         "a new session token must still rebind the identity-bound workflow plane"
     );
     assert_eq!(

--- a/src/openhuman/platform/socket/ws_loop_part_01.rs
+++ b/src/openhuman/platform/socket/ws_loop_part_01.rs
@@ -145,6 +145,12 @@ pub(super) async fn ws_loop(
             "[socket] Attempting connection (token_len={})...",
             token.len()
         );
+        // Record the credential this attempt actually authenticates with. The
+        // provider is re-read every iteration, so a session refreshed mid-loop
+        // would otherwise leave `SocketManager::is_live_for` comparing against
+        // the token this loop was spawned with and tearing down a healthy socket
+        // on the next connect (#6181).
+        *shared.connection_identity.write() = Some((url.clone(), token.clone()));
         *shared.status.write() = ConnectionStatus::Connecting;
         emit_state_change(&shared);
 

--- a/src/openhuman/platform/socket/ws_loop_tests.rs
+++ b/src/openhuman/platform/socket/ws_loop_tests.rs
@@ -14,6 +14,7 @@ fn make_shared() -> Arc<SharedState> {
         status: RwLock::new(ConnectionStatus::Connected),
         socket_id: RwLock::new(None),
         error: RwLock::new(None),
+        connection_identity: RwLock::new(None),
     })
 }
 


### PR DESCRIPTION
## Summary

- A cold start opened **two** Engine.IO sessions ~2s apart because the core's bootstrap auto-connect and the renderer's `socket_connect_with_session` RPC each unconditionally ran `disconnect() → rebind → connect`.
- `SocketManager` now records the `(url, token)` its background loop is serving and exposes `is_live_for`; both connect paths consult it and skip the rebind when the live socket already serves that identity.
- **The reported impact does not occur**: the two sockets never coexist. Evidence and the corrected diagnosis are below.
- An account switch (same URL, new token) still forces a real disconnect → workflow-bridge rebind → reconnect, and any status other than `Connected` still reconnects.

## Problem

Two independent paths connect the same core to the same backend with the same session token:

- `spawn_socket_auto_connect` (`src/core/runtime/services.rs:491`) during core bootstrap, and
- `openhuman.socket_connect_with_session`, fired by `SocketProvider` (`app/src/providers/SocketProvider.tsx:53`) as soon as the session token appears in the core snapshot.

Both ran the full identity-rebind transaction unconditionally, so whichever went second tore down a socket that had **already completed its Socket.IO CONNECT ACK** and redid the whole handshake.

### The issue's stated impact is wrong — corrected here

The report infers from two `EIO OPEN` lines that both connections stay live, and warns about duplicate event delivery and a possible link to the #6174 ping timeouts. Reproducing on `~/.openhuman/logs/openhuman.2026-09-10.log` shows the opposite — the first socket is cleanly torn down between the two opens:

```
11:42:33 INF [socket] Connecting to https://api.tinyhumans.ai      <- manager.rs, auto-connect
11:42:33 INF [socket] Auto-connect initiated successfully
11:42:34 INF [socket] EIO OPEN: sid=WGTjZohffMDGOPhMAI9d           <- session 1
11:42:35 INF [socket:rpc] connect_with_session — resolving credentials  <- renderer RPC
11:42:35 INF [socket] SIO CONNECT ACK: sid=Some("ADD6Hz_DM7S8tTSKAI9e") <- session 1 fully authenticated
11:42:35 INF [socket] Shutdown signal received
11:42:35 INF [socket] Clean shutdown
11:42:35 INF [socket] WebSocket loop exiting                       <- session 1 gone
11:42:35 INF [socket] Connecting to https://api.tinyhumans.ai
11:42:36 INF [socket] EIO OPEN: sid=-IQboPAqg_P5gdomAI-O           <- session 2
```

The teardown is invisible in the reporter's excerpt because `SocketManager::disconnect` logs at `DEBUG` while `EIO OPEN` logs at `INFO`. There is therefore **no duplicate event delivery and no second live socket**, and this is unlikely to be a contributor to #6174.

What is real: a full authenticated handshake is thrown away on every launch, there is a ~1s window with no socket at all (anything inbound in it is discarded — the renderer is the only persister of thread messages), and a backend session is burned per start.

Both log lines are from `[socket]`, the core's **outbound** Socket.IO client (`ws_loop_part_01.rs:501`) — not `[socketio]`, the renderer↔core server. No frontend change is involved.

## Solution

`SocketManager` gains `connection_identity: RwLock<Option<(String, String)>>`, set in `spawn_loop` from the token the entry point already validated, and cleared in `disconnect()`. `is_live_for(url, token)` reports `true` only when the status is `Connected` **and** that recorded pair matches.

- `ops::connect_with_session` is refactored into `connect_with_session_using(manager, url, token, provider, install_bridge)` — mirroring the existing `connect_static_using` seam — with the `is_live_for` short-circuit before the disconnect, so the transaction is drivable from tests without a `Config` fixture.
- `spawn_socket_auto_connect` gets the symmetric guard, closing the mirror-image race if the renderer ever wins.
- The guard must sit **before** the caller's `disconnect()`, not inside `spawn_loop`: by the time `spawn_loop` runs, the caller has already destroyed the socket and swapped the workflow bridge. That disconnect → bridge-install → connect ordering is load-bearing and is left untouched.

Deliberately not guarded: `ops::connect_static`, the explicit token-carrying RPC that also clears the identity-bound workflow plane. It records its identity like any other connect, so `is_live_for` is accurate for it, but an explicit imperative reconnect is left to do what it says.

`spawn_loop` now takes the validated token rather than calling the provider again, so the recorded credential is exactly the one the connection was started with (and one fewer profile-store read per connect).

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — three in `ops_tests.rs`: the redundant connect reuses the live socket, a **different token still rebinds**, and `is_live_for` is scoped to url+token and cleared on disconnect.
- [x] **Diff coverage ≥ 80%** — every changed line in `manager.rs` and `ops.rs` is exercised by the three new tests. The `services.rs` guard is the same predicate applied at the mirror call site and is not separately covered (it needs a bootstrap `Config`); coverage there rests on the `is_live_for` contract test. `pnpm test:coverage` not run: **no frontend files changed**.
- [x] N/A: behaviour-only change — no feature rows added, removed or renamed, so `docs/TEST-COVERAGE-MATRIX.md` is unchanged.
- [x] N/A: no matrix feature IDs apply to this change; the linked issue is listed under `## Related`.
- [x] No new external network dependencies introduced — the new tests drive a hand-rolled Engine.IO v4 mock on a `127.0.0.1:0` listener, in the style of the existing `ws_loop_tests.rs` mocks.
- [x] N/A: does not touch a release-cut surface in `docs/RELEASE-MANUAL-SMOKE.md`; the observable change is one fewer socket handshake at startup.
- [x] Linked issue closed via `Closes #6181` in the `## Related` section.

## Impact

- **Desktop/CLI (core):** one Engine.IO session at startup instead of two. Removes a ~1s post-handshake window in which the socket is torn down and re-established.
- **Backend:** one fewer authenticated Socket.IO session established and abandoned per app launch.
- **Security/identity:** the guard is conservative in the safe direction — it only ever *skips* a reconnect, and only when URL and token both match a `Connected` socket. Account switches, token rotation, and unhealthy sockets all still take the full rebind path, which is covered by a dedicated test.
- No migration, no API change, no frontend change.

## Related

- Closes: #6181
- Follow-up PR(s)/TODOs: none. Noted while tracing, not addressed here: a third `connect_with_session` arrived ~36s after startup in the same log (11:43:11), which the `SocketProvider` `previousTokenRef` guard should have suppressed — with this change it is a cheap no-op, but the repeated RPC itself is unexplained.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/6181-duplicate-startup-socket`
- Commit SHA: `e006558651f4469fa83b404bf2957d5efab88934`

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend files changed.
- [x] N/A: `pnpm typecheck` — no TypeScript files changed.
- [x] Focused tests: `cargo test -p openhuman --no-default-features --features "$(bash scripts/ci/product-features.sh)" --lib socket::` → **160 passed, 0 failed**.
- [x] Rust fmt/check: `cargo fmt`; `cargo clippy -p openhuman --features "$(bash scripts/ci/product-features.sh)" -- -D warnings` → clean; `cargo check --no-default-features` → exit 0 (proves the `#[cfg(feature = "flows")]` bridge closure compiles with flows off).
- [x] N/A: Tauri fmt/check — no Tauri sources changed.

### Validation Blocked

- `command:` `cargo test -p openhuman --lib --bins --features "$(bash scripts/ci/product-features.sh)"`
- `error:` 4 of 11799 failed under parallel execution — `budget_gate::{dropping_the_crate_permit_releases_the_scheduler_permit, explicit_release_returns_capacity_before_end_of_scope}`, `harness::session::builder::memory_access_instruction_is_present_with_learning_disabled`, `modules::ops::a_bounded_wait_with_nothing_cached_and_downloads_off_fails_rather_than_loading`.
- `impact:` None on this change. All four pass on re-run with `--test-threads=1`; they contend on process-global state and touch no socket code. Flagged rather than silently dropped.

### Behavior Changes

- Intended behavior change: a connect request for a URL+token already served by a `Connected` socket returns that socket's state instead of tearing it down and re-handshaking.
- User-visible effect: one socket session at startup instead of two, and no ~1s gap where the core has no backend connection. No UI change.

### Parity Contract

- Legacy behavior preserved: every connect whose identity differs from the live one — different backend URL, different session token, or a socket in any state other than `Connected` — takes the unchanged `disconnect → install bridge → connect` path. `connect_static` and `disconnect` are untouched. The `identity_rebind` lock still serializes the whole transaction, and the guard is evaluated inside it.
- Guard/fallback/dispatch parity checks: `a_session_connect_with_a_different_token_still_rebinds` asserts the bridge-install closure runs and a second EIO session opens when the token changes; `is_live_for_is_scoped_to_url_and_token_and_cleared_on_disconnect` asserts the predicate rejects a mismatched URL, a mismatched token, and a disconnected manager.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none — no cross-referenced PR on #6181 and no commit on `upstream/main` mentioning it.
- Canonical PR: this one.
- Resolution: N/A

### Reproduction and revert-check

Before touching production code, a probe asserted the defect against today's API — two `connect_with_provider` calls with an identical URL and token, against a mock Engine.IO server counting accepts:

```
probe_6181_second_identical_connect_opens_a_second_eio_session ... FAILED
  assertion `left == right` failed: a second connect for an identical
  identity opened a duplicate EIO session
    left: 2
   right: 1
```

The probe became `a_redundant_session_connect_reuses_the_live_socket`. Both halves of the fix were then reverted independently:

- Short-circuit removed from `connect_with_session_using` → `a_redundant_session_connect_reuses_the_live_socket` fails on `left: 2, right: 1`.
- Identity recording removed from `spawn_loop` → that test **and** `is_live_for_is_scoped_to_url_and_token_and_cleared_on_disconnect` fail.

One correction made along the way: the accept-count assertion was initially vacuous — `connect_with_provider` returns as soon as the loop is spawned, so the counter was read before a duplicate could arrive. `settle_for_a_second_accept` now waits out that window (returning early the moment a second accept appears), which is what makes the revert-check land on the duplicate-session assertion rather than a weaker downstream one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ipSkHi47nsBmnxX5dC4dA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant socket reconnections when the requested connection is already active.
  * Ensured connections are correctly refreshed when the URL or session token changes.
  * Preserved workflow functionality when reusing an active connection.
  * Improved socket state tracking and clearing after disconnects.

* **Tests**
  * Added coverage for connection reuse, workflow restoration, token changes, URL/token identity checks, and disconnect behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->