### PR TITLE
fix(chat): rehydrate the turn snapshot when the socket reconnects

### DIFF
--- a/app/src/providers/ChatRuntimeProvider.tsx
+++ b/app/src/providers/ChatRuntimeProvider.tsx
@@ -42,6 +42,7 @@ import {
   clearStreamingAssistantForThread,
   endInferenceTurn,
   fetchAndHydrateCompletedTurnState,
+  fetchAndHydrateTurnState,
   markInferenceTurnStreaming,
   parseToolFailure,
   recordChatTurnUsage,
@@ -1634,6 +1635,16 @@ const ChatRuntimeProvider = ({ children }: { children: React.ReactNode }) => {
         // emitted, and dropping the id here would strand that thread until the
         // user reselected it; keeping it means the next connection retries.
         if (joined) interruptedThreadsRef.current.delete(threadId);
+        // Re-read the messages AND rehydrate the turn snapshot — the same
+        // pair the thread-switch path dispatches (`Conversations.tsx`).
+        // Messages alone recover the final text of a turn that finished in
+        // the gap, but nothing of a turn still running: every frame emitted
+        // while `thread:<id>` had no member was dropped (the emit is
+        // fire-and-forget), so the live lifecycle, iteration counter and tool
+        // timeline can only come back from the core's persisted snapshot.
+        // Without this a turn that outlives the reconnect renders nothing at
+        // all until the user reselects the thread or restarts the app.
+        void dispatch(fetchAndHydrateTurnState(threadId));
         return dispatch(loadThreadMessages(threadId));
       });
     }

--- a/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
+++ b/app/src/providers/__tests__/ChatRuntimeProvider.test.tsx
@@ -42,6 +42,8 @@ vi.mock('../../services/api/threadApi', () => ({
     purge: vi.fn(),
     getTaskBoard: vi.fn(),
     putTaskBoard: vi.fn(),
+    getTurnState: vi.fn(),
+    listRuns: vi.fn(),
   },
 }));
 
@@ -98,6 +100,8 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
     resetRuntimeState();
     vi.mocked(threadApi.appendMessage).mockImplementation(async (_tid, msg) => msg);
     vi.mocked(threadApi.getThreads).mockResolvedValue({ threads: [], count: 0 });
+    vi.mocked(threadApi.getTurnState).mockResolvedValue(null);
+    vi.mocked(threadApi.listRuns).mockResolvedValue([]);
     vi.mocked(threadApi.generateTitleIfNeeded).mockResolvedValue({
       id: 'tid',
       title: 'new',
@@ -1243,6 +1247,40 @@ describe('ChatRuntimeProvider — dedupe, proactive resolution, mid-turn invaria
       await waitFor(() => expect(socketService.subscribeThread).toHaveBeenCalledWith('t-flaky'));
     });
 
+    it('rehydrates the in-flight turn snapshot for an interrupted thread', async () => {
+      // A socket drop takes ~3s to heal (socket.io reconnectionDelay 2000 +
+      // handshake). `thread:<id>` has NO member for that whole window, and
+      // `emit_web_channel_event` is fire-and-forget — every progress frame and
+      // even the terminal `chat_done` emitted in the gap is dropped for good.
+      //
+      // Re-reading persisted messages is not enough: it recovers the final
+      // text but not the turn's live state, so a turn STILL running after the
+      // reconnect repaints nothing and the thread sits silent until the user
+      // reselects it or restarts the app. The core already persists that state
+      // and `fetchAndHydrateTurnState` already reads it — the thread-switch
+      // path (`Conversations.tsx`) dispatches it alongside `loadThreadMessages`.
+      // The reconnect path must do the same.
+      vi.mocked(threadApi.getThreadMessages).mockResolvedValue({
+        messages: [],
+      } as unknown as Awaited<ReturnType<typeof threadApi.getThreadMessages>>);
+
+      renderProvider();
+      act(() => {
+        store.dispatch(setActiveThread('t-inflight'));
+      });
+      vi.mocked(threadApi.getTurnState).mockClear();
+
+      act(() => {
+        store.dispatch(setStatusForUser({ userId: '__pending__', status: 'disconnected' }));
+      });
+      act(() => {
+        store.dispatch(setStatusForUser({ userId: '__pending__', status: 'connected' }));
+      });
+
+      await waitFor(() => expect(socketService.subscribeThread).toHaveBeenCalledWith('t-inflight'));
+      await waitFor(() => expect(threadApi.getTurnState).toHaveBeenCalledWith('t-inflight'));
+    });
+
     it('does nothing on a connect with no interrupted threads', async () => {
       renderProvider();
       vi.mocked(socketService.subscribeThread).mockClear();
@@ -2300,6 +2338,8 @@ describe('ChatRuntimeProvider — skill tool-chain latency (#4273 AC3)', () => {
     resetRuntimeState();
     vi.mocked(threadApi.appendMessage).mockImplementation(async (_tid, msg) => msg);
     vi.mocked(threadApi.getThreads).mockResolvedValue({ threads: [], count: 0 });
+    vi.mocked(threadApi.getTurnState).mockResolvedValue(null);
+    vi.mocked(threadApi.listRuns).mockResolvedValue([]);
     vi.mocked(threadApi.generateTitleIfNeeded).mockResolvedValue({
       id: 'tid',
       title: 'new',


### PR DESCRIPTION
## Summary

- A socket drop mid-turn leaves `thread:<id>` with **no members** for the whole heal window (socket.io `reconnectionDelay: 2000` + handshake ≈ 3s). `emit_web_channel_event` is fire-and-forget, so every progress frame emitted in that window — up to and including the terminal `chat_done` — is delivered to an empty room and lost permanently.
- The reconnect-heal path already rejoins the room and re-reads persisted **messages**. That recovers the final text of a turn that ended in the gap, but nothing of a turn **still running**.
- Fix: the heal now also dispatches `fetchAndHydrateTurnState(threadId)` — the exact pair the thread-switch path already dispatches — so a reconnect heals to the same state a thread switch does.
- One line of behaviour change, reusing an existing seam. No new mechanism, no core change.

## Problem

Symptom: a turn is sent, the UI shows the user's message and then **nothing at all** — no thinking, no status line, no tool rows, no reply, no error. The turn runs fine, completes, and persists; the answer appears in full only after the app is restarted or the thread reloaded.

**The delivery mechanism is not at fault.** #6034's dual-room delivery works. I verified it directly against a standalone core with a socket.io client:

- Socket A starts a turn; A is killed mid-flight; socket B connects and sends `thread:subscribe` (ack `joined:true`) → **B receives the turn's terminal event**, still carrying A's dead `client_id`. The stale `client_id` in the payload is cosmetic; it is not the routing key for the thread-room leg.
- Negative control, identical run but B does **not** subscribe → B receives **nothing**.

So loss is confined to the interval where the room has no member. Reproduced in a real browser renderer against a core I controlled, dropping the transport on `inference_start`:

```
+11946ms RECV inference_start thread=thread-7ec2c0ad… client=yuERZgyc2TFxtTkw
+12727ms >>> engine.close()
+12731ms LIFE disconnect reason=forced close
+15727ms LIFE reconnect_attempt 1
+15735ms LIFE connect sid=bFr1xFccTiafBwWS     <- new sid, ~3s later
+15760ms RECV ready
          (nothing further — no chat_done, no deltas)
```

The renderer *does* rejoin correctly: a forced drop with no turn in flight emits `thread:subscribe` for `selectedThreadId` on the next `connect`. The room membership is fine. What is missing is the state that was dropped while nobody was in it.

The live lifecycle, iteration counter and tool timeline live only in the core's turn-state snapshot. The heal effect read messages and not that snapshot, so a turn outliving the reconnect repainted nothing. `fetchAndHydrateTurnState`'s own docstring names the case — *"a turn that was mid-flight when the user navigated away (or when the previous app session ended) re-renders rather than appearing as an empty composer"* — and it was wired only to thread switch (`Conversations.tsx:769`) and app start. **That is precisely why a restart or a thread reload fixes it and waiting does not.**

## Solution

In the reconnect-heal effect (`ChatRuntimeProvider.tsx`), after the room join is acknowledged, dispatch `fetchAndHydrateTurnState(threadId)` alongside the existing `loadThreadMessages(threadId)` — mirroring `Conversations.tsx`, where the two have always been dispatched together.

Ordering and retry semantics are untouched: the hydrate rides inside the existing `subscribeThread(...).then(...)`, so it still runs only after the join is acknowledged, and a thread whose join never emitted is still retried on the next connection.

Deliberately **not** done: no replay buffer, no re-routing of events to a "current" client, no change to `emit_web_channel_event`. The core already persists everything needed and already exposes it over RPC; adding a second recovery mechanism alongside the one that exists would be the wrong shape.

### Verification

Test-first:

1. Added `rehydrates the in-flight turn snapshot for an interrupted thread` to the existing `socket reconnect recovery (#6034)` block, **before** touching `ChatRuntimeProvider.tsx`.
2. It failed on `expect(threadApi.getTurnState).toHaveBeenCalledWith('t-inflight')` — never called. The three existing heal tests passed throughout, so the harness was sound and only the new assertion was unmet.
3. With the fix: passes.
4. **Revert-check:** removed the single `void dispatch(fetchAndHydrateTurnState(threadId));` line, re-ran — `FAIL` on the same assertion, my line 1281. Restored: green.

Suites run: `src/providers/__tests__/`, `socketService.events.test.ts`, `socketService.subscribeThread.test.ts` — **19 files, 224 tests, 0 failures**. `ChatRuntimeProvider.test.tsx` alone: 78/78. Prettier clean. `tsc --noEmit` passed via the pre-push hook.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — the new test covers the failure path (turn in flight across a reconnect → snapshot must be rehydrated); the existing `does nothing on a connect with no interrupted threads` covers the negative case and still passes unchanged.
- [x] **Diff coverage ≥ 80%** — the changed production line is executed by the new test (asserted via `threadApi.getTurnState` being called for the interrupted thread). Full `pnpm test:coverage` not run — see Validation Blocked.
- [x] N/A: behaviour-only change — no feature row added, removed or renamed in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] N/A: no coverage-matrix feature IDs apply (see the item above).
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — the unit test mocks `threadApi`; the manual reproduction ran against `scripts/mock-api-server.mjs` on an isolated workspace, never a real backend.
- [x] N/A: does not touch a release-cut surface in `docs/RELEASE-MANUAL-SMOKE.md` — this is recovery behaviour inside an existing effect.
- [x] N/A: no issue exists for this — it was reported directly from a live session, not filed. Nothing to close.

## Impact

- **Runtime/platform:** desktop and web renderer. No core change, no protocol change, no migration.
- **Behaviour change:** after a socket reconnect, a thread that had a turn in flight now repaints that turn's live state (lifecycle, iteration, tool timeline) instead of showing an empty thread until the user reselects it or restarts.
- **No behaviour change** when nothing was in flight — the heal still early-returns on an empty interrupted set, and that test is unchanged.
- **Cost:** one extra `threads_get_turn_state` RPC (plus its `listRuns`) per interrupted thread per reconnect. Bounded by the number of threads that had a turn in flight when the socket dropped, and it is the same call a thread switch already makes.
- **Security/compatibility:** none.

## Related

- Closes: N/A — reported from a live session; no issue was filed.
- Follow-up PR(s)/TODOs: two things this does **not** address, reported separately rather than folded in — (a) the ~3s window itself still loses live frames, which only a replay/`since-seq` catch-up on `thread:subscribe` would close; (b) the renderer opened eight socket connections in one evening in the original session, whose cause is unestablished.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A — not tracked in Linear.
- URL: N/A — no issue; reported directly from a live session.

### Commit & Branch

- Branch: `fix/lost-turn-progress-reconnect`
- Commit SHA: `33ae2c3217f2955664d2f67fc0c4a21340ca162d`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — Prettier clean on both changed files.
- [x] `pnpm typecheck` — `tsc --noEmit` passed (ran via the pre-push hook).
- [x] Focused tests: `npx vitest run --config test/vitest.config.ts src/providers/__tests__/ src/services/__tests__/socketService.events.test.ts src/services/__tests__/socketService.subscribeThread.test.ts` → 19 files, 224 passed, 0 failed. Test-first + revert-check performed (see Verification).
- [x] N/A: Rust fmt/check — no Rust files changed.
- [x] N/A: Tauri fmt/check — no files under the Tauri shell changed.

### Validation Blocked

- `command:` post-fix manual confirmation in the live browser lane, and full `pnpm test:coverage`
- `error:` the Chrome extension disconnected immediately after the fix landed ("Browser extension is not connected"), so the post-fix run of the live reproduction did not complete. Full-workspace coverage is not affordable in the 3-slot local lane.
- `impact:` the **pre-fix** reproduction is solid and recorded above; the **post-fix** live confirmation is not. The behaviour is pinned by the revert-checked unit test, but a reviewer should be aware the end-to-end repaint was not eyeballed after the change. The lane is scripted and cheap to re-run.

### Behavior Changes

- Intended behavior change: the socket-reconnect heal rehydrates the persisted turn snapshot in addition to re-reading messages.
- User-visible effect: a turn interrupted by a reconnect keeps rendering its progress instead of leaving the thread blank until a restart or thread reselect.

### Parity Contract

- Legacy behavior preserved: `subscribeThread` ordering, the `joined` retry semantics, and the `loadThreadMessages` re-read are all unchanged; the hydrate is additive inside the same `.then`.
- Guard/fallback/dispatch parity checks: `fetchAndHydrateTurnState` swallows its own errors and no-ops on a missing snapshot, so a thread with nothing persisted behaves exactly as before. The reconnect path now matches the thread-switch path, which has always dispatched both thunks.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A — no open PR touches `ChatRuntimeProvider.tsx`'s reconnect path.
- Canonical PR: this one.
- Resolution: N/A.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ipSkHi47nsBmnxX5dC4dA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery after socket disconnects by restoring interrupted conversation turns automatically.
  * Live turn status, iteration counts, and tool activity now reappear correctly after reconnecting.

* **Tests**
  * Added coverage to verify that interrupted turn state is retrieved when the connection is restored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->