### PR TITLE
fix(tests): construct DelegationTarget explicitly so main compiles

### DIFF
--- a/tests/raw_coverage/inference_agent_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/inference_agent_raw_coverage_e2e.rs
@@ -3035,7 +3035,9 @@ async fn agent_public_tools_cover_validation_and_metadata_paths() {
         AskClarificationTool, DelegateToPersonalityTool, DelegateTool, RunWorkflowTool, TodoTool,
         RUN_WORKFLOW_TOOL_NAME,
     };
-    use openhuman_core::openhuman::tools::{ArchetypeDelegationTool, SkillDelegationTool};
+    use openhuman_core::openhuman::tools::{
+        ArchetypeDelegationTool, DelegationTarget, SkillDelegationTool,
+    };
 
     let ask = AskClarificationTool::new();
     assert_eq!(ask.name(), "ask_user_clarification");
@@ -3083,7 +3085,11 @@ async fn agent_public_tools_cover_validation_and_metadata_paths() {
 
     let archetype = ArchetypeDelegationTool {
         tool_name: "delegate_researcher".into(),
-        agent_id: "researcher".into(),
+        // `DelegationTarget` is deliberately not `From<&str>`: the newtype exists
+        // so the `Any` host-extension slot cannot be satisfied by any other tool
+        // that parked a `String` there, and a blanket conversion would make the
+        // distinction easy to lose again. Construct it.
+        agent_id: DelegationTarget("researcher".to_string()),
         tool_description: "Use for research.".into(),
     };
     assert_eq!(


### PR DESCRIPTION
## Summary

- **`main` does not compile.** #6214 merged a `DelegationTarget` newtype and left one `tests/` call site relying on `From<&str>`.
- One line plus an import. Constructed explicitly rather than adding a blanket `From<&str>`.
- Verified by compiler, before and after, on a detached `upstream/main` worktree.

## Problem

```
error[E0277]: the trait bound `DelegationTarget: From<&str>` is not satisfied
    --> tests/raw_coverage/inference_agent_raw_coverage_e2e.rs:3086:32
     |
3086 |         agent_id: "researcher".into(),
     |                                ^^^^ the trait `From<&str>` is not implemented for `DelegationTarget`
error: could not compile `openhuman` (test "raw_coverage_all") due to 1 previous error
```

#6214 changed `ArchetypeDelegationTool::agent_id` from `String` to
`DelegationTarget(pub String)` and updated every construction site in `src/`.
This one is in `tests/`, and used to resolve through `From<&str> for String`.

**Only this site is affected.** `:1668` looks similar but is
`AgentProfile::agent_id`, a different struct whose field is still a `String`;
the compiler's "due to 1 previous error" confirms it.

## Solution

Construct `DelegationTarget` explicitly, rather than adding
`impl From<&str> for DelegationTarget`.

The newtype's own doc comment gives the reason — it exists because the
`host_extension` slot is one `Any` per tool, and *"a downcast to `String` would
happily match any **other** tool that parked a string there"*. A blanket
conversion would not break that property, but it makes the distinction easy to
lose again, and a compile fix should not widen a public API to do its job.

## Verification

Detached worktree at `upstream/main` (`10d2f1c67`), own `CARGO_TARGET_DIR`:

```
cargo check -p openhuman --test raw_coverage_all \
  --features "$(bash scripts/ci/product-features.sh)" --no-default-features

before:  exit 101   (the error above)
after:   exit 0
```

## Impact

Unbreaks `main`. Test-only change; no `src/` behaviour touched.

## Why CI did not catch this

`Rust Quality` runs clippy **without `--all-targets`**, and
`Rust Core Coverage` is **`--lib`-scoped**. Nothing in CI compiles `tests/`, so
a break confined to that tree merges green — #6214 went in with 19 green checks.

That gap is not fixed here and should be closed separately; this PR only
unbreaks `main`.

## Related

- Breakage introduced by #6214.
- Follow-up: CI cannot compile `tests/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated agent tool coverage tests to use the revised delegation target format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->