### PR TITLE
fix(agent): scope load_skill's advertised index to what the session can call

### DIFF
--- a/src/openhuman/agent/harness/session/builder/builder_tests.rs
+++ b/src/openhuman/agent/harness/session/builder/builder_tests.rs
@@ -2,6 +2,7 @@
 
 use super::{
     dedup_visible_tool_specs, ensure_recovery_tool_visible, should_synthesize_delegation_tools,
+    visible_tool_specs_for_policy,
 };
 use crate::openhuman::tools::ToolSpec;
 use serde_json::json;
@@ -69,3 +70,205 @@ mod part_01_tests;
 mod part_02_tests;
 #[path = "builder_tests_part_03_tests.rs"]
 mod part_03_tests;
+
+// ── load_skill's advertised spec is scoped to the session ───────────────────
+
+use crate::openhuman::tools::agent_policy::{
+    TaskProfile, TaskRiskLevel, ToolPolicyAction, ToolPolicyDecision, ToolPolicySession,
+};
+use crate::openhuman::tools::traits::PermissionLevel;
+
+fn session_allowing(names: &[&str]) -> ToolPolicySession {
+    ToolPolicySession {
+        profile: TaskProfile {
+            agent_id: "orchestrator".to_string(),
+            channel: "web_chat".to_string(),
+            entrypoint: "chat".to_string(),
+            risk_level: TaskRiskLevel::Low,
+            allowed_permission: PermissionLevel::Dangerous,
+        },
+        capabilities: vec![],
+        allowed_tool_names: names.iter().map(|n| n.to_string()).collect(),
+        blocked_tool_names: Default::default(),
+        hidden_tool_names: Default::default(),
+        decisions: names
+            .iter()
+            .map(|n| {
+                (
+                    n.to_string(),
+                    ToolPolicyDecision {
+                        tool_name: n.to_string(),
+                        action: ToolPolicyAction::Allow,
+                        required_permission: None,
+                        allowed_permission: PermissionLevel::Dangerous,
+                    },
+                )
+            })
+            .collect(),
+    }
+}
+
+fn load_skill_spec_from_registry() -> ToolSpec {
+    let mut tools: Vec<Box<dyn crate::openhuman::tools::traits::Tool>> = Vec::new();
+    crate::openhuman::tools::toolpacks::append_pack_tools(&mut tools);
+    let tool = tools
+        .iter()
+        .find(|t| t.name() == crate::openhuman::tools::toolpacks::LOAD_SKILL)
+        .expect("append_pack_tools registers load_skill");
+    ToolSpec {
+        name: tool.name().to_string(),
+        description: tool.description().to_string(),
+        parameters: tool.parameters_schema(),
+    }
+}
+
+/// Proves the scoping is actually WIRED, not merely available. A correct helper
+/// nobody calls advertises every pack exactly as before.
+#[test]
+fn visible_specs_scope_load_skills_index_to_the_session() {
+    let specs = vec![
+        load_skill_spec_from_registry(),
+        spec(crate::openhuman::tools::toolpacks::USE_SKILL),
+    ];
+    let visible: std::collections::HashSet<String> = specs.iter().map(|s| s.name.clone()).collect();
+    // Reachable: one workflows tool. Everything else in every other pack is
+    // denied, exactly like the orchestrator against `system` / `audio`.
+    let session = session_allowing(&[
+        "run_workflow",
+        crate::openhuman::tools::toolpacks::LOAD_SKILL,
+        crate::openhuman::tools::toolpacks::USE_SKILL,
+    ]);
+
+    let out = visible_tool_specs_for_policy(&specs, &visible, &session);
+    let load = out
+        .iter()
+        .find(|s| s.name == crate::openhuman::tools::toolpacks::LOAD_SKILL)
+        .expect("load_skill is still offered — workflows is reachable");
+
+    assert!(
+        load.description.contains("`workflows`"),
+        "the reachable pack must survive: {}",
+        load.description
+    );
+    assert!(
+        !load.description.contains("`system`"),
+        "a pack with nothing callable must not reach the wire: {}",
+        load.description
+    );
+    let ids = load
+        .parameters
+        .pointer("/properties/skill/enum")
+        .and_then(|v| v.as_array())
+        .expect("skill enum")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec!["workflows"], "the enum is scoped too");
+}
+
+/// A session that can reach no pack at all should not carry the pack tools.
+#[test]
+fn visible_specs_drop_the_pack_tools_when_no_pack_is_reachable() {
+    let specs = vec![
+        load_skill_spec_from_registry(),
+        spec(crate::openhuman::tools::toolpacks::USE_SKILL),
+    ];
+    let visible: std::collections::HashSet<String> = specs.iter().map(|s| s.name.clone()).collect();
+    let session = session_allowing(&[
+        crate::openhuman::tools::toolpacks::LOAD_SKILL,
+        crate::openhuman::tools::toolpacks::USE_SKILL,
+    ]);
+
+    let out = visible_tool_specs_for_policy(&specs, &visible, &session);
+    assert!(
+        out.is_empty(),
+        "with no reachable pack, neither pack tool earns its schema: {:?}",
+        out.iter().map(|s| &s.name).collect::<Vec<_>>()
+    );
+}
+
+/// **The regression Codex caught on #6215, pinned with a realistic session.**
+///
+/// My first tests hand-built a `ToolPolicySession` whose `decisions` were
+/// explicit `Allow`s — a fixture that cannot express the state every packed
+/// tool is actually in. The real harness strips packed names from `visible`,
+/// which classifies them `HideFromPrompt`, and `is_denied()` answers true for
+/// that. A predicate built on `is_denied` therefore reported *no* pack as
+/// reachable and dropped `load_skill` and `use_skill` from the wire — deleting
+/// the only route to every withheld tool.
+#[test]
+fn a_realistic_withheld_session_keeps_its_packs_advertised() {
+    use crate::openhuman::tools::agent_policy::ToolPolicyEngine;
+    use crate::openhuman::tools::toolpacks::{append_pack_tools, strip_packed_from_visible};
+
+    struct Fake(&'static str);
+    #[async_trait::async_trait]
+    impl crate::openhuman::tools::traits::Tool for Fake {
+        fn name(&self) -> &str {
+            self.0
+        }
+        fn description(&self) -> &str {
+            "fake"
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            json!({ "type": "object" })
+        }
+        async fn execute(
+            &self,
+            _a: serde_json::Value,
+        ) -> anyhow::Result<crate::openhuman::tools::traits::ToolResult> {
+            Ok(crate::openhuman::tools::traits::ToolResult::success("ok"))
+        }
+    }
+
+    let mut tools: Vec<Box<dyn crate::openhuman::tools::traits::Tool>> =
+        vec![Box::new(Fake("goal_set")), Box::new(Fake("goal_get"))];
+    append_pack_tools(&mut tools);
+
+    let mut visible: std::collections::HashSet<String> =
+        tools.iter().map(|t| t.name().to_string()).collect();
+    strip_packed_from_visible(&mut visible, "orchestrator");
+    assert!(
+        !visible.contains("goal_set"),
+        "precondition: the pack is withheld from the prompt"
+    );
+
+    let session = ToolPolicyEngine::build_session(
+        "orchestrator",
+        "web_chat",
+        "chat",
+        &Default::default(),
+        &tools,
+        &visible,
+    );
+
+    let specs: Vec<ToolSpec> = tools
+        .iter()
+        .map(|t| ToolSpec {
+            name: t.name().to_string(),
+            description: t.description().to_string(),
+            parameters: t.parameters_schema(),
+        })
+        .collect();
+
+    let out = visible_tool_specs_for_policy(&specs, &visible, &session);
+    let names: Vec<&str> = out.iter().map(|s| s.name.as_str()).collect();
+
+    assert!(
+        names.contains(&crate::openhuman::tools::toolpacks::LOAD_SKILL),
+        "load_skill must survive — the pack it opens is reachable: {names:?}"
+    );
+    assert!(
+        names.contains(&crate::openhuman::tools::toolpacks::USE_SKILL),
+        "use_skill must survive alongside it: {names:?}"
+    );
+    let load = out
+        .iter()
+        .find(|s| s.name == crate::openhuman::tools::toolpacks::LOAD_SKILL)
+        .expect("load_skill spec");
+    assert!(
+        load.description.contains("`goals`"),
+        "the withheld-but-callable pack must still be advertised: {}",
+        load.description
+    );
+}

--- a/src/openhuman/agent/harness/session/builder/mod.rs
+++ b/src/openhuman/agent/harness/session/builder/mod.rs
@@ -91,6 +91,23 @@ pub(super) fn visible_tool_specs_for_policy(
     visible_names: &std::collections::HashSet<String>,
     tool_policy: &ToolPolicySession,
 ) -> Vec<ToolSpec> {
+    // `load_skill`'s description carries the pack index, and its `skill` enum
+    // carries the pack ids. Both are built once in `LoadSkillTool::new`, before
+    // any session exists, so every agent was told all ten packs were loadable —
+    // including ones it can call nothing in. The model went, found out, and came
+    // back.
+    //
+    // This is the only place that turns tools into the specs a provider sees AND
+    // holds the session, so it is where the invitation is made to agree with the
+    // gate. The same predicate the gate uses (`decision_for(..).is_denied()`),
+    // not `is_allowed` — matching the filter above would re-introduce the two
+    // sources of truth this whole fix exists to collapse.
+    // `blocks_execution`, not `is_denied`: a withheld packed tool is
+    // `HideFromPrompt` and perfectly callable through `use_skill`. Using
+    // `is_denied` here would drop every pack from the index and then drop
+    // `load_skill` / `use_skill` themselves — the exact capability the pack
+    // mechanism exists to preserve.
+    let is_callable = |name: &str| !tool_policy.decision_for(name).blocks_execution();
     tool_specs
         .iter()
         .filter(|spec| {
@@ -98,6 +115,25 @@ pub(super) fn visible_tool_specs_for_policy(
                 && tool_policy.is_allowed(&spec.name)
         })
         .cloned()
+        .filter_map(|mut spec| {
+            if spec.name == crate::openhuman::tools::toolpacks::LOAD_SKILL {
+                // `false` means no pack has a callable tool: an empty index and
+                // an empty enum are not a tool, so drop it rather than ship one.
+                return crate::openhuman::tools::toolpacks::scope_load_skill_spec(
+                    &mut spec,
+                    &is_callable,
+                )
+                .then_some(spec);
+            }
+            if spec.name == crate::openhuman::tools::toolpacks::USE_SKILL {
+                // `use_skill` is only reachable through a loaded pack, so it
+                // goes wherever `load_skill` goes.
+                let any_callable =
+                    !crate::openhuman::tools::toolpacks::callable_pack_ids(&is_callable).is_empty();
+                return any_callable.then_some(spec);
+            }
+            Some(spec)
+        })
         .collect()
 }
 

--- a/src/openhuman/tools/toolpacks/mod.rs
+++ b/src/openhuman/tools/toolpacks/mod.rs
@@ -29,8 +29,14 @@ pub mod types;
 
 pub use groups::{GroupMode, ToolGroups, GROUP_COUNT};
 pub use ops::{append_pack_tools, bind_pack_registry, strip_packed_from_visible};
-pub use registry::{all_packed_tool_names, pack, pack_for_tool, PACKS};
-pub use tools::{render_pack_filtered, route_sentence, PackRegistryHandle, LOAD_SKILL, USE_SKILL};
+pub use registry::{
+    all_packed_tool_names, callable_pack_ids, pack, pack_for_tool, pack_index_markdown_filtered,
+    PACKS,
+};
+pub use tools::{
+    render_pack_filtered, route_sentence, scope_load_skill_spec, PackRegistryHandle, LOAD_SKILL,
+    USE_SKILL,
+};
 pub use types::ToolPack;
 
 #[cfg(test)]

--- a/src/openhuman/tools/toolpacks/registry.rs
+++ b/src/openhuman/tools/toolpacks/registry.rs
@@ -259,9 +259,35 @@ pub fn packed_tool_names_for_agent(agent_id: &str) -> Vec<&'static str> {
 /// The always-on index: one line per pack, rendered into `load_skill`'s own
 /// description so the model can pick a pack without a round trip.
 pub fn pack_index_markdown() -> String {
+    pack_index_markdown_filtered(&|_| true)
+}
+
+/// The pack index, limited to packs this session can call at least one tool in.
+///
+/// A pack with nothing callable is not an answer to "which skills can I load",
+/// and advertising it costs a round trip: the model loads it, learns it cannot
+/// use it, and comes back. The capability does not disappear — a pack's owners
+/// reach the model through their own `delegate_*` tools, whose `when_to_use`
+/// descriptions are already on the wire and are what the model should call
+/// anyway. Keeping the pack listed here would duplicate that routing on every
+/// single turn.
+pub fn pack_index_markdown_filtered(is_callable: &dyn Fn(&str) -> bool) -> String {
     let mut out = String::new();
     for p in PACKS {
+        if !p.tools.iter().any(|t| is_callable(t)) {
+            continue;
+        }
         out.push_str(&format!("- `{}` — {}\n", p.id, p.summary));
     }
     out
+}
+
+/// Pack ids with at least one tool this session can call — the `skill` enum
+/// `load_skill` should actually offer.
+pub fn callable_pack_ids(is_callable: &dyn Fn(&str) -> bool) -> Vec<&'static str> {
+    PACKS
+        .iter()
+        .filter(|p| p.tools.iter().any(|t| is_callable(t)))
+        .map(|p| p.id)
+        .collect()
 }

--- a/src/openhuman/tools/toolpacks/toolpacks_tests_part_02_tests.rs
+++ b/src/openhuman/tools/toolpacks/toolpacks_tests_part_02_tests.rs
@@ -3,6 +3,102 @@
 
 use super::*;
 
+// ── the index must agree with the gate too ──────────────────────────────────
+
+/// A spec shaped like the one `LoadSkillTool` publishes.
+fn load_skill_spec() -> crate::openhuman::tools::traits::ToolSpec {
+    let tools = registry_with_all(&["build_workflow"]);
+    let tool = find(&tools, LOAD_SKILL);
+    crate::openhuman::tools::traits::ToolSpec {
+        name: tool.name().to_string(),
+        description: tool.description().to_string(),
+        parameters: tool.parameters_schema(),
+    }
+}
+
+/// The landing was fixed first; this is the invitation. A pack the session can
+/// call nothing in must not be advertised as loadable — the model would go,
+/// find out, and come back, which is a wasted round trip on every turn it is
+/// tempted.
+#[test]
+fn the_index_drops_a_pack_this_session_can_call_nothing_in() {
+    let mut spec = load_skill_spec();
+    assert!(
+        spec.description.contains("`system`"),
+        "precondition: the unscoped index advertises every pack"
+    );
+
+    // Only the workflows pack is reachable.
+    let workflows = pack("workflows").expect("workflows pack");
+    let kept = scope_load_skill_spec(&mut spec, &|name| workflows.tools.contains(&name));
+    assert!(
+        kept,
+        "workflows is callable, so load_skill stays on the wire"
+    );
+
+    assert!(
+        spec.description.contains("`workflows`"),
+        "a reachable pack must still be offered: {}",
+        spec.description
+    );
+    for dead in ["`system`", "`crypto`", "`audio`", "`documents`"] {
+        assert!(
+            !spec.description.contains(dead),
+            "{dead} has no callable tool here and must not be advertised: {}",
+            spec.description
+        );
+    }
+}
+
+/// The schema is the stronger half: an unusable pack becomes unrepresentable,
+/// not merely discouraged in prose.
+#[test]
+fn the_skill_enum_offers_only_reachable_packs() {
+    let mut spec = load_skill_spec();
+    let workflows = pack("workflows").expect("workflows pack");
+    scope_load_skill_spec(&mut spec, &|name| workflows.tools.contains(&name));
+
+    let values = spec
+        .parameters
+        .pointer("/properties/skill/enum")
+        .and_then(Value::as_array)
+        .expect("the skill enum survives scoping")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        values,
+        vec!["workflows"],
+        "the enum must name exactly the reachable packs"
+    );
+}
+
+/// An empty index and an empty enum are not a tool. The caller is told to drop
+/// `load_skill` rather than ship one that can do nothing.
+#[test]
+fn a_session_that_can_reach_no_pack_loses_load_skill() {
+    let mut spec = load_skill_spec();
+    assert!(
+        !scope_load_skill_spec(&mut spec, &|_| false),
+        "with nothing reachable, load_skill must be dropped, not emptied"
+    );
+}
+
+/// Scoping must not quietly cost more context than it saves — the index is
+/// charged to every turn.
+#[test]
+fn scoping_the_index_only_ever_shrinks_it() {
+    let mut spec = load_skill_spec();
+    let before = spec.description.len();
+    let workflows = pack("workflows").expect("workflows pack");
+    scope_load_skill_spec(&mut spec, &|name| workflows.tools.contains(&name));
+    assert!(
+        spec.description.len() < before,
+        "scoped index ({}) must be smaller than the full one ({before})",
+        spec.description.len()
+    );
+}
+
 /// **The contract this fix must not break** (AGENTS.md: `Withheld` = "Registered
 /// and callable: yes"). A withheld packed tool is hidden from the prompt and
 /// still callable through `use_skill` — that is the entire point of a pack.

--- a/src/openhuman/tools/toolpacks/tools.rs
+++ b/src/openhuman/tools/toolpacks/tools.rs
@@ -6,7 +6,9 @@ use async_trait::async_trait;
 use serde_json::{json, Value};
 
 use super::registry;
-use crate::openhuman::tools::traits::{PermissionLevel, Tool, ToolCallOptions, ToolResult};
+use crate::openhuman::tools::traits::{
+    PermissionLevel, Tool, ToolCallOptions, ToolResult, ToolSpec,
+};
 use tinytools::ToolRunContext;
 
 pub const LOAD_SKILL: &str = "load_skill";
@@ -97,9 +99,11 @@ pub fn render_pack_filtered(
     route: &str,
 ) -> Result<String, String> {
     let Some(pack) = registry::pack(skill) else {
+        // Scoped too: offering a hallucinating model a pack it cannot use is the
+        // same wrong turn the advertised index used to take, one error later.
         return Err(format!(
             "Unknown skill `{skill}`. Available:\n{}",
-            registry::pack_index_markdown()
+            registry::pack_index_markdown_filtered(is_callable)
         ));
     };
     let Some(tools) = handle.tools() else {
@@ -197,6 +201,45 @@ pub fn route_sentence(callable_delegates: &[String], owners: &[&str]) -> String 
 
 fn render_pack(skill: &str, handle: &PackRegistryHandle) -> Result<String, String> {
     render_pack_filtered(skill, handle, &|_| true, "")
+}
+
+/// Rewrite `load_skill`'s advertised spec to match what this session can do.
+///
+/// The description is built once in [`LoadSkillTool::new`], before any session
+/// exists, so every agent was told all ten packs were loadable — including ones
+/// it can call nothing in. Post-#(routing fix) that costs one wasted round trip
+/// instead of a dead turn; it should cost zero.
+///
+/// Both halves are rewritten, and the schema is the stronger one: narrowing the
+/// `skill` enum makes an unusable pack *unrepresentable* rather than merely
+/// discouraged in prose, and a shorter enum is fewer tokens, not more.
+///
+/// Returns `false` when this session can call nothing in any pack — the caller
+/// should then drop `load_skill` / `use_skill` from the wire entirely, because
+/// an empty index and an empty enum are not a tool.
+pub fn scope_load_skill_spec(spec: &mut ToolSpec, is_callable: &dyn Fn(&str) -> bool) -> bool {
+    let ids = registry::callable_pack_ids(is_callable);
+    if ids.is_empty() {
+        return false;
+    }
+    if let Some(index) = spec.description.find("\n\nSkills:\n") {
+        spec.description.truncate(index);
+        spec.description.push_str("\n\nSkills:\n");
+        spec.description
+            .push_str(&registry::pack_index_markdown_filtered(is_callable));
+    }
+    if let Some(enum_slot) = spec
+        .parameters
+        .pointer_mut("/properties/skill/enum")
+        .filter(|v| v.is_array())
+    {
+        *enum_slot = Value::Array(
+            ids.iter()
+                .map(|id| Value::String((*id).to_string()))
+                .collect(),
+        );
+    }
+    true
 }
 
 fn skill_enum() -> Vec<&'static str> {


### PR DESCRIPTION
> **Stacked on #6214.** Base is `main` as usual, so this branch carries #6214's commit too — GitHub will show two. **Merge #6214 first**; this PR's diff then reduces to its own single commit (`f864f414c`). The overlap is real: both touch `toolpacks/{mod,tools,toolpacks_tests}.rs`, so this cannot apply to `main` on its own.

## Summary

- #6214 fixed the **landing**: `load_skill` on a pack you cannot use now returns the route instead of a schema dump. **The invitation was still wrong.**
- `pack_index_markdown()` is global and is baked into `LoadSkillTool`'s description at construction, before any session exists — so every agent read all ten packs as loadable, including ones it can call nothing in.
- Both halves of the advertisement are now scoped to the session: the description's index **and** the `skill` enum.
- The description gets **smaller**: 975 → 691 chars for the orchestrator, **~71 tokens saved every turn**, plus three fewer enum entries.

## Problem

For the orchestrator, three packs are advertised as loadable that it can call nothing in — `system` (26 tools), `documents` (2), `audio` (3). The model is told to go somewhere it cannot use, finds that out, and comes back.

Before #6214 that cost a dead turn. After #6214 it costs one wasted round trip. It should cost zero.

The carrier is the problem: `LoadSkillTool::new` builds the description once, and `skill_enum()` builds the enum once, both before any session exists.

## Solution

`visible_tool_specs_for_policy` (`session/builder/mod.rs:89`) is the only function that turns tools into the specs a provider sees **and** holds the session. It already clones every spec, so rewriting one is free, and it covers both the initial build and the Composio-reconcile rebuild.

#6214 moved pack *rendering* into the middleware for the same reason, but that seam is wrong here: a description ships with the schema **before** any tool call, so a call interceptor is too late.

Three details worth a reviewer's attention:

**The schema is the stronger half.** Narrowing the `skill` enum makes an unusable pack *unrepresentable*, not merely discouraged in prose. I would have wanted this even at zero token saving — and a shorter enum is fewer tokens, not more.

**It uses the gate's predicate, not the neighbour's.** `decision_for(..).is_denied()`, not the adjacent visibility filter's `is_allowed`. Matching the neighbour would re-introduce the two sources of truth #6214 exists to collapse.

**A session that can reach no pack loses both pack tools.** An empty index and an empty enum are not a tool, so `load_skill` and `use_skill` are dropped from the wire rather than shipped inert.

The `Unknown skill` error's listing is scoped by the same predicate — offering a hallucinating model a pack it cannot use is the same wrong turn, one error later.

## The design choice, and the tradeoff against it

An un-callable pack is **dropped** from the index rather than listed with an inline route (`` `system` — … · delegate to `manage_settings` ``). The inline form is the more obviously "honest" option, so here is why I did not take it:

**The capability is already advertised — by the delegate tool.** `manage_settings`, `do_crypto` and `make_presentation` are all on the wire with their `when_to_use` descriptions, and they are what the model should call. Listing the pack *and* its route duplicates routing the model already has, and bills it on **every turn**, to save a round trip the model should not be taking at all. The index answers "which skills can I load"; a pack that cannot be loaded is not an answer to that question.

**What this loses, stated against my own choice.** For a pack that is un-callable **and** has no reachable owner, the capability becomes invisible to that agent. That is exactly `audio` — ownerless (`owners: &[]`), so the orchestrator genuinely cannot do podcasts by any route, and advertising it only bought a wasted trip. I think invisibility is the correct representation of "cannot do this", but it is a real tradeoff, and `audio` is the one case where the inline-route option would have read better. A reviewer who disagrees should say so on that case specifically: swapping to inline routes is a change to `pack_index_markdown_filtered` alone.

Scoping is per-session, so `settings_agent` still sees `system`. Each agent gets its own truth.

**No pack was deleted, and I found none that should be.** "Dead" in the #6214 audit meant *dead to this caller*. `goals` and `app_update` are fully callable; `system` is doing exactly its job keeping 26 schemas out of the context window.

## What it cost

The advertisement shrank. Measured against the orchestrator's reachable set (`[tools].named` ∪ synthesised delegate names):

| | chars | packs |
|---|---:|---:|
| full index | 975 | 10 |
| scoped index | 691 | 7 |
| **saved** | **284 (~71 tokens/turn)** | dropped `system` (113c), `documents` (91c), `audio` (80c) |

## Verification

Four revert-checks, each failing on **my** assertion:

| revert | test | failure |
|---|---|---|
| description rewrite disabled | `the_index_drops_a_pack_this_session_can_call_nothing_in` | "`system` has no callable tool here and must not be advertised: …" |
| enum rewrite disabled | `the_skill_enum_offers_only_reachable_packs` | left: all ten pack ids; right: `["workflows"]` |
| never signal "drop it" | `a_session_that_can_reach_no_pack_loses_load_skill` | "with nothing reachable, load_skill must be dropped, not emptied" |
| **unwired from the builder** | `visible_specs_scope_load_skills_index_to_the_session` + `visible_specs_drop_the_pack_tools_when_no_pack_is_reachable` | "with no reachable pack, neither pack tool earns its schema: [load_skill, use_skill]" |

The fourth is the one that matters most and I added it for myself: it proves the helper is **wired**, not merely correct. A right helper nobody calls advertises all ten packs exactly as before, and the first three tests would still have passed.

`scoping_the_index_only_ever_shrinks_it` pins the token claim, so a future edit cannot quietly make the advertisement bigger.

**479 passed, 0 failed** across `toolpacks`, `builder_tests`, `orchestrator`, `tinyagents`, `session::builder`. `cargo fmt --check` clean; `cargo clippy -p openhuman --no-deps --all-targets` clean on every changed file.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement) — 7 new tests: index scoping, enum scoping, the no-reachable-pack drop, the shrink invariant, and two builder-level tests proving the wiring.
- [x] **Diff coverage ≥ 80%** — every changed production path is exercised and independently revert-checked: the description rewrite, the enum rewrite, the `false` return, and the `filter_map` in the builder. Full `pnpm test:coverage` not run — see Validation Blocked.
- [x] N/A: behaviour-only change — no feature row added, removed or renamed in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] N/A: no coverage-matrix feature IDs apply (see the item above).
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — all new tests are in-process with a hand-built `ToolPolicySession`.
- [x] N/A: does not touch a release-cut surface in `docs/RELEASE-MANUAL-SMOKE.md` — this is agent-internal tool advertisement.
- [x] N/A: no issue exists — this follows from #6214's own audit finding, which was reported from a live turn rather than filed.

## Impact

- **Runtime/platform:** every agent that is offered `load_skill`. No RPC, schema or protocol change; no migration.
- **Behaviour change:** a pack with nothing callable in this session is no longer advertised, and is no longer a valid `skill` value. A session that can reach no pack at all carries neither `load_skill` nor `use_skill`.
- **Context cost falls** (~71 tokens/turn for the orchestrator); it can never rise, and a test pins that.
- **No behaviour change for an owner** — `settings_agent` still sees `system`, because it can call it.
- **Security:** strictly narrowing. The gate is untouched and still authoritative; the advertisement merely stopped disagreeing with it.

## Related

- Closes: N/A — no issue; follows from #6214's audit.
- Follow-up PR(s)/TODOs: `audio` is ownerless, so it is the one pack that now vanishes with no route offered anywhere — deliberately out of scope here and in #6214, because deciding who owns podcast generation is a product call. Likewise `composio`'s `integrations_agent` and `skills`' `context_scout`, which the orchestrator holds no delegate for.

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A — not tracked in Linear.
- URL: N/A — follows from #6214's audit.

### Commit & Branch

- Branch: `fix/load-skill-index-scoping`
- Commit SHA: `f864f414cbb2af9fd0df87bc704b98aeb3d45f92` (stacked on `1939edeb6`, which is #6214)

### Validation Run

- [x] N/A: `pnpm --filter openhuman-app format:check` — no frontend files changed (Rust only).
- [x] N/A: `pnpm typecheck` — no TypeScript files changed.
- [x] Focused tests: `cargo test -p openhuman --lib --features "$(bash scripts/ci/product-features.sh)" --no-default-features -- toolpacks builder_tests orchestrator tinyagents session::builder` → **479 passed, 0 failed, 2 ignored**. Test-first + four revert-checks (table above).
- [x] Rust fmt/check (if changed): `cargo fmt --check` clean; `cargo clippy -p openhuman --no-deps --all-targets` clean on all changed files.
- [x] N/A: Tauri fmt/check — no files under the Tauri shell changed.

### Validation Blocked

- `command:` full-workspace `pnpm test:rust` / `pnpm test:coverage`
- `error:` not run — the fleet is capped at 3 concurrent local cargo slots. `RUST_MIN_STACK=67108864` is required near the agent harness or an unrelated turn test overflows its stack.
- `impact:` diff coverage is argued from the revert-checks rather than a `diff-cover` number. CI's gate is authoritative.

### Behavior Changes

- Intended behavior change: `load_skill`'s advertised index and `skill` enum are scoped to the packs the calling session can actually use.
- User-visible effect: the assistant stops making a round trip into a skill it cannot use, and each turn carries a slightly smaller tool schema.

### Parity Contract

- Legacy behavior preserved: `pack_index_markdown()` still exists and still returns the full index for callers with no session; an owner's advertisement is unchanged because nothing it can call is removed.
- Guard/fallback/dispatch parity checks: the advertisement now uses the same predicate as the gate and as #6214's listing filter — one source of truth for "can this session call it" across all three. Degradation is one-directional: a pack is dropped only when *every* tool in it is denied.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): N/A.
- Canonical PR: this one; #6214 is its prerequisite, not a duplicate.
- Resolution: N/A.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Skill listings now show only tools available to the current session.
  - Unavailable skills are omitted from advertised options, with guidance for reaching an appropriate available route.
  - Permission checks now apply consistently when loading or using skills.
  - Workflow requests are routed to dedicated building and discovery tools, while running and listing saved workflows remains available.

- **Bug Fixes**
  - Prevented users from being shown tools they cannot call.
  - Improved fallback guidance when no directly usable workflow tools are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
