### PR TITLE
test(reaper): isolate the build-runtime test in a child process (fixes 40 order-dependent failures on the full CI lane)

### DIFF
--- a/src/core/runtime/context.rs
+++ b/src/core/runtime/context.rs
@@ -297,23 +297,7 @@ impl CoreContext {
 
         // Register the process default context (first build wins). Dispatch
         // resolves to this when no per-call context is scoped.
-        //
-        // Not under `cfg(test)`: the lib test binary runs every unit test in
-        // one process, and a `OnceLock` cannot be unset. A single test that
-        // builds a core (`reaper_tests::a_build_only_runtime_is_swept_…`, with
-        // `DomainSet::harness()` and a tmp workspace) would otherwise install
-        // that narrowed context as the fallback for every test that runs after
-        // it — `all_tools` drops the acting tool groups, memory-binding and
-        // origin-label tests see a workspace they never set up — which is
-        // exactly the order-dependent failure CI's full `--test-threads=1`
-        // lane hit. Unit tests that need an ambient context scope one
-        // explicitly via `CoreContext::scope` / `for_test`; the builder still
-        // hands the built context back directly. Integration tests compile the
-        // lib without `cfg(test)`, so the desktop/CLI path is unchanged.
-        #[cfg(not(test))]
-        {
-            let _ = DEFAULT_CONTEXT.set(ctx.clone());
-        }
+        let _ = DEFAULT_CONTEXT.set(ctx.clone());
 
         Ok((ctx, has_operator_token, runtime_config))
     }

--- a/src/core/runtime/context.rs
+++ b/src/core/runtime/context.rs
@@ -297,7 +297,23 @@ impl CoreContext {
 
         // Register the process default context (first build wins). Dispatch
         // resolves to this when no per-call context is scoped.
-        let _ = DEFAULT_CONTEXT.set(ctx.clone());
+        //
+        // Not under `cfg(test)`: the lib test binary runs every unit test in
+        // one process, and a `OnceLock` cannot be unset. A single test that
+        // builds a core (`reaper_tests::a_build_only_runtime_is_swept_…`, with
+        // `DomainSet::harness()` and a tmp workspace) would otherwise install
+        // that narrowed context as the fallback for every test that runs after
+        // it — `all_tools` drops the acting tool groups, memory-binding and
+        // origin-label tests see a workspace they never set up — which is
+        // exactly the order-dependent failure CI's full `--test-threads=1`
+        // lane hit. Unit tests that need an ambient context scope one
+        // explicitly via `CoreContext::scope` / `for_test`; the builder still
+        // hands the built context back directly. Integration tests compile the
+        // lib without `cfg(test)`, so the desktop/CLI path is unchanged.
+        #[cfg(not(test))]
+        {
+            let _ = DEFAULT_CONTEXT.set(ctx.clone());
+        }
 
         Ok((ctx, has_operator_token, runtime_config))
     }

--- a/src/openhuman/agent/tinyagents/reaper_tests.rs
+++ b/src/openhuman/agent/tinyagents/reaper_tests.rs
@@ -90,10 +90,25 @@ async fn reap_on_empty_workspace_is_a_noop() {
 /// from `serve()`) would leave that caller reading the previous process's
 /// graveyard. This pins the sweep to the build path with every optional
 /// service off.
+///
+/// The build itself runs in a **child process** (this same test binary,
+/// re-invoked with `--exact` on this test and `REAPER_BOOT_CHILD` set).
+/// `CoreBuilder::build` → `CoreContext::init` → `bootstrap_core_runtime`
+/// installs process-wide `OnceLock` singletons that can never be unset — the
+/// default `CoreContext` (here with `DomainSet::harness()` and a throw-away
+/// workspace), the global `ApprovalGate`, the socket manager, native-bus
+/// handlers. Booting in the lib test binary leaked all of them into every
+/// test that ran afterwards under `--test-threads=1`: `all_tools` lost its
+/// acting tool groups, the tinyflows HTTP adapter hit the origin-label gate
+/// instead of the SSRF guard, memory-binding tests saw a workspace they never
+/// set up. The parent seeds the store and verifies the sweep; only the child
+/// touches the singletons, and it exits with them.
 #[tokio::test]
 async fn a_build_only_runtime_is_swept_before_it_can_be_invoked() {
-    use crate::core::runtime::{CoreBuilder, DomainSet, ServiceSet};
-    use crate::core::types::HostKind;
+    if std::env::var_os(REAPER_BOOT_CHILD_ENV).is_some() {
+        boot_child().await;
+        return;
+    }
 
     let tmp = std::env::temp_dir().join(format!("oh-reaper-boot-{}", uuid::Uuid::new_v4()));
     // `OPENHUMAN_WORKSPACE` names the root; the resolved workspace is the
@@ -103,38 +118,25 @@ async fn a_build_only_runtime_is_swept_before_it_can_be_invoked() {
     let orphan = seed_status(&store, ExecutionStatus::Running).await;
     assert_eq!(store.list_active().await.unwrap().len(), 1);
 
-    // Point the runtime at this workspace, then build it with no transport
-    // and no services — the shape `examples/embed_headless.rs` documents.
-    //
-    // Two process-global locks, because `build()` touches two kinds of global
-    // state. `TEST_ENV_LOCK` covers `OPENHUMAN_WORKSPACE`, which is read from
-    // the environment. `BUS_HANDLER_LOCK` covers the native-bus registrations
-    // `CoreContext::init` performs: without it this build re-registers the real
-    // `agent.run_turn` handler over a `mock_agent_run_turn` stub another test is
-    // relying on, and that test then reaches a real harness it never scripted.
-    // `bus_testing` states the rule — "any test that touches global native-bus
-    // registration state should acquire this lock first" — and building a core
-    // is exactly that.
-    let _bus = crate::core::bus_testing::BUS_HANDLER_LOCK.lock().await;
-    let _env = crate::openhuman::config::TEST_ENV_LOCK
-        .lock()
-        .unwrap_or_else(|e| e.into_inner());
-    let previous = std::env::var("OPENHUMAN_WORKSPACE").ok();
-    std::env::set_var("OPENHUMAN_WORKSPACE", &tmp);
-    let built = CoreBuilder::new(HostKind::Cli)
-        .services(ServiceSet::none())
-        .domains(DomainSet::harness())
-        .build()
-        .await;
-    match previous {
-        Some(value) => std::env::set_var("OPENHUMAN_WORKSPACE", value),
-        None => std::env::remove_var("OPENHUMAN_WORKSPACE"),
-    }
-    let built = built.expect("a headless build succeeds");
-    assert_eq!(
-        built.context().workspace_dir().ok(),
-        Some(workspace.clone()),
-        "the build must have resolved the workspace this test seeded"
+    let exe = std::env::current_exe().expect("test binary path");
+    let output = std::process::Command::new(exe)
+        .args([
+            "--exact",
+            "openhuman::agent::tinyagents::reaper::tests::\
+             a_build_only_runtime_is_swept_before_it_can_be_invoked",
+            "--test-threads=1",
+            "--nocapture",
+        ])
+        .env(REAPER_BOOT_CHILD_ENV, "1")
+        .env("OPENHUMAN_WORKSPACE", &tmp)
+        .output()
+        .expect("spawn the boot child");
+    assert!(
+        output.status.success(),
+        "the boot child must build a core and pass its own assertions\n\
+         --- stdout ---\n{}\n--- stderr ---\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
     );
 
     let after = store
@@ -151,4 +153,33 @@ async fn a_build_only_runtime_is_swept_before_it_can_be_invoked() {
     assert!(store.list_active().await.unwrap().is_empty());
 
     let _ = std::fs::remove_dir_all(&tmp);
+}
+
+/// Set on the re-invoked test binary so the test body knows it is the boot
+/// child rather than the seeding/verifying parent.
+const REAPER_BOOT_CHILD_ENV: &str = "OPENHUMAN_TEST_REAPER_BOOT_CHILD";
+
+/// The child half of `a_build_only_runtime_is_swept_before_it_can_be_invoked`:
+/// build a runtime with no transport and no services — the shape
+/// `examples/embed_headless.rs` documents — against the `OPENHUMAN_WORKSPACE`
+/// the parent exported, and check the build resolved that workspace. The
+/// parent reads the sweep's effect out of the store afterwards.
+async fn boot_child() {
+    use crate::core::runtime::{CoreBuilder, DomainSet, ServiceSet};
+    use crate::core::types::HostKind;
+
+    let root = std::path::PathBuf::from(
+        std::env::var_os("OPENHUMAN_WORKSPACE").expect("parent exports OPENHUMAN_WORKSPACE"),
+    );
+    let built = CoreBuilder::new(HostKind::Cli)
+        .services(ServiceSet::none())
+        .domains(DomainSet::harness())
+        .build()
+        .await
+        .expect("a headless build succeeds");
+    assert_eq!(
+        built.context().workspace_dir().ok(),
+        Some(root.join("workspace")),
+        "the build must have resolved the workspace the parent seeded"
+    );
 }

--- a/src/openhuman/platform/socket/medulla/mod.rs
+++ b/src/openhuman/platform/socket/medulla/mod.rs
@@ -636,9 +636,16 @@ fn emit<T: serde::Serialize>(event: &str, payload: T) {
         log::debug!("[medulla] no socket manager — dropping {event}");
         return;
     };
+    // `emit` is reachable from synchronous callers (socket event handlers,
+    // unit tests). `tokio::spawn` panics outside a runtime, so resolve the
+    // handle first and treat "no runtime" like "no socket": best-effort drop.
+    let Ok(handle) = tokio::runtime::Handle::try_current() else {
+        log::debug!("[medulla] no tokio runtime — dropping {event}");
+        return;
+    };
     let mgr = Arc::clone(mgr);
     let event = event.to_string();
-    tokio::spawn(async move {
+    handle.spawn(async move {
         if let Err(err) = mgr.emit(&event, data).await {
             log::warn!("[medulla] failed to emit {event}: {err}");
         }

--- a/tests/claude_code_stream_e2e.rs
+++ b/tests/claude_code_stream_e2e.rs
@@ -3,8 +3,10 @@
 //! Feeds a captured representative CC 2.x stream-json transcript through
 //! `StreamJsonParser` → `EventMapper` and asserts that:
 //! - text deltas arrive in order and aggregate into the final response
-//! - tool-use blocks emit ToolCallStart + ToolCallArgsDelta + a final
-//!   ToolCall with parsed JSON arguments
+//! - a `tool_use` block is the CLI's **own, already-executed** call: its
+//!   `input_json_delta`s are kept out of the visible text and nothing is
+//!   surfaced to the harness — no `ToolCallStart`, no `ToolCallArgsDelta`,
+//!   no aggregated `ToolCall` (see the `event_mapper` module docs; #5739)
 //! - the `result` event finalizes usage tokens (incl. cache_read)
 //! - session_id is captured from the first `system` event
 //!
@@ -69,30 +71,29 @@ fn captures_text_tool_call_and_usage() {
         .collect();
     assert_eq!(text_chunks, vec!["Hello", " world"]);
 
-    // Tool call lifecycle.
-    assert!(deltas.iter().any(|d| matches!(
-        d,
-        ProviderDelta::ToolCallStart { tool_name, call_id }
-            if tool_name == "memory_search" && call_id == "call_42"
-    )));
-    let args_concat: String = deltas
-        .iter()
-        .filter_map(|d| match d {
-            ProviderDelta::ToolCallArgsDelta { call_id, delta } if call_id == "call_42" => {
-                Some(delta.as_str())
-            }
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .join("");
-    assert_eq!(args_concat, r#"{"query":"foo"}"#);
+    // The CLI's own tool call is suppressed end to end: nothing about
+    // `call_42` reaches the harness, and its argument JSON never leaks into
+    // the text stream.
+    assert!(
+        !deltas.iter().any(|d| matches!(
+            d,
+            ProviderDelta::ToolCallStart { .. } | ProviderDelta::ToolCallArgsDelta { .. }
+        )),
+        "a self-executed CLI tool_use block must not surface as a harness tool call: {deltas:?}"
+    );
+    assert!(
+        !text_chunks
+            .iter()
+            .any(|t| t.contains("que") || t.contains("ry\"")),
+        "input_json_delta text must stay out of the visible text: {text_chunks:?}"
+    );
 
     // Aggregated response.
     assert_eq!(mapper.final_text, "Hello world");
-    assert_eq!(mapper.tool_calls.len(), 1);
-    assert_eq!(mapper.tool_calls[0].name, "memory_search");
-    assert_eq!(mapper.tool_calls[0].id, "call_42");
-    assert_eq!(mapper.tool_calls[0].arguments, r#"{"query":"foo"}"#);
+    assert!(
+        mapper.tool_calls.is_empty(),
+        "no ToolCall is aggregated for a CLI-internal tool_use block"
+    );
 
     // Usage from the `result` event.
     assert!(mapper.finished);

--- a/tests/raw_coverage/app_state_credentials_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/app_state_credentials_raw_coverage_e2e.rs
@@ -1425,7 +1425,7 @@ fn round14_profiles_cover_oauth_token_selection_schema_and_quarantine_edges() {
         .expect("legacy profile re-keyed to its canonical id");
     assert_eq!(legacy.id, "legacy:empty");
     assert_eq!(legacy.provider, "legacy");
-    assert!(legacy.token.as_deref().is_none_or(str::is_empty));
+    assert_eq!(legacy.token.as_deref(), Some(""));
 
     raw["schema_version"] = json!(999);
     std::fs::write(

--- a/tests/raw_coverage/app_state_credentials_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/app_state_credentials_raw_coverage_e2e.rs
@@ -1412,14 +1412,20 @@ fn round14_profiles_cover_oauth_token_selection_schema_and_quarantine_edges() {
 
     let migrated = store.load().expect("schema 0 should migrate in memory");
     assert_eq!(migrated.schema_version, 1);
-    assert!(migrated.profiles.contains_key("legacy-empty"));
-    assert!(migrated
+    // Since #5432 the migration re-keys every profile to its canonical
+    // `<provider>:<profile_name>` id, so the raw `legacy-empty` key is
+    // rewritten to `legacy:empty` rather than kept verbatim.
+    assert!(
+        !migrated.profiles.contains_key("legacy-empty"),
+        "a non-canonical profile id must be re-keyed by the migration"
+    );
+    let legacy = migrated
         .profiles
-        .get("legacy-empty")
-        .expect("legacy")
-        .token
-        .as_deref()
-        .is_none_or(str::is_empty));
+        .get("legacy:empty")
+        .expect("legacy profile re-keyed to its canonical id");
+    assert_eq!(legacy.id, "legacy:empty");
+    assert_eq!(legacy.provider, "legacy");
+    assert!(legacy.token.as_deref().is_none_or(str::is_empty));
 
     raw["schema_version"] = json!(999);
     std::fs::write(

--- a/tests/raw_coverage/app_state_credentials_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/app_state_credentials_raw_coverage_e2e.rs
@@ -1425,7 +1425,14 @@ fn round14_profiles_cover_oauth_token_selection_schema_and_quarantine_edges() {
         .expect("legacy profile re-keyed to its canonical id");
     assert_eq!(legacy.id, "legacy:empty");
     assert_eq!(legacy.provider, "legacy");
-    assert_eq!(legacy.token.as_deref(), Some(""));
+    // The empty legacy token surfaces as `Some("")` from the file-backed store
+    // and as `None` where the secret lives in a keychain (CI has none), so
+    // accept either — what matters is that no non-empty token appears.
+    assert!(
+        legacy.token.as_deref().is_none_or(str::is_empty),
+        "legacy token must be empty, got {:?}",
+        legacy.token
+    );
 
     raw["schema_version"] = json!(999);
     std::fs::write(

--- a/tests/raw_coverage/near90_closure_raw_coverage_e2e.rs
+++ b/tests/raw_coverage/near90_closure_raw_coverage_e2e.rs
@@ -380,14 +380,33 @@ fn round20_credentials_profiles_cover_legacy_plaintext_errors_and_active_edges()
     .expect("write legacy plaintext store");
 
     let loaded = store.load().expect("load plaintext legacy profiles");
+    // Since #5432 `load` re-keys every profile to its canonical
+    // `<provider>:<profile_name>` id and rewrites `active_profiles` to match,
+    // so the raw `legacy-*` keys are gone after the load.
+    assert!(
+        !loaded.profiles.contains_key("legacy-token")
+            && !loaded.profiles.contains_key("legacy-oauth"),
+        "non-canonical profile ids must be re-keyed on load"
+    );
     assert_eq!(
         loaded
             .profiles
-            .get("legacy-token")
+            .get("token:plain")
             .and_then(|profile| profile.token.as_deref()),
         Some("plain-secret")
     );
-    let oauth = loaded.profiles.get("legacy-oauth").expect("oauth loaded");
+    assert_eq!(
+        loaded.active_profiles.get("token").map(String::as_str),
+        Some("token:plain")
+    );
+    assert_eq!(
+        loaded.active_profiles.get("github").map(String::as_str),
+        Some("github:oauth")
+    );
+    let oauth = loaded
+        .profiles
+        .get("github:oauth")
+        .expect("oauth re-keyed to its canonical id");
     assert_eq!(oauth.kind, AuthProfileKind::OAuth);
     assert_eq!(
         oauth.token_set.as_ref().map(|tokens| (


### PR DESCRIPTION
## Problem

Every PR that trips CI Lite's **full-suite** coverage lane (vendor/, scripts/ci, workflow edits — e.g. #5321, #5778, #5833, #6001) fails `Rust Core Coverage` with the same 40 tests, none of which the PR touches:

- 32 × `tools::ops::tests::*` — `expected tool \`shell\` to be registered; got: [only agent/memory/config tools]`
- `memory::ops::guard::tests` ×2, `flows::tinyflows::tests` ×2 (`'flows_http_request' was blocked because this agent turn is missing its origin label`), `flows::tinyflows::memory_adapter` ×1, `mcp::server::tools` ×1, `platform::socket::{ws_loop,event_handlers}` ×2 (`there is no reactor running`).

They all pass in isolation. Main never sees them because its own CI Lite run is module-scoped.

## Root cause

`reaper_tests::a_build_only_runtime_is_swept_before_it_can_be_invoked` (added 2026‑09‑02) builds a real core via `CoreBuilder::build()` inside the lib test binary. `CoreContext::init` → `bootstrap_core_runtime` installs process‑wide `OnceLock` singletons that can never be unset: the default `CoreContext` (here `DomainSet::harness()` + a throw‑away workspace), the global `ApprovalGate`, the socket manager. Under `--test-threads=1` every test that sorts after `agent::tinyagents::reaper` then runs against that leaked state — `all_tools` drops the acting tool groups, the HTTP adapter hits the origin‑label gate instead of the SSRF guard, and so on.

Minimal repro on `main` (CI feature set):
```
cargo test -p openhuman --lib -- --test-threads=1 \
  a_build_only_runtime_is_swept_before_it_can_be_invoked \
  all_tools_default_registry_contains_expected_baseline_surface
# → second test FAILED
```

## Fix

- **`reaper_tests.rs`**: the build now happens in a child process — the same test binary re‑invoked with `--exact` on this test and `OPENHUMAN_TEST_REAPER_BOOT_CHILD=1`. The parent seeds the orphan run and verifies the sweep through the store as before; only the child touches the singletons, and it exits with them. Same assertions, same build shape (`ServiceSet::none()`, `DomainSet::harness()`), no more `TEST_ENV_LOCK`/`BUS_HANDLER_LOCK` juggling. The doc comment records why.
- **`platform/socket/medulla/mod.rs`**: `emit` resolved a global socket manager and then `tokio::spawn`ed from synchronous callers, which panics outside a runtime. It now takes `Handle::try_current()` and drops the event (debug log) when there is none — the same best‑effort contract it already has for "no socket manager".
- **`tests/claude_code_stream_e2e.rs`**: the same full lane also runs the integration targets, and this one has been red on `main` since #5739 (merged today) changed the `EventMapper` contract — a `tool_use` block is the CLI's own already‑executed call and is no longer surfaced as `ToolCallStart`/`ToolCallArgsDelta`/`ToolCall`. #5739 updated the unit tests but not this e2e; it now asserts the new contract (nothing about `call_42` reaches the harness, argument JSON stays out of the text, `tool_calls` is empty) with the text/usage/session assertions unchanged. This is the failure #6001 hit.
- **`tests/raw_coverage/app_state_credentials_raw_coverage_e2e.rs`** (`round14_profiles_cover_oauth_token_selection_schema_and_quarantine_edges`): red on `main` since #5432 (merged today) made the schema‑0 migration re‑key every profile to its canonical `<provider>:<profile_name>` id. The test still expected the raw `legacy-empty` key to survive verbatim; it now asserts the re‑key (`legacy:empty`, provider `legacy`, empty token) and the rest of the round is unchanged. This is the failure #5320 hit (`raw_coverage_all` runs on the app_state lane: 15 passed / 1 failed → 16 / 16). Same fallout in `near90_closure_raw_coverage_e2e::round20_…`, which loads a schema‑1 store with raw `legacy-token` / `legacy-oauth` keys and now asserts they come back as `token:plain` / `github:oauth` with `active_profiles` rewritten to match. Every other `raw_coverage_all` module was run locally under CI settings; the only remaining reds are the two `git_operations` tests that trip on a developer‑machine global `core.hookspath` and never fail in CI.
- The intermediate `#[cfg(not(test))]` guard on `DEFAULT_CONTEXT` registration is reverted in‑branch (commit history kept per repo convention); with the test isolated it isn't needed and production code stays identical between test and non‑test builds.

## Verification

Full `-p openhuman --lib -- --test-threads=1` with CI's feature list and `RUST_MIN_STACK=67108864`, on `upstream/main`:

| | passed | failed |
|---|---|---|
| before | 12040 | 46 (the 40 above + 6 local‑env: `git_operations` under a global `core.hookspath`, one `modules::ops` with a warm module cache) |
| after | 12080 | 6 (only the local‑env ones; none of the 40 CI failures remain) |

The three reaper tests pass, including the child‑process one. `cargo test --test claude_code_stream_e2e` passes (fails on `upstream/main`).

Once this lands, #5320 / #5321 / #5778 / #5833 / #6001 should go green on a rebase or a re‑run of their CI Lite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented socket events from causing runtime panics when triggered from synchronous contexts; events are safely skipped when no runtime is active.
  * Internal tool-use details are no longer exposed as visible text or surfaced as duplicate tool-call events.
  * Profile records are now consistently migrated to canonical identifiers while preserving provider and token information.

* **Tests**
  * Improved runtime startup and cleanup coverage, including workspace resolution and isolated build verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->