### PR TITLE
feat(agents): let an agent default to a managed OpenRouter model

### DIFF
--- a/app/src/components/settings/panels/AgentEditorPage.test.tsx
+++ b/app/src/components/settings/panels/AgentEditorPage.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { agentRegistryApi, type AgentRegistryEntry } from '../../../services/api/agentRegistryApi';
+import { listProviderModels } from '../../../services/api/aiSettingsApi';
 import AgentEditorPage from './AgentEditorPage';
 
 vi.mock('../../../services/api/agentRegistryApi', () => ({
@@ -17,6 +18,8 @@ vi.mock('../../../services/api/agentRegistryApi', () => ({
   },
 }));
 
+vi.mock('../../../services/api/aiSettingsApi', () => ({ listProviderModels: vi.fn() }));
+
 const mockNavigate = vi.fn();
 vi.mock('react-router-dom', async importOriginal => {
   const actual = await importOriginal<typeof import('react-router-dom')>();
@@ -27,6 +30,7 @@ const mockGet = vi.mocked(agentRegistryApi.get);
 const mockAvailableTools = vi.mocked(agentRegistryApi.availableTools);
 const mockCreate = vi.mocked(agentRegistryApi.createCustom);
 const mockUpdate = vi.mocked(agentRegistryApi.update);
+const mockListProviderModels = vi.mocked(listProviderModels);
 
 function agent(overrides: Partial<AgentRegistryEntry> = {}): AgentRegistryEntry {
   return {
@@ -56,6 +60,7 @@ function renderAt(path: string) {
 describe('AgentEditorPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockListProviderModels.mockResolvedValue([]);
     mockAvailableTools.mockResolvedValue([
       { name: 'web_search', description: 'Search the web for information.' },
       { name: 'memory.search', description: 'Search the user memory store.' },
@@ -240,5 +245,64 @@ describe('AgentEditorPage', () => {
     await waitFor(() => {
       expect(screen.queryByRole('button', { name: 'Remove web_search' })).not.toBeInTheDocument();
     });
+  });
+
+  /**
+   * The agent's model is the persistent default for its chats, unlike the
+   * composer picker which only overrides the current conversation. Managed
+   * catalog models must therefore be selectable here, labelled by name and
+   * charged price rather than a bare slug.
+   */
+  it('offers managed catalog models and saves one as the agent default', async () => {
+    mockListProviderModels.mockResolvedValue([
+      {
+        id: 'openrouter/deepseek/deepseek-v4-flash',
+        owned_by: 'openrouter',
+        display_name: 'DeepSeek V4 Flash',
+        input_per_1m: 0.44,
+        output_per_1m: 1.32,
+      },
+    ]);
+    mockCreate.mockResolvedValue(agent({ id: 'helper', name: 'Helper' }));
+    renderAt('/settings/agents/new');
+
+    // Fetched with the managed slug, not a BYOK provider id.
+    await waitFor(() => expect(mockListProviderModels).toHaveBeenCalledWith('openhuman'));
+
+    const option = await screen.findByRole('option', {
+      name: /DeepSeek V4 Flash — \$0.44\/\$1.32 per 1M/,
+    });
+    expect(option).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Helper' } });
+    fireEvent.change(screen.getByLabelText('Description'), { target: { value: 'Helps out.' } });
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'openrouter/deepseek/deepseek-v4-flash' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Create agent/ }));
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalledTimes(1));
+    expect(mockCreate.mock.calls[0][0].model).toBe('openrouter/deepseek/deepseek-v4-flash');
+  });
+
+  /**
+   * A saved catalog id is not in KNOWN_MODELS, so the initial load flips the
+   * editor into free-text "custom" mode. The catalog arrives after that load, so
+   * without a re-check the user sees a raw id in a text box instead of the
+   * entry selected in the dropdown.
+   */
+  it('selects a saved managed model in the dropdown rather than the custom text box', async () => {
+    mockGet.mockResolvedValue(agent({ model: 'openrouter/deepseek/deepseek-v4-flash' }));
+    mockListProviderModels.mockResolvedValue([
+      { id: 'openrouter/deepseek/deepseek-v4-flash', owned_by: 'openrouter' },
+    ]);
+    renderAt('/settings/agents/edit/finance');
+
+    await waitFor(() =>
+      expect(screen.getByRole('combobox')).toHaveValue('openrouter/deepseek/deepseek-v4-flash')
+    );
+    // The custom free-text box is the fallback for an id the catalog lacks; it
+    // must not be showing for a model we can offer properly.
+    expect(screen.queryByLabelText(/Custom model id/i)).toBeNull();
   });
 });

--- a/app/src/components/settings/panels/AgentEditorPage.tsx
+++ b/app/src/components/settings/panels/AgentEditorPage.tsx
@@ -19,6 +19,7 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { useT } from '../../../lib/i18n/I18nContext';
 import { agentRegistryApi, type AgentRegistryEntry } from '../../../services/api/agentRegistryApi';
+import { listProviderModels, type ModelInfo } from '../../../services/api/aiSettingsApi';
 import { Alert, AlertDescription } from '../../ui/Alert';
 import Badge from '../../ui/Badge';
 import Button from '../../ui/Button';
@@ -57,6 +58,28 @@ const MODEL_TIERS = [
 const KNOWN_MODELS = new Set([...MODEL_HINTS, ...MODEL_TIERS]);
 const CUSTOM_MODEL = '__custom__';
 
+/**
+ * `cloud_providers` slug of the managed backend, used to list the models it can
+ * serve. Pinning one here sets the agent's persistent default — unlike the
+ * composer's picker, which only overrides the current conversation.
+ *
+ * The listing is the OpenRouter passthrough catalog and is empty unless the
+ * backend has `OPENROUTER_PASSTHROUGH_ENABLED` on, so the optgroup simply does
+ * not render against a backend without it.
+ */
+const MANAGED_PROVIDER_SLUG = 'openhuman';
+
+/** `Display Name — $in/$out per 1M`, falling back to the bare id. */
+const managedOptionLabel = (m: ModelInfo): string => {
+  const name = m.display_name?.trim() || m.id;
+  const inPrice = m.input_per_1m;
+  const outPrice = m.output_per_1m;
+  if (typeof inPrice !== 'number' || typeof outPrice !== 'number') return name;
+  const fmt = (n: number) =>
+    n === 0 ? '$0' : `$${n < 1 ? n.toFixed(3).replace(/0+$/, '') : n.toFixed(2)}`;
+  return `${name} — ${fmt(inPrice)}/${fmt(outPrice)} per 1M`;
+};
+
 function slugify(name: string): string {
   return name
     .trim()
@@ -84,6 +107,7 @@ const AgentEditorPage = () => {
   const [description, setDescription] = useState('');
   const [model, setModel] = useState('');
   const [customModelMode, setCustomModelMode] = useState(false);
+  const [managedModels, setManagedModels] = useState<ModelInfo[]>([]);
   const [systemPrompt, setSystemPrompt] = useState('');
   const [toolAllowlist, setToolAllowlist] = useState<string[]>([]);
 
@@ -179,6 +203,33 @@ const AgentEditorPage = () => {
       if (mountedRef.current) setSubmitting(false);
     }
   };
+
+  // Managed catalog for the optgroup below. A failure or an empty result is not
+  // an error worth surfacing here: the backend returns an empty list when the
+  // passthrough is off or the session is stale, and the rest of the editor is
+  // unaffected — the optgroup just does not render.
+  useEffect(() => {
+    let active = true;
+    void listProviderModels(MANAGED_PROVIDER_SLUG)
+      .then(models => {
+        if (active) setManagedModels(models);
+      })
+      .catch(() => {
+        if (active) setManagedModels([]);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // A saved managed-catalog id is not in KNOWN_MODELS, so the load above flips
+  // the editor into free-text "custom" mode for it. The catalog arrives after
+  // that load, so re-check once it does and select the entry properly instead of
+  // showing a raw id in a text box. Only ever clears custom mode — a genuine
+  // BYOK id the catalog does not contain keeps its text box.
+  useEffect(() => {
+    if (model && managedModels.some(m => m.id === model)) setCustomModelMode(false);
+  }, [managedModels, model]);
 
   const selectValue = customModelMode ? CUSTOM_MODEL : model;
 
@@ -324,6 +375,15 @@ const AgentEditorPage = () => {
                         </option>
                       ))}
                     </optgroup>
+                    {managedModels.length > 0 && (
+                      <optgroup label={t('settings.agents.editor.modelManaged')}>
+                        {managedModels.map(m => (
+                          <option key={m.id} value={m.id}>
+                            {managedOptionLabel(m)}
+                          </option>
+                        ))}
+                      </optgroup>
+                    )}
                     <option value={CUSTOM_MODEL}>{t('settings.agents.editor.modelCustom')}</option>
                   </NativeSelect>
                   {customModelMode && (

--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -5936,6 +5936,7 @@ const messages: TranslationMap = {
   'settings.agents.editor.modelHints': 'تلميحات التوجيه',
   'settings.agents.editor.modelTiers': 'مستويات النموذج',
   'settings.agents.editor.modelCustom': 'معرّف نموذج مخصص…',
+  'settings.agents.editor.modelManaged': 'النماذج المُدارة',
   'settings.agents.editor.modelCustomPlaceholder': 'مثال: anthropic/claude-sonnet-4',
   'settings.agents.editor.selectTools': 'إضافة أدوات',
   'settings.agents.editor.toolsAllSelected': 'كل الأدوات',

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -6078,6 +6078,7 @@ const messages: TranslationMap = {
   'settings.agents.editor.modelHints': 'রুট হিন্টস',
   'settings.agents.editor.modelTiers': 'মডেল স্তর',
   'settings.agents.editor.modelCustom': 'কাস্টম মডেল আইডি…',
+  'settings.agents.editor.modelManaged': 'পরিচালিত মডেল',
   'settings.agents.editor.modelCustomPlaceholder': 'যেমন anthropic/claude-sonnet-4',
   'settings.agents.editor.selectTools': 'টুল যোগ করুন',
   'settings.agents.editor.toolsAllSelected': 'সব টুল',

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -6240,6 +6240,7 @@ const messages: TranslationMap = {
   'settings.agents.editor.modelHints': 'Routing-Hinweise',
   'settings.agents.editor.modelTiers': 'Modellstufen',
   'settings.agents.editor.modelCustom': 'Benutzerdefinierte Modell-ID…',
+  'settings.agents.editor.modelManaged': 'Verwaltete Modelle',
   'settings.agents.editor.modelCustomPlaceholder': 'z. B. anthropic/claude-sonnet-4',
   'settings.agents.editor.selectTools': 'Tools hinzufügen',
   'settings.agents.editor.toolsAllSelected': 'Alle Tools',

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -6872,6 +6872,7 @@ const en: TranslationMap = {
   'settings.agents.editor.modelHints': 'Route hints',
   'settings.agents.editor.modelTiers': 'Model tiers',
   'settings.agents.editor.modelCustom': 'Custom model id…',
+  'settings.agents.editor.modelManaged': 'Managed models',
   'settings.agents.editor.modelCustomPlaceholder': 'e.g. anthropic/claude-sonnet-4',
   'settings.agents.editor.selectTools': 'Add tools',
   'settings.agents.editor.toolsAllSelected': 'All tools',

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -6203,6 +6203,7 @@ const messages: TranslationMap = {
   'settings.agents.editor.modelHints': 'Sugerencias de enrutamiento',
   'settings.agents.editor.modelTiers': 'Niveles de modelo',
   'settings.agents.editor.modelCustom': 'ID de modelo personalizado…',
+  'settings.agents.editor.modelManaged': 'Modelos gestionados',
   'settings.agents.editor.modelCustomPlaceholder': 'ej. anthropic/claude-sonnet-4',
   'settings.agents.editor.selectTools': 'Agregar herramientas',
   'settings.agents.editor.toolsAllSelected': 'Todas las herramientas',

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -6229,6 +6229,7 @@ const messages: TranslationMap = {
   'settings.agents.editor.modelHints': 'Conseils de routage',
   'settings.agents.editor.modelTiers': 'Niveaux de modèle',
   'settings.agents.editor.modelCustom': 'Identifiant de modèle personnalisé…',
+  'settings.agents.editor.modelManaged': 'Modèles gérés',
   'settings.agents.editor.modelCustomPlaceholder': 'ex. anthropic/claude-sonnet-4',
   'settings.agents.editor.selectTools': 'Ajouter des outils',
   'settings.agents.editor.toolsAllSelected': 'Tous les outils',

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -6079,6 +6079,7 @@ const messages: TranslationMap = {
   'settings.agents.editor.modelHints': 'रूट संकेत',
   'settings.agents.editor.modelTiers': 'मॉडल स्तर',
   'settings.agents.editor.modelCustom': 'कस्टम मॉडल आईडी…',
+  'settings.agents.editor.modelManaged': 'प्रबंधित मॉडल',
   'settings.agents.editor.modelCustomPlaceholder': 'जैसे anthropic/claude-sonnet-4',
   'settings.agents.editor.selectTools': 'टूल जोड़ें',
   'settings.agents.editor.toolsAllSelected': 'सभी टूल',

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -6107,6 +6107,7 @@ const messages: TranslationMap = {
   'settings.agents.editor.modelHints': 'Petunjuk rute',
   'settings.agents.editor.modelTiers': 'Tingkatan model',
   'settings.agents.editor.modelCustom': 'ID model kustom…',
+  'settings.agents.editor.modelManaged': 'Model terkelola',
   'settings.agents.editor.modelCustomPlaceholder': 'mis. anthropic/claude-sonnet-4',
   'settings.agents.editor.selectTools': 'Tambah alat',
   'settings.agents.editor.toolsAllSelected': 'Semua alat',

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -6185,6 +6185,7 @@ const messages: TranslationMap = {
   'settings.agents.editor.modelHints': 'Suggerimenti di instradamento',
   'settings.agents.editor.modelTiers': 'Livelli di modello',
   'settings.agents.editor.modelCustom': 'ID modello personalizzato…',
+  'settings.agents.editor.modelManaged': 'Modelli gestiti',
   'settings.agents.editor.modelCustomPlaceholder': 'es. anthropic/claude-sonnet-4',
   'settings.agents.editor.selectTools': 'Aggiungi strumenti',
   'settings.agents.editor.toolsAllSelected': 'Tutti gli strumenti',

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -6007,6 +6007,7 @@ const messages: TranslationMap = {
   'settings.agents.editor.modelHints': '라우트 힌트',
   'settings.agents.editor.modelTiers': '모델 등급',
   'settings.agents.editor.modelCustom': '사용자 정의 모델 ID…',
+  'settings.agents.editor.modelManaged': '관리형 모델',
   'settings.agents.editor.modelCustomPlaceholder': '예: anthropic/claude-sonnet-4',
   'settings.agents.editor.selectTools': '도구 추가',
   'settings.agents.editor.toolsAllSelected': '모든 도구',

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -6168,6 +6168,7 @@ const messages: TranslationMap = {
   'settings.agents.editor.modelHints': 'Wskazówki trasowania',
   'settings.agents.editor.modelTiers': 'Poziomy modelu',
   'settings.agents.editor.modelCustom': 'Własny identyfikator modelu…',
+  'settings.agents.editor.modelManaged': 'Modele zarządzane',
   'settings.agents.editor.modelCustomPlaceholder': 'np. anthropic/claude-sonnet-4',
   'settings.agents.editor.selectTools': 'Dodaj narzędzia',
   'settings.agents.editor.toolsAllSelected': 'Wszystkie narzędzia',

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -6176,6 +6176,7 @@ const messages: TranslationMap = {
   'settings.agents.editor.modelHints': 'Dicas de roteamento',
   'settings.agents.editor.modelTiers': 'Níveis de modelo',
   'settings.agents.editor.modelCustom': 'ID de modelo personalizado…',
+  'settings.agents.editor.modelManaged': 'Modelos geridos',
   'settings.agents.editor.modelCustomPlaceholder': 'ex.: anthropic/claude-sonnet-4',
   'settings.agents.editor.selectTools': 'Adicionar ferramentas',
   'settings.agents.editor.toolsAllSelected': 'Todas as ferramentas',

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -6142,6 +6142,7 @@ const messages: TranslationMap = {
   'settings.agents.editor.modelHints': 'Подсказки маршрутизации',
   'settings.agents.editor.modelTiers': 'Уровни моделей',
   'settings.agents.editor.modelCustom': 'Идентификатор модели…',
+  'settings.agents.editor.modelManaged': 'Управляемые модели',
   'settings.agents.editor.modelCustomPlaceholder': 'напр. anthropic/claude-sonnet-4',
   'settings.agents.editor.selectTools': 'Добавить инструменты',
   'settings.agents.editor.toolsAllSelected': 'Все инструменты',

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -5738,6 +5738,7 @@ const messages: TranslationMap = {
   'settings.agents.editor.modelHints': '路由提示',
   'settings.agents.editor.modelTiers': '模型层级',
   'settings.agents.editor.modelCustom': '自定义模型 ID…',
+  'settings.agents.editor.modelManaged': '托管模型',
   'settings.agents.editor.modelCustomPlaceholder': '例如 anthropic/claude-sonnet-4',
   'settings.agents.editor.selectTools': '添加工具',
   'settings.agents.editor.toolsAllSelected': '所有工具',


### PR DESCRIPTION
## Summary

Lets an agent default to a managed OpenRouter model, so new chats use it without re-picking each time.

The agent editor's model dropdown now lists the managed catalog alongside the existing route hints and model tiers, labelled by display name and charged price. It reuses the same `listProviderModels('openhuman')` fetch the composer picker uses.

## Problem

#6201 added catalog models to the composer's picker, but that writes `composerModelOverride` — React state scoped to the current conversation, reset on every launch. There was no way to make a managed model **the default**.

An agent profile's `model_override` is that default: the composer sends `profile?.modelOverride ?? 'hint:chat'`, and it persists in `agent_profiles.json`. The editor that sets it offered only a hardcoded list of hints and tiers, plus a free-text escape hatch — so pinning a catalog model meant typing a slug from memory, with no discovery and no price visible.

## Why no core change was needed

Tracing `resolve_managed_backend_with_model_override` first, rather than assuming:

- `managed_tier_for_role` has **no `"chat"` arm**, so the chat role falls through to `config.default_model` (defaulting to `reasoning-v1` — the value that shows in the composer when nothing is pinned)
- `model_override` is applied **last**, overriding everything above it
- its `None` arm **forwards a raw non-tier id verbatim** instead of collapsing it onto a tier

So an `openrouter/<author>/<slug>` already reaches the managed backend intact, and the backend accepts it wherever `OPENROUTER_PASSTHROUGH_ENABLED` is on. The plumbing was already there; only the selection UI was missing.

## Solution

A `Managed models` optgroup between the existing tiers and the custom escape hatch.

An empty result omits the optgroup entirely — the backend returns one when the passthrough is off *or* the session is stale — so this is inert against a backend without the feature, and the free-text custom option is untouched.

**One subtlety worth flagging for review.** A saved catalog id is not in `KNOWN_MODELS`, so the initial load flips the editor into free-text "custom" mode for it, and the catalog only arrives *after* that load. Without a re-check the user sees a raw id in a text box instead of the entry selected in the dropdown. It is now re-checked once the catalog lands, and that only ever *clears* custom mode — a genuine BYOK id the catalog does not contain keeps its text box.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — two cases: the catalog is offered and a selection saves as the agent's model; a saved catalog id selects in the dropdown rather than the custom text box. Existing tests keep an empty catalog via the mock default, covering the passthrough-off path.
- [x] **Diff coverage ≥ 80%** — both new branches (optgroup render, saved-id re-check) are exercised; the CI diff-cover gate enforces the threshold (`diff-cover` not run locally).
- [x] Coverage matrix updated — `N/A: no feature row added/removed/renamed`.
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix rows touched`.
- [x] No new external network dependencies introduced — reuses the existing managed-backend listing over the established session-authed path; tests mock it.
- [x] Manual smoke checklist updated — `N/A: does not touch a release-cut surface`; with the passthrough off the dropdown is unchanged.
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue`.

## Testing

- Vitest `components/settings/` + `components/chat/` — **1505 passed**, 129 files
- `pnpm typecheck` — clean
- `prettier --check` — clean
- `pnpm i18n:check` and `pnpm i18n:english:check` — both exit 0; the new key has real translations in all 14 locales, no untranslated English

## Related

Follow-up to #6201, which added the same catalog to the composer picker (per-conversation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TE9ECLDivW9LsMZmEkbK9F


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added managed models to the agent editor’s model selector.
  - Managed models display their names and per-million-token pricing.
  - Existing agents now correctly retain and select their saved managed model.

- **Localization**
  - Added translated labels for managed models across supported languages.

- **Tests**
  - Added coverage for displaying, selecting, saving, and restoring managed models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->