### PR TITLE
fix(inference): stop the managed catalog erroring when the session is stale

### DIFF
--- a/src/openhuman/inference/provider/ops/models.rs
+++ b/src/openhuman/inference/provider/ops/models.rs
@@ -150,29 +150,51 @@ pub async fn list_configured_models_from_config(
         // Do NOT propagate a missing session: a self-hosted entry may carry a
         // provider-scoped key instead, and the auth arm below documents that
         // fallback. Only fail when neither credential exists, so the error the
-        // caller sees names the real problem. `require_live_session_token` also
-        // publishes `SessionExpired` for a locally-expired token, which we still
-        // want on the session path.
-        match crate::openhuman::security::credentials::session_support::require_live_session_token(
-            config,
-        ) {
-            Ok(token) => managed_token = token,
-            // Signed out is not a provider failure. The managed catalog simply
-            // has nothing to offer until there is a session, and the picker
-            // still shows managed with its automatic routing — so return an
-            // empty list rather than surfacing "could not load models".
-            Err(err) if api_key.is_empty() => {
+        // caller sees names the real problem.
+        //
+        // Classify the session directly rather than going through
+        // `require_live_session_token`, which flattens "signed out" and "could
+        // not read the credential store" into one opaque Err. A lock timeout or
+        // filesystem error is a recoverable fault the picker should surface —
+        // swallowing it into a successful empty catalog hides it (review, #6206).
+        // A store error still propagates; only a genuinely absent/expired
+        // session degrades to an empty list.
+        use crate::openhuman::security::credentials::session_support::{
+            classify_session_token, load_app_session_profile, publish_local_session_expiry,
+            SessionTokenCheck,
+        };
+        let profile = load_app_session_profile(config)?;
+        match classify_session_token(profile.as_ref(), chrono::Utc::now()) {
+            SessionTokenCheck::Live(token) => managed_token = token,
+            // Signed out is not a provider failure. The managed catalog has
+            // nothing to offer until there is a session, and managed stays
+            // selectable on its automatic routing — so return an empty list
+            // rather than surfacing "could not load models".
+            check if api_key.is_empty() => {
+                let reason = match check {
+                    SessionTokenCheck::Expired => {
+                        // Still announce the expiry: `require_live_session_token`
+                        // did this for us before, and without it an expired token
+                        // stays in the store with nothing prompting a re-auth.
+                        publish_local_session_expiry("list_configured_models");
+                        "session expired"
+                    }
+                    _ => "no session",
+                };
                 log::info!(
-                    "[providers][list_models] managed catalog unavailable — no live session ({err}); returning an empty list"
+                    "[providers][list_models] managed catalog unavailable — {reason}; returning an empty list"
                 );
                 return Ok(crate::rpc::RpcOutcome::new(
                     serde_json::json!({ "models": Vec::<ModelInfo>::new() }),
-                    vec!["no live session; managed catalog is empty".to_string()],
+                    vec![format!("{reason}; managed catalog is empty")],
                 ));
             }
-            Err(err) => {
+            check => {
+                if matches!(check, SessionTokenCheck::Expired) {
+                    publish_local_session_expiry("list_configured_models");
+                }
                 log::debug!(
-                    "[providers][list_models] no live session ({err}); falling back to the provider-scoped key"
+                    "[providers][list_models] no live session; falling back to the provider-scoped key"
                 );
             }
         }
@@ -270,7 +292,7 @@ pub async fn list_configured_models_from_config(
         // Scoped to the managed provider on purpose: for a BYOK provider a 401
         // IS the actionable error (a wrong or revoked API key), and hiding it
         // would strand the user with a silently empty dropdown.
-        if managed_401_means_signed_out(status.as_u16(), entry.auth_style) {
+        if managed_401_means_signed_out(status.as_u16(), entry.auth_style, &managed_token) {
             log::info!(
                 "[providers][list_models] managed catalog unavailable — backend rejected the session token (401); returning an empty list"
             );

--- a/src/openhuman/inference/provider/ops/models.rs
+++ b/src/openhuman/inference/provider/ops/models.rs
@@ -214,6 +214,11 @@ pub async fn list_configured_models_from_config(
         validate_openrouter_api_key(&client, &routing.endpoint, &api_key).await?;
     }
 
+    // Whether the app session token actually made it onto the wire. It is not
+    // the same question as "is `managed_token` non-empty": the credential-safety
+    // guard below can decline to attach it, and a 401 on an unauthenticated
+    // request must not be read as a stale session (review, #6206).
+    let mut managed_session_attached = false;
     let mut request = client.get(&models_url);
     if routing.using_oauth {
         request = request
@@ -249,6 +254,7 @@ pub async fn list_configured_models_from_config(
             } else {
                 api_key.as_str()
             };
+            managed_session_attached = managed_session_attaches(&managed_token, &models_url);
             // Never put a bearer credential on the wire in clear text. `https`
             // or a loopback host only — loopback stays allowed so a local
             // backend (BACKEND_URL=http://127.0.0.1:...) still works in dev.
@@ -292,7 +298,8 @@ pub async fn list_configured_models_from_config(
         // Scoped to the managed provider on purpose: for a BYOK provider a 401
         // IS the actionable error (a wrong or revoked API key), and hiding it
         // would strand the user with a silently empty dropdown.
-        if managed_401_means_signed_out(status.as_u16(), entry.auth_style, &managed_token) {
+        if managed_401_means_signed_out(status.as_u16(), entry.auth_style, managed_session_attached)
+        {
             log::info!(
                 "[providers][list_models] managed catalog unavailable — backend rejected the session token (401); returning an empty list"
             );

--- a/src/openhuman/inference/provider/ops/models.rs
+++ b/src/openhuman/inference/provider/ops/models.rs
@@ -83,6 +83,7 @@ pub async fn list_configured_models_from_config(
         .find(|e| e.id == provider_id || e.slug == provider_id)
         .cloned()
         .or_else(|| synthesize_local_runtime_entry(&provider_id, config))
+        .or_else(|| synthesize_managed_entry(&provider_id))
         .ok_or_else(|| format!("no cloud provider with id or slug '{}' found", provider_id))?;
 
     let looked_up =
@@ -154,7 +155,19 @@ pub async fn list_configured_models_from_config(
             config,
         ) {
             Ok(token) => managed_token = token,
-            Err(err) if api_key.is_empty() => return Err(err),
+            // Signed out is not a provider failure. The managed catalog simply
+            // has nothing to offer until there is a session, and the picker
+            // still shows managed with its automatic routing — so return an
+            // empty list rather than surfacing "could not load models".
+            Err(err) if api_key.is_empty() => {
+                log::info!(
+                    "[providers][list_models] managed catalog unavailable — no live session ({err}); returning an empty list"
+                );
+                return Ok(crate::rpc::RpcOutcome::new(
+                    serde_json::json!({ "models": Vec::<ModelInfo>::new() }),
+                    vec!["no live session; managed catalog is empty".to_string()],
+                ));
+            }
             Err(err) => {
                 log::debug!(
                     "[providers][list_models] no live session ({err}); falling back to the provider-scoped key"
@@ -463,6 +476,38 @@ fn json_value_kind(v: &serde_json::Value) -> &'static str {
 /// Returns `None` for any slug that is not a recognized local-runtime
 /// alias — callers continue down the normal "no cloud provider" error
 /// path for `openai` / `anthropic` / opaque ids / typos.
+/// Synthesize the managed (`openhuman`) provider entry when `cloud_providers`
+/// has no row for it.
+///
+/// The row is normally seeded by the `unify_ai_provider_settings` migration,
+/// but it is absent in a freshly created profile — which is exactly what the
+/// app falls back to when a stored session is rejected server-side. Managed is
+/// the product's own backend, not user-supplied configuration, so requiring a
+/// config row to list its models turned "signed out" into
+/// "no cloud provider with id or slug 'openhuman' found".
+///
+/// Endpoint and auth style only have to identify the entry as managed: the
+/// caller replaces the URL with `effective_backend_api_url` and the credential
+/// with the live session token before the request goes out.
+fn synthesize_managed_entry(
+    slug: &str,
+) -> Option<crate::openhuman::config::schema::cloud_providers::CloudProviderCreds> {
+    use crate::openhuman::config::schema::cloud_providers::{AuthStyle, CloudProviderCreds};
+    if slug != "openhuman" {
+        return None;
+    }
+    Some(CloudProviderCreds {
+        id: "openhuman".to_string(),
+        slug: "openhuman".to_string(),
+        label: "OpenHuman".to_string(),
+        endpoint: crate::openhuman::config::schema::cloud_providers::CloudProviderType::Openhuman
+            .default_endpoint()
+            .to_string(),
+        auth_style: AuthStyle::OpenhumanJwt,
+        ..Default::default()
+    })
+}
+
 pub fn synthesize_local_runtime_entry(
     slug: &str,
     config: &crate::openhuman::config::Config,

--- a/src/openhuman/inference/provider/ops/models.rs
+++ b/src/openhuman/inference/provider/ops/models.rs
@@ -255,6 +255,28 @@ pub async fn list_configured_models_from_config(
 
     let status = response.status();
     if !status.is_success() {
+        // A 401 from the MANAGED catalog means the caller is not signed in —
+        // the stored session was rejected server-side even though its local
+        // `exp` was still valid, so `require_live_session_token` handed us a
+        // token the backend no longer honours. That is a signed-out state, not
+        // a provider failure, and rendering it as "could not load models" put a
+        // red error under managed for a user whose only problem is a stale
+        // session. Managed stays selectable on its automatic routing, so return
+        // an empty catalog and let the app's normal auth surfaces prompt for
+        // re-authentication.
+        //
+        // Scoped to the managed provider on purpose: for a BYOK provider a 401
+        // IS the actionable error (a wrong or revoked API key), and hiding it
+        // would strand the user with a silently empty dropdown.
+        if managed_401_means_signed_out(status.as_u16(), entry.auth_style) {
+            log::info!(
+                "[providers][list_models] managed catalog unavailable — backend rejected the session token (401); returning an empty list"
+            );
+            return Ok(crate::rpc::RpcOutcome::new(
+                serde_json::json!({ "models": Vec::<ModelInfo>::new() }),
+                vec!["session not accepted; managed catalog is empty".to_string()],
+            ));
+        }
         let body = response.text().await.unwrap_or_default();
         let sanitized = sanitize_api_error(&body);
         let truncated = crate::openhuman::util::truncate_with_ellipsis(&sanitized, 300);
@@ -591,6 +613,23 @@ pub fn model_items_from_body(body: &serde_json::Value) -> Option<Vec<serde_json:
         .and_then(|d| d.as_array())
         .or_else(|| body.get("models").and_then(|d| d.as_array()))
         .cloned()
+}
+
+/// Whether a non-2xx from a `/models` probe should be read as "signed out"
+/// rather than a provider failure.
+///
+/// Only for the MANAGED provider, and only on 401. A managed 401 means the
+/// stored session was rejected server-side — often while its local `exp` is
+/// still valid, so nothing upstream flagged it — which is a signed-out state,
+/// not a broken provider. For a BYOK provider a 401 IS the actionable error (a
+/// wrong or revoked API key); swallowing it there would strand the user with a
+/// silently empty dropdown and no clue why.
+fn managed_401_means_signed_out(
+    status: u16,
+    auth_style: crate::openhuman::config::schema::cloud_providers::AuthStyle,
+) -> bool {
+    use crate::openhuman::config::schema::cloud_providers::AuthStyle;
+    status == 401 && auth_style == AuthStyle::OpenhumanJwt
 }
 
 /// Whether a bearer credential may be attached to this URL.

--- a/src/openhuman/inference/provider/ops/models.rs
+++ b/src/openhuman/inference/provider/ops/models.rs
@@ -7,6 +7,8 @@ use super::super::openai_codex::{
 };
 use super::sanitize::sanitize_api_error;
 
+include!("models_part_01.rs");
+
 #[derive(Debug, Serialize)]
 pub struct ModelInfo {
     pub id: String,
@@ -478,58 +480,6 @@ fn json_value_kind(v: &serde_json::Value) -> &'static str {
     }
 }
 
-/// Synthesize a transient [`CloudProviderCreds`] entry for the well-known
-/// local-runtime slugs (`ollama`, `lmstudio`) so [`list_configured_models`]
-/// can probe their OpenAI-compatible `/v1/models` endpoint even when the
-/// user has not registered a matching `cloud_providers` row.
-///
-/// Background: the AI settings panel registers an `ollama` `cloud_providers`
-/// entry when the user configures Ollama (see comment on
-/// [`crate::openhuman::config::schema::cloud_providers::is_slug_reserved`]),
-/// but in practice some users hit
-/// `inference_list_models("ollama")` without that entry — config drift,
-/// flush-vs-probe race, or upgrade from a build that only persisted
-/// `config.local_ai.base_url`. Sentry TAURI-RUST-28Z captures this:
-/// 24 events / 7d, all `domain=rpc, method=openhuman.inference_list_models,
-/// operation=invoke_method`. Without this fallback, the dropdown surfaces
-/// the bare `"no cloud provider with id or slug 'ollama' found"` error
-/// (also visible in the Sentry breadcrumb) instead of returning models.
-///
-/// Returns `None` for any slug that is not a recognized local-runtime
-/// alias — callers continue down the normal "no cloud provider" error
-/// path for `openai` / `anthropic` / opaque ids / typos.
-/// Synthesize the managed (`openhuman`) provider entry when `cloud_providers`
-/// has no row for it.
-///
-/// The row is normally seeded by the `unify_ai_provider_settings` migration,
-/// but it is absent in a freshly created profile — which is exactly what the
-/// app falls back to when a stored session is rejected server-side. Managed is
-/// the product's own backend, not user-supplied configuration, so requiring a
-/// config row to list its models turned "signed out" into
-/// "no cloud provider with id or slug 'openhuman' found".
-///
-/// Endpoint and auth style only have to identify the entry as managed: the
-/// caller replaces the URL with `effective_backend_api_url` and the credential
-/// with the live session token before the request goes out.
-fn synthesize_managed_entry(
-    slug: &str,
-) -> Option<crate::openhuman::config::schema::cloud_providers::CloudProviderCreds> {
-    use crate::openhuman::config::schema::cloud_providers::{AuthStyle, CloudProviderCreds};
-    if slug != "openhuman" {
-        return None;
-    }
-    Some(CloudProviderCreds {
-        id: "openhuman".to_string(),
-        slug: "openhuman".to_string(),
-        label: "OpenHuman".to_string(),
-        endpoint: crate::openhuman::config::schema::cloud_providers::CloudProviderType::Openhuman
-            .default_endpoint()
-            .to_string(),
-        auth_style: AuthStyle::OpenhumanJwt,
-        ..Default::default()
-    })
-}
-
 pub fn synthesize_local_runtime_entry(
     slug: &str,
     config: &crate::openhuman::config::Config,
@@ -613,45 +563,6 @@ pub fn model_items_from_body(body: &serde_json::Value) -> Option<Vec<serde_json:
         .and_then(|d| d.as_array())
         .or_else(|| body.get("models").and_then(|d| d.as_array()))
         .cloned()
-}
-
-/// Whether a non-2xx from a `/models` probe should be read as "signed out"
-/// rather than a provider failure.
-///
-/// Only for the MANAGED provider, and only on 401. A managed 401 means the
-/// stored session was rejected server-side — often while its local `exp` is
-/// still valid, so nothing upstream flagged it — which is a signed-out state,
-/// not a broken provider. For a BYOK provider a 401 IS the actionable error (a
-/// wrong or revoked API key); swallowing it there would strand the user with a
-/// silently empty dropdown and no clue why.
-fn managed_401_means_signed_out(
-    status: u16,
-    auth_style: crate::openhuman::config::schema::cloud_providers::AuthStyle,
-) -> bool {
-    use crate::openhuman::config::schema::cloud_providers::AuthStyle;
-    status == 401 && auth_style == AuthStyle::OpenhumanJwt
-}
-
-/// Whether a bearer credential may be attached to this URL.
-///
-/// `https` always, plus loopback over plain `http` so a locally-hosted backend
-/// (`BACKEND_URL=http://127.0.0.1:5005`) still authenticates in development. Any
-/// other plaintext destination gets the request without the credential rather
-/// than leaking it.
-fn url_is_credential_safe(url: &str) -> bool {
-    match reqwest::Url::parse(url) {
-        Ok(parsed) => {
-            if parsed.scheme() == "https" {
-                return true;
-            }
-            matches!(
-                parsed.host_str(),
-                Some("localhost" | "127.0.0.1" | "::1" | "[::1]")
-            )
-        }
-        // Unparseable: treat as unsafe rather than guessing.
-        Err(_) => false,
-    }
 }
 
 fn model_info_from_catalog_item(item: &serde_json::Value) -> Option<ModelInfo> {

--- a/src/openhuman/inference/provider/ops/models_part_01.rs
+++ b/src/openhuman/inference/provider/ops/models_part_01.rs
@@ -1,0 +1,101 @@
+// Managed-provider helpers for the `/models` listing.
+//
+// Split out of `models.rs` to keep it under the repo's per-file line limit.
+// `include!`d textually rather than declared as a module, so these stay private
+// to `models` and the existing test module sees them unchanged — which also
+// means only `//` comments are legal here, not `//!`.
+//
+// All three exist because the MANAGED backend is not just another entry in
+// `cloud_providers`: it has its own URL, its own credential, and its own
+// meaning for a 401.
+
+/// Synthesize a transient [`CloudProviderCreds`] entry for the well-known
+/// local-runtime slugs (`ollama`, `lmstudio`) so [`list_configured_models`]
+/// can probe their OpenAI-compatible `/v1/models` endpoint even when the
+/// user has not registered a matching `cloud_providers` row.
+///
+/// Background: the AI settings panel registers an `ollama` `cloud_providers`
+/// entry when the user configures Ollama (see comment on
+/// [`crate::openhuman::config::schema::cloud_providers::is_slug_reserved`]),
+/// but in practice some users hit
+/// `inference_list_models("ollama")` without that entry — config drift,
+/// flush-vs-probe race, or upgrade from a build that only persisted
+/// `config.local_ai.base_url`. Sentry TAURI-RUST-28Z captures this:
+/// 24 events / 7d, all `domain=rpc, method=openhuman.inference_list_models,
+/// operation=invoke_method`. Without this fallback, the dropdown surfaces
+/// the bare `"no cloud provider with id or slug 'ollama' found"` error
+/// (also visible in the Sentry breadcrumb) instead of returning models.
+///
+/// Returns `None` for any slug that is not a recognized local-runtime
+/// alias — callers continue down the normal "no cloud provider" error
+/// path for `openai` / `anthropic` / opaque ids / typos.
+/// Synthesize the managed (`openhuman`) provider entry when `cloud_providers`
+/// has no row for it.
+///
+/// The row is normally seeded by the `unify_ai_provider_settings` migration,
+/// but it is absent in a freshly created profile — which is exactly what the
+/// app falls back to when a stored session is rejected server-side. Managed is
+/// the product's own backend, not user-supplied configuration, so requiring a
+/// config row to list its models turned "signed out" into
+/// "no cloud provider with id or slug 'openhuman' found".
+///
+/// Endpoint and auth style only have to identify the entry as managed: the
+/// caller replaces the URL with `effective_backend_api_url` and the credential
+/// with the live session token before the request goes out.
+fn synthesize_managed_entry(
+    slug: &str,
+) -> Option<crate::openhuman::config::schema::cloud_providers::CloudProviderCreds> {
+    use crate::openhuman::config::schema::cloud_providers::{AuthStyle, CloudProviderCreds};
+    if slug != "openhuman" {
+        return None;
+    }
+    Some(CloudProviderCreds {
+        id: "openhuman".to_string(),
+        slug: "openhuman".to_string(),
+        label: "OpenHuman".to_string(),
+        endpoint: crate::openhuman::config::schema::cloud_providers::CloudProviderType::Openhuman
+            .default_endpoint()
+            .to_string(),
+        auth_style: AuthStyle::OpenhumanJwt,
+        ..Default::default()
+    })
+}
+
+/// Whether a bearer credential may be attached to this URL.
+///
+/// `https` always, plus loopback over plain `http` so a locally-hosted backend
+/// (`BACKEND_URL=http://127.0.0.1:5005`) still authenticates in development. Any
+/// other plaintext destination gets the request without the credential rather
+/// than leaking it.
+fn url_is_credential_safe(url: &str) -> bool {
+    match reqwest::Url::parse(url) {
+        Ok(parsed) => {
+            if parsed.scheme() == "https" {
+                return true;
+            }
+            matches!(
+                parsed.host_str(),
+                Some("localhost" | "127.0.0.1" | "::1" | "[::1]")
+            )
+        }
+        // Unparseable: treat as unsafe rather than guessing.
+        Err(_) => false,
+    }
+}
+
+/// Whether a non-2xx from a `/models` probe should be read as "signed out"
+/// rather than a provider failure.
+///
+/// Only for the MANAGED provider, and only on 401. A managed 401 means the
+/// stored session was rejected server-side — often while its local `exp` is
+/// still valid, so nothing upstream flagged it — which is a signed-out state,
+/// not a broken provider. For a BYOK provider a 401 IS the actionable error (a
+/// wrong or revoked API key); swallowing it there would strand the user with a
+/// silently empty dropdown and no clue why.
+fn managed_401_means_signed_out(
+    status: u16,
+    auth_style: crate::openhuman::config::schema::cloud_providers::AuthStyle,
+) -> bool {
+    use crate::openhuman::config::schema::cloud_providers::AuthStyle;
+    status == 401 && auth_style == AuthStyle::OpenhumanJwt
+}

--- a/src/openhuman/inference/provider/ops/models_part_01.rs
+++ b/src/openhuman/inference/provider/ops/models_part_01.rs
@@ -95,7 +95,13 @@ fn url_is_credential_safe(url: &str) -> bool {
 fn managed_401_means_signed_out(
     status: u16,
     auth_style: crate::openhuman::config::schema::cloud_providers::AuthStyle,
+    managed_token: &str,
 ) -> bool {
     use crate::openhuman::config::schema::cloud_providers::AuthStyle;
-    status == 401 && auth_style == AuthStyle::OpenhumanJwt
+    // `managed_token` non-empty means the request actually carried the app
+    // session. When it is empty the request went out with the provider-scoped
+    // fallback key instead, and a 401 then means THAT key is wrong or revoked —
+    // an actionable credential error that must not be hidden behind an empty
+    // catalog just because the entry's auth_style is OpenhumanJwt (review, #6206).
+    status == 401 && auth_style == AuthStyle::OpenhumanJwt && !managed_token.is_empty()
 }

--- a/src/openhuman/inference/provider/ops/models_part_01.rs
+++ b/src/openhuman/inference/provider/ops/models_part_01.rs
@@ -92,16 +92,36 @@ fn url_is_credential_safe(url: &str) -> bool {
 /// not a broken provider. For a BYOK provider a 401 IS the actionable error (a
 /// wrong or revoked API key); swallowing it there would strand the user with a
 /// silently empty dropdown and no clue why.
+/// Whether the app session token will actually be attached to the managed
+/// request — the input to [`managed_401_means_signed_out`].
+///
+/// This is deliberately not "is there a session": `url_is_credential_safe`
+/// refuses to put a bearer token on a non-https, non-loopback URL, and in that
+/// case the request goes out unauthenticated even though a live session exists.
+/// A 401 on that request describes the misconfigured URL, not the session.
+///
+/// Note the token-emptiness check in the caller is subsumed here: whenever
+/// `managed_token` is non-empty it *is* the token being sent, so a non-empty
+/// managed token plus a safe URL is exactly the attach condition.
+fn managed_session_attaches(managed_token: &str, url: &str) -> bool {
+    !managed_token.is_empty() && url_is_credential_safe(url)
+}
+
 fn managed_401_means_signed_out(
     status: u16,
     auth_style: crate::openhuman::config::schema::cloud_providers::AuthStyle,
-    managed_token: &str,
+    managed_session_attached: bool,
 ) -> bool {
     use crate::openhuman::config::schema::cloud_providers::AuthStyle;
-    // `managed_token` non-empty means the request actually carried the app
-    // session. When it is empty the request went out with the provider-scoped
-    // fallback key instead, and a 401 then means THAT key is wrong or revoked —
-    // an actionable credential error that must not be hidden behind an empty
-    // catalog just because the entry's auth_style is OpenhumanJwt (review, #6206).
-    status == 401 && auth_style == AuthStyle::OpenhumanJwt && !managed_token.is_empty()
+    // Only a 401 on a request that actually carried the app session token says
+    // anything about the session. The two other ways to reach a 401 here are
+    // real, actionable faults that must not be hidden behind an empty catalog
+    // just because the entry's auth_style is OpenhumanJwt (review, #6206):
+    //
+    //   * no session, so the request went out on the provider-scoped fallback
+    //     key — a 401 means THAT key is wrong or revoked.
+    //   * a live session that the credential-safety guard refused to attach
+    //     (non-https, non-loopback backend URL) — the request was
+    //     unauthenticated, and the misconfigured URL is the thing to report.
+    status == 401 && auth_style == AuthStyle::OpenhumanJwt && managed_session_attached
 }

--- a/src/openhuman/inference/provider/ops/models_tests.rs
+++ b/src/openhuman/inference/provider/ops/models_tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    managed_401_means_signed_out, resolve_local_runtime_key, synthesize_managed_entry,
-    url_is_credential_safe,
+    managed_401_means_signed_out, managed_session_attaches, resolve_local_runtime_key,
+    synthesize_managed_entry, url_is_credential_safe,
 };
 use crate::openhuman::config::Config;
 
@@ -94,7 +94,7 @@ fn a_managed_401_reads_as_signed_out() {
     assert!(managed_401_means_signed_out(
         401,
         AuthStyle::OpenhumanJwt,
-        "session-jwt"
+        true
     ));
 }
 
@@ -107,7 +107,52 @@ fn a_401_against_the_fallback_key_still_surfaces() {
     assert!(!managed_401_means_signed_out(
         401,
         AuthStyle::OpenhumanJwt,
-        ""
+        false
+    ));
+}
+
+/// A live session is not enough on its own: the credential-safety guard refuses
+/// to attach a bearer token to a non-https, non-loopback URL, so the request
+/// goes out unauthenticated. Reporting that 401 as signed-out would hide the
+/// misconfigured backend URL behind an empty catalog — the same failure this
+/// whole change exists to stop.
+#[test]
+fn a_session_is_not_attached_to_an_unsafe_url() {
+    for url in [
+        "http://api.example.com/openai/v1/models",
+        "http://192.168.1.10:8080/openai/v1/models",
+    ] {
+        assert!(
+            !managed_session_attaches("session-jwt", url),
+            "a live session must not be attached to {url}"
+        );
+    }
+    for url in [
+        "https://api.tinyhumans.ai/openai/v1/models",
+        "http://127.0.0.1:8787/openai/v1/models",
+    ] {
+        assert!(
+            managed_session_attaches("session-jwt", url),
+            "a live session must be attached to {url}"
+        );
+    }
+    // No session: nothing to attach, whatever the URL.
+    assert!(!managed_session_attaches(
+        "",
+        "https://api.tinyhumans.ai/openai/v1/models"
+    ));
+}
+
+/// The two halves composed: a live session withheld by the safety guard reaches
+/// the 401 classifier as "not attached", so the error still surfaces.
+#[test]
+fn a_401_on_a_token_the_safety_guard_withheld_still_surfaces() {
+    use crate::openhuman::config::schema::cloud_providers::AuthStyle;
+    let attached = managed_session_attaches("session-jwt", "http://api.example.com/v1/models");
+    assert!(!managed_401_means_signed_out(
+        401,
+        AuthStyle::OpenhumanJwt,
+        attached
     ));
 }
 
@@ -119,13 +164,13 @@ fn other_statuses_and_providers_still_surface_the_error() {
     use crate::openhuman::config::schema::cloud_providers::AuthStyle;
     for style in [AuthStyle::Bearer, AuthStyle::Anthropic, AuthStyle::None] {
         assert!(
-            !managed_401_means_signed_out(401, style, "session-jwt"),
+            !managed_401_means_signed_out(401, style, true),
             "{style:?} 401"
         );
     }
     for status in [400, 403, 404, 429, 500, 503] {
         assert!(
-            !managed_401_means_signed_out(status, AuthStyle::OpenhumanJwt, "session-jwt"),
+            !managed_401_means_signed_out(status, AuthStyle::OpenhumanJwt, true),
             "managed {status}"
         );
     }

--- a/src/openhuman/inference/provider/ops/models_tests.rs
+++ b/src/openhuman/inference/provider/ops/models_tests.rs
@@ -1,4 +1,7 @@
-use super::{resolve_local_runtime_key, synthesize_managed_entry, url_is_credential_safe};
+use super::{
+    managed_401_means_signed_out, resolve_local_runtime_key, synthesize_managed_entry,
+    url_is_credential_safe,
+};
 use crate::openhuman::config::Config;
 
 #[test]
@@ -78,5 +81,32 @@ fn managed_entry_is_synthesized_when_the_config_row_is_missing() {
 fn other_slugs_do_not_synthesize_a_managed_entry() {
     for slug in ["openai", "openrouter", "ollama", "", "openhuman-x"] {
         assert!(synthesize_managed_entry(slug).is_none(), "{slug}");
+    }
+}
+
+/// A managed 401 is a signed-out state, not a provider failure: the stored
+/// session was rejected server-side while its local `exp` was still valid, so
+/// the picker rendered "could not load models" for a user whose only problem
+/// was a stale session.
+#[test]
+fn a_managed_401_reads_as_signed_out() {
+    use crate::openhuman::config::schema::cloud_providers::AuthStyle;
+    assert!(managed_401_means_signed_out(401, AuthStyle::OpenhumanJwt));
+}
+
+/// Everything else must keep surfacing the error. A BYOK 401 is the actionable
+/// case (wrong or revoked key) and must not be swallowed into an empty list,
+/// and a managed non-401 is a genuine provider failure.
+#[test]
+fn other_statuses_and_providers_still_surface_the_error() {
+    use crate::openhuman::config::schema::cloud_providers::AuthStyle;
+    for style in [AuthStyle::Bearer, AuthStyle::Anthropic, AuthStyle::None] {
+        assert!(!managed_401_means_signed_out(401, style), "{style:?} 401");
+    }
+    for status in [400, 403, 404, 429, 500, 503] {
+        assert!(
+            !managed_401_means_signed_out(status, AuthStyle::OpenhumanJwt),
+            "managed {status}"
+        );
     }
 }

--- a/src/openhuman/inference/provider/ops/models_tests.rs
+++ b/src/openhuman/inference/provider/ops/models_tests.rs
@@ -91,7 +91,24 @@ fn other_slugs_do_not_synthesize_a_managed_entry() {
 #[test]
 fn a_managed_401_reads_as_signed_out() {
     use crate::openhuman::config::schema::cloud_providers::AuthStyle;
-    assert!(managed_401_means_signed_out(401, AuthStyle::OpenhumanJwt));
+    assert!(managed_401_means_signed_out(
+        401,
+        AuthStyle::OpenhumanJwt,
+        "session-jwt"
+    ));
+}
+
+/// When no session existed, the request went out with the provider-scoped
+/// fallback key — so a 401 means THAT key is wrong or revoked. Hiding it behind
+/// an empty catalog would strand a self-hosted entry with no clue why.
+#[test]
+fn a_401_against_the_fallback_key_still_surfaces() {
+    use crate::openhuman::config::schema::cloud_providers::AuthStyle;
+    assert!(!managed_401_means_signed_out(
+        401,
+        AuthStyle::OpenhumanJwt,
+        ""
+    ));
 }
 
 /// Everything else must keep surfacing the error. A BYOK 401 is the actionable
@@ -101,11 +118,14 @@ fn a_managed_401_reads_as_signed_out() {
 fn other_statuses_and_providers_still_surface_the_error() {
     use crate::openhuman::config::schema::cloud_providers::AuthStyle;
     for style in [AuthStyle::Bearer, AuthStyle::Anthropic, AuthStyle::None] {
-        assert!(!managed_401_means_signed_out(401, style), "{style:?} 401");
+        assert!(
+            !managed_401_means_signed_out(401, style, "session-jwt"),
+            "{style:?} 401"
+        );
     }
     for status in [400, 403, 404, 429, 500, 503] {
         assert!(
-            !managed_401_means_signed_out(status, AuthStyle::OpenhumanJwt),
+            !managed_401_means_signed_out(status, AuthStyle::OpenhumanJwt, "session-jwt"),
             "managed {status}"
         );
     }

--- a/src/openhuman/inference/provider/ops/models_tests.rs
+++ b/src/openhuman/inference/provider/ops/models_tests.rs
@@ -1,4 +1,4 @@
-use super::{resolve_local_runtime_key, url_is_credential_safe};
+use super::{resolve_local_runtime_key, synthesize_managed_entry, url_is_credential_safe};
 use crate::openhuman::config::Config;
 
 #[test]
@@ -55,5 +55,28 @@ fn credentials_are_withheld_from_remote_plaintext_and_junk_urls() {
         "",
     ] {
         assert!(!url_is_credential_safe(url), "{url}");
+    }
+}
+
+/// The managed row is normally seeded by a migration, but a freshly created
+/// profile has none — which is what the app falls back to when a stored session
+/// is rejected. Managed is the product's own backend, so it must not depend on a
+/// user-config row; without this, being signed out surfaced
+/// "no cloud provider with id or slug 'openhuman' found".
+#[test]
+fn managed_entry_is_synthesized_when_the_config_row_is_missing() {
+    use crate::openhuman::config::schema::cloud_providers::AuthStyle;
+    let entry = synthesize_managed_entry("openhuman").expect("managed entry");
+    assert_eq!(entry.slug, "openhuman");
+    assert_eq!(entry.auth_style, AuthStyle::OpenhumanJwt);
+    assert!(!entry.endpoint.is_empty());
+}
+
+/// Only the managed slug synthesizes: anything else must keep reporting an
+/// unknown provider rather than being silently treated as managed.
+#[test]
+fn other_slugs_do_not_synthesize_a_managed_entry() {
+    for slug in ["openai", "openrouter", "ollama", "", "openhuman-x"] {
+        assert!(synthesize_managed_entry(slug).is_none(), "{slug}");
     }
 }

--- a/src/openhuman/security/credentials/session_support.rs
+++ b/src/openhuman/security/credentials/session_support.rs
@@ -211,26 +211,41 @@ pub fn require_live_session_token(config: &Config) -> Result<String, String> {
             Err("no backend session token; run auth_store_session first".to_string())
         }
         SessionTokenCheck::Expired => {
-            // Dedupe the publish via the scheduler gate so N parallel authed
-            // callers in one tick don't emit N SessionExpired events.
-            if !crate::openhuman::cron::scheduler_gate::is_signed_out() {
-                tracing::info!(
-                    domain = "credentials",
-                    operation = "require_live_session_token",
-                    "[credentials] app-session token expired locally — publishing SessionExpired before any backend call"
-                );
-                crate::core::bus::BUS.publish(crate::core::events::DomainEvent::SessionExpired {
-                    source: "credentials.local_expiry_precheck".to_string(),
-                    reason: "backend session token expired locally — re-authentication required"
-                        .to_string(),
-                });
-            }
+            publish_local_session_expiry("require_live_session_token");
             Err(
                 "SESSION_EXPIRED: backend session token expired locally — re-authentication required"
                     .to_string(),
             )
         }
     }
+}
+
+/// Announce a locally-detected session expiry on the bus so
+/// `SessionExpiredSubscriber` clears credentials and the UI re-authenticates,
+/// exactly as it would on a real network 401.
+///
+/// Callers that classify the session themselves — rather than going through
+/// [`require_live_session_token`] — MUST call this on the
+/// [`SessionTokenCheck::Expired`] arm. Classifying without publishing leaves an
+/// expired token in the store with the scheduler gate still open, so nothing
+/// ever prompts a re-auth (that regression was caught in review on #6206).
+///
+/// `operation` names the calling site for the log line only.
+pub fn publish_local_session_expiry(operation: &'static str) {
+    // Dedupe the publish via the scheduler gate so N parallel authed
+    // callers in one tick don't emit N SessionExpired events.
+    if crate::openhuman::cron::scheduler_gate::is_signed_out() {
+        return;
+    }
+    tracing::info!(
+        domain = "credentials",
+        operation = operation,
+        "[credentials] app-session token expired locally — publishing SessionExpired before any backend call"
+    );
+    crate::core::bus::BUS.publish(crate::core::events::DomainEvent::SessionExpired {
+        source: "credentials.local_expiry_precheck".to_string(),
+        reason: "backend session token expired locally — re-authentication required".to_string(),
+    });
 }
 
 /// Load the `app-session` profile once. Callers that need both the


### PR DESCRIPTION
## Summary

Two follow-ups to #6201, both found by pointing the desktop app at **production** — neither was reachable on staging, where the session was valid and the config row existed.

- Synthesize the managed (`openhuman`) provider entry when `cloud_providers` has no row for it.
- Treat a managed **401** as signed out rather than a provider failure.

Together they stop the picker showing a red *"Could not load models from this provider"* under **Managed by OpenHuman** whenever the user's session is stale.

## Problem

Against production the picker showed a load error, and the core logged in sequence — the second only appearing once the first was fixed:

```
list_models:unknown-provider provider_id="openhuman"
  error=no cloud provider with id or slug 'openhuman' found

list_models:error: provider returned 401: {"error":"Invalid token","errorCode":"UNAUTHORIZED"}
```

**First cause.** The `openhuman` row in `cloud_providers` is seeded by the `unify_ai_provider_settings` migration, but a freshly created profile has none — and that is exactly what the app falls back to when a stored session is rejected. Managed is the product's own backend, not user-supplied configuration, so requiring a config row turned "signed out" into "unknown provider".

**Second cause.** With the entry synthesized the flow got further: `require_live_session_token` returned `Ok` because a token existed with a locally-valid `exp` (Oct 7), the request went out, and the backend rejected it. The "no session" branch never fired, because there *was* a session locally — it was dead server-side.

## Solution

`synthesize_managed_entry` mirrors the existing `synthesize_local_runtime_entry` precedent; only the `openhuman` slug synthesizes, so any other unknown provider still reports an unknown-provider error. The endpoint and auth style only identify the entry as managed — the caller replaces the URL via `effective_backend_api_url` and the credential via the live session token before the request goes out.

`managed_401_means_signed_out` is extracted as a predicate so the decision is unit-testable; the branch itself sits behind a live HTTP call. **Scoped to `AuthStyle::OpenhumanJwt` deliberately** — for a BYOK provider a 401 IS the actionable error (a wrong or revoked API key), and swallowing it there would strand the user with a silently empty dropdown and no clue why.

Both paths return an empty catalog, which the picker already renders as "no select, no error", and managed stays selectable on its automatic routing.

## Not fixed here

The app still *believes* it is signed in: the local `exp` is in the future while the backend rejects every call, and `[jsonrpc] unconfirmed unauthorized error ... (not session expiry) — leaving session intact` means nothing drives re-authentication. Making that probe classify through `BackendOAuthClient` + `classify_sdk_error` is the fix, and it is the cross-repo `tinyhumans-sdk` work raised on #6201 — deliberately left to its own PR.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — 4 new cases: managed entry synthesized / only for that slug; a managed 401 reads as signed out / every other status and auth style still surfaces the error.
- [x] **Diff coverage ≥ 80%** — both new branches are exercised by those tests; the CI diff-cover gate enforces the threshold (`diff-cover` not run locally).
- [x] Coverage matrix updated — `N/A: behaviour-only change, no feature row added/removed/renamed`.
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix rows touched`.
- [x] No new external network dependencies introduced — same managed backend over the existing session-authed path.
- [x] Manual smoke checklist updated — `N/A: does not touch a release-cut surface`; the change only removes an error state.
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue`.

## Testing

- `cargo test --lib inference::provider::ops::models` — **9 passed**
- `cargo fmt --check`, `cargo check` — clean
- Verified live against production: the first fix removed the unknown-provider error, and the second removed the 401 error — `managed catalog unavailable ... returning an empty list` ×4, `list_models:error` 0.

## Related

Follow-up to #6201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE9ECLDivW9LsMZmEkbK9F


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Managed models now appear for fresh profiles even when provider configuration is not yet available.
  - Missing, expired, or unaccepted sessions now show an empty model list with an informational message instead of an error.
  - Credential-store failures continue to be reported rather than treated as signed-out sessions.
  - Session credentials are no longer sent to unsafe remote URLs.
  - Authentication failures are only interpreted as signed-out sessions when credentials were actually sent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->