### PR TITLE
fix(tests): construct DelegationTarget explicitly in the raw-coverage e2e

### DIFF
--- a/tests/raw_coverage/inference_agent_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/inference_agent_raw_coverage_e2e.rs
@@ -3035,6 +3035,7 @@ async fn agent_public_tools_cover_validation_and_metadata_paths() {
         AskClarificationTool, DelegateToPersonalityTool, DelegateTool, RunWorkflowTool, TodoTool,
         RUN_WORKFLOW_TOOL_NAME,
     };
+    use openhuman_core::openhuman::agent::orchestration::tools::DelegationTarget;
     use openhuman_core::openhuman::tools::{ArchetypeDelegationTool, SkillDelegationTool};
 
     let ask = AskClarificationTool::new();
@@ -3083,7 +3084,11 @@ async fn agent_public_tools_cover_validation_and_metadata_paths() {
 
     let archetype = ArchetypeDelegationTool {
         tool_name: "delegate_researcher".into(),
-        agent_id: "researcher".into(),
+        // Constructed explicitly rather than via `.into()`: `DelegationTarget`
+        // exists so a routing target cannot be an anonymous string, and an
+        // ambient `From<&str>` would let any `.into()` mint one silently —
+        // re-opening the hole the newtype was added to close.
+        agent_id: DelegationTarget("researcher".into()),
         tool_description: "Use for research.".into(),
     };
     assert_eq!(


### PR DESCRIPTION
## Summary

**`main` does not compile `--test raw_coverage_all` right now.** One-line fix plus an import.

```
error[E0277]: the trait bound `DelegationTarget: From<&str>` is not satisfied
  --> tests/raw_coverage/inference_agent_raw_coverage_e2e.rs:3086:32
```

## Problem

#6214 (merged) changed `ArchetypeDelegationTool::agent_id` from `String` to a `DelegationTarget` newtype. It updated the construction sites under `src/` and missed this one under `tests/`, which was passing `"researcher".into()` and resolving through `From<&str> for String`.

That is my miss, from my PR.

**Why no lane caught it, which is the part worth keeping:** `Rust Quality` runs clippy **without** `--all-targets`, and `Rust Core Coverage` is `--lib` scoped. A break confined to `tests/` ships green through both, and "all checks passed" on a PR is therefore not evidence about that target. The only thing that sees it is:

```
cargo test -p openhuman --test raw_coverage_all \
  --features "$(bash scripts/ci/product-features.sh)" --no-default-features
```

## Solution

Construct `DelegationTarget` explicitly, rather than adding `impl From<&str> for DelegationTarget`.

The newtype exists so a routing target cannot be an anonymous string: it is what `traits::delegation_target` downcasts on, and what stops an unrelated `String` parked in another tool's host-extension slot being misread as a delegate. An ambient `From<&str>` would let any `.into()` mint one silently — re-opening exactly the hole the newtype was introduced to close. One explicit call site is a cheap price for keeping it shut.

## Verification

- With the fix: `--test raw_coverage_all … --no-run` → `Finished` (compiles).
- **Revert-check:** reverted the file to `main`'s version on the same tree → `error[E0277] … DelegationTarget: From<&str>` at `:3086:32`, the exact error above. Restored → compiles.
- Layout gate passes.

This is deliberately the smallest possible diff — a red `main` should be unblocked before anything else. The remaining review follow-up from #6214 (a shared gate predicate, so a route hint cannot advertise a delegate the permission ceiling refuses) is a separate PR.

## Submission Checklist

- [x] N/A: fixes a compile break in an existing test; no new behaviour to test. The existing `raw_coverage_all` target is the coverage, and it goes from *not compiling* to compiling.
- [x] **Diff coverage ≥ 80%** — the changed line is inside a test that the target executes; it cannot be reached without being compiled and run.
- [x] N/A: behaviour-only/test-only change — no feature row added, removed or renamed in `docs/TEST-COVERAGE-MATRIX.md`.
- [x] N/A: no coverage-matrix feature IDs apply.
- [x] No new external network dependencies introduced.
- [x] N/A: does not touch a release-cut surface in `docs/RELEASE-MANUAL-SMOKE.md`.
- [x] N/A: no issue exists — found by a worker running the target locally after #6214 merged.

## Impact

- Restores `cargo test --test raw_coverage_all` on `main`. No production code changed; the diff is one test construction site and one import.

## Related

- Follow-up to #6214 (merged), which introduced the newtype.
- Follow-up PR(s)/TODOs: the CI gap itself — no lane compiles `tests/` — is left as-is here and is worth a separate decision, since adding `--all-targets` to `Rust Quality` has a cost.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test coverage to use the supported delegation target format when validating agent tool behavior.
  - Expanded coverage for delegation routing and metadata-related paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->