### PR TITLE
fix(flows): pre-flight Composio required args from the local contract

### DIFF
--- a/src/openhuman/flows/ops_part_03.rs
+++ b/src/openhuman/flows/ops_part_03.rs
@@ -455,6 +455,34 @@ pub(crate) async fn validate_tool_contracts(config: &Config, graph: &WorkflowGra
         let Some(toolkit) = toolkit_from_slug(slug) else {
             continue;
         };
+
+        // Local authoritative arg check, run BEFORE the live-catalog fetch below
+        // so it holds offline and when Composio's schema is silent about a field.
+        // This is the same pure pre-dispatch validator the runtime path runs
+        // (`prepare_execute_arguments`), which encodes OpenHuman's own required
+        // fields — e.g. GMAIL_SEND_EMAIL needs a recipient under any of the
+        // `to`/`recipient_email`/`recipientEmail` aliases. Every earlier gate
+        // delegates that question to the live catalog and skips when it is silent
+        // or unreachable, which is how a `to`-less email node reached dispatch
+        // (#6154). A required arg wired to an `=`-expression is a non-empty string
+        // and passes; a missing or empty literal is rejected here at author time.
+        if let Err(err) =
+            crate::openhuman::integrations::composio::execute_prepare::prepare_execute_arguments(
+                slug,
+                Some(node.config.get("args").cloned().unwrap_or(Value::Null)),
+            )
+        {
+            tracing::warn!(
+                target: "flows",
+                node = %node.id,
+                %slug,
+                %err,
+                "[flows] tool-contract check: local required-arg check failed — rejecting"
+            );
+            errors.push(format!("Node '{}': {err}", node.id));
+            continue;
+        }
+
         let Some(catalog) = fetch_live_toolkit_catalog(config, &toolkit).await else {
             tracing::debug!(
                 target: "flows",

--- a/src/openhuman/flows/ops_tests_part_08_tests.rs
+++ b/src/openhuman/flows/ops_tests_part_08_tests.rs
@@ -133,6 +133,48 @@ async fn validate_tool_contracts_passes_a_fully_wired_real_slug() {
     assert!(errors.is_empty(), "{errors:?}");
 }
 
+// #6154: the recipient-required rule for GMAIL_SEND_EMAIL lives in OpenHuman's
+// own `prepare_execute_arguments`, not in the live Composio schema. These two
+// seed NO catalog, so `fetch_live_toolkit_catalog` returns `None` and every
+// catalog-backed check is skipped — proving the local authoritative check runs
+// before that guard and holds offline.
+#[tokio::test]
+async fn validate_tool_contracts_rejects_gmail_missing_recipient_offline() {
+    let config = Config::default();
+    let g = graph(json!({
+        "nodes": [
+            { "id": "t", "kind": "trigger", "name": "Manual" },
+            { "id": "notify", "kind": "tool_call", "name": "Notify",
+              "config": { "slug": "GMAIL_SEND_EMAIL",
+                "args": { "subject": "hi", "body": "there" } } }
+        ],
+        "edges": [ { "from_node": "t", "to_node": "notify" } ]
+    }));
+    let errors = validate_tool_contracts(&config, &g).await;
+    assert_eq!(errors.len(), 1, "{errors:?}");
+    assert!(errors[0].contains("GMAIL_SEND_EMAIL"), "{}", errors[0]);
+    assert!(errors[0].contains("recipient"), "{}", errors[0]);
+    assert!(errors[0].contains("notify"), "{}", errors[0]);
+}
+
+#[tokio::test]
+async fn validate_tool_contracts_accepts_gmail_with_recipient_offline() {
+    let config = Config::default();
+    let g = graph(json!({
+        "nodes": [
+            { "id": "t", "kind": "trigger", "name": "Manual" },
+            { "id": "notify", "kind": "tool_call", "name": "Notify",
+              "config": { "slug": "GMAIL_SEND_EMAIL",
+                "args": { "to": "a@b.com", "body": "there" } } }
+        ],
+        "edges": [ { "from_node": "t", "to_node": "notify" } ]
+    }));
+    // A wired recipient passes the local check; the catalog-backed checks then
+    // skip offline, so the node raises no error.
+    let errors = validate_tool_contracts(&config, &g).await;
+    assert!(errors.is_empty(), "{errors:?}");
+}
+
 #[test]
 fn connection_refs_reject_the_transcript_wrong_id_naming_the_right_ref() {
     // Twitter node carrying the TIKTOK connection id: toolkit segment matches

--- a/src/openhuman/flows/tinyflows/caps/ops.rs
+++ b/src/openhuman/flows/tinyflows/caps/ops.rs
@@ -414,6 +414,24 @@ pub(crate) async fn preflight_composio_args(
     slug: &str,
     args: &Value,
 ) -> Result<()> {
+    // Local authoritative pre-flight: `prepare_execute_arguments` is the same
+    // pure check the Composio dispatch path runs, and it knows OpenHuman's own
+    // required fields (e.g. GMAIL_SEND_EMAIL's recipient under any of the
+    // `to`/`recipient_email`/`recipientEmail` aliases) even when the live schema
+    // is silent or the catalog is unreachable — the two cases where the
+    // `composio_required_args` check below degrades to a skip and lets a
+    // structurally-invalid call reach dispatch (#6154). Surface it here, at the
+    // named pre-flight seam, before dispatch.
+    if let Err(err) =
+        crate::openhuman::integrations::composio::execute_prepare::prepare_execute_arguments(
+            slug,
+            Some(args.clone()),
+        )
+    {
+        tracing::warn!(target: "flows", %slug, %err, "[flows] preflight: local required-arg check failed — failing before dispatch");
+        return Err(EngineError::Capability(err));
+    }
+
     let Some(required) = composio_required_args(config, slug).await else {
         tracing::debug!(target: "flows", %slug, "[flows] preflight: no schema for action — skipping required-arg check");
         return Ok(());

--- a/src/openhuman/flows/tinyflows/tinyflows_tests_part_01_tests.rs
+++ b/src/openhuman/flows/tinyflows/tinyflows_tests_part_01_tests.rs
@@ -367,6 +367,37 @@ async fn preflight_fails_before_dispatch_naming_the_missing_field() {
     .expect("wired args must pass preflight");
 }
 
+// #6154: GMAIL_SEND_EMAIL's recipient rule is OpenHuman's own
+// (`prepare_execute_arguments`), not the live Composio schema. With NO catalog
+// seeded the schema-backed check below can only skip, so this proves the local
+// authoritative check still fails a recipient-less send before dispatch. It
+// never seeds the `"gmail"` cache entry, so it is safe under this file's shared
+// process-global `LIVE_CATALOG_CACHE`.
+#[tokio::test]
+async fn preflight_fails_offline_on_gmail_missing_recipient() {
+    let tmp = TempDir::new().unwrap();
+    let config = test_config(&tmp);
+    let err = super::super::caps::preflight_composio_args(
+        &config,
+        "GMAIL_SEND_EMAIL",
+        &json!({ "subject": "hi", "body": "text" }),
+    )
+    .await
+    .expect_err("recipient-less GMAIL_SEND_EMAIL must fail preflight offline");
+    let msg = err.to_string();
+    assert!(msg.contains("GMAIL_SEND_EMAIL"), "{msg}");
+    assert!(msg.contains("recipient"), "{msg}");
+
+    // A wired recipient passes the local check (and then skips offline).
+    super::super::caps::preflight_composio_args(
+        &config,
+        "GMAIL_SEND_EMAIL",
+        &json!({ "to": "a@b.com", "subject": "hi", "body": "text" }),
+    )
+    .await
+    .expect("wired recipient must pass preflight");
+}
+
 #[tokio::test]
 async fn preflight_skips_when_no_schema_is_available() {
     let tmp = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- Reuse OpenHuman's own authoritative pre-dispatch validator (`prepare_execute_arguments`) to catch a missing Composio required arg (e.g. `GMAIL_SEND_EMAIL` with no recipient) at two earlier seams: author-time `validate_tool_contracts` and run-time `preflight_composio_args`.
- The author-time check runs **before** the live-catalog fetch, so it holds offline and when Composio's schema is silent about a field.
- The permissive UI/RPC save path (`flows_update`/`flows_create`) is intentionally left unchanged.

## Problem

A flow node using `GMAIL_SEND_EMAIL` without a `to`/`recipient_email` argument was only rejected at Composio dispatch time (locally, before any request left the machine — so no credits were spent, but the run wasted its first attempt and the failure was not surfaced ahead of time). The knowledge that this action needs a recipient lives in exactly one place — `integrations/composio/execute_prepare.rs::validate_gmail_send_email` — and it was the **last** gate in the chain. Every earlier gate delegates the required-arg question to Composio's live schema (`contract.required_args`) and degrades to a **skip** when that schema is silent or the catalog is unreachable ("best-effort, never false-rejects"). So there was no seam by which the local, authoritative knowledge reached author time or run-time pre-flight.

## Solution

- `prepare_execute_arguments` is a pure, I/O-free function that already encodes the authoritative rules for `GMAIL_SEND_EMAIL` (recipient required, under the `to`/`recipient_email`/`recipientEmail` aliases), `GMAIL_ADD_LABEL_TO_EMAIL`, `GOOGLECALENDAR_*`, and `NOTION_FETCH_DATA`. Reuse it rather than adding a second contract layer.
- **Author-time** (`flows/ops_part_03.rs::validate_tool_contracts`): call it per tool-call node right after the toolkit resolves and **before** `fetch_live_toolkit_catalog`, pushing its `Err` as a rejection. This closes the "catalog unreachable / schema silent → skip" hole and works offline. A required arg wired to an `=`-expression is a non-empty string and correctly passes; a missing or empty literal is correctly rejected.
- **Run-time** (`flows/tinyflows/caps/ops.rs::preflight_composio_args`): the same call at the top of the pre-flight, mapping `Err` to `EngineError::Capability`, so the failure surfaces at the named pre-flight seam (with the node and the wiring fix) instead of deep inside dispatch — even when the schema-backed check below can only skip.
- **Deliberately not changed:** the UI/RPC save path (`flows_update`/`flows_create`) stays permissive. It has an explicit `strict_gate` opt-in and its doc states the canvas may save a work-in-progress graph; making the required-arg check a hard save-time reject there would contradict that design and would start failing existing saved flows on their next edit. The author-time gate still covers the agent-builder save/propose/validate paths, and the run-time pre-flight covers everything at execution.

## Submission Checklist

- [x] Tests added or updated (happy path + failure/edge) — offline `validate_tool_contracts` reject + accept, and offline `preflight_composio_args` reject + accept.
- [x] **Diff coverage ≥ 80%** — both changed blocks are exercised by the added tests (full `flows::` suite green, 689/0, no regressions); the CI diff-cover gate enforces the threshold. (`diff-cover` not run locally.)
- [x] Coverage matrix updated — `N/A: validation-guardrail fix, no feature row added/removed/renamed`.
- [x] All affected feature IDs listed in `## Related` — `N/A: no matrix rows touched`.
- [x] No new external network dependencies introduced — the offline path uses the local validator only.
- [x] Manual smoke checklist updated — `N/A: does not touch release-cut surfaces`.
- [x] Linked issue closed via `Closes #NNN` in `## Related`.

## Impact

- Flows authoring + execution (desktop/CLI). A recipient-less `GMAIL_SEND_EMAIL` (and the other locally-known required args) is now rejected at flow-build/validate and at run-time pre-flight instead of only at dispatch. No credits or external side effects were involved before or after. Existing saved flows are unaffected until edited through the agent-builder path or run. No migration.

## Related

- Closes: #6154
- Follow-up PR(s)/TODOs: the test-fixture that fabricated the Composio contract (the reason this gate was inert in CI) is tracked separately as #6165.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/6154-composio-required-arg-preflight`
- Commit SHA: `73469678a`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check`
- [x] `pnpm typecheck`
- [x] Focused tests: `cargo test --lib flows::` → 689 passed, 0 failed (no existing flows test regressed)
- [x] Rust fmt/check (if changed): `cargo fmt` clean; `cargo clippy -p openhuman -- -D warnings` — no findings referencing changed files
- [x] Tauri fmt/check (if changed): N/A — no shell change

### Validation Blocked

- `command:` N/A
- `error:` N/A
- `impact:` N/A

### Behavior Changes

- Intended behavior change: a Composio tool-call node missing a locally-known required arg is rejected at author-time (agent-builder path) and at run-time pre-flight, instead of only at dispatch.
- User-visible effect: earlier, node-named error when building or running a flow whose email node has no recipient; no change to the permissive canvas save.

### Parity Contract

- Legacy behavior preserved: the catalog-backed checks and their best-effort skip are unchanged; the UI/RPC save path stays permissive; `=`-bound args still pass.
- Guard/fallback/dispatch parity checks: the dispatch-time check remains the last line for `=`-bound args that resolve empty at run-time.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this
- Resolution: N/A
