### PR TITLE
fix(main): restore raw_coverage_all — main does not compile after #6214

### DIFF
--- a/tests/raw_coverage/inference_agent_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/inference_agent_raw_coverage_e2e.rs
@@ -3035,7 +3035,9 @@ async fn agent_public_tools_cover_validation_and_metadata_paths() {
         AskClarificationTool, DelegateToPersonalityTool, DelegateTool, RunWorkflowTool, TodoTool,
         RUN_WORKFLOW_TOOL_NAME,
     };
-    use openhuman_core::openhuman::tools::{ArchetypeDelegationTool, SkillDelegationTool};
+    use openhuman_core::openhuman::tools::{
+        ArchetypeDelegationTool, DelegationTarget, SkillDelegationTool,
+    };
 
     let ask = AskClarificationTool::new();
     assert_eq!(ask.name(), "ask_user_clarification");
@@ -3083,7 +3085,7 @@ async fn agent_public_tools_cover_validation_and_metadata_paths() {
 
     let archetype = ArchetypeDelegationTool {
         tool_name: "delegate_researcher".into(),
-        agent_id: "researcher".into(),
+        agent_id: DelegationTarget("researcher".to_string()),
         tool_description: "Use for research.".into(),
     };
     assert_eq!(


### PR DESCRIPTION
## Summary

- `main` does not compile `--test raw_coverage_all`. This restores it.
- One line: construct `DelegationTarget` explicitly at the single `tests/` site that #6214 missed.
- Explicit construction rather than a blanket `From<&str>`, to preserve what the newtype is for.

## Problem

```
error[E0277]: the trait bound `DelegationTarget: From<&str>` is not satisfied
  --> tests/raw_coverage/inference_agent_raw_coverage_e2e.rs:3086:32
   |
3086 |         agent_id: "researcher".into(),
```

#6214 changed `ArchetypeDelegationTool.agent_id` from `String` to the `DelegationTarget` newtype and updated every construction site under `src/`. This one lives in `tests/`, where `"researcher".into()` had been resolving through `From<&str> for String`.

Measured on a tree with verified-clean submodules (0 top-level, 0 nested drift), so the failure is the trait bound and not a dependency-resolution artifact:

| Tree | `cargo check -p openhuman --no-default-features --features "$(bash scripts/ci/product-features.sh)" --test raw_coverage_all` |
|---|---|
| `10d2f1c67` (`main`) | **exit 101** |
| this branch | **exit 0** |

`raw_coverage_all` aggregates ~76 suites, so while it does not compile, *every* suite inside it is unrunnable locally — not just the one that broke.

### Why it merged green

No lane on a PR builds integration test targets:

- `Rust Quality` runs `cargo clippy -p openhuman --features …` with no `--all-targets`.
- `Rust Core Coverage` (`scripts/ci/rust-coverage-changed.sh`) is changed-files-scoped; a `src/`-only change maps to a `--lib` filter plus `domain_integration_targets()`, which is two directories and one target in total.
- `test-reusable.yml` is the only workflow running `cargo test --test <target>`, and `test.yml` which calls it is `on: workflow_dispatch: {}`.

#6214 changed only `src/`, so `raw_coverage_all` was never selected, and all 19 of its checks passed. Filed as #6219; this PR only unbreaks `main`.

## Solution

Construct explicitly, matching every other construction site in the tree — `orchestrator_tools.rs:137`, `archetype_delegation_tests.rs:7`, `middleware_tests_part_04_tests.rs:62`:

```rust
agent_id: DelegationTarget("researcher".to_string()),
```

**Not** `impl From<&str> for DelegationTarget` — but not for the reason an earlier revision of this body gave, which was wrong and is corrected here.

I wrote that the newtype exists "to stop an arbitrary string being passed as an agent id". It does not. Its own doc says what it is for (`archetype_delegation.rs:16-18`):

> A newtype rather than a bare `String` because that slot is one `Any` per tool: a downcast to `String` would happily match any *other* tool that parked a string there.

`host_extension()` returns `&(dyn Any + Send + Sync)` (`:50`) and `tools::traits::delegation_target` reads the id back off it — the distinct type is what makes that downcast unambiguous. A blanket `From<&str>` would **not** break that property. It would only let a target be minted implicitly at any `.into()`, which is a fair reason to prefer explicit construction, just a weaker one. The type cannot prevent stringly-typed construction in any case: the field is `pub`, so `DelegationTarget(anything)` already compiles anywhere.

So: explicit construction because it matches every other site in the tree and keeps targets from appearing by inference — not because a `From` impl would re-open a hole.

**Exactly one site, not two.** `inference_agent_raw_coverage_e2e.rs:1668` also reads `agent_id: "planner".into()`, but it belongs to `AgentProfile`, whose `agent_id` is still `String` (`profiles/types.rs:22`). It compiles and is untouched. I had earlier reported this as two sites on #6214 and that was wrong — a grep for `agent_id: "…".into()` matched two different structs.

## Impact

Restores local `cargo test --tests` / `--test raw_coverage_all` and any lane that builds test targets. Test-only change; no shipped code touched, no behaviour change.

## Submission Checklist

- [x] Tests added or updated — `N/A: this repairs an existing test's construction site; the suite it belongs to is the coverage.`
- [x] **Diff coverage ≥ 80%** — `N/A: the changed line is test code, exercised by the test it is in` (`agent_public_tools_cover_validation_and_metadata_paths`, run below).
- [x] Coverage matrix updated — `N/A: no feature rows added, removed or renamed.`
- [x] All affected feature IDs listed under `## Related` — `N/A: no matrix rows touched.`
- [x] No new external network dependencies introduced.
- [x] Manual smoke checklist updated — `N/A: no release-cut surface; this is test-only.`
- [x] Linked issue closed via `Closes #NNN` — `N/A: no issue for the breakage itself; the structural cause is #6219 and is not closed by this.`

## Related

- **#6222 is the same one-line fix and is also open.** Only one should land; that one's import comes from the defining module, mine extends the `openhuman::tools` re-export already in the file. #6223 was a third copy, closed as a duplicate. Happy to close this in favour of #6222 — flagging rather than deciding unilaterally.
- #6214 — where the newtype landed; merged green, which is how this reached `main`.
- #6219 — the CI hole that let it through. **Not** closed by this PR.
- #6215 — same author, now standalone; worth re-checking against this once rebased.

### Validation Run

- [x] `pnpm --filter openhuman-app format:check` — `N/A: no frontend files changed.`
- [x] `pnpm typecheck` — `N/A: no TypeScript changed.`
- [x] Focused test: `cargo test … --test raw_coverage_all agent_public_tools_cover_validation_and_metadata_paths` — **1 passed, 0 failed**.
- [x] Rust fmt/check: `cargo fmt --check` exit 0, `node scripts/ci/check-openhuman-rust-layout.mjs` exit 0. Clippy not re-run: it does not build test targets, which is the whole subject of #6219.
- [x] Tauri fmt/check — `N/A: no Tauri source changed.`
