### PR TITLE
fix(settings): stop the provider name overflowing the model picker's column

### DIFF
--- a/app/src/components/settings/panels/ai/ProviderModelPickerDialog.tsx
+++ b/app/src/components/settings/panels/ai/ProviderModelPickerDialog.tsx
@@ -281,7 +281,7 @@ export function ProviderModelPickerDialog({
           autoFocus
         />
       </div>
-      <div className="grid min-h-80 grid-cols-1 divide-y divide-line-subtle md:grid-cols-[13rem_1fr] md:divide-x md:divide-y-0">
+      <div className="grid min-h-80 grid-cols-1 divide-y divide-line-subtle md:grid-cols-[15rem_1fr] md:divide-x md:divide-y-0">
         <div className="p-2">
           <p className="px-2 pb-2 text-xs font-medium text-content-muted">
             {t('settings.ai.picker.providersLabel')}
@@ -305,11 +305,21 @@ export function ProviderModelPickerDialog({
                     label={sourceLabel(candidate, cloudProviders, t)}
                     tone={slugTone(sourceSlug(candidate))}
                   />
-                  <span className="flex min-w-0 flex-col items-start gap-0.5">
-                    <span className="truncate text-sm font-medium">
+                  {/* `flex-1` + `min-w-0` is load-bearing, not cosmetic:
+                      without it this wrapper sizes to its content instead of
+                      shrinking, and a long provider name overflows the column
+                      into the detail pane instead of wrapping inside it.
+                      `min-w-0` alone does not shrink a flex item that was never
+                      told it may flex.
+
+                      The name wraps rather than truncating — a provider the
+                      user cannot fully read is not a provider they can choose
+                      between. The row is `h-auto`, so it grows to fit. */}
+                  <span className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
+                    <span className="w-full text-left text-sm font-medium break-words whitespace-normal">
                       {sourceLabel(candidate, cloudProviders, t)}
                     </span>
-                    <span className="text-xs font-normal text-content-muted">
+                    <span className="w-full text-left text-xs font-normal break-words whitespace-normal text-content-muted">
                       {sourceDetail(candidate, t)}
                     </span>
                   </span>


### PR DESCRIPTION
## Summary

- The provider name in the model picker's left column overflowed and painted over the detail pane beside it — the managed description rendered as `penHuman will run all inference…`, with its leading character covered.
- Cause is a flex item that was never told it may flex, so it sized to its content instead of shrinking to the column.
- Names now wrap in full rather than clipping, and the column is wide enough that the default provider fits on one line.

## Problem

`ProviderModelPickerDialog.tsx`, the provider list row:

```tsx
<span className="flex min-w-0 flex-col items-start gap-0.5">
  <span className="truncate text-sm font-medium">
```

`min-w-0` on its own does not shrink a flex item that has no `flex-1`. The wrapper therefore sized to its content, grew past the `13rem` column, and overlapped the pane to its right. The `truncate` on the inner span was inert for the same reason — nothing had constrained the box it was meant to clip.

Both symptoms in the screenshot come from that one omission: the label spilling across the divider, and the detail text underneath it losing its first character.

## Solution

**`flex-1` on the wrapper** — the actual fix. It now shrinks to the column instead of overflowing it.

**Wrap instead of truncate.** A provider the user cannot read in full is not one they can choose between, and this list is short enough that a second line costs nothing. The row is already `h-auto`, so it grows to fit. Truncating was my first attempt and it was the wrong call for a list of two.

**Column `13rem` → `15rem`.** "Managed by OpenHuman" needs roughly 210px once the swatch, gap and padding are counted, against a 208px column — so the default provider was wrapping to two lines purely from being a couple of pixels short. At 15rem it sits on one line, and wrapping still handles a long custom provider name.

The `flex-1` carries a comment explaining why it is load-bearing. It reads as a cosmetic utility class, and deleting it silently reintroduces the overlap.

## Impact

- Presentation only. No behaviour, no state, no data, no new dependency.
- Every provider name is now fully readable at any length; a long one wraps inside its column instead of over the pane beside it.

## Submission Checklist

- [x] N/A: presentation-only change to existing markup; the 6 existing `ProviderModelPickerDialog` tests cover the component's behaviour and pass unchanged. Tests added or updated
- [x] N/A: no logic added — the diff is class names and a comment, which carry no coverable statements. **Diff coverage ≥ 80%**
- [x] N/A: no feature rows added, removed or renamed. Coverage matrix updated
- [x] N/A: no matrix feature IDs affected. All affected feature IDs listed under `## Related`
- [x] No new external network dependencies introduced
- [x] N/A: no release-cut surface touched. Manual smoke checklist updated
- [x] N/A: found by using the app; no issue filed. Linked issue closed via `Closes #NNN`

## Related

- Closes: N/A — spotted while testing the picker on a live build.
- Context: #6201 and #6206 both extended this dialog; the overflow predates them and only became conspicuous once the managed pane had content beside the list.

---

## AI Authored PR Metadata

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/picker-provider-label-overflow`
- Commit SHA: `7f93c68d7`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — Prettier reports the file unchanged
- [x] `pnpm typecheck` — `tsc --noEmit` clean
- [x] Focused tests: `ProviderModelPickerDialog.test.tsx` — 6 passed
- [x] N/A: no Rust changed. Rust fmt/check
- [x] N/A: no Tauri source changed. Tauri fmt/check

### Validation Blocked

- `command:` none
- `error:` none
- `impact:` none. Verified visually against a running dev build on this branch, not only by tests.

### Behavior Changes

- Intended behavior change: none functional.
- User-visible effect: the provider name no longer overlaps the detail pane, and long names wrap inside their column instead of being cut off.

### Parity Contract

- Legacy behavior preserved: selection, search filtering and the managed pane are untouched; the diff is class names on two spans plus one grid column width.
- Guard/fallback/dispatch parity checks: none applicable.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ipSkHi47nsBmnxX5dC4dA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the AI provider picker layout by widening the provider column.
  * Long provider names and details now wrap cleanly instead of being truncated or overflowing.
  * Updated alignment and spacing for clearer provider selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->