### PR TITLE
fix(approval): replay a parked approval to a socket that joins the thread room

### DIFF
--- a/src/core/socketio.rs
+++ b/src/core/socketio.rs
@@ -704,6 +704,13 @@ pub fn attach_socketio() -> (socketioxide::layer::SocketIoLayer, SocketIo) {
                     // stops queueing the thread for retry and reads on the
                     // strength of a room it is not in.
                     let joined = join_room_logged(&socket, &room, &socket.id.to_string());
+                    // Hand this socket whatever the approval gate still has
+                    // parked on the thread, BEFORE acknowledging the join, so a
+                    // client that orders its recovery reads against the ack
+                    // already holds the card.
+                    if joined {
+                        replay_parked_approval(&socket, thread_id);
+                    }
                     ack.send(&ThreadSubscribeAck { joined }).ok();
                 },
             );
@@ -1493,6 +1500,52 @@ fn event_alias(name: &str) -> Option<String> {
         return Some(name.replace(':', "_"));
     }
     None
+}
+
+/// Re-send the approval parked on `thread_id`, if any, to the socket that just
+/// joined that thread's room.
+///
+/// An approval is durable server-side state — the gate holds the parked call
+/// and a `pending_approvals` row — but it reaches the UI as ONE fire-and-forget
+/// emit from [`emit_web_channel_event`]. That emit can miss with no error and
+/// no trace: `io.to(room).emit()` on a room whose only member has gone is a
+/// silent no-op, there is no disconnect handler here so the core never learns a
+/// client died, a socket that reconnects lands in the thread room only for
+/// events emitted *after* it joins, and the bridge drops frames wholesale on
+/// broadcast lag. Any one of those leaves the turn parked forever with no card
+/// on screen and no way for the user to act.
+///
+/// `thread:subscribe` is the one signal that says "this socket is now watching
+/// this thread", which makes it the place to reconcile the two. Replaying is
+/// safe to repeat: the client keys the card by `request_id` and a decided
+/// request is no longer parked, so a socket that already has the card just
+/// re-renders the same one.
+#[cfg(feature = "http-server")]
+fn replay_parked_approval(socket: &SocketRef, thread_id: &str) {
+    let Some(gate) = crate::openhuman::security::approval::ApprovalGate::try_global() else {
+        return;
+    };
+    let Some(row) = gate.parked_request_for_thread(thread_id) else {
+        return;
+    };
+    let client_id = socket.id.to_string();
+    let event = crate::openhuman::web_chat::approval_request_event(
+        &row.request_id,
+        &row.tool_name,
+        &row.action_summary,
+        &row.args_redacted,
+        thread_id,
+        &client_id,
+    );
+    let Ok(payload) = serde_json::to_value(&event) else {
+        return;
+    };
+    log::info!(
+        "[socketio] replaying parked approval_request to joining socket client_id={client_id} thread_id={thread_id} request_id={} tool={}",
+        row.request_id,
+        row.tool_name
+    );
+    emit_with_aliases(socket, "approval_request", &payload);
 }
 
 #[cfg(feature = "http-server")]

--- a/src/openhuman/security/approval/gate_state.rs
+++ b/src/openhuman/security/approval/gate_state.rs
@@ -186,6 +186,33 @@ impl ApprovalGate {
         self.thread_to_request.lock().get(thread_id).cloned()
     }
 
+    /// The full pending row parked on `thread_id`, if any.
+    ///
+    /// [`Self::pending_for_thread`] answers *which* request is parked; this
+    /// answers *what it is*, which is what a UI needs to rebuild the approval
+    /// card from scratch.
+    ///
+    /// The card reaches the UI as ONE fire-and-forget socket emit. If that emit
+    /// misses — the addressed client's room is empty because the page reloaded,
+    /// a rejoining socket was not yet in the thread room, or the bridge dropped
+    /// the frame on broadcast lag — nothing re-sends it. The request stays
+    /// parked server-side and the user is left with no card and no way to act,
+    /// which is the whole failure: durable state delivered as an ephemeral
+    /// event, with no way to reconcile the two. This lookup is that
+    /// reconciliation, so a socket (re)joining a thread can be handed whatever
+    /// is parked on it.
+    ///
+    /// Reads the routing map first and the durable rows second, so a request
+    /// decided between the two reads simply falls out as `None` rather than
+    /// replaying a card the user has already answered.
+    pub fn parked_request_for_thread(&self, thread_id: &str) -> Option<PendingApproval> {
+        let request_id = self.pending_for_thread(thread_id)?;
+        self.list_pending()
+            .ok()?
+            .into_iter()
+            .find(|row| row.request_id == request_id)
+    }
+
     /// Drop the thread → request mapping when it still belongs to this request.
     fn clear_thread(&self, thread_id: &Option<String>, request_id: &str) {
         if let Some(t) = thread_id {

--- a/src/openhuman/security/approval/gate_state.rs
+++ b/src/openhuman/security/approval/gate_state.rs
@@ -207,10 +207,27 @@ impl ApprovalGate {
     /// replaying a card the user has already answered.
     pub fn parked_request_for_thread(&self, thread_id: &str) -> Option<PendingApproval> {
         let request_id = self.pending_for_thread(thread_id)?;
-        self.list_pending()
+        let row = self
+            .list_pending()
             .ok()?
             .into_iter()
-            .find(|row| row.request_id == request_id)
+            .find(|row| row.request_id == request_id)?;
+        // Re-read the route before answering. `list_pending` is a store read and
+        // runs without the route lock held, so between the two the mapping can
+        // be cleared by a caller-bound abandon or overwritten by a replacement
+        // turn parking a new approval on the same thread (#4774's scenario).
+        // Either leaves this row pending while it is no longer the thread's, and
+        // the only caller replays what it gets straight onto the user's screen —
+        // so a stale row here is a stale approval card, not a harmless read.
+        //
+        // Narrowing, not closing: the row itself could still be decided after
+        // this check. That is the pre-existing fire-and-forget property of the
+        // replay path, and `request_id` idempotency on the client is what covers
+        // it; this only stops the lookup from *starting* with a row it can
+        // already tell is not the thread's (#6212 review).
+        self.pending_for_thread(thread_id)
+            .is_some_and(|current| current == request_id)
+            .then_some(row)
     }
 
     /// Drop the thread → request mapping when it still belongs to this request.

--- a/src/openhuman/security/approval/gate_tests_part_02_tests.rs
+++ b/src/openhuman/security/approval/gate_tests_part_02_tests.rs
@@ -633,3 +633,83 @@ async fn intercept_with_workflow_require_approval_persists_and_ttl_denies() {
         other => panic!("expected deny, got {other:?}"),
     }
 }
+
+/// A parked approval must be recoverable from its thread alone.
+///
+/// The card is delivered to the UI as ONE fire-and-forget socket emit
+/// (`web_chat::event_bus` → `core::socketio::emit_web_channel_event`). If that
+/// emit misses — the addressed client's room is empty because it reloaded, the
+/// rejoining socket was not yet in the thread room, or the bridge dropped the
+/// frame on broadcast lag — nothing re-sends it, and the turn stays parked with
+/// no card and no way for the user to act. Recovering the full row from the
+/// thread is what lets a (re)joining socket rebuild the card, so the durable
+/// park stops depending on a single delivery.
+#[tokio::test]
+async fn a_parked_approval_is_recoverable_from_its_thread_for_replay() {
+    let (gate, _dir) = test_gate_with_ttl(Duration::from_secs(10));
+    let gate = Arc::new(gate);
+
+    let g = gate.clone();
+    let ctx = ApprovalChatContext {
+        thread_id: "thread-replay".into(),
+        client_id: "client-that-went-away".into(),
+    };
+    let origin = AgentTurnOrigin::WebChat {
+        thread_id: "thread-replay".into(),
+        client_id: "client-that-went-away".into(),
+        request_id: Some("req-replay".into()),
+    };
+    let handle = tokio::spawn(async move {
+        turn_origin::with_origin(
+            origin,
+            APPROVAL_CHAT_CONTEXT.scope(
+                ctx,
+                g.intercept(
+                    "create_workflow",
+                    "create a workflow",
+                    serde_json::json!({ "name": "nightly" }),
+                ),
+            ),
+        )
+        .await
+    });
+
+    let mut tries = 0;
+    loop {
+        if gate.pending_for_thread("thread-replay").is_some() {
+            break;
+        }
+        tries += 1;
+        assert!(tries < 50, "thread mapping never appeared");
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let row = gate.parked_request_for_thread("thread-replay").expect(
+        "a parked approval must be recoverable from its thread, or a client that missed the \
+         single live emit can never rebuild the card and the turn stays parked forever",
+    );
+    assert_eq!(
+        row.tool_name, "create_workflow",
+        "the recovered row must carry the payload the card renders"
+    );
+    assert_eq!(
+        gate.pending_for_thread("thread-replay").as_deref(),
+        Some(row.request_id.as_str()),
+        "the recovered row must be the one actually parked on this thread"
+    );
+
+    // Another thread must not inherit it — replay is thread-scoped.
+    assert!(
+        gate.parked_request_for_thread("thread-unrelated").is_none(),
+        "a thread with nothing parked must have nothing to replay"
+    );
+
+    gate.decide(&row.request_id, ApprovalDecision::Deny)
+        .unwrap();
+    let _ = handle.await.unwrap();
+
+    assert!(
+        gate.parked_request_for_thread("thread-replay").is_none(),
+        "a decided approval must not be replayed to the next socket that joins"
+    );
+}

--- a/src/openhuman/web_chat/event_bus.rs
+++ b/src/openhuman/web_chat/event_bus.rs
@@ -299,6 +299,33 @@ pub fn fresh_approval_surface_subscription() -> Option<SubscriptionHandle> {
     crate::core::bus::BUS.subscribe(Arc::new(ApprovalSurfaceSubscriber))
 }
 
+/// Build the `approval_request` web-channel event for a parked approval.
+///
+/// Shared by the live surface below (on `ApprovalRequested`) and by the replay
+/// path in `core::socketio` (a socket joining a thread room that already has an
+/// approval parked on it). One constructor so a client that missed the live
+/// emit is handed a byte-identical payload rather than a second shape kept in
+/// step by hand.
+pub fn approval_request_event(
+    request_id: &str,
+    tool_name: &str,
+    action_summary: &str,
+    args_redacted: &serde_json::Value,
+    thread_id: &str,
+    client_id: &str,
+) -> WebChannelEvent {
+    WebChannelEvent {
+        event: "approval_request".to_string(),
+        client_id: client_id.to_string(),
+        thread_id: thread_id.to_string(),
+        request_id: request_id.to_string(),
+        tool_name: Some(tool_name.to_string()),
+        message: Some(format!("Run `{tool_name}` — {action_summary}")),
+        args: Some(args_redacted.clone()),
+        ..Default::default()
+    }
+}
+
 struct ApprovalSurfaceSubscriber;
 
 #[async_trait]
@@ -324,20 +351,17 @@ impl EventHandler<DomainEvent> for ApprovalSurfaceSubscriber {
         {
             match (thread_id, client_id) {
                 (Some(thread_id), Some(client_id)) => {
-                    let question = format!("Run `{tool_name}` — {action_summary}");
                     log::info!(
                         "[web-channel] approval-surface emitting approval_request request_id={request_id} thread_id={thread_id} client_id={client_id} tool={tool_name}"
                     );
-                    publish_web_channel_event(WebChannelEvent {
-                        event: "approval_request".to_string(),
-                        client_id: client_id.clone(),
-                        thread_id: thread_id.clone(),
-                        request_id: request_id.clone(),
-                        tool_name: Some(tool_name.clone()),
-                        message: Some(question),
-                        args: Some(args_redacted.clone()),
-                        ..Default::default()
-                    });
+                    publish_web_channel_event(approval_request_event(
+                        request_id,
+                        tool_name,
+                        action_summary,
+                        args_redacted,
+                        thread_id,
+                        client_id,
+                    ));
                 }
                 _ => {
                     log::warn!(

--- a/src/openhuman/web_chat/mod.rs
+++ b/src/openhuman/web_chat/mod.rs
@@ -22,7 +22,7 @@ pub(crate) use web_errors::{
 
 // Public API — event bus
 pub use event_bus::{
-    publish_web_channel_event, register_approval_surface_subscriber,
+    approval_request_event, publish_web_channel_event, register_approval_surface_subscriber,
     register_artifact_surface_subscriber, register_egress_surface_subscriber,
     subscribe_web_channel_events,
 };


### PR DESCRIPTION
## Summary

- A parked chat approval is durable server-side state but reaches the UI as exactly **one** fire-and-forget socket emit, with nothing reconciling the two. A single missed delivery strands the turn: the core stays parked, the user sees no card and cannot act, and both sides log success.
- `thread:subscribe` — the one signal that says "this socket is now watching this thread" — now replays whatever the approval gate still holds parked on that thread.
- The live surface and the replay build their payload through one shared constructor, so the two shapes cannot drift.

## Problem

Observed on a live dev session (thread `28c3ac9f`): the core published `ApprovalRequested`, logged the surface emit with both `thread_id` and `client_id` set, and parked `create_workflow`. No card ever appeared. The workflow was never persisted and the request stayed parked until an unrelated `threads_delete` tore it down 8 minutes later.

**The card has exactly one way to appear.** `setPendingApprovalForThread` has a single production writer — `app/src/providers/ChatRuntimeProvider.tsx:1198`, inside the socket handler. If that event does not land, nothing else can produce the card.

**The emit cannot report failure.** `io.to(room).emit()` on a room whose members have gone is a silent no-op and the `Result` is discarded (`src/core/socketio.rs:1448`). There is no disconnect handler anywhere in `socketio.rs`, so the core never learns a client died.

**Three independent ways the delivery misses**, any one of which is permanent:
1. the addressed client's room is empty because the page reloaded or the window closed;
2. a reconnected socket joins the `thread:<id>` room and so receives events emitted *after* the join — one already emitted is gone;
3. the bridge drops frames wholesale on broadcast lag (`src/core/socketio.rs:733`, `RecvError::Lagged` → warn + `continue`).

### What this is *not*

Worth stating, because the obvious diagnosis is wrong. `approval_request` is **not** client_id-only addressed. `emit_web_channel_event` already fans out to the client room **and** `thread:<id>` minus that room (`socketio.rs:1430,1453-1463`), the approval event does carry `thread_id` (`web_chat/event_bus.rs`), and the frontend already re-subscribes to every active thread room on connect (`app/src/services/socketService.ts:243-250`). That mitigation works. It just only carries events emitted *after* the join. **The defect is timing, not addressing** — and the missing piece is replay.

### The server already knew the answer

`ApprovalGate::pending_for_thread` (`gate_state.rs:185`) returns the request parked on a thread. It had **zero production callers** — the capability existed, was tested, and was wired to nothing.

The durable queue could not fill the gap either: `PendingApproval` carries no `thread_id`, so `approval_list_pending` — which the *flows* UI polls every 2s — cannot tell the chat UI which row belongs to the open thread. Chat had a queue it structurally could not consume.

## Solution

- **`gate_state.rs`** — `parked_request_for_thread()` returns the full pending row for a thread. Routing map first, durable rows second, so a request decided between the two reads falls out as `None` rather than replaying a card the user has already answered.
- **`web_chat/event_bus.rs`** — extracted `approval_request_event()`, now used by both the live surface and the replay, so a client that missed the live emit is handed a byte-identical payload rather than a second shape maintained by hand.
- **`core/socketio.rs`** — `thread:subscribe` calls `replay_parked_approval` on a successful join, **before** the ack, so a client that orders its recovery reads against the ack already holds the card.

Idempotent by construction: the client keys the card by `request_id`, and a decided request is no longer parked, so a socket that already has the card simply re-renders the same one.

This covers every loss path that ends in the client re-joining the room — paths 1 and 2 — because the replay does not depend on *why* the original emit missed.

**It does not cover path 3 on its own** (corrected after review by @chatgpt-codex-connector; the earlier wording claimed it did). `replay_parked_approval` runs only from the `thread:subscribe` handler, and the frontend emits that event in exactly two places: `socketService.ts:250` inside the `connect` handler, and `socketService.ts:511` in `subscribeThread` when a thread is opened or switched. Neither is reachable from `RecvError::Lagged`, which warns and `continue`s. A socket that stays connected and stays joined across a lag drop therefore gets no replay, and the approval stays parked until its TTL.

A user who notices nothing happened and reloads *does* recover the card, because that produces a join. The genuinely uncovered case is a live socket that never re-subscribes — which is also the case where the user has no reason to suspect anything was lost.

Closing it properly is a reconciliation mechanism, not a call site: the bridge holds the `SocketIo` server rather than a socket, so it knows neither which rooms are joined nor which threads have something parked. That is left as a follow-up rather than folded in here.

## Follow-up in `eec1b2392`

- **Revalidate the thread route after the durable lookup** (@coderabbitai). `parked_request_for_thread` read the route, then called `list_pending` — a store read — with no lock held; an abandon or a replacement landing in that window left it returning a row that was no longer the thread's, and the only caller replays straight onto the user's screen. The route is now re-read and the row returned only if it still matches. Narrowing, not closing: the row can still be decided after the check, which `request_id` idempotency on the client already covers. No test — `list_pending` is a free function over `&self.config` with no injectable seam, and every reachable *state* is answered identically by both versions, so a state-based test could not fail for the reason it exists. Reasoning in the thread.
- **Corrected the lag overclaim above** (@chatgpt-codex-connector). No code change; the change does what it always did, the body now describes it accurately.

## Impact

- **Desktop/web chat.** An approval parked on a thread survives a reload, a reconnect, a second window and a mid-turn join. A lag-dropped frame is recovered only once the client re-joins the room — see the correction under Solution.
- No API or schema change; no new dependency. One additional gate read per `thread:subscribe`.
- `plan_review_request` is **the same class and is NOT fixed here** — see Related.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — the new lookup is covered by `a_parked_approval_is_recoverable_from_its_thread_for_replay`, confirmed failing before the fix and passing after. Full `pnpm test:coverage` / `pnpm test:rust` not run: this worker shares a fleet-wide cargo slot cap and the full suites do not fit it; the focused lanes `approval::` (125), `web_chat::` (176) and `socketio` (11) were run instead, all green. **Not covered:** the `socketio.rs` call site — see Related.
- [x] N/A: Coverage matrix updated — behaviour-only change to an existing event path; no feature rows added, removed or renamed.
- [x] N/A: All affected feature IDs from the matrix are listed under `## Related` — no matrix rows are affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — the test drives a real in-process `ApprovalGate` against a `TempDir`; no network, no new dependency.
- [x] N/A: Manual smoke checklist updated — no release-cut surface changes; the approval card's shape and decision RPC are unchanged.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Related

- Closes: N/A — found from a live session rather than an existing issue; filing follow-ups below.
- Follow-up PR(s)/TODOs:
  - **`plan_review_request` is the same defect and is deliberately not fixed here.** It parks in a separate gate (`src/openhuman/agent/plan_review/gate.rs:43`) whose `thread_to_request` map keeps only the `request_id` — **not** the summary or steps the card renders. Replaying it therefore needs payload retention the gate does not currently have, which is new state rather than a wiring change. The class is **not** closed by this PR.
  - **No automated coverage of the `socketio.rs` call site.** The test pins the decision function; the wiring is verified by reading. A regression that deleted the `replay_parked_approval` call would still pass. Closing that honestly needs a socket.io *client* dependency to drive a real `thread:subscribe`, which is disproportionate for one call site — flagged rather than bought.
  - `socketio.rs` has no disconnect handler at all, so the core cannot distinguish a live client from a departed one. Not needed for this fix, but it is why the original emit could report success into an empty room.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `fix/approval-replay-on-thread-join`
- Commit SHA: see head of this PR

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend files changed.
- [x] N/A: `pnpm typecheck` — no TypeScript changed.
- [x] Focused tests: `cargo test -p openhuman --lib` for `approval::gate` → 47 passed; `approval::` → 125; `web_chat::` → 176; `socketio` → 11. All 0 failed.
- [x] Rust fmt/check (if changed): `cargo fmt --check` exit 0; `node scripts/ci/check-openhuman-rust-layout.mjs` passes.
- [x] N/A: Tauri fmt/check — nothing under `app/src-tauri/` changed.

### Validation Blocked

- `command:` full `pnpm test:coverage` / `pnpm test:rust`
- `error:` not attempted
- `impact:` fleet-wide cargo slot cap; the focused lanes cover every changed Rust line and were run before and after the fix, plus a revert-check. CI runs the full gate.

### Behavior Changes

- Intended behavior change: a socket joining a thread room is sent the approval currently parked on that thread, if any.
- User-visible effect: an approval card survives a reload, reconnect, second window or mid-turn join instead of being lost for the life of the turn. A frame dropped to bridge lag on a socket that never re-joins is still lost until TTL. No change when the original emit lands — the replay is idempotent on `request_id`.

### Parity Contract

- Legacy behavior preserved: the live emit path is unchanged apart from being routed through the shared payload constructor; the wire shape is identical. A thread with nothing parked replays nothing. A decided request is never replayed.
- Guard/fallback/dispatch parity checks: the existing `pending_for_thread` routing tests, the mid-park teardown test (`#4774`) and the full `approval::` lane all still pass unmodified.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ipSkHi47nsBmnxX5dC4dA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Approval requests are now restored when reconnecting or rejoining a chat thread.
  * Recovered approval cards appear before the join confirmation, improving recovery reliability.
  * Resolved or outdated approval requests are no longer replayed after thread activity changes.

* **Tests**
  * Added coverage for recovering parked approvals, filtering unrelated threads, and preventing replay after resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
