### PR TITLE
test(e2e): browser coverage for the managed OpenRouter catalog in the model picker

### DIFF
--- a/app/scripts/e2e-web-session.sh
+++ b/app/scripts/e2e-web-session.sh
@@ -112,6 +112,23 @@ label = "E2E Mock"
 endpoint = "http://127.0.0.1:${E2E_MOCK_PORT}/openai/v1"
 auth_style = "none"
 default_model = "e2e-mock-model"
+
+# The managed backend row. The unify_ai_provider_settings migration seeds this
+# on a real install, but its seed_cloud_providers step returns early when
+# cloud_providers is already non-empty -- and this fixture ships one entry, so
+# the managed row was never seeded here. Without it every managed-source model
+# listing fails with: no cloud provider with id or slug 'openhuman' found.
+#
+# auth_style MUST be spelled openhumanjwt. AuthStyle derives
+# serde rename_all = lowercase, so that -- not the openhuman_jwt that
+# AuthStyle::as_str returns -- is the wire value. An entry spelled the other
+# way fails to deserialize and is dropped from the array in silence.
+[[cloud_providers]]
+id = "p_e2e_openhuman"
+slug = "openhuman"
+label = "OpenHuman"
+endpoint = "http://127.0.0.1:${E2E_MOCK_PORT}/v1"
+auth_style = "openhumanjwt"
 EOF
 
 node "$REPO_ROOT/scripts/mock-api-server.mjs" --port "$E2E_MOCK_PORT" >"$OPENHUMAN_WORKSPACE/mock.log" 2>&1 &

--- a/app/test/playwright/specs/chat-model-managed-catalog.spec.ts
+++ b/app/test/playwright/specs/chat-model-managed-catalog.spec.ts
@@ -1,0 +1,268 @@
+/**
+ * Managed OpenRouter catalog in the composer's model picker.
+ *
+ * `#6201` (feat(inference): surface the managed OpenRouter catalog in the model
+ * picker) shipped with unit tests only, and those tests mock
+ * `listProviderModels` outright — so nothing exercised the chain that actually
+ * has to work: browser → core RPC `openhuman.inference_list_models` →
+ * `list_configured_models_from_config` resolving the managed backend's URL and
+ * session JWT → `GET /openai/v1/models?catalog=openrouter` → back through the
+ * picker's render and round-trip helpers.
+ *
+ * # Why the sibling spec could not cover this
+ *
+ * `chat-model-override.spec.ts` documents (and deletes) a case that could not
+ * be made honest: the only selectable source in this fixture was the managed
+ * tier, managed was already the active model, and managed carried no model id —
+ * so "select managed" was a legitimate no-op with nothing observable to assert.
+ *
+ * #6201 is exactly what changes that. Managed now carries a model id, so a
+ * selection is observable in the chip label, and the same source can be driven
+ * to two distinguishable states. That is what makes these cases possible at all.
+ *
+ * # What is pinned here, and why each one can regress
+ *
+ * 1. The managed pane lists catalog models. Before #6201 it showed prose and no
+ *    models; a regression in the fetch seam (`fetchSlug`, the managed URL, the
+ *    session credential) puts it straight back there.
+ * 2. Round-trip. A pinned managed id is encoded BARE, and `selectionFromValue`
+ *    used to decode anything without a `:` to null — the selection vanished on
+ *    reopen. Only a reopen catches it.
+ * 3. A `:free` variant renders its full name. `displayValue` used to split on
+ *    `:` as if it were `providerSlug:model` and render the chip as "free".
+ * 4. Options are labelled by display name and charged price, not a bare slug.
+ *
+ * Item 4 of the PR — cost classification of `openrouter/<a>/<b>` as `Managed`
+ * rather than `Byok` — is deliberately NOT here. It is a pure core-side routing
+ * decision with no browser-observable surface, and `route_tests.rs` covers it
+ * directly.
+ *
+ * # Environment dependency, stated plainly
+ *
+ * The catalog comes from the mock backend's `GET /openai/v1/models` route
+ * (`scripts/mock-api/routes/llm.mjs`), which serves the curated tier list
+ * without `?catalog=openrouter` and the passthrough catalog with it. That
+ * two-shape distinction is the feature. Against a real backend with
+ * `OPENROUTER_PASSTHROUGH_ENABLED` off the catalog is empty and no select
+ * renders — expected behaviour, pinned by its own case below.
+ */
+import { expect, type Locator, type Page, test } from '@playwright/test';
+
+import { bootAuthenticatedPage, dismissWalkthroughIfPresent } from '../helpers/core-rpc';
+
+const MOCK_ADMIN_BASE = `http://127.0.0.1:${process.env.E2E_MOCK_PORT || '18473'}`;
+const USER_ID = 'pw-chat-managed-catalog';
+
+/** Mirrors the fixture in `scripts/mock-api/routes/llm.mjs`. */
+const PLAIN_ID = 'openrouter/nex-agi/nex-n2.5-mini';
+const FREE_ID = 'openrouter/nex-agi/nex-n2.5-mini:free';
+const NO_METADATA_ID = 'openrouter/acme/plain-model';
+
+async function resetMock(): Promise<void> {
+  await fetch(`${MOCK_ADMIN_BASE}/__admin/reset`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+}
+
+async function setMockBehavior(key: string, value: string): Promise<void> {
+  await fetch(`${MOCK_ADMIN_BASE}/__admin/behavior`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ key, value }),
+  });
+}
+
+/**
+ * Make `isTauri()` true for this page.
+ *
+ * `listProviderModels` (`aiSettingsApi.ts:778-781`) returns `[]` without
+ * issuing any RPC when `isTauri()` is false — its comment says "browser dev
+ * mode has no RPC bridge", which is stale for this lane: `callCoreRpc` reaches
+ * the core over plain HTTP here and ~58 other RPCs succeed on a single page
+ * load. Without this shim the managed catalog fetch never leaves the browser,
+ * the pane renders no select, and every case below fails for a reason that has
+ * nothing to do with #6201.
+ *
+ * The stubbed `invoke` is never reached: `callCoreRpc` dispatches
+ * `openhuman.*` methods over HTTP, not through the Tauri IPC bridge. Same
+ * pattern as `settings-advanced-config.spec.ts` and
+ * `settings-recovery-phrase-replace.spec.ts`.
+ */
+async function emulateTauriRuntime(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const win = window as typeof window & {
+      isTauri?: boolean;
+      __TAURI_INTERNALS__?: { invoke?: (cmd: string, args?: unknown) => Promise<unknown> };
+    };
+    win.isTauri = true;
+    win.__TAURI_INTERNALS__ = win.__TAURI_INTERNALS__ ?? {};
+    win.__TAURI_INTERNALS__.invoke = win.__TAURI_INTERNALS__.invoke ?? (async () => null);
+  });
+}
+
+async function openChat(page: Page): Promise<void> {
+  await bootAuthenticatedPage(page, USER_ID, '/chat');
+  await dismissWalkthroughIfPresent(page);
+  await expect(page.getByTestId('chat-message-input')).toBeVisible({ timeout: 30_000 });
+  await emulateTauriRuntime(page);
+}
+
+const modelChip = (page: Page): Locator =>
+  page.locator('[data-analytics-id="chat-model-selector"]');
+const pickerTitle = (page: Page): Locator => page.getByText('Choose provider and model');
+const managedSelect = (page: Page): Locator => page.getByTestId('model-picker-managed-select');
+
+/**
+ * Open the picker and land on the managed source's pane.
+ *
+ * The source row is clicked ONLY when the dialog did not already open on the
+ * managed pane. `selectSource` (`ProviderModelPickerDialog.tsx:211-213`) does an
+ * unconditional `setModel('')`, so re-clicking the source you are already on
+ * silently discards the pinned model — which would destroy exactly the state a
+ * reopen is meant to verify and turn a passing round-trip into a false failure.
+ * When a managed model is pinned the dialog opens on managed anyway, because
+ * `source` is seeded from `initial?.source`.
+ */
+async function openManagedPane(page: Page): Promise<void> {
+  await modelChip(page).click();
+  await expect(pickerTitle(page)).toBeVisible({ timeout: 10_000 });
+  if ((await page.getByTestId('model-picker-managed-pane').count()) === 0) {
+    await page.getByText('Managed by OpenHuman', { exact: true }).first().click();
+  }
+  await expect(page.getByTestId('model-picker-managed-pane')).toBeVisible();
+}
+
+/** Cold start budget, as measured and explained in `chat-model-override.spec.ts`. */
+test.describe.configure({ timeout: 120_000 });
+
+test.describe('Managed OpenRouter catalog in the model picker', () => {
+  test.beforeEach(async () => {
+    await resetMock();
+  });
+
+  test('the managed pane lists the backend catalog, labelled by name and price', async ({
+    page,
+  }) => {
+    await openChat(page);
+    await openManagedPane(page);
+
+    const select = managedSelect(page);
+    await expect(
+      select,
+      'before #6201 the managed pane rendered prose and no model control at all'
+    ).toBeVisible({ timeout: 20_000 });
+
+    // The catalog reached the browser through the real core fetch, not a stub.
+    const optionValues = await select.locator('option').evaluateAll(nodes =>
+      nodes.map(node => (node as HTMLOptionElement).value)
+    );
+    expect(optionValues).toContain(PLAIN_ID);
+    expect(optionValues).toContain(FREE_ID);
+    // "Automatic" is always present so a pin is reversible.
+    expect(optionValues).toContain('');
+
+    // Labelled by display name + charged price, not the bare slug. Asserting
+    // the price text matters: the id alone would satisfy a label that ignored
+    // `display_name` / `pricing` entirely.
+    const plainLabel = await select.locator(`option[value="${PLAIN_ID}"]`).textContent();
+    expect(plainLabel?.trim()).toBe('Nex N2.5 Mini — $0.15/$0.6 per 1M');
+
+    // A catalog entry with neither name nor pricing falls back to the bare id
+    // rather than rendering "undefined" or an empty option.
+    const plainestLabel = await select
+      .locator(`option[value="${NO_METADATA_ID}"]`)
+      .textContent();
+    expect(plainestLabel?.trim()).toBe(NO_METADATA_ID);
+  });
+
+  test('a pinned managed model survives closing and reopening the picker', async ({ page }) => {
+    await openChat(page);
+
+    const chip = modelChip(page);
+    const before = (await chip.textContent())?.trim() ?? '';
+    // Without this the case is vacuous: an empty label before and after would
+    // compare equal while proving nothing.
+    expect(before, 'the model chip must name the current model').not.toBe('');
+
+    await openManagedPane(page);
+    await expect(managedSelect(page)).toBeVisible({ timeout: 20_000 });
+    await managedSelect(page).selectOption(PLAIN_ID);
+    await page.getByRole('button', { name: 'Use this model' }).click();
+    await expect(pickerTitle(page)).toHaveCount(0);
+
+    // The pin took effect: the chip names the pinned model, not what it named
+    // before. A handler that discarded the selection fails right here.
+    await expect(chip).toHaveText(/nex-n2\.5-mini/, { timeout: 10_000 });
+    expect((await chip.textContent())?.trim() ?? '').not.toBe(before);
+
+    // The round trip: reopen and the select still shows the pinned id.
+    // `selectionFromValue` decoded a bare id (no `:`) to null, so the selection
+    // was silently dropped here and the pane reopened on "Automatic".
+    await openManagedPane(page);
+    await expect(managedSelect(page)).toBeVisible({ timeout: 20_000 });
+    await expect(
+      managedSelect(page),
+      'a pinned managed id round-trips through selectionValue/selectionFromValue'
+    ).toHaveValue(PLAIN_ID);
+  });
+
+  test('a :free variant keeps its full name on the chip', async ({ page }) => {
+    await openChat(page);
+    await openManagedPane(page);
+    await expect(managedSelect(page)).toBeVisible({ timeout: 20_000 });
+
+    await managedSelect(page).selectOption(FREE_ID);
+    await page.getByRole('button', { name: 'Use this model' }).click();
+    await expect(pickerTitle(page)).toHaveCount(0);
+
+    const chip = modelChip(page);
+    // `displayValue` split on the FIRST `:` as if this were `providerSlug:model`,
+    // reducing the whole id to the bare word "free".
+    await expect(chip).toHaveText(/nex-n2\.5-mini:free/, { timeout: 10_000 });
+    expect(
+      (await chip.textContent())?.trim(),
+      'the chip must not collapse the variant suffix into just "free"'
+    ).not.toBe('free');
+
+    // And it round-trips: the variant suffix is not lost on reopen either.
+    await openManagedPane(page);
+    await expect(managedSelect(page)).toHaveValue(FREE_ID, { timeout: 20_000 });
+  });
+
+  test('a pinned model can be cleared back to automatic', async ({ page }) => {
+    await openChat(page);
+    await openManagedPane(page);
+    await expect(managedSelect(page)).toBeVisible({ timeout: 20_000 });
+    await managedSelect(page).selectOption(PLAIN_ID);
+    await page.getByRole('button', { name: 'Use this model' }).click();
+    await expect(pickerTitle(page)).toHaveCount(0);
+    const pinned = (await modelChip(page).textContent())?.trim() ?? '';
+    expect(pinned).toMatch(/nex-n2\.5-mini/);
+
+    await openManagedPane(page);
+    await expect(managedSelect(page)).toHaveValue(PLAIN_ID, { timeout: 20_000 });
+    await managedSelect(page).selectOption('');
+    await page.getByRole('button', { name: 'Use this model' }).click();
+    await expect(pickerTitle(page)).toHaveCount(0);
+
+    // Back to automatic routing: the chip no longer names the pinned model.
+    await expect(modelChip(page)).not.toHaveText(/nex-n2\.5-mini/, { timeout: 10_000 });
+  });
+
+  test('an empty catalog renders no select, exactly as before the feature', async ({ page }) => {
+    // Models the real backend with OPENROUTER_PASSTHROUGH_ENABLED off: it
+    // returns an empty set with HTTP 200, not an error. The managed pane must
+    // degrade to its pre-#6201 appearance rather than surfacing a failure.
+    await setMockBehavior('managedCatalogEmpty', 'true');
+    await openChat(page);
+    await openManagedPane(page);
+
+    await expect(page.getByTestId('model-picker-managed-pane')).toBeVisible();
+    await expect(managedSelect(page)).toHaveCount(0);
+    // Managed is still selectable with no model id — the original contract.
+    await page.getByRole('button', { name: 'Use this model' }).click();
+    await expect(pickerTitle(page)).toHaveCount(0);
+  });
+});

--- a/app/test/playwright/specs/chat-model-managed-catalog.spec.ts
+++ b/app/test/playwright/specs/chat-model-managed-catalog.spec.ts
@@ -155,9 +155,9 @@ test.describe('Managed OpenRouter catalog in the model picker', () => {
     ).toBeVisible({ timeout: 20_000 });
 
     // The catalog reached the browser through the real core fetch, not a stub.
-    const optionValues = await select.locator('option').evaluateAll(nodes =>
-      nodes.map(node => (node as HTMLOptionElement).value)
-    );
+    const optionValues = await select
+      .locator('option')
+      .evaluateAll(nodes => nodes.map(node => (node as HTMLOptionElement).value));
     expect(optionValues).toContain(PLAIN_ID);
     expect(optionValues).toContain(FREE_ID);
     // "Automatic" is always present so a pin is reversible.
@@ -171,9 +171,7 @@ test.describe('Managed OpenRouter catalog in the model picker', () => {
 
     // A catalog entry with neither name nor pricing falls back to the bare id
     // rather than rendering "undefined" or an empty option.
-    const plainestLabel = await select
-      .locator(`option[value="${NO_METADATA_ID}"]`)
-      .textContent();
+    const plainestLabel = await select.locator(`option[value="${NO_METADATA_ID}"]`).textContent();
     expect(plainestLabel?.trim()).toBe(NO_METADATA_ID);
   });
 

--- a/scripts/mock-api/routes/llm.mjs
+++ b/scripts/mock-api/routes/llm.mjs
@@ -762,3 +762,74 @@ export function handleLlmCompletions(ctx) {
   );
   return true;
 }
+
+/**
+ * `GET /openai/v1/models` — the managed backend's model listing.
+ *
+ * Two deliberately different shapes behind one path, because that distinction
+ * is the whole point of the feature:
+ *
+ *   * **no `catalog` param** → only the curated tier list (`chat-v1`,
+ *     `reasoning-v1`, …), bare OpenAI-compatible entries with no display name
+ *     and no pricing. This is the legacy payload the client saw before the
+ *     OpenRouter passthrough existed.
+ *   * **`?catalog=openrouter`** → the passthrough catalog: `openrouter/<author>/<slug>`
+ *     ids, each with `name` and `pricing.{inputPer1M,outputPer1M}` so the picker
+ *     can label by name and charged price rather than a bare slug.
+ *
+ * The real backend gates the catalog on `OPENROUTER_PASSTHROUGH_ENABLED` and
+ * returns an EMPTY set when it is off — not an error. `managedCatalogEmpty`
+ * models that flag being off, so a spec can assert the picker degrades to the
+ * pre-feature behaviour (no select) rather than showing an error.
+ */
+const MANAGED_TIER_MODELS = [
+  { id: "chat-v1", object: "model", owned_by: "openhuman" },
+  { id: "reasoning-v1", object: "model", owned_by: "openhuman" },
+];
+
+const MANAGED_OPENROUTER_CATALOG = [
+  {
+    id: "openrouter/nex-agi/nex-n2.5-mini",
+    object: "model",
+    owned_by: "openrouter",
+    name: "Nex N2.5 Mini",
+    context_window: 131072,
+    pricing: { inputPer1M: 0.15, outputPer1M: 0.6 },
+  },
+  {
+    // The `:free` variant. `displayValue` used to split on `:` as if this were
+    // `providerSlug:model` and render the chip as the bare word "free".
+    id: "openrouter/nex-agi/nex-n2.5-mini:free",
+    object: "model",
+    owned_by: "openrouter",
+    name: "Nex N2.5 Mini (free)",
+    context_window: 131072,
+    pricing: { inputPer1M: 0, outputPer1M: 0 },
+  },
+  {
+    // No `name` and no `pricing`: the label must fall back to the bare id
+    // rather than rendering "undefined" or an empty option.
+    id: "openrouter/acme/plain-model",
+    object: "model",
+    owned_by: "openrouter",
+  },
+];
+
+export function handleModelListing(ctx) {
+  const { method, url, res } = ctx;
+  const [path, query = ""] = url.split("?");
+  if (method !== "GET" || !/^(\/openai)?(\/v1)?\/models\/?$/.test(path)) {
+    return false;
+  }
+  setCors(res);
+  const catalog = new URLSearchParams(query).get("catalog");
+  if (catalog !== "openrouter") {
+    json(res, 200, { object: "list", data: MANAGED_TIER_MODELS });
+    return true;
+  }
+  // Mirror OPENROUTER_PASSTHROUGH_ENABLED=false: an empty set, HTTP 200.
+  const data =
+    behavior().managedCatalogEmpty === "true" ? [] : MANAGED_OPENROUTER_CATALOG;
+  json(res, 200, { object: "list", data });
+  return true;
+}

--- a/scripts/mock-api/server.mjs
+++ b/scripts/mock-api/server.mjs
@@ -15,7 +15,7 @@ import { handleConversations } from "./routes/conversations.mjs";
 import { handleCron } from "./routes/cron.mjs";
 import { handleIntegrations } from "./routes/integrations.mjs";
 import { handleInvites } from "./routes/invites.mjs";
-import { handleLlmCompletions } from "./routes/llm.mjs";
+import { handleLlmCompletions, handleModelListing } from "./routes/llm.mjs";
 import { handleOAuth } from "./routes/oauth.mjs";
 import { handlePayments } from "./routes/payments.mjs";
 import { handleTelegram } from "./routes/telegram.mjs";
@@ -52,6 +52,7 @@ const ROUTE_HANDLERS = [
   // `handleIntegrations` so keyword-driven test scripts can override
   // the default "Hello from e2e mock agent" reply.
   handleLlmCompletions,
+  handleModelListing,
   handleIntegrations,
   handleWebhooks,
   handleCron,


### PR DESCRIPTION
## Summary

- Five Playwright cases covering the managed OpenRouter catalog in the composer's model picker, shipped by #6201 (merged `8d9734c6c`) with unit tests only.
- The mock backend gains `GET /openai/v1/models`, serving two deliberately different shapes: the curated tier list without a `catalog` param, the passthrough catalog with `?catalog=openrouter`.
- The e2e fixture gains the managed `openhuman` cloud-provider row it never had, without which every managed model listing fails.
- Two blockers had to be cleared to make a real fetch reachable from the browser at all. Both were verified in the browser, and one of them is a latent defect worth a look (see **Findings**).

## Problem

#6201's four picker tests and three `ModelQualityPill` tests all mock `listProviderModels`. That leaves the chain the feature actually depends on completely unexercised:

```
browser → callCoreRpc openhuman.inference_list_models
        → list_configured_models_from_config  (managed URL + session JWT)
        → GET /openai/v1/models?catalog=openrouter
        → ModelInfo{display_name, input_per_1m, output_per_1m}
        → picker render + selectionValue / selectionFromValue / displayValue
```

Every bug #6201 fixed lives on that chain, and a mocked `listProviderModels` cannot see any of it.

`chat-model-override.spec.ts` already drives this picker, and its header explains why it could not cover this before: the only selectable source in the fixture was the managed tier, managed was already the active model, and managed carried **no model id** — so "select managed" was a legitimate no-op with nothing observable to assert, and the author deleted the case rather than weaken it. #6201 is exactly what changes that: managed now carries a model id, so a selection is observable in the chip label.

## Solution

**Mock route** (`scripts/mock-api/routes/llm.mjs`). `GET /openai/v1/models` serves the curated tier list bare and the OpenRouter passthrough catalog under `?catalog=openrouter`. The catalog fixture is chosen to exercise the label and round-trip paths: a plain id with name + pricing, a `:free` variant, and one entry with **neither** name nor pricing so the label's fallback to the bare id is covered. A `managedCatalogEmpty` behaviour models `OPENROUTER_PASSTHROUGH_ENABLED` being off — an empty set with HTTP 200, not an error.

(The brief named `scripts/mock-api-server.mjs`; that file is a 55-line CLI wrapper. The routes live under `scripts/mock-api/`.)

**Spec** (`app/test/playwright/specs/chat-model-managed-catalog.spec.ts`), pinning what #6201 fixed:

1. the managed pane lists catalog models at all (it used to render prose and no control);
2. a pinned id round-trips through close/reopen (a bare id with no `:` decoded to `null` and the selection vanished);
3. a `:free` variant keeps its full name on the chip (it was split on `:` as if it were `providerSlug:model` and rendered as `free`);
4. options are labelled by display name and charged price, not a bare slug;
5. an empty catalog still renders no select — the pre-feature behaviour, which must survive.

**Not covered, deliberately:** cost classification of `openrouter/<author>/<slug>` as `Managed` rather than `Byok`. It is a pure core-side routing decision with no browser-observable surface, and `route_tests.rs` covers it directly. Forcing it through an e2e test would produce a worse test, not more coverage.

## Findings

Both were verified by observation, not read off the source.

**1. `listProviderModels` short-circuits outside Tauri, and its reason is stale.** `aiSettingsApi.ts:778-781` returns `[]` when `isTauri()` is false, commented "browser dev mode has no RPC bridge". This lane *does* have one: capturing every RPC POST during a single picker open recorded **58 calls and zero `inference_list_models`** — the catalog fetch never left the page, while everything else worked. The spec uses the lane's established `emulateTauriRuntime` shim (as in `settings-advanced-config.spec.ts` and `settings-recovery-phrase-replace.spec.ts`); `callCoreRpc` dispatches `openhuman.*` over HTTP, so the stubbed `invoke` is never reached. **Whether that guard should still be there is a product decision and is not touched here.**

**2. `AuthStyle`'s serde value and its `as_str()` disagree — a mismatched row is dropped in silence.** `AuthStyle` derives `#[serde(rename_all = "lowercase")]`, making the wire value `openhumanjwt`, while `AuthStyle::as_str()` returns `openhuman_jwt` (asserted at `tests/config_auth_app_state_connectivity_e2e.rs:691`). A `cloud_providers` entry spelled the `as_str()` way **fails to deserialize and is dropped from the array**, with no error logged — observed directly: present in `config.toml` before core start, absent after, while `auth_style = "none"` on the same row survived. The fixture is spelled `openhumanjwt` and carries a comment saying why. Anything else that persists this field by `as_str()` would silently lose the row; that seemed worth reporting rather than fixing here.

Separately, `unify_ai_provider_settings::seed_cloud_providers` returns early when `cloud_providers` is already non-empty, which is why this fixture — one entry, hand-written — never got the managed row.

## Impact

- Test-only plus the mock backend and the e2e session fixture. No product code changed.
- The added fixture row is a managed provider pointed at the local mock; it is inert for every other spec (`chat-model-override`'s two cases were re-run alongside and still pass).
- This lane does not run on PRs to `main`, so CI here says nothing about these tests. The evidence is the local runs recorded below.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — five cases; the empty-catalog case is the failure/degraded path, and the no-metadata catalog entry covers the label fallback.
- [x] N/A: **Diff coverage ≥ 80%** — this PR adds only tests and test fixtures; there are no changed product lines for `diff-cover` to measure.
- [x] N/A: Coverage matrix updated — no feature row added, removed, or renamed; this covers a feature that already shipped.
- [x] N/A: All affected feature IDs from the matrix are listed under `## Related` — no matrix rows are affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — the catalog is served by the existing mock backend; the one non-local request made during this work was a single unauthenticated GET to staging, recorded below.
- [x] N/A: Manual smoke checklist updated — no release-cut surface changes.
- [x] N/A: Linked issue closed via `Closes #NNN` — no tracking issue; this is follow-up coverage for the already-merged #6201.

## Related

- Follow-up coverage for #6201 (`8d9734c6c`). No `Closes` — that PR is already merged and there is no tracking issue.
- Follow-up PR(s)/TODOs: the two findings above (the `isTauri()` guard on `listProviderModels`; the `AuthStyle` serde / `as_str()` mismatch) are reported, not fixed.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A — no Linear issue; follow-up to GitHub PR #6201.
- URL: N/A

### Commit & Branch

- Branch: `test/e2e-openrouter-picker`
- Commit SHA: `4f51a633c5da8f62ec468a79552a322ee37db5b2`

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no product frontend files changed; the added spec was written to the lane's existing style.
- [x] `pnpm typecheck` — `tsc --noEmit -p app/tsconfig.json` clean with the new spec.
- [x] Focused tests: `pnpm test:e2e:web` scoped to this spec plus `chat-model-override.spec.ts` → **7 passed**. Mock route unit suite `node --test scripts/mock-api/routes/__tests__/llm.test.mjs` → **18 passed**.
- [x] N/A: Rust fmt/check — no Rust changed.
- [x] N/A: Tauri fmt/check — no Tauri code changed.

### Validation Blocked

- `command:` confirming whether the staging backend serves a non-empty OpenRouter catalog
- `error:` `GET https://staging-api.tinyhumans.ai/openai/v1/models?catalog=openrouter` → `401 {"errorCode":"UNAUTHORIZED"}`; the endpoint is deployed but needs a session token, and the app's core bearer is in memory
- `impact:` none on this PR — the empty-catalog case pins that behaviour either way. The only evidence that `OPENROUTER_PASSTHROUGH_ENABLED` is on is #6201's own note (117 models, 5/5 sampled served chat). Unverified independently.

### Behavior Changes

- Intended behavior change: none in product code. The e2e fixture now seeds a managed cloud-provider row, so managed model listings resolve in the web e2e lane instead of failing with `no cloud provider with id or slug 'openhuman' found`.
- User-visible effect: none.

### Parity Contract

- Legacy behavior preserved: the mock's `/openai/v1/models` returns the curated tier list when no `catalog` param is present, matching the legacy payload the client saw before the passthrough existed. The empty-catalog case pins that a backend with the flag off behaves exactly as it did pre-#6201.
- Guard/fallback/dispatch parity checks: `chat-model-override.spec.ts`'s two existing cases were run alongside the new file (7 passed total) to show the fixture change does not disturb specs that use the same picker.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A — none.
- Canonical PR: this one.
- Resolution (closed/superseded/updated): N/A

### Revert-check

Run in two parts, rebuilding `dist-web` between each — a Playwright revert-proof is vacuous without a rebuild, since the session serves the prebuilt bundle. Each revert was written to keep every import used, so the `noUnusedLocals` gate could not fail the build and leave a stale bundle passing as a green run.

- **Reverting the round-trip helpers** in `ModelQualityPill.tsx` (`selectionValue` back to `null` for managed; `selectionFromValue` / `displayValue` back to splitting on `:`) fails the round-trip, `:free` and clear-to-automatic cases. The round-trip failure names this PR's assertion: `Expected pattern: /nex-n2\.5-mini/ Received string: "e2e-mock-model"`. The listing case still passes, correctly — that revert does not touch the listing. (A fourth case failed on a 180s browser-launch timeout under machine load, not on an assertion.)
- **Reverting the managed pane's catalog select** in `ProviderModelPickerDialog.tsx` fails the listing case with this PR's own message: `before #6201 the managed pane rendered prose and no model control at all`.

Two flaws in the first draft of this spec were caught and fixed by these runs rather than shipped: the price label was asserted as `$.15/$.6` when the formatter emits `$0.15/$0.6`, and the reopen helper clicked the source row unconditionally — `selectSource` does an unconditional `setModel('')`, so re-selecting the source you are already on discards the pin, which turned a passing round-trip into a false failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ipSkHi47nsBmnxX5dC4dA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added end-to-end coverage for managed model catalogs in the composer’s model picker.
  - Verified display names, pricing, free-model labels, fallback identifiers, pinned-model persistence, and clearing pinned selections.
  - Confirmed that empty catalogs leave the managed source selectable without displaying an empty model selector.

- **Chores**
  - Expanded mock API coverage for managed model-listing responses, including curated models, OpenRouter catalogs, and empty results.
  - Added fixture coverage for managed provider configuration and model-listing resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->