### PR TITLE
fix(settings): spacing, hierarchy and destructive-action design across five panels

### DIFF
--- a/app/src/components/feedback/FeedbackSubmitForm.test.tsx
+++ b/app/src/components/feedback/FeedbackSubmitForm.test.tsx
@@ -215,6 +215,56 @@ describe('<FeedbackSubmitForm /> quality tiers', () => {
     expect(await screen.findByText('Add steps to reproduce.')).toBeInTheDocument();
   });
 
+  // The advice from an accepted-with-warning submission outlives the draft it
+  // was about, so the only thing that should discard it is an edit. Selecting
+  // the type you are already on is not an edit -- and it went from an unlikely
+  // misclick on a full-width button to an easy one on an adjacent pill.
+  it('keeps warned-submission advice when the already-selected type is re-clicked', async () => {
+    mockValidate.mockResolvedValue({ tier: 'warn', reason: 'Add steps to reproduce.' });
+    mockSubmit.mockResolvedValueOnce({
+      accepted: true,
+      reason: 'ok',
+      feedback: makeItem(),
+      quality: { tier: 'warn', reason: 'Add steps to reproduce.' },
+    });
+
+    render(<FeedbackSubmitForm onAccepted={() => {}} />);
+    fillForm('Crash', 'It crashes.');
+    await screen.findByTestId('feedback-quality-hint');
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(await screen.findByText('Add steps to reproduce.')).toBeInTheDocument();
+
+    // `feature` is the default, so this is the pill that is already active.
+    fireEvent.click(screen.getByRole('button', { name: 'Feature' }));
+
+    expect(screen.getByText('Add steps to reproduce.')).toBeInTheDocument();
+  });
+
+  // The other half of the same guard: it must skip the reset only when the type
+  // is unchanged. A guard that swallowed the reset outright would leave stale
+  // advice attached to a draft whose type just changed.
+  it('discards warned-submission advice when the type actually changes', async () => {
+    mockValidate.mockResolvedValue({ tier: 'warn', reason: 'Add steps to reproduce.' });
+    mockSubmit.mockResolvedValueOnce({
+      accepted: true,
+      reason: 'ok',
+      feedback: makeItem(),
+      quality: { tier: 'warn', reason: 'Add steps to reproduce.' },
+    });
+
+    render(<FeedbackSubmitForm onAccepted={() => {}} />);
+    fillForm('Crash', 'It crashes.');
+    await screen.findByTestId('feedback-quality-hint');
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+    expect(await screen.findByText('Add steps to reproduce.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Bug' }));
+
+    await waitFor(() =>
+      expect(screen.queryByText('Add steps to reproduce.')).not.toBeInTheDocument()
+    );
+  });
+
   // apiClient rejects with a plain `{ success, error }` object, not an Error.
   // Without handling that shape the server's reason is replaced by the generic
   // failure copy, and a blocked submitter is told nothing useful.

--- a/app/src/components/feedback/FeedbackSubmitForm.tsx
+++ b/app/src/components/feedback/FeedbackSubmitForm.tsx
@@ -189,6 +189,10 @@ export default function FeedbackSubmitForm({ onAccepted }: FeedbackSubmitFormPro
             onClick={() => {
               // Changing the type is an edit like any other: the advice the last
               // submission came back with is no longer about what is on screen.
+              // Clicking the pill that is already selected is not an edit, so it
+              // must not discard advice an accepted-with-warning submission just
+              // produced -- easier to hit now that these are adjacent pills.
+              if (type === 'feature') return;
               setType('feature');
               setSubmittedQuality(null);
             }}
@@ -200,6 +204,7 @@ export default function FeedbackSubmitForm({ onAccepted }: FeedbackSubmitFormPro
             size="sm"
             className="rounded-full"
             onClick={() => {
+              if (type === 'bug') return;
               setType('bug');
               setSubmittedQuality(null);
             }}

--- a/app/src/components/feedback/FeedbackSubmitForm.tsx
+++ b/app/src/components/feedback/FeedbackSubmitForm.tsx
@@ -44,7 +44,11 @@ interface FeedbackSubmitFormProps {
   onAccepted: (result: CreateFeedbackResult) => void;
 }
 
-const INPUT_CLASS = 'w-full rounded-xl bg-surface-muted px-4 py-2.5';
+// The card fills the pane; the fields inside it do not. A title line and a
+// description are prose, and prose past ~80 characters per line is measurably
+// harder to read -- a full-pane textarea also makes a short body look like a
+// mistake. 68ch keeps both comfortable without leaving the field looking stunted.
+const INPUT_CLASS = 'w-full max-w-[68ch] rounded-xl bg-surface-muted px-4 py-2.5';
 
 export default function FeedbackSubmitForm({ onAccepted }: FeedbackSubmitFormProps) {
   const { t } = useT();
@@ -159,57 +163,50 @@ export default function FeedbackSubmitForm({ onAccepted }: FeedbackSubmitFormPro
 
   return (
     <div className="rounded-2xl border border-line bg-surface p-6 shadow-soft dark:shadow-none">
-      <h2 className="font-title text-base font-semibold text-content">
-        {t('feedback.submit.heading')}
-      </h2>
-      <p className="mb-4 mt-0.5 text-xs text-content-muted">{t('feedback.submit.subheading')}</p>
+      {/* The type toggle used to be two full-width `size="lg"` buttons stacked
+          above the fields: a binary property of the draft, rendered larger and
+          louder than the title, the body and Submit combined, so the form read
+          as "pick one of two things" and the primary action read as dead.
+          It is now a pill beside the heading -- the same shape and placement
+          the billing panel gives its monthly/annual switch, which is the same
+          kind of control: one bit that qualifies the thing below it. */}
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="max-w-[52ch]">
+          <h2 className="font-title text-base font-semibold text-content">
+            {t('feedback.submit.heading')}
+          </h2>
+          <p className="mt-0.5 text-xs text-content-muted">{t('feedback.submit.subheading')}</p>
+        </div>
 
-      <div className="mb-4 grid grid-cols-2 gap-2.5">
-        <Button
-          variant="secondary"
-          size="lg"
-          onClick={() => {
-            // Changing the type is an edit like any other: the advice the last
-            // submission came back with is no longer about what is on screen.
-            setType('feature');
-            setSubmittedQuality(null);
-          }}
-          aria-pressed={type === 'feature'}
-          className={
-            type === 'feature'
-              ? 'border-primary-500 bg-primary-500/10 text-primary-600 ring-1 ring-primary-500/30 dark:text-primary-400'
-              : 'text-content-muted'
-          }>
-          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={1.8}
-              d="M12 3l1.6 4.4L18 9l-4.4 1.6L12 15l-1.6-4.4L6 9l4.4-1.6L12 3zM18.5 14.5l.7 1.8 1.8.7-1.8.7-.7 1.8-.7-1.8-1.8-.7 1.8-.7.7-1.8z"
-            />
-          </svg>
-          {t('feedback.type.feature')}
-        </Button>
-        <Button
-          variant="secondary"
-          size="lg"
-          onClick={() => {
-            setType('bug');
-            setSubmittedQuality(null);
-          }}
-          aria-pressed={type === 'bug'}
-          tone={type === 'bug' ? 'danger' : 'default'}
-          className={type === 'bug' ? 'ring-1 ring-coral-500/30' : 'text-content-muted'}>
-          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={1.8}
-              d="M12 8a4 4 0 00-4 4v2a4 4 0 008 0v-2a4 4 0 00-4-4zM9.5 5.5L8.2 4.2M14.5 5.5l1.3-1.3M8 12.5H4.5M16 12.5h3.5M8 16l-2.8 1.6M16 16l2.8 1.6"
-            />
-          </svg>
-          {t('feedback.type.bug')}
-        </Button>
+        <div
+          role="group"
+          aria-label={t('feedback.submit.heading')}
+          className="inline-flex w-fit shrink-0 rounded-full bg-surface-subtle p-1 ring-1 ring-line">
+          <Button
+            variant={type === 'feature' ? 'primary' : 'tertiary'}
+            size="sm"
+            className="rounded-full"
+            onClick={() => {
+              // Changing the type is an edit like any other: the advice the last
+              // submission came back with is no longer about what is on screen.
+              setType('feature');
+              setSubmittedQuality(null);
+            }}
+            aria-pressed={type === 'feature'}>
+            {t('feedback.type.feature')}
+          </Button>
+          <Button
+            variant={type === 'bug' ? 'primary' : 'tertiary'}
+            size="sm"
+            className="rounded-full"
+            onClick={() => {
+              setType('bug');
+              setSubmittedQuality(null);
+            }}
+            aria-pressed={type === 'bug'}>
+            {t('feedback.type.bug')}
+          </Button>
+        </div>
       </div>
 
       <label htmlFor="feedback-title" className="sr-only">

--- a/app/src/components/settings/LogoutAndClearActions.tsx
+++ b/app/src/components/settings/LogoutAndClearActions.tsx
@@ -50,13 +50,26 @@ const LogoutAndClearActions = () => {
     }
   };
 
-  const arrowOutIcon = (
-    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+  // Two actions, two glyphs. They shared one arrow-out icon, which is most of
+  // why an irreversible wipe and a routine sign-out read as the same control.
+  const signOutIcon = (
+    <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path
         strokeLinecap="round"
         strokeLinejoin="round"
         strokeWidth={2}
         d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+      />
+    </svg>
+  );
+
+  const eraseIcon = (
+    <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
       />
     </svg>
   );
@@ -69,24 +82,51 @@ const LogoutAndClearActions = () => {
 
   return (
     <div>
+      {/* Log out is routine and reversible, so it reads as an ordinary row.
+          It was `dangerous` and amber, identical to the wipe below it. */}
       <SettingsMenuItem
-        icon={arrowOutIcon}
-        title={t('settings.clearAppData')}
-        description={t('settings.clearAppDataDesc')}
-        onClick={() => setShowLogoutAndClearModal(true)}
-        testId="settings-nav-logout-and-clear"
-        dangerous
-        isFirst
-      />
-      <SettingsMenuItem
-        icon={arrowOutIcon}
+        icon={signOutIcon}
         title={t('settings.logOut')}
         description={t('settings.logOutDesc')}
         onClick={handleLogout}
         testId="settings-nav-logout"
-        dangerous
+        isFirst
         isLast
       />
+
+      {/* Clearing app data is not a peer of logging out, so it stops being a
+          row in the same menu. Separating it is the fix: the two were the same
+          amber, the same weight and the same icon, one row apart, and amber is
+          this app's WARNING ramp -- coral is the destructive one. Placement,
+          ramp, glyph and an explicit consequence line now all say the same
+          thing, and the action sits behind a confirm. */}
+      <section
+        className="mt-5 rounded-xl border border-coral-500/30 bg-coral-500/[0.06] p-4"
+        data-testid="account-destructive-zone">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="max-w-[52ch]">
+            <h3 className="font-title text-sm font-semibold text-content">
+              {t('settings.clearAppData')}
+            </h3>
+            <p className="mt-1 text-xs leading-relaxed text-content-muted">
+              {t('settings.clearAppDataDesc')}
+            </p>
+            <p className="mt-1 text-xs font-medium text-coral-600 dark:text-coral-300">
+              {t('settings.clearAppDataIrreversible')}
+            </p>
+          </div>
+          <Button
+            variant="secondary"
+            tone="danger"
+            size="sm"
+            leadingIcon={eraseIcon}
+            onClick={() => setShowLogoutAndClearModal(true)}
+            data-testid="settings-nav-logout-and-clear"
+            className="shrink-0">
+            {t('settings.clearAppDataAction')}
+          </Button>
+        </div>
+      </section>
 
       {showInlineError && (
         <div
@@ -101,7 +141,7 @@ const LogoutAndClearActions = () => {
         <ModalShell
           title={t('clearData.title')}
           titleId={modalTitleId}
-          icon={arrowOutIcon}
+          icon={eraseIcon}
           onClose={() => {
             setShowLogoutAndClearModal(false);
             setError(null);
@@ -120,12 +160,16 @@ const LogoutAndClearActions = () => {
                 className="flex-1">
                 {t('common.cancel')}
               </Button>
+              {/* Was an amber wash painted over `variant="tertiary"`, which
+                  bypassed the danger tone entirely and used the warning ramp
+                  for the most destructive confirm in the app. */}
               <Button
-                variant="tertiary"
+                variant="primary"
+                tone="danger"
                 onClick={handleLogoutAndClearData}
                 disabled={isLoading}
                 leadingIcon={isLoading ? <Spinner /> : undefined}
-                className="flex-1 bg-amber-600 hover:bg-amber-500 text-content-inverted dark:bg-amber-600 dark:hover:bg-amber-500">
+                className="flex-1">
                 {isLoading ? t('clearData.clearing') : t('clearData.title')}
               </Button>
             </div>

--- a/app/src/components/settings/__tests__/LogoutAndClearActions.test.tsx
+++ b/app/src/components/settings/__tests__/LogoutAndClearActions.test.tsx
@@ -34,17 +34,22 @@ describe('LogoutAndClearActions', () => {
     mockClearAllAppData.mockReset().mockResolvedValue(undefined);
   });
 
-  it('renders the destructive actions row', () => {
+  it('renders log out as a row and clearing data as a separate destructive zone', () => {
     renderActions();
-    expect(screen.getByText('Clear App Data')).toBeInTheDocument();
+    // The two used to be adjacent rows with the same amber, weight and icon.
+    // Clearing data is now its own zone with its own button, so the assertion
+    // checks the split rather than just that both strings exist.
     expect(screen.getByText('Log out')).toBeInTheDocument();
+    expect(screen.getByText('Clear app data')).toBeInTheDocument();
+    expect(screen.getByTestId('account-destructive-zone')).toBeInTheDocument();
+    expect(screen.getByTestId('settings-nav-logout-and-clear')).toHaveTextContent('Clear data');
   });
 
   it('passes the current snapshot user id + clearSession to clearAllAppData', async () => {
     const user = userEvent.setup();
     renderActions();
 
-    await user.click(screen.getByText('Clear App Data').closest('button')!);
+    await user.click(screen.getByTestId('settings-nav-logout-and-clear'));
     const confirmButtons = screen.getAllByRole('button', { name: /Clear App Data/i });
     await user.click(confirmButtons[confirmButtons.length - 1]);
 
@@ -63,7 +68,7 @@ describe('LogoutAndClearActions', () => {
     );
     renderActions();
 
-    await user.click(screen.getByText('Clear App Data').closest('button')!);
+    await user.click(screen.getByTestId('settings-nav-logout-and-clear'));
     const confirmButtons = screen.getAllByRole('button', { name: /Clear App Data/i });
     await user.click(confirmButtons[confirmButtons.length - 1]);
 
@@ -77,7 +82,7 @@ describe('LogoutAndClearActions', () => {
     mockClearAllAppData.mockRejectedValueOnce(new Error(''));
     renderActions();
 
-    await user.click(screen.getByText('Clear App Data').closest('button')!);
+    await user.click(screen.getByTestId('settings-nav-logout-and-clear'));
     const confirmButtons = screen.getAllByRole('button', { name: /Clear App Data/i });
     await user.click(confirmButtons[confirmButtons.length - 1]);
 

--- a/app/src/components/settings/layout/SettingsPanel.tsx
+++ b/app/src/components/settings/layout/SettingsPanel.tsx
@@ -98,6 +98,11 @@ export default function SettingsPanel<T extends string = string>({
   // above this panel, so render just the tabs/body without title/description/
   // sub-nav to avoid a doubled header.
   if (headerless) {
+    // `scrollable` / `bodyClassName` are forwarded here too. They were declared
+    // on the props but only wired into the routed return, so a headerless host
+    // passing either got the PanelPage defaults with no type error and no
+    // warning -- the same silent-drop failure the `children` comment below
+    // describes. `PanelPage` calls the body class `contentClassName`.
     if (tabs && tabs.length > 0) {
       return (
         <PanelPage<T>
@@ -109,11 +114,17 @@ export default function SettingsPanel<T extends string = string>({
           onChange={onChange}
           tabsAriaLabel={tabsAriaLabel}
           tabsTestIdPrefix={tabsTestIdPrefix}
+          scrollable={scrollable}
         />
       );
     }
     return (
-      <PanelPage className="z-10" testId={testId} action={action}>
+      <PanelPage
+        className="z-10"
+        testId={testId}
+        action={action}
+        scrollable={scrollable}
+        contentClassName={bodyClassName}>
         {children}
       </PanelPage>
     );

--- a/app/src/components/settings/layout/SettingsPanel.tsx
+++ b/app/src/components/settings/layout/SettingsPanel.tsx
@@ -11,6 +11,19 @@ import SettingsTabbedPage from './SettingsTabbedPage';
 
 interface SettingsPanelProps<T extends string = string> {
   /**
+   * Replaces the default `space-y-5` body wrapper. A panel whose main region is
+   * meant to fill the height (a live log, a list) needs to be a flex column
+   * rather than a stack of margins, and cannot express that from the outside.
+   */
+  bodyClassName?: string;
+  /**
+   * Forwarded to {@link SettingsTabbedPage}. Pass `false` when the panel owns
+   * its own scroll region: the page wrapper then has a definite height, which
+   * is what a `flex-1` child needs in order to fill it. Without this the log
+   * region below sized to its content and left the rest of the pane blank.
+   */
+  scrollable?: boolean;
+  /**
    * Override the panel title. Defaults to the active route's registry title, so
    * most panels omit it. Supply it for dynamic sub-pages (profile/agent
    * editors, team management) that don't map 1:1 to a registry entry.
@@ -74,6 +87,8 @@ export default function SettingsPanel<T extends string = string>({
   tabsTestIdPrefix,
   children,
   testId,
+  bodyClassName,
+  scrollable,
 }: SettingsPanelProps<T>) {
   const { t } = useT();
   const { currentRoute, navigateBack } = useSettingsNavigation();
@@ -129,7 +144,7 @@ export default function SettingsPanel<T extends string = string>({
       {children}
     </div>
   ) : (
-    <div className="space-y-5">{children}</div>
+    <div className={bodyClassName ?? 'space-y-5'}>{children}</div>
   );
 
   return (
@@ -151,7 +166,8 @@ export default function SettingsPanel<T extends string = string>({
         value={active ? active.id : undefined}
         onChange={onChange}
         tabsAriaLabel={tabsAriaLabel}
-        tabsTestIdPrefix={tabsTestIdPrefix}>
+        tabsTestIdPrefix={tabsTestIdPrefix}
+        scrollable={scrollable}>
         {body}
       </SettingsTabbedPage>
     </div>

--- a/app/src/components/settings/panels/AppearancePanel.tsx
+++ b/app/src/components/settings/panels/AppearancePanel.tsx
@@ -99,7 +99,7 @@ const AppearancePanel = () => {
 
       {/* ── Font size picker — intentional bespoke tile UI ─────────── */}
       <div>
-        <h3 className="text-xs font-semibold uppercase tracking-wider text-content-faint mb-2 px-1">
+        <h3 className="mb-2 px-1 font-title text-sm font-semibold text-content">
           {t('settings.appearance.fontSizeHeading')}
         </h3>
         {/* Card forwards no `role`/`aria-label` to its wrapper, so the

--- a/app/src/components/settings/panels/EventLogPanel.tsx
+++ b/app/src/components/settings/panels/EventLogPanel.tsx
@@ -307,7 +307,11 @@ const EventLogPanel = () => {
   const domains = [...new Set(entries.map(e => e.domain))].sort();
 
   return (
-    <SettingsPanel testId="event-log-panel" description={t('settings.developerMenu.eventLog.desc')}>
+    <SettingsPanel
+      testId="event-log-panel"
+      scrollable={false}
+      bodyClassName="flex h-full min-h-0 flex-col gap-4"
+      description={t('settings.developerMenu.eventLog.desc')}>
       {/* Status bar */}
       <div className="flex flex-wrap items-center gap-2">
         <SettingsSelect
@@ -375,18 +379,33 @@ const EventLogPanel = () => {
         </Button>
       )}
 
-      {/* Event stream */}
-      <section className="space-y-1">
+      {/* Event stream.
+          This is a live region, not a document, so it claims the height rather
+          than taking a narrow measure: it was a `max-h-[60vh]` box that sized
+          to its content, so with no events the whole panel was a filter bar,
+          one grey sentence, and 700px of nothing -- indistinguishable from a
+          page that failed to load. Bounded and framed, the same emptiness reads
+          as a log that is connected and has not received anything yet, which is
+          what it is. */}
+      <section className="flex min-h-[22rem] flex-1 flex-col overflow-hidden rounded-xl border border-line">
         <div
           ref={containerRef}
           onScroll={handleScroll}
-          className="max-h-[60vh] overflow-y-auto space-y-1">
+          data-testid="event-log-scroll"
+          className="min-h-0 flex-1 space-y-1 overflow-y-auto p-2">
           {filteredEntries.length === 0 && (
-            <p className="text-xs text-content-muted py-4 text-center">
-              {isLive
-                ? t('settings.developerMenu.eventLog.waiting')
-                : t('settings.developerMenu.eventLog.notConnected')}
-            </p>
+            <div className="flex h-full min-h-[18rem] flex-col items-center justify-center gap-1 text-center">
+              <p className="text-sm text-content-secondary">
+                {isLive
+                  ? t('settings.developerMenu.eventLog.waiting')
+                  : t('settings.developerMenu.eventLog.notConnected')}
+              </p>
+              <p className="max-w-[44ch] text-xs text-content-faint">
+                {isLive
+                  ? t('settings.developerMenu.eventLog.waitingHint')
+                  : t('settings.developerMenu.eventLog.notConnectedHint')}
+              </p>
+            </div>
           )}
           {filteredEntries.map(entry => {
             const colors = DOMAIN_BADGE_COLORS[entry.domain] || {

--- a/app/src/components/settings/panels/EventLogPanel.tsx
+++ b/app/src/components/settings/panels/EventLogPanel.tsx
@@ -387,14 +387,14 @@ const EventLogPanel = () => {
           page that failed to load. Bounded and framed, the same emptiness reads
           as a log that is connected and has not received anything yet, which is
           what it is. */}
-      <section className="flex min-h-[22rem] flex-1 flex-col overflow-hidden rounded-xl border border-line">
+      <section className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-line">
         <div
           ref={containerRef}
           onScroll={handleScroll}
           data-testid="event-log-scroll"
           className="min-h-0 flex-1 space-y-1 overflow-y-auto p-2">
           {filteredEntries.length === 0 && (
-            <div className="flex h-full min-h-[18rem] flex-col items-center justify-center gap-1 text-center">
+            <div className="flex h-full flex-col items-center justify-center gap-1 text-center">
               <p className="text-sm text-content-secondary">
                 {isLive
                   ? t('settings.developerMenu.eventLog.waiting')

--- a/app/src/components/settings/panels/MigrationPanel.tsx
+++ b/app/src/components/settings/panels/MigrationPanel.tsx
@@ -135,11 +135,19 @@ const MigrationPanel = ({ embedded = false }: MigrationPanelProps = {}) => {
 
   const body = (
     <>
-      <p className="text-sm text-content-secondary">{t('migration.description')}</p>
+      {/* The card fills the pane, but a paragraph does not want to: at this
+          pane width an uncapped line runs past 180 characters. */}
+      <p className="max-w-[68ch] text-sm text-content-secondary">{t('migration.description')}</p>
 
       <SettingsSection>
         <div className="p-4 space-y-5" data-testid="migration-form">
-          <div className="space-y-1">
+          {/* The card fills the pane; each field takes the width its own value
+              needs. A two-option vendor picker a metre wide puts its label and
+              its value at opposite ends of an empty control; a workspace path is
+              long and genuinely uses the room. Sized per field, not uniformly.
+              NOTE: the sibling Core connection panel runs its URL and token
+              fields at full width, so the app has no settled rule here yet. */}
+          <div className="max-w-sm space-y-1">
             <label className="block text-xs font-medium text-content-secondary">
               {t('migration.vendorLabel')}
             </label>
@@ -155,7 +163,7 @@ const MigrationPanel = ({ embedded = false }: MigrationPanelProps = {}) => {
             </SettingsSelect>
           </div>
 
-          <div className="space-y-1">
+          <div className="max-w-2xl space-y-1">
             <label className="block text-xs font-medium text-content-secondary">
               {t('migration.sourceLabel')}
             </label>
@@ -185,19 +193,25 @@ const MigrationPanel = ({ embedded = false }: MigrationPanelProps = {}) => {
               disabled={isPreviewing || isApplying}>
               {isPreviewing ? t('migration.previewRunning') : t('migration.previewAction')}
             </Button>
+            {/* Was an amber wash over `variant="tertiary"`, which bypassed the
+                danger tone and used the warning ramp. Disabled, that wash read
+                as a broken button rather than a locked one; the gate is
+                explained in the line below the row instead. */}
             <Button
               type="button"
-              variant="tertiary"
+              variant="primary"
+              tone="danger"
               size="sm"
               data-testid="migration-apply-button"
               onClick={() => void runApply()}
-              disabled={!canApply}
-              className="bg-amber-600 hover:bg-amber-700 text-content-inverted disabled:bg-amber-600/50">
+              disabled={!canApply}>
               {isApplying ? t('migration.applyRunning') : t('migration.applyAction')}
             </Button>
           </div>
 
-          <p className="text-[11px] text-content-muted">{t('migration.applyDisclaimer')}</p>
+          <p className="max-w-[68ch] text-[11px] text-content-muted">
+            {t('migration.applyDisclaimer')}
+          </p>
         </div>
       </SettingsSection>
 
@@ -256,7 +270,7 @@ const MigrationPanel = ({ embedded = false }: MigrationPanelProps = {}) => {
             </div>
           )}
 
-          <p className="text-[11px] text-content-muted">
+          <p className="max-w-[68ch] text-[11px] text-content-muted">
             {appliedReport != null
               ? t('migration.report.appliedHint')
               : t('migration.report.previewHint')}

--- a/app/src/components/settings/panels/ThemeStudioPanel.tsx
+++ b/app/src/components/settings/panels/ThemeStudioPanel.tsx
@@ -215,7 +215,7 @@ const ThemeStudioPanel = ({ embedded = false }: ThemeStudioPanelProps = {}) => {
       {/* ── Theme gallery: family tiles + one Light/Dark/Auto toggle ──── */}
       <div>
         <div className="mb-2 flex items-center justify-between px-1">
-          <h3 className="text-xs font-semibold uppercase tracking-wider text-content-faint">
+          <h3 className="font-title text-sm font-semibold text-content">
             {t('settings.theme.presetsHeading', 'Themes')}
           </h3>
           <ToggleGroupRoot
@@ -304,7 +304,7 @@ const ThemeStudioPanel = ({ embedded = false }: ThemeStudioPanelProps = {}) => {
                 </span>
                 <span className="flex items-center justify-between gap-1">
                   <span className="text-sm font-medium text-content truncate">{th.name}</span>
-                  <span className="text-[10px] uppercase tracking-wide text-content-faint">
+                  <span className="text-[11px] text-content-faint">
                     {t('settings.theme.customBadge', 'Custom')}
                   </span>
                 </span>
@@ -337,7 +337,9 @@ const ThemeStudioPanel = ({ embedded = false }: ThemeStudioPanelProps = {}) => {
       {/* ── Colour editor ──────────────────────────────────────────── */}
       {COLOR_GROUPS.map(group => (
         <SettingsSection key={group.id} title={t(group.i18nKey, humanize(group.id))}>
-          <div className="px-1">
+          {/* A ruled list, matching the billing panel: the hairlines do the
+              separating so each row needs no box of its own. */}
+          <div className="divide-y divide-line-subtle px-4">
             {group.keys.map(key => (
               <ColorTokenField
                 key={key}

--- a/app/src/components/settings/panels/__tests__/EventLogPanel.test.tsx
+++ b/app/src/components/settings/panels/__tests__/EventLogPanel.test.tsx
@@ -213,7 +213,10 @@ describe('EventLogPanel', () => {
       expect(screen.getByText('ScrollTest')).toBeTruthy();
     });
 
-    const scrollDiv = container.querySelector('.max-h-\\[60vh\\]')!;
+    // Was `container.querySelector('.max-h-[60vh]')` — the scroll region was
+    // addressed by a utility class, so restyling it broke the test without any
+    // behaviour changing. A testid is the stable handle.
+    const scrollDiv = container.querySelector('[data-testid="event-log-scroll"]')!;
     Object.defineProperty(scrollDiv, 'scrollTop', { value: 100, writable: true });
     fireEvent.scroll(scrollDiv);
 

--- a/app/src/components/settings/panels/theme/ColorTokenField.test.tsx
+++ b/app/src/components/settings/panels/theme/ColorTokenField.test.tsx
@@ -16,7 +16,11 @@ describe('ColorTokenField', () => {
     );
 
     expect(screen.getByText('Canvas')).toBeInTheDocument();
-    expect(screen.getByText('--surface-canvas · #2f6ef4')).toBeInTheDocument();
+    // The token id and the hex used to be one interpolated description string
+    // on the far side of the row from the swatch. They are separate spans beside
+    // the swatch now, so they are asserted separately.
+    expect(screen.getByText('--surface-canvas')).toBeInTheDocument();
+    expect(screen.getByText('#2f6ef4')).toBeInTheDocument();
   });
 
   it('exposes the native colour swatch with the converted hex value and an accessible name', () => {

--- a/app/src/components/settings/panels/theme/ColorTokenField.tsx
+++ b/app/src/components/settings/panels/theme/ColorTokenField.tsx
@@ -1,7 +1,6 @@
 import { useId } from 'react';
 
 import { channelsToHex, hexToChannels } from '../../../../lib/theme/color';
-import Field from '../../../ui/Field';
 
 interface ColorTokenFieldProps {
   /** Token key without `--` (e.g. `surface-canvas`). */
@@ -17,32 +16,40 @@ interface ColorTokenFieldProps {
 }
 
 /**
- * A single editable colour token row: a native colour swatch + read-only hex
- * label. Converts between the stored channel format and the hex the native
- * `<input type="color">` speaks.
+ * A single editable colour token row: the swatch, then what it is.
+ *
+ * It used to be a `Field`, whose row is `justify-between` — so the name sat on
+ * the far left and a 48px swatch on the far right, with the whole panel width
+ * between them. The swatch is the content of this row and it was both the
+ * smallest thing in it and the furthest from its own label. Leading the row
+ * with it puts the colour next to the name it belongs to, and the row no longer
+ * cares how wide the panel is.
  */
 const ColorTokenField = ({ tokenKey, label, value, disabled, onChange }: ColorTokenFieldProps) => {
   const id = useId();
   const hex = channelsToHex(value);
 
   return (
-    <Field
+    <label
       htmlFor={id}
-      label={label}
-      description={`--${tokenKey} · ${hex}`}
-      className="px-0 py-1.5"
-      control={
-        <input
-          id={id}
-          type="color"
-          value={hex}
-          disabled={disabled}
-          onChange={e => onChange(hexToChannels(e.target.value))}
-          aria-label={label}
-          className="h-8 w-12 shrink-0 cursor-pointer rounded-md border border-line bg-surface disabled:cursor-not-allowed disabled:opacity-50"
-        />
-      }
-    />
+      className={`flex items-center gap-3 py-2 ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}`}>
+      <input
+        id={id}
+        type="color"
+        value={hex}
+        disabled={disabled}
+        onChange={e => onChange(hexToChannels(e.target.value))}
+        aria-label={label}
+        className="h-9 w-9 shrink-0 cursor-pointer rounded-lg border border-line bg-surface p-0 disabled:cursor-not-allowed disabled:opacity-50"
+      />
+      <span className="flex min-w-0 flex-1 items-baseline gap-2">
+        <span className="truncate text-sm text-content">{label}</span>
+        {/* The hex is the value you are about to change, so it stays on the
+            same line as the name rather than dropping to a sub-label. */}
+        <span className="shrink-0 font-mono text-xs tabular-nums text-content-muted">{hex}</span>
+        <span className="truncate font-mono text-[11px] text-content-faint">--{tokenKey}</span>
+      </span>
+    </label>
   );
 };
 

--- a/app/src/components/ui/NativeSelect.tsx
+++ b/app/src/components/ui/NativeSelect.tsx
@@ -18,6 +18,13 @@ export interface NativeSelectProps extends SelectHTMLAttributes<HTMLSelectElemen
  * to drive under jsdom. The native control also remains the right answer on the
  * mobile route tree, where the OS picker beats any HTML popup.
  */
+/**
+ * KNOWN LIMITATION: the `%23a3a3a3` stroke is a literal, so the chevron does not
+ * follow the theme. A data-URI cannot read a CSS variable, and the fix that does
+ * work -- a wrapper element with an inline `currentColor` SVG -- moves where the
+ * caller's width class has to land, which would touch every `NativeSelect` call
+ * site. Left deliberately, not overlooked.
+ */
 const CHEVRON_BG =
   "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M2 4l4 4 4-4' stroke='%23a3a3a3' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3C/svg%3E\")";
 
@@ -30,6 +37,13 @@ const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
       data-testid={testId}
       className={cn(
         'block cursor-pointer appearance-none rounded-lg border border-line-strong bg-surface bg-no-repeat pr-7 text-sm text-content',
+        // `@plugin '@tailwindcss/forms'` puts `padding: 0.5rem 0.75rem` on bare
+        // `select`. Only the horizontal half was ever overridden here, so 16px
+        // of vertical padding stayed inside the 32px `h-8` box: 8 + 8 padding +
+        // 2 border leaves 14px for a 20px line box, and the overflow clipped
+        // every descender. `py-0` + an explicit `leading-none` centres the text
+        // in the box the height already declares.
+        'py-0 leading-none',
         'transition-colors duration-150',
         'focus:border-primary-500 focus:outline-hidden focus:ring-2 focus:ring-primary-500/20',
         'disabled:cursor-not-allowed disabled:opacity-50',

--- a/app/src/lib/i18n/ar.ts
+++ b/app/src/lib/i18n/ar.ts
@@ -521,6 +521,8 @@ const messages: TranslationMap = {
   'settings.developerMode.enabledByBuild': 'مفعّل دائمًا في إصدارات التطوير',
   'settings.clearAppData': 'مسح بيانات التطبيق',
   'settings.clearAppDataDesc': 'تسجيل الخروج وحذف جميع البيانات المحلية للتطبيق نهائيًا',
+  'settings.clearAppDataIrreversible': 'لا يمكن التراجع عن هذا الإجراء.',
+  'settings.clearAppDataAction': 'حذف البيانات',
   'settings.logOut': 'تسجيل الخروج',
   'settings.logOutDesc': 'تسجيل الخروج من حسابك',
   'settings.exitLocalSession': 'الخروج من الجلسة المحلية',
@@ -4838,6 +4840,9 @@ const messages: TranslationMap = {
   'settings.developerMenu.eventLog.live': 'الحياة',
   'settings.developerMenu.eventLog.disconnected': 'مفصولة',
   'settings.developerMenu.eventLog.waiting': 'ننتظر الأحداث...',
+  'settings.developerMenu.eventLog.waitingHint':
+    'تظهر الأحداث هنا عندما تعمل الوكلاء والأدوات والنظام. لم يحدث شيء بعد.',
+  'settings.developerMenu.eventLog.notConnectedHint': 'أعد الاتصال بالنواة لاستئناف البث.',
   'settings.developerMenu.eventLog.notConnected': 'غير متصل بالنواة',
   'settings.developerMenu.eventLog.jumpToLatest': 'اقفز على آخر',
   'settings.developerMenu.eventLog.badge.tool': 'TOOL',

--- a/app/src/lib/i18n/bn.ts
+++ b/app/src/lib/i18n/bn.ts
@@ -535,6 +535,8 @@ const messages: TranslationMap = {
   'settings.developerMode.enabledByBuild': 'ডেভেলপমেন্ট বিল্ডে সবসময় চালু',
   'settings.clearAppData': 'অ্যাপ ডেটা মুছুন',
   'settings.clearAppDataDesc': 'সাইন আউট করুন এবং সব লোকাল ডেটা স্থায়ীভাবে মুছুন',
+  'settings.clearAppDataIrreversible': 'এটি আর ফেরানো যাবে না।',
+  'settings.clearAppDataAction': 'ডেটা মুছুন',
   'settings.logOut': 'লগ আউট',
   'settings.logOutDesc': 'আপনার অ্যাকাউন্ট থেকে সাইন আউট করুন',
   'settings.exitLocalSession': 'স্থানীয় সেশন থেকে প্রস্থান করুন',
@@ -4950,6 +4952,10 @@ const messages: TranslationMap = {
   'settings.developerMenu.eventLog.live': 'লাইভ',
   'settings.developerMenu.eventLog.disconnected': 'বিচ্ছিন্ন',
   'settings.developerMenu.eventLog.waiting': 'ইভেন্টের অপেক্ষা করা হচ্ছে...',
+  'settings.developerMenu.eventLog.waitingHint':
+    'এজেন্ট, টুল ও সিস্টেম কাজ করলে ঘটনাগুলি এখানে দেখা যাবে। এখনও কিছু ঘটেনি।',
+  'settings.developerMenu.eventLog.notConnectedHint':
+    'স্ট্রিম আবার চালু করতে কোরের সঙ্গে পুনরায় সংযোগ করুন।',
   'settings.developerMenu.eventLog.notConnected': 'সংযুক্ত নয়',
   'settings.developerMenu.eventLog.jumpToLatest': 'সর্বশেষ গুরুত্বপূর্ণ',
   'settings.developerMenu.eventLog.badge.tool': 'TOOL',

--- a/app/src/lib/i18n/de.ts
+++ b/app/src/lib/i18n/de.ts
@@ -556,6 +556,8 @@ const messages: TranslationMap = {
   'settings.developerMode.enabledByBuild': 'In Entwicklungs-Builds immer aktiviert',
   'settings.clearAppData': 'App-Daten löschen',
   'settings.clearAppDataDesc': 'Melde dich ab und lösche alle lokalen App-Daten dauerhaft',
+  'settings.clearAppDataIrreversible': 'Dies kann nicht rückgängig gemacht werden.',
+  'settings.clearAppDataAction': 'Daten löschen',
   'settings.logOut': 'Abmelden',
   'settings.logOutDesc': 'Melde dich von deinem Konto ab',
   'settings.exitLocalSession': 'Lokale Sitzung beenden',
@@ -5086,6 +5088,10 @@ const messages: TranslationMap = {
   'settings.developerMenu.eventLog.live': 'Live',
   'settings.developerMenu.eventLog.disconnected': 'Nicht verbunden',
   'settings.developerMenu.eventLog.waiting': 'Warten auf Ereignisse...',
+  'settings.developerMenu.eventLog.waitingHint':
+    'Ereignisse erscheinen hier, sobald Agenten, Tools und das System arbeiten. Bisher ist nichts passiert.',
+  'settings.developerMenu.eventLog.notConnectedHint':
+    'Verbinden Sie sich erneut mit dem Core, um den Stream fortzusetzen.',
   'settings.developerMenu.eventLog.notConnected': 'Mit dem Hauptprogramm verbundenName',
   'settings.developerMenu.eventLog.jumpToLatest': 'Zur neuesten Seite springen',
   'settings.developerMenu.eventLog.badge.tool': 'TOOL',

--- a/app/src/lib/i18n/en.ts
+++ b/app/src/lib/i18n/en.ts
@@ -338,8 +338,11 @@ const en: TranslationMap = {
   'settings.developerMode.title': 'Developer mode',
   'settings.developerMode.description': 'Show advanced developer & diagnostic tools',
   'settings.developerMode.enabledByBuild': 'Always on in development builds',
-  'settings.clearAppData': 'Clear App Data',
-  'settings.clearAppDataDesc': 'Sign out and permanently clear all local app data',
+  'settings.clearAppData': 'Clear app data',
+  'settings.clearAppDataDesc':
+    'Signs you out and deletes every thread, setting, and cached file stored on this device.',
+  'settings.clearAppDataIrreversible': 'This cannot be undone.',
+  'settings.clearAppDataAction': 'Clear data',
   'settings.logOut': 'Log out',
   'settings.logOutDesc': 'Sign out of your account',
   'settings.exitLocalSession': 'Exit local session',
@@ -430,7 +433,7 @@ const en: TranslationMap = {
   'settings.ai.llmProviderDesc': 'Choose and configure your AI provider',
 
   // Clear App Data modal
-  'clearData.title': 'Clear App Data',
+  'clearData.title': 'Clear app data',
   'clearData.warning': 'This will sign you out and permanently delete local app data including:',
   'clearData.bulletSettings': 'App settings and conversations',
   'clearData.bulletCache': 'All local integration cache data',
@@ -5654,6 +5657,9 @@ const en: TranslationMap = {
   'settings.developerMenu.eventLog.live': 'Live',
   'settings.developerMenu.eventLog.disconnected': 'Disconnected',
   'settings.developerMenu.eventLog.waiting': 'Waiting for events...',
+  'settings.developerMenu.eventLog.waitingHint':
+    'Events appear here as agents, tools, and the system do work. Nothing has happened yet.',
+  'settings.developerMenu.eventLog.notConnectedHint': 'Reconnect to the core to resume the stream.',
   'settings.developerMenu.eventLog.notConnected': 'Not connected to core',
   'settings.developerMenu.eventLog.jumpToLatest': 'Jump to latest',
   'settings.developerMenu.eventLog.badge.tool': 'TOOL',

--- a/app/src/lib/i18n/es.ts
+++ b/app/src/lib/i18n/es.ts
@@ -547,6 +547,8 @@ const messages: TranslationMap = {
   'settings.clearAppData': 'Borrar datos de la app',
   'settings.clearAppDataDesc':
     'Cerrar sesión y eliminar permanentemente todos los datos locales de la app',
+  'settings.clearAppDataIrreversible': 'Esto no se puede deshacer.',
+  'settings.clearAppDataAction': 'Borrar datos',
   'settings.logOut': 'Cerrar sesión',
   'settings.logOutDesc': 'Salir de tu cuenta',
   'settings.exitLocalSession': 'Salir de la sesión local',
@@ -5041,6 +5043,10 @@ const messages: TranslationMap = {
   'settings.developerMenu.eventLog.live': 'Vivir',
   'settings.developerMenu.eventLog.disconnected': 'desconectado',
   'settings.developerMenu.eventLog.waiting': 'Esperando eventos...',
+  'settings.developerMenu.eventLog.waitingHint':
+    'Los eventos aparecen aquí a medida que los agentes, las herramientas y el sistema trabajan. Todavía no ha ocurrido nada.',
+  'settings.developerMenu.eventLog.notConnectedHint':
+    'Vuelve a conectar con el core para reanudar el flujo.',
   'settings.developerMenu.eventLog.notConnected': 'No conectado al núcleo',
   'settings.developerMenu.eventLog.jumpToLatest': 'Saltar a lo más reciente',
   'settings.developerMenu.eventLog.badge.tool': 'TOOL',

--- a/app/src/lib/i18n/fr.ts
+++ b/app/src/lib/i18n/fr.ts
@@ -559,6 +559,8 @@ const messages: TranslationMap = {
   'settings.clearAppData': "Effacer les données de l'app",
   'settings.clearAppDataDesc':
     'Se déconnecter et supprimer définitivement toutes les données locales',
+  'settings.clearAppDataIrreversible': 'Cette action est irréversible.',
+  'settings.clearAppDataAction': 'Effacer les données',
   'settings.logOut': 'Se déconnecter',
   'settings.logOutDesc': 'Se déconnecter de ton compte',
   'settings.exitLocalSession': 'Quitter le local session',
@@ -5068,6 +5070,10 @@ const messages: TranslationMap = {
   'settings.developerMenu.eventLog.live': 'Vivre',
   'settings.developerMenu.eventLog.disconnected': 'Déconnecté',
   'settings.developerMenu.eventLog.waiting': 'En attente des événements...',
+  'settings.developerMenu.eventLog.waitingHint':
+    'Les événements apparaissent ici quand les agents, les outils et le système travaillent. Rien pour le moment.',
+  'settings.developerMenu.eventLog.notConnectedHint':
+    'Reconnectez-vous au core pour reprendre le flux.',
   'settings.developerMenu.eventLog.notConnected': 'Non connecté au noyau',
   'settings.developerMenu.eventLog.jumpToLatest': 'Aller au plus récent',
   'settings.developerMenu.eventLog.badge.tool': 'TOOL',

--- a/app/src/lib/i18n/hi.ts
+++ b/app/src/lib/i18n/hi.ts
@@ -535,6 +535,8 @@ const messages: TranslationMap = {
   'settings.developerMode.enabledByBuild': 'डेवलपमेंट बिल्ड में हमेशा चालू',
   'settings.clearAppData': 'ऐप डेटा क्लियर करें',
   'settings.clearAppDataDesc': 'साइन आउट करें और सारा लोकल ऐप डेटा हमेशा के लिए मिटाएं',
+  'settings.clearAppDataIrreversible': 'इसे पूर्ववत नहीं किया जा सकता।',
+  'settings.clearAppDataAction': 'डेटा हटाएँ',
   'settings.logOut': 'लॉग आउट',
   'settings.logOutDesc': 'अपने अकाउंट से साइन आउट करें',
   'settings.exitLocalSession': 'स्थानीय सत्र से बाहर निकलें',
@@ -4953,6 +4955,10 @@ const messages: TranslationMap = {
   'settings.developerMenu.eventLog.live': 'लाइव',
   'settings.developerMenu.eventLog.disconnected': 'डिस्कनेक्ट',
   'settings.developerMenu.eventLog.waiting': 'घटनाओं के लिए प्रतीक्षा...',
+  'settings.developerMenu.eventLog.waitingHint':
+    'जब एजेंट, टूल और सिस्टम काम करते हैं तो घटनाएँ यहाँ दिखती हैं। अभी तक कुछ नहीं हुआ है।',
+  'settings.developerMenu.eventLog.notConnectedHint':
+    'स्ट्रीम फिर से शुरू करने के लिए कोर से दोबारा कनेक्ट करें।',
   'settings.developerMenu.eventLog.notConnected': 'कोर से जुड़ा नहीं है',
   'settings.developerMenu.eventLog.jumpToLatest': 'नवीनतम',
   'settings.developerMenu.eventLog.badge.tool': 'TOOL',

--- a/app/src/lib/i18n/id.ts
+++ b/app/src/lib/i18n/id.ts
@@ -542,6 +542,8 @@ const messages: TranslationMap = {
   'settings.developerMode.enabledByBuild': 'Selalu aktif di build pengembangan',
   'settings.clearAppData': 'Bersihkan Data Aplikasi',
   'settings.clearAppDataDesc': 'Keluar dan hapus permanen semua data aplikasi lokal',
+  'settings.clearAppDataIrreversible': 'Tindakan ini tidak dapat dibatalkan.',
+  'settings.clearAppDataAction': 'Hapus data',
   'settings.logOut': 'Keluar',
   'settings.logOutDesc': 'Keluar dari akun Anda',
   'settings.exitLocalSession': 'Keluar dari sesi lokal',
@@ -4979,6 +4981,10 @@ const messages: TranslationMap = {
   'settings.developerMenu.eventLog.live': 'Live',
   'settings.developerMenu.eventLog.disconnected': 'Terputus',
   'settings.developerMenu.eventLog.waiting': 'Menunggu peristiwa...',
+  'settings.developerMenu.eventLog.waitingHint':
+    'Peristiwa muncul di sini saat agen, alat, dan sistem bekerja. Belum ada yang terjadi.',
+  'settings.developerMenu.eventLog.notConnectedHint':
+    'Hubungkan kembali ke core untuk melanjutkan aliran.',
   'settings.developerMenu.eventLog.notConnected': 'Tidak terhubung ke inti',
   'settings.developerMenu.eventLog.jumpToLatest': 'Lompat ke terbaru',
   'settings.developerMenu.eventLog.badge.tool': 'TOOL',

--- a/app/src/lib/i18n/it.ts
+++ b/app/src/lib/i18n/it.ts
@@ -551,6 +551,8 @@ const messages: TranslationMap = {
   'settings.clearAppData': 'Cancella dati app',
   'settings.clearAppDataDesc':
     "Disconnetti e cancella permanentemente tutti i dati locali dell'app",
+  'settings.clearAppDataIrreversible': 'Questa azione è irreversibile.',
+  'settings.clearAppDataAction': 'Cancella i dati',
   'settings.logOut': 'Disconnetti',
   'settings.logOutDesc': 'Disconnetti dal tuo account',
   'settings.exitLocalSession': 'Esci dalla sessione locale',
@@ -5031,6 +5033,10 @@ const messages: TranslationMap = {
   'settings.developerMenu.eventLog.live': 'Vivere',
   'settings.developerMenu.eventLog.disconnected': 'Disconnesso',
   'settings.developerMenu.eventLog.waiting': 'In attesa degli eventi...',
+  'settings.developerMenu.eventLog.waitingHint':
+    'Gli eventi compaiono qui mentre agenti, strumenti e sistema lavorano. Per ora non è successo nulla.',
+  'settings.developerMenu.eventLog.notConnectedHint':
+    'Riconnettiti al core per riprendere lo streaming.',
   'settings.developerMenu.eventLog.notConnected': 'Non connesso al nucleo',
   'settings.developerMenu.eventLog.jumpToLatest': "Vai all'ultimo",
   'settings.developerMenu.eventLog.badge.tool': 'TOOL',

--- a/app/src/lib/i18n/ko.ts
+++ b/app/src/lib/i18n/ko.ts
@@ -528,6 +528,8 @@ const messages: TranslationMap = {
   'settings.developerMode.enabledByBuild': '개발 빌드에서 항상 활성화',
   'settings.clearAppData': '앱 데이터 삭제',
   'settings.clearAppDataDesc': '로그아웃하고 모든 로컬 앱 데이터를 영구적으로 삭제',
+  'settings.clearAppDataIrreversible': '되돌릴 수 없습니다.',
+  'settings.clearAppDataAction': '데이터 삭제',
   'settings.logOut': '로그아웃',
   'settings.logOutDesc': '계정에서 로그아웃',
   'settings.exitLocalSession': '로컬 세션 종료',
@@ -4896,6 +4898,9 @@ const messages: TranslationMap = {
   'settings.developerMenu.eventLog.live': '실시간',
   'settings.developerMenu.eventLog.disconnected': '연결 끊김',
   'settings.developerMenu.eventLog.waiting': '이벤트 대기 중...',
+  'settings.developerMenu.eventLog.waitingHint':
+    '에이전트, 도구, 시스템이 작업하면 여기에 이벤트가 나타납니다. 아직 아무 일도 없었습니다.',
+  'settings.developerMenu.eventLog.notConnectedHint': '스트림을 재개하려면 코어에 다시 연결하세요.',
   'settings.developerMenu.eventLog.notConnected': '코어에 연결되지 않음',
   'settings.developerMenu.eventLog.jumpToLatest': '최신으로 이동',
   'settings.developerMenu.eventLog.badge.tool': 'TOOL',

--- a/app/src/lib/i18n/pl.ts
+++ b/app/src/lib/i18n/pl.ts
@@ -547,6 +547,8 @@ const messages: TranslationMap = {
   'settings.developerMode.enabledByBuild': 'Zawsze włączony w buildach deweloperskich',
   'settings.clearAppData': 'Wyczyść dane aplikacji',
   'settings.clearAppDataDesc': 'Wyloguj się i trwale wyczyść wszystkie lokalne dane aplikacji',
+  'settings.clearAppDataIrreversible': 'Tej operacji nie można cofnąć.',
+  'settings.clearAppDataAction': 'Wyczyść dane',
   'settings.logOut': 'Wyloguj się',
   'settings.logOutDesc': 'Wyloguj się ze swojego konta',
   'settings.exitLocalSession': 'Zakończ sesję lokalną',
@@ -5031,6 +5033,10 @@ const messages: TranslationMap = {
   'settings.developerMenu.eventLog.live': 'Na żywo',
   'settings.developerMenu.eventLog.disconnected': 'Rozłączono',
   'settings.developerMenu.eventLog.waiting': 'Oczekiwanie na zdarzenia...',
+  'settings.developerMenu.eventLog.waitingHint':
+    'Zdarzenia pojawiają się tutaj, gdy agenci, narzędzia i system pracują. Na razie nic się nie wydarzyło.',
+  'settings.developerMenu.eventLog.notConnectedHint':
+    'Połącz się ponownie z rdzeniem, aby wznowić strumień.',
   'settings.developerMenu.eventLog.notConnected': 'Brak połączenia z rdzeniem',
   'settings.developerMenu.eventLog.jumpToLatest': 'Przejdź do najnowszego',
   'settings.developerMenu.eventLog.badge.tool': 'TOOL',

--- a/app/src/lib/i18n/pt.ts
+++ b/app/src/lib/i18n/pt.ts
@@ -545,6 +545,8 @@ const messages: TranslationMap = {
   'settings.developerMode.enabledByBuild': 'Sempre ativado em builds de desenvolvimento',
   'settings.clearAppData': 'Limpar Dados do App',
   'settings.clearAppDataDesc': 'Sair e excluir permanentemente todos os dados locais do app',
+  'settings.clearAppDataIrreversible': 'Isso não pode ser desfeito.',
+  'settings.clearAppDataAction': 'Limpar dados',
   'settings.logOut': 'Sair',
   'settings.logOutDesc': 'Sair da sua conta',
   'settings.exitLocalSession': 'Sair da sessão local',
@@ -5026,6 +5028,9 @@ const messages: TranslationMap = {
   'settings.developerMenu.eventLog.live': 'Ao vivo',
   'settings.developerMenu.eventLog.disconnected': 'Desconectado',
   'settings.developerMenu.eventLog.waiting': 'Aguardando eventos...',
+  'settings.developerMenu.eventLog.waitingHint':
+    'Os eventos aparecem aqui conforme os agentes, as ferramentas e o sistema trabalham. Ainda não aconteceu nada.',
+  'settings.developerMenu.eventLog.notConnectedHint': 'Reconecte ao core para retomar o fluxo.',
   'settings.developerMenu.eventLog.notConnected': 'Não conectado ao núcleo',
   'settings.developerMenu.eventLog.jumpToLatest': 'Ir para o mais recente',
   'settings.developerMenu.eventLog.badge.tool': 'TOOL',

--- a/app/src/lib/i18n/ru.ts
+++ b/app/src/lib/i18n/ru.ts
@@ -543,6 +543,8 @@ const messages: TranslationMap = {
   'settings.developerMode.enabledByBuild': 'Всегда включён в сборках разработки',
   'settings.clearAppData': 'Очистить данные приложения',
   'settings.clearAppDataDesc': 'Выйти из аккаунта и удалить все локальные данные приложения',
+  'settings.clearAppDataIrreversible': 'Это действие нельзя отменить.',
+  'settings.clearAppDataAction': 'Удалить данные',
   'settings.logOut': 'Выйти',
   'settings.logOutDesc': 'Выйти из своего аккаунта',
   'settings.exitLocalSession': 'Выход из локального сеанса',
@@ -5002,6 +5004,10 @@ const messages: TranslationMap = {
   'settings.developerMenu.eventLog.live': 'Жить',
   'settings.developerMenu.eventLog.disconnected': 'Отключено',
   'settings.developerMenu.eventLog.waiting': 'Ждем событий...',
+  'settings.developerMenu.eventLog.waitingHint':
+    'События появляются здесь по мере работы агентов, инструментов и системы. Пока ничего не произошло.',
+  'settings.developerMenu.eventLog.notConnectedHint':
+    'Подключитесь к ядру снова, чтобы возобновить поток.',
   'settings.developerMenu.eventLog.notConnected': 'Не подключен к ядру',
   'settings.developerMenu.eventLog.jumpToLatest': 'Перейти к последней версии',
   'settings.developerMenu.eventLog.badge.tool': 'TOOL',

--- a/app/src/lib/i18n/zh-CN.ts
+++ b/app/src/lib/i18n/zh-CN.ts
@@ -497,6 +497,8 @@ const messages: TranslationMap = {
   'settings.developerMode.enabledByBuild': '开发版本中始终启用',
   'settings.clearAppData': '清除应用数据',
   'settings.clearAppDataDesc': '退出登录并永久清除所有本地应用数据',
+  'settings.clearAppDataIrreversible': '此操作无法撤销。',
+  'settings.clearAppDataAction': '清除数据',
   'settings.logOut': '退出登录',
   'settings.logOutDesc': '退出当前账户',
   'settings.exitLocalSession': '退出本地会话',
@@ -4679,6 +4681,9 @@ const messages: TranslationMap = {
   'settings.developerMenu.eventLog.live': '实时',
   'settings.developerMenu.eventLog.disconnected': '已断开连接',
   'settings.developerMenu.eventLog.waiting': '正在等待事件...',
+  'settings.developerMenu.eventLog.waitingHint':
+    '当智能体、工具和系统开始工作时，事件会显示在这里。目前还没有任何事件。',
+  'settings.developerMenu.eventLog.notConnectedHint': '重新连接到核心以恢复事件流。',
   'settings.developerMenu.eventLog.notConnected': '未连接到核心',
   'settings.developerMenu.eventLog.jumpToLatest': '跳到最新',
   'settings.developerMenu.eventLog.badge.tool': '工具',


### PR DESCRIPTION
## Summary

- Five settings panels read as broken rather than short. Containers now fill the pane; the text and inputs inside them keep a readable measure.
- **Account: an irreversible wipe and a routine sign-out were rendered identically** — same amber, same weight, same icon, one row apart. Split into an ordinary row and a separate destructive zone.
- One shared select bug fixed in one place: `NativeSelect` clipped every descender, which presented as two unrelated bugs in Event Log and Import.
- Three destructive controls were painting amber (the **warning** ramp) over `variant="tertiary"`, bypassing `tone="danger"` (coral) entirely.
- All-caps tracked-out eyebrows removed; Appearance's colour token rows lead with the swatch instead of stranding it a full pane-width from its label.

## Problem

Every one of these panels was a shallow band of content at the top of an 800px column with no answer for the rest of the height, plus real defects inside:

1. **`NativeSelect` clipped descenders.** `@plugin '@tailwindcss/forms'` sets `padding: 0.5rem 0.75rem` on bare `select`, and `NativeSelect` only ever overrode the horizontal half. 8px + 8px padding + 2px border inside a 32px `h-8` box leaves 14px for a 20px line box, so the overflow cut every descender. This is **one bug**, not the two it looked like.
2. **Account gave a destructive action and a routine one the same treatment.** Both `dangerous`, both amber, both the same arrow-out glyph, adjacent. Amber is this app's warning ramp; coral is the destructive one, so the most dangerous action in the app was also in the wrong semantic colour.
3. **Amber-over-`tertiary`** in Import's Apply button and the clear-data modal confirm, which bypassed `tone="danger"`. Disabled, Import's read as a broken button rather than a locked one.
4. **Share Feedback's Feature/Bug toggle** was two full-width `size="lg"` buttons stacked above the fields — a single bit of metadata rendered louder than the title, the body and Submit combined.
5. **Appearance's token rows** used a `justify-between` `Field`: the name at the far left, a 48px swatch at the far right, the whole pane between them. The swatch is the content of that row and was both the smallest thing in it and the furthest from its own label.

## Solution

**The layout rule, applied five times:** containers fill the pane; contents keep a measure. Settings deliberately has **no** column cap — `SettingsLayout.tsx:36` says so and explains why ("capping the column and centring it reads as a left/right gutter the other routed pages do not have, which is what made settings look inset") — so width belongs to the box and measure belongs to what is inside it. Which way a panel claims its height follows from its content: a document or form takes a readable measure and the space below it is page; a stream or grid keeps the width and fills the height. Event Log is the one that fills, via `scrollable={false}` + a bounded region, so an empty log reads as connected-and-idle rather than failed-to-load.

**Shared vs local.** Shared where the defect genuinely was: `NativeSelect`, and two opt-in props on `SettingsPanel`/`SettingsTabbedPage` (`bodyClassName`, `scrollable`) that **default to today's behaviour**, so no unreviewed panel moves. Everything else is local. I deliberately did **not** touch `Card.tsx:60`'s `tracking-wide` — it is mild (no `uppercase`) and changing it restyles every card in the product.

### Tradeoffs and things a reviewer cannot reconstruct

- **I built the opposite of this first and reverted it.** An earlier pass capped Account/Import/Feedback at `max-w-3xl`, which is what produced half-width cards. That reintroduced exactly what the `SettingsLayout` comment was written to remove. The prop is deleted rather than left unused, so it never reached a panel outside this set.
- **I also tried a terminal hairline** to mark where content ends, and cut it in review: three of five panels already end in a `Card`, which is a closed container — the edge was never missing. What reads as broken is proportion, not a missing boundary.
- **Inconsistency I introduced, and did not hide.** The sibling **Core connection** panel (not in scope here) runs its URL and token fields at full pane width. Import's fields are now sized to their values — vendor picker `max-w-sm`, workspace path `max-w-2xl` — so Import differs from its neighbour. The app has no settled rule for field width; I followed the narrower reading and left a code comment saying so. Easy to flip either way if reviewers prefer consistency over content-fit.
- **A reported "bug" that was not one, where my fix was a regression.** The feedback board's clamp was reported as inconsistent. It is identical on every card. I changed it anyway — gated "Show more" on measured overflow and split the comment count off it — and the existing test caught that **"Show more" is designed to reveal the comment thread**; the shared `expanded` state is intentional and my version would have made comments unreachable on short items. Fully reverted, `FeedbackItemRow.tsx` is untouched.
- **A chevron left deliberately unfixed.** `NativeSelect`'s chevron is a `%23a3a3a3` literal in a data-URI, so it does not follow the theme. A CSS mask does not work (`mask-image` applies to the whole element and hides the select's own text — tried, reverted). The fix that does work is a wrapper with an inline `currentColor` SVG, which moves where every caller's width class lands. Marked `KNOWN LIMITATION` in the source; worth its own issue.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) — 4 test updates, each annotated in-diff with why: three pinned copy/markup this PR intentionally changes, and `EventLogPanel.test.tsx` addressed its scroll region by a Tailwind utility class (`.max-h-[60vh]`), so restyling broke it with no behaviour change. Given a `data-testid` instead.
- [x] **Diff coverage ≥ 80%** — N/A to run locally: no `pnpm test:coverage` run here (see Validation Blocked). Changed lines are presentational JSX plus locale entries; the four touched test files all execute the changed components. Deferring to the CI gate.
- [x] Coverage matrix updated — `N/A: behaviour-only change`, no feature rows added, removed or renamed.
- [x] All affected feature IDs from the matrix are listed under `## Related` — `N/A: no matrix feature IDs touched`.
- [x] No new external network dependencies introduced — none added; no network code touched.
- [x] Manual smoke checklist updated if this touches release-cut surfaces — `N/A: no release-cut surface changed`. Verified by hand in a running app instead (screenshots below).
- [x] Linked issue closed via `Closes #NNN` — `N/A: no tracking issue; this came from a direct design brief.`

## Impact

- **Desktop/web renderer only.** No Rust, no core, no RPC, no migration, no dependency change.
- **User-visible behaviour change in one place worth calling out:** Account's "Clear App Data" is no longer a menu row. It is a button inside a destructive zone, still behind the same confirmation modal — the action and its guard are unchanged, only its presentation and its ramp.
- **Copy changes:** `settings.clearAppData` and `clearData.title` move to sentence case, `settings.clearAppDataDesc` now states the consequence. Four new keys, with real translations in **all 14 locales** — the i18n suite enforces completeness, so the runtime English fallback is not sufficient on its own.
- Themability: every colour added is a token, verified against Sepia (light) as well as the default dark theme.

## Related

- Closes: N/A — direct design brief, no tracking issue.
- Follow-up PR(s)/TODOs: `NativeSelect` chevron is theme-blind (`KNOWN LIMITATION` in source); settle a house rule for form-field width (Import vs Core connection).

---

## AI Authored PR Metadata (required for Codex/Linear PRs)

### Linear Issue

- Key: N/A
- URL: N/A

### Commit & Branch

- Branch: `design/settings-panels`
- Commit SHA: `bdb6bea8cd5f33c0619f0f9523f7ac8a0ee44ce3`

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — ran as `npx prettier --check` over the changed paths from `app/`: clean.
- [x] `pnpm typecheck` — ran as `npx tsc --noEmit -p tsconfig.json` from `app/`: **0 errors in `src/`**.
- [x] Focused tests: `npx vitest run --config test/vitest.config.ts src/components/settings/ src/components/feedback/ src/components/ui/ src/lib/i18n/` — **1733 passed**, 1 skipped, 150 files.
- [x] Rust fmt/check (if changed): `N/A: no Rust changed.`
- [x] Tauri fmt/check (if changed): `N/A: no Tauri shell code changed.`

### Validation Blocked

- `command:` `pnpm typecheck` / `pnpm test:coverage` at the repo root
- `error:` this worktree symlinks `node_modules` from the primary clone rather than running its own install, so root-workspace resolution is incomplete (`packages/tauri-plugin-ptt` reports 7 unrelated `TS2307`/`TS7006` errors, none in `src/`)
- `impact:` none on the change — the equivalents were run from `app/` and are recorded above. CI runs both properly on a clean install.

### Behavior Changes

- Intended behavior change: a destructive action stops looking identical to a routine one; select text stops being clipped; panels stop reading as failed loads.
- User-visible effect: Account, Event Log, Import, Share Feedback and Appearance re-laid out; no data, action or guard semantics changed.

### Parity Contract

- Legacy behavior preserved: every action keeps its handler, its `data-testid` and its confirmation flow. `SettingsPanel`/`SettingsTabbedPage`'s new props default to prior behaviour, so panels outside this set render byte-identically.
- Guard/fallback/dispatch parity checks: the clear-data modal still gates on the same confirm; Import's Apply is still gated on a successful Preview; `FeedbackItemRow` reverted to `main`'s behaviour after the test proved the intended contract.

### Duplicate / Superseded PR Handling

- Duplicate PR(s): none
- Canonical PR: this one
- Resolution: N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mWvL5s6eJP7gUeaw5AsMT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer empty-state guidance for the developer event log, including waiting and disconnected states.
  - Added localized messaging for irreversible app-data clearing and event-log states.
  - Improved settings panel layout and scrolling behavior.

- **UI Improvements**
  - Separated logout and clear-data actions with distinct icons and stronger warnings.
  - Refined feedback controls, appearance settings, theme editing, migration controls, and native select alignment.
  - Improved event-log layout and color-token presentation.

- **Bug Fixes**
  - Prevented selecting the active feedback type from clearing submission guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->