### PR TITLE
fix(skills): downgrade deprecated YAML field warnings to debug

### DIFF
--- a/src/openhuman/skills/ops_parse.rs
+++ b/src/openhuman/skills/ops_parse.rs
@@ -198,9 +198,9 @@ pub(crate) fn load_from_workflow_md(
         frontmatter.description.clone()
     };
 
-    let version = extract_version(&frontmatter, &mut warnings);
-    let author = extract_author(&frontmatter, &mut warnings);
-    let tags = extract_tags(&frontmatter, &mut warnings);
+    let version = extract_version(&frontmatter, &name, &mut warnings);
+    let author = extract_author(&frontmatter, &name, &mut warnings);
+    let tags = extract_tags(&frontmatter, &name, &mut warnings);
     let platforms = frontmatter.platforms.clone();
     let related_skills = extract_related_skills(&frontmatter);
     let source_format = detect_source_format(&frontmatter);

--- a/src/openhuman/skills/ops_types.rs
+++ b/src/openhuman/skills/ops_types.rs
@@ -126,12 +126,22 @@ pub(crate) fn metadata_string_seq(value: &serde_yaml::Value) -> Vec<String> {
         .unwrap_or_default()
 }
 
-pub(crate) fn extract_version(fm: &WorkflowFrontmatter, warnings: &mut Vec<String>) -> String {
+pub(crate) fn extract_version(
+    fm: &WorkflowFrontmatter,
+    name: &str,
+    warnings: &mut Vec<String>,
+) -> String {
     if let Some(v) = metadata_string(fm, "version") {
         return v;
     }
     if let Some(v) = fm.extra.get("version").and_then(|v| v.as_str()) {
-        log::warn!("[skills] top-level 'version' is deprecated; move under 'metadata.version'");
+        // The actionable, skill-named surface is the `warnings` vec below, which
+        // the Skills Explorer renders per skill. Keep the log line at debug (and
+        // name the skill) so it stays in a support dump without drowning cold
+        // starts and cron ticks, where discovery re-parses every skill (#6155).
+        log::debug!(
+            "[skills] skill '{name}': top-level 'version' is deprecated; move under 'metadata.version'"
+        );
         warnings
             .push("top-level 'version' is deprecated; move under 'metadata.version'".to_string());
         return v.to_string();
@@ -141,20 +151,27 @@ pub(crate) fn extract_version(fm: &WorkflowFrontmatter, warnings: &mut Vec<Strin
 
 pub(crate) fn extract_author(
     fm: &WorkflowFrontmatter,
+    name: &str,
     warnings: &mut Vec<String>,
 ) -> Option<String> {
     if let Some(v) = metadata_string(fm, "author") {
         return Some(v);
     }
     if let Some(v) = fm.extra.get("author").and_then(|v| v.as_str()) {
-        log::warn!("[skills] top-level 'author' is deprecated; move under 'metadata.author'");
+        log::debug!(
+            "[skills] skill '{name}': top-level 'author' is deprecated; move under 'metadata.author'"
+        );
         warnings.push("top-level 'author' is deprecated; move under 'metadata.author'".to_string());
         return Some(v.to_string());
     }
     None
 }
 
-pub(crate) fn extract_tags(fm: &WorkflowFrontmatter, warnings: &mut Vec<String>) -> Vec<String> {
+pub(crate) fn extract_tags(
+    fm: &WorkflowFrontmatter,
+    name: &str,
+    warnings: &mut Vec<String>,
+) -> Vec<String> {
     let mut tags = Vec::new();
     if let Some(v) = fm.metadata.get("tags") {
         tags.extend(metadata_string_seq(v));
@@ -168,7 +185,9 @@ pub(crate) fn extract_tags(fm: &WorkflowFrontmatter, warnings: &mut Vec<String>)
         tags.extend(metadata_string_seq(hermes_tags));
     }
     if let Some(v) = fm.extra.get("tags") {
-        log::warn!("[skills] top-level 'tags' is deprecated; move under 'metadata.tags'");
+        log::debug!(
+            "[skills] skill '{name}': top-level 'tags' is deprecated; move under 'metadata.tags'"
+        );
         warnings.push("top-level 'tags' is deprecated; move under 'metadata.tags'".to_string());
         tags.extend(metadata_string_seq(v));
     }


### PR DESCRIPTION
## Summary

- Downgrade the three `log::warn!` deprecation notices in `skills/ops_types.rs` (`extract_version`/`extract_author`/`extract_tags`) to `log::debug!` and include the skill name in the message.
- Keep the existing per-skill `warnings.push` channel untouched — it is the actionable surface already rendered in the Skills Explorer.

## Problem

On every skill parse, a skill using the old top-level `version`/`author`/`tags` YAML fields emits a WARN deprecation notice. Discovery re-parses every skill on each workflow lookup and cron tick, so these lines repeat on every cold start and cron pass, drowning real signal while triaging. The log line was also unactionable: it named neither the skill, the file, nor the path. There are no bundled skills to migrate (the issue's remediation step 1 is a no-op) — every warning comes from a user-installed or catalog-installed skill, so the noise, not a migration, is the real defect.

## Solution

- The deprecated fields are still honoured (`extract_*` return the value and fall through), so there is no functional change — only log level and content.
- The three notices move to `debug`, so they survive in a support log dump without flooding WARN.
- Each message now names the skill (`name` is already in scope at the caller and is threaded into the three extractors), making the line actionable if it is ever read.
- The structured `warnings` vec — the channel that already names the skill in the UI — is deliberately left as-is. No warn-once dedup cache was added: it would be per-process state to suppress a message that should not be at WARN in the first place, and it would not survive the app restarts that produce most of these lines.

## Submission Checklist

- [x] Tests added or updated — the existing `deprecated_top_level_fields_load_with_migration_warning` exercises all three changed extractors; this is a log-level-only change and the `warnings` vec behaviour is unchanged, so no new assertion path is required.
- [x] **Diff coverage ≥ 80%** — the changed extractor branches are exercised by the existing test above; the CI diff-cover gate enforces the threshold. (`diff-cover` not run locally.)
- [x] Coverage matrix updated — `N/A: log-level-only change, no feature row added/removed/renamed`.
- [x] All affected feature IDs listed in `## Related` — `N/A: no matrix rows touched`.
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — `N/A: does not touch release-cut surfaces`.
- [x] Linked issue closed via `Closes #NNN` in `## Related`.

## Impact

- Desktop/CLI only, log-readability improvement. No runtime behaviour change: deprecated fields keep working, the Skills Explorer warning is unchanged. No performance, security, or migration implications.

## Related

- Closes: #6155
- Follow-up PR(s)/TODOs: the double full-disk skill rescan in `get_workflow_with_profile` (`registry.rs`) is why this warning set repeats as often as it does — tracked separately as #6166, out of scope here.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/6155-skill-yaml-deprecation-log-level`
- Commit SHA: `eca2bd85e`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `cargo test --lib skills::` → 296 passed, 0 failed
- [x] Rust fmt/check (if changed): `cargo fmt` clean; `cargo clippy -p openhuman -- -D warnings` — no findings referencing changed files
- [ ] Tauri fmt/check (if changed): N/A — no shell change

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: three skill-YAML deprecation notices move from WARN to DEBUG and gain the skill name.
- User-visible effect: quieter cold-start / cron logs; Skills Explorer warning unchanged.

### Parity Contract

- Legacy behavior preserved: deprecated fields still parsed and honoured; `warnings` vec unchanged.
- Guard/fallback/dispatch parity checks: N/A.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A
