### PR TITLE
fix(memory): name the stale module binding instead of a bare NotFound

### DIFF
--- a/src/core/runtime/context.rs
+++ b/src/core/runtime/context.rs
@@ -99,6 +99,42 @@ struct WorkspaceBinding {
     memory_subsystem: crate::openhuman::config::schema::MemorySubsystemConfig,
 }
 
+/// Say so when the workspace is rebound after the memory module has already
+/// loaded.
+///
+/// The module is handed its `config_path` once, when it loads, and tinybus
+/// never unloads a library — there is no shutdown path and nothing a shutdown
+/// could reclaim (`modules/host.rs`). So a rebind after the module is `Ready`
+/// leaves it reading the *previous* profile's source registry for the rest of
+/// the process: the host writes `[[memory_sources]]` into the new profile's
+/// `config.toml`, and every id it registers is unknown to the driver.
+///
+/// This is the boot-signed-out-then-log-in case. It cannot be repaired in
+/// process, so this does not try. It makes the moment the binding went stale
+/// visible in the log, beside the rebind that caused it, instead of leaving a
+/// bare `NotFound` on a sync minutes later as the only evidence.
+///
+/// Best-effort and never fatal: a build without the modules feature, or a
+/// process whose memory module never loaded, has nothing stale to report.
+#[cfg(feature = "modules")]
+fn warn_if_memory_module_outlived_its_profile(workspace_dir: &std::path::Path) {
+    use crate::openhuman::modules::types::ModuleState;
+    if crate::openhuman::modules::state_of(crate::openhuman::modules::memory::MODULE_ID)
+        == ModuleState::Ready
+    {
+        log::warn!(
+            "[core-context] workspace rebound to {} while the memory module is already loaded. \
+             The module keeps the source registry it was given when it loaded and cannot be \
+             rebound in this process, so memory sources registered under this profile will not \
+             be visible to it until the app is restarted.",
+            workspace_dir.display()
+        );
+    }
+}
+
+#[cfg(not(feature = "modules"))]
+fn warn_if_memory_module_outlived_its_profile(_workspace_dir: &std::path::Path) {}
+
 impl CoreContext {
     /// Run the core initialization sequence and return the context plus whether
     /// an operator-supplied RPC bearer exists (for the public-bind safety check
@@ -482,6 +518,7 @@ impl CoreContext {
             workspace_dir: Some(workspace_dir.to_path_buf()),
             memory_subsystem,
         };
+        warn_if_memory_module_outlived_its_profile(workspace_dir);
         Ok(())
     }
 

--- a/src/openhuman/memory/sources/rpc_part_01.rs
+++ b/src/openhuman/memory/sources/rpc_part_01.rs
@@ -549,6 +549,41 @@ pub(crate) fn sync_dispatch(entry: &MemorySourceEntry) -> Result<SyncDispatch, S
     })
 }
 
+/// Turn a source-sync failure into something a reader can act on.
+///
+/// A `NotFound` from the driver is ambiguous: either nobody ever registered the
+/// id, or the driver is reading a different registry than the host is writing.
+/// The second happens because the memory module is loaded once per process and
+/// tinybus never unloads a library (`modules/ops.rs`), so the `config_path` it
+/// is handed at load is the one it keeps for the life of the process. Boot
+/// signed out, log in, and the host starts writing `[[memory_sources]]` into
+/// the new profile's `config.toml` while the module still reads the pre-login
+/// one — every id the host registers is then unknown to it, permanently.
+///
+/// The host can tell the two apart, because at this point it holds both halves
+/// of the contradiction: `host_has_source` is its own registry's answer for the
+/// same id. When the host has it and the driver does not, the registries
+/// disagree, and the only in-process remedy is a restart — the same remedy
+/// `ops` already states for a module that failed to load.
+///
+/// Every other failure is returned exactly as the driver stated it; inventing a
+/// diagnosis for those would send the reader down the wrong path.
+fn describe_source_sync_failure(
+    source_id: &str,
+    host_has_source: bool,
+    error: &crate::openhuman::memory::api::error::MemoryError,
+) -> String {
+    match error {
+        crate::openhuman::memory::api::error::MemoryError::NotFound(_) if host_has_source => format!(
+            "the memory module cannot see source '{source_id}', but this profile has it \
+             registered. The module is bound to a different profile's source registry — it \
+             reads the config it was given when it first loaded, and that binding cannot be \
+             changed while the app is running. Restart the app to rebind it."
+        ),
+        other => other.to_string(),
+    }
+}
+
 pub async fn sync_rpc(req: SyncRequest) -> Result<RpcOutcome<SyncResponse>, String> {
     tracing::info!(source_id = %req.source_id, "[memory_sources] sync_rpc: entry");
 
@@ -565,7 +600,11 @@ pub async fn sync_rpc(req: SyncRequest) -> Result<RpcOutcome<SyncResponse>, Stri
     // that refuse a disabled entry, and this RPC is the third caller, the one
     // behind the user's Sync button. Same words as `sync_source` so the UI
     // reads one message (#5820).
-    if let Some(entry) = super::registry::get_source_in(&config, &req.source_id)? {
+    // Kept past the `if let` because the failure path below needs the host's own
+    // answer for this id: a driver `NotFound` means something different when the
+    // host has the source than when it does not.
+    let host_entry = super::registry::get_source_in(&config, &req.source_id)?;
+    if let Some(entry) = &host_entry {
         if !entry.enabled {
             return Err(format!("source '{}' is disabled", entry.id));
         }
@@ -575,7 +614,7 @@ pub async fn sync_rpc(req: SyncRequest) -> Result<RpcOutcome<SyncResponse>, Stri
         if let SyncDispatch::Connector {
             connection_id,
             max_items,
-        } = sync_dispatch(&entry)?
+        } = sync_dispatch(entry)?
         {
             crate::openhuman::integrations::composio::ops::composio_sync_budgeted(
                 &config,
@@ -606,7 +645,9 @@ pub async fn sync_rpc(req: SyncRequest) -> Result<RpcOutcome<SyncResponse>, Stri
     })?;
     sync.run_source_sync(&req.source_id)
         .await
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| {
+            describe_source_sync_failure(&req.source_id, host_entry.is_some(), &error)
+        })?;
 
     Ok(RpcOutcome::new(
         SyncResponse {

--- a/src/openhuman/memory/sources/rpc_tests.rs
+++ b/src/openhuman/memory/sources/rpc_tests.rs
@@ -9,6 +9,7 @@
 
 use super::*;
 use crate::core::subsystem::DriverClass;
+use crate::openhuman::memory::api::error::MemoryError;
 // Needed to call the family accessors on the *concrete* null provider
 // below; the handlers above reach them through `dyn MemoryProvider`, where
 // the trait is in scope by construction.
@@ -309,5 +310,65 @@ async fn add_generates_an_id_and_caps_a_request_that_left_its_limits_unset() {
         fetched.url.as_deref(),
         Some("https://github.invalid/owner/repo"),
         "the request's url"
+    );
+}
+
+// ── Profile-drift diagnosis on sync (#5820 follow-up) ────────────────────────
+//
+// The memory module is loaded once per process and tinybus never unloads a
+// library, so the `config_path` it is handed at load is the one it keeps. When
+// the host rebinds its workspace mid-process — boot signed out, then log in —
+// the host starts writing `[[memory_sources]]` into the new profile's
+// config.toml while the module is still reading the old one. Every id the host
+// registers is then unknown to the driver, and the user sees a bare
+// `NotFound` that reads like a missing source rather than a stale binding.
+//
+// The host holds both halves of that contradiction at the point of failure: its
+// own registry has the id, and the driver says it does not. Saying so is the
+// difference between a ten-minute diagnosis and half a day.
+
+#[test]
+fn a_not_found_for_a_source_the_host_has_registered_reports_the_stale_binding() {
+    let message = describe_source_sync_failure(
+        "src_8cc5c81a3a7b482b8f832a84faaa6c4e",
+        true,
+        &MemoryError::NotFound(
+            "no memory source registered as src_8cc5c81a3a7b482b8f832a84faaa6c4e".to_string(),
+        ),
+    );
+    assert!(
+        message.contains("different profile") || message.contains("restart"),
+        "a NotFound for an id the host DID register must name the stale binding and the \
+         remedy, not repeat the driver's 'no memory source registered' — got: {message}"
+    );
+    assert!(
+        message.contains("src_8cc5c81a3a7b482b8f832a84faaa6c4e"),
+        "the message must still name the source id: {message}"
+    );
+}
+
+#[test]
+fn a_not_found_for_an_id_the_host_never_registered_is_passed_through() {
+    let message = describe_source_sync_failure(
+        "src_never_existed",
+        false,
+        &MemoryError::NotFound("no memory source registered as src_never_existed".to_string()),
+    );
+    assert!(
+        !message.contains("different profile"),
+        "an id the host does not have either is a genuinely missing source, not drift — \
+         diagnosing it as a stale binding would send the reader down the wrong path: {message}"
+    );
+}
+
+#[test]
+fn a_non_not_found_failure_is_passed_through_unchanged() {
+    let inner = MemoryError::Backend("sqlite is locked".to_string());
+    let message = describe_source_sync_failure("src_1", true, &inner);
+    assert_eq!(
+        message,
+        inner.to_string(),
+        "only NotFound is ambiguous between 'missing' and 'stale binding'; every other \
+         failure must reach the caller as the driver stated it"
     );
 }


### PR DESCRIPTION
## Summary

- A folder memory source added after login syncs forever with `NotFound`, because the memory module is still reading the **pre-login profile's** source registry. Only a restart clears it.
- The module cannot be rebound in process — tinybus never unloads a library — so this PR does not pretend to repair the binding. It makes the failure **name itself** at both points where the host can see it.
- A complete correctness fix needs a `tinymemory-module` release; the evaluation and the reason are below, so the next person does not re-derive it.

## Problem

```
[memory_sources] sync_rpc: entry source_id=src_8cc5c81a…
ERR rpc.invoke_method failed: not found: ai.tinyhumans.tinymemory.Error.NotFound:
    no memory source registered as src_8cc5c81a…
```

The source **is** registered — it is in the host's `config.toml` with a valid `path` and `glob`, beside composio sources that sync fine. The add succeeds; the sync a second later fails and keeps failing. Logging in again does not help.

Three links, each verified:

1. **The module is handed its registry path once, at load.** `modules/ops.rs` builds the module payload including `"config_path": config.config_path`. The comment there records that this exists to stop the module deriving a path that does not exist and answering `NotFound` for every host-registered source (#5820). That fixed the *derivation*. It did not address *timing*.
2. **`ensure_loaded` is a no-op once the module is `Ready`.** `modules/ops.rs` — `Claim::Done(Resolution::Ready) => return Ok(())`. The `config` argument is dropped on the floor, so `module_config()` never runs again and the module keeps its first `config_path` for the life of the process.
3. **Workspace rebind tells the module nothing.** `core/runtime/context.rs` `rebind_workspace` swaps a `WorkspaceBinding` under a lock and returns. There is no module-facing call — and its own doc comment says the point of the rebind is to stop the driver "silently carrying over from the previous user", which is exactly what still happens to the already-loaded module.

**So:** boot signed out → the module loads against the pre-login profile → the user logs in → the host writes `[[memory_sources]]` into the real profile's `config.toml` → the module is still reading the old one → every id the host registers is unknown to it, permanently.

Staging never hit it because staging always boots with a stored session, so the workspace resolves *before* the module loads.

**Repro:** boot signed out → log in → add a folder memory source → sync.

## Solution

### Why the binding is not repaired here

`modules/host.rs` states it directly: *"tinybus also never unloads a library… Everything here is created once and lives for the process. There is no shutdown path because there is nothing a shutdown could reclaim."*

So of the three candidate shapes:

- **Invalidate the resolution entry and re-run `ensure_loaded` — rejected.** This is not a matter of reload *cost*; there is no unload at all. A second resolve would initialise a fresh module instance over a library whose previous instance is still mapped and still holding its SQLite handles, with no way to tear the first one down. That is worse than the bug.
- **A reconfigure entry point on the module — viable, not host-only.** It needs a new bus method in `tinymemory-module`, a new released cdylib, and a registry pin + digest bump (`modules/registry_part_01.rs`, currently `v1.14.1`). It cannot ship from this repo alone.
- **Resolve `config_path` dynamically per call — viable, largest.** Same release requirement plus a host callback on every source operation.

Both viable options are a module release. **This PR is therefore the host-side half**, and it is deliberately diagnostic rather than corrective. Shipping a half-fix that *looked* corrective would be worse than shipping one that says what is wrong.

### What it does

- **`memory/sources/rpc_part_01.rs` — `describe_source_sync_failure`.** At the point of failure the host holds both halves of the contradiction: its own registry answered for this id (it already reads it, three lines above, for the `enabled` gate), and the driver says `NotFound`. When the host has the source and the driver does not, the registries disagree, and the message now says so and names the remedy. Every other failure — and a `NotFound` for an id the host does not have either — passes through exactly as the driver stated it, because inventing a diagnosis for a genuinely missing source sends the reader down the wrong path.
- **`core/runtime/context.rs` — a warning at the rebind.** When the workspace is rebound while the memory module is already `Ready`, the binding has just gone stale. That is logged beside the rebind that caused it, rather than leaving a bare `NotFound` on a sync minutes later as the only evidence. Best-effort, never fatal, and `#[cfg]`-paired so a build without the `modules` feature compiles unchanged.

Together these turn a half-day diagnosis into a log line and an error message that name the cause.

## Impact

- **No behaviour change on any path that was working.** The diagnosis replaces an error string only when the host's own registry contradicts the driver; the rebind warning is a log line.
- Memory sources added after a mid-process login still do not sync until restart. That is stated by the error now instead of being silent.
- No new dependency, no schema change, no module pin change.

## Submission Checklist

- [x] Tests added or updated (happy path + at least one failure / edge case) per [Testing Strategy](../gitbooks/developing/testing-strategy.md#failure-path-requirement)
- [x] **Diff coverage ≥ 80%** — three tests cover the diagnosis: the drift case, the genuinely-missing case, and the pass-through case. Confirmed failing before the fix and passing after. Full `pnpm test:coverage` / `pnpm test:rust` not run: this worker shares a fleet-wide cargo slot cap and the full suites do not fit it; `memory::sources::rpc` (24), `memory::sources`, `runtime::context` and `modules::` were run instead. **Not covered:** the rebind warning is a log-only side effect with no assertable return — see Related.
- [x] N/A: Coverage matrix updated — diagnostic-only change to an existing RPC path; no feature rows added, removed or renamed.
- [x] N/A: All affected feature IDs from the matrix are listed under `## Related` — no matrix rows affected.
- [x] No new external network dependencies introduced (mock backend used per [Testing Strategy](../gitbooks/developing/testing-strategy.md#mock-policy)) — the tests call the diagnosis directly with constructed `MemoryError` values; no network, no module load.
- [x] N/A: Manual smoke checklist updated — no release-cut surface changes.
- [x] Linked issue closed via `Closes #NNN` in the `## Related` section

## Related

- Closes: N/A — reported from a live production reproduction rather than an existing issue.
- Follow-up PR(s)/TODOs:
  - **The correctness fix needs a `tinymemory-module` release** carrying a reconfigure entry point, then a registry pin + digest bump here. Until then a profile change mid-process requires a restart for memory sources to be visible, which the error now states.
  - **The rebind warning has no automated test.** It returns nothing and only logs; asserting it would mean a log-capture harness for one `warn!`. Verified by reading. A regression that deleted the call would not be caught.
  - Unrelated observation, settled and **not** a defect: a workspace switch with no accompanying `[memory:binding]` line is a `BINDINGS` cache hit (`memory/binding.rs`) — `for_config` returns the cached binding before `build()`, and the log line lives inside `build()`. Every switch that logs one is a first bind of that `(workspace, subdir, cfg)` triple. Benign, but it does make the log read as though a step were skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics when memory synchronization encounters a source unavailable due to a profile mismatch.
  * Warnings now identify when a memory module cannot be rebound without restarting.
  * Unrelated synchronization errors continue to be reported unchanged.

* **Tests**
  * Added coverage for profile-mismatch diagnostics, unknown sources, and other synchronization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->